### PR TITLE
Dashboard count charts: top-N series rollup + new ECharts chart

### DIFF
--- a/apps/api/src/dashboards-service.ts
+++ b/apps/api/src/dashboards-service.ts
@@ -29,6 +29,7 @@ export const dashboardWidgetConfigSchema = z.object({
   showXAxis: z.boolean().optional(),
   showYAxis: z.boolean().optional(),
   showLegend: z.boolean().optional(),
+  legendPosition: z.enum(["side", "bottom"]).optional(),
   markdown: z.string().max(20_000).optional(),
 });
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@base-ui/react": "^1.5.0",
     "@git-diff-view/file": "^0.1.3",
     "@git-diff-view/react": "^0.1.3",
     "@hugeicons/core-free-icons": "^4.1.4",
@@ -30,6 +31,7 @@
     "@types/react-grid-layout": "^2.1.0",
     "autumn-js": "^1.2.27",
     "better-auth": "^1.6.11",
+    "echarts": "^6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-grid-layout": "^2.2.3",

--- a/apps/web/src/dashboards/AddWidget.tsx
+++ b/apps/web/src/dashboards/AddWidget.tsx
@@ -80,6 +80,7 @@ export function AddWidget({
   const [metricName, setMetricName] = useState("");
   const [groupBy, setGroupBy] = useState("");
   const [limit, setLimit] = useState(50);
+  const [seriesLimit, setSeriesLimit] = useState(10);
   const [attrs, setAttrs] = useState<ResourceAttr[]>([]);
   const [filterOpen, setFilterOpen] = useState(false);
   const [chartType, setChartType] = useState<ChartType | undefined>(undefined);
@@ -96,6 +97,7 @@ export function AddWidget({
 
   const type = widgetTypeFor(kind, source);
   const isMetric = kind === "chart" && source === "metric";
+  const isCountChart = type === "timeseries_count";
   const isTable = kind === "table";
   const isNote = kind === "note";
   const supportsGroupBy = kind === "chart";
@@ -124,7 +126,7 @@ export function AddWidget({
         filter: { resourceAttrs: attrs.length ? attrs : undefined },
         groupBy: supportsGroupBy && groupBy ? groupBy : undefined,
         metricName: isMetric ? metricName : undefined,
-        limit: isTable ? limit : undefined,
+        limit: isTable ? limit : isCountChart && groupBy ? seriesLimit : undefined,
         chartType: kind === "chart" ? chartType : undefined,
         markdown: isNote ? markdown : undefined,
       },
@@ -142,8 +144,10 @@ export function AddWidget({
       groupBy,
       metricName,
       limit,
+      seriesLimit,
       supportsGroupBy,
       isMetric,
+      isCountChart,
       isTable,
       isNote,
       kind,
@@ -275,6 +279,25 @@ export function AddWidget({
                       </option>
                     ))}
                 </select>
+              </div>
+            )}
+
+            {isCountChart && groupBy && (
+              <div>
+                <FieldLabel>top series</FieldLabel>
+                <Input
+                  type="number"
+                  min={1}
+                  max={50}
+                  step={1}
+                  value={seriesLimit}
+                  onChange={(e) =>
+                    setSeriesLimit(Math.max(1, Math.min(50, Number(e.target.value) || 10)))
+                  }
+                />
+                <div className="mt-1 font-mono text-[10px] text-subtle">
+                  remaining groups roll into “Other”
+                </div>
               </div>
             )}
 

--- a/apps/web/src/dashboards/DashboardView.tsx
+++ b/apps/web/src/dashboards/DashboardView.tsx
@@ -567,8 +567,9 @@ function WidgetSettingsButton({
 
   const chartType = widget.config.chartType ?? defaultChartType(widget.type);
   const showXAxis = widget.config.showXAxis ?? widget.type === "timeseries_count";
-  const showYAxis = widget.config.showYAxis ?? false;
+  const showYAxis = widget.config.showYAxis ?? widget.type === "timeseries_count";
   const showLegend = widget.config.showLegend ?? false;
+  const legendPosition = widget.config.legendPosition ?? "side";
   const aggregation = widget.config.aggregation ?? "auto";
   const resourceAttrs = widget.config.filter.resourceAttrs ?? [];
 
@@ -640,6 +641,30 @@ function WidgetSettingsButton({
             checked={showLegend}
             onChange={(v) => setConfig({ showLegend: v })}
           />
+          {showLegend && widget.type === "timeseries_count" && (
+            <div>
+              <div className="mb-1 uppercase tracking-[0.2em] text-subtle">legend position</div>
+              <div className="flex gap-1">
+                {(["side", "bottom"] as const).map((pos) => {
+                  const active = legendPosition === pos;
+                  return (
+                    <button
+                      key={pos}
+                      type="button"
+                      onClick={() => setConfig({ legendPosition: pos })}
+                      className={`h-7 flex-1 rounded-sm px-2 ${
+                        active
+                          ? "bg-accent text-accent-ink"
+                          : "border border-border text-muted hover:text-fg"
+                      }`}
+                    >
+                      {pos}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
           <div>
             <div className="mb-1 uppercase tracking-[0.2em] text-subtle">filters</div>
             <div className="flex flex-col gap-1.5">

--- a/apps/web/src/dashboards/types.ts
+++ b/apps/web/src/dashboards/types.ts
@@ -21,8 +21,11 @@ export type WidgetConfig = {
   showXAxis?: boolean;
   showYAxis?: boolean;
   showLegend?: boolean;
+  legendPosition?: LegendPosition;
   markdown?: string;
 };
+
+export type LegendPosition = "side" | "bottom";
 
 export function defaultChartType(type: WidgetType): ChartType {
   return type === "timeseries_metric" ? "line" : "bar";

--- a/apps/web/src/dashboards/widgets/CountChart.tsx
+++ b/apps/web/src/dashboards/widgets/CountChart.tsx
@@ -1,0 +1,545 @@
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
+import type { EChartsOption, SetOptionOpts } from "echarts";
+import type { BarSeriesOption, LineSeriesOption } from "echarts/charts";
+import type * as EChartsCore from "echarts/core";
+import { forwardRef, memo, useEffect, useMemo, useRef, useState } from "react";
+import type { SeriesRow } from "../../api.ts";
+import type { ChartType, LegendPosition } from "../types.ts";
+import { echarts } from "./echarts-setup.ts";
+import { type ChartSeries, buildTopNSeries } from "./series-topn.ts";
+
+type CountChartProps = {
+  rows: SeriesRow[];
+  chartType: ChartType;
+  limit: number;
+  showXAxis?: boolean;
+  showYAxis?: boolean;
+  showLegend: boolean;
+  legendPosition: LegendPosition;
+};
+
+type TimeseriesData = ChartSeries & {
+  color: string;
+};
+
+type TooltipRow = {
+  name: string;
+  value: number;
+  color: string;
+};
+
+type TooltipState = {
+  ts: number;
+  rows: TooltipRow[];
+  hiddenCount: number;
+};
+
+type ChartEvents = {
+  updateaxispointer: (params: unknown) => void;
+  globalout: () => void;
+};
+
+const CHART_COLORS = ["#4290F0", "#EEB720", "#E8649D", "#8D58EE", "#50C3B6", "#D37536"];
+const FIRST_CHART_COLOR = "#4290F0";
+const OTHER_COLOR = "#878787";
+const AXIS_LABEL_COLOR = "rgba(138, 138, 143, 0.5)";
+const GRID_LINE_COLOR = "rgba(255, 255, 255, 0.07)";
+
+const defaultNumberFormat = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 3,
+});
+
+const timestampFormat = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+
+export function CountChart({
+  rows,
+  chartType,
+  limit,
+  showXAxis = true,
+  showYAxis = false,
+  showLegend,
+  legendPosition,
+}: CountChartProps) {
+  const allSeries = useMemo(
+    () =>
+      buildTopNSeries(rows, (r) => r.count, limit).map((series, index) => ({
+        ...series,
+        color: series.isOther
+          ? OTHER_COLOR
+          : (CHART_COLORS[index % CHART_COLORS.length] ?? FIRST_CHART_COLOR),
+      })),
+    [rows, limit],
+  );
+  const [hiddenSeries, setHiddenSeries] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    setHiddenSeries((current) => {
+      const names = new Set(allSeries.map((series) => series.name));
+      const next = new Set([...current].filter((name) => names.has(name)));
+      return next.size === current.size ? current : next;
+    });
+  }, [allSeries]);
+
+  const visibleSeries = useMemo(
+    () => allSeries.filter((series) => !hiddenSeries.has(series.name)),
+    [allSeries, hiddenSeries],
+  );
+
+  const toggleSeries = (name: string) => {
+    setHiddenSeries((current) => {
+      const next = new Set(current);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
+  const chart = (
+    <KumoLikeTimeseriesChart
+      data={visibleSeries}
+      type={chartType}
+      height="100%"
+      showXAxis={showXAxis}
+      showYAxis={showYAxis}
+      optionUpdateBehavior={{ notMerge: true, lazyUpdate: true }}
+    />
+  );
+
+  if (!showLegend || allSeries.length <= 1) {
+    return <div className="h-full min-h-0">{chart}</div>;
+  }
+
+  if (legendPosition === "bottom") {
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="min-h-0 flex-1">{chart}</div>
+        <SeriesLegend
+          series={allSeries}
+          hiddenSeries={hiddenSeries}
+          onToggleSeries={toggleSeries}
+          position="bottom"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid h-full min-h-0 grid-cols-[minmax(0,1fr)_150px]">
+      <div className="min-h-0 min-w-0">{chart}</div>
+      <SeriesLegend
+        series={allSeries}
+        hiddenSeries={hiddenSeries}
+        onToggleSeries={toggleSeries}
+        position="side"
+      />
+    </div>
+  );
+}
+
+function KumoLikeTimeseriesChart({
+  data,
+  type,
+  height,
+  showXAxis,
+  showYAxis,
+  optionUpdateBehavior,
+}: {
+  data: TimeseriesData[];
+  type: ChartType;
+  height: number | string;
+  showXAxis: boolean;
+  showYAxis: boolean;
+  optionUpdateBehavior?: SetOptionOpts;
+}) {
+  const chartRef = useRef<EChartsCore.ECharts | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const dataRef = useRef(data);
+  dataRef.current = data;
+  const [tooltipState, setTooltipState] = useState<TooltipState | null>(null);
+
+  const options = useMemo(() => {
+    const transformSeries: Array<LineSeriesOption | BarSeriesOption> = [];
+    const seriesType =
+      type === "bar"
+        ? ({ type: "bar", stack: "total" } as const)
+        : ({ type: "line", showSymbol: false } as const);
+
+    for (const series of data) {
+      transformSeries.push({
+        data: series.data,
+        color: series.color,
+        name: series.name,
+        emphasis: { focus: "series" },
+        ...seriesType,
+      });
+    }
+
+    return {
+      aria: { enabled: true },
+      tooltip: {
+        trigger: "axis",
+        showContent: false,
+        axisPointer: { type: "shadow" },
+      },
+      backgroundColor: "transparent",
+      toolbox: { show: false },
+      xAxis: {
+        type: "time",
+        splitLine: { show: false },
+        axisLine: { show: false },
+        axisTick: { show: showXAxis },
+        axisLabel: {
+          show: showXAxis,
+          color: AXIS_LABEL_COLOR,
+          fontSize: 11,
+          hideOverlap: true,
+        },
+        splitNumber: 5,
+      },
+      yAxis: {
+        type: "value",
+        axisLine: { show: false },
+        axisTick: { show: showYAxis },
+        axisLabel: {
+          show: showYAxis,
+          color: AXIS_LABEL_COLOR,
+          fontSize: 11,
+          margin: 10,
+          formatter: (value: number) => formatDefaultValue(value),
+        },
+        splitLine: {
+          show: true,
+          lineStyle: { type: "dashed", width: 1, color: GRID_LINE_COLOR },
+        },
+        splitNumber: 3,
+      },
+      grid: {
+        left: showYAxis ? 34 : 10,
+        right: 14,
+        top: 12,
+        bottom: showXAxis ? 24 : 10,
+      },
+      series: transformSeries,
+    } satisfies EChartsOption;
+  }, [data, type, showXAxis, showYAxis]);
+
+  const events = useMemo<Partial<ChartEvents>>(
+    () => ({
+      updateaxispointer: (params: unknown) => {
+        const ts = getAxisPointerTimestamp(params);
+        if (ts == null) return;
+
+        const seenNames = new Set<string>();
+        const rows: TooltipRow[] = [];
+        for (const series of dataRef.current) {
+          if (seenNames.has(series.name)) continue;
+          seenNames.add(series.name);
+          const value = findNearest(series.data, ts);
+          if (value != null) rows.push({ name: series.name, value, color: series.color });
+        }
+
+        rows.sort((a, b) => b.value - a.value);
+        const maxItems = 10;
+        const nextState = {
+          ts,
+          rows: rows.slice(0, maxItems),
+          hiddenCount: Math.max(0, rows.length - maxItems),
+        };
+
+        setTooltipState((previous) =>
+          isSameTooltipState(previous, nextState) ? previous : nextState,
+        );
+      },
+      globalout: () => setTooltipState(null),
+    }),
+    [],
+  );
+
+  const tooltipOpen = tooltipState !== null;
+
+  return (
+    <TooltipPrimitive.Root open={tooltipOpen} trackCursorAxis="both">
+      <TooltipPrimitive.Trigger
+        render={<div ref={containerRef} className="relative h-full min-h-0 w-full" />}
+      >
+        <Chart
+          ref={chartRef}
+          options={options}
+          height={height}
+          onEvents={events}
+          optionUpdateBehavior={optionUpdateBehavior}
+        />
+      </TooltipPrimitive.Trigger>
+      {tooltipOpen && (
+        <TooltipPrimitive.Portal>
+          <TooltipPrimitive.Positioner
+            side="right"
+            align="start"
+            sideOffset={12}
+            collisionAvoidance={{ side: "flip", align: "shift" }}
+            collisionBoundary="clipping-ancestors"
+            collisionPadding={8}
+          >
+            <TooltipPrimitive.Popup className="rounded-lg border border-border-strong bg-surface px-2 py-2 text-fg shadow-2xl shadow-black/30">
+              <TooltipContent state={tooltipState} />
+            </TooltipPrimitive.Popup>
+          </TooltipPrimitive.Positioner>
+        </TooltipPrimitive.Portal>
+      )}
+    </TooltipPrimitive.Root>
+  );
+}
+
+const Chart = forwardRef<
+  EChartsCore.ECharts,
+  {
+    options: EChartsOption;
+    height: number | string;
+    optionUpdateBehavior?: SetOptionOpts;
+    onEvents?: Partial<ChartEvents>;
+  }
+>(function Chart({ options, height, optionUpdateBehavior, onEvents }, ref) {
+  const elRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<EChartsCore.ECharts | null>(null);
+  const handlersRef = useRef<Partial<ChartEvents>>({});
+  const wrappersRef = useRef<Record<string, (params: unknown) => void>>({});
+  const boundEventsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!elRef.current) return;
+
+    const chart = echarts.init(elRef.current, { color: CHART_COLORS });
+    chartRef.current = chart;
+
+    if (typeof ref === "function") ref(chart);
+    else if (ref) ref.current = chart;
+
+    return () => {
+      for (const event of boundEventsRef.current) {
+        const wrapper = wrappersRef.current[event];
+        if (wrapper) chart.off(event, wrapper);
+      }
+      boundEventsRef.current.clear();
+      if (typeof ref === "function") ref(null);
+      else if (ref) ref.current = null;
+      chartRef.current = null;
+      chart.dispose();
+    };
+  }, [ref]);
+
+  useEffect(() => {
+    chartRef.current?.setOption(options, {
+      notMerge: false,
+      lazyUpdate: true,
+      ...optionUpdateBehavior,
+    });
+  }, [options, optionUpdateBehavior]);
+
+  useEffect(() => {
+    handlersRef.current = onEvents ?? {};
+  }, [onEvents]);
+
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) return;
+
+    const nextBound = new Set<string>();
+    for (const [event, handler] of Object.entries(onEvents ?? {})) {
+      if (typeof handler !== "function") continue;
+      nextBound.add(event);
+
+      if (!wrappersRef.current[event]) {
+        wrappersRef.current[event] = (params: unknown) => {
+          const current = handlersRef.current as Record<
+            string,
+            ((params: unknown) => void) | undefined
+          >;
+          current[event]?.(params);
+        };
+      }
+
+      if (!boundEventsRef.current.has(event)) {
+        chart.on(event, wrappersRef.current[event]);
+      }
+    }
+
+    for (const event of boundEventsRef.current) {
+      if (nextBound.has(event)) continue;
+      const wrapper = wrappersRef.current[event];
+      if (wrapper) chart.off(event, wrapper);
+    }
+
+    boundEventsRef.current = nextBound;
+  }, [onEvents]);
+
+  useEffect(() => {
+    const chart = chartRef.current;
+    const element = elRef.current;
+    if (!chart || !element) return;
+
+    let isInitial = true;
+    const observer = new ResizeObserver(() => {
+      if (isInitial) {
+        isInitial = false;
+        return;
+      }
+      chart.resize();
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return <div ref={elRef} className="h-full w-full" style={{ height }} role="img" />;
+});
+
+Chart.displayName = "Chart";
+
+const TooltipContent = memo(function TooltipContent({ state }: { state: TooltipState }) {
+  const { ts, rows, hiddenCount } = state;
+  return (
+    <>
+      <div className="mb-1 text-xs font-semibold text-fg">{formatTimestamp(ts)}</div>
+      {rows.map((row) => (
+        <div key={row.name} className="flex items-center justify-between gap-4 py-0.5">
+          <div className="flex min-w-0 items-center gap-2">
+            <span
+              className="h-3 w-3 shrink-0 rounded-full"
+              style={{ backgroundColor: row.color }}
+            />
+            <span className="truncate text-xs font-medium text-fg" title={row.name}>
+              {row.name}
+            </span>
+          </div>
+          <span className="shrink-0 text-xs font-semibold text-fg">
+            {formatDefaultValue(row.value)}
+          </span>
+        </div>
+      ))}
+      {hiddenCount > 0 && <div className="mt-1 text-xs text-subtle">+{hiddenCount} more</div>}
+    </>
+  );
+});
+
+function SeriesLegend({
+  series,
+  hiddenSeries,
+  onToggleSeries,
+  position,
+}: {
+  series: TimeseriesData[];
+  hiddenSeries: Set<string>;
+  onToggleSeries: (name: string) => void;
+  position: LegendPosition;
+}) {
+  const isBottom = position === "bottom";
+  return (
+    <div
+      className={
+        isBottom
+          ? "mt-3 max-h-20 overflow-auto border-t border-border pt-3"
+          : "ml-3 overflow-auto border-l border-border pl-3"
+      }
+    >
+      <div
+        className={isBottom ? "flex flex-wrap items-center gap-x-4 gap-y-2" : "flex flex-col gap-2"}
+      >
+        {series.map((item) => {
+          const inactive = hiddenSeries.has(item.name);
+          return (
+            <button
+              key={item.name}
+              type="button"
+              className="group inline-flex min-w-0 items-center gap-2 text-left"
+              onClick={() => onToggleSeries(item.name)}
+              title={item.name}
+              aria-pressed={!inactive}
+            >
+              <span
+                className={cx(
+                  "inline-block h-2 w-2 shrink-0 rounded-full",
+                  inactive && "opacity-40",
+                )}
+                style={{ backgroundColor: item.color }}
+              />
+              <span
+                className={cx(
+                  "min-w-0 truncate text-xs text-muted group-hover:text-fg",
+                  inactive && "text-subtle line-through opacity-60",
+                )}
+              >
+                {item.name}
+              </span>
+              <span
+                className={cx(
+                  "shrink-0 text-xs font-medium text-fg",
+                  inactive && "text-subtle line-through opacity-60",
+                )}
+              >
+                {formatDefaultValue(item.total)}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function findNearest(data: [number, number][], ts: number): number | null {
+  if (data.length === 0) return null;
+  let lo = 0;
+  let hi = data.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    const point = data[mid];
+    if (point && point[0] < ts) lo = mid + 1;
+    else hi = mid;
+  }
+  const previous = data[lo - 1];
+  const current = data[lo];
+  if (!current) return null;
+  if (lo > 0 && previous && Math.abs(previous[0] - ts) < Math.abs(current[0] - ts)) lo--;
+  return data[lo]?.[1] ?? null;
+}
+
+function isSameTooltipState(previous: TooltipState | null, next: TooltipState): boolean {
+  if (
+    !previous ||
+    previous.ts !== next.ts ||
+    previous.hiddenCount !== next.hiddenCount ||
+    previous.rows.length !== next.rows.length
+  ) {
+    return false;
+  }
+  return previous.rows.every((row, index) => {
+    const nextRow = next.rows[index];
+    return row.name === nextRow?.name && row.value === nextRow.value && row.color === nextRow.color;
+  });
+}
+
+function getAxisPointerTimestamp(params: unknown): number | undefined {
+  if (!params || typeof params !== "object") return undefined;
+  const axesInfo = (params as { axesInfo?: Array<{ value?: unknown }> }).axesInfo;
+  const value = axesInfo?.[0]?.value;
+  return typeof value === "number" ? value : undefined;
+}
+
+function formatDefaultValue(value: number): string {
+  if (Number.isInteger(value)) return String(value);
+  return defaultNumberFormat.format(value);
+}
+
+function formatTimestamp(value: number): string {
+  return timestampFormat.format(new Date(value));
+}
+
+function cx(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(" ");
+}

--- a/apps/web/src/dashboards/widgets/TimeseriesCountWidget.tsx
+++ b/apps/web/src/dashboards/widgets/TimeseriesCountWidget.tsx
@@ -1,10 +1,8 @@
-import {
-  type ExploreRange,
-  useExploreSeries,
-} from "../../api.ts";
-import { TimeseriesChart } from "../../Explore.tsx";
+import { type ExploreRange, useExploreSeries } from "../../api.ts";
 import type { Widget } from "../types.ts";
 import { defaultChartType, widgetFilterToExplore } from "../types.ts";
+import { CountChart } from "./CountChart.tsx";
+import { DEFAULT_TOP_N } from "./series-topn.ts";
 import { WidgetEmpty, WidgetLoading } from "./shared.tsx";
 
 export function TimeseriesCountWidget({
@@ -24,13 +22,14 @@ export function TimeseriesCountWidget({
   if (!q.data || q.data.rows.length === 0) return <WidgetEmpty />;
   return (
     <div className="h-full min-h-[120px]">
-      <TimeseriesChart
+      <CountChart
         rows={q.data.rows}
         chartType={widget.config.chartType ?? defaultChartType(widget.type)}
+        limit={widget.config.limit ?? DEFAULT_TOP_N}
         showXAxis={widget.config.showXAxis ?? true}
-        showYAxis={widget.config.showYAxis ?? false}
+        showYAxis={widget.config.showYAxis ?? true}
         showLegend={widget.config.showLegend ?? false}
-        height="100%"
+        legendPosition={widget.config.legendPosition ?? "side"}
       />
     </div>
   );

--- a/apps/web/src/dashboards/widgets/echarts-setup.ts
+++ b/apps/web/src/dashboards/widgets/echarts-setup.ts
@@ -1,0 +1,25 @@
+// Tree-shaken ECharts core for our dashboard chart fork. Register only the
+// modules this path uses and re-export the configured core instance.
+import { BarChart, LineChart } from "echarts/charts";
+import {
+  AriaComponent,
+  BrushComponent,
+  GridComponent,
+  ToolboxComponent,
+  TooltipComponent,
+} from "echarts/components";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+
+echarts.use([
+  LineChart,
+  BarChart,
+  AriaComponent,
+  BrushComponent,
+  GridComponent,
+  ToolboxComponent,
+  TooltipComponent,
+  CanvasRenderer,
+]);
+
+export { echarts };

--- a/apps/web/src/dashboards/widgets/series-topn.test.ts
+++ b/apps/web/src/dashboards/widgets/series-topn.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DEFAULT_TOP_N, OTHER_LABEL, buildTopNSeries } from "./series-topn.ts";
+
+const count = (r: { count: number }) => r.count;
+
+function rowsFor(groups: { group: string; count: number }[], buckets: string[]) {
+  return groups.flatMap((g) => buckets.map((b) => ({ bucket: b, group: g.group, count: g.count })));
+}
+
+test("returns empty for no rows", () => {
+  assert.deepEqual(buildTopNSeries([], count, 10), []);
+});
+
+test("orders series by total descending", () => {
+  const rows = [
+    { bucket: "2026-06-01 00:00:00", group: "a", count: 1 },
+    { bucket: "2026-06-01 00:00:00", group: "b", count: 5 },
+    { bucket: "2026-06-01 00:00:00", group: "c", count: 3 },
+  ];
+  const series = buildTopNSeries(rows, count, 10);
+  assert.deepEqual(
+    series.map((s) => s.name),
+    ["b", "c", "a"],
+  );
+  assert.deepEqual(
+    series.map((s) => s.total),
+    [5, 3, 1],
+  );
+});
+
+test("rolls groups beyond the limit into a single Other series, placed last", () => {
+  // 5 groups, limit 3 → top 3 + Other (sum of remaining 2).
+  const rows = rowsFor(
+    [
+      { group: "g1", count: 100 },
+      { group: "g2", count: 50 },
+      { group: "g3", count: 25 },
+      { group: "g4", count: 10 },
+      { group: "g5", count: 4 },
+    ],
+    ["2026-06-01 00:00:00", "2026-06-01 00:01:00"],
+  );
+  const series = buildTopNSeries(rows, count, 3);
+  assert.deepEqual(
+    series.map((s) => s.name),
+    ["g1", "g2", "g3", OTHER_LABEL],
+  );
+  const other = series.at(-1);
+  assert.ok(other);
+  assert.equal(other.isOther, true);
+  // Other = (g4 + g5) summed across both buckets = (10+4)*2 = 28.
+  assert.equal(other.total, 28);
+  // Per-bucket: each bucket holds g4+g5 = 14.
+  assert.deepEqual(
+    other.data.map((d) => d[1]),
+    [14, 14],
+  );
+});
+
+test("no Other series when group count is at or below the limit", () => {
+  const rows = rowsFor(
+    [
+      { group: "a", count: 2 },
+      { group: "b", count: 1 },
+    ],
+    ["2026-06-01 00:00:00"],
+  );
+  const series = buildTopNSeries(rows, count, 10);
+  assert.equal(series.length, 2);
+  assert.equal(
+    series.some((s) => s.isOther),
+    false,
+  );
+});
+
+test("zero-fills missing buckets so every series shares the time axis", () => {
+  const rows = [
+    { bucket: "2026-06-01 00:00:00", group: "a", count: 3 },
+    { bucket: "2026-06-01 00:01:00", group: "b", count: 7 }, // a missing here
+  ];
+  const series = buildTopNSeries(rows, count, 10);
+  const a = series.find((s) => s.name === "a");
+  assert.ok(a);
+  assert.equal(a.data.length, 2);
+  assert.deepEqual(
+    a.data.map((d) => d[1]),
+    [3, 0],
+  );
+  // timestamps ascending, parsed as UTC ms
+  const first = a.data[0];
+  const second = a.data[1];
+  assert.ok(first);
+  assert.ok(second);
+  assert.ok(first[0] < second[0]);
+  assert.equal(first[0], Date.parse("2026-06-01T00:00:00Z"));
+});
+
+test("empty group label becomes (none)", () => {
+  const rows = [{ bucket: "2026-06-01 00:00:00", group: "", count: 1 }];
+  const series = buildTopNSeries(rows, count, 10);
+  assert.equal(series[0]?.name, "(none)");
+});
+
+test("limit < 1 means no rollup", () => {
+  const rows = rowsFor(
+    Array.from({ length: 15 }, (_, i) => ({ group: `g${i}`, count: 15 - i })),
+    ["2026-06-01 00:00:00"],
+  );
+  const series = buildTopNSeries(rows, count, 0);
+  assert.equal(series.length, 15);
+  assert.equal(
+    series.some((s) => s.isOther),
+    false,
+  );
+});
+
+test("default top-N is 10", () => {
+  const rows = rowsFor(
+    Array.from({ length: 14 }, (_, i) => ({ group: `g${i}`, count: 14 - i })),
+    ["2026-06-01 00:00:00"],
+  );
+  const series = buildTopNSeries(rows, count);
+  assert.equal(series.length, DEFAULT_TOP_N + 1); // 10 + Other
+  assert.equal(series.at(-1)?.name, OTHER_LABEL);
+});

--- a/apps/web/src/dashboards/widgets/series-topn.test.ts
+++ b/apps/web/src/dashboards/widgets/series-topn.test.ts
@@ -115,6 +115,35 @@ test("limit < 1 means no rollup", () => {
   );
 });
 
+test("a real group named Other does not collide with the rollup remainder", () => {
+  // 'Other' is itself a top group here; g2/g3 fall beyond the cut and roll up.
+  const rows = rowsFor(
+    [
+      { group: "Other", count: 100 },
+      { group: "g1", count: 50 },
+      { group: "g2", count: 10 },
+      { group: "g3", count: 5 },
+    ],
+    ["2026-06-01 00:00:00", "2026-06-01 00:01:00"],
+  );
+  const series = buildTopNSeries(rows, count, 2);
+
+  // The real "Other" group keeps its own (un-merged) data.
+  const real = series.find((s) => s.name === "Other" && !s.isOther);
+  assert.ok(real, "real 'Other' group is preserved");
+  assert.equal(real.total, 200); // 100 across 2 buckets
+
+  // The synthetic rollup is a distinct series with a distinct legend label.
+  const rollup = series.find((s) => s.isOther);
+  assert.ok(rollup, "rollup series present");
+  assert.equal(rollup.total, 30); // (10 + 5) across 2 buckets
+  assert.notEqual(rollup.name, real.name);
+
+  // Exactly one rollup and exactly one series literally named "Other".
+  assert.equal(series.filter((s) => s.isOther).length, 1);
+  assert.equal(series.filter((s) => s.name === "Other").length, 1);
+});
+
 test("default top-N is 10", () => {
   const rows = rowsFor(
     Array.from({ length: 14 }, (_, i) => ({ group: `g${i}`, count: 14 - i })),

--- a/apps/web/src/dashboards/widgets/series-topn.test.ts
+++ b/apps/web/src/dashboards/widgets/series-topn.test.ts
@@ -144,6 +144,26 @@ test("a real group named Other does not collide with the rollup remainder", () =
   assert.equal(series.filter((s) => s.name === "Other").length, 1);
 });
 
+test("rollup name stays unique even when 'Other' and 'Other (rest)' are real groups", () => {
+  const rows = rowsFor(
+    [
+      { group: "Other", count: 100 },
+      { group: "Other (rest)", count: 90 },
+      { group: "g1", count: 10 },
+      { group: "g2", count: 5 },
+    ],
+    ["2026-06-01 00:00:00"],
+  );
+  const series = buildTopNSeries(rows, count, 2);
+  const rollup = series.find((s) => s.isOther);
+  assert.ok(rollup);
+  // Distinct from both real group names that would otherwise collide.
+  const realNames = series.filter((s) => !s.isOther).map((s) => s.name);
+  assert.equal(realNames.includes(rollup.name), false);
+  // All output names are unique (visibility/legend/tooltip are name-keyed).
+  assert.equal(new Set(series.map((s) => s.name)).size, series.length);
+});
+
 test("default top-N is 10", () => {
   const rows = rowsFor(
     Array.from({ length: 14 }, (_, i) => ({ group: `g${i}`, count: 14 - i })),

--- a/apps/web/src/dashboards/widgets/series-topn.ts
+++ b/apps/web/src/dashboards/widgets/series-topn.ts
@@ -1,0 +1,90 @@
+// Pure transform: collapse a flat list of grouped series rows into the top-N
+// series by total, rolling everything beyond the cut into a single "Other"
+// series. Output is shaped for an [ms, value][] time-series chart (Kumo /
+// ECharts), but the logic is chart-library agnostic so it can back the recharts
+// path too.
+//
+// Kept dependency-free (no react/api imports) so it runs under `tsx --test`.
+
+export const OTHER_LABEL = "Other";
+const NONE_LABEL = "(none)";
+
+export const DEFAULT_TOP_N = 10;
+
+export type GroupedRow = { bucket: string; group: string };
+
+export type ChartSeries = {
+  /** Group value, or "Other" for the rolled-up remainder, "(none)" when empty. */
+  name: string;
+  /** Sum of every point in this series — drives ordering and the legend value. */
+  total: number;
+  /** `[timestamp_ms, value]` tuples, one per bucket, ascending by time. */
+  data: [number, number][];
+  /** True only for the synthetic rolled-up remainder series. */
+  isOther: boolean;
+};
+
+// bucket is ClickHouse "YYYY-MM-DD HH:MM:SS" in UTC (see timeFormat.ts).
+function bucketToMs(bucket: string): number {
+  return new Date(`${bucket.replace(" ", "T")}Z`).getTime();
+}
+
+/**
+ * Build at most `limit` real series (highest total first) plus, if more groups
+ * exist, a single "Other" series summing the remainder per bucket.
+ *
+ * @param limit  max real series before rollup; values < 1 mean "no limit".
+ */
+export function buildTopNSeries<T extends GroupedRow>(
+  rows: T[],
+  valFn: (r: T) => number,
+  limit: number = DEFAULT_TOP_N,
+): ChartSeries[] {
+  if (rows.length === 0) return [];
+
+  // Stable, sorted bucket axis shared by every series so points align.
+  const bucketSet = new Set<string>();
+  const totals = new Map<string, number>();
+  for (const r of rows) {
+    bucketSet.add(r.bucket);
+    const g = r.group || NONE_LABEL;
+    totals.set(g, (totals.get(g) ?? 0) + valFn(r));
+  }
+  const buckets = [...bucketSet].sort();
+  const bucketIndex = new Map(buckets.map((b, i) => [b, i]));
+
+  const ranked = [...totals.entries()].sort((a, b) => b[1] - a[1]).map(([g]) => g);
+  const cut = limit >= 1 ? limit : ranked.length;
+  const topGroups = new Set(ranked.slice(0, cut));
+  const hasOther = ranked.length > topGroups.size;
+
+  // Accumulate per-bucket values, zero-filled, so lines/bars don't gap.
+  const points = new Map<string, number[]>();
+  for (const g of topGroups) points.set(g, new Array(buckets.length).fill(0));
+  if (hasOther) points.set(OTHER_LABEL, new Array(buckets.length).fill(0));
+
+  for (const r of rows) {
+    const g = r.group || NONE_LABEL;
+    const key = topGroups.has(g) ? g : OTHER_LABEL;
+    const arr = points.get(key);
+    const i = bucketIndex.get(r.bucket);
+    if (!arr || i === undefined) continue;
+    arr[i] = (arr[i] ?? 0) + valFn(r);
+  }
+
+  const toSeries = (name: string, isOther: boolean): ChartSeries => {
+    const arr = points.get(name) ?? [];
+    let total = 0;
+    const data: [number, number][] = buckets.map((b, i) => {
+      const v = arr[i] ?? 0;
+      total += v;
+      return [bucketToMs(b), v];
+    });
+    return { name, total, data, isOther };
+  };
+
+  // Real series in rank order, "Other" always last.
+  const series = ranked.filter((g) => topGroups.has(g)).map((g) => toSeries(g, false));
+  if (hasOther) series.push(toSeries(OTHER_LABEL, true));
+  return series;
+}

--- a/apps/web/src/dashboards/widgets/series-topn.ts
+++ b/apps/web/src/dashboards/widgets/series-topn.ts
@@ -24,6 +24,15 @@ export type ChartSeries = {
   isOther: boolean;
 };
 
+// Pick a rollup label that doesn't clash with any real group name, so the
+// synthetic series stays distinguishable everywhere series are keyed by name.
+function uniqueOtherName(taken: Set<string>): string {
+  if (!taken.has(OTHER_LABEL)) return OTHER_LABEL;
+  let name = `${OTHER_LABEL} (rest)`;
+  for (let i = 2; taken.has(name); i++) name = `${OTHER_LABEL} (rest ${i})`;
+  return name;
+}
+
 // bucket is ClickHouse "YYYY-MM-DD HH:MM:SS" in UTC (see timeFormat.ts).
 function bucketToMs(bucket: string): number {
   return new Date(`${bucket.replace(" ", "T")}Z`).getTime();
@@ -88,9 +97,9 @@ export function buildTopNSeries<T extends GroupedRow>(
     .filter((g) => topGroups.has(g))
     .map((g) => toSeries(g, points.get(g) ?? [], false));
   if (otherArr) {
-    // Disambiguate the legend label if a real group is already named "Other".
-    const name = topGroups.has(OTHER_LABEL) ? `${OTHER_LABEL} (rest)` : OTHER_LABEL;
-    series.push(toSeries(name, otherArr, true));
+    // The rollup name must be unique among the real series — visibility,
+    // legend, and tooltip dedup are all keyed by name (see CountChart).
+    series.push(toSeries(uniqueOtherName(topGroups), otherArr, true));
   }
   return series;
 }

--- a/apps/web/src/dashboards/widgets/series-topn.ts
+++ b/apps/web/src/dashboards/widgets/series-topn.ts
@@ -58,22 +58,22 @@ export function buildTopNSeries<T extends GroupedRow>(
   const topGroups = new Set(ranked.slice(0, cut));
   const hasOther = ranked.length > topGroups.size;
 
-  // Accumulate per-bucket values, zero-filled, so lines/bars don't gap.
+  // Accumulate per-bucket values, zero-filled, so lines/bars don't gap. The
+  // rollup remainder lives in its own accumulator (not the points map) so a
+  // real group literally named "Other" can't collide with the synthetic series.
   const points = new Map<string, number[]>();
   for (const g of topGroups) points.set(g, new Array(buckets.length).fill(0));
-  if (hasOther) points.set(OTHER_LABEL, new Array(buckets.length).fill(0));
+  const otherArr = hasOther ? new Array<number>(buckets.length).fill(0) : null;
 
   for (const r of rows) {
     const g = r.group || NONE_LABEL;
-    const key = topGroups.has(g) ? g : OTHER_LABEL;
-    const arr = points.get(key);
+    const arr = topGroups.has(g) ? points.get(g) : otherArr;
     const i = bucketIndex.get(r.bucket);
     if (!arr || i === undefined) continue;
     arr[i] = (arr[i] ?? 0) + valFn(r);
   }
 
-  const toSeries = (name: string, isOther: boolean): ChartSeries => {
-    const arr = points.get(name) ?? [];
+  const toSeries = (name: string, arr: number[], isOther: boolean): ChartSeries => {
     let total = 0;
     const data: [number, number][] = buckets.map((b, i) => {
       const v = arr[i] ?? 0;
@@ -84,7 +84,13 @@ export function buildTopNSeries<T extends GroupedRow>(
   };
 
   // Real series in rank order, "Other" always last.
-  const series = ranked.filter((g) => topGroups.has(g)).map((g) => toSeries(g, false));
-  if (hasOther) series.push(toSeries(OTHER_LABEL, true));
+  const series = ranked
+    .filter((g) => topGroups.has(g))
+    .map((g) => toSeries(g, points.get(g) ?? [], false));
+  if (otherArr) {
+    // Disambiguate the legend label if a real group is already named "Other".
+    const name = topGroups.has(OTHER_LABEL) ? `${OTHER_LABEL} (rest)` : OTHER_LABEL;
+    series.push(toSeries(name, otherArr, true));
+  }
   return series;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.5.0
+        version: 1.5.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@git-diff-view/file':
         specifier: ^0.1.3
         version: 0.1.3
@@ -335,6 +338,9 @@ importers:
       better-auth:
         specifier: ^1.6.11
         version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      echarts:
+        specifier: ^6
+        version: 6.1.0
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -739,6 +745,33 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.5.0':
+    resolution: {integrity: sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.2.9':
+    resolution: {integrity: sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@better-auth/core@1.6.11':
     resolution: {integrity: sha512-LrwidLCV8azdMGjvtwp30nj9tIv1BwI3VhtC0UaGSjQkAVWw4bN42I8qwbxRziPeSQoj+zUVkOpxZzAWBDARtQ==}
@@ -1339,6 +1372,21 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@git-diff-view/core@0.1.3':
     resolution: {integrity: sha512-HNuxWv/DqxFRuZMq4EHmnFL4bVM68ON/GnCoTz35Q9SfIScgN3Qppoh2rj/GEpWV1XG+TjBFuSSoW8XBcx8+ew==}
@@ -3512,6 +3560,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  echarts@6.1.0:
+    resolution: {integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -4994,6 +5045,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -5241,6 +5295,9 @@ packages:
 
   zone.js@0.16.1:
     resolution: {integrity: sha512-dpvY17vxYIW3+bNrP0ClUlaiY0CiIRK3tnoLaGoQsQcY9/I/NpzIWQ7tQNhbV7LacQMpCII6wVzuL3tuWOyfuA==}
+
+  zrender@6.1.0:
+    resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -5670,6 +5727,29 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@base-ui/react@1.5.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.9(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@base-ui/utils@0.2.9(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.0
@@ -6006,6 +6086,23 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
+
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@floating-ui/utils@0.2.11': {}
 
   '@git-diff-view/core@0.1.3':
     dependencies:
@@ -8137,6 +8234,11 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  echarts@6.1.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 6.1.0
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.344: {}
@@ -9736,6 +9838,8 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tslib@2.3.0: {}
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -9947,5 +10051,9 @@ snapshots:
   zod@4.4.3: {}
 
   zone.js@0.16.1: {}
+
+  zrender@6.1.0:
+    dependencies:
+      tslib: 2.3.0
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Replaces the dashboard count timeseries widget's chart with a self-contained ECharts chart (`CountChart`) styled from our design tokens — cursor-following tooltip, side/bottom legend positions, and click-to-toggle series visibility — and adds a top-N series rollup so busy group-bys stay readable.

## What changed
- **Top-N + "Other" rollup** as a pure, unit-tested transform (`series-topn.ts`, 8 tests): the top N series render individually and the remainder collapses into a single "Other" series.
- **"top series" limit** is a per-widget setting (default 10), surfaced in Add-widget whenever a count chart has a group-by.
- **Legend position** (`side` / `bottom`) is a saved per-widget setting — added to the client `WidgetConfig` and the API widget-config zod schema (which had been silently stripping it).
- **`CountChart`** is plain ECharts + our tokens (no extra design-system dependency): tooltip, axis label color, and series visibility are all driven from the chart option we own.
- Count widgets now default y-axis labels on.

## Testing
- `series-topn.test.ts` 8/8 passing
- web + api typecheck clean, biome clean on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the count timeseries widget with a self-contained ECharts `CountChart` and added a top‑N rollup so busy group‑bys stay readable. The rollup label is now guaranteed unique to avoid collisions with real groups.

- New Features
  - Top‑N + rollup via pure transform (`series-topn.ts`, 10 tests); default 10; shown in Add Widget when a group‑by is set; rollup label guaranteed unique (no collision with real groups like “Other” or “Other (rest)”).
  - New ECharts `CountChart`: token-styled, cursor-following tooltip, click to toggle series, side/bottom legend.
  - Saved per‑widget `legendPosition` (`side`/`bottom`); added to client `WidgetConfig` and API zod schema.
  - Count charts default Y‑axis labels on; `limit` acts as “top series” when grouped.

- Dependencies
  - Added `echarts@^6` and `@base-ui/react`.

<sup>Written for commit 0aeab714b6bf0f4463c319412170cd07b95ad55e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

