### PR TITLE
Handle cumulative metric counters in series queries

### DIFF
--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -230,6 +230,31 @@ test("metricSeries can exclude resource attributes by substring", async () => {
   assert.equal(capture.params?.attr_v_0, ".local");
 });
 
+test("metricSeries converts cumulative monotonic sum counters into per-bucket deltas", async () => {
+  const queries: string[] = [];
+
+  await metricSeries(
+    fakeClickhouseMulti(queries),
+    "project-1",
+    "superlog.proxy.ingest.requests",
+    { range: { since: "now() - INTERVAL 1 HOUR", until: "now()" } },
+    "attr:tenant.org.name",
+    { n: 1, unit: "MINUTE" },
+    "sum",
+  );
+
+  const sumQuery = queries.find((q) => q.includes("FROM otel_metrics_sum"));
+  assert.ok(sumQuery, "expected a sum metric query");
+  assert.match(sumQuery, /AggregationTemporality = 2/);
+  assert.match(sumQuery, /IsMonotonic/);
+  assert.match(sumQuery, /lagInFrame\(toNullable\(Value\), 1, NULL\)/);
+  assert.match(sumQuery, /Value - previous_value/);
+  assert.match(sumQuery, /StartTimeUnix >= now\(\) - INTERVAL 1 HOUR/);
+  assert.match(sumQuery, /NOT \(AggregationTemporality = 2 AND IsMonotonic\)/);
+  assert.match(sumQuery, /Attributes\[\{groupKey:String\}\] AS group_key/);
+  assert.equal(queries.length, 4);
+});
+
 test("queryTraces returns resource attributes and flattened exception fields", async () => {
   const capture: { query?: string; params?: Record<string, unknown> } = {};
 

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -831,6 +831,74 @@ function histogramQuantileQuery(args: {
   `;
 }
 
+function cumulativeMonotonicSumQuery(args: {
+  table: string;
+  step: Step;
+  groupExpr: string;
+  conds: string[];
+  sinceExpr: string;
+}): string {
+  const { table, step, groupExpr, conds, sinceExpr } = args;
+  const where = conds.join(" AND ");
+  return `
+    SELECT
+      bucket,
+      group_key,
+      sum(v) AS v
+    FROM (
+      SELECT
+        toString(toStartOfInterval(TimeUnix, INTERVAL ${step.n} ${step.unit})) AS bucket,
+        group_key,
+        if(
+          previous_value IS NULL,
+          if(StartTimeUnix >= ${sinceExpr}, Value, 0),
+          if(Value >= previous_value, Value - previous_value, 0)
+        ) AS v
+      FROM (
+        SELECT
+          TimeUnix,
+          StartTimeUnix,
+          Value,
+          ${groupExpr} AS group_key,
+          lagInFrame(toNullable(Value), 1, NULL) OVER (
+            PARTITION BY series_key
+            ORDER BY TimeUnix ASC
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+          ) AS previous_value
+        FROM (
+          SELECT
+            *,
+            cityHash64(
+              ServiceName,
+              MetricName,
+              MetricUnit,
+              toString(ResourceAttributes),
+              toString(Attributes),
+              toString(StartTimeUnix)
+            ) AS series_key
+          FROM ${table}
+          WHERE ${where}
+            AND AggregationTemporality = 2
+            AND IsMonotonic
+        )
+      )
+
+      UNION ALL
+
+      SELECT
+        toString(toStartOfInterval(TimeUnix, INTERVAL ${step.n} ${step.unit})) AS bucket,
+        ${groupExpr} AS group_key,
+        Value AS v
+      FROM ${table}
+      WHERE ${where}
+        AND NOT (AggregationTemporality = 2 AND IsMonotonic)
+    )
+    GROUP BY bucket, group_key
+    ORDER BY bucket ASC
+    LIMIT 10000
+  `;
+}
+
 export async function listMetricNames(
   ch: ClickHouseClient,
   projectId: string,
@@ -918,6 +986,14 @@ export async function metricSeries(
             conds,
             q: aggregation === "p95" ? 0.95 : 0.99,
           })
+        : kind === "sum" && (!aggregation || aggregation === "sum")
+          ? cumulativeMonotonicSumQuery({
+              table,
+              step,
+              groupExpr,
+              conds,
+              sinceExpr,
+            })
         : `
           SELECT
             toString(toStartOfInterval(TimeUnix, INTERVAL ${step.n} ${step.unit})) AS bucket,


### PR DESCRIPTION
Metric series queries now convert cumulative monotonic sum points into per-bucket deltas before grouping, while leaving delta/non-monotonic sums and other metric kinds on their existing paths.

This fixes dashboards for counters exported with cumulative OTel temporality so charts show interval volume instead of an artificial monotonic climb.

Added coverage for proxy ingest request counters grouped by org.

Checks: pnpm --dir superlog --filter @superlog/api test -- src/mcp/clickhouse.test.ts; pnpm --dir superlog --filter @superlog/api typecheck.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert cumulative monotonic sum counters to per-interval deltas in metric series queries so dashboards show true interval volume instead of a monotonic climb. Non-monotonic sums, deltas, and other metric kinds keep their existing behavior.

- **Bug Fixes**
  - Detect cumulative monotonic sums (`AggregationTemporality = 2` and `IsMonotonic`) and compute per-bucket deltas using a window `lag`, with reset-safe logic and first-sample handling within the range.
  - Keep the original query path for other sums and metric kinds.
  - Add test coverage for proxy ingest request counters grouped by org; validates the generated SQL and grouping.

<sup>Written for commit c8d6cf1b64ddd3aee14664d35d20deebd61c765b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

