### PR TITLE
Smooth cumulative counter charts: spread increases across render buckets

### DIFF
--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -247,7 +247,7 @@ test("metricSeries can exclude resource attributes by substring", async () => {
   assert.equal(capture.params?.attr_v_0, ".local");
 });
 
-test("metricSeries converts cumulative monotonic sum counters into per-bucket deltas", async () => {
+test("metricSeries spreads cumulative monotonic sum increases across the interval each sample covers", async () => {
   const queries: string[] = [];
 
   await metricSeries(
@@ -264,9 +264,21 @@ test("metricSeries converts cumulative monotonic sum counters into per-bucket de
   assert.ok(sumQuery, "expected a sum metric query");
   assert.match(sumQuery, /AggregationTemporality = 2/);
   assert.match(sumQuery, /IsMonotonic/);
+  // Per-sample increase (delta) from the cumulative value.
   assert.match(sumQuery, /lagInFrame\(toNullable\(Value\), 1, NULL\)/);
   assert.match(sumQuery, /Value - previous_value/);
+  // First sample of a series has no predecessor: only count it if the series
+  // actually started inside the window.
   assert.match(sumQuery, /StartTimeUnix >= now\(\) - INTERVAL 1 HOUR/);
+  // The increase is spread over the wall-clock interval (prev sample -> this
+  // sample) by weighting each render bucket's overlap with that interval —
+  // this is what removes the "comb" when the step is finer than the export
+  // interval. Needs the previous sample's timestamp and an overlap weight.
+  assert.match(sumQuery, /lagInFrame\(TimeUnix, 1, TimeUnix\)/);
+  assert.match(sumQuery, /ARRAY JOIN spread/);
+  assert.match(sumQuery, /least\(b, g \+ 60\) - greatest\(a, g\)/);
+  assert.match(sumQuery, /\/ dt/);
+  // Non-cumulative / non-monotonic points are still summed as-is.
   assert.match(sumQuery, /NOT \(AggregationTemporality = 2 AND IsMonotonic\)/);
   assert.match(sumQuery, /Attributes\[\{groupKey:String\}\] AS group_key/);
   assert.equal(queries.length, 4);

--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -276,7 +276,10 @@ test("metricSeries spreads cumulative monotonic sum increases across the interva
   // interval. Needs the previous sample's timestamp and an overlap weight.
   assert.match(sumQuery, /lagInFrame\(TimeUnix, 1, TimeUnix\)/);
   assert.match(sumQuery, /ARRAY JOIN spread/);
-  assert.match(sumQuery, /least\(b, g \+ 60\) - greatest\(a, g\)/);
+  // Interval math is in nanoseconds (1 MINUTE step = 60e9 ns) so sub-second
+  // sample intervals aren't quantized away.
+  assert.match(sumQuery, /toUnixTimestamp64Nano\(prev_time\)/);
+  assert.match(sumQuery, /least\(b, g \+ 60000000000\) - greatest\(a, g\)/);
   assert.match(sumQuery, /\/ dt/);
   // Non-cumulative / non-monotonic points are still summed as-is.
   assert.match(sumQuery, /NOT \(AggregationTemporality = 2 AND IsMonotonic\)/);

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -815,6 +815,23 @@ function histogramQuantileQuery(args: {
   `;
 }
 
+// Cumulative monotonic counters (OTel temporality=2, IsMonotonic) report a
+// running total per series. To chart them we need the *increase* per render
+// bucket. The naive approach — diff consecutive samples and drop each diff into
+// the single bucket the later sample lands in — produces a "comb" whenever the
+// render step is finer than the export interval: every bucket without a sample
+// renders as zero, so a 60s-exported counter drawn at a 30s step alternates
+// full/empty bars that read as two interleaved series.
+//
+// Instead we spread each sample's increase across the wall-clock interval it
+// actually covers (previous sample -> this sample), à la Prometheus rate(),
+// weighting by how much each render bucket overlaps that interval. A 60s
+// increase straddling two 30s buckets contributes ~half to each, so the series
+// is continuous. The spread is conservative: the weights for one interval sum
+// to its full duration, so the total increase over the range is unchanged —
+// only its distribution across buckets is smoothed. When the step is coarser
+// than the export interval the whole interval lands in one bucket and this
+// collapses back to the plain per-bucket delta.
 function cumulativeMonotonicSumQuery(args: {
   table: string;
   step: Step;
@@ -824,6 +841,7 @@ function cumulativeMonotonicSumQuery(args: {
 }): string {
   const { table, step, groupExpr, conds, sinceExpr } = args;
   const where = conds.join(" AND ");
+  const stepSec = stepSeconds(step);
   return `
     SELECT
       bucket,
@@ -831,41 +849,67 @@ function cumulativeMonotonicSumQuery(args: {
       sum(v) AS v
     FROM (
       SELECT
-        toString(toStartOfInterval(TimeUnix, INTERVAL ${step.n} ${step.unit})) AS bucket,
+        toString(toStartOfInterval(toDateTime(sp.1), INTERVAL ${step.n} ${step.unit})) AS bucket,
         group_key,
-        if(
-          previous_value IS NULL,
-          if(StartTimeUnix >= ${sinceExpr}, Value, 0),
-          if(Value >= previous_value, Value - previous_value, 0)
-        ) AS v
+        sp.2 AS v
       FROM (
         SELECT
-          TimeUnix,
-          StartTimeUnix,
-          Value,
-          ${groupExpr} AS group_key,
-          lagInFrame(toNullable(Value), 1, NULL) OVER (
-            PARTITION BY series_key
-            ORDER BY TimeUnix ASC
-            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-          ) AS previous_value
+          group_key,
+          if(
+            previous_value IS NULL,
+            -- First sample of a series: no interval to spread over. Only count
+            -- it when the series started inside the window, dropped into the
+            -- bucket the sample lands in.
+            [ tuple(intDiv(b, ${stepSec}) * ${stepSec}, if(StartTimeUnix >= ${sinceExpr}, Value, 0)) ],
+            -- Spread the increase across every step-aligned bucket the interval
+            -- (a, b] touches, weighted by overlap seconds / interval seconds.
+            arrayMap(
+              g -> tuple(g, delta * (least(b, g + ${stepSec}) - greatest(a, g)) / dt),
+              arrayMap(
+                i -> first_bucket + i * ${stepSec},
+                range(toUInt32(intDiv(intDiv(b - 1, ${stepSec}) * ${stepSec} - first_bucket, ${stepSec}) + 1))
+              )
+            )
+          ) AS spread
         FROM (
           SELECT
-            *,
-            cityHash64(
-              ServiceName,
-              MetricName,
-              MetricUnit,
-              toString(ResourceAttributes),
-              toString(Attributes),
-              toString(StartTimeUnix)
-            ) AS series_key
-          FROM ${table}
-          WHERE ${where}
-            AND AggregationTemporality = 2
-            AND IsMonotonic
+            group_key,
+            StartTimeUnix,
+            Value,
+            previous_value,
+            if(Value >= previous_value, Value - previous_value, 0) AS delta,
+            toUnixTimestamp(prev_time) AS a,
+            toUnixTimestamp(TimeUnix) AS b,
+            greatest(toUnixTimestamp(TimeUnix) - toUnixTimestamp(prev_time), 1) AS dt,
+            intDiv(toUnixTimestamp(prev_time), ${stepSec}) * ${stepSec} AS first_bucket
+          FROM (
+            SELECT
+              TimeUnix,
+              StartTimeUnix,
+              Value,
+              ${groupExpr} AS group_key,
+              lagInFrame(toNullable(Value), 1, NULL) OVER series AS previous_value,
+              lagInFrame(TimeUnix, 1, TimeUnix) OVER series AS prev_time
+            FROM ${table}
+            WHERE ${where}
+              AND AggregationTemporality = 2
+              AND IsMonotonic
+            WINDOW series AS (
+              PARTITION BY cityHash64(
+                ServiceName,
+                MetricName,
+                MetricUnit,
+                toString(ResourceAttributes),
+                toString(Attributes),
+                toString(StartTimeUnix)
+              )
+              ORDER BY TimeUnix ASC
+              ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            )
+          )
         )
       )
+      ARRAY JOIN spread AS sp
 
       UNION ALL
 

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -841,7 +841,11 @@ function cumulativeMonotonicSumQuery(args: {
 }): string {
   const { table, step, groupExpr, conds, sinceExpr } = args;
   const where = conds.join(" AND ");
-  const stepSec = stepSeconds(step);
+  // Bucket arithmetic is done in nanoseconds (TimeUnix is DateTime64) so that
+  // sub-second sample intervals aren't quantized away — truncating to whole
+  // seconds can collapse a short interval to zero duration and silently drop
+  // its increase.
+  const stepNs = stepSeconds(step) * 1_000_000_000;
   return `
     SELECT
       bucket,
@@ -849,7 +853,7 @@ function cumulativeMonotonicSumQuery(args: {
       sum(v) AS v
     FROM (
       SELECT
-        toString(toStartOfInterval(toDateTime(sp.1), INTERVAL ${step.n} ${step.unit})) AS bucket,
+        toString(toStartOfInterval(toDateTime(intDiv(sp.1, 1000000000)), INTERVAL ${step.n} ${step.unit})) AS bucket,
         group_key,
         sp.2 AS v
       FROM (
@@ -860,14 +864,14 @@ function cumulativeMonotonicSumQuery(args: {
             -- First sample of a series: no interval to spread over. Only count
             -- it when the series started inside the window, dropped into the
             -- bucket the sample lands in.
-            [ tuple(intDiv(b, ${stepSec}) * ${stepSec}, if(StartTimeUnix >= ${sinceExpr}, Value, 0)) ],
+            [ tuple(intDiv(b, ${stepNs}) * ${stepNs}, if(StartTimeUnix >= ${sinceExpr}, Value, 0)) ],
             -- Spread the increase across every step-aligned bucket the interval
-            -- (a, b] touches, weighted by overlap seconds / interval seconds.
+            -- (a, b] touches, weighted by overlap nanos / interval nanos.
             arrayMap(
-              g -> tuple(g, delta * (least(b, g + ${stepSec}) - greatest(a, g)) / dt),
+              g -> tuple(g, delta * (least(b, g + ${stepNs}) - greatest(a, g)) / dt),
               arrayMap(
-                i -> first_bucket + i * ${stepSec},
-                range(toUInt32(intDiv(intDiv(b - 1, ${stepSec}) * ${stepSec} - first_bucket, ${stepSec}) + 1))
+                i -> first_bucket + i * ${stepNs},
+                range(toUInt32(intDiv(intDiv(b - 1, ${stepNs}) * ${stepNs} - first_bucket, ${stepNs}) + 1))
               )
             )
           ) AS spread
@@ -878,10 +882,10 @@ function cumulativeMonotonicSumQuery(args: {
             Value,
             previous_value,
             if(Value >= previous_value, Value - previous_value, 0) AS delta,
-            toUnixTimestamp(prev_time) AS a,
-            toUnixTimestamp(TimeUnix) AS b,
-            greatest(toUnixTimestamp(TimeUnix) - toUnixTimestamp(prev_time), 1) AS dt,
-            intDiv(toUnixTimestamp(prev_time), ${stepSec}) * ${stepSec} AS first_bucket
+            toUnixTimestamp64Nano(prev_time) AS a,
+            toUnixTimestamp64Nano(TimeUnix) AS b,
+            greatest(toUnixTimestamp64Nano(TimeUnix) - toUnixTimestamp64Nano(prev_time), 1) AS dt,
+            intDiv(toUnixTimestamp64Nano(prev_time), ${stepNs}) * ${stepNs} AS first_bucket
           FROM (
             SELECT
               TimeUnix,


### PR DESCRIPTION
## Problem

When a cumulative monotonic counter (OTel `AggregationTemporality=2`, `IsMonotonic`) is exported less frequently than a metric chart's render step — e.g. a counter exported every 60s drawn at a 30s bucket — the chart shows a **comb**: every other bar is full height and the bars in between are empty. Visually it reads as two interleaved series.

Root cause: `metricSeries` (`apps/api/src/mcp/clickhouse.ts`) diffed consecutive samples into a per-bucket increase and dropped each diff into the **single** bucket the later sample landed in. Buckets with no sample render as zero. `pickStep` happily chooses a step finer than the export interval (e.g. 30s for a ~1h range), so half the buckets are always empty.

## Fix

Spread each sample's increase across the wall-clock interval it actually covers (previous sample → this sample), à la Prometheus `rate()`, weighting by how much each render bucket overlaps that interval:

- A 60s increase straddling two 30s buckets contributes ~half to each → continuous line, no comb.
- The overlap weights for one interval sum to its full duration, so the **total increase over the range is unchanged** — only its distribution across buckets is smoothed.
- When the step is **coarser** than the export interval the whole interval lands in one bucket, so this collapses back to the plain per-bucket delta (with more correct handling of intervals that straddle a bucket boundary).
- Self-adapting: it uses each sample's real inter-sample gap as the window, so it works for any export cadence without hardcoding an interval.

The non-monotonic / delta-temporality branch is unchanged.

## Verification

Validated the generated query against real metric data:

- Comb gone at a 30s step — adjacent buckets now carry ~equal values.
- Total over the window preserved to within ~0.04% of the raw per-sample delta sum (the remainder is intervals straddling the window's start/end bound).
- Coarse step (5m) matches the plain per-bucket delta on interior buckets.

Updated the `metricSeries` unit test to assert the interval-spread constructs (`ARRAY JOIN spread`, overlap weighting, division by interval duration).