### PR TITLE
Drain ingest consumer gracefully on SIGTERM

### DIFF
--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -436,3 +436,35 @@ logger.info(
   },
   "superlog proxy listening",
 );
+
+// Drain gracefully on the SIGTERM an ECS rolling deploy sends before SIGKILL:
+// stop accepting new HTTP requests, then let the queue consumer finish (and
+// delete) its in-flight messages. Without this the task is killed mid-batch and
+// the received-but-undeleted SQS messages stay invisible for the full visibility
+// timeout before redelivering — the sawtooth that pins ApproximateAgeOfOldestMessage
+// and trips the ingest-lag page on every deploy. ECS's stopTimeout bounds how long
+// we get; the consumer aborts its idle long-poll so the drain is fast in practice.
+let shuttingDown = false;
+async function shutdown(signal: NodeJS.Signals): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  logger.info({ signal }, "received shutdown signal; draining");
+  try {
+    await new Promise<void>((resolve) => {
+      if ("close" in server && typeof server.close === "function") {
+        server.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+    if (ingestQueue && ingestQueueConfig?.consumerEnabled) {
+      await ingestQueue.stop();
+    }
+  } catch (err) {
+    logger.error({ err }, "error during graceful shutdown");
+  } finally {
+    process.exit(0);
+  }
+}
+process.once("SIGTERM", () => void shutdown("SIGTERM"));
+process.once("SIGINT", () => void shutdown("SIGINT"));

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -461,10 +461,12 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
       await ingestQueue.stop();
     }
   } catch (err) {
+    // Exit non-zero so a failed drain is visible rather than masquerading as a
+    // clean stop.
     logger.error({ err }, "error during graceful shutdown");
-  } finally {
-    process.exit(0);
+    process.exit(1);
   }
+  process.exit(0);
 }
 process.once("SIGTERM", () => void shutdown("SIGTERM"));
 process.once("SIGINT", () => void shutdown("SIGINT"));

