### PR TITLE
slack: redirect to the app on invalid OAuth state + log connect failures

### DIFF
--- a/apps/api/src/slack-oauth-callback.test.ts
+++ b/apps/api/src/slack-oauth-callback.test.ts
@@ -1,0 +1,45 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { Hono } from "hono";
+
+// Importing slack.ts pulls in @superlog/db, whose client throws at import time
+// when DATABASE_URL is unset. postgres-js connects lazily, so a dummy value is
+// enough — the failure branches under test never touch the database.
+process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
+process.env.BETTER_AUTH_SECRET ??= "test-better-auth-secret";
+process.env.SLACK_CLIENT_ID = "slack-client";
+process.env.SLACK_CLIENT_SECRET = "slack-secret";
+process.env.STATE_SIGNING_SECRET = "state-secret";
+process.env.WEB_ORIGIN = "https://app.example.test";
+
+async function mountCallback(): Promise<Hono> {
+  const { mountSlackPublic } = await import("./slack.js");
+  const app = new Hono();
+  mountSlackPublic(app);
+  return app;
+}
+
+test("oauth callback with an invalid/expired state redirects back to the app with ?slack=error", async () => {
+  const app = await mountCallback();
+  // A garbage state fails HMAC verification — the same code path a user hits
+  // when their signed state has expired (they lingered >10 min on Slack's
+  // consent screen). This must bounce them back to the app with a retryable
+  // error, not dead-end on a bare JSON 400.
+  const res = await app.request("/slack/oauth/callback?code=abc&state=not-a-valid-state");
+  assert.equal(res.status, 302);
+  assert.equal(res.headers.get("location"), "https://app.example.test/?slack=error");
+});
+
+test("oauth callback with a Slack error param redirects back with ?slack=denied", async () => {
+  const app = await mountCallback();
+  const res = await app.request("/slack/oauth/callback?error=access_denied");
+  assert.equal(res.status, 302);
+  assert.equal(res.headers.get("location"), "https://app.example.test/?slack=denied");
+});
+
+test("oauth callback with no code redirects back with ?slack=error", async () => {
+  const app = await mountCallback();
+  const res = await app.request("/slack/oauth/callback?state=whatever");
+  assert.equal(res.status, 302);
+  assert.equal(res.headers.get("location"), "https://app.example.test/?slack=error");
+});

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -67,15 +67,30 @@ export function mountSlackPublic(app: Hono<any>): void {
     }
     const callbackWebOrigin = resolveCallbackWebOrigin(c, webOrigin);
     const callbackRedirectUrl = resolveSlackRedirectUrl(c, redirectUrl);
+    const host = c.req.header("host") ?? null;
     const err = c.req.query("error");
-    if (err) return c.redirect(`${callbackWebOrigin}/?slack=denied`, 302);
+    if (err) {
+      log.warn({ error: err, host }, "slack oauth callback denied at slack");
+      return c.redirect(`${callbackWebOrigin}/?slack=denied`, 302);
+    }
 
     const code = c.req.query("code");
     const state = c.req.query("state") ?? "";
-    if (!code) return c.redirect(`${callbackWebOrigin}/?slack=error`, 302);
+    if (!code) {
+      log.warn({ host }, "slack oauth callback missing code");
+      return c.redirect(`${callbackWebOrigin}/?slack=error`, 302);
+    }
 
     const decoded = verifyState(state, stateSecret);
-    if (!decoded) return c.json({ error: "invalid state" }, 400);
+    if (!decoded) {
+      // State failed HMAC verification or aged past its 10-minute TTL — the
+      // latter is what a user hits when they linger on Slack's consent screen
+      // (e.g. waiting on workspace-admin approval) and then return. Bounce them
+      // back to the app with a retryable error instead of dead-ending on a bare
+      // JSON 400, and log it so connect drop-offs are diagnosable.
+      log.warn({ host }, "slack oauth callback rejected: invalid or expired state");
+      return c.redirect(`${callbackWebOrigin}/?slack=error`, 302);
+    }
     const orgId = decoded.orgId;
     const projectId = decoded.projectId;
     log.info(


### PR DESCRIPTION
## Problem

A user reported being unable to connect Slack. Tracing it through logs, their org created a `slack install url created` entry and then **nothing** — no `slack oauth callback received`, no install. Two gaps made this both possible and undiagnosable:

1. **Dead-end on invalid state.** `/slack/oauth/callback` returned a bare `{"error":"invalid state"}` JSON 400 when `verifyState` failed. State carries a 10-minute TTL, so a user who lingers on Slack's authorization screen — e.g. waiting on workspace-admin approval — and then returns lands on a dead JSON page with no path back into the app.
2. **Silent failure branches.** The user-denied, missing-code, and invalid-state branches logged nothing. After `slack install url created`, a connect that dropped off left no trace, so failures couldn't be investigated.

## Change

- On invalid/expired state, redirect to `${webOrigin}/?slack=error` (302) — consistent with the other failure branches — so the flow is retryable instead of dead-ending.
- Add `warn`-level logging to all three previously-silent branches, with the request host for context.
- Add a focused test (`slack-oauth-callback.test.ts`) covering the denied / missing-code / invalid-state redirects.

## Test

`tsx --test src/slack-oauth-callback.test.ts` — 3 passing. `tsc --noEmit` clean.

Note: the same JSON-400 dead-end pattern exists in the GitHub and Linear OAuth callbacks; left out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect invalid or expired Slack OAuth state back to the app instead of returning a JSON 400, making the connect flow retryable. Add warn-level logs for failure branches to make drop-offs diagnosable.

- **Bug Fixes**
  - Redirect invalid/expired state to `${WEB_ORIGIN}/?slack=error` (302) instead of a JSON 400.

- **New Features**
  - Warn-level logs for denied, missing-code, and invalid/expired state (includes request host).
  - Tests covering denied, missing-code, and invalid/expired state redirects.

<sup>Written for commit b6c027f537833b3655614d22973cca83076ab91d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

