### PR TITLE
worker: add pgboss:migrate (install/migrate the pgboss schema as owner)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -9,6 +9,7 @@
     "start": "tsx --import ./tracing.ts src/index.ts",
     "backfill:issue-activity-daily": "tsx scripts/backfill-issue-activity-daily.ts",
     "seed:worker-telemetry-dashboard": "tsx scripts/seed-worker-telemetry-dashboard.ts",
+    "pgboss:migrate": "tsx scripts/pgboss-migrate.ts",
     "test:jobs-loader": "tsx --test src/jobs.test.ts",
     "test:jobs-runner": "tsx --test src/jobs/runner.test.ts",
     "test:git-auth-no-argv": "tsx scripts/test-git-auth-no-argv.ts",

--- a/apps/worker/scripts/pgboss-migrate.ts
+++ b/apps/worker/scripts/pgboss-migrate.ts
@@ -8,17 +8,27 @@
 // DATABASE_URL for local/worktree use. supervise/schedule are disabled so this
 // only installs/migrates and does no maintenance or cron work before exiting.
 
+// Preload .env / .env.local so local/worktree runs pick up DATABASE_URL without
+// exporting it manually. No-op in the migrate task, where PG* comes from the
+// task definition (env.ts only loads dotenv; it never validates or throws).
+import "../src/env.js";
 import { PgBoss } from "pg-boss";
 
 function dbConfig(): Record<string, unknown> {
   const connectionString = process.env.DATABASE_URL;
   if (connectionString) return { connectionString };
+  const { PGHOST, PGUSER, PGDATABASE } = process.env;
+  if (!PGHOST || !PGUSER || !PGDATABASE) {
+    throw new Error(
+      "pgboss:migrate needs a database connection: set DATABASE_URL, or PGHOST + PGUSER + PGDATABASE (libpq) env",
+    );
+  }
   return {
-    host: process.env.PGHOST,
+    host: PGHOST,
     port: process.env.PGPORT ? Number(process.env.PGPORT) : 5432,
-    user: process.env.PGUSER,
+    user: PGUSER,
     password: process.env.PGPASSWORD,
-    database: process.env.PGDATABASE,
+    database: PGDATABASE,
     ssl: process.env.PGSSLMODE === "require" ? { rejectUnauthorized: false } : undefined,
   };
 }

--- a/apps/worker/scripts/pgboss-migrate.ts
+++ b/apps/worker/scripts/pgboss-migrate.ts
@@ -1,0 +1,50 @@
+// One-shot: install/migrate the pg-boss schema, then exit. Meant to run in the
+// SAME gated step as Drizzle migrations, as the schema-owner role — NOT on app
+// boot (the runtime worker connects with migrate:false). pg-boss owns its own
+// schema DDL across versions, so this is how its migrations ride the normal
+// gated-migration path instead of being hand-authored.
+//
+// Reads PG* (libpq) env like the Drizzle migrate task, falling back to
+// DATABASE_URL for local/worktree use. supervise/schedule are disabled so this
+// only installs/migrates and does no maintenance or cron work before exiting.
+
+import { PgBoss } from "pg-boss";
+
+function dbConfig(): Record<string, unknown> {
+  const connectionString = process.env.DATABASE_URL;
+  if (connectionString) return { connectionString };
+  return {
+    host: process.env.PGHOST,
+    port: process.env.PGPORT ? Number(process.env.PGPORT) : 5432,
+    user: process.env.PGUSER,
+    password: process.env.PGPASSWORD,
+    database: process.env.PGDATABASE,
+    ssl: process.env.PGSSLMODE === "require" ? { rejectUnauthorized: false } : undefined,
+  };
+}
+
+const schema = process.env.PGBOSS_SCHEMA || "pgboss";
+const boss = new PgBoss({
+  ...dbConfig(),
+  schema,
+  migrate: true,
+  supervise: false,
+  schedule: false,
+});
+
+try {
+  await boss.start();
+  console.log(JSON.stringify({ scope: "pgboss.migrate", schema, status: "ok" }));
+} catch (err) {
+  console.error(
+    JSON.stringify({
+      scope: "pgboss.migrate",
+      schema,
+      status: "error",
+      error: err instanceof Error ? err.message : String(err),
+    }),
+  );
+  process.exitCode = 1;
+} finally {
+  await boss.stop({ graceful: false }).catch(() => {});
+}

