### PR TITLE
Add incident MCP tools (get_incident + search_incidents)

### DIFF
--- a/apps/api/src/incidents/detail.test.ts
+++ b/apps/api/src/incidents/detail.test.ts
@@ -1,0 +1,74 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import type { Issue, IssueSample } from "@superlog/db";
+
+// detail.ts transitively imports the db client, which throws at import time
+// without a connection string. Set a dummy URL before the dynamic import (the
+// porsager client connects lazily, so these pure-function tests never open a
+// socket). Same dynamic-import pattern as linear.test.ts / loops.test.ts.
+process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
+const { toIssueContext } = await import("./detail.js");
+
+test("issue context carries the stored telemetry sample as-is", () => {
+  const sample: IssueSample = {
+    kind: "span",
+    service: "api",
+    severity: "ERROR",
+    message: "boom",
+    body: null,
+    exceptionType: "TypeError",
+    topFrame: "checkout.ts:42",
+    normalizedFrames: ["checkout.ts:42", "handler.ts:10"],
+    stacktrace: "TypeError: boom\n  at checkout.ts:42",
+    seenAt: "2026-05-24T01:00:00.000Z",
+    traceId: "abc123",
+    spanId: "def456",
+    spanName: "POST /checkout",
+    spanAttrs: { "http.route": "/checkout" },
+  };
+  const ctx = toIssueContext({ ...baseIssue(), lastSample: sample });
+
+  assert.equal(ctx.id, "issue-1");
+  assert.equal(ctx.kind, "span");
+  assert.equal(ctx.exceptionType, "TypeError");
+  assert.equal(ctx.eventCount, 12);
+  assert.equal(ctx.firstSeen, "2026-05-24T00:00:00.000Z");
+  assert.equal(ctx.lastSeen, "2026-05-24T01:00:00.000Z");
+  // The full log/trace shape is passed through untouched so the agent can walk
+  // to live telemetry via the trace_id / span_id.
+  assert.deepEqual(ctx.sample, sample);
+  assert.equal(ctx.sample?.traceId, "abc123");
+});
+
+test("issue context tolerates issues that never captured a sample", () => {
+  const ctx = toIssueContext({ ...baseIssue(), lastSample: null });
+  assert.equal(ctx.sample, null);
+});
+
+function baseIssue(): Issue {
+  return {
+    id: "issue-1",
+    projectId: "project-1",
+    fingerprint: "fp-1",
+    kind: "span",
+    service: "api",
+    exceptionType: "TypeError",
+    title: "TypeError in checkout",
+    message: "boom",
+    topFrame: "checkout.ts:42",
+    normalizedFrames: ["checkout.ts:42"],
+    lastSample: null,
+    firstSeen: new Date("2026-05-24T00:00:00.000Z"),
+    lastSeen: new Date("2026-05-24T01:00:00.000Z"),
+    silencedAt: null,
+    lastAlertedAt: null,
+    slackMessageTs: null,
+    eventCount: 12,
+    groupingState: "grouped",
+    groupingSource: null,
+    groupingReason: null,
+    groupingAttemptedAt: null,
+    groupingAttemptCount: 0,
+    createdAt: new Date("2026-05-24T00:00:00.000Z"),
+  };
+}

