### PR TITLE
feat(worker): link filed Linear ticket in agent-opened PR body

### DIFF
--- a/apps/worker/src/agent-runs/pr-copy.test.ts
+++ b/apps/worker/src/agent-runs/pr-copy.test.ts
@@ -46,3 +46,44 @@ test("buildPrBody fallback only includes summary and incident link", () => {
   assert.ok(!body.includes("Testing"));
   assert.ok(!body.includes("Changed files"));
 });
+
+test("buildPrBody appends a linked Linear reference when the run filed a ticket", () => {
+  const body = buildPrBody({
+    incidentUrl: "https://superlog.sh/incidents/inc-1",
+    result: {
+      summary: "Users get an Unauthorized error.",
+      linearTicket: { id: "ENG-123", url: "https://linear.app/acme/issue/ENG-123" },
+    },
+    pr: { body: "# Summary\n\nFix the auth check." },
+  });
+
+  assert.ok(body.startsWith("# Summary\n\nFix the auth check."));
+  assert.ok(body.endsWith("\n\nLinear: [ENG-123](https://linear.app/acme/issue/ENG-123)"));
+});
+
+test("buildPrBody falls back to a bare Linear id when the ticket has no URL", () => {
+  const body = buildPrBody({
+    incidentUrl: "https://superlog.sh/incidents/inc-1",
+    result: {
+      summary: "Users get an Unauthorized error.",
+      linearTicket: { id: "ENG-123", url: null },
+    },
+    pr: {},
+  });
+
+  assert.ok(body.includes("[Incident on Superlog](https://superlog.sh/incidents/inc-1)"));
+  assert.ok(body.endsWith("\n\nLinear: ENG-123"));
+});
+
+test("buildPrBody does not duplicate a Linear reference the agent already wrote", () => {
+  const body = buildPrBody({
+    incidentUrl: "https://superlog.sh/incidents/inc-1",
+    result: {
+      summary: "summary",
+      linearTicket: { id: "ENG-123", url: "https://linear.app/acme/issue/ENG-123" },
+    },
+    pr: { body: "# Summary\n\nAlready tracked in ENG-123." },
+  });
+
+  assert.equal(body, "# Summary\n\nAlready tracked in ENG-123.");
+});

--- a/apps/worker/src/agent-runs/pr-copy.test.ts
+++ b/apps/worker/src/agent-runs/pr-copy.test.ts
@@ -47,6 +47,25 @@ test("buildPrBody fallback only includes summary and incident link", () => {
   assert.ok(!body.includes("Changed files"));
 });
 
+test("buildPrBody falls back to the generated summary for a whitespace-only body", () => {
+  const body = buildPrBody({
+    incidentUrl: "https://superlog.sh/incidents/inc-1",
+    result: { summary: "Users get an Unauthorized error." },
+    pr: { body: "   \n  " },
+  });
+
+  assert.equal(
+    body,
+    [
+      "# Summary",
+      "",
+      "Users get an Unauthorized error.",
+      "",
+      "[Incident on Superlog](https://superlog.sh/incidents/inc-1)",
+    ].join("\n"),
+  );
+});
+
 test("buildPrBody appends a linked Linear reference when the run filed a ticket", () => {
   const body = buildPrBody({
     incidentUrl: "https://superlog.sh/incidents/inc-1",

--- a/apps/worker/src/agent-runs/pr-copy.ts
+++ b/apps/worker/src/agent-runs/pr-copy.ts
@@ -37,7 +37,7 @@ export function buildPrBody(opts: {
 }): string {
   const explicit = opts.pr.body?.trim();
   const base =
-    explicit ??
+    explicit ||
     [
       "# Summary",
       "",

--- a/apps/worker/src/agent-runs/pr-copy.ts
+++ b/apps/worker/src/agent-runs/pr-copy.ts
@@ -5,6 +5,7 @@ type PrCopyContext = {
 type PrCopyResult = {
   summary: string;
   proposedTitle?: string | null;
+  linearTicket?: { id: string; url?: string | null } | null;
 };
 
 type PrCopyPr = {
@@ -35,12 +36,29 @@ export function buildPrBody(opts: {
   pr: PrCopyPr;
 }): string {
   const explicit = opts.pr.body?.trim();
-  if (explicit) return explicit;
-  return [
-    "# Summary",
-    "",
-    opts.result.summary.trim(),
-    "",
-    `[Incident on Superlog](${opts.incidentUrl})`,
-  ].join("\n");
+  const base =
+    explicit ??
+    [
+      "# Summary",
+      "",
+      opts.result.summary.trim(),
+      "",
+      `[Incident on Superlog](${opts.incidentUrl})`,
+    ].join("\n");
+  return withLinearReference(base, opts.result.linearTicket);
+}
+
+// Deterministically stitch the filed Linear ticket into the PR body so the
+// agent doesn't have to remember to (its body schema actively pushes toward a
+// minimal body), and so Linear's GitHub integration auto-links the PR to the
+// issue. We mention the id without a `Closes`/`Fixes` magic word on purpose —
+// linking is always wanted, but auto-resolving the tracking issue on merge is a
+// per-team call we don't make here. Skip if the body already names the ticket.
+function withLinearReference(
+  body: string,
+  ticket: { id: string; url?: string | null } | null | undefined,
+): string {
+  if (!ticket?.id || body.includes(ticket.id)) return body;
+  const reference = ticket.url ? `[${ticket.id}](${ticket.url})` : ticket.id;
+  return `${body}\n\nLinear: ${reference}`;
 }


### PR DESCRIPTION
When an investigation agent files a Linear ticket **and** opens a fix PR in the same run, the PR body now ends with a `Linear: <id>` reference so Linear's GitHub integration auto-links the PR to the issue. This is done deterministically in `buildPrBody` (which already receives `result.linearTicket`) rather than relying on the agent, whose body schema pushes toward a minimal description. It skips when the body already names the ticket, and uses a plain mention rather than a `Closes`/`Fixes` magic word so merging links the issue without auto-resolving the tracking ticket. Covered by unit tests in `pr-copy.test.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Appends a Linear issue reference to agent-opened PR bodies for GitHub auto-linking, done in `buildPrBody` via `result.linearTicket`; skips if already mentioned, links when a URL exists, avoids Closes/Fixes, and preserves the whitespace-only body fallback.

<sup>Written for commit e91e73349a29d12d4a2dd6ac268432bdd16982aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