--- a/apps/proxy/src/ingest-queue.shutdown.test.ts
+++ b/apps/proxy/src/ingest-queue.shutdown.test.ts
@@ -1,0 +1,113 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { IngestQueue, type IngestQueueConfig, encodeIngestMessage } from "./ingest-queue.js";
+
+const noopLogger = { info: () => {}, warn: () => {}, error: () => {} };
+
+const config: IngestQueueConfig = {
+  queueUrl: "http://localhost/queue",
+  region: "us-west-2",
+  oversizePrefix: "otlp-oversize",
+  maxMessageBytes: 240_000,
+  maxBodyBytes: 10_000,
+  consumerEnabled: true,
+  waitTimeSeconds: 20,
+  visibilityTimeoutSeconds: 120,
+  batchSize: 1,
+  consumerConcurrency: 1,
+};
+
+const inlineBody = encodeIngestMessage(
+  {
+    path: "/v1/logs",
+    projectId: "project-1",
+    contentType: "application/x-protobuf",
+    body: Buffer.from("hello"),
+  },
+  config,
+).messageBody;
+
+/**
+ * Fake SQS that delivers exactly one message on the first ReceiveMessage and
+ * then blocks (like a real 20s long-poll) until the consumer's AbortController
+ * fires — at which point it rejects with an AbortError, exactly as the AWS SDK
+ * does when send() is aborted. Records every DeleteMessage.
+ */
+class FakeConsumerSqs {
+  receiveCount = 0;
+  deleted: string[] = [];
+  private delivered = false;
+
+  // biome-ignore lint/suspicious/noExplicitAny: minimal AWS client test double
+  async send(cmd: any, opts?: { abortSignal?: AbortSignal }): Promise<unknown> {
+    const name = cmd.constructor.name;
+    if (name === "ReceiveMessageCommand") {
+      this.receiveCount++;
+      if (!this.delivered) {
+        this.delivered = true;
+        return {
+          Messages: [{ MessageId: "m-1", ReceiptHandle: "r-1", Body: inlineBody }],
+        };
+      }
+      return await new Promise((_resolve, reject) => {
+        const signal = opts?.abortSignal;
+        const abort = () => {
+          const err = new Error("Request aborted");
+          err.name = "AbortError";
+          reject(err);
+        };
+        if (signal?.aborted) return abort();
+        signal?.addEventListener("abort", abort, { once: true });
+      });
+    }
+    if (name === "DeleteMessageCommand") {
+      this.deleted.push(cmd.input.ReceiptHandle);
+      return {};
+    }
+    throw new Error(`unexpected SQS command: ${name}`);
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error("timed out waiting for condition");
+    await delay(5);
+  }
+}
+
+test("stop() drains the in-flight message and halts polling", async () => {
+  const queue = new IngestQueue(config, noopLogger);
+  const sqs = new FakeConsumerSqs();
+  (queue as unknown as { sqs: FakeConsumerSqs }).sqs = sqs;
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(new Uint8Array(0), { status: 200 })) as typeof fetch;
+
+  try {
+    queue.startConsumer("http://collector.local");
+
+    // The first delivered message must be forwarded to the collector and then
+    // deleted from SQS before we initiate shutdown.
+    await waitFor(() => sqs.deleted.length === 1);
+    assert.deepEqual(sqs.deleted, ["r-1"]);
+
+    const receivesBeforeStop = sqs.receiveCount;
+    await queue.stop();
+
+    // After draining, the loop must not issue any further ReceiveMessage calls.
+    await delay(50);
+    assert.equal(
+      sqs.receiveCount,
+      receivesBeforeStop,
+      "consumer must stop polling once stop() resolves",
+    );
+    assert.equal(sqs.deleted.length, 1, "the in-flight message must remain deleted exactly once");
+
+    // stop() is idempotent.
+    await queue.stop();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/apps/proxy/src/ingest-queue.ts
+++ b/apps/proxy/src/ingest-queue.ts
@@ -482,13 +482,18 @@ export class IngestQueue {
         this.consumeLoop(collectorUrl, index + 1),
       ),
     );
-    // Resolves on a clean drain (stop()); rejects only on an unexpected loop
-    // failure, which we surface as a non-zero exit below.
-    this.consumersDone = loops.then(() => undefined);
+    // Surface an unexpected loop failure as a non-zero exit.
     loops.catch((err: unknown) => {
       this.logger.error({ err }, "ingest queue consumer stopped unexpectedly");
       process.exitCode = 1;
     });
+    // Settles (never rejects) once every loop has exited, so stop() can await it
+    // without risking an unhandled rejection when a loop fails and stop() is
+    // never called. The failure itself is logged + flagged via loops.catch above.
+    this.consumersDone = loops.then(
+      () => undefined,
+      () => undefined,
+    );
   }
 
   /**
@@ -509,11 +514,9 @@ export class IngestQueue {
       { queueUrl: this.config.queueUrl },
       "ingest queue consumer draining in-flight messages",
     );
-    try {
-      await this.consumersDone;
-    } catch {
-      // An unexpected loop failure is already logged + flagged in startConsumer.
-    }
+    // consumersDone never rejects (see startConsumer); a loop failure is logged
+    // and surfaced as a non-zero exit there.
+    await this.consumersDone;
     this.logger.info({ queueUrl: this.config.queueUrl }, "ingest queue consumer drained");
   }
 

--- a/apps/proxy/src/ingest-queue.ts
+++ b/apps/proxy/src/ingest-queue.ts
@@ -12,6 +12,7 @@ import {
   DeleteMessageCommand,
   type Message,
   ReceiveMessageCommand,
+  type ReceiveMessageCommandOutput,
   SQSClient,
   SendMessageCommand,
 } from "@aws-sdk/client-sqs";
@@ -466,15 +467,54 @@ export class IngestQueue {
     };
   }
 
+  // Set by stop(); flips the consume loops out of their receive cycle so a
+  // rolling deploy can drain cleanly instead of abandoning in-flight messages.
+  private shuttingDown = false;
+  // Aborts an idle long-poll ReceiveMessage immediately on stop() so draining
+  // does not wait out the full waitTimeSeconds before the loop notices.
+  private readonly shutdownController = new AbortController();
+  // Resolves once every consume loop has exited; stop() awaits it.
+  private consumersDone: Promise<void> | null = null;
+
   startConsumer(collectorUrl: string): void {
-    void Promise.all(
+    const loops = Promise.all(
       Array.from({ length: this.config.consumerConcurrency }, (_, index) =>
         this.consumeLoop(collectorUrl, index + 1),
       ),
-    ).catch((err: unknown) => {
+    );
+    // Resolves on a clean drain (stop()); rejects only on an unexpected loop
+    // failure, which we surface as a non-zero exit below.
+    this.consumersDone = loops.then(() => undefined);
+    loops.catch((err: unknown) => {
       this.logger.error({ err }, "ingest queue consumer stopped unexpectedly");
       process.exitCode = 1;
     });
+  }
+
+  /**
+   * Drain the consumer for a graceful shutdown (e.g. SIGTERM from an ECS rolling
+   * deploy). Stops issuing new ReceiveMessage calls, aborts any idle long-poll,
+   * and waits for in-flight messages to finish processing — each delivered
+   * message is deleted before its loop exits. Without this, a deploy kills the
+   * task mid-batch and the received-but-undeleted messages stay invisible for the
+   * full visibility timeout before redelivering, which pins SQS
+   * ApproximateAgeOfOldestMessage into a sawtooth and trips the ingest-lag page.
+   * Idempotent.
+   */
+  async stop(): Promise<void> {
+    if (this.shuttingDown) return;
+    this.shuttingDown = true;
+    this.shutdownController.abort();
+    this.logger.info(
+      { queueUrl: this.config.queueUrl },
+      "ingest queue consumer draining in-flight messages",
+    );
+    try {
+      await this.consumersDone;
+    } catch {
+      // An unexpected loop failure is already logged + flagged in startConsumer.
+    }
+    this.logger.info({ queueUrl: this.config.queueUrl }, "ingest queue consumer drained");
   }
 
   private async consumeLoop(collectorUrl: string, consumerId: number): Promise<void> {
@@ -489,21 +529,38 @@ export class IngestQueue {
       "ingest queue consumer started",
     );
 
-    for (;;) {
-      const result = await this.sqs.send(
-        new ReceiveMessageCommand({
-          QueueUrl: this.config.queueUrl,
-          MaxNumberOfMessages: this.config.batchSize,
-          WaitTimeSeconds: this.config.waitTimeSeconds,
-          VisibilityTimeout: this.config.visibilityTimeoutSeconds,
-        }),
-      );
+    while (!this.shuttingDown) {
+      let result: ReceiveMessageCommandOutput;
+      try {
+        result = await this.sqs.send(
+          new ReceiveMessageCommand({
+            QueueUrl: this.config.queueUrl,
+            MaxNumberOfMessages: this.config.batchSize,
+            WaitTimeSeconds: this.config.waitTimeSeconds,
+            VisibilityTimeout: this.config.visibilityTimeoutSeconds,
+          }),
+          { abortSignal: this.shutdownController.signal },
+        );
+      } catch (err) {
+        // stop() aborts the in-flight long-poll; that surfaces here as an abort
+        // error. Exit cleanly when draining; otherwise preserve the previous
+        // crash-on-unexpected-failure behaviour.
+        if (this.shuttingDown) break;
+        throw err;
+      }
 
+      // A batch received just before stop() is still drained: we finish
+      // processing (and deleting) it before the while-condition exits the loop.
       const messages = result.Messages ?? [];
       if (messages.length === 0) continue;
 
       await Promise.all(messages.map((message) => this.processMessage(message, collectorUrl)));
     }
+
+    this.logger.info(
+      { queueUrl: this.config.queueUrl, consumerId },
+      "ingest queue consumer stopped",
+    );
   }
 
   private async processMessage(message: Message, collectorUrl: string): Promise<void> {

--- a/apps/proxy/src/ingest-queue.ts
+++ b/apps/proxy/src/ingest-queue.ts
@@ -477,23 +477,21 @@ export class IngestQueue {
   private consumersDone: Promise<void> | null = null;
 
   startConsumer(collectorUrl: string): void {
-    const loops = Promise.all(
-      Array.from({ length: this.config.consumerConcurrency }, (_, index) =>
-        this.consumeLoop(collectorUrl, index + 1),
-      ),
+    const loops = Array.from({ length: this.config.consumerConcurrency }, (_, index) =>
+      this.consumeLoop(collectorUrl, index + 1),
     );
-    // Surface an unexpected loop failure as a non-zero exit.
-    loops.catch((err: unknown) => {
-      this.logger.error({ err }, "ingest queue consumer stopped unexpectedly");
-      process.exitCode = 1;
-    });
-    // Settles (never rejects) once every loop has exited, so stop() can await it
-    // without risking an unhandled rejection when a loop fails and stop() is
-    // never called. The failure itself is logged + flagged via loops.catch above.
-    this.consumersDone = loops.then(
-      () => undefined,
-      () => undefined,
-    );
+    // Surface an unexpected loop failure promptly: log it and flag a non-zero exit.
+    for (const loop of loops) {
+      loop.catch((err: unknown) => {
+        this.logger.error({ err }, "ingest queue consumer stopped unexpectedly");
+        process.exitCode = 1;
+      });
+    }
+    // Resolve only once EVERY loop has settled. allSettled neither short-circuits
+    // on the first rejection (so stop() never returns while a sibling loop is
+    // still draining) nor rejects itself (so there is no unhandled rejection when
+    // a loop fails and stop() is never called).
+    this.consumersDone = Promise.allSettled(loops).then(() => undefined);
   }
 
   /**


### PR DESCRIPTION
## Problem

The ingest-consumer (the proxy package run in consume mode) polls SQS in infinite loops with **no shutdown handling**. On a rolling deploy the task is SIGKILLed mid-batch, so any message it had *received but not yet deleted* stays invisible for the full SQS visibility timeout before redelivering. That pins `ApproximateAgeOfOldestMessage` into a long sawtooth and can trip ingest-lag alerting on every deploy.

## Change

- **`IngestQueue.stop()`** — sets a shutting-down flag, aborts the idle long-poll via an `AbortController` passed to `sqs.send(cmd, { abortSignal })`, and awaits in-flight `processMessage` completion. Each delivered message is deleted before its loop exits, so a graceful drain orphans nothing.
- **`consumeLoop`** — `for(;;)` → `while (!this.shuttingDown)`; an aborted long-poll during drain exits cleanly, while a genuine error still propagates (preserving the crash-on-unexpected-failure behaviour).
- **`index.ts`** — handles `SIGTERM`/`SIGINT`: close the HTTP server, then `await ingestQueue.stop()`, then `process.exit(0)`.

## Why this is safe

- Only the *idle* long-poll receive is aborted; in-flight `processMessage` calls (collector POST + SQS delete) are left to finish.
- `stop()` is idempotent.
- A real loop failure still sets a non-zero exit code as before.

## Deploy note

Graceful drain depends on the deployment giving the container enough time after SIGTERM before SIGKILL (e.g. ECS `stopTimeout`), and on the SQS visibility timeout being sized so a redelivery after an ungraceful kill is quick. Those deploy-side settings are managed separately and should land alongside the image that includes this handler.

## Test

`apps/proxy/src/ingest-queue.shutdown.test.ts` — a fake SQS delivers one message then blocks like a long-poll; the test asserts the message is forwarded + deleted, then `stop()` halts polling and is idempotent. Full `@superlog/proxy` suite (28 tests) + `typecheck` green.