### PR TITLE
proxy/api: widen HTTP keep-alive margin over the LB idle timeout

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2747,10 +2747,11 @@ const server = serve({ fetch: app.fetch, port: PORT });
 // Same load-balancer keep-alive concern as the proxy: Node's default 5s
 // keepAliveTimeout lets it close idle sockets an upstream LB (typically ~60s
 // idle timeout) still pools, so reused connections RST and surface as a 502
-// even though the app is healthy. Keep the keep-alive above the LB idle
-// timeout, with headersTimeout above keepAliveTimeout per Node's required order.
+// even though the app is healthy. Keep the keep-alive comfortably above the LB
+// idle timeout — a thin margin still leaks 502s under bursty connection reuse —
+// with headersTimeout above keepAliveTimeout per Node's required order.
 if ("keepAliveTimeout" in server) {
-  server.keepAliveTimeout = 65_000;
-  server.headersTimeout = 66_000;
+  server.keepAliveTimeout = 75_000;
+  server.headersTimeout = 76_000;
 }
 logger.info({ port: PORT }, "superlog api listening");

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -417,12 +417,14 @@ const server = serve({ fetch: app.fetch, port: PORT });
 // default 5s keepAliveTimeout closes idle keep-alive sockets the balancer still
 // considers pooled; reusing one then gets a RST and surfaces as a 502 to the
 // client even though the app returned 200. Periodic OTLP metric exporters
-// (default ~60s interval) hit this race the hardest. Keep the keep-alive above
-// the balancer idle timeout, and headersTimeout above keepAliveTimeout per
-// Node's required ordering.
+// (default ~60s interval) hit this race the hardest. Keep the keep-alive
+// comfortably above the balancer idle timeout: a thin (~5s) margin still leaks
+// 502s in bursts where many wall-clock-aligned exporters reuse pooled sockets at
+// once and the event loop is briefly busy, so we keep a wide margin. headersTimeout
+// stays above keepAliveTimeout per Node's required ordering.
 if ("keepAliveTimeout" in server) {
-  server.keepAliveTimeout = 65_000;
-  server.headersTimeout = 66_000;
+  server.keepAliveTimeout = 75_000;
+  server.headersTimeout = 76_000;
 }
 if (ingestQueue && ingestQueueConfig?.consumerEnabled) {
   ingestQueue.startConsumer(COLLECTOR_URL);


### PR DESCRIPTION
Both the proxy and api set `keepAliveTimeout = 65s` (`headersTimeout 66s`) so Node does not close idle keep-alive sockets that an upstream load balancer (typically a 60s idle timeout) still considers pooled — the classic reused-socket RST that the balancer surfaces as a `502` even though the app responded fine.

## Problem

A ~5s margin is too thin in practice. Under bursts where many wall-clock-aligned clients (e.g. OTLP exporters flushing on the same ~60s interval) reuse pooled sockets at the same instant and the event loop is briefly busy, a slice of those reuses still races the socket close and the load balancer emits `502 Bad Gateway`. We observe this as a recurring, self-recovering burst of LB-generated 502s clustered at the top of each hour, with zero target-side 5xx and healthy, non-saturated tasks (CPU well under target). OTLP exporters retry on 502 so no data is lost, but delivery lags.

## Fix

Widen the margin to `keepAliveTimeout = 75s` / `headersTimeout = 76s` on both servers, so the load balancer (60s idle) always closes an idle connection before Node does and the reuse race window closes. Node still requires `headersTimeout > keepAliveTimeout`, preserved here.

No behavior change for healthy request/response flow; this only affects when an *idle* pooled socket is torn down.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased HTTP keep-alive timeouts in the proxy and API to sit safely above the LB’s 60s idle timeout and stop periodic 502s from reused idle sockets. This only changes when idle keep-alive connections are closed.

- **Bug Fixes**
  - Set `server.keepAliveTimeout` to 75_000 and `headersTimeout` to 76_000 in `apps/proxy` and `apps/api`.
  - Ensures the LB closes idle connections before Node, eliminating the reuse race that caused bursty 502s during synchronized client flushes.

<sup>Written for commit 90c51005c847f5e4615018722b5f3fd47027d308. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