--- a/apps/api/src/incidents/detail.ts
+++ b/apps/api/src/incidents/detail.ts
@@ -1,0 +1,115 @@
+import { type AgentRun, type Issue, type IssueSample, db, schema } from "@superlog/db";
+import { desc, eq, inArray } from "drizzle-orm";
+import { type IncidentSummary, toIncidentSummary } from "./search.js";
+
+export type IssueContext = {
+  id: string;
+  kind: string;
+  service: string | null;
+  exceptionType: string;
+  title: string;
+  message: string | null;
+  topFrame: string | null;
+  fingerprint: string;
+  eventCount: number;
+  firstSeen: string;
+  lastSeen: string;
+  /**
+   * The representative log/trace shape captured for this issue: trace_id /
+   * span_id, stacktrace, and span/log/resource attributes. This is the inline
+   * "issue context" — the agent can read it directly, then walk to live
+   * telemetry with query_traces / query_logs using the trace_id.
+   */
+  sample: IssueSample | null;
+};
+
+/** Compact, agent-friendly projection of an issue plus its stored telemetry sample. */
+export function toIssueContext(issue: Issue): IssueContext {
+  return {
+    id: issue.id,
+    kind: issue.kind,
+    service: issue.service,
+    exceptionType: issue.exceptionType,
+    title: issue.title,
+    message: issue.message,
+    topFrame: issue.topFrame,
+    fingerprint: issue.fingerprint,
+    eventCount: issue.eventCount,
+    firstSeen: issue.firstSeen.toISOString(),
+    lastSeen: issue.lastSeen.toISOString(),
+    sample: issue.lastSample ?? null,
+  };
+}
+
+export type AgentRunPointer = {
+  id: string;
+  state: string;
+  runtime: string;
+  selectedRepoFullName: string | null;
+  failureReason: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+};
+
+function toAgentRunPointer(run: AgentRun): AgentRunPointer {
+  return {
+    id: run.id,
+    state: run.state,
+    runtime: run.runtime,
+    selectedRepoFullName: run.selectedRepoFullName,
+    failureReason: run.failureReason,
+    startedAt: run.startedAt ? run.startedAt.toISOString() : null,
+    completedAt: run.completedAt ? run.completedAt.toISOString() : null,
+  };
+}
+
+export type IncidentDetail = {
+  incident: IncidentSummary;
+  issues: IssueContext[];
+  latestAgentRun: AgentRunPointer | null;
+};
+
+/**
+ * Load an incident by its (global) id and assemble the full detail an agent
+ * needs to answer "what's going on in this incident": the incident summary
+ * (with project_id for follow-up telemetry queries), every linked issue with
+ * its stored log/trace sample, and a pointer to the latest investigation.
+ *
+ * Returns null when the incident does not exist. Access control is the
+ * caller's responsibility — resolve `incident.projectId` against the session.
+ */
+export async function getIncidentDetail(incidentId: string): Promise<IncidentDetail | null> {
+  const incident = await db.query.incidents.findFirst({
+    where: eq(schema.incidents.id, incidentId),
+  });
+  if (!incident) return null;
+
+  const [links, agentRuns] = await Promise.all([
+    db.query.incidentIssues.findMany({
+      where: eq(schema.incidentIssues.incidentId, incident.id),
+      orderBy: [desc(schema.incidentIssues.createdAt)],
+    }),
+    db.query.agentRuns.findMany({
+      where: eq(schema.agentRuns.incidentId, incident.id),
+      orderBy: [desc(schema.agentRuns.createdAt)],
+      limit: 1,
+    }),
+  ]);
+
+  const issues =
+    links.length > 0
+      ? await db.query.issues.findMany({
+          where: inArray(
+            schema.issues.id,
+            links.map((link) => link.issueId),
+          ),
+          orderBy: [desc(schema.issues.lastSeen)],
+        })
+      : [];
+
+  return {
+    incident: toIncidentSummary(incident),
+    issues: issues.map(toIssueContext),
+    latestAgentRun: agentRuns[0] ? toAgentRunPointer(agentRuns[0]) : null,
+  };
+}

