### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+We take the security of Superlog and its users seriously. Thank you for helping
+keep Superlog and the people who use it safe.
+
+## Supported Versions
+
+Superlog ships from `main`. Security fixes are applied to the latest release and
+the current `main` branch only. Older commits and tags are not patched — please
+upgrade to the latest version before reporting an issue.
+
+| Version            | Supported          |
+| ------------------ | ------------------ |
+| Latest release / `main` | :white_check_mark: |
+| Anything older     | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or our Discord.**
+
+Instead, use either of these private channels:
+
+- **GitHub Private Vulnerability Reporting** (preferred): open a report from the
+  [Security tab](https://github.com/superloglabs/superlog/security/advisories/new)
+  of this repository. This keeps the discussion private until a fix is released.
+- **Email**: send details to **security@superlog.sh**.
+
+Please include as much of the following as you can:
+
+- The type of issue (e.g. injection, authn/authz bypass, SSRF, RCE, data exposure).
+- The affected component (`apps/web`, `apps/api`, `apps/proxy`, `apps/worker`,
+  `packages/*`) and file paths or commit if known.
+- Step-by-step instructions to reproduce, including any required configuration.
+- Proof-of-concept or exploit code, if you have it.
+- The impact of the issue and how an attacker might exploit it.
+
+This information helps us triage your report more quickly.
+
+## What to Expect
+
+- **Acknowledgement** within 3 business days of your report.
+- An **initial assessment** and severity triage within 7 business days.
+- We will keep you informed of progress as we work on a fix, and we will let you
+  know when the issue is resolved.
+- We practice **coordinated disclosure**: we ask that you give us a reasonable
+  opportunity to release a fix before any public disclosure. We are happy to
+  credit you in the release notes and advisory unless you prefer to remain
+  anonymous.
+
+## Scope
+
+This policy covers the open-source code in this repository. Issues in the hosted
+**Superlog Cloud** service should also be reported through the channels above.
+
+Out of scope (please do not report these):
+
+- Reports from automated scanners without a demonstrated, exploitable impact.
+- Denial-of-service achievable only through unrealistic traffic volumes.
+- Vulnerabilities in third-party dependencies that are already publicly known —
+  open a regular issue or PR to bump the dependency instead.
+
+## Safe Harbor
+
+We will not pursue legal action against researchers who act in good faith,
+follow this policy, avoid privacy violations and service degradation, and give
+us a reasonable time to remediate before disclosing.


### PR DESCRIPTION
Adds a `SECURITY.md` to the open-core repo so vulnerability reports go to private channels instead of public issues.

## What

- **Reporting channels:** GitHub Private Vulnerability Reporting (preferred) + `security@superlog.sh`.
- **Supported versions:** latest release / `main` only.
- Response-time expectations, coordinated-disclosure ask, scope (incl. Superlog Cloud), out-of-scope list, and a good-faith safe-harbor clause.

## Follow-ups (need repo-admin action)

- Enable **Private Vulnerability Reporting** in Settings → Code security (the policy links to the advisory form).
- Make sure **security@superlog.sh** is monitored.

GitHub surfaces this file in the repo's Security tab and the "Report a vulnerability" UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add SECURITY.md to establish a clear vulnerability disclosure policy. Reports go to GitHub Private Vulnerability Reporting or security@superlog.sh, with defined support window, response times, coordinated disclosure, scope, out-of-scope, and safe harbor.

- **Migration**
  - Enable Private Vulnerability Reporting in repo settings.
  - Ensure security@superlog.sh is monitored.

<sup>Written for commit 200b73cabaffce0249cf022358846f3812bd70de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

