### PR TITLE
worker: auto-discover background jobs from a jobs/ folder

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -9,6 +9,7 @@
     "start": "tsx --import ./tracing.ts src/index.ts",
     "backfill:issue-activity-daily": "tsx scripts/backfill-issue-activity-daily.ts",
     "seed:worker-telemetry-dashboard": "tsx scripts/seed-worker-telemetry-dashboard.ts",
+    "test:jobs-loader": "tsx --test src/jobs.test.ts",
     "test:git-auth-no-argv": "tsx scripts/test-git-auth-no-argv.ts",
     "test:patch-normalization": "tsx scripts/test-patch-normalization.ts",
     "test:slack-pinning": "tsx --test src/slack-pinning.test.ts",

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -4,6 +4,7 @@ import { db } from "@superlog/db";
 import { initAiUsageSink } from "./ai-usage.js";
 import { createUsageMeterTicker } from "./billing/usage-meter-ticker.js";
 import { handleIssueTransition } from "./incidents/workflow.js";
+import { loadJobs } from "./jobs.js";
 import { logger } from "./logger.js";
 import { registerDatastoreObservability } from "./observability/datastores.js";
 import { createTelemetryIngestor, registerTelemetryIngestMetrics } from "./telemetry/ingest.js";
@@ -46,7 +47,15 @@ registerTelemetryIngestMetrics({
 });
 
 const usageMeter = createUsageMeterTicker({ db, clickhouse: ch });