--- a/apps/api/src/incidents/search.test.ts
+++ b/apps/api/src/incidents/search.test.ts
@@ -1,0 +1,109 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import type { Incident } from "@superlog/db";
+
+// search.ts transitively imports the db client, which throws at import time
+// without a connection string. Set a dummy URL before the dynamic import (the
+// porsager client connects lazily, so these pure-function tests never open a
+// socket). Same dynamic-import pattern as linear.test.ts / loops.test.ts.
+process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
+const { resolveIncidentSearchStatus, toIncidentSummary } = await import("./search.js");
+
+test("status defaults to hiding agent-classified noise", () => {
+  assert.deepEqual(resolveIncidentSearchStatus(undefined), { kind: "exclude_noise" });
+});
+
+test("status='all' includes every status, noise included", () => {
+  assert.deepEqual(resolveIncidentSearchStatus("all"), { kind: "all" });
+});
+
+test("a concrete status narrows to exactly that status", () => {
+  assert.deepEqual(resolveIncidentSearchStatus("open"), { kind: "only", status: "open" });
+  assert.deepEqual(resolveIncidentSearchStatus("autoresolved_noise"), {
+    kind: "only",
+    status: "autoresolved_noise",
+  });
+});
+
+test("an unknown status is rejected rather than silently ignored", () => {
+  assert.throws(() => resolveIncidentSearchStatus("bogus"), /invalid incident status/i);
+});
+
+test("summary is a compact, agent-friendly projection with ISO timestamps", () => {
+  const summary = toIncidentSummary(baseIncident());
+
+  assert.equal(summary.id, "incident-1");
+  assert.equal(summary.projectId, "project-1");
+  assert.equal(summary.codename, "steady-amber");
+  assert.equal(summary.title, "Checkout failures");
+  assert.equal(summary.service, "api");
+  assert.equal(summary.severity, "SEV-2");
+  assert.equal(summary.status, "open");
+  assert.equal(summary.issueCount, 1);
+  assert.equal(summary.firstSeen, "2026-05-24T00:00:00.000Z");
+  assert.equal(summary.lastSeen, "2026-05-24T01:00:00.000Z");
+  assert.equal(summary.resolvedAt, null);
+  // Heavy/internal columns must not leak into the MCP payload.
+  assert.equal("noiseClassification" in summary, false);
+  assert.equal("slackInstallationId" in summary, false);
+});
+
+test("summary surfaces agent findings and resolution metadata when present", () => {
+  const summary = toIncidentSummary({
+    ...baseIncident(),
+    status: "resolved",
+    agentSummary: "DB pool exhausted",
+    rootCauseText: "connection leak in checkout handler",
+    rootCauseConfidence: 80,
+    resolvedAt: new Date("2026-05-25T00:00:00.000Z"),
+    resolvedReasonCode: "agent_pr_merged",
+  });
+
+  assert.equal(summary.agentSummary, "DB pool exhausted");
+  assert.equal(summary.rootCauseText, "connection leak in checkout handler");
+  assert.equal(summary.rootCauseConfidence, 80);
+  assert.equal(summary.resolvedAt, "2026-05-25T00:00:00.000Z");
+  assert.equal(summary.resolvedReasonCode, "agent_pr_merged");
+});
+
+function baseIncident(): Incident {
+  return {
+    id: "incident-1",
+    projectId: "project-1",
+    service: "api",
+    title: "Checkout failures",
+    codename: "steady-amber",
+    severity: "SEV-2",
+    status: "open",
+    noiseReason: null,
+    noiseResolvedAt: null,
+    mergedAt: null,
+    slackInstallationId: null,
+    lastSlackPostedAt: null,
+    firstSeen: new Date("2026-05-24T00:00:00.000Z"),
+    lastSeen: new Date("2026-05-24T01:00:00.000Z"),
+    issueCount: 1,
+    slackChannelId: null,
+    slackThreadTs: null,
+    autoInvestigateSuppressedUntil: null,
+    autorecoveryLastEvaluatedAt: null,
+    agentSummary: null,
+    rootCauseText: null,
+    rootCauseConfidence: null,
+    estimatedImpactText: null,
+    estimatedImpactConfidence: null,
+    suggestedSeverity: null,
+    noiseClassification: null,
+    resolutionClassification: null,
+    findingsAgentRunId: null,
+    resolvedByKind: null,
+    resolvedByUserId: null,
+    resolvedBySlackUserId: null,
+    resolvedReasonCode: null,
+    resolvedReasonText: null,
+    resolvedAt: null,
+    mergedIntoId: null,
+    createdAt: new Date("2026-05-24T00:00:00.000Z"),
+    updatedAt: new Date("2026-05-24T00:00:00.000Z"),
+  };
+}

