### PR TITLE
Fix incident resolve cleanup handling

### DIFF
--- a/apps/api/src/incidents/resolution-side-effects.test.ts
+++ b/apps/api/src/incidents/resolution-side-effects.test.ts
@@ -53,6 +53,44 @@ test("runResolvedIncidentSideEffects still refreshes Slack when PR closure repor
   assert.deepEqual(calls, ["close-prs", "slack"]);
 });
 
+test("runResolvedIncidentSideEffects still refreshes Slack when PR closure throws", async () => {
+  const calls: string[] = [];
+  const result = await runResolvedIncidentSideEffects({
+    incident: { id: "inc-1", title: "Checkout API timeout", service: null },
+    projectName: "Acme",
+    deps: {
+      closeIncidentPullRequests: async () => {
+        calls.push("close-prs");
+        throw new Error("github unavailable");
+      },
+      updateSlackRootMessage: async () => {
+        calls.push("slack");
+      },
+    },
+  });
+
+  assert.deepEqual(result, { closedPullRequestCount: 0, failedPullRequestCount: 1 });
+  assert.deepEqual(calls, ["close-prs", "slack"]);
+});
+
+test("runResolvedIncidentSideEffects does not fail when Slack refresh throws", async () => {
+  const result = await runResolvedIncidentSideEffects({
+    incident: { id: "inc-1", title: "Checkout API timeout", service: null },
+    projectName: "Acme",
+    deps: {
+      closeIncidentPullRequests: async () => ({
+        closedPullRequestCount: 1,
+        failedPullRequestCount: 0,
+      }),
+      updateSlackRootMessage: async () => {
+        throw new Error("slack unavailable");
+      },
+    },
+  });
+
+  assert.deepEqual(result, { closedPullRequestCount: 1, failedPullRequestCount: 0 });
+});
+
 test("buildResolvedIncidentSlackRoot removes resolve action and keeps feedback action", () => {
   const update = buildResolvedIncidentSlackRoot({
     incident: {

--- a/apps/api/src/incidents/resolution-side-effects.ts
+++ b/apps/api/src/incidents/resolution-side-effects.ts
@@ -31,17 +31,30 @@ export async function runResolvedIncidentSideEffects(opts: {
   projectName: string;
   deps: ResolvedIncidentSideEffectDeps;
 }): Promise<CloseIncidentOpenPullRequestsResult> {
-  const closed = await opts.deps.closeIncidentPullRequests(opts.incident.id);
+  let closed: CloseIncidentOpenPullRequestsResult;
+  try {
+    closed = await opts.deps.closeIncidentPullRequests(opts.incident.id);
+  } catch (err) {
+    log.warn({ err, incident_id: opts.incident.id }, "failed to close incident PRs after resolve");
+    closed = { closedPullRequestCount: 0, failedPullRequestCount: 1 };
+  }
 
   const slackRoot = buildResolvedIncidentSlackRoot({
     incident: opts.incident,
     projectName: opts.projectName,
   });
-  await opts.deps.updateSlackRootMessage({
-    incident: opts.incident,
-    text: slackRoot.text,
-    blocks: slackRoot.blocks,
-  });
+  try {
+    await opts.deps.updateSlackRootMessage({
+      incident: opts.incident,
+      text: slackRoot.text,
+      blocks: slackRoot.blocks,
+    });
+  } catch (err) {
+    log.warn(
+      { err, incident_id: opts.incident.id },
+      "failed to update resolved incident Slack root",
+    );
+  }
 
   return closed;
 }

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -45,6 +45,7 @@ import {
   useUpdateIncident,
 } from "./api.ts";
 import { Btn, Chip } from "./design/ui.tsx";
+import { getIncidentStatusAction } from "./incident-status-action.ts";
 import { getIssueIncidentLinkState } from "./issue-incident-link-state.ts";
 
 const IncidentPrDiffView = lazy(() => import("./IncidentPrDiffView.tsx"));
@@ -839,11 +840,12 @@ function IncidentDrawerBody({
     );
   }
   const { incident, issues, agentRun, agentRuns, timeline } = q.data;
+  const statusAction = getIncidentStatusAction(incident.status);
 
   function handleToggleStatus() {
     updateIncident.mutate({
       incidentId: incident.id,
-      status: incident.status === "open" ? "resolved" : "open",
+      status: statusAction.targetStatus,
     });
   }
 
@@ -873,6 +875,7 @@ function IncidentDrawerBody({
       onDecideProposal={(proposalId, decision) =>
         decideProposal.mutate({ incidentId: incident.id, proposalId, decision })
       }
+      updateIncidentError={updateIncident.error}
       decidingProposal={decideProposal.isPending}
       updatingIncident={updateIncident.isPending}
       restartingAgentRun={restartAgentRun.isPending}
@@ -1319,6 +1322,7 @@ export function IncidentDetailContent({
   onRestartAgentRun,
   onRetryPrDelivery,
   onDecideProposal,
+  updateIncidentError = null,
   decidingProposal,
   updatingIncident,
   restartingAgentRun = false,
@@ -1338,12 +1342,14 @@ export function IncidentDetailContent({
   onRestartAgentRun?: () => void;
   onRetryPrDelivery?: () => void;
   onDecideProposal?: (proposalId: string, decision: "confirm" | "dismiss") => void;
+  updateIncidentError?: Error | null;
   decidingProposal?: boolean;
   updatingIncident: boolean;
   restartingAgentRun?: boolean;
   retryingPrDelivery?: boolean;
 }) {
   const [detailTab, setDetailTab] = useState<"incident" | "pr">("incident");
+  const statusAction = getIncidentStatusAction(incident.status);
 
   return (
     <div className="space-y-8 p-4">
@@ -1436,14 +1442,19 @@ export function IncidentDetailContent({
           </div>
 
           <Btn
-            variant={incident.status === "open" ? "secondary" : "ghost"}
+            variant={statusAction.variant}
             size="sm"
             onClick={onToggleStatus}
             loading={updatingIncident}
             className="w-full justify-center"
           >
-            {incident.status === "open" ? "Resolve incident" : "Reopen incident"}
+            {statusAction.label}
           </Btn>
+          {updateIncidentError && (
+            <p className="rounded-sm border border-danger/40 bg-danger/10 px-3 py-2 text-[12px] text-danger">
+              Status update failed: {String(updateIncidentError)}
+            </p>
+          )}
         </>
       ) : (
         <IncidentPullRequestPanel projectId={incident.projectId} incidentId={incident.id} />

--- a/apps/web/src/incident-status-action.test.ts
+++ b/apps/web/src/incident-status-action.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getIncidentStatusAction } from "./incident-status-action.ts";
+
+test("open incidents can be resolved", () => {
+  assert.deepEqual(getIncidentStatusAction("open"), {
+    label: "Resolve incident",
+    targetStatus: "resolved",
+    variant: "secondary",
+  });
+});
+
+test("noise incidents can be reopened", () => {
+  assert.deepEqual(getIncidentStatusAction("autoresolved_noise"), {
+    label: "Reopen incident",
+    targetStatus: "open",
+    variant: "ghost",
+  });
+});

--- a/apps/web/src/incident-status-action.ts
+++ b/apps/web/src/incident-status-action.ts
@@ -1,0 +1,20 @@
+export type IncidentStatusAction = {
+  label: "Resolve incident" | "Reopen incident";
+  targetStatus: "open" | "resolved";
+  variant: "secondary" | "ghost";
+};
+
+export function getIncidentStatusAction(status: string): IncidentStatusAction {
+  if (status === "open") {
+    return {
+      label: "Resolve incident",
+      targetStatus: "resolved",
+      variant: "secondary",
+    };
+  }
+  return {
+    label: "Reopen incident",
+    targetStatus: "open",
+    variant: "ghost",
+  };
+}


### PR DESCRIPTION
## Summary
- keep incident resolve responses successful when follow-up cleanup fails
- show incident status update errors in the drawer instead of failing silently
- add focused tests for resolve cleanup failures and status action mapping

## Root cause
Incident resolution performed follow-up cleanup after the incident state changed. A thrown cleanup dependency could make the request fail even though the primary resolve action had already completed, leaving the UI looking stale. The drawer also did not surface status mutation errors.

## Validation
- pnpm exec tsx --test apps/web/src/incident-status-action.test.ts
- pnpm exec tsx --test apps/api/src/incidents/resolution-side-effects.test.ts
- pnpm --filter @superlog/web typecheck
- pnpm --filter @superlog/api typecheck


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure incident resolves succeed even if follow-up cleanup (closing PRs or Slack refresh) fails. The incident drawer now shows status update errors instead of failing silently.

- **Bug Fixes**
  - API: Catch errors from `closeIncidentPullRequests` and `updateSlackRootMessage`; log and continue so resolve stays successful. Slack refresh still runs even if PR closure fails.
  - Web: Surface incident status update errors in the drawer with a clear message.
  - Tests: Added coverage for cleanup failure handling and Slack update resiliency.

- **Refactors**
  - Introduced `getIncidentStatusAction` to unify label, target status, and button variant; added focused tests.

<sup>Written for commit e6f267e3fe74aef89492ef41497eda11cace6c81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

