### PR TITLE
Render dashboard metric widgets with the new ECharts chart

### DIFF
--- a/apps/web/src/dashboards/AddWidget.tsx
+++ b/apps/web/src/dashboards/AddWidget.tsx
@@ -97,7 +97,6 @@ export function AddWidget({
 
   const type = widgetTypeFor(kind, source);
   const isMetric = kind === "chart" && source === "metric";
-  const isCountChart = type === "timeseries_count";
   const isTable = kind === "table";
   const isNote = kind === "note";
   const supportsGroupBy = kind === "chart";
@@ -126,7 +125,7 @@ export function AddWidget({
         filter: { resourceAttrs: attrs.length ? attrs : undefined },
         groupBy: supportsGroupBy && groupBy ? groupBy : undefined,
         metricName: isMetric ? metricName : undefined,
-        limit: isTable ? limit : isCountChart && groupBy ? seriesLimit : undefined,
+        limit: isTable ? limit : supportsGroupBy && groupBy ? seriesLimit : undefined,
         chartType: kind === "chart" ? chartType : undefined,
         markdown: isNote ? markdown : undefined,
       },
@@ -147,7 +146,6 @@ export function AddWidget({
       seriesLimit,
       supportsGroupBy,
       isMetric,
-      isCountChart,
       isTable,
       isNote,
       kind,
@@ -282,7 +280,7 @@ export function AddWidget({
               </div>
             )}
 
-            {isCountChart && groupBy && (
+            {supportsGroupBy && groupBy && (
               <div>
                 <FieldLabel>top series</FieldLabel>
                 <Input

--- a/apps/web/src/dashboards/DashboardView.tsx
+++ b/apps/web/src/dashboards/DashboardView.tsx
@@ -566,8 +566,8 @@ function WidgetSettingsButton({
   };
 
   const chartType = widget.config.chartType ?? defaultChartType(widget.type);
-  const showXAxis = widget.config.showXAxis ?? widget.type === "timeseries_count";
-  const showYAxis = widget.config.showYAxis ?? widget.type === "timeseries_count";
+  const showXAxis = widget.config.showXAxis ?? isChart;
+  const showYAxis = widget.config.showYAxis ?? isChart;
   const showLegend = widget.config.showLegend ?? false;
   const legendPosition = widget.config.legendPosition ?? "side";
   const aggregation = widget.config.aggregation ?? "auto";
@@ -641,7 +641,7 @@ function WidgetSettingsButton({
             checked={showLegend}
             onChange={(v) => setConfig({ showLegend: v })}
           />
-          {showLegend && widget.type === "timeseries_count" && (
+          {showLegend && isChart && (
             <div>
               <div className="mb-1 uppercase tracking-[0.2em] text-subtle">legend position</div>
               <div className="flex gap-1">

--- a/apps/web/src/dashboards/widgets/CountChart.tsx
+++ b/apps/web/src/dashboards/widgets/CountChart.tsx
@@ -3,13 +3,14 @@ import type { EChartsOption, SetOptionOpts } from "echarts";
 import type { BarSeriesOption, LineSeriesOption } from "echarts/charts";
 import type * as EChartsCore from "echarts/core";
 import { forwardRef, memo, useEffect, useMemo, useRef, useState } from "react";
-import type { SeriesRow } from "../../api.ts";
 import type { ChartType, LegendPosition } from "../types.ts";
 import { echarts } from "./echarts-setup.ts";
-import { type ChartSeries, buildTopNSeries } from "./series-topn.ts";
+import { type ChartSeries, type GroupedRow, buildTopNSeries } from "./series-topn.ts";
 
-type CountChartProps = {
-  rows: SeriesRow[];
+type SeriesChartProps<T extends GroupedRow> = {
+  rows: T[];
+  /** Per-row value accessor — `r.count` for count series, `r.value` for metrics. */
+  value: (row: T) => number;
   chartType: ChartType;
   limit: number;
   showXAxis?: boolean;
@@ -58,24 +59,25 @@ const timestampFormat = new Intl.DateTimeFormat(undefined, {
   hour12: false,
 });
 
-export function CountChart({
+export function CountChart<T extends GroupedRow>({
   rows,
+  value,
   chartType,
   limit,
   showXAxis = true,
   showYAxis = false,
   showLegend,
   legendPosition,
-}: CountChartProps) {
+}: SeriesChartProps<T>) {
   const allSeries = useMemo(
     () =>
-      buildTopNSeries(rows, (r) => r.count, limit).map((series, index) => ({
+      buildTopNSeries(rows, value, limit).map((series, index) => ({
         ...series,
         color: series.isOther
           ? OTHER_COLOR
           : (CHART_COLORS[index % CHART_COLORS.length] ?? FIRST_CHART_COLOR),
       })),
-    [rows, limit],
+    [rows, value, limit],
   );
   const [hiddenSeries, setHiddenSeries] = useState<Set<string>>(() => new Set());
 

--- a/apps/web/src/dashboards/widgets/TimeseriesCountWidget.tsx
+++ b/apps/web/src/dashboards/widgets/TimeseriesCountWidget.tsx
@@ -1,9 +1,12 @@
-import { type ExploreRange, useExploreSeries } from "../../api.ts";
+import { type ExploreRange, type SeriesRow, useExploreSeries } from "../../api.ts";
 import type { Widget } from "../types.ts";
 import { defaultChartType, widgetFilterToExplore } from "../types.ts";
 import { CountChart } from "./CountChart.tsx";
 import { DEFAULT_TOP_N } from "./series-topn.ts";
 import { WidgetEmpty, WidgetLoading } from "./shared.tsx";
+
+// Stable ref so CountChart's series memo doesn't recompute every render.
+const countValue = (r: SeriesRow) => r.count;
 
 export function TimeseriesCountWidget({
   projectId,
@@ -24,6 +27,7 @@ export function TimeseriesCountWidget({
     <div className="h-full min-h-[120px]">
       <CountChart
         rows={q.data.rows}
+        value={countValue}
         chartType={widget.config.chartType ?? defaultChartType(widget.type)}
         limit={widget.config.limit ?? DEFAULT_TOP_N}
         showXAxis={widget.config.showXAxis ?? true}

--- a/apps/web/src/dashboards/widgets/TimeseriesMetricWidget.tsx
+++ b/apps/web/src/dashboards/widgets/TimeseriesMetricWidget.tsx
@@ -1,8 +1,12 @@
-import { MetricLineChart } from "../../Explore.tsx";
-import { type ExploreRange, useExploreMetricSeries } from "../../api.ts";
+import { type ExploreRange, type MetricSeriesRow, useExploreMetricSeries } from "../../api.ts";
 import type { Widget } from "../types.ts";
 import { defaultChartType, widgetFilterToExplore } from "../types.ts";
+import { CountChart } from "./CountChart.tsx";
+import { DEFAULT_TOP_N } from "./series-topn.ts";
 import { WidgetEmpty, WidgetLoading } from "./shared.tsx";
+
+// Stable ref so CountChart's series memo doesn't recompute every render.
+const metricValue = (r: MetricSeriesRow) => r.value;
 
 export function TimeseriesMetricWidget({
   projectId,
@@ -33,13 +37,15 @@ export function TimeseriesMetricWidget({
   if (!q.data || q.data.rows.length === 0) return <WidgetEmpty />;
   return (
     <div className="h-full min-h-[120px]">
-      <MetricLineChart
+      <CountChart
         rows={q.data.rows}
+        value={metricValue}
         chartType={widget.config.chartType ?? defaultChartType(widget.type)}
-        showXAxis={widget.config.showXAxis ?? false}
-        showYAxis={widget.config.showYAxis ?? false}
+        limit={widget.config.limit ?? DEFAULT_TOP_N}
+        showXAxis={widget.config.showXAxis ?? true}
+        showYAxis={widget.config.showYAxis ?? true}
         showLegend={widget.config.showLegend ?? false}
-        height="100%"
+        legendPosition={widget.config.legendPosition ?? "side"}
       />
     </div>
   );

--- a/apps/web/src/dashboards/widgets/series-topn.test.ts
+++ b/apps/web/src/dashboards/widgets/series-topn.test.ts
@@ -164,6 +164,19 @@ test("rollup name stays unique even when 'Other' and 'Other (rest)' are real gro
   assert.equal(new Set(series.map((s) => s.name)).size, series.length);
 });
 
+test("works with an arbitrary value accessor (metric series use r.value)", () => {
+  const rows = [
+    { bucket: "2026-06-01 00:00:00", group: "p99", value: 12.5 },
+    { bucket: "2026-06-01 00:00:00", group: "p50", value: 3.2 },
+  ];
+  const series = buildTopNSeries(rows, (r) => r.value, 10);
+  assert.deepEqual(
+    series.map((s) => s.name),
+    ["p99", "p50"],
+  );
+  assert.equal(series[0]?.total, 12.5);
+});
+
 test("default top-N is 10", () => {
   const rows = rowsFor(
     Array.from({ length: 14 }, (_, i) => ({ group: `g${i}`, count: 14 - i })),


### PR DESCRIPTION
Extends the new dashboard count chart to metric timeseries widgets so every dashboard chart widget shares the same look and behavior.

## What changed
- Generalized `CountChart` to take a per-row **value accessor** (`r.count` for counts, `r.value` for metrics) instead of hard-coding count.
- `TimeseriesMetricWidget` now renders `CountChart` instead of the Explore `MetricLineChart`, so metric widgets get the cursor-following tooltip, top-N + "Other" rollup, side/bottom legend, click-to-toggle visibility, and dimmed axes.
- The "top series" limit and legend-position controls (and the y/x-axis defaults) now apply to **any** chart widget with a group-by, not just count.

## Scope
Dashboard table/note widgets aren't charts (nothing to restyle). The Explore-page charts still use the old component and can follow separately.

## Testing
- `series-topn.test.ts` 11/11 (added a value-accessor case)
- web typecheck, production build, and biome clean on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches metric timeseries dashboard widgets to the new ECharts chart by generalizing `CountChart` with a value accessor, unifying look and interactions across count and metric charts. Also extends top-N, legend position, and axis defaults to all chart widgets with a group-by.

- **New Features**
  - Metric timeseries widgets now use the ECharts chart with cursor tooltip, top-N + “Other” rollup, side/bottom legend with click-to-toggle, and dimmed axes.
  - “Top series” limit, legend position, and x/y-axis defaults now apply to any chart widget with a group-by.

- **Refactors**
  - `CountChart` now takes a per-row value accessor (e.g., `r.count`, `r.value`) and is reused by metric widgets.
  - Replaced the Explore `MetricLineChart` in metric widgets and added a test for the value-accessor path.

<sup>Written for commit 4939a91788e1a036b2936c01c573443180741b6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