--- a/apps/api/src/incidents/search.ts
+++ b/apps/api/src/incidents/search.ts
@@ -1,0 +1,157 @@
+import {
+  type Incident,
+  type IncidentSeverity,
+  type IncidentStatus,
+  db,
+  schema,
+} from "@superlog/db";
+import { and, desc, eq, gte, ilike, lte, ne, or } from "drizzle-orm";
+
+const INCIDENT_STATUSES: readonly IncidentStatus[] = [
+  "open",
+  "resolved",
+  "autoresolved_noise",
+  "merged",
+];
+
+function isIncidentStatus(value: string): value is IncidentStatus {
+  return (INCIDENT_STATUSES as readonly string[]).includes(value);
+}
+
+export type IncidentSearchStatusFilter =
+  | { kind: "exclude_noise" }
+  | { kind: "all" }
+  | { kind: "only"; status: IncidentStatus };
+
+/**
+ * Mirror the web list endpoint's default: with no status given, hide
+ * agent-classified noise. `all` opts into every status; any concrete status
+ * narrows to exactly that one. An unrecognised value is rejected so a typo
+ * doesn't silently return the whole backlog.
+ */
+export function resolveIncidentSearchStatus(
+  status: string | undefined,
+): IncidentSearchStatusFilter {
+  if (!status) return { kind: "exclude_noise" };
+  if (status === "all") return { kind: "all" };
+  if (isIncidentStatus(status)) return { kind: "only", status };
+  throw new Error(`invalid incident status: ${status}`);
+}
+
+export type IncidentSummary = {
+  id: string;
+  projectId: string;
+  codename: string;
+  title: string;
+  service: string | null;
+  severity: IncidentSeverity | null;
+  status: IncidentStatus;
+  firstSeen: string;
+  lastSeen: string;
+  issueCount: number;
+  agentSummary: string | null;
+  rootCauseText: string | null;
+  rootCauseConfidence: number | null;
+  estimatedImpactText: string | null;
+  resolvedAt: string | null;
+  resolvedReasonCode: string | null;
+  mergedIntoId: string | null;
+  slackChannelId: string | null;
+  slackThreadTs: string | null;
+};
+
+/**
+ * Compact, agent-friendly projection of an incident. Drops the heavy/internal
+ * columns (noise & resolution classification blobs, slack install pointers,
+ * autorecovery bookkeeping) and renders timestamps as ISO strings.
+ */
+export function toIncidentSummary(incident: Incident): IncidentSummary {
+  return {
+    id: incident.id,
+    projectId: incident.projectId,
+    codename: incident.codename,
+    title: incident.title,
+    service: incident.service,
+    severity: incident.severity,
+    status: incident.status,
+    firstSeen: incident.firstSeen.toISOString(),
+    lastSeen: incident.lastSeen.toISOString(),
+    issueCount: incident.issueCount,
+    agentSummary: incident.agentSummary,
+    rootCauseText: incident.rootCauseText,
+    rootCauseConfidence: incident.rootCauseConfidence,
+    estimatedImpactText: incident.estimatedImpactText,
+    resolvedAt: incident.resolvedAt ? incident.resolvedAt.toISOString() : null,
+    resolvedReasonCode: incident.resolvedReasonCode,
+    mergedIntoId: incident.mergedIntoId,
+    slackChannelId: incident.slackChannelId,
+    slackThreadTs: incident.slackThreadTs,
+  };
+}
+
+export type IncidentSearchInput = {
+  status?: string;
+  severity?: IncidentSeverity;
+  service?: string;
+  query?: string;
+  since?: string;
+  until?: string;
+  limit?: number;
+};
+
+function parseTimestamp(value: string | undefined, label: string): Date | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`invalid ${label} timestamp: ${value}`);
+  }
+  return date;
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (!limit || !Number.isFinite(limit)) return 50;
+  return Math.min(Math.max(Math.trunc(limit), 1), 200);
+}
+
+/**
+ * Search a project's incidents by status, severity, service, free-text
+ * (title/codename substring), and `last_seen` window. Newest activity first.
+ */
+export async function searchIncidents(
+  projectId: string,
+  input: IncidentSearchInput,
+): Promise<IncidentSummary[]> {
+  const conditions = [eq(schema.incidents.projectId, projectId)];
+
+  const status = resolveIncidentSearchStatus(input.status);
+  if (status.kind === "exclude_noise") {
+    conditions.push(ne(schema.incidents.status, "autoresolved_noise"));
+  } else if (status.kind === "only") {
+    conditions.push(eq(schema.incidents.status, status.status));
+  }
+
+  if (input.severity) conditions.push(eq(schema.incidents.severity, input.severity));
+  if (input.service) conditions.push(eq(schema.incidents.service, input.service));
+
+  if (input.query) {
+    const like = `%${input.query}%`;
+    const textMatch = or(
+      ilike(schema.incidents.title, like),
+      ilike(schema.incidents.codename, like),
+    );
+    if (textMatch) conditions.push(textMatch);
+  }
+
+  const since = parseTimestamp(input.since, "since");
+  if (since) conditions.push(gte(schema.incidents.lastSeen, since));
+  const until = parseTimestamp(input.until, "until");
+  if (until) conditions.push(lte(schema.incidents.lastSeen, until));
+
+  const rows = await db.query.incidents.findMany({
+    where: and(...conditions),
+    orderBy: [desc(schema.incidents.lastSeen)],
+    limit: clampLimit(input.limit),
+  });
+
+  return rows.map(toIncidentSummary);
+}

