### PR TITLE
Load PR target branch choices from GitHub and validate them

### DIFF
--- a/apps/api/src/github-branches.test.ts
+++ b/apps/api/src/github-branches.test.ts
@@ -1,0 +1,51 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { mergeRepoBranches, prBaseBranchExists } from "./github-branches.js";
+
+test("mergeRepoBranches dedupes across repos, marks defaults, and sorts defaults first", () => {
+  const merged = mergeRepoBranches([
+    { defaultBranch: "main", branches: ["main", "dev", "feature/x"] },
+    { defaultBranch: "master", branches: ["master", "dev"] },
+  ]);
+  assert.deepEqual(merged, [
+    { name: "main", isDefault: true },
+    { name: "master", isDefault: true },
+    { name: "dev", isDefault: false },
+    { name: "feature/x", isDefault: false },
+  ]);
+});
+
+test("mergeRepoBranches treats a branch as default if it is the default in any repo", () => {
+  const merged = mergeRepoBranches([
+    { defaultBranch: null, branches: ["dev"] },
+    { defaultBranch: "dev", branches: ["dev"] },
+  ]);
+  assert.deepEqual(merged, [{ name: "dev", isDefault: true }]);
+});
+
+test("mergeRepoBranches includes the default branch even if absent from the branch list", () => {
+  const merged = mergeRepoBranches([{ defaultBranch: "main", branches: [] }]);
+  assert.deepEqual(merged, [{ name: "main", isDefault: true }]);
+});
+
+test("mergeRepoBranches ignores blank names and trims", () => {
+  const merged = mergeRepoBranches([{ defaultBranch: "  ", branches: ["  ", " dev "] }]);
+  assert.deepEqual(merged, [{ name: "dev", isDefault: false }]);
+});
+
+test("prBaseBranchExists allows blank (uses repository default)", () => {
+  const branches = [{ name: "main", isDefault: true }];
+  assert.equal(prBaseBranchExists(null, branches), true);
+  assert.equal(prBaseBranchExists("", branches), true);
+  assert.equal(prBaseBranchExists("   ", branches), true);
+});
+
+test("prBaseBranchExists requires a non-blank branch to be present", () => {
+  const branches = [
+    { name: "main", isDefault: true },
+    { name: "dev", isDefault: false },
+  ];
+  assert.equal(prBaseBranchExists("dev", branches), true);
+  assert.equal(prBaseBranchExists(" dev ", branches), true);
+  assert.equal(prBaseBranchExists("nope", branches), false);
+});

