### PR TITLE
Fix incident PR diff rendering

### DIFF
--- a/apps/web/src/IncidentPrDiffView.tsx
+++ b/apps/web/src/IncidentPrDiffView.tsx
@@ -1,6 +1,7 @@
-import { parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs";
-import { FileDiff, PatchDiff } from "@pierre/diffs/react";
+import type { FileDiffMetadata } from "@pierre/diffs";
+import { FileDiff } from "@pierre/diffs/react";
 import { useMemo, useState } from "react";
+import { parseIncidentPrPatchFiles, visibleIncidentPrDiffFiles } from "./incident-pr-diff-model.ts";
 
 const DIFF_OPTIONS = {
   theme: "pierre-dark",
@@ -19,36 +20,30 @@ export default function IncidentPrDiffView({
   patchKey: string;
 }) {
   const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
-  const files = useMemo(() => parsePrPatchFiles(patch), [patch]);
-  const selectedFile = selectedFileName
-    ? (files.find((file) => file.name === selectedFileName) ?? null)
-    : null;
+  const files = useMemo(() => parseIncidentPrPatchFiles(patch), [patch]);
+  const visibleFiles = visibleIncidentPrDiffFiles(files, selectedFileName);
 
   return (
     <div className="grid min-h-[520px] grid-cols-[190px_minmax(0,1fr)] overflow-hidden rounded-md border border-border bg-surface">
       <FileTree files={files} selectedFileName={selectedFileName} onSelect={setSelectedFileName} />
       <div className="min-w-0 overflow-auto bg-[#0d0d0f]">
-        {selectedFile ? (
-          <FileDiff
-            key={`${patchKey}:${selectedFile.name}`}
-            fileDiff={selectedFile}
-            options={DIFF_OPTIONS}
-            disableWorkerPool
-          />
+        {visibleFiles.length > 0 ? (
+          <div className="space-y-4">
+            {visibleFiles.map((file) => (
+              <FileDiff
+                key={`${patchKey}:${file.name}`}
+                fileDiff={file}
+                options={DIFF_OPTIONS}
+                disableWorkerPool
+              />
+            ))}
+          </div>
         ) : (
-          <PatchDiff key={patchKey} patch={patch} options={DIFF_OPTIONS} disableWorkerPool />
+          <div className="p-4 text-[12px] text-muted">Diff could not be parsed.</div>
         )}
       </div>
     </div>
   );
-}
-
-function parsePrPatchFiles(patch: string): FileDiffMetadata[] {
-  try {
-    return parsePatchFiles(patch, "incident-pr", true).flatMap((parsed) => parsed.files);
-  } catch {
-    return [];
-  }
 }
 
 function FileTree({

--- a/apps/web/src/incident-pr-diff-model.test.ts
+++ b/apps/web/src/incident-pr-diff-model.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseIncidentPrPatchFiles, visibleIncidentPrDiffFiles } from "./incident-pr-diff-model.ts";
+
+const MULTI_FILE_PATCH = `diff --git a/apps/api/src/checkout.ts b/apps/api/src/checkout.ts
+index 4f52110..ab9e031 100644
+--- a/apps/api/src/checkout.ts
++++ b/apps/api/src/checkout.ts
+@@ -18,1 +18,2 @@ export async function createCheckoutSession(cart: Cart) {
+-  const couponCode = cart.metadata.couponCode;
++  const metadata = cart.metadata ?? {};
++  const couponCode = metadata.couponCode ?? null;
+diff --git a/apps/api/src/checkout.test.ts b/apps/api/src/checkout.test.ts
+new file mode 100644
+index 0000000..441f0f8
+--- /dev/null
++++ b/apps/api/src/checkout.test.ts
+@@ -0,0 +1,3 @@
++import test from "node:test";
++
++test("handles missing metadata", () => {});
+`;
+
+test("parses every file in a multi-file incident PR patch", () => {
+  const files = parseIncidentPrPatchFiles(MULTI_FILE_PATCH);
+
+  assert.deepEqual(
+    files.map((file) => file.name),
+    ["apps/api/src/checkout.ts", "apps/api/src/checkout.test.ts"],
+  );
+});
+
+test("shows every parsed file when no file is selected", () => {
+  const files = parseIncidentPrPatchFiles(MULTI_FILE_PATCH);
+
+  assert.deepEqual(visibleIncidentPrDiffFiles(files, null), files);
+});
+
+test("shows one parsed file when a file is selected", () => {
+  const files = parseIncidentPrPatchFiles(MULTI_FILE_PATCH);
+
+  assert.deepEqual(
+    visibleIncidentPrDiffFiles(files, "apps/api/src/checkout.test.ts").map((file) => file.name),
+    ["apps/api/src/checkout.test.ts"],
+  );
+});

--- a/apps/web/src/incident-pr-diff-model.ts
+++ b/apps/web/src/incident-pr-diff-model.ts
@@ -1,0 +1,20 @@
+import { parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs";
+
+export type IncidentPrDiffFile = FileDiffMetadata;
+
+export function parseIncidentPrPatchFiles(patch: string): IncidentPrDiffFile[] {
+  try {
+    return parsePatchFiles(patch, "incident-pr", true).flatMap((parsed) => parsed.files);
+  } catch {
+    return [];
+  }
+}
+
+export function visibleIncidentPrDiffFiles(
+  files: IncidentPrDiffFile[],
+  selectedFileName: string | null,
+): IncidentPrDiffFile[] {
+  if (!selectedFileName) return files;
+  const selectedFile = files.find((file) => file.name === selectedFileName);
+  return selectedFile ? [selectedFile] : files;
+}


### PR DESCRIPTION
Fixes the incident PR diff drawer crash when a recorded patch contains multiple files. The all-files view now renders each parsed file diff separately instead of passing a multi-file patch into the single-file renderer. Adds a focused test covering multi-file patch parsing and file selection. Validated with the focused test, web typecheck, web build, and worktree verify.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse multi-file incident PR patches into per-file diffs and render each with `@pierre/diffs/react` `FileDiff` to stop the drawer crash. The all-files view lists all diffs; selecting a file shows only that one, with a small fallback if parsing fails.

- **Bug Fixes**
  - Replaced `PatchDiff` with per-file `FileDiff` rendering in `IncidentPrDiffView`.
  - Added `incident-pr-diff-model` with `parseIncidentPrPatchFiles` and `visibleIncidentPrDiffFiles`, plus tests for multi-file parsing and selection.

<sup>Written for commit a121d673098121771eea620df70457fc1b5914ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