--- a/apps/api/src/mcp/incidents.ts
+++ b/apps/api/src/mcp/incidents.ts
@@ -21,23 +21,26 @@ export function registerIncidentTools(
   server: McpServer,
   session: { userId: string; activeProjectId: string; allowedOrgId?: string },
 ): void {
-  const resolve = async (explicit: string | undefined): Promise<string> => {
-    const id = explicit ?? session.activeProjectId;
-    await assertProjectAccess(session.userId, id);
-    return id;
-  };
-
-  // For org-scoped MCP tokens, reject incidents whose project lives outside the
-  // token's org. get_incident takes a bare (global) id, so this is the only
-  // thing keeping a scoped token from reaching another org's incident.
+  // For org-scoped MCP tokens, reject any project outside the token's org —
+  // even one the user is individually a member of. Mirrors the boundary every
+  // telemetry tool enforces via server.ts's resolveProject. Both an explicit
+  // project_id (search_incidents) and an incident's resolved project
+  // (get_incident, which takes a bare global id) must pass this.
   const assertTokenScope = async (projectId: string): Promise<void> => {
     if (!session.allowedOrgId) return;
     const project = await db.query.projects.findFirst({
       where: eq(schema.projects.id, projectId),
     });
     if (!project || project.orgId !== session.allowedOrgId) {
-      throw new HTTPException(403, { message: "incident is outside this MCP token's org scope" });
+      throw new HTTPException(403, { message: "project is outside this MCP token's org scope" });
     }
+  };
+
+  const resolve = async (explicit: string | undefined): Promise<string> => {
+    const id = explicit ?? session.activeProjectId;
+    await assertTokenScope(id);
+    await assertProjectAccess(session.userId, id);
+    return id;
   };
 
   server.registerTool(

--- a/apps/api/src/mcp/incidents.ts
+++ b/apps/api/src/mcp/incidents.ts
@@ -1,0 +1,118 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { db, schema } from "@superlog/db";
+import { eq } from "drizzle-orm";
+import { HTTPException } from "hono/http-exception";
+import { z } from "zod";
+import { getIncidentDetail } from "../incidents/detail.js";
+import { searchIncidents } from "../incidents/search.js";
+import { assertProjectAccess } from "./projects.js";
+
+const projectIdSchema = z
+  .string()
+  .uuid()
+  .optional()
+  .describe(
+    "Project to search. Defaults to the session's active project. Use list_projects to discover ids.",
+  );
+
+const text = (v: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(v) }] });
+
+export function registerIncidentTools(
+  server: McpServer,
+  session: { userId: string; activeProjectId: string; allowedOrgId?: string },
+): void {
+  const resolve = async (explicit: string | undefined): Promise<string> => {
+    const id = explicit ?? session.activeProjectId;
+    await assertProjectAccess(session.userId, id);
+    return id;
+  };
+
+  // For org-scoped MCP tokens, reject incidents whose project lives outside the
+  // token's org. get_incident takes a bare (global) id, so this is the only
+  // thing keeping a scoped token from reaching another org's incident.
+  const assertTokenScope = async (projectId: string): Promise<void> => {
+    if (!session.allowedOrgId) return;
+    const project = await db.query.projects.findFirst({
+      where: eq(schema.projects.id, projectId),
+    });
+    if (!project || project.orgId !== session.allowedOrgId) {
+      throw new HTTPException(403, { message: "incident is outside this MCP token's org scope" });
+    }
+  };
+
+  server.registerTool(
+    "get_incident",
+    {
+      title: "Get incident",
+      description:
+        "Fetch one incident by its id — the uuid in a superlog.sh/incidents/<id> link — and everything needed to explain it. " +
+        "No project_id is required; the project is resolved from the incident. Returns: the incident summary with the agent's findings (root_cause_text, agent_summary, estimated_impact_text) and its project_id; every linked issue with a stored telemetry `sample` (trace_id, span_id, stacktrace, span/log/resource attributes); and a pointer to the latest investigation run. " +
+        "To pull live telemetry, take a sample's trace_id and call query_traces, or filter query_logs/query_traces by the issue's service + exception type — passing the returned project_id.",
+      inputSchema: {
+        incident_id: z.string().uuid().describe("Incident id (the uuid from the incident URL)."),
+      },
+    },
+    async (input) => {
+      const detail = await getIncidentDetail(input.incident_id);
+      if (!detail) throw new HTTPException(404, { message: "incident not found" });
+      await assertProjectAccess(session.userId, detail.incident.projectId);
+      await assertTokenScope(detail.incident.projectId);
+      return text(detail);
+    },
+  );
+
+  server.registerTool(
+    "search_incidents",
+    {
+      title: "Search incidents",
+      description:
+        "Search incidents in the active project (or project_id). Incidents are auto-grouped error/anomaly investigations; each row carries the agent's findings (agent_summary, root_cause_text) when available. " +
+        "Filter by status, severity, service, a free-text substring over title/codename, and a last_seen time window. Results are newest-activity-first. " +
+        "By default agent-classified noise (status='autoresolved_noise') is hidden; pass status='all' to include it or status='autoresolved_noise' to inspect just the noise pile. " +
+        "Use get_incident to drill into a single incident's linked issues and telemetry.",
+      inputSchema: {
+        project_id: projectIdSchema,
+        status: z
+          .enum(["open", "resolved", "autoresolved_noise", "merged", "all"])
+          .optional()
+          .describe(
+            "Incident status filter. Omit to see everything except auto-classified noise; 'all' includes noise.",
+          ),
+        severity: z
+          .enum(["SEV-1", "SEV-2", "SEV-3"])
+          .optional()
+          .describe("Filter by assigned severity."),
+        service: z
+          .string()
+          .optional()
+          .describe("Exact match on the incident's primary service.name."),
+        query: z
+          .string()
+          .optional()
+          .describe("Case-insensitive substring matched against incident title and codename."),
+        since: z
+          .string()
+          .optional()
+          .describe("ISO-8601 timestamp; only incidents with last_seen >= since are returned."),
+        until: z
+          .string()
+          .optional()
+          .describe("ISO-8601 timestamp; only incidents with last_seen <= until are returned."),
+        limit: z.number().int().positive().max(200).default(50),
+      },
+    },
+    async (input) => {
+      const projectId = await resolve(input.project_id);
+      const incidents = await searchIncidents(projectId, {
+        status: input.status,
+        severity: input.severity,
+        service: input.service,
+        query: input.query,
+        since: input.since,
+        until: input.until,
+        limit: input.limit,
+      });
+      return text({ count: incidents.length, incidents });
+    },
+  );
+}

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { registerAlertTools } from "./alerts.js";
 import { listServices, queryLogs, queryMetrics, queryTraces } from "./clickhouse.js";
 import { registerDashboardTools } from "./dashboards.js";
