### PR TITLE
Expose mobile test build target discovery

### DIFF
--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -295,6 +295,8 @@ test("mobileRegressionGateTerminatedSummary explains terminal repair failures", 
 test("mobileRegressionRepairPrompt tells the agent exactly how to repair the result", () => {
   const prompt = mobileRegressionRepairPrompt();
   assert.match(prompt, /mobileRegressionTest/);
+  assert.match(prompt, /revyl_list_apps/);
+  assert.match(prompt, /test\.build\.name/);
   assert.match(prompt, /revyl_validate_yaml/);
   assert.match(prompt, /revyl_create_test_from_yaml/);
   assert.match(prompt, /Do not resubmit/);

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -117,6 +117,7 @@ export function mobileRegressionRepairPrompt(): string {
   return [
     "Your previous result proposed a mobile PR while Revyl is enabled, but it did not include a `mobileRegressionTest` decision.",
     "Do not resubmit the final result until you repair this omission.",
+    "If you create a Revyl test, first call `revyl_list_apps` with the target platform and choose a listed app name. The YAML must include `test.build.name` matching that app name exactly.",
     'If the fix can be covered by a reliable mobile user flow, author the Revyl YAML, call `revyl_validate_yaml`, then call `revyl_create_test_from_yaml`, and resubmit with `mobileRegressionTest.status="created"` plus the returned `testId`.',
     'If it cannot be represented as a reliable mobile user flow, resubmit with `mobileRegressionTest.status="skipped"` and a concrete `reason`.',
     'Use `mobileRegressionTest.status="not_applicable"` only for backend-only, noise-only, development-only, or non-mobile incidents, and include a concrete `reason`.',

--- a/apps/worker/src/integrations.test.ts
+++ b/apps/worker/src/integrations.test.ts
@@ -1,0 +1,48 @@
+import "./agent-run.test-env.js";
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { REVYL_INTEGRATION, executeIntegrationOperation } from "./integrations.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("Revyl app listing operation calls the build vars endpoint with platform filter", async () => {
+  const op = REVYL_INTEGRATION.operations.find((candidate) => candidate.name === "revyl_list_apps");
+  assert.ok(op, "expected revyl_list_apps operation");
+
+  let requestedUrl: string | null = null;
+  let requestedAuth: string | null = null;
+  globalThis.fetch = (async (url, init) => {
+    requestedUrl = String(url);
+    requestedAuth = String((init?.headers as Record<string, string>).Authorization);
+    return new Response(
+      JSON.stringify({
+        items: [{ id: "app-1", name: "Juno Android", platform: "android", latest_version: "1" }],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof fetch;
+
+  const result = await executeIntegrationOperation(
+    {
+      row: {} as never,
+      definition: REVYL_INTEGRATION,
+      secrets: { REVYL_API_KEY: "revyl_test_key" },
+    },
+    op,
+    { platform: "android" },
+    { incident_id: "incident-1", session_id: "session-1" },
+  );
+
+  assert.equal(
+    requestedUrl,
+    "https://backend.revyl.ai/api/v1/builds/vars?page=1&page_size=100&platform=android",
+  );
+  assert.equal(requestedAuth, "Bearer revyl_test_key");
+  assert.deepEqual(result, {
+    items: [{ id: "app-1", name: "Juno Android", platform: "android", latest_version: "1" }],
+  });
+});

--- a/apps/worker/src/integrations.test.ts
+++ b/apps/worker/src/integrations.test.ts
@@ -1,7 +1,11 @@
 import "./agent-run.test-env.js";
 import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
-import { REVYL_INTEGRATION, executeIntegrationOperation } from "./integrations.js";
+import {
+  REVYL_INTEGRATION,
+  buildCustomToolParams,
+  executeIntegrationOperation,
+} from "./integrations.js";
 
 const originalFetch = globalThis.fetch;
 
@@ -45,4 +49,30 @@ test("Revyl app listing operation calls the build vars endpoint with platform fi
   assert.deepEqual(result, {
     items: [{ id: "app-1", name: "Juno Android", platform: "android", latest_version: "1" }],
   });
+});
+
+test("Revyl run status operation is exposed with a compact response filter", () => {
+  const op = REVYL_INTEGRATION.operations.find(
+    (candidate) => candidate.name === "revyl_get_test_run",
+  );
+  assert.ok(op, "expected revyl_get_test_run operation");
+  assert.equal(op.docs_only, undefined);
+
+  const toolNames = buildCustomToolParams([
+    {
+      row: {} as never,
+      definition: REVYL_INTEGRATION,
+      secrets: { REVYL_API_KEY: "revyl_test_key" },
+    },
+  ]).map((tool) => tool.name);
+
+  assert.ok(toolNames.includes("revyl_get_test_run"));
+  assert.deepEqual(op.response_filter, [
+    "status",
+    "message",
+    "result",
+    "error",
+    "report_url",
+    "artifacts",
+  ]);
 });

--- a/apps/worker/src/integrations.ts
+++ b/apps/worker/src/integrations.ts
@@ -64,7 +64,6 @@ export const REVYL_INTEGRATION: IntegrationDefinition = {
       description: "Retrieve current status and result of a previously triggered test run.",
       method: "GET",
       path: "/api/v1/tests/get_test_execution_task",
-      docs_only: true,
       input_schema: {
         type: "object",
         required: ["task_id"],
@@ -72,6 +71,7 @@ export const REVYL_INTEGRATION: IntegrationDefinition = {
         properties: { task_id: { type: "string" } },
       },
       query_template: { task_id: "{{input.task_id}}" },
+      response_filter: ["status", "message", "result", "error", "report_url", "artifacts"],
     },
     {
       name: "revyl_cancel_test_run",

--- a/apps/worker/src/integrations.ts
+++ b/apps/worker/src/integrations.ts
@@ -134,6 +134,30 @@ export const REVYL_INTEGRATION: IntegrationDefinition = {
       query_template: { limit: "{{input.limit?}}" },
     },
     {
+      name: "revyl_list_apps",
+      description:
+        "List Revyl apps/build targets available to this org. Use before creating YAML tests so test.build.name matches an existing app name exactly.",
+      method: "GET",
+      path: "/api/v1/builds/vars",
+      input_schema: {
+        type: "object",
+        required: [],
+        additionalProperties: false,
+        properties: {
+          platform: {
+            type: "string",
+            description: "Optional platform filter, typically android or ios.",
+          },
+        },
+      },
+      query_template: {
+        page: "1",
+        page_size: "100",
+        platform: "{{input.platform?}}",
+      },
+      response_filter: ["items", "total", "page", "page_size", "has_next", "has_previous"],
+    },
+    {
       name: "revyl_validate_yaml",
       description:
         "Pre-flight a YAML test definition before creating it. Returns is_valid + per-line messages.",


### PR DESCRIPTION
## Summary\n- add a read-only mobile test build target listing operation\n- include coverage for platform-filtered requests and auth header rendering\n- update the mobile regression repair prompt to require build target discovery before YAML creation\n\n## Validation\n- pnpm --dir superlog exec node --import tsx/esm --test apps/worker/src/integrations.test.ts\n- pnpm --dir superlog exec node --import tsx/esm --test apps/worker/src/agent-runs/sync.test.ts\n- pnpm --dir superlog --filter @superlog/worker typecheck\n- docker build -f infra/aws/docker/worker.Dockerfile .

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `revyl_list_apps` to list mobile build targets with optional `platform` filter (calls `/api/v1/builds/vars?page=1&page_size=100`) and exposed `revyl_get_test_run` as a callable tool with a compact response for status polling. Updated the mobile repair prompt to require choosing a listed app so `test.build.name` matches exactly; added tests for URL/auth, platform filtering, tool exposure, and response filtering.

<sup>Written for commit a5c2c0828c6231f2a9198362491e977572b42c89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