-const tick = createWorkerTick({ clickhouse: ch, telemetryIngestor, usageMeter });
+
+// Discover and register background jobs from the jobs dir. Empty by default
+// (stock builds register nothing); deployments overlay extra job files in.
+const extraJobs = await loadJobs({ db, clickhouse: ch });
+if (extraJobs.length > 0) {
+  logger.info({ scope: "boot", jobs: extraJobs.map((j) => j.name) }, "background jobs registered");
+}
+
+const tick = createWorkerTick({ clickhouse: ch, telemetryIngestor, usageMeter, extraJobs });
 
 runWorker({ pollIntervalMs: POLL_INTERVAL_MS, batchSize: BATCH_SIZE, tick }).catch((err) => {
   logger.fatal({ err }, "worker crashed");

--- a/apps/worker/src/jobs-fixtures/disabled.ts
+++ b/apps/worker/src/jobs-fixtures/disabled.ts
@@ -1,0 +1,8 @@
+import type { JobDefinition } from "../jobs.js";
+
+// A job that opts out at create() time (e.g. a required env var / API key is
+// absent). The loader must skip it rather than register a no-op ticker.
+export const job: JobDefinition = {
+  name: "fixture.disabled",
+  create: () => null,
+};

--- a/apps/worker/src/jobs-fixtures/ignored.test.ts
+++ b/apps/worker/src/jobs-fixtures/ignored.test.ts
@@ -1,0 +1,9 @@
+import type { JobDefinition } from "../jobs.js";
+
+// A `*.test.ts` file that happens to export a job. The loader must NOT pick it
+// up — test files are not jobs. (Intentionally registers no node:test cases so
+// it is inert if a future glob test runner ever discovers it.)
+export const job: JobDefinition = {
+  name: "fixture.ignored-test",
+  create: () => async () => 1,
+};

--- a/apps/worker/src/jobs-fixtures/no-job-export.ts
+++ b/apps/worker/src/jobs-fixtures/no-job-export.ts
@@ -1,0 +1,3 @@
+// A module in the jobs dir that does not export a `job`. The loader must skip
+// it (and warn) rather than crash.
+export const notAJob = 1;

--- a/apps/worker/src/jobs-fixtures/throws-on-create.ts
+++ b/apps/worker/src/jobs-fixtures/throws-on-create.ts
@@ -1,0 +1,10 @@
+import type { JobDefinition } from "../jobs.js";
+
+// create() throws. A single broken job must not take down worker boot — the
+// loader logs and skips it, and the rest still load.
+export const job: JobDefinition = {
+  name: "fixture.throws",
+  create: () => {
+    throw new Error("boom");
+  },
+};

--- a/apps/worker/src/jobs-fixtures/valid.ts
+++ b/apps/worker/src/jobs-fixtures/valid.ts
@@ -1,0 +1,7 @@
+import type { JobDefinition } from "../jobs.js";
+
+// A normal job: create() returns a ticker that reports a fixed count.
+export const job: JobDefinition = {
+  name: "fixture.valid",
+  create: () => async () => 7,
+};

--- a/apps/worker/src/jobs.test.ts
+++ b/apps/worker/src/jobs.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { type JobDeps, loadJobs } from "./jobs.js";
+
+// Deps are injected into each job's create(); the fixtures ignore them, so a
+// bare stub is enough to exercise the loader.
+const deps = {} as unknown as JobDeps;
+
+const fixturesDir = new URL("./jobs-fixtures/", import.meta.url);
+
+test("loads every valid job file and returns its ticker", async () => {
+  const jobs = await loadJobs(deps, { dir: fixturesDir });
+  const valid = jobs.find((j) => j.name === "fixture.valid");
+  assert.ok(valid, "expected the valid fixture job to be registered");
+  assert.equal(await valid.tick(), 7);
+});
+
+test("skips a job whose create() returns null (opted out)", async () => {
+  const jobs = await loadJobs(deps, { dir: fixturesDir });
+  assert.equal(
+    jobs.some((j) => j.name === "fixture.disabled"),
+    false,
+  );
+});
+
+test("skips a job whose create() throws, without failing the load", async () => {
+  const jobs = await loadJobs(deps, { dir: fixturesDir });
+  // The valid job still loads even though throws-on-create.ts blew up.
+  assert.ok(jobs.some((j) => j.name === "fixture.valid"));
+  assert.equal(
+    jobs.some((j) => j.name === "fixture.throws"),
+    false,
+  );
+});
+
+test("skips files that do not export a job", async () => {
+  const jobs = await loadJobs(deps, { dir: fixturesDir });
+  // no-job-export.ts contributes nothing; loader does not throw.
+  assert.ok(Array.isArray(jobs));
+});
+
+test("ignores *.test.ts files even if they export a job", async () => {
+  const jobs = await loadJobs(deps, { dir: fixturesDir });
+  assert.equal(
+    jobs.some((j) => j.name === "fixture.ignored-test"),
+    false,
+  );
+});
+
+test("returns an empty list when the jobs dir does not exist", async () => {
+  const jobs = await loadJobs(deps, {
+    dir: new URL("./jobs-fixtures-does-not-exist/", import.meta.url),
+  });
+  assert.deepEqual(jobs, []);
+});
+
+test("loads jobs in a deterministic (filename-sorted) order", async () => {
+  const a = await loadJobs(deps, { dir: fixturesDir });
+  const b = await loadJobs(deps, { dir: fixturesDir });
+  assert.deepEqual(
+    a.map((j) => j.name),
+    b.map((j) => j.name),
+  );
+});

--- a/apps/worker/src/jobs.ts
+++ b/apps/worker/src/jobs.ts
@@ -1,0 +1,104 @@
+// Background-job registry. The worker runs a fixed set of built-in ticks
+// (telemetry ingest, alerts, digests, …) from worker/tick.ts; this module adds
+// a convention-over-configuration way to contribute *additional* recurring
+// jobs: drop a file in ./jobs/ that exports a `job`, and it gets picked up at
+// boot and run inside the same tick loop.
+//
+// The point of the folder convention is the build seam. A stock checkout ships
+// whatever jobs live in ./jobs/ here; a deployment can overlay extra job files
+// into that same directory at image-build time (the way the managed-agent
+// runtime and AI-usage sink are overlaid) without this repo having to name or
+// know about them. An empty ./jobs/ dir — the default — registers nothing, so
+// stock builds are unaffected.
+
+import { readdir } from "node:fs/promises";
+import type { ClickHouseClient } from "@clickhouse/client";
+import type { DB } from "@superlog/db";
+import { logger } from "./logger.js";
+
+// A job's unit of work: run a slice, return how many items it processed (0 when
+// it had nothing to do — e.g. an interval-gated job between runs). Mirrors the
+// built-in tick functions so jobs slot into the same `safe()` loop.
+export type JobTick = () => Promise<number>;
+
+// Everything a job might need to do its work. Kept deliberately small; widen it
+// only when a real job needs more.
+export type JobDeps = {
+  db: DB;
+  clickhouse: Pick<ClickHouseClient, "query">;
+};
+
+// A registered, ready-to-run job.
+export type Job = {
+  name: string;
+  tick: JobTick;
+};
+
+// The shape each file in the jobs dir exports as `job`. create() receives the
+// shared deps and returns a ticker — or null to opt out (e.g. a required API
+// key is absent), in which case the loader skips it entirely.
+export type JobDefinition = {
+  name: string;
+  create: (deps: JobDeps) => JobTick | null | Promise<JobTick | null>;
+};
+
+type JobModule = { job?: unknown };
+
+const DEFAULT_JOBS_DIR = new URL("./jobs/", import.meta.url);
+
+function isJobFile(name: string): boolean {
+  if (name.endsWith(".d.ts")) return false;
+  if (name.endsWith(".test.ts") || name.endsWith(".test.js")) return false;
+  return name.endsWith(".ts") || name.endsWith(".js");
+}
+
+function isJobDefinition(value: unknown): value is JobDefinition {
+  if (!value || typeof value !== "object") return false;
+  const def = value as Partial<JobDefinition>;
+  return typeof def.name === "string" && typeof def.create === "function";
+}
+
+// Scan the jobs directory, import each job file, and return the tickers of the
+// jobs that opted in. Resilient by design: a missing directory yields an empty
+// list, and a file that fails to import / throws in create() / exports no valid
+// job is logged and skipped so one bad job can never take down worker boot.
+export async function loadJobs(deps: JobDeps, options: { dir?: URL } = {}): Promise<Job[]> {
+  const dir = options.dir ?? DEFAULT_JOBS_DIR;
+
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+
+  const files = entries.filter(isJobFile).sort();
+  const jobs: Job[] = [];
+
+  for (const file of files) {
+    const specifier = new URL(file, dir).href;
+    try {
+      const mod = (await import(specifier)) as JobModule;
+      if (!isJobDefinition(mod.job)) {
+        logger.warn({ scope: "jobs.load", file }, "jobs dir file exports no valid `job`; skipping");
+        continue;
+      }
+      const def = mod.job;
+      const tick = await def.create(deps);
+      if (!tick) {
+        logger.info({ scope: "jobs.load", job: def.name }, "job opted out at create(); skipping");
+        continue;
+      }
+      jobs.push({ name: def.name, tick });
+      logger.info({ scope: "jobs.load", job: def.name }, "registered background job");
+    } catch (err) {
+      logger.error(
+        { scope: "jobs.load", file, err: err instanceof Error ? err.message : String(err) },
+        "failed to load background job; skipping",
+      );
+    }
+  }
+
+  return jobs;
+}

--- a/apps/worker/src/jobs/README.md
+++ b/apps/worker/src/jobs/README.md
@@ -1,0 +1,32 @@
+# Background jobs
+
+Files in this directory are auto-discovered at worker boot by `loadJobs()` in
+`../jobs.ts` and run inside the main tick loop (`../worker/tick.ts`), alongside
+the built-in ticks (telemetry ingest, alerts, digests, …).
+
+To add a job, drop a file here that exports a `job`:
+
+```ts
+import type { JobDefinition } from "../jobs.js";
+
+export const job: JobDefinition = {
+  name: "my-thing.sync",
+  // Receives shared deps; return a ticker, or null to opt out (e.g. a required
+  // env var is missing). The ticker returns how many items it processed (0 when
+  // it had nothing to do — interval-gate inside the ticker if it should not run
+  // every poll).
+  create: ({ db, clickhouse }) => createMyTicker({ db, clickhouse }),
+};
+```
+
+Rules the loader enforces:
+
+- `*.test.ts` and `*.d.ts` files are ignored.
+- A file that fails to import, throws in `create()`, or exports no valid `job`
+  is logged and skipped — one bad job never blocks worker boot.
+- Files load in filename-sorted order.
+
+This is a build seam as much as a convention: a deployment can overlay
+additional job files into this directory at image-build time without this
+repository having to know about them, the same way the managed-agent runtime
+and AI-usage sink are overlaid.

--- a/apps/worker/src/worker/tick.ts
+++ b/apps/worker/src/worker/tick.ts
@@ -4,6 +4,7 @@ import { tickAlerts } from "../alerts.js";
 import { tickAutorecovery } from "../autorecovery.js";
 import { tickDigests } from "../digest.js";
 import { handleIssueTransition } from "../incidents/workflow.js";
+import type { Job } from "../jobs.js";
 import { logger } from "../logger.js";
 import type { TelemetryIngestor } from "../telemetry/ingest.js";
 import { tickWebhooks } from "../webhooks.js";
@@ -21,12 +22,18 @@ export type WorkerTickResult = {
   webhooks: number;
   autorecoveryProposals: number;
   usageReported: number;
+  // Total items processed across all registered background jobs (see jobs.ts).
+  jobsReported: number;
 };
 
 export function createWorkerTick(opts: {
   clickhouse: ClickHouseClientLike;
   telemetryIngestor: TelemetryIngestor;
   usageMeter?: (() => Promise<number>) | null;
+  // Extra jobs discovered from the jobs dir at boot. Each runs through the same
+  // `safe()` wrapper as the built-in steps, so one failing job is logged and
+  // skipped rather than aborting the tick.
+  extraJobs?: Job[];
 }): () => Promise<WorkerTickResult> {
   return () =>
     tracer.startActiveSpan("worker.tick", async (span) => {
@@ -70,6 +77,12 @@ export function createWorkerTick(opts: {
         const usageReported = opts.usageMeter
           ? await safe("usage_metering", opts.usageMeter, 0)
           : 0;
+        let jobsReported = 0;
+        for (const job of opts.extraJobs ?? []) {
+          const processed = await safe(`job:${job.name}`, job.tick, 0);
+          span.setAttribute(`tick.job.${job.name}`, processed);
+          jobsReported += processed;
+        }
         span.setAttribute("tick.spans", spans);
         span.setAttribute("tick.logs", logs);
         span.setAttribute("tick.agent_runs", agentRuns);
@@ -78,6 +91,7 @@ export function createWorkerTick(opts: {
         span.setAttribute("tick.webhooks", webhooks);
         span.setAttribute("tick.autorecovery_proposals", autorecoveryProposals);
         span.setAttribute("tick.usage_reported", usageReported);
+        span.setAttribute("tick.jobs_reported", jobsReported);
         return {
           spans,
           logs,
@@ -87,6 +101,7 @@ export function createWorkerTick(opts: {
           webhooks,
           autorecoveryProposals,
           usageReported,
+          jobsReported,
         };
       } catch (err) {
         span.recordException(err as Error);


### PR DESCRIPTION
## What

Adds a convention-over-configuration registry for recurring background work in the worker.

`loadJobs()` (`apps/worker/src/jobs.ts`) scans `apps/worker/src/jobs/` at boot, imports each file that exports a `job`, calls its `create(deps)`, and runs the returned tickers inside the existing worker tick loop (`worker/tick.ts`) alongside the built-in steps (telemetry ingest, alerts, digests, …).

## Why

The worker already has an in-process scheduler — a tight poll loop that fans out to a fixed list of ticks. Adding a new recurring job meant editing that list by hand. This makes "add a job" mean "drop a file in `jobs/`", which is also a clean extension seam: a deployment can layer additional job files into that directory at image-build time without this repo having to know about them, the same way the managed-agent runtime and AI-usage sink are layered in.

## Contract

Each job file exports:

```ts
export const job: JobDefinition = {
  name: "my-thing.sync",
  create: ({ db, clickhouse }) => createMyTicker(...), // ticker, or null to opt out
};
```

The loader is deliberately resilient:

- A missing `jobs/` dir yields no jobs.
- A file that fails to import, throws in `create()`, or exports no valid `job` is logged and **skipped** — one bad job can never block worker boot.
- `*.test.ts` / `*.d.ts` are ignored; files load in filename-sorted order.
- `create()` returning `null` (e.g. a required env var is absent) skips the job rather than registering a no-op.

Each job's tick runs through the same `safe()` wrapper as the built-ins and reports a per-job span attribute plus a `tick.jobs_reported` total.

A stock build ships an empty `jobs/` dir (just a README), so nothing is registered by default — behaviour is unchanged unless a job file is present.

## Tests

`src/jobs.test.ts` (run via `pnpm --filter @superlog/worker test:jobs-loader`) covers: loading valid jobs, opt-out via `null`, a throwing file being skipped without failing the load, files with no job export, `*.test.ts` skipping, a missing dir returning `[]`, and deterministic ordering.