### PR TITLE
Add incident PR diff tab

### DIFF
--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -998,12 +998,17 @@ async function githubRequest<T>(pathname: string, bearerToken: string): Promise<
   return (await res.json()) as T;
 }
 
-async function createInstallationReadToken(installationId: number): Promise<string> {
+type GithubPermission = "read" | "write";
+
+async function createInstallationToken(opts: {
+  installationId: number;
+  permissions: Record<string, GithubPermission>;
+}): Promise<string> {
   const cfg = getGithubAppConfig();
   if (!cfg) throw new Error("GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY are required");
   const appJwt = signGithubAppJwt(cfg.appId, cfg.privateKey);
   const res = await fetch(
-    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    `https://api.github.com/app/installations/${opts.installationId}/access_tokens`,
     {
       method: "POST",
       headers: {
@@ -1013,17 +1018,57 @@ async function createInstallationReadToken(installationId: number): Promise<stri
         "x-github-api-version": "2022-11-28",
         "user-agent": "superlog-api",
       },
-      body: JSON.stringify({ permissions: { contents: "read" } }),
+      body: JSON.stringify({ permissions: opts.permissions }),
     },
   );
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `github POST /app/installations/${installationId}/access_tokens failed: ${res.status} ${text}`,
+      `github POST /app/installations/${opts.installationId}/access_tokens failed: ${res.status} ${text}`,
     );
   }
   const data = (await res.json()) as { token: string };
   return data.token;
