### PR TITLE
Add GitHub link to landing navbar

### DIFF
--- a/apps/web/src/Landing.test.ts
+++ b/apps/web/src/Landing.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
+
+test("landing navbar uses the public Superlog GitHub repository URL", () => {
+  assert.equal(LANDING_GITHUB_REPO_URL, "https://github.com/superloglabs/superlog");
+});
+
+test("landing top nav renders a GitHub link wired to the repository URL", async () => {
+  const source = await readFile(new URL("./Landing.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /href=\{LANDING_GITHUB_REPO_URL\}[\s\S]*<GitHubIcon \/>[\s\S]*GitHub\s*<\/a>/);
+});

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { AuthForm } from "./AuthForm.tsx";
 import { Btn, Chip, Label, Tile, Wordmark } from "./design/ui.tsx";
 import { INSTALL_PROMPT } from "./installPrompt.ts";
+import { LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
 
 // ---------------------------------------------------------------------------
 // Landing — /
@@ -110,6 +111,15 @@ function TopNav({
           <Wordmark />
           <div className="flex items-center gap-3">
             <a
+              href={LANDING_GITHUB_REPO_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="hidden items-center gap-1.5 text-[12px] font-medium text-muted transition-colors hover:text-fg sm:inline-flex"
+            >
+              <GitHubIcon />
+              GitHub
+            </a>
+            <a
               href="/pricing"
               className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg sm:inline"
             >
@@ -125,6 +135,19 @@ function TopNav({
         </nav>
       </div>
     </header>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg
+      className="h-3.5 w-3.5"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38v-1.33c-2.22.48-2.69-1.07-2.69-1.07-.36-.92-.89-1.17-.89-1.17-.73-.5.06-.49.06-.49.81.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.13 0 0 .67-.21 2.2.82A7.6 7.6 0 0 1 8 3.86c.68 0 1.36.09 2 .27 1.53-1.03 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.51.56.82 1.28.82 2.15 0 3.07-1.87 3.74-3.65 3.94.29.25.54.73.54 1.48v2.19c0 .21.15.46.55.38A8 8 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+    </svg>
   );
 }
 

--- a/apps/web/src/landingLinks.ts
+++ b/apps/web/src/landingLinks.ts
@@ -1,0 +1,1 @@
+export const LANDING_GITHUB_REPO_URL = "https://github.com/superloglabs/superlog";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a GitHub link to the landing page navbar that opens the public repo in a new tab, making the repository easy to find from the homepage.

- New Features
  - Added a GitHub link with icon to `TopNav` using `LANDING_GITHUB_REPO_URL` and `target="_blank"`.
  - Introduced `landingLinks.ts` to centralize the repo URL.
  - Added tests to verify the URL constant and the rendered link in `Landing.tsx`.

<sup>Written for commit a48115059d9cffe0fb3a92c50fadcd64110ee9a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