+import { registerIncidentTools } from "./incidents.js";
 import {
   assertProjectAccess,
   listAccessibleProjects,
@@ -279,6 +280,7 @@ export function createMcpServerForSession(session: McpSession): McpServer {
   if (!session.telemetryOnly) {
     registerAlertTools(server, session, session.ch);
     registerDashboardTools(server, session);
+    registerIncidentTools(server, session);
   }
 
   return server;


### PR DESCRIPTION
Surfaces incidents through the Superlog MCP server (`apps/api/src/mcp`), which previously exposed only telemetry, alerts, and dashboards. The use case: an agent handed a `superlog.sh/incidents/<id>` link can answer "what's going on in there".

- **`get_incident(incident_id)`** takes the bare incident uuid, resolves the project from the incident row (access- and token-org-scope-checked), and returns the incident summary + agent findings, every linked issue with its stored telemetry `sample` (trace_id/span_id/stacktrace/attrs) for walking to live telemetry, and a pointer to the latest agent run.
- **`search_incidents(...)`** lists/finds incidents in a project by status, severity, service, free-text title/codename, and last_seen window, hiding agent-classified noise by default.

Pure status-filter and projection helpers are unit-tested; `@superlog/api` typechecks and biome is clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose incidents in the MCP server so agents can open a superlog.sh/incidents/<id> link and get context fast. Adds get_incident and search_incidents for summaries, linked issues, and walkable telemetry.

- **New Features**
  - get_incident: fetch by incident_id, resolves project, enforces access, returns incident summary (with findings and project_id), all linked issues with stored telemetry samples (trace_id/span_id/stacktrace/attrs), and a pointer to the latest agent run.
  - search_incidents: filter by status, severity, service, free-text (title/codename), and last_seen window; newest first; hides agent-classified noise by default; accepts status='all' or a specific status.
  - Validation + tests: rejects unknown statuses, parses ISO timestamps, clamps limit to 1–200; unit tests for status resolution and summary/issue projections.

- **Bug Fixes**
  - search_incidents: enforce token org-scope when resolving project_id to prevent cross‑org access, matching telemetry tool boundaries.

<sup>Written for commit 605eafdd3fbd2c00e0bf627dfcfcd00bd755622c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

