### PR TITLE
web: floating MCP-install pill for users who skipped onboarding

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -25,6 +25,7 @@ import { authClient, useSession } from "./auth-client.ts";
 import { DashboardView } from "./dashboards/DashboardView.tsx";
 import { DashboardsList } from "./dashboards/DashboardsList.tsx";
 import { AppShell, ThemeToggle, Wordmark } from "./design/ui.tsx";
+import { McpInstallPill } from "./onboarding/McpInstallPill.tsx";
 import { OnboardingGate } from "./onboarding/OnboardingGate.tsx";
 import { startSkillOnboarding } from "./skillOnboarding.ts";
 
@@ -205,6 +206,7 @@ function AuthenticatedApp() {
         </RouteContainer>
       </AppShell>
       <CommandPalette />
+      <McpInstallPill />
     </OnboardingGate>
   );
 }

--- a/apps/web/src/onboarding/McpInstallPill.test.ts
+++ b/apps/web/src/onboarding/McpInstallPill.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { shouldShowMcpPill } from "./mcpPill.ts";
+
+test("pill stays hidden until the project + mcp status have loaded", () => {
+  assert.equal(
+    shouldShowMcpPill({ projectId: undefined, connected: false, dismissed: false }),
+    false,
+  );
+  assert.equal(
+    shouldShowMcpPill({ projectId: "p1", connected: undefined, dismissed: false }),
+    false,
+  );
+});
+
+test("pill shows when a project exists and mcp is not connected", () => {
+  assert.equal(shouldShowMcpPill({ projectId: "p1", connected: false, dismissed: false }), true);
+});
+
+test("pill hides once mcp is connected", () => {
+  assert.equal(shouldShowMcpPill({ projectId: "p1", connected: true, dismissed: false }), false);
+});
+
+test("pill stays hidden after the user dismisses it", () => {
+  assert.equal(shouldShowMcpPill({ projectId: "p1", connected: false, dismissed: true }), false);
+});
+
+test("pill is fixed to the bottom-left and opens the install dialog", async () => {
+  const source = await readFile(new URL("./McpInstallPill.tsx", import.meta.url), "utf8");
+  assert.match(source, /fixed/);
+  assert.match(source, /bottom-/);
+  assert.match(source, /left-/);
+  assert.match(source, /McpInstallDialog/);
+  assert.match(source, /useMcpStatus/);
+});
+
+test("pill is mounted in the authenticated app shell", async () => {
+  const source = await readFile(new URL("../App.tsx", import.meta.url), "utf8");
+  assert.match(source, /<McpInstallPill \/>/);
+});

--- a/apps/web/src/onboarding/McpInstallPill.tsx
+++ b/apps/web/src/onboarding/McpInstallPill.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { useMcpStatus, useMe } from "../api.ts";
+import { McpInstallDialog } from "./McpInstallDialog.tsx";
+import { TerminalIcon } from "./icons.tsx";
+import { isMcpPillDismissed, rememberMcpPillDismiss, shouldShowMcpPill } from "./mcpPill.ts";
+
+// Floating bottom-left reminder for users who skipped the MCP install during
+// onboarding. Mounted app-wide; auto-hides once the MCP OAuth flow completes.
+export function McpInstallPill() {
+  const me = useMe();
+  const projectId = me.data?.project?.id;
+  const mcp = useMcpStatus(projectId);
+  const [dismissed, setDismissed] = useState(isMcpPillDismissed);
+  const [open, setOpen] = useState(false);
+
+  if (!shouldShowMcpPill({ projectId, connected: mcp.data?.connected, dismissed })) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="fixed bottom-5 left-5 z-40 flex items-center overflow-hidden rounded-full border border-border-strong bg-surface shadow-[0_10px_30px_rgba(0,0,0,0.35)]">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="flex items-center gap-2 py-2 pl-4 pr-3 text-[13px] font-medium text-fg transition-colors hover:bg-surface-2"
+        >
+          <TerminalIcon size={14} className="text-accent" />
+          Install the MCP server
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            rememberMcpPillDismiss();
+            setDismissed(true);
+          }}
+          aria-label="Dismiss"
+          className="grid h-9 w-8 place-items-center border-l border-border text-muted transition-colors hover:text-fg"
+        >
+          <svg
+            viewBox="0 0 12 12"
+            className="h-3 w-3"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            aria-hidden="true"
+          >
+            <path d="m3 3 6 6m0-6-6 6" />
+          </svg>
+        </button>
+      </div>
+      {open && <McpInstallDialog onClose={() => setOpen(false)} />}
+    </>
+  );
+}

--- a/apps/web/src/onboarding/mcpPill.ts
+++ b/apps/web/src/onboarding/mcpPill.ts
@@ -1,0 +1,41 @@
+// Pure show/hide rules for the floating MCP-install pill, split out from the
+// component so they're unit-testable (the `.tsx` can't be imported by the
+// node:test runner). `connected` is undefined until the status query resolves —
+// keep the pill hidden until then so it never flashes for an already-connected
+// user.
+export function shouldShowMcpPill({
+  projectId,
+  connected,
+  dismissed,
+}: {
+  projectId: string | undefined;
+  connected: boolean | undefined;
+  dismissed: boolean;
+}): boolean {
+  if (!projectId) return false;
+  if (connected === undefined) return false;
+  if (connected) return false;
+  if (dismissed) return false;
+  return true;
+}
+
+// Once a user closes the pill we remember it so we don't nag on every reload.
+// Keyed globally — connecting the MCP on any project hides the pill anyway.
+export const MCP_PILL_DISMISS_KEY = "superlog.mcpPill.dismissed";
+
+export function isMcpPillDismissed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(MCP_PILL_DISMISS_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function rememberMcpPillDismiss(): void {
+  try {
+    window.localStorage.setItem(MCP_PILL_DISMISS_KEY, "1");
+  } catch {
+    // Private mode / blocked storage: just skip persistence.
+  }
+}


### PR DESCRIPTION
Adds a bottom-left floating pill that reminds signed-in users to install the Superlog MCP server if they didn't during onboarding. Clicking it opens the existing MCP install dialog; it reuses the `mcp-status` query so it auto-hides once the MCP OAuth flow completes, and it can be dismissed (remembered in `localStorage`). The show/hide rules live in a pure, unit-tested helper (`mcpPill.ts`), and the pill is mounted app-wide inside the authenticated shell so it never appears during onboarding. Verified with `tsc`, biome, the new `node:test` suite, and a running worktree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bottom-left floating pill that reminds signed-in users to install the Superlog MCP server if they skipped onboarding. Clicking it opens the existing MCP install dialog; it auto-hides after a successful connection and can be dismissed.

- **New Features**
  - Mounted app-wide in the authenticated shell; never shown during onboarding.
  - Uses the `mcp-status` query and project presence to decide visibility; stays hidden until data loads to avoid flicker.
  - Remembers dismiss in localStorage.
  - Show/hide rules extracted to a pure helper with unit tests via `node:test`.

<sup>Written for commit 812b800642386dc41dd3ee8b8613359225ed3d7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