--- a/apps/worker/scripts/pgboss-migrate.ts
+++ b/apps/worker/scripts/pgboss-migrate.ts
@@ -8,11 +8,17 @@
 // DATABASE_URL for local/worktree use. supervise/schedule are disabled so this
 // only installs/migrates and does no maintenance or cron work before exiting.
 
-// Preload .env / .env.local so local/worktree runs pick up DATABASE_URL without
-// exporting it manually. No-op in the migrate task, where PG* comes from the
-// task definition (env.ts only loads dotenv; it never validates or throws).
-import "../src/env.js";
+// Fill DATABASE_URL/PG* from .env.local/.env for local/worktree convenience,
+// but NEVER override env already present in the process. The migrate task runs
+// as the schema-owner with PG* injected from the task definition; using
+// override (as src/env.js does for app boot) would let a stray .env file
+// repoint this migration at the wrong database/credentials. dotenv defaults to
+// override:false, so real task env always wins; files only supply what's unset.
+import { config as loadDotenv } from "dotenv";
 import { PgBoss } from "pg-boss";
+
+loadDotenv({ path: ".env.local" });
+loadDotenv();
 
 function dbConfig(): Record<string, unknown> {
   const connectionString = process.env.DATABASE_URL;


### PR DESCRIPTION
## Why

Follow-up to #20. pg-boss needs its `pgboss` schema created, which requires `CREATE`. Where the runtime role is DML-only (and shouldn't run DDL on boot), the schema must be installed/migrated ahead of time as a privileged role — in the **same gated migration step** that runs Drizzle, as the schema-owner.

pg-boss owns its own schema DDL (tables + a `job_state` type + plpgsql functions, and it evolves across versions), so we let **pg-boss's own migrator** run there rather than hand-authoring SQL (which our migration rules forbid and which would drift per pg-boss version).

## What

`pnpm --filter @superlog/worker pgboss:migrate` — constructs pg-boss with `migrate:true, supervise:false, schedule:false`, calls `start()` (installs/migrates), then exits. Reads `PG*` (libpq) env like the Drizzle migrate task, falling back to `DATABASE_URL` for local/worktree.

The runtime worker stays `migrate:false` and connects as the DML-only role.

## Verified (Postgres 18, throwaway container)

1. `pgboss:migrate` as owner → `pgboss` schema + tables created, exit 0.
2. Owner applies grants (USAGE/DML/EXECUTE + `ALTER DEFAULT PRIVILEGES` so future pg-boss-version objects are auto-covered) to a DML-only role.
3. That DML-only role runs pg-boss with `migrate:false` and successfully `createQueue` + `send` + `fetch`.

## Follow-up (overlay)

Wire this into the gated migrate step (run on the worker image, which has pg-boss, alongside Drizzle migrate + the grants), set `PGBOSS_MIGRATE=false` on the worker, and move the CRM sync job onto the runner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a one-shot `pgboss:migrate` command in `@superlog/worker` to install/migrate the `pg-boss` schema as the owner during the gated migration step. This keeps runtime workers DML-only and avoids running DDL on boot.

- **New Features**
  - Adds `scripts/pgboss-migrate.ts` and `pgboss:migrate` script.
  - Runs `PgBoss` with `migrate:true`, `supervise:false`, `schedule:false`; calls `start()` then exits.
  - Reads `PG*` env with a `DATABASE_URL` fallback; supports `PGBOSS_SCHEMA` (default `pgboss`).

- **Bug Fixes**
  - Loads `.env.local`/`.env` via `dotenv` without overriding existing env, preventing local files from replacing task-injected DB creds; validates required DB vars and errors early if missing.

<sup>Written for commit 01b8fd4e879be01851fb55fe6a0d8ef1bda85c63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

