### PR TITLE
Fix Slack private channel dropdown

### DIFF
--- a/apps/api/src/slack.test.ts
+++ b/apps/api/src/slack.test.ts
@@ -55,8 +55,8 @@ test("listSlackChannels requests both public and private channels", async () => 
   await listSlackChannels("xoxb-token", fetchImpl);
 
   assert.equal(calls.length, 1);
-  assert.equal(calls[0]!.searchParams.get("types"), "public_channel,private_channel");
-  assert.equal(calls[0]!.searchParams.get("exclude_archived"), "true");
+  assert.equal(calls[0]?.searchParams.get("types"), "public_channel,private_channel");
+  assert.equal(calls[0]?.searchParams.get("exclude_archived"), "true");
 });
 
 test("listSlackChannels follows cursor pagination and aggregates all channels", async () => {
@@ -77,7 +77,7 @@ test("listSlackChannels follows cursor pagination and aggregates all channels", 
 
   assert.equal(result.ok, true);
   assert.equal(calls.length, 2);
-  assert.equal(calls[1]!.searchParams.get("cursor"), "page2");
+  assert.equal(calls[1]?.searchParams.get("cursor"), "page2");
   assert.ok(result.ok);
   assert.deepEqual(result.channels, [
     { id: "C1", name: "general", isPrivate: false },
@@ -97,4 +97,22 @@ test("listSlackChannels returns the Slack error without paginating further", asy
   assert.equal(calls.length, 1);
   assert.ok(!result.ok);
   assert.equal(result.error, "token_revoked");
+});
+
+test("listSlackChannels returns an error when the page cap is exhausted", async () => {
+  const { listSlackChannels } = await import("./slack.js");
+  const { fetchImpl, calls } = fakeFetch(
+    Array.from({ length: 50 }, (_, i) => ({
+      ok: true,
+      channels: [{ id: `C${i}`, name: `channel-${i}` }],
+      cursor: `page-${i + 1}`,
+    })),
+  );
+
+  const result = await listSlackChannels("xoxb-token", fetchImpl);
+
+  assert.equal(calls.length, 50);
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok);
+  assert.equal(result.error, "pagination_limit_exceeded");
 });

--- a/apps/api/src/slack.test.ts
+++ b/apps/api/src/slack.test.ts
@@ -6,8 +6,25 @@ import { test } from "node:test";
 // porsager client connects lazily, so these pure-function tests never open a
 // socket). Same dynamic-import pattern as detail.test.ts / loops.test.ts.
 process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
-process.env.BETTER_AUTH_SECRET ??= "test-secret";
+process.env.BETTER_AUTH_SECRET ??= "test-better-auth-secret-with-enough-length";
 const { preferPinnedInstallation } = await import("./slack.js");
+
+type FakeResponse = { ok: boolean; channels?: unknown[]; error?: string; cursor?: string };
+
+function fakeFetch(pages: FakeResponse[]) {
+  const calls: URL[] = [];
+  let i = 0;
+  const fetchImpl: typeof fetch = async (input) => {
+    calls.push(input as URL);
+    const page = pages[i++] ?? { ok: true, channels: [] };
+    const body: Record<string, unknown> = { ok: page.ok };
+    if (page.error) body.error = page.error;
+    if (page.channels) body.channels = page.channels;
+    if (page.cursor) body.response_metadata = { next_cursor: page.cursor };
+    return { json: async () => body } as unknown as Response;
+  };
+  return { fetchImpl, calls };
+}
 
 // Regression guard: a workspace installed into multiple Superlog projects owns
 // several non-revoked `slack_installations` rows (upsertInstallation keys by
@@ -29,4 +46,55 @@ test("falls back to the team match when the incident has no pinned installation"
 
 test("returns null when neither a pin nor a team match resolves", () => {
   assert.equal(preferPinnedInstallation(null, null), null);
+});
+
+test("listSlackChannels requests both public and private channels", async () => {
+  const { listSlackChannels } = await import("./slack.js");
+  const { fetchImpl, calls } = fakeFetch([{ ok: true, channels: [] }]);
+
+  await listSlackChannels("xoxb-token", fetchImpl);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.searchParams.get("types"), "public_channel,private_channel");
+  assert.equal(calls[0]!.searchParams.get("exclude_archived"), "true");
+});
+
+test("listSlackChannels follows cursor pagination and aggregates all channels", async () => {
+  const { listSlackChannels } = await import("./slack.js");
+  const { fetchImpl, calls } = fakeFetch([
+    {
+      ok: true,
+      channels: [{ id: "C1", name: "general", is_private: false }],
+      cursor: "page2",
+    },
+    {
+      ok: true,
+      channels: [{ id: "G1", name: "secret-room", is_private: true }],
+    },
+  ]);
+
+  const result = await listSlackChannels("xoxb-token", fetchImpl);
+
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[1]!.searchParams.get("cursor"), "page2");
+  assert.ok(result.ok);
+  assert.deepEqual(result.channels, [
+    { id: "C1", name: "general", isPrivate: false },
+    { id: "G1", name: "secret-room", isPrivate: true },
+  ]);
+  // the private channel must survive into the final list
+  assert.ok(result.channels.some((c) => c.isPrivate && c.name === "secret-room"));
+});
+
+test("listSlackChannels returns the Slack error without paginating further", async () => {
+  const { listSlackChannels } = await import("./slack.js");
+  const { fetchImpl, calls } = fakeFetch([{ ok: false, error: "token_revoked" }]);
+
+  const result = await listSlackChannels("xoxb-token", fetchImpl);
+
+  assert.equal(result.ok, false);
+  assert.equal(calls.length, 1);
+  assert.ok(!result.ok);
+  assert.equal(result.error, "token_revoked");
 });

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -1003,6 +1003,7 @@ export async function listSlackChannels(
     cursor = data.response_metadata?.next_cursor || undefined;
     if (!cursor) break;
   }
+  if (cursor) return { ok: false, error: "pagination_limit_exceeded" };
   return { ok: true, channels };
 }
 

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -682,33 +682,18 @@ export function mountSlackAuthed(app: Hono<any>): void {
     const row = await findInstallation(ctx.projectId);
     if (!row) return c.json({ error: "slack not installed" }, 404);
 
-    const url = new URL("https://slack.com/api/conversations.list");
-    url.searchParams.set("types", "public_channel,private_channel");
-    url.searchParams.set("exclude_archived", "true");
-    url.searchParams.set("limit", "200");
-    const res = await fetch(url, {
-      headers: { authorization: `Bearer ${row.botAccessToken}` },
-    });
-    const data = (await res.json()) as SlackConversationsList;
-    if (!data.ok) {
-      log.warn(
-        { team_id: row.teamId, error: data.error ?? "unknown" },
-        "slack conversations.list failed",
-      );
-      if (data.error === "not_authed" || data.error === "token_revoked") {
+    const result = await listSlackChannels(row.botAccessToken);
+    if (!result.ok) {
+      log.warn({ team_id: row.teamId, error: result.error }, "slack conversations.list failed");
+      if (result.error === "not_authed" || result.error === "token_revoked") {
         await db
           .update(schema.slackInstallations)
           .set({ revokedAt: new Date() })
           .where(eq(schema.slackInstallations.id, row.id));
       }
-      return c.json({ error: data.error ?? "unknown" }, 502);
+      return c.json({ error: result.error }, 502);
     }
-    const channels = (data.channels ?? []).map((ch) => ({
-      id: ch.id,
-      name: ch.name,
-      isPrivate: ch.is_private ?? false,
-    }));
-    return c.json({ channels });
+    return c.json({ channels: result.channels });
   });
 
   app.get("/api/projects/:projectId/slack-route", async (c) => {
@@ -978,7 +963,48 @@ type SlackConversationsList = {
   ok: boolean;
   error?: string;
   channels?: { id: string; name: string; is_private?: boolean }[];
+  response_metadata?: { next_cursor?: string };
 };
+
+export type SlackChannelSummary = { id: string; name: string; isPrivate: boolean };
+
+export type ListSlackChannelsResult =
+  | { ok: true; channels: SlackChannelSummary[] }
+  | { ok: false; error: string };
+
+// Slack's conversations.list returns at most `limit` channels per page; a big
+// workspace needs cursor pagination or the list silently truncates — and a
+// private channel the bot was invited to can fall off the end and "disappear"
+// from the dropdown. Walk every page (capped) and aggregate. Note: even with
+// groups:read, Slack only returns private channels the bot is a *member* of,
+// so the user still has to `/invite` the bot to a private channel for it to
+// show up at all.
+export async function listSlackChannels(
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ListSlackChannelsResult> {
+  const channels: SlackChannelSummary[] = [];
+  let cursor: string | undefined;
+  // Hard page cap (200 * 50 = 10k channels) so a misbehaving cursor can't loop.
+  for (let page = 0; page < 50; page++) {
+    const url = new URL("https://slack.com/api/conversations.list");
+    url.searchParams.set("types", "public_channel,private_channel");
+    url.searchParams.set("exclude_archived", "true");
+    url.searchParams.set("limit", "200");
+    if (cursor) url.searchParams.set("cursor", cursor);
+    const res = await fetchImpl(url, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const data = (await res.json()) as SlackConversationsList;
+    if (!data.ok) return { ok: false, error: data.error ?? "unknown" };
+    for (const ch of data.channels ?? []) {
+      channels.push({ id: ch.id, name: ch.name, isPrivate: ch.is_private ?? false });
+    }
+    cursor = data.response_metadata?.next_cursor || undefined;
+    if (!cursor) break;
+  }
+  return { ok: true, channels };
+}
 
 // Slack interactivity envelope. `view.state.values` is keyed by block_id
 // then action_id; for the feedback modal that's

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -70,6 +70,7 @@ import {
   useWebhookDeliveries,
   useWebhooks,
 } from "./api";
+import { Dropdown } from "./design/Dropdown.tsx";
 import { Btn, Chip, FieldLabel, Input, Label, Tile } from "./design/ui";
 import { BillingCard } from "./settings/BillingCard.tsx";
 import { OrgGeneralCard } from "./settings/OrgGeneralCard.tsx";
@@ -1257,26 +1258,29 @@ function SlackRoutingCard({ projectId }: { projectId: string | undefined }) {
         <div className="flex flex-wrap items-end gap-3">
           <div className="min-w-[260px] flex-1">
             <FieldLabel>Channel</FieldLabel>
-            <select
+            <Dropdown
               value={pendingChannelId}
-              onChange={(e) => setPendingChannelId(e.target.value)}
+              onChange={setPendingChannelId}
               disabled={!projectId || channels.isLoading || channels.isError}
-              className="h-9 w-full appearance-none rounded-sm border border-border bg-surface-2 px-3 text-[13px] text-fg focus:border-border-strong focus:outline-none"
-            >
-              <option value="">
-                {channels.isLoading
+              placeholder={
+                channels.isLoading
                   ? "Loading channels…"
                   : channels.isError
                     ? "Failed to load channels"
-                    : "Select a channel…"}
-              </option>
-              {channelList.map((ch) => (
-                <option key={ch.id} value={ch.id}>
-                  {ch.isPrivate ? "🔒 " : "#"}
-                  {ch.name}
-                </option>
-              ))}
-            </select>
+                    : "Select a channel…"
+              }
+              emptyLabel="No channels found"
+              options={channelList.map((ch) => ({
+                value: ch.id,
+                searchText: `${ch.isPrivate ? "🔒 " : "#"}${ch.name}`,
+                label: (
+                  <span className="flex items-center gap-1.5">
+                    <span className="text-subtle">{ch.isPrivate ? "🔒" : "#"}</span>
+                    <span>{ch.name}</span>
+                  </span>
+                ),
+              }))}
+            />
           </div>
           <Btn
             size="md"
@@ -1304,10 +1308,13 @@ function SlackRoutingCard({ projectId }: { projectId: string | undefined }) {
           )}
         </div>
 
-        {channels.isError && (
+        {channels.isError ? (
+          <p className="text-[12px] text-muted">Couldn't fetch the channel list — try reconnecting Slack.</p>
+        ) : (
           <p className="text-[12px] text-muted">
-            Couldn't fetch the channel list. Make sure the bot is invited to private channels you
-            want to use.
+            Don't see a private channel? Slack only lists private channels the bot belongs to — run{" "}
+            <code className="rounded-sm bg-surface-2 px-1 py-0.5 text-[11px]">/invite @Superlog</code>{" "}
+            in that channel, then reopen this list.
           </p>
         )}
       </div>
@@ -1373,11 +1380,10 @@ function WeeklyDigestCard() {
         <div className="flex flex-wrap items-end gap-3">
           <div className="min-w-[260px] flex-1">
             <FieldLabel>Channel</FieldLabel>
-            <select
+            <Dropdown
               value={channelId}
               disabled={channels.isLoading || channels.isError || save.isPending}
-              onChange={(e) => {
-                const next = e.target.value;
+              onChange={(next) => {
                 if (!next) {
                   save.mutate({ enabled: false, channelId: null, channelName: null });
                   return;
@@ -1385,22 +1391,28 @@ function WeeklyDigestCard() {
                 const ch = channelList.find((c) => c.id === next);
                 save.mutate({ channelId: next, channelName: ch?.name ?? null });
               }}
-              className="h-9 w-full appearance-none rounded-sm border border-border bg-surface-2 px-3 text-[13px] text-fg focus:border-border-strong focus:outline-none"
-            >
-              <option value="">
-                {channels.isLoading
+              placeholder={
+                channels.isLoading
                   ? "Loading channels…"
                   : channels.isError
                     ? "Failed to load channels"
-                    : "— No channel —"}
-              </option>
-              {channelList.map((ch) => (
-                <option key={ch.id} value={ch.id}>
-                  {ch.isPrivate ? "🔒 " : "#"}
-                  {ch.name}
-                </option>
-              ))}
-            </select>
+                    : "No channel"
+              }
+              emptyLabel="No channels found"
+              options={[
+                { value: "", searchText: "No channel", label: "No channel" },
+                ...channelList.map((ch) => ({
+                  value: ch.id,
+                  searchText: `${ch.isPrivate ? "🔒 " : "#"}${ch.name}`,
+                  label: (
+                    <span className="flex items-center gap-1.5">
+                      <span className="text-subtle">{ch.isPrivate ? "🔒" : "#"}</span>
+                      <span>{ch.name}</span>
+                    </span>
+                  ),
+                })),
+              ]}
+            />
           </div>
           <Btn
             size="md"

--- a/apps/web/src/design/Dropdown.test.ts
+++ b/apps/web/src/design/Dropdown.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("non-searchable dropdown focuses its popover so keyboard navigation works", async () => {
+  const source = await readFile(new URL("./Dropdown.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /const listRef = useRef<HTMLDivElement>\(null\)/);
+  assert.match(source, /listRef\.current\?\.focus\(\)/);
+  assert.match(source, /ref=\{listRef\}/);
+  assert.match(source, /tabIndex=\{-1\}/);
+  assert.match(source, /onKeyDown=\{onKey\}/);
+});

--- a/apps/web/src/design/Dropdown.tsx
+++ b/apps/web/src/design/Dropdown.tsx
@@ -36,6 +36,7 @@ export function Dropdown({
   const [highlight, setHighlight] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
   const selected = options.find((o) => o.value === value);
 
@@ -45,20 +46,25 @@ export function Dropdown({
     return options.filter((o) => (o.searchText ?? o.value).toLowerCase().includes(q));
   }, [options, query]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: initialize selection only when the menu opens.
   useEffect(() => {
     if (!open) return;
     setQuery("");
     const idx = options.findIndex((o) => o.value === value);
     setHighlight(idx >= 0 ? idx : 0);
-    setTimeout(() => inputRef.current?.focus(), 0);
+    setTimeout(() => {
+      if (searchable) {
+        inputRef.current?.focus();
+      } else {
+        listRef.current?.focus();
+      }
+    }, 0);
     const onDoc = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
     };
     window.addEventListener("mousedown", onDoc);
     return () => window.removeEventListener("mousedown", onDoc);
-    // Only re-init when the menu opens; `filtered`/`value` are read once here.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  }, [open, searchable]);
 
   // Keep the highlight in range as the filter narrows the list.
   useEffect(() => {
@@ -93,7 +99,7 @@ export function Dropdown({
       <button
         type="button"
         disabled={disabled}
-        aria-haspopup="listbox"
+        aria-haspopup="menu"
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
         className="flex h-9 w-full items-center gap-2 rounded-sm border border-border bg-surface-2 px-3 text-left text-[13px] text-fg transition-colors hover:border-border-strong focus:border-border-strong focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
@@ -105,7 +111,9 @@ export function Dropdown({
       </button>
       {open && (
         <div
-          role="listbox"
+          ref={listRef}
+          tabIndex={-1}
+          onKeyDown={onKey}
           className="absolute left-0 top-full z-20 mt-1.5 w-full overflow-hidden rounded-lg border border-border bg-surface shadow-[0_10px_30px_-10px_rgba(0,0,0,0.4)]"
         >
           {searchable && (
@@ -120,7 +128,7 @@ export function Dropdown({
               />
             </div>
           )}
-          <div className="max-h-64 overflow-y-auto p-1" onKeyDown={onKey}>
+          <div className="max-h-64 overflow-y-auto p-1 focus:outline-none">
             {filtered.length === 0 ? (
               <div className="px-2.5 py-2 text-[12px] text-subtle">{emptyLabel}</div>
             ) : (
@@ -131,8 +139,7 @@ export function Dropdown({
                   <button
                     key={opt.value}
                     type="button"
-                    role="option"
-                    aria-selected={active}
+                    aria-pressed={active}
                     onClick={() => apply(opt.value)}
                     onMouseEnter={() => setHighlight(i)}
                     className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] transition-colors ${
@@ -162,6 +169,7 @@ function ChevronIcon() {
       strokeWidth="2"
       aria-hidden
     >
+      <title>Open dropdown</title>
       <path d="m6 9 6 6 6-6" />
     </svg>
   );
@@ -179,6 +187,7 @@ function CheckIcon() {
       strokeLinejoin="round"
       aria-hidden
     >
+      <title>Selected</title>
       <path d="m5 13 4 4L19 7" />
     </svg>
   );

--- a/apps/web/src/design/Dropdown.tsx
+++ b/apps/web/src/design/Dropdown.tsx
@@ -1,0 +1,185 @@
+import { type KeyboardEvent, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+
+export type DropdownOption = {
+  value: string;
+  label: ReactNode;
+  // Plain text used for the search filter and the collapsed trigger label.
+  // Falls back to `value` when omitted.
+  searchText?: string;
+};
+
+// Styled single-select dropdown matching the app's popover language (see
+// RangePicker / RowMenu) — replaces the native <select> so the menu, search,
+// and option rows are themed instead of the OS chrome. Searchable by default;
+// pass `searchable={false}` for short lists.
+export function Dropdown({
+  value,
+  onChange,
+  options,
+  placeholder = "Select…",
+  disabled = false,
+  searchable = true,
+  emptyLabel = "No matches",
+  className = "",
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  options: DropdownOption[];
+  placeholder?: ReactNode;
+  disabled?: boolean;
+  searchable?: boolean;
+  emptyLabel?: string;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [highlight, setHighlight] = useState(0);
+  const ref = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const selected = options.find((o) => o.value === value);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return options;
+    return options.filter((o) => (o.searchText ?? o.value).toLowerCase().includes(q));
+  }, [options, query]);
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery("");
+    const idx = options.findIndex((o) => o.value === value);
+    setHighlight(idx >= 0 ? idx : 0);
+    setTimeout(() => inputRef.current?.focus(), 0);
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    window.addEventListener("mousedown", onDoc);
+    return () => window.removeEventListener("mousedown", onDoc);
+    // Only re-init when the menu opens; `filtered`/`value` are read once here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Keep the highlight in range as the filter narrows the list.
+  useEffect(() => {
+    setHighlight((h) => Math.min(h, Math.max(0, filtered.length - 1)));
+  }, [filtered.length]);
+
+  const apply = (next: string) => {
+    onChange(next);
+    setOpen(false);
+  };
+
+  const onKey = (e: KeyboardEvent) => {
+    const lastIndex = Math.max(filtered.length - 1, 0);
+    if (e.key === "Escape") {
+      e.preventDefault();
+      setOpen(false);
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlight((h) => Math.min(h + 1, lastIndex));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const opt = filtered[highlight];
+      if (opt) apply(opt.value);
+    }
+  };
+
+  return (
+    <div ref={ref} className={`relative ${className}`}>
+      <button
+        type="button"
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex h-9 w-full items-center gap-2 rounded-sm border border-border bg-surface-2 px-3 text-left text-[13px] text-fg transition-colors hover:border-border-strong focus:border-border-strong focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <span className={`flex-1 truncate ${selected ? "text-fg" : "text-subtle"}`}>
+          {selected ? (selected.searchText ?? selected.label) : placeholder}
+        </span>
+        <ChevronIcon />
+      </button>
+      {open && (
+        <div
+          role="listbox"
+          className="absolute left-0 top-full z-20 mt-1.5 w-full overflow-hidden rounded-lg border border-border bg-surface shadow-[0_10px_30px_-10px_rgba(0,0,0,0.4)]"
+        >
+          {searchable && (
+            <div className="border-b border-border px-2.5">
+              <input
+                ref={inputRef}
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={onKey}
+                placeholder="Search…"
+                className="h-9 w-full bg-transparent text-[13px] text-fg placeholder:text-subtle focus:outline-none"
+              />
+            </div>
+          )}
+          <div className="max-h-64 overflow-y-auto p-1" onKeyDown={onKey}>
+            {filtered.length === 0 ? (
+              <div className="px-2.5 py-2 text-[12px] text-subtle">{emptyLabel}</div>
+            ) : (
+              filtered.map((opt, i) => {
+                const active = opt.value === value;
+                const highlighted = i === highlight;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    role="option"
+                    aria-selected={active}
+                    onClick={() => apply(opt.value)}
+                    onMouseEnter={() => setHighlight(i)}
+                    className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] transition-colors ${
+                      highlighted ? "bg-surface-2 text-fg" : active ? "text-fg" : "text-muted"
+                    }`}
+                  >
+                    <span className="flex-1 truncate">{opt.label}</span>
+                    {active && <CheckIcon />}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChevronIcon() {
+  return (
+    <svg
+      className="pointer-events-none h-3 w-3 shrink-0 text-subtle"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      className="h-3.5 w-3.5 shrink-0 text-fg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="m5 13 4 4L19 7" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- Paginate Slack `conversations.list` while requesting public and private channel types.
- Replace Slack channel native selects with a styled searchable dropdown.
- Clarify that Slack only lists private channels after the bot is invited.

## Validation
- `pnpm --dir superlog --filter @superlog/api test -- src/slack.test.ts`
- `pnpm --dir superlog --filter @superlog/api typecheck`
- `pnpm --dir superlog --filter @superlog/web typecheck`
- `pnpm --dir superlog --filter @superlog/web build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paginated Slack channel fetching via a new `listSlackChannels` utility to reliably include private channels, and replaced native selects with a searchable, styled `Dropdown` for channel selection. Polished copy, error states, and keyboard navigation (focus on the popover) based on feedback.

- **Bug Fixes**
  - Walk all `conversations.list` pages (public + private, exclude archived, limit 200) with a 50-page cap; aggregate channels and return `pagination_limit_exceeded` when still paginating.
  - Propagate Slack errors and mark `not_authed`/`token_revoked` installations as revoked; API route now uses `listSlackChannels`. Tests cover types, pagination, error pass-through, and cap overflow.

- **New Features**
  - Added a reusable `Dropdown` (searchable by default, focusable list for keyboard nav, placeholders, and empty states); used in Settings and Weekly Digest.
  - Clearer hint that private channels only appear after inviting the bot (example: `/invite @Superlog`), and a more direct error message when fetching fails.

<sup>Written for commit 6db8118baa33e14c8d5150368397212a204dae61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