+}
+
+async function createInstallationReadToken(installationId: number): Promise<string> {
+  return createInstallationToken({ installationId, permissions: { contents: "read" } });
+}
+
+async function createInstallationWriteToken(installationId: number): Promise<string> {
+  return createInstallationToken({
+    installationId,
+    permissions: { contents: "write", pull_requests: "write" },
+  });
+}
+
+export async function mergeGithubPullRequest(opts: {
+  installationId: number;
+  repoFullName: string;
+  prNumber: number;
+  method: "squash" | "merge" | "rebase";
+}): Promise<{ sha: string | null }> {
+  const token = await createInstallationWriteToken(opts.installationId);
+  const res = await fetch(
+    `https://api.github.com/repos/${opts.repoFullName}/pulls/${opts.prNumber}/merge`,
+    {
+      method: "PUT",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json; charset=utf-8",
+        "x-github-api-version": "2022-11-28",
+        "user-agent": "superlog-api",
+      },
+      body: JSON.stringify({ merge_method: opts.method }),
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`github PUT /pulls/${opts.prNumber}/merge failed: ${res.status} ${text}`);
+  }
+  const body = (await res.json().catch(() => ({}))) as { sha?: string };
+  return { sha: body.sha ?? null };
 }
 
 export async function listCurrentInstallationRepos(installationId: number): Promise<StoredRepo[]> {

--- a/apps/api/src/incidents/pr-view.test.ts
+++ b/apps/api/src/incidents/pr-view.test.ts
@@ -1,0 +1,76 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { buildIncidentPullRequestViews } from "./pr-view.js";
+
+test("incident PR view includes the recorded PR patch from its agent run", () => {
+  const now = new Date("2026-06-06T12:00:00.000Z");
+  const views = buildIncidentPullRequestViews(
+    [
+      {
+        id: "pr-1",
+        agentRunId: "run-1",
+        repoFullName: "acme/app",
+        prNumber: 42,
+        url: "https://github.com/acme/app/pull/42",
+        branchName: "ash/fix-checkout",
+        baseBranch: "main",
+        headSha: "abc123",
+        state: "open",
+        title: "Fix checkout",
+        createdAt: now,
+        updatedAt: now,
+        mergedAt: null,
+        closedAt: null,
+      },
+    ],
+    [
+      {
+        id: "run-1",
+        result: {
+          state: "complete",
+          summary: "Fixed it",
+          pr: {
+            selectedRepoFullName: "acme/app",
+            branchName: "ash/fix-checkout",
+            baseBranch: "main",
+            validationPassed: true,
+            openStatus: "opened",
+            patch: "diff --git a/app.ts b/app.ts\n+ok\n",
+          },
+        },
+      },
+    ],
+  );
+
+  assert.equal(views.length, 1);
+  assert.equal(views[0]?.repoFullName, "acme/app");
+  assert.equal(views[0]?.patch, "diff --git a/app.ts b/app.ts\n+ok\n");
+  assert.equal(views[0]?.createdAt, "2026-06-06T12:00:00.000Z");
+});
+
+test("incident PR view returns null patch when the agent run has no patch body", () => {
+  const now = new Date("2026-06-06T12:00:00.000Z");
+  const views = buildIncidentPullRequestViews(
+    [
+      {
+        id: "pr-1",
+        agentRunId: "run-1",
+        repoFullName: "acme/app",
+        prNumber: 42,
+        url: "https://github.com/acme/app/pull/42",
+        branchName: "ash/fix-checkout",
+        baseBranch: "main",
+        headSha: null,
+        state: "open",
+        title: null,
+        createdAt: now,
+        updatedAt: now,
+        mergedAt: null,
+        closedAt: null,
+      },
+    ],
+    [{ id: "run-1", result: { state: "complete", summary: "Fixed it", pr: null } }],
+  );
+
+  assert.equal(views[0]?.patch, null);
+});

--- a/apps/api/src/incidents/pr-view.ts
+++ b/apps/api/src/incidents/pr-view.ts
@@ -1,0 +1,67 @@
+import type { schema } from "@superlog/db";
+
+export type IncidentPullRequestView = {
+  id: string;
+  agentRunId: string;
+  repoFullName: string;
+  prNumber: number;
+  url: string;
+  branchName: string;
+  baseBranch: string;
+  headSha: string | null;
+  state: schema.AgentPrState;
+  title: string | null;
+  patch: string | null;
+  createdAt: string;
+  updatedAt: string;
+  mergedAt: string | null;
+  closedAt: string | null;
+};
+
+type AgentRunWithResult = Pick<schema.AgentRun, "id" | "result">;
+type AgentPullRequestRow = Pick<
+  schema.AgentPullRequest,
+  | "id"
+  | "agentRunId"
+  | "repoFullName"
+  | "prNumber"
+  | "url"
+  | "branchName"
+  | "baseBranch"
+  | "headSha"
+  | "state"
+  | "title"
+  | "createdAt"
+  | "updatedAt"
+  | "mergedAt"
+  | "closedAt"
+>;
+
+export function buildIncidentPullRequestViews(
+  prs: AgentPullRequestRow[],
+  agentRuns: AgentRunWithResult[],
+): IncidentPullRequestView[] {
+  const runsById = new Map(agentRuns.map((run) => [run.id, run] as const));
+  return prs.map((pr) => {
+    const run = runsById.get(pr.agentRunId) ?? null;
+    const runPr = run?.result?.pr ?? null;
+    const patch = typeof runPr?.patch === "string" && runPr.patch.trim() ? runPr.patch : null;
+    return {
+      id: pr.id,
+      agentRunId: pr.agentRunId,
+      repoFullName: pr.repoFullName,
+      prNumber: pr.prNumber,
+      url: pr.url,
+      branchName: pr.branchName,
+      baseBranch: pr.baseBranch,
+      headSha: pr.headSha,
+      state: pr.state,
+      title: pr.title,
+      patch,
+      createdAt: pr.createdAt.toISOString(),
+      updatedAt: pr.updatedAt.toISOString(),
+      mergedAt: pr.mergedAt?.toISOString() ?? null,
+      closedAt: pr.closedAt?.toISOString() ?? null,
+    };
+  });
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -33,11 +33,17 @@ import { shouldRunMigrationsOnBoot } from "./boot-migrations.js";
 import { mountDashboards } from "./dashboards.js";
 import { mountFeedbackAuthed, mountFeedbackPublic } from "./feedback.js";
 import { type GatewayVars, mountGateway } from "./gateway.js";
-import { mountGithubAuthed, mountGithubAuthorOAuth, mountGithubPublic } from "./github.js";
+import {
+  mergeGithubPullRequest,
+  mountGithubAuthed,
+  mountGithubAuthorOAuth,
+  mountGithubPublic,
+} from "./github.js";
 import { createApiHttpObservabilityMiddleware } from "./http-observability.js";
 import { mountImpersonation } from "./impersonation.js";
 import { buildIncidentListItem, shouldInlineIncidentListStats } from "./incidents/list.js";
 import { getPrDeliveryRetryEligibility } from "./incidents/pr-retry.js";
+import { buildIncidentPullRequestViews } from "./incidents/pr-view.js";
 import {
   buildIncidentStatsFromActivityRows,
   buildIncidentStatsFromIssues,
@@ -1928,6 +1934,126 @@ app.get("/api/projects/:projectId/incidents/:incidentId", async (c) => {
     agentRuns,
     timeline,
     pendingResolutionProposal: pendingProposalMap.get(incident.id) ?? null,
+  });
+});
+
+app.get("/api/projects/:projectId/incidents/:incidentId/pull-requests", async (c) => {
+  const projectId = c.req.param("projectId");
+  const incidentId = c.req.param("incidentId");
+  await requireProjectAccess(c, projectId);
+
+  const incident = await getProjectIncident(projectId, incidentId);
+  if (!incident) throw new HTTPException(404, { message: "incident not found" });
+
+  const [prs, agentRuns] = await Promise.all([
+    db.query.agentPullRequests.findMany({
+      where: eq(schema.agentPullRequests.incidentId, incidentId),
+      orderBy: [desc(schema.agentPullRequests.createdAt)],
+    }),
+    db.query.agentRuns.findMany({
+      where: eq(schema.agentRuns.incidentId, incidentId),
+    }),
+  ]);
+
+  return c.json(buildIncidentPullRequestViews(prs, agentRuns));
+});
+
+const VALID_MANUAL_MERGE_METHODS = new Set(["squash", "merge", "rebase"]);
+
+app.post("/api/projects/:projectId/incidents/:incidentId/pull-requests/:prId/merge", async (c) => {
+  const projectId = c.req.param("projectId");
+  const incidentId = c.req.param("incidentId");
+  const prId = c.req.param("prId");
+  await requireProjectAccess(c, projectId);
+
+  const incident = await getProjectIncident(projectId, incidentId);
+  if (!incident) throw new HTTPException(404, { message: "incident not found" });
+
+  const pr = await db.query.agentPullRequests.findFirst({
+    where: and(
+      eq(schema.agentPullRequests.id, prId),
+      eq(schema.agentPullRequests.incidentId, incidentId),
+    ),
+  });
+  if (!pr) throw new HTTPException(404, { message: "pull request not found" });
+  if (pr.state !== "open") {
+    throw new HTTPException(409, { message: `pull request is already ${pr.state}` });
+  }
+
+  const installation = await db.query.githubInstallations.findFirst({
+    where: eq(schema.githubInstallations.id, pr.installationId),
+  });
+  if (!installation || installation.revokedAt) {
+    throw new HTTPException(409, { message: "github installation is unavailable" });
+  }
+
+  const body = (await c.req.json().catch(() => ({}))) as { method?: unknown };
+  const method =
+    typeof body.method === "string" && VALID_MANUAL_MERGE_METHODS.has(body.method)
+      ? (body.method as "squash" | "merge" | "rebase")
+      : "squash";
+
+  const merged = await mergeGithubPullRequest({
+    installationId: installation.installationId,
+    repoFullName: pr.repoFullName,
+    prNumber: pr.prNumber,
+    method,
+  });
+
+  const now = new Date();
+  const [updatedPr] = await db
+    .update(schema.agentPullRequests)
+    .set({
+      state: "merged",
+      mergedAt: now,
+      closedAt: now,
+      headSha: merged.sha ?? pr.headSha,
+      lastSyncedAt: now,
+      updatedAt: now,
+    })
+    .where(eq(schema.agentPullRequests.id, pr.id))
+    .returning();
+
+  await db
+    .insert(schema.agentPrEvents)
+    .values({
+      agentPrId: pr.id,
+      kind: "pr_merged",
+      summary: `PR #${pr.prNumber} merged from dashboard`,
+      payload: { method, sha: merged.sha, prUrl: pr.url, repoFullName: pr.repoFullName },
+      providerEventId: `dashboard_merge:${pr.id}`,
+      occurredAt: now,
+    })
+    .onConflictDoNothing();
+
+  await resolveIncident({
+    incidentId: pr.incidentId,
+    kind: "agent_pr_merged",
+    reasonCode: "agent_pr_merged",
+    reasonText: `Resolved because agent PR #${pr.prNumber} (${pr.repoFullName}) was merged.`,
+    agentRunId: pr.agentRunId,
+    eventSummary: `Incident resolved because PR #${pr.prNumber} was merged.`,
+    eventDetail: {
+      agentPrId: pr.id,
+      repoFullName: pr.repoFullName,
+      prNumber: pr.prNumber,
+      prUrl: pr.url,
+      mergedByLogin: null,
+    },
+    eventDedupeKey: `incident_resolved:agent_pr:${pr.id}`,
+    resolvedAt: now,
+  });
+
+  const agentRun = await db.query.agentRuns.findFirst({
+    where: eq(schema.agentRuns.id, pr.agentRunId),
+  });
+
+  return c.json({
+    ok: true,
+    sha: merged.sha,
+    pullRequest: updatedPr
+      ? (buildIncidentPullRequestViews([updatedPr], agentRun ? [agentRun] : [])[0] ?? null)
+      : null,
   });
 });
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@opentelemetry/resources": "^2.7.0",
     "@opentelemetry/sdk-trace-web": "^2.7.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
+    "@pierre/diffs": "^1.2.7",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@tanstack/react-query": "^5.62.8",
     "@types/react-grid-layout": "^2.1.0",

--- a/apps/web/src/IncidentPrDiffView.tsx
+++ b/apps/web/src/IncidentPrDiffView.tsx
@@ -1,0 +1,98 @@
+import { parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs";
+import { FileDiff, PatchDiff } from "@pierre/diffs/react";
+import { useMemo, useState } from "react";
+
+const DIFF_OPTIONS = {
+  theme: "pierre-dark",
+  themeType: "dark",
+  diffStyle: "unified",
+  overflow: "wrap",
+  hunkSeparators: "line-info-basic",
+  diffIndicators: "bars",
+} as const;
+
+export default function IncidentPrDiffView({
+  patch,
+  patchKey,
+}: {
+  patch: string;
+  patchKey: string;
+}) {
+  const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
+  const files = useMemo(() => parsePrPatchFiles(patch), [patch]);
+  const selectedFile = selectedFileName
+    ? (files.find((file) => file.name === selectedFileName) ?? null)
+    : null;
+
+  return (
+    <div className="grid min-h-[520px] grid-cols-[190px_minmax(0,1fr)] overflow-hidden rounded-md border border-border bg-surface">
+      <FileTree files={files} selectedFileName={selectedFileName} onSelect={setSelectedFileName} />
+      <div className="min-w-0 overflow-auto bg-[#0d0d0f]">
+        {selectedFile ? (
+          <FileDiff
+            key={`${patchKey}:${selectedFile.name}`}
+            fileDiff={selectedFile}
+            options={DIFF_OPTIONS}
+            disableWorkerPool
+          />
+        ) : (
+          <PatchDiff key={patchKey} patch={patch} options={DIFF_OPTIONS} disableWorkerPool />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function parsePrPatchFiles(patch: string): FileDiffMetadata[] {
+  try {
+    return parsePatchFiles(patch, "incident-pr", true).flatMap((parsed) => parsed.files);
+  } catch {
+    return [];
+  }
+}
+
+function FileTree({
+  files,
+  selectedFileName,
+  onSelect,
+}: {
+  files: FileDiffMetadata[];
+  selectedFileName: string | null;
+  onSelect: (name: string | null) => void;
+}) {
+  return (
+    <aside className="border-r border-border bg-bg/80">
+      <button
+        type="button"
+        onClick={() => onSelect(null)}
+        className={`flex h-9 w-full items-center justify-between border-b border-border px-3 text-left text-[12px] ${
+          selectedFileName === null ? "bg-surface-2 text-fg" : "text-muted hover:text-fg"
+        }`}
+      >
+        <span>All files</span>
+        <span className="font-mono text-[11px] text-subtle">{files.length}</span>
+      </button>
+      <div className="max-h-[480px] overflow-y-auto py-1">
+        {files.length === 0 ? (
+          <p className="px-3 py-2 text-[12px] text-muted">No file list</p>
+        ) : (
+          files.map((file) => (
+            <button
+              key={file.name}
+              type="button"
+              onClick={() => onSelect(file.name)}
+              className={`block w-full truncate px-3 py-1.5 text-left font-mono text-[11px] ${
+                selectedFileName === file.name
+                  ? "bg-surface-2 text-fg"
+                  : "text-muted hover:bg-surface hover:text-fg"
+              }`}
+              title={file.name}
+            >
+              {file.name}
+            </button>
+          ))
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -1,6 +1,15 @@
 import { ChartIncreaseIcon, CheckmarkCircle02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { type ReactNode, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  lazy,
+  type ReactNode,
+  Suspense,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import { type EvidenceLinkContext, EvidenceMarkdown } from "./EvidenceMarkdown.tsx";
 import { FeedbackTrigger } from "./FeedbackDialog.tsx";
@@ -12,6 +21,7 @@ import {
   type Incident,
   type IncidentEvent,
   type IncidentListItem,
+  type IncidentPullRequest,
   type IncidentSeverity,
   type IncidentStats,
   type Issue,
@@ -20,12 +30,14 @@ import {
   type PendingResolutionProposal,
   useDecideResolutionProposal,
   useIncident,
+  useIncidentPullRequests,
   useIncidentStats,
   useIncidents,
   useIssue,
   useIssueAgentRun,
   useIssues,
   useMe,
+  useMergeIncidentPullRequest,
   useRestartAgentRun,
   useRetryPrDelivery,
   useSilenceIssue,
@@ -34,6 +46,8 @@ import {
 } from "./api.ts";
 import { Btn, Chip } from "./design/ui.tsx";
 import { getIssueIncidentLinkState } from "./issue-incident-link-state.ts";
+
+const IncidentPrDiffView = lazy(() => import("./IncidentPrDiffView.tsx"));
 
 type IssueFilter = "active" | "silenced" | "all";
 type IncidentStatus = "open" | "resolved" | "autoresolved_noise" | "all";
@@ -1329,6 +1343,8 @@ export function IncidentDetailContent({
   restartingAgentRun?: boolean;
   retryingPrDelivery?: boolean;
 }) {
+  const [detailTab, setDetailTab] = useState<"incident" | "pr">("incident");
+
   return (
     <div className="space-y-8 p-4">
       <div className="flex items-start justify-between gap-3">
@@ -1363,63 +1379,229 @@ export function IncidentDetailContent({
         </div>
       </div>
 
-      <div className="space-y-2">
-        <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
-          <MetaInline label="Service" value={incident.service ?? "—"} />
-          <MetaInline label="Environment" value={incident.environment ?? "—"} />
+      <IncidentDetailTabs active={detailTab} onChange={setDetailTab} />
+
+      {detailTab === "incident" ? (
+        <>
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+              <MetaInline label="Service" value={incident.service ?? "—"} />
+              <MetaInline label="Environment" value={incident.environment ?? "—"} />
+            </div>
+            <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+              <MetaInline label="First seen" value={fmtRelative(incident.firstSeen)} />
+              <MetaInline label="Last seen" value={fmtRelative(incident.lastSeen)} />
+            </div>
+          </div>
+
+          <IncidentActivityPanel projectId={incident.projectId} incidentId={incident.id} />
+
+          {pendingResolutionProposal && onDecideProposal && (
+            <ResolutionProposalBanner
+              proposal={pendingResolutionProposal}
+              onConfirm={() => onDecideProposal(pendingResolutionProposal.id, "confirm")}
+              onDismiss={() => onDecideProposal(pendingResolutionProposal.id, "dismiss")}
+              deciding={!!decidingProposal}
+            />
+          )}
+
+          <div className="space-y-3">
+            <SectionHeading>Issues in this incident</SectionHeading>
+            {issues.length === 0 ? (
+              <p className="text-[12px] text-muted">none</p>
+            ) : (
+              <IssueList issues={issues} onViewIssue={onViewIssue} />
+            )}
+          </div>
+
+          <AgentRunView
+            incident={incident}
+            agentRun={agentRun}
+            agentRuns={agentRuns}
+            events={events}
+            eventsError={eventsError}
+            eventsLoading={eventsLoading}
+            onRestart={onRestartAgentRun}
+            onRetryPrDelivery={onRetryPrDelivery}
+            restarting={restartingAgentRun}
+            retryingPrDelivery={retryingPrDelivery}
+          />
+
+          <div className="mt-8 border-t border-border pt-6">
+            <IncidentTimeline
+              events={events}
+              eventsError={eventsError}
+              eventsLoading={eventsLoading}
+            />
+          </div>
+
+          <Btn
+            variant={incident.status === "open" ? "secondary" : "ghost"}
+            size="sm"
+            onClick={onToggleStatus}
+            loading={updatingIncident}
+            className="w-full justify-center"
+          >
+            {incident.status === "open" ? "Resolve incident" : "Reopen incident"}
+          </Btn>
+        </>
+      ) : (
+        <IncidentPullRequestPanel projectId={incident.projectId} incidentId={incident.id} />
+      )}
+    </div>
+  );
+}
+
+function IncidentDetailTabs({
+  active,
+  onChange,
+}: {
+  active: "incident" | "pr";
+  onChange: (tab: "incident" | "pr") => void;
+}) {
+  const tabs: { id: "incident" | "pr"; label: string }[] = [
+    { id: "incident", label: "Incident" },
+    { id: "pr", label: "PR" },
+  ];
+  return (
+    <div className="-mx-4 border-b border-border px-4">
+      <div className="flex gap-9">
+        {tabs.map((tab) => {
+          const selected = active === tab.id;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => onChange(tab.id)}
+              className={`relative h-11 text-[14px] font-medium transition-colors ${
+                selected ? "text-fg" : "text-muted hover:text-fg"
+              }`}
+            >
+              {tab.label}
+              {selected && (
+                <span className="absolute inset-x-0 bottom-0 h-[3px] bg-fg" aria-hidden />
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function IncidentPullRequestPanel({
+  projectId,
+  incidentId,
+}: {
+  projectId: string;
+  incidentId: string;
+}) {
+  const prs = useIncidentPullRequests(projectId, incidentId);
+  const mergePr = useMergeIncidentPullRequest(projectId, incidentId);
+  const [selectedPrId, setSelectedPrId] = useState<string | null>(null);
+
+  const selectedPr = prs.data?.find((pr) => pr.id === selectedPrId) ?? prs.data?.[0] ?? null;
+
+  useEffect(() => {
+    if (!prs.data?.length) {
+      setSelectedPrId(null);
+      return;
+    }
+    if (!selectedPrId || !prs.data.some((pr) => pr.id === selectedPrId)) {
+      setSelectedPrId(prs.data[0]!.id);
+    }
+  }, [prs.data, selectedPrId]);
+
+  if (prs.isLoading) {
+    return <p className="text-[12px] text-muted">Loading PR…</p>;
+  }
+  if (prs.error) {
+    return <p className="text-[12px] text-danger">Failed to load PR: {String(prs.error)}</p>;
+  }
+  if (!prs.data || prs.data.length === 0) {
+    return (
+      <div className="rounded-md border border-border bg-surface p-4">
+        <SectionHeading>Pull request</SectionHeading>
+        <p className="mt-2 text-[12px] text-muted">No PR has been opened for this incident.</p>
+      </div>
+    );
+  }
+  if (!selectedPr) return null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <SectionHeading>Pull request</SectionHeading>
+          <a
+            href={selectedPr.url}
+            target="_blank"
+            rel="noreferrer"
+            className="block truncate text-[13px] font-medium text-fg hover:underline"
+          >
+            {selectedPr.repoFullName} #{selectedPr.prNumber}
+          </a>
+          <p className="truncate text-[12px] text-muted">
+            {selectedPr.title ?? selectedPr.branchName} into {selectedPr.baseBranch}
+          </p>
         </div>
-        <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
-          <MetaInline label="First seen" value={fmtRelative(incident.firstSeen)} />
-          <MetaInline label="Last seen" value={fmtRelative(incident.lastSeen)} />
+        <div className="flex items-center gap-2">
+          <Chip tone={selectedPr.state === "merged" ? "success" : "neutral"} dot>
+            {selectedPr.state}
+          </Chip>
+          {selectedPr.state === "open" && (
+            <Btn
+              size="sm"
+              variant="primary"
+              loading={mergePr.isPending}
+              onClick={() => mergePr.mutate({ prId: selectedPr.id })}
+            >
+              Merge PR
+            </Btn>
+          )}
         </div>
       </div>
 
-      <IncidentActivityPanel projectId={incident.projectId} incidentId={incident.id} />
-
-      {pendingResolutionProposal && onDecideProposal && (
-        <ResolutionProposalBanner
-          proposal={pendingResolutionProposal}
-          onConfirm={() => onDecideProposal(pendingResolutionProposal.id, "confirm")}
-          onDismiss={() => onDecideProposal(pendingResolutionProposal.id, "dismiss")}
-          deciding={!!decidingProposal}
-        />
+      {prs.data.length > 1 && (
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {prs.data.map((pr) => (
+            <button
+              key={pr.id}
+              type="button"
+              onClick={() => setSelectedPrId(pr.id)}
+              className={`shrink-0 rounded-sm border px-2.5 py-1 text-[12px] ${
+                selectedPr.id === pr.id
+                  ? "border-border-strong bg-surface-2 text-fg"
+                  : "border-border text-muted hover:text-fg"
+              }`}
+            >
+              #{pr.prNumber}
+            </button>
+          ))}
+        </div>
       )}
 
-      <div className="space-y-3">
-        <SectionHeading>Issues in this incident</SectionHeading>
-        {issues.length === 0 ? (
-          <p className="text-[12px] text-muted">none</p>
-        ) : (
-          <IssueList issues={issues} onViewIssue={onViewIssue} />
-        )}
-      </div>
+      {mergePr.error && (
+        <p className="rounded-sm border border-danger/40 bg-danger/10 px-3 py-2 text-[12px] text-danger">
+          Merge failed: {String(mergePr.error)}
+        </p>
+      )}
 
-      <AgentRunView
-        incident={incident}
-        agentRun={agentRun}
-        agentRuns={agentRuns}
-        events={events}
-        eventsError={eventsError}
-        eventsLoading={eventsLoading}
-        onRestart={onRestartAgentRun}
-        onRetryPrDelivery={onRetryPrDelivery}
-        restarting={restartingAgentRun}
-        retryingPrDelivery={retryingPrDelivery}
-      />
-
-      <div className="mt-8 border-t border-border pt-6">
-        <IncidentTimeline events={events} eventsError={eventsError} eventsLoading={eventsLoading} />
-      </div>
-
-      <Btn
-        variant={incident.status === "open" ? "secondary" : "ghost"}
-        size="sm"
-        onClick={onToggleStatus}
-        loading={updatingIncident}
-        className="w-full justify-center"
-      >
-        {incident.status === "open" ? "Resolve incident" : "Reopen incident"}
-      </Btn>
+      {!selectedPr.patch ? (
+        <div className="rounded-md border border-border bg-surface p-4">
+          <p className="text-[12px] text-muted">No patch body was recorded for this PR.</p>
+        </div>
+      ) : (
+        <Suspense
+          fallback={
+            <div className="min-h-[520px] rounded-md border border-border bg-surface p-4 text-[12px] text-muted">
+              Loading diff…
+            </div>
+          }
+        >
+          <IncidentPrDiffView patch={selectedPr.patch} patchKey={selectedPr.id} />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1437,6 +1437,24 @@ export type IncidentDetail = {
   pendingResolutionProposal: PendingResolutionProposal | null;
 };
 
+export type IncidentPullRequest = {
+  id: string;
+  agentRunId: string;
+  repoFullName: string;
+  prNumber: number;
+  url: string;
+  branchName: string;
+  baseBranch: string;
+  headSha: string | null;
+  state: "open" | "closed" | "merged";
+  title: string | null;
+  patch: string | null;
+  createdAt: string;
+  updatedAt: string;
+  mergedAt: string | null;
+  closedAt: string | null;
+};
+
 export function useIncidents(
   projectId: string | undefined,
   status: "open" | "resolved" | "autoresolved_noise" | "all" = "open",
@@ -1458,6 +1476,42 @@ export function useIncident(projectId: string | undefined, incidentId: string | 
     queryKey: ["incident", projectId, incidentId],
     queryFn: () => fetcher<IncidentDetail>(`/api/projects/${projectId}/incidents/${incidentId}`),
     enabled: !!projectId && !!incidentId,
+  });
+}
+
+export function useIncidentPullRequests(
+  projectId: string | undefined,
+  incidentId: string | undefined,
+  enabled = true,
+) {
+  const fetcher = useFetcher();
+  return useQuery({
+    queryKey: ["incident-prs", projectId, incidentId],
+    queryFn: () =>
+      fetcher<IncidentPullRequest[]>(
+        `/api/projects/${projectId}/incidents/${incidentId}/pull-requests`,
+      ),
+    enabled: !!projectId && !!incidentId && enabled,
+  });
+}
+
+export function useMergeIncidentPullRequest(projectId: string, incidentId: string) {
+  const fetcher = useFetcher();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { prId: string; method?: "squash" | "merge" | "rebase" }) =>
+      fetcher<{ ok: true; sha: string | null; pullRequest: IncidentPullRequest | null }>(
+        `/api/projects/${projectId}/incidents/${incidentId}/pull-requests/${vars.prId}/merge`,
+        {
+          method: "POST",
+          body: JSON.stringify({ method: vars.method ?? "squash" }),
+        },
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["incidents", projectId] });
+      qc.invalidateQueries({ queryKey: ["incident", projectId, incidentId] });
+      qc.invalidateQueries({ queryKey: ["incident-prs", projectId, incidentId] });
+    },
   });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,9 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.40.0
         version: 1.40.0
+      '@pierre/diffs':
+        specifier: ^1.2.7
+        version: 1.2.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.10
         version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -2380,6 +2383,16 @@ packages:
   '@oslojs/jwt@0.2.0':
     resolution: {integrity: sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==}
 
+  '@pierre/diffs@1.2.7':
+    resolution: {integrity: sha512-YrHmFZLDtiLZ4DkiVqMDUFqTFIct3ML3t20nMp0UeuiUtqrmRcenYVxPb4IafiNkhZZURhCiwcs89tVb/HrSDA==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+
+  '@pierre/theme@1.0.3':
+    resolution: {integrity: sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==}
+    engines: {vscode: ^1.0.0}
+
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
@@ -2686,17 +2699,29 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
   '@shikijs/core@4.0.2':
     resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
     engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
 
   '@shikijs/engine-javascript@4.0.2':
     resolution: {integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==}
     engines: {node: '>=20'}
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
   '@shikijs/engine-oniguruma@4.0.2':
     resolution: {integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==}
     engines: {node: '>=20'}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
 
   '@shikijs/langs@4.0.2':
     resolution: {integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==}
@@ -2706,9 +2731,18 @@ packages:
     resolution: {integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==}
     engines: {node: '>=20'}
 
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
   '@shikijs/themes@4.0.2':
     resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
     engines: {node: '>=20'}
+
+  '@shikijs/transformers@3.23.0':
+    resolution: {integrity: sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/types@4.0.2':
     resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
@@ -3519,6 +3553,10 @@ packages:
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
+    engines: {node: '>=0.3.1'}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -4269,6 +4307,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru_map@0.4.1:
+    resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
+
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
@@ -4970,6 +5011,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
   shiki@4.0.2:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
@@ -7417,6 +7461,19 @@ snapshots:
     dependencies:
       '@oslojs/encoding': 0.4.1
 
+  '@pierre/diffs@1.2.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@pierre/theme': 1.0.3
+      '@shikijs/transformers': 3.23.0
+      diff: 8.0.3
+      hast-util-to-html: 9.0.5
+      lru_map: 0.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      shiki: 3.23.0
+
+  '@pierre/theme@1.0.3': {}
+
   '@pinojs/redact@0.4.0': {}
 
   '@posthog/core@1.30.3':
@@ -7643,6 +7700,13 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
   '@shikijs/core@4.0.2':
     dependencies:
       '@shikijs/primitive': 4.0.2
@@ -7651,16 +7715,31 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
+  '@shikijs/engine-javascript@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
   '@shikijs/engine-javascript@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.6
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@shikijs/engine-oniguruma@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
 
   '@shikijs/langs@4.0.2':
     dependencies:
@@ -7672,9 +7751,23 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
   '@shikijs/themes@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
+
+  '@shikijs/transformers@3.23.0':
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   '@shikijs/types@4.0.2':
     dependencies:
@@ -8415,6 +8508,8 @@ snapshots:
 
   didyoumean@1.2.2: {}
 
+  diff@8.0.3: {}
+
   diff@8.0.4: {}
 
   dlv@1.1.3: {}
@@ -9149,6 +9244,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru_map@0.4.1: {}
 
   luxon@3.7.2: {}
 
@@ -9886,6 +9983,17 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shiki@3.23.0:
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   shiki@4.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
Adds an Incident/PR tab switcher to incident details so users can inspect agent-opened PRs without leaving the dashboard.
The PR tab loads recorded pull requests, renders stored patch diffs with a file tree, and exposes a merge action that records PR merge state and resolves the incident.

## Validation
- `pnpm --dir apps/api exec tsx --test src/incidents/pr-view.test.ts`
- `pnpm --filter @superlog/api typecheck`
- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PR tab to incident details so teams can inspect agent-opened PRs and merge them without leaving the dashboard. Merging from the dashboard updates PR state and resolves the incident.

- New Features
  - Incident detail now has "Incident" and "PR" tabs; the PR tab lists incident PRs and renders stored patch diffs with a file tree.
  - "Merge PR" action (default squash) calls GitHub, records merge state, emits a PR event, and resolves the incident.
  - API: `GET /api/projects/:projectId/incidents/:incidentId/pull-requests` and `POST /api/projects/:projectId/incidents/:incidentId/pull-requests/:prId/merge`.
  - Server: `buildIncidentPullRequestViews` maps DB rows + agent run patch into view models; `mergeGithubPullRequest` adds GitHub merge support with write permissions.
  - Web: `IncidentPrDiffView` renders diffs; hooks `useIncidentPullRequests` and `useMergeIncidentPullRequest` manage data and merge flow.
  - Tests: `pr-view.test.ts` covers patch extraction and null-patch behavior.

- Dependencies
  - Added `@pierre/diffs` for parsing and rendering PR patch diffs.

<sup>Written for commit f6d9118a7deecc81d18041084367dbcfe5272c74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

