### PR TITLE
Handle stale incident resolve actions

### DIFF
--- a/apps/api/src/slack.test.ts
+++ b/apps/api/src/slack.test.ts
@@ -48,6 +48,18 @@ test("returns null when neither a pin nor a team match resolves", () => {
   assert.equal(preferPinnedInstallation(null, null), null);
 });
 
+test("Slack resolve clicks on noise incidents refresh resolved-side effects", async () => {
+  const { resolveSlackResolveClickDisposition } = await import("./slack.js");
+
+  assert.equal(resolveSlackResolveClickDisposition("autoresolved_noise"), "refresh_side_effects");
+});
+
+test("Slack resolve clicks on open incidents perform a fresh resolve", async () => {
+  const { resolveSlackResolveClickDisposition } = await import("./slack.js");
+
+  assert.equal(resolveSlackResolveClickDisposition("open"), "resolve");
+});
+
 test("listSlackChannels requests both public and private channels", async () => {
   const { listSlackChannels } = await import("./slack.js");
   const { fetchImpl, calls } = fakeFetch([{ ok: true, channels: [] }]);

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -25,6 +25,12 @@ const SCOPES =
 
 type Vars = { userId: string; orgId: string | null };
 
+export type SlackResolveClickDisposition = "resolve" | "refresh_side_effects";
+
+export function resolveSlackResolveClickDisposition(status: string): SlackResolveClickDisposition {
+  return status === "open" ? "resolve" : "refresh_side_effects";
+}
+
 // biome-ignore lint/suspicious/noExplicitAny: Hono Variables invariance.
 export function mountSlackPublic(app: Hono<any>): void {
   const clientId = process.env.SLACK_CLIENT_ID;
@@ -335,11 +341,12 @@ async function handleSlackResolveIncident(
     log.warn({ incidentId }, "resolve_incident click for unknown incident");
     return;
   }
-  if (incident.status !== "open") {
+  if (resolveSlackResolveClickDisposition(incident.status) === "refresh_side_effects") {
     log.info(
       { incidentId, status: incident.status },
-      "resolve_incident click on already-closed incident, ignoring",
+      "resolve_incident click on already-closed incident, refreshing side effects",
     );
+    await runSlackResolvedIncidentSideEffects(incidentId);
     return;
   }
 
@@ -363,15 +370,7 @@ async function handleSlackResolveIncident(
     return;
   }
 
-  await runResolvedIncidentSideEffectsForIncident({
-    incidentId,
-    closePullRequest: (pr) =>
-      closeAgentPullRequestOnGithub({
-        installationId: pr.githubInstallationId,
-        repoFullName: pr.repoFullName,
-        prNumber: pr.prNumber,
-      }),
-  });
+  await runSlackResolvedIncidentSideEffects(incidentId);
 
   const installation = await installationForIncident({
     pinnedId: incident.slackInstallationId,
@@ -389,6 +388,18 @@ async function handleSlackResolveIncident(
       text: `:white_check_mark: Incident resolved by ${attribution}. If the underlying error reappears it will re-open automatically.`,
     });
   }
+}
+
+async function runSlackResolvedIncidentSideEffects(incidentId: string): Promise<void> {
+  await runResolvedIncidentSideEffectsForIncident({
+    incidentId,
+    closePullRequest: (pr) =>
+      closeAgentPullRequestOnGithub({
+        installationId: pr.githubInstallationId,
+        repoFullName: pr.repoFullName,
+        prNumber: pr.prNumber,
+      }),
+  });
 }
 
 // Confirm / Dismiss buttons on a sweep-agent resolution proposal posted


### PR DESCRIPTION
## Summary
- make stale incident Resolve button clicks refresh resolved-side effects instead of no-oping
- close linked open PRs and refresh the incident thread root when the incident is already in a closed/noise state
- add focused Slack resolve disposition tests

## Root cause
Slack resolve actions returned early for every non-open incident. Noise-classified incidents can still have stale Resolve buttons in the thread, so clicking the button did nothing: no DB change, no PR cleanup, and no root-message refresh.

## Validation
- pnpm exec tsx --test apps/api/src/slack.test.ts
- pnpm --filter @superlog/api typecheck


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Slack Resolve clicks on incidents that are already closed or classified as noise. Instead of doing nothing, we now refresh resolved side effects: close linked PRs and refresh the incident thread root; adds focused tests and a small helper for disposition logic.

<sup>Written for commit a95f3b59cfed8236b635e52553306aa58ef0a8b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

