### PR TITLE
Fix Slack feedback modal: ack view_submission with an empty body

### DIFF
--- a/apps/api/src/slack.test.ts
+++ b/apps/api/src/slack.test.ts
@@ -99,6 +99,54 @@ test("listSlackChannels returns the Slack error without paginating further", asy
   assert.equal(result.error, "token_revoked");
 });
 
+// Regression guard: clicking Send on the Slack incident feedback modal kept
+// surfacing "We had some trouble connecting. Try again?". Slack's
+// view_submission ack contract requires an EMPTY 200 body to close the modal;
+// our route was returning `{"ok":true}`, which Slack treats as an invalid
+// response and refuses to close. The ack body must be empty.
+test("view_submission ack is an empty 200 body (closes the Slack modal)", async () => {
+  const { Hono } = await import("hono");
+  const { mountSlackPublic } = await import("./slack.js");
+
+  const secret = "test-slack-signing-secret";
+  process.env.SLACK_SIGNING_SECRET = secret;
+
+  const app = new Hono();
+  mountSlackPublic(app);
+
+  // Empty feedback value → handler returns before any DB access, isolating the
+  // ack-body behavior we care about.
+  const payload = {
+    type: "view_submission",
+    view: {
+      callback_id: "feedback_modal:incident-123",
+      state: { values: { feedback_body: { value: { value: "" } } } },
+    },
+    user: { id: "U1" },
+    team: { id: "T1" },
+  };
+  const rawBody = `payload=${encodeURIComponent(JSON.stringify(payload))}`;
+  const ts = Math.floor(Date.now() / 1000).toString();
+  const crypto = await import("node:crypto");
+  const sig = `v0=${crypto
+    .createHmac("sha256", secret)
+    .update(`v0:${ts}:${rawBody}`)
+    .digest("hex")}`;
+
+  const res = await app.request("/slack/interactivity", {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "x-slack-signature": sig,
+      "x-slack-request-timestamp": ts,
+    },
+    body: rawBody,
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), "");
+});
+
 test("listSlackChannels returns an error when the page cap is exhausted", async () => {
   const { listSlackChannels } = await import("./slack.js");
   const { fetchImpl, calls } = fakeFetch(

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -202,7 +202,16 @@ export function mountSlackPublic(app: Hono<any>): void {
     } catch (err) {
       log.error({ err, type: payload.type }, "slack interactivity handler failed");
     }
-    return c.json({ ok: true });
+
+    // view_submission has a strict ack contract: to close the modal, respond
+    // HTTP 200 with an EMPTY body. Any non-empty body that isn't a recognized
+    // `response_action` makes Slack surface "We had some trouble connecting.
+    // Try again?" and leave the modal open — which is exactly what broke the
+    // incident feedback modal's Send step (we were returning `{"ok":true}`).
+    // block_actions has no such constraint (Slack ignores the ack body), so an
+    // empty 200 is a valid ack there too — return one for every interactivity
+    // type to stay on the safe side of the contract.
+    return c.body(null, 200);
   });
 }
 


### PR DESCRIPTION
Clicking **Send** on the Slack incident feedback modal showed "We had some trouble connecting. Try again?" even though the feedback was recorded.

Slack's `view_submission` ack contract requires an HTTP 200 with an **empty body** to close the modal; any non-empty body that isn't a recognized `response_action` makes Slack surface the connecting error. The `/slack/interactivity` route was returning `{"ok":true}` for every interactivity type. It now acks with an empty 200 body, which is also a valid ack for `block_actions`. Added a regression test that posts a signed `view_submission` and asserts the ack body is empty.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Slack incident feedback modal so Send closes the modal correctly. We now ack `view_submission` with HTTP 200 and an empty body to stop Slack’s “We had some trouble connecting. Try again?” error.

- **Bug Fixes**
  - Return an empty 200 body from `/slack/interactivity` for all interactivity types (complies with `view_submission`; also valid for `block_actions`).
  - Add a regression test that posts a signed `view_submission` and asserts the ack body is empty.

<sup>Written for commit 59bfdd6a3ee9c30a691e33f429ed3bb6fb288255. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

