### PR TITLE
Cap rows scanned when listing explore attribute keys

### DIFF
--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -120,6 +120,23 @@ test("listAttributeKeys includes prefixed span attributes for trace exploration"
   assert.match(capture.query ?? "", /concat\('span\.', k\)/);
 });
 
+test("listAttributeKeys caps the rows scanned per source so high-volume projects don't time out", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await listAttributeKeys(
+    fakeClickhouse(capture),
+    "project-1",
+    { since: "now() - INTERVAL 1 HOUR", until: "now()" },
+    "traces",
+  );
+
+  // Each per-source key scan reads at most ATTRIBUTE_KEY_SCAN_ROW_CAP rows
+  // before arrayJoin/group, so the query stays ~1s instead of 15-30s.
+  const limitMatches = (capture.query ?? "").match(/LIMIT 1000000/g) ?? [];
+  // resource.* from traces + span.* from traces = two capped scans.
+  assert.equal(limitMatches.length, 2);
+});
+
 test("listAttributeValues resolves prefixed span attributes", async () => {
   const capture: { query?: string; params?: Record<string, unknown> } = {};
 

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -570,6 +570,18 @@ export async function listServices(ch: ClickHouseClient, projectId: string, rang
   return rows.map((r) => r.service);
 }
 
+// Discovering which attribute keys exist only needs a representative sample of
+// rows, not every row in the window. High-volume projects produce millions of
+// spans/logs per hour, and reading the full ResourceAttributes/SpanAttributes
+// map columns across all of them took 15-30s — past the 10s ClickHouse
+// request_timeout — so the explore filter dropdown 500'd. Capping the rows each
+// scan reads before the arrayJoin/group keeps the query ~1s while still
+// surfacing effectively every key: ClickHouse reads parts in parallel, so the
+// cap samples across the window rather than just the head. Counts become
+// approximate, which is fine for ordering the dropdown. Low-volume projects read
+// fewer rows than the cap and stay exact.
+const ATTRIBUTE_KEY_SCAN_ROW_CAP = 1_000_000;
+
 export async function listAttributeKeys(
   ch: ClickHouseClient,
   projectId: string,
@@ -579,66 +591,38 @@ export async function listAttributeKeys(
   const { sinceSql, untilSql, sinceExpr, untilExpr } = resolveRange(range);
   const resourceFromLogs = source === undefined || source === "logs" || source === "metrics";
   const resourceFromTraces = source === undefined || source === "traces" || source === "metrics";
+  // Reads at most ATTRIBUTE_KEY_SCAN_ROW_CAP rows from `table`, then expands the
+  // chosen map column's keys. `prefix` namespaces keys by scope (resource./span./log.);
+  // pass "" to emit the bare key (the unscoped `source === undefined` case).
+  const keyScan = (table: string, column: string, prefix: string): string => {
+    const keyExpr = prefix ? `concat('${prefix}', k)` : "k";
+    return `
+      SELECT ${keyExpr} AS k, count() AS c FROM (
+        SELECT mapKeys(${column}) AS mk
+        FROM ${table}
+        WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+          AND Timestamp >= ${sinceExpr}
+          AND Timestamp <= ${untilExpr}
+        LIMIT ${ATTRIBUTE_KEY_SCAN_ROW_CAP}
+      ) ARRAY JOIN mk AS k
+      GROUP BY k`;
+  };
   const subqueries: string[] = [];
   if (source === undefined) {
-    subqueries.push(`
-      SELECT arrayJoin(mapKeys(ResourceAttributes)) AS k, count() AS c
-      FROM otel_logs
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
-        AND Timestamp >= ${sinceExpr}
-        AND Timestamp <= ${untilExpr}
-      GROUP BY k`);
-    subqueries.push(`
-      SELECT arrayJoin(mapKeys(ResourceAttributes)) AS k, count() AS c
-      FROM otel_traces
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
-        AND Timestamp >= ${sinceExpr}
-        AND Timestamp <= ${untilExpr}
-      GROUP BY k`);
+    subqueries.push(keyScan("otel_logs", "ResourceAttributes", ""));
+    subqueries.push(keyScan("otel_traces", "ResourceAttributes", ""));
   } else {
     if (resourceFromLogs) {
-      subqueries.push(`
-      SELECT concat('resource.', k) AS k, c FROM (
-        SELECT arrayJoin(mapKeys(ResourceAttributes)) AS k, count() AS c
-        FROM otel_logs
-        WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
-          AND Timestamp >= ${sinceExpr}
-          AND Timestamp <= ${untilExpr}
-        GROUP BY k
-      )`);
+      subqueries.push(keyScan("otel_logs", "ResourceAttributes", "resource."));
     }
     if (source === "logs") {
-      subqueries.push(`
-      SELECT concat('log.', k) AS k, c FROM (
-        SELECT arrayJoin(mapKeys(LogAttributes)) AS k, count() AS c
-        FROM otel_logs
-        WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
-          AND Timestamp >= ${sinceExpr}
-          AND Timestamp <= ${untilExpr}
-        GROUP BY k
-      )`);
+      subqueries.push(keyScan("otel_logs", "LogAttributes", "log."));
     }
     if (resourceFromTraces) {
-      subqueries.push(`
-      SELECT concat('resource.', k) AS k, c FROM (
-        SELECT arrayJoin(mapKeys(ResourceAttributes)) AS k, count() AS c
-        FROM otel_traces
-        WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
-          AND Timestamp >= ${sinceExpr}
-          AND Timestamp <= ${untilExpr}
-        GROUP BY k
-      )`);
+      subqueries.push(keyScan("otel_traces", "ResourceAttributes", "resource."));
     }
     if (source === "traces") {
-      subqueries.push(`
-      SELECT concat('span.', k) AS k, c FROM (
-        SELECT arrayJoin(mapKeys(SpanAttributes)) AS k, count() AS c
-        FROM otel_traces
-        WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
-          AND Timestamp >= ${sinceExpr}
-          AND Timestamp <= ${untilExpr}
-        GROUP BY k
-      )`);
+      subqueries.push(keyScan("otel_traces", "SpanAttributes", "span."));
     }
   }
   const query = `


### PR DESCRIPTION
## Problem

The explore filter dropdown calls `GET /explore/attribute-keys`, which `arrayJoin`s the keys of the `ResourceAttributes` / `SpanAttributes` / `LogAttributes` maps across **every row** in the selected window. On a high-volume project (millions of spans/hour) ClickHouse has to decompress the full wide map columns for all rows — measured at **15s warm / 31s cold** for a 1-hour window with ~7.7M spans. That blows past the ClickHouse client's 10s `request_timeout`, so the dropdown intermittently 500s (and feels slow even when it squeaks under).

## Fix

A filter dropdown only needs the *set* of attribute keys with rough frequency ordering — not exact counts over millions of rows. Each per-source key scan now reads at most `ATTRIBUTE_KEY_SCAN_ROW_CAP` (1M) rows before the `arrayJoin`/group:

```sql
SELECT concat('span.', k) AS k, count() AS c FROM (
  SELECT mapKeys(SpanAttributes) AS mk
  FROM otel_traces
  WHERE <project + time>
  LIMIT 1000000
) ARRAY JOIN mk AS k
GROUP BY k
```

ClickHouse reads table parts in parallel, so the cap samples across the window rather than just the head.

Measured against the same project/window:

| | latency | keys returned |
|---|---|---|
| before (full scan) | 15–31s → 500 | 118 |
| after (1M cap) | ~1.3s | 116 |

The two keys not recovered are ultra-rare. **Counts become approximate** (fine for ordering the dropdown), and low-volume projects read fewer rows than the cap so they stay exact — no behavior change there.

This is the immediate mitigation to stop the 500s; a pre-aggregating materialized view is the longer-term fix that would restore exact key coverage and make this volume-independent.

## Test

Added a unit test asserting each per-source scan carries the row cap. Full `clickhouse.test.ts` suite green (17/17).