--- a/apps/api/src/github-branches.ts
+++ b/apps/api/src/github-branches.ts
@@ -1,0 +1,44 @@
+import { normalizePrBaseBranch } from "@superlog/db/schema";
+
+export type RepoBranch = { name: string; isDefault: boolean };
+
+export type RepoBranchInfo = { defaultBranch: string | null; branches: string[] };
+
+// Pure: collapse the per-repo branch lists of a project into one deduped,
+// sorted set for the config dropdown. A name is `isDefault` if it's the
+// default branch of ANY repo. The default branch is always included even if
+// the paginated branch list didn't surface it. Defaults sort first, then
+// alphabetical — so the most likely target is at the top of the picker.
+export function mergeRepoBranches(perRepo: RepoBranchInfo[]): RepoBranch[] {
+  const names = new Set<string>();
+  const defaults = new Set<string>();
+  for (const repo of perRepo) {
+    for (const raw of repo.branches) {
+      const name = raw.trim();
+      if (name) names.add(name);
+    }
+    const def = repo.defaultBranch?.trim();
+    if (def) {
+      names.add(def);
+      defaults.add(def);
+    }
+  }
+  return [...names]
+    .map((name) => ({ name, isDefault: defaults.has(name) }))
+    .sort((a, b) => {
+      if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+}
+
+// Pure: a configured PR base branch is valid if it's blank (meaning "use the
+// repository default") or it matches a branch that actually exists in one of
+// the project's repos.
+export function prBaseBranchExists(
+  candidate: string | null | undefined,
+  branches: RepoBranch[],
+): boolean {
+  const normalized = normalizePrBaseBranch(candidate);
+  if (!normalized) return true;
+  return branches.some((branch) => branch.name === normalized);
+}

--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -15,6 +15,7 @@ import {
   recordFeedback,
 } from "./feedback.js";
 import { getDeviceFlow, getLinkedDevice, getSkillDeviceForIntegration } from "./gateway.js";
+import { type RepoBranch, type RepoBranchInfo, mergeRepoBranches } from "./github-branches.js";
 import { runResolvedIncidentSideEffectsForIncident } from "./incidents/resolution-side-effects.js";
 import { logger } from "./logger.js";
 import { resolveActiveOrgContext } from "./org-context.js";
@@ -1150,6 +1151,70 @@ export async function fetchInstallationRepoById(
     }
     throw err;
   }
+}
+
+async function fetchRepoBranchInfo(
+  installationId: number,
+  repoFullName: string,
+): Promise<RepoBranchInfo> {
+  const token = await createInstallationReadToken(installationId);
+  const repo = await githubRequest<{ default_branch?: string }>(`/repos/${repoFullName}`, token);
+  const branches: string[] = [];
+  for (let page = 1; page <= 10; page += 1) {
+    const data = await githubRequest<{ name: string }[]>(
+      `/repos/${repoFullName}/branches?per_page=100&page=${page}`,
+      token,
+    );
+    branches.push(...data.map((b) => b.name));
+    if (data.length < 100) break;
+  }
+  return { defaultBranch: repo.default_branch ?? null, branches };
+}
+
+// Lists the branch set the agent could target for a project: the union of
+// branches across every enabled repo the project's GitHub installation(s) can
+// reach. `errored` is true when there were repos to inspect but every lookup
+// failed (token/network), so callers can disable the picker instead of
+// pretending the repo simply has no branches.
+export async function listProjectRepoBranches(
+  projectId: string,
+): Promise<{ branches: RepoBranch[]; errored: boolean }> {
+  const accessible = await listAccessibleGithubInstallsForProject(projectId);
+  const perRepo: RepoBranchInfo[] = [];
+  const seenRepos = new Set<string>();
+  let sawError = false;
+  for (const { installation: row, allowedRepoIds } of accessible) {
+    if (!row.agentEnabled) continue;
+    let repos: StoredRepo[];
+    try {
+      repos = await listCurrentInstallationRepos(row.installationId);
+    } catch (err) {
+      sawError = true;
+      log.warn(
+        { err, projectId, installationId: row.installationId },
+        "github repository listing failed while loading branches",
+      );
+      continue;
+    }
+    const grantSet = allowedRepoIds === null ? null : new Set(allowedRepoIds);
+    const repoAccess = normalizeRepoAccess(row.repoAccess);
+    for (const repo of repos) {
+      if (grantSet && !grantSet.has(repo.id)) continue;
+      if (!isRepoEnabled(repoAccess, repo.id)) continue;
+      if (seenRepos.has(repo.fullName)) continue;
+      seenRepos.add(repo.fullName);
+      try {
+        perRepo.push(await fetchRepoBranchInfo(row.installationId, repo.fullName));
+      } catch (err) {
+        sawError = true;
+        log.warn({ err, projectId, repo: repo.fullName }, "github branch listing failed for repo");
+      }
+    }
+  }
+  // Distinguish "GitHub call failed" from "project genuinely has no branches":
+  // only flag errored when something broke AND we produced nothing, so a
+  // partial failure still returns the branches we did manage to load.
+  return { branches: mergeRepoBranches(perRepo), errored: sawError && perRepo.length === 0 };
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: Hono Variables invariance.

--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -1113,16 +1113,28 @@ export async function closeAgentPullRequestOnGithub(opts: {
   }
 }
 
+// Safety ceiling on paginated GitHub list calls: 100 pages × 100 per page =
+// 10k items. High enough to cover every realistic repo/branch count while
+// still bounding the loop so a pathological account can't spin it forever.
+const GITHUB_LIST_MAX_PAGES = 100;
+
 export async function listCurrentInstallationRepos(installationId: number): Promise<StoredRepo[]> {
   const token = await createInstallationReadToken(installationId);
   const repos: StoredRepo[] = [];
-  for (let page = 1; page <= 10; page += 1) {
+  let page = 1;
+  for (; page <= GITHUB_LIST_MAX_PAGES; page += 1) {
     const data = await githubRequest<GithubInstallationReposResponse>(
       `/installation/repositories?per_page=100&page=${page}`,
       token,
     );
     repos.push(...data.repositories.map(toStoredRepo));
     if (data.repositories.length < 100) break;
+  }
+  if (page > GITHUB_LIST_MAX_PAGES) {
+    log.warn(
+      { installationId, cap: GITHUB_LIST_MAX_PAGES * 100 },
+      "installation repo list hit the pagination cap; results may be truncated",
+    );
   }
   return repos;
 }
@@ -1160,13 +1172,20 @@ async function fetchRepoBranchInfo(
   const token = await createInstallationReadToken(installationId);
   const repo = await githubRequest<{ default_branch?: string }>(`/repos/${repoFullName}`, token);
   const branches: string[] = [];
-  for (let page = 1; page <= 10; page += 1) {
+  let page = 1;
+  for (; page <= GITHUB_LIST_MAX_PAGES; page += 1) {
     const data = await githubRequest<{ name: string }[]>(
       `/repos/${repoFullName}/branches?per_page=100&page=${page}`,
       token,
     );
     branches.push(...data.map((b) => b.name));
     if (data.length < 100) break;
+  }
+  if (page > GITHUB_LIST_MAX_PAGES) {
+    log.warn(
+      { repo: repoFullName, cap: GITHUB_LIST_MAX_PAGES * 100 },
+      "repo branch list hit the pagination cap; results may be truncated",
+    );
   }
   return { defaultBranch: repo.default_branch ?? null, branches };
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -33,8 +33,10 @@ import { shouldRunMigrationsOnBoot } from "./boot-migrations.js";
 import { mountDashboards } from "./dashboards.js";
 import { mountFeedbackAuthed, mountFeedbackPublic } from "./feedback.js";
 import { type GatewayVars, mountGateway } from "./gateway.js";
+import { prBaseBranchExists } from "./github-branches.js";
 import {
   closeAgentPullRequestOnGithub,
+  listProjectRepoBranches,
   mergeGithubPullRequest,
   mountGithubAuthed,
   mountGithubAuthorOAuth,
@@ -1580,6 +1582,19 @@ function parsePrBaseBranch(input: unknown, current: string | null): string | nul
   return branch;
 }
 
+// Branches the agent could target for PRs: the union across the project's
+// enabled GitHub repos. Powers the strict PR-target-branch picker in Settings.
+app.get("/api/projects/:projectId/github/branches", async (c) => {
+  const projectId = c.req.param("projectId");
+  await requireProjectAccess(c, projectId);
+
+  const result = await listProjectRepoBranches(projectId);
+  if (result.errored) {
+    return c.json({ error: "failed to load branches from GitHub" }, 502);
+  }
+  return c.json({ branches: result.branches });
+});
+
 app.patch("/api/projects/:projectId/automation", async (c) => {
   const projectId = c.req.param("projectId");
   await requireProjectAccess(c, projectId);
@@ -1676,6 +1691,20 @@ app.patch("/api/projects/:projectId/automation", async (c) => {
     maxHumanResumeCount > 10
   ) {
     throw new HTTPException(400, { message: "maxHumanResumeCount must be between 0 and 10" });
+  }
+
+  // When the target branch changed to a non-blank value, confirm it actually
+  // exists in one of the project's repos. Skipped when GitHub can't be reached
+  // (errored) so a transient API failure can't lock the user out of saving
+  // unrelated settings — the worker still falls back to the repo default at PR
+  // time if the branch later disappears.
+  if (prBaseBranch && prBaseBranch !== current.prBaseBranch) {
+    const { branches, errored } = await listProjectRepoBranches(projectId);
+    if (!errored && !prBaseBranchExists(prBaseBranch, branches)) {
+      throw new HTTPException(400, {
+        message: `Branch "${prBaseBranch}" was not found in this project's connected repositories.`,
+      });
+    }
   }
 
   const values = {

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -21,6 +21,8 @@ import {
   useDeleteOrgProject,
   useDeleteSlackRoute,
   useDeleteWebhook,
+  type RepoBranch,
+  useGithubBranches,
   useGithubInstallation,
   useGrantOrgRepoToProject,
   useIntegrations,
@@ -70,7 +72,7 @@ import {
   useWebhookDeliveries,
   useWebhooks,
 } from "./api";
-import { Dropdown } from "./design/Dropdown.tsx";
+import { Dropdown, type DropdownOption } from "./design/Dropdown.tsx";
 import { Btn, Chip, FieldLabel, Input, Label, Tile } from "./design/ui";
 import { BillingCard } from "./settings/BillingCard.tsx";
 import { OrgGeneralCard } from "./settings/OrgGeneralCard.tsx";
@@ -1562,6 +1564,7 @@ function AgentFlowchart({ projectId }: { projectId: string | undefined }) {
   const linearConnected = linear.data?.installed === true && !linear.data.needsReauth;
   const linearNeedsReauth = linear.data?.installed === true && linear.data.needsReauth;
   const githubConnected = github.data?.installed === true;
+  const branches = useGithubBranches(projectId, githubConnected);
 
   const data: AgentSettings = settings.data ?? {
     customInstructions: "",
@@ -1728,6 +1731,9 @@ function AgentFlowchart({ projectId }: { projectId: string | undefined }) {
               </p>
               <PrBaseBranchField
                 value={data.prBaseBranch}
+                branches={branches.data?.branches ?? []}
+                loading={branches.isLoading}
+                loadError={branches.isError}
                 disabled={!downstreamEligible || data.prPolicy === "never" || save.isPending}
                 onSave={(v) => patch({ prBaseBranch: v })}
               />
@@ -1745,42 +1751,81 @@ function AgentFlowchart({ projectId }: { projectId: string | undefined }) {
   );
 }
 
+// The empty-string option means "use the repository default branch" — it maps
+// to a null prBaseBranch on save.
+const REPO_DEFAULT_BRANCH = "";
+
 function PrBaseBranchField({
   value,
+  branches,
+  loading,
+  loadError,
   disabled,
   onSave,
 }: {
   value: string | null;
+  branches: RepoBranch[];
+  loading: boolean;
+  loadError: boolean;
   disabled: boolean;
   onSave: (value: string | null) => void;
 }) {
-  const [draft, setDraft] = useState(value ?? "");
-  useEffect(() => setDraft(value ?? ""), [value]);
-  const normalized = draft.trim();
-  const dirty = normalized !== (value ?? "");
+  const [draft, setDraft] = useState(value ?? REPO_DEFAULT_BRANCH);
+  useEffect(() => setDraft(value ?? REPO_DEFAULT_BRANCH), [value]);
+  const dirty = draft !== (value ?? REPO_DEFAULT_BRANCH);
+
+  // Loading/error disable the picker — strict mode means we only ever offer
+  // branches we've confirmed exist, so we can't let the user save against a
+  // list we couldn't fetch.
+  const pickerDisabled = disabled || loading || loadError;
+
+  const options: DropdownOption[] = [
+    { value: REPO_DEFAULT_BRANCH, label: "Repository default", searchText: "Repository default" },
+    ...branches.map((branch) => ({
+      value: branch.name,
+      searchText: branch.name,
+      label: (
+        <span className="flex items-center gap-2">
+          <span className="font-mono">{branch.name}</span>
+          {branch.isDefault && <span className="text-[11px] text-subtle">default</span>}
+        </span>
+      ),
+    })),
+  ];
 
   return (
     <div className="space-y-2">
       <FieldLabel>PR target branch</FieldLabel>
       <div className="flex flex-col gap-2 sm:flex-row">
-        <Input
-          value={draft}
-          disabled={disabled}
-          onChange={(e) => setDraft(e.target.value.slice(0, 200))}
-          placeholder="Use repository default"
-          className="font-mono text-[12.5px]"
-        />
+        <div className="min-w-[260px] flex-1">
+          <Dropdown
+            value={draft}
+            onChange={setDraft}
+            disabled={pickerDisabled}
+            options={options}
+            placeholder={
+              loading
+                ? "Loading branches…"
+                : loadError
+                  ? "Couldn't load branches"
+                  : "Repository default"
+            }
+            emptyLabel="No branches found"
+          />
+        </div>
         <Btn
           size="sm"
           variant="secondary"
-          disabled={disabled || !dirty}
-          onClick={() => onSave(normalized || null)}
+          disabled={pickerDisabled || !dirty}
+          onClick={() => onSave(draft || null)}
         >
           Save
         </Btn>
       </div>
       <p className="text-[12px] text-muted">
-        Leave blank for the repo default branch, or set a branch like development.
+        {loadError
+          ? "Couldn't load branches from GitHub — try again, or check the App's repo access."
+          : "Pick the branch agent PRs target. Defaults to each repo's default branch."}
       </p>
     </div>
   );

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -568,6 +568,20 @@ export function useStartGithubInstall() {
   });
 }
 
+export type RepoBranch = { name: string; isDefault: boolean };
+
+// Branches the agent can target for PRs, fetched live from the project's
+// connected GitHub repos. Used by the PR-target-branch picker in Settings.
+export function useGithubBranches(projectId: string | undefined, enabled: boolean) {
+  const fetcher = useFetcher();
+  return useQuery({
+    queryKey: ["github-branches", projectId],
+    queryFn: () =>
+      fetcher<{ branches: RepoBranch[] }>(`/api/projects/${projectId}/github/branches`),
+    enabled: enabled && !!projectId,
+  });
+}
+
 export function useStartGithubAuthorLogin() {
   const fetcher = useFetcher();
   return useMutation({


### PR DESCRIPTION
The "PR target branch" project setting was a free-text field validated only for branch-name format, so a typo or a non-existent branch saved silently. This replaces it with a strict picker populated live from the branches of the project's connected GitHub repos — the union across enabled repos, with default branches sorted first and tagged.

Only a branch that actually exists can be picked or saved: the save path re-validates the choice against the live repo branch set and rejects one present in none of them. When branches can't be loaded the picker is disabled with an error instead of letting a value be saved against an unverified list, and save-time validation is skipped in that case so a transient GitHub failure can't block unrelated settings changes (the agent still falls back to the repo default at PR time).

Pure merge/dedup/sort/validation logic is split into `github-branches.ts` and covered by unit tests; the new `GET /api/projects/:id/github/branches` endpoint and `useGithubBranches` hook feed the dropdown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the free‑text PR target branch setting with a strict dropdown loaded from GitHub, preventing typos and non‑existent branches. The picker disables on GitHub errors and save‑time validation avoids blocking unrelated setting changes, with expanded pagination to avoid missing branches in large repos.

- **New Features**
  - Added a PR target branch dropdown populated from the union of connected repos, fully paginated; default branches tagged and sorted first.
  - Introduced `GET /api/projects/:projectId/github/branches` and a `useGithubBranches` hook to power the picker.
  - Save path re‑validates the selected branch against the live branch set; rejects unknown branches. If GitHub is unreachable, the picker is disabled and validation is skipped; the agent still falls back to the repo default at PR time.
  - Extracted merge/dedup/sort/validation logic to `github-branches.ts` with unit tests.

<sup>Written for commit 569740583a38fbf9494c376448834bdf0904d2f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

