### PR TITLE
worker: schedule background jobs with pg-boss, out of the tick loop

### DIFF
--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,5 +1,6 @@
 # Build context: repo root. Build with `docker build -f apps/worker/Dockerfile .`
-FROM node:20-slim
+# Node 22 (LTS): required by pg-boss v12, which backs the background job runner.
+FROM node:22-slim
 
 WORKDIR /app
 

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -10,6 +10,7 @@
     "backfill:issue-activity-daily": "tsx scripts/backfill-issue-activity-daily.ts",
     "seed:worker-telemetry-dashboard": "tsx scripts/seed-worker-telemetry-dashboard.ts",
     "test:jobs-loader": "tsx --test src/jobs.test.ts",
+    "test:jobs-runner": "tsx --test src/jobs/runner.test.ts",
     "test:git-auth-no-argv": "tsx scripts/test-git-auth-no-argv.ts",
     "test:patch-normalization": "tsx scripts/test-patch-normalization.ts",
     "test:slack-pinning": "tsx --test src/slack-pinning.test.ts",
@@ -54,7 +55,11 @@
     "@superlog/fingerprint": "workspace:*",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
+    "pg-boss": "^12.0.0",
     "pino": "^10.3.1"
+  },
+  "engines": {
+    "node": ">=22.12.0"
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.2.17",

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -4,7 +4,7 @@ import { db } from "@superlog/db";
 import { initAiUsageSink } from "./ai-usage.js";
 import { createUsageMeterTicker } from "./billing/usage-meter-ticker.js";
 import { handleIssueTransition } from "./incidents/workflow.js";
-import { loadJobs } from "./jobs.js";
+import { startJobRunner } from "./jobs/runner.js";
 import { logger } from "./logger.js";
 import { registerDatastoreObservability } from "./observability/datastores.js";
 import { createTelemetryIngestor, registerTelemetryIngestMetrics } from "./telemetry/ingest.js";
@@ -47,15 +47,19 @@ registerTelemetryIngestMetrics({
 });
 
 const usageMeter = createUsageMeterTicker({ db, clickhouse: ch });
+const tick = createWorkerTick({ clickhouse: ch, telemetryIngestor, usageMeter });
 
-// Discover and register background jobs from the jobs dir. Empty by default
-// (stock builds register nothing); deployments overlay extra job files in.
-const extraJobs = await loadJobs({ db, clickhouse: ch });
-if (extraJobs.length > 0) {
-  logger.info({ scope: "boot", jobs: extraJobs.map((j) => j.name) }, "background jobs registered");
+// Start the pg-boss background job runner: discovers jobs from the jobs dir and
+// schedules them on their own queues, OUTSIDE this tick loop. A runner failure
+// must not take down telemetry ingest, so it is isolated — log and continue.
+try {
+  await startJobRunner({ db, clickhouse: ch });
+} catch (err) {
+  logger.error(
+    { scope: "boot", err: err instanceof Error ? err.message : String(err) },
+    "background job runner failed to start; continuing without it",
+  );
 }
-
-const tick = createWorkerTick({ clickhouse: ch, telemetryIngestor, usageMeter, extraJobs });
 
 runWorker({ pollIntervalMs: POLL_INTERVAL_MS, batchSize: BATCH_SIZE, tick }).catch((err) => {
   logger.fatal({ err }, "worker crashed");

--- a/apps/worker/src/jobs-fixtures/disabled.ts
+++ b/apps/worker/src/jobs-fixtures/disabled.ts
@@ -4,5 +4,6 @@ import type { JobDefinition } from "../jobs.js";
 // absent). The loader must skip it rather than register a no-op ticker.
 export const job: JobDefinition = {
   name: "fixture.disabled",
+  schedule: "*/5 * * * *",
   create: () => null,
 };

--- a/apps/worker/src/jobs-fixtures/ignored.test.ts
+++ b/apps/worker/src/jobs-fixtures/ignored.test.ts
@@ -5,5 +5,6 @@ import type { JobDefinition } from "../jobs.js";
 // it is inert if a future glob test runner ever discovers it.)
 export const job: JobDefinition = {
   name: "fixture.ignored-test",
-  create: () => async () => 1,
+  schedule: "*/5 * * * *",
+  create: () => async () => {},
 };

--- a/apps/worker/src/jobs-fixtures/throws-on-create.ts
+++ b/apps/worker/src/jobs-fixtures/throws-on-create.ts
@@ -4,6 +4,7 @@ import type { JobDefinition } from "../jobs.js";
 // loader logs and skips it, and the rest still load.
 export const job: JobDefinition = {
   name: "fixture.throws",
+  schedule: "*/5 * * * *",
   create: () => {
     throw new Error("boom");
   },

--- a/apps/worker/src/jobs-fixtures/valid.ts
+++ b/apps/worker/src/jobs-fixtures/valid.ts
@@ -1,7 +1,11 @@
 import type { JobDefinition } from "../jobs.js";
 
-// A normal job: create() returns a ticker that reports a fixed count.
+// A normal job: create() returns a handler. Records that it ran via a global so
+// the test can assert invocation.
 export const job: JobDefinition = {
   name: "fixture.valid",
-  create: () => async () => 7,
+  schedule: "*/5 * * * *",
+  create: () => async () => {
+    (globalThis as Record<string, unknown>).__fixtureValidRan = true;
+  },
 };

--- a/apps/worker/src/jobs.test.ts
+++ b/apps/worker/src/jobs.test.ts
@@ -8,11 +8,14 @@ const deps = {} as unknown as JobDeps;
 
 const fixturesDir = new URL("./jobs-fixtures/", import.meta.url);
 
-test("loads every valid job file and returns its ticker", async () => {
+test("loads every valid job file with its schedule and handler", async () => {
   const jobs = await loadJobs(deps, { dir: fixturesDir });
   const valid = jobs.find((j) => j.name === "fixture.valid");
   assert.ok(valid, "expected the valid fixture job to be registered");
-  assert.equal(await valid.tick(), 7);
+  assert.equal(valid.schedule, "*/5 * * * *");
+  assert.equal(typeof valid.handler, "function");
+  await valid.handler();
+  assert.equal((globalThis as Record<string, unknown>).__fixtureValidRan, true);
 });
 
 test("skips a job whose create() returns null (opted out)", async () => {

--- a/apps/worker/src/jobs.ts
+++ b/apps/worker/src/jobs.ts
@@ -1,25 +1,17 @@
-// Background-job registry. The worker runs a fixed set of built-in ticks
-// (telemetry ingest, alerts, digests, …) from worker/tick.ts; this module adds
-// a convention-over-configuration way to contribute *additional* recurring
-// jobs: drop a file in ./jobs/ that exports a `job`, and it gets picked up at
-// boot and run inside the same tick loop.
+// Background-job discovery. Files in the jobs dir (./jobs/) that export a `job`
+// are picked up at boot and scheduled on a pg-boss queue (see jobs/runner.ts),
+// running OUTSIDE the worker tick loop so a long job never blocks telemetry
+// ingest, alerts, or agent-runs.
 //
-// The point of the folder convention is the build seam. A stock checkout ships
-// whatever jobs live in ./jobs/ here; a deployment can overlay extra job files
-// into that same directory at image-build time (the way the managed-agent
-// runtime and AI-usage sink are overlaid) without this repo having to name or
-// know about them. An empty ./jobs/ dir — the default — registers nothing, so
-// stock builds are unaffected.
+// The folder is a build seam as much as a convention: a deployment can overlay
+// extra job files into ./jobs/ at image-build time without this repo having to
+// name or know about them. An empty ./jobs/ dir — the default — schedules
+// nothing, so stock builds are unaffected.
 
 import { readdir } from "node:fs/promises";
 import type { ClickHouseClient } from "@clickhouse/client";
 import type { DB } from "@superlog/db";
 import { logger } from "./logger.js";
-
-// A job's unit of work: run a slice, return how many items it processed (0 when
-// it had nothing to do — e.g. an interval-gated job between runs). Mirrors the
-// built-in tick functions so jobs slot into the same `safe()` loop.
-export type JobTick = () => Promise<number>;
 
 // Everything a job might need to do its work. Kept deliberately small; widen it
 // only when a real job needs more.
@@ -28,18 +20,27 @@ export type JobDeps = {
   clickhouse: Pick<ClickHouseClient, "query">;
 };
 
-// A registered, ready-to-run job.
-export type Job = {
-  name: string;
-  tick: JobTick;
-};
+// The unit of work for a scheduled job: run once per fire. pg-boss owns the
+// schedule, retries, and single-active semantics, so handlers do NOT self-gate
+// or loop — they just do one pass.
+export type JobHandler = () => Promise<void>;
 
-// The shape each file in the jobs dir exports as `job`. create() receives the
-// shared deps and returns a ticker — or null to opt out (e.g. a required API
-// key is absent), in which case the loader skips it entirely.
+// The shape each file in the jobs dir exports as `job`.
 export type JobDefinition = {
   name: string;
-  create: (deps: JobDeps) => JobTick | null | Promise<JobTick | null>;
+  // 5-field cron expression (minute precision); pg-boss checks every 30s.
+  schedule: string;
+  // create() receives the shared deps and returns the handler — or null to opt
+  // out (e.g. a required env var / API key is absent), in which case the job is
+  // skipped entirely.
+  create: (deps: JobDeps) => JobHandler | null | Promise<JobHandler | null>;
+};
+
+// A discovered, ready-to-schedule job.
+export type LoadedJob = {
+  name: string;
+  schedule: string;
+  handler: JobHandler;
 };
 
 type JobModule = { job?: unknown };
@@ -55,14 +56,20 @@ function isJobFile(name: string): boolean {
 function isJobDefinition(value: unknown): value is JobDefinition {
   if (!value || typeof value !== "object") return false;
   const def = value as Partial<JobDefinition>;
-  return typeof def.name === "string" && typeof def.create === "function";
+  return (
+    typeof def.name === "string" &&
+    typeof def.schedule === "string" &&
+    def.schedule.length > 0 &&
+    typeof def.create === "function"
+  );
 }
 
-// Scan the jobs directory, import each job file, and return the tickers of the
-// jobs that opted in. Resilient by design: a missing directory yields an empty
-// list, and a file that fails to import / throws in create() / exports no valid
-// job is logged and skipped so one bad job can never take down worker boot.
-export async function loadJobs(deps: JobDeps, options: { dir?: URL } = {}): Promise<Job[]> {
+// Scan the jobs directory, import each job file, and return the jobs that opted
+// in (create() returned a handler). Resilient by design: a missing directory
+// yields an empty list, and a file that fails to import / throws in create() /
+// exports no valid job is logged and skipped, so one bad job can never block
+// worker boot.
+export async function loadJobs(deps: JobDeps, options: { dir?: URL } = {}): Promise<LoadedJob[]> {
   const dir = options.dir ?? DEFAULT_JOBS_DIR;
 
   let entries: string[];
@@ -74,7 +81,7 @@ export async function loadJobs(deps: JobDeps, options: { dir?: URL } = {}): Prom
   }
 
   const files = entries.filter(isJobFile).sort();
-  const jobs: Job[] = [];
+  const jobs: LoadedJob[] = [];
 
   for (const file of files) {
     const specifier = new URL(file, dir).href;
@@ -85,13 +92,16 @@ export async function loadJobs(deps: JobDeps, options: { dir?: URL } = {}): Prom
         continue;
       }
       const def = mod.job;
-      const tick = await def.create(deps);
-      if (!tick) {
+      const handler = await def.create(deps);
+      if (!handler) {
         logger.info({ scope: "jobs.load", job: def.name }, "job opted out at create(); skipping");
         continue;
       }
-      jobs.push({ name: def.name, tick });
-      logger.info({ scope: "jobs.load", job: def.name }, "registered background job");
+      jobs.push({ name: def.name, schedule: def.schedule, handler });
+      logger.info(
+        { scope: "jobs.load", job: def.name, schedule: def.schedule },
+        "discovered background job",
+      );
     } catch (err) {
       logger.error(
         { scope: "jobs.load", file, err: err instanceof Error ? err.message : String(err) },

--- a/apps/worker/src/jobs/README.md
+++ b/apps/worker/src/jobs/README.md
@@ -1,8 +1,9 @@
 # Background jobs
 
 Files in this directory are auto-discovered at worker boot by `loadJobs()` in
-`../jobs.ts` and run inside the main tick loop (`../worker/tick.ts`), alongside
-the built-in ticks (telemetry ingest, alerts, digests, …).
+`../jobs.ts` and scheduled on their own [pg-boss](https://github.com/timgit/pg-boss)
+queue by `runner.ts` — they run **outside** the worker tick loop, so a long job
+never blocks telemetry ingest, alerts, or agent-runs.
 
 To add a job, drop a file here that exports a `job`:
 
@@ -11,11 +12,14 @@ import type { JobDefinition } from "../jobs.js";
 
 export const job: JobDefinition = {
   name: "my-thing.sync",
-  // Receives shared deps; return a ticker, or null to opt out (e.g. a required
-  // env var is missing). The ticker returns how many items it processed (0 when
-  // it had nothing to do — interval-gate inside the ticker if it should not run
-  // every poll).
-  create: ({ db, clickhouse }) => createMyTicker({ db, clickhouse }),
+  // 5-field cron (minute precision; pg-boss checks schedules every 30s).
+  schedule: "0 */6 * * *",
+  // Receives shared deps; return a handler that does ONE pass, or null to opt
+  // out (e.g. a required env var is missing). pg-boss owns scheduling, retries,
+  // and single-active semantics — handlers do not loop or self-gate.
+  create: ({ db, clickhouse }) => async () => {
+    await doTheWork(db, clickhouse);
+  },
 };
 ```
 
@@ -23,10 +27,22 @@ Rules the loader enforces:
 
 - `*.test.ts` and `*.d.ts` files are ignored.
 - A file that fails to import, throws in `create()`, or exports no valid `job`
-  is logged and skipped — one bad job never blocks worker boot.
+  (needs a `name`, a non-empty `schedule`, and a `create` function) is logged
+  and skipped — one bad job never blocks worker boot.
 - Files load in filename-sorted order.
+
+Each job gets an `exclusive` pg-boss queue (at most one queued-or-active at a
+time), so a slow run never overlaps its next schedule.
 
 This is a build seam as much as a convention: a deployment can overlay
 additional job files into this directory at image-build time without this
 repository having to know about them, the same way the managed-agent runtime
 and AI-usage sink are overlaid.
+
+## Schema / privileges
+
+pg-boss stores its state in a dedicated `pgboss` schema. Creating it requires
+`CREATE` on the database. Local/self-host roles usually have that, so the
+runner self-installs (`migrate: true`). Where the runtime role is DML-only, set
+`PGBOSS_MIGRATE=false` and install/migrate the schema ahead of time as a
+privileged role (e.g. in the same gated step that runs Drizzle migrations).

--- a/apps/worker/src/jobs/runner.test.ts
+++ b/apps/worker/src/jobs/runner.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { LoadedJob } from "../jobs.js";
+import { type JobBoss, registerJobs } from "./runner.js";
+
+type WorkHandler = (jobs: unknown[]) => Promise<unknown>;
+
+function fakeBoss() {
+  const calls: string[] = [];
+  const queues: string[] = [];
+  const schedules: Array<{ name: string; cron: string }> = [];
+  const workers = new Map<string, WorkHandler>();
+  const boss: JobBoss = {
+    async start() {
+      calls.push("start");
+    },
+    async createQueue(name, options) {
+      queues.push(name);
+      calls.push(`createQueue:${name}:${JSON.stringify(options)}`);
+    },
+    async work(name, handler) {
+      workers.set(name, handler);
+      calls.push(`work:${name}`);
+    },
+    async schedule(name, cron) {
+      schedules.push({ name, cron });
+      calls.push(`schedule:${name}:${cron}`);
+    },
+  };
+  return { boss, calls, queues, schedules, workers };
+}
+
+test("registerJobs starts the boss and registers a queue, worker, and cron schedule per job", async () => {
+  const fb = fakeBoss();
+  const jobs: LoadedJob[] = [
+    { name: "a.sync", schedule: "0 */6 * * *", handler: async () => {} },
+    { name: "b.sync", schedule: "*/5 * * * *", handler: async () => {} },
+  ];
+
+  await registerJobs(fb.boss, jobs);
+
+  assert.equal(fb.calls[0], "start", "boss must be started before registration");
+  assert.deepEqual(fb.queues, ["a.sync", "b.sync"]);
+  assert.deepEqual(fb.schedules, [
+    { name: "a.sync", cron: "0 */6 * * *" },
+    { name: "b.sync", cron: "*/5 * * * *" },
+  ]);
+  // Each queue is created exclusive (at most one queued-or-active).
+  assert.ok(fb.calls.includes('createQueue:a.sync:{"policy":"exclusive"}'));
+});
+
+test("the registered worker invokes the job handler", async () => {
+  const fb = fakeBoss();
+  let ran = 0;
+  await registerJobs(fb.boss, [
+    {
+      name: "a.sync",
+      schedule: "0 */6 * * *",
+      handler: async () => {
+        ran += 1;
+      },
+    },
+  ]);
+
+  const worker = fb.workers.get("a.sync");
+  assert.ok(worker, "a worker should be registered for the queue");
+  await worker([{ id: "job-1" }]);
+  assert.equal(ran, 1);
+});
+
+test("a job that fails to register is skipped without aborting the others", async () => {
+  const fb = fakeBoss();
+  const boss: JobBoss = {
+    ...fb.boss,
+    async createQueue(name, options) {
+      if (name === "bad.sync") throw new Error("createQueue failed");
+      return fb.boss.createQueue(name, options);
+    },
+  };
+  await registerJobs(boss, [
+    { name: "bad.sync", schedule: "* * * * *", handler: async () => {} },
+    { name: "good.sync", schedule: "* * * * *", handler: async () => {} },
+  ]);
+
+  // good.sync still got scheduled despite bad.sync throwing.
+  assert.deepEqual(fb.schedules, [{ name: "good.sync", cron: "* * * * *" }]);
+});

--- a/apps/worker/src/jobs/runner.ts
+++ b/apps/worker/src/jobs/runner.ts
@@ -1,0 +1,85 @@
+// pg-boss-backed runner for discovered background jobs. Each job gets its own
+// queue with an `exclusive` policy (at most one queued-or-active at a time) and
+// a cron schedule; pg-boss polls and runs the handler out-of-band, so jobs
+// never block the worker's tick loop.
+//
+// In prod the worker connects as a DML-only role that cannot run DDL, so the
+// pgboss schema is installed/migrated ahead of time by the gated migrate task
+// and the runtime is started with migrate:false (PGBOSS_MIGRATE=false). Locally
+// the connecting role can CREATE, so it self-installs.
+
+import { PgBoss } from "pg-boss";
+import { type JobDeps, type LoadedJob, loadJobs } from "../jobs.js";
+import { logger } from "../logger.js";
+
+// The slice of the pg-boss API the runner uses. Declared as an interface so
+// registerJobs can be tested with a fake, no database required.
+export interface JobBoss {
+  start(): Promise<unknown>;
+  createQueue(name: string, options?: unknown): Promise<unknown>;
+  work(name: string, handler: (jobs: unknown[]) => Promise<unknown>): Promise<unknown>;
+  schedule(name: string, cron: string, data?: unknown, options?: unknown): Promise<unknown>;
+}
+
+// Start the boss and register every job: one exclusive queue + worker + cron
+// schedule each. A failure registering one job is logged and skipped so it
+// can't block the others or worker boot.
+export async function registerJobs(boss: JobBoss, jobs: LoadedJob[]): Promise<void> {
+  await boss.start();
+  for (const job of jobs) {
+    try {
+      await boss.createQueue(job.name, { policy: "exclusive" });
+      await boss.work(job.name, async () => {
+        await job.handler();
+      });
+      await boss.schedule(job.name, job.schedule);
+      logger.info(
+        { scope: "jobs.runner", job: job.name, schedule: job.schedule },
+        "scheduled background job",
+      );
+    } catch (err) {
+      logger.error(
+        {
+          scope: "jobs.runner",
+          job: job.name,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "failed to schedule background job; skipping",
+      );
+    }
+  }
+}
+
+// Boot the job runner: construct pg-boss from the environment, discover jobs
+// from the jobs dir, and schedule them. Returns the PgBoss instance (or null
+// when no jobs were discovered — stock builds) so the caller can stop it on
+// shutdown. Never throws on an empty jobs dir.
+export async function startJobRunner(deps: JobDeps): Promise<PgBoss | null> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    logger.warn({ scope: "jobs.runner" }, "DATABASE_URL unset; background job runner disabled");
+    return null;
+  }
+
+  const jobs = await loadJobs(deps);
+  if (jobs.length === 0) return null;
+
+  const boss = new PgBoss({
+    connectionString,
+    schema: process.env.PGBOSS_SCHEMA || "pgboss",
+    // The DML-only prod role can't run DDL; the migrate task installs the schema
+    // and the render forces this false. Local/self-host roles can CREATE, so it
+    // defaults on and self-installs.
+    migrate: process.env.PGBOSS_MIGRATE !== "false",
+  });
+  boss.on("error", (err: Error) =>
+    logger.error({ scope: "jobs.runner", err: err.message }, "pg-boss error"),
+  );
+
+  await registerJobs(boss, jobs);
+  logger.info(
+    { scope: "jobs.runner", jobs: jobs.map((j) => j.name) },
+    "background job runner started",
+  );
+  return boss;
+}

--- a/apps/worker/src/worker/tick.ts
+++ b/apps/worker/src/worker/tick.ts
@@ -4,7 +4,6 @@ import { tickAlerts } from "../alerts.js";
 import { tickAutorecovery } from "../autorecovery.js";
 import { tickDigests } from "../digest.js";
 import { handleIssueTransition } from "../incidents/workflow.js";
-import type { Job } from "../jobs.js";
 import { logger } from "../logger.js";
 import type { TelemetryIngestor } from "../telemetry/ingest.js";
 import { tickWebhooks } from "../webhooks.js";
@@ -22,18 +21,12 @@ export type WorkerTickResult = {
   webhooks: number;
   autorecoveryProposals: number;
   usageReported: number;
-  // Total items processed across all registered background jobs (see jobs.ts).
-  jobsReported: number;
 };
 
 export function createWorkerTick(opts: {
   clickhouse: ClickHouseClientLike;
   telemetryIngestor: TelemetryIngestor;
   usageMeter?: (() => Promise<number>) | null;
-  // Extra jobs discovered from the jobs dir at boot. Each runs through the same
-  // `safe()` wrapper as the built-in steps, so one failing job is logged and
-  // skipped rather than aborting the tick.
-  extraJobs?: Job[];
 }): () => Promise<WorkerTickResult> {
   return () =>
     tracer.startActiveSpan("worker.tick", async (span) => {
@@ -77,12 +70,6 @@ export function createWorkerTick(opts: {
         const usageReported = opts.usageMeter
           ? await safe("usage_metering", opts.usageMeter, 0)
           : 0;
-        let jobsReported = 0;
-        for (const job of opts.extraJobs ?? []) {
-          const processed = await safe(`job:${job.name}`, job.tick, 0);
-          span.setAttribute(`tick.job.${job.name}`, processed);
-          jobsReported += processed;
-        }
         span.setAttribute("tick.spans", spans);
         span.setAttribute("tick.logs", logs);
         span.setAttribute("tick.agent_runs", agentRuns);
@@ -91,7 +78,6 @@ export function createWorkerTick(opts: {
         span.setAttribute("tick.webhooks", webhooks);
         span.setAttribute("tick.autorecovery_proposals", autorecoveryProposals);
         span.setAttribute("tick.usage_reported", usageReported);
-        span.setAttribute("tick.jobs_reported", jobsReported);
         return {
           spans,
           logs,
@@ -101,7 +87,6 @@ export function createWorkerTick(opts: {
           webhooks,
           autorecoveryProposals,
           usageReported,
-          jobsReported,
         };
       } catch (err) {
         span.recordException(err as Error);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 1.1.8(@types/node@22.19.17)(@types/react@19.2.14)(typescript@5.9.3)
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9)
+        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
       portless:
         specifier: ^0.11.1
         version: 0.11.1
@@ -127,16 +127,16 @@ importers:
         version: link:../../packages/fingerprint
       autumn-js:
         specifier: ^1.2.27
-        version: 1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.6.11
-        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9)
+        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
       hono:
         specifier: ^4.6.12
         version: 4.12.14
@@ -227,7 +227,7 @@ importers:
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9)
+        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
       hono:
         specifier: ^4.6.12
         version: 4.12.14
@@ -334,10 +334,10 @@ importers:
         version: 2.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       autumn-js:
         specifier: ^1.2.27
-        version: 1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.6.11
-        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       echarts:
         specifier: ^6
         version: 6.1.0
@@ -440,7 +440,10 @@ importers:
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9)
+        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
+      pg-boss:
+        specifier: ^12.0.0
+        version: 12.18.2
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -474,10 +477,10 @@ importers:
     dependencies:
       better-auth:
         specifier: ^1.6.11
-        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9)
+        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
       nanoid:
         specifier: ^5.0.9
         version: 5.1.9
@@ -3387,6 +3390,10 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cron-parser@5.5.0:
+    resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -4262,6 +4269,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
+
   macos-version@6.0.0:
     resolution: {integrity: sha512-O2S8voA+pMfCHhBn/TIYDXzJ1qNHpPDU32oFxglKnVdJABiYYITt45oLkV9yhwA3E2FDwn3tQqUFrTsr1p3sBQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4395,6 +4406,10 @@ packages:
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
+  non-error@0.1.0:
+    resolution: {integrity: sha512-TMB1uHiGsHRGv1uYclfhivcnf0/PdFp2pNqRxXjncaAsjYMoisaQJI+SSZCqRq+VliwRTC8tsMQfmrWjDMhkPQ==}
+    engines: {node: '>=20'}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -4481,16 +4496,47 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
+  pg-boss@12.18.2:
+    resolution: {integrity: sha512-06kXeWvVWY+BUNsOt2me1okg6NXx2DBnAQHTurA9jtrvbAO9qUOSE3/0ERERQDrokI+FREFM2Twha+JbrFT/8Q==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.13.0:
+    resolution: {integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==}
+
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
   pg-protocol@1.13.0:
     resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-protocol@1.14.0:
+    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
+
+  pg@8.21.0:
+    resolution: {integrity: sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -4895,6 +4941,10 @@ packages:
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  serialize-error@13.0.1:
+    resolution: {integrity: sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA==}
+    engines: {node: '>=20'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -5849,12 +5899,12 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9))':
+  '@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))':
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
 
   '@better-auth/kysely-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
     dependencies:
@@ -8015,13 +8065,13 @@ snapshots:
       postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  autumn-js@1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
+  autumn-js@1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
     dependencies:
       query-string: 9.4.0
       rou3: 0.6.3
       zod: 4.4.3
     optionalDependencies:
-      better-auth: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      better-auth: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       better-call: 1.3.5(zod@4.4.3)
       express: 5.2.1
       hono: 4.12.14
@@ -8042,10 +8092,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.21: {}
 
-  better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9))
+      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))
       '@better-auth/kysely-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
       '@better-auth/mongo-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
@@ -8063,8 +8113,9 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
       next: 15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      pg: 8.21.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
@@ -8264,6 +8315,10 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cron-parser@5.5.0:
+    dependencies:
+      luxon: 3.7.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -8381,12 +8436,13 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9):
     optionalDependencies:
       '@electric-sql/pglite': 0.2.17
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.15.6
       kysely: 0.28.17
+      pg: 8.21.0
       postgres: 3.4.9
 
   dunder-proto@1.0.1:
@@ -9094,6 +9150,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  luxon@3.7.2: {}
+
   macos-version@6.0.0:
     dependencies:
       semver: 7.7.4
@@ -9212,6 +9270,8 @@ snapshots:
 
   node-releases@2.0.38: {}
 
+  non-error@0.1.0: {}
+
   normalize-path@3.0.0: {}
 
   npm-run-path@4.0.1:
@@ -9278,9 +9338,28 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
+  pg-boss@12.18.2:
+    dependencies:
+      cron-parser: 5.5.0
+      pg: 8.21.0
+      serialize-error: 13.0.1
+    transitivePeerDependencies:
+      - pg-native
+
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.13.0: {}
+
   pg-int8@1.0.1: {}
 
+  pg-pool@3.14.0(pg@8.21.0):
+    dependencies:
+      pg: 8.21.0
+
   pg-protocol@1.13.0: {}
+
+  pg-protocol@1.14.0: {}
 
   pg-types@2.2.0:
     dependencies:
@@ -9289,6 +9368,20 @@ snapshots:
       postgres-bytea: 1.0.1
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
+
+  pg@8.21.0:
+    dependencies:
+      pg-connection-string: 2.13.0
+      pg-pool: 3.14.0(pg@8.21.0)
+      pg-protocol: 1.14.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   picocolors@1.1.1: {}
 
@@ -9735,6 +9828,11 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  serialize-error@13.0.1:
+    dependencies:
+      non-error: 0.1.0
+      type-fest: 5.6.0
 
   serve-static@2.2.1:
     dependencies:


### PR DESCRIPTION
## Why

The `jobs/` folder loader ran discovered jobs **inside the worker tick loop**, which is sequential. A long job (a CRM sync making hundreds of sequential API calls runs ~9 min) therefore blocked telemetry ingest, alerts, and agent-runs for its entire duration every interval. The fix is a real out-of-loop job runner.

## What

Move job execution onto **pg-boss** — a Postgres-backed job queue (no new infrastructure; uses the database we already run).

- **Add `pg-boss` v12** and bump the worker to **Node 22** (LTS; pg-boss v12's floor). The worker's prod deps are all pure JS, so there's nothing to rebuild against the new ABI; api/proxy/web are untouched.
- **Evolve the jobs contract** (only one job exists so far, so free to change): a job exports `{ name, schedule (cron), create }`, and `create(deps)` returns a **one-pass handler** (or `null` to opt out). pg-boss owns scheduling, retries, and single-active semantics, so handlers no longer loop or self-gate.
- **`jobs/runner.ts`** boots pg-boss and gives each discovered job its own **`exclusive`** queue + cron `schedule` + `work`er, so a slow run never overlaps its next fire. `registerJobs` takes an injectable `JobBoss` interface, so it's unit-tested **without a database**. A job that fails to register is logged and skipped.
- **`index.ts`** starts the runner at boot, isolated in try/catch so a runner failure can't take down telemetry ingest; `createWorkerTick` no longer runs jobs.

## Prod / DML-only roles

pg-boss stores state in a `pgboss` schema and needs `CREATE` to install it. Where the runtime role is DML-only, construct with **`migrate: false`** (`PGBOSS_MIGRATE=false`) and install/migrate the schema ahead of time as a privileged role — same pattern as the gated DB-migration step. Local/self-host roles can `CREATE`, so the runner self-installs by default. (The deployment wiring for that lands separately.)

## Tests

- `src/jobs.test.ts` — discovery returns `{name, schedule, handler}`, skips opt-outs / throwing / invalid / `*.test.ts`, missing dir → `[]`, deterministic order.
- `src/jobs/runner.test.ts` — starts the boss then registers an exclusive queue + worker + cron per job, the worker invokes the handler, and a failing registration is skipped without aborting the rest.

Typecheck + both job test suites green.

## Follow-ups (separate PRs)
- Deployment: install the `pgboss` schema + grant the app role in the gated migrate step; set `PGBOSS_MIGRATE=false`.
- Move the CRM sync job onto this runner (replaces its interim non-blocking workaround).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run background jobs with `pg-boss` on dedicated queues outside the worker tick loop, so long jobs no longer block telemetry, alerts, or agent runs. Jobs now use cron-based, one-pass handlers.

- **New Features**
  - Added `jobs/runner.ts` to start `pg-boss`, creating an exclusive queue + worker + cron schedule per discovered job; failed registrations are logged and skipped.
  - Updated job contract to `{ name, schedule, create }`; `create()` returns a one-pass handler or `null` to opt out. Scheduling/retries/single-active are handled by `pg-boss`.
  - Boot starts the runner behind try/catch; the tick loop no longer runs jobs.

- **Migration**
  - Worker now requires Node 22; Dockerfile and `engines` updated.
  - For DML-only roles, set `PGBOSS_MIGRATE=false` and preinstall/migrate the `pgboss` schema in the gated migration step; otherwise it self-installs.
  - Uses existing Postgres; no new infrastructure.

<sup>Written for commit 6d1311f459b1558cdbbfa92e9af82f34cf43ade5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

