### PR TITLE
web: test added for timeFormat.ts and fix local timestamp rounding

### DIFF
--- a/apps/web/src/timeFormat.test.ts
+++ b/apps/web/src/timeFormat.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatLocalHm, formatLocalTimestamp, formatLocalTimestampMs } from "./timeFormat.ts";
+
+type TimeFormatModule = typeof import("./timeFormat.ts");
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}
+
+function localTimestamp(utcIso: string): string {
+  const date = new Date(utcIso);
+  return (
+    `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ` +
+    `${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`
+  );
+}
+
+function localHm(utcIso: string): string {
+  const date = new Date(utcIso);
+  return `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+}
+
+async function freshModule(name: string): Promise<TimeFormatModule> {
+  // Append a unique query string so Node's ESM loader treats each import as a new module URL, bypassing the module cache.
+  const url = new URL("./timeFormat.ts", import.meta.url);
+  url.searchParams.set("test", name);
+  return (await import(url.href)) as TimeFormatModule;
+}
+
+async function withMockDateTimeFormat<T>(
+  mock: typeof Intl.DateTimeFormat,
+  run: () => T | Promise<T>,
+): Promise<T> {
+  const original = Intl.DateTimeFormat;
+  Intl.DateTimeFormat = mock;
+  try {
+    return await run();
+  } finally {
+    Intl.DateTimeFormat = original;
+  }
+}
+
+test("formatLocalTimestamp treats ClickHouse timestamp strings as UTC", () => {
+  assert.equal(formatLocalTimestamp("2026-06-08 00:05:09"), localTimestamp("2026-06-08T00:05:09Z"));
+});
+
+test("formatLocalTimestamp accepts ISO separators and strips fractional seconds", () => {
+  assert.equal(
+    formatLocalTimestamp("2026-06-08T00:05:09.987654"),
+    localTimestamp("2026-06-08T00:05:09Z"),
+  );
+});
+
+test("formatLocalTimestamp returns unparseable input unchanged", () => {
+  assert.equal(formatLocalTimestamp("not a timestamp"), "not a timestamp");
+  assert.equal(formatLocalTimestamp(""), "");
+});
+
+test("formatLocalTimestampMs appends hundredths for whole-second timestamps", () => {
+  assert.equal(
+    formatLocalTimestampMs("2026-06-08 00:05:09"),
+    `${localTimestamp("2026-06-08T00:05:09Z")}.00`,
+  );
+});
+
+test("formatLocalTimestampMs rounds fractional seconds to two digits", () => {
+  assert.equal(
+    formatLocalTimestampMs("2026-06-08 00:05:09.124"),
+    `${localTimestamp("2026-06-08T00:05:09Z")}.12`,
+  );
+  assert.equal(
+    formatLocalTimestampMs("2026-06-08 00:05:09.125"),
+    `${localTimestamp("2026-06-08T00:05:09Z")}.13`,
+  );
+  assert.equal(
+    formatLocalTimestampMs("2026-06-08 00:05:09.999"),
+    `${localTimestamp("2026-06-08T00:05:10Z")}.00`,
+  );
+});
+
+test("formatLocalTimestampMs defaults malformed fractions to zero hundredths", () => {
+  assert.equal(
+    formatLocalTimestampMs("2026-06-08 00:05:09.nope"),
+    `${localTimestamp("2026-06-08T00:05:09Z")}.00`,
+  );
+});
+
+test("formatLocalTimestampMs returns unparseable input unchanged", () => {
+  assert.equal(formatLocalTimestampMs("not a timestamp"), "not a timestamp");
+  assert.equal(formatLocalTimestampMs(""), "");
+});
+
+test("formatLocalHm emits local hour and minute for valid UTC timestamps", () => {
+  assert.equal(formatLocalHm("2026-06-08 00:05:09"), localHm("2026-06-08T00:05:09Z"));
+  assert.equal(formatLocalHm("2026-06-08T23:59:59"), localHm("2026-06-08T23:59:59Z"));
+});
+
+test("formatLocalHm falls back to the original string or its time slice", () => {
+  assert.equal(formatLocalHm("bad"), "bad");
+  assert.equal(formatLocalHm("2026-06-08 xx:yy"), "xx:yy");
+});
+
+test("localTzAbbr reads and caches the short timezone name", async () => {
+  const mod = await freshModule("cache");
+  let calls = 0;
+  let zoneName = "TST";
+
+  function MockDateTimeFormat() {
+    calls += 1;
+    return {
+      formatToParts: () => [{ type: "timeZoneName", value: zoneName }],
+      resolvedOptions: () => ({ timeZone: "Etc/Unused" }),
+    };
+  }
+
+  await withMockDateTimeFormat(MockDateTimeFormat as unknown as typeof Intl.DateTimeFormat, () => {
+    assert.equal(mod.localTzAbbr(), "TST");
+    zoneName = "NEXT";
+    assert.equal(mod.localTzAbbr(), "TST");
+    assert.equal(calls, 1);
+  });
+});
+
+test("localTzAbbr falls back to the resolved timezone when no short name is available", async () => {
+  const mod = await freshModule("resolved-timezone");
+
+  function MockDateTimeFormat() {
+    return {
+      formatToParts: () => [{ type: "literal", value: "" }],
+      resolvedOptions: () => ({ timeZone: "Etc/Fixture" }),
+    };
+  }
+
+  await withMockDateTimeFormat(MockDateTimeFormat as unknown as typeof Intl.DateTimeFormat, () => {
+    assert.equal(mod.localTzAbbr(), "Etc/Fixture");
+  });
+});
+
+test("localTzAbbr falls back to local when Intl formatting throws", async () => {
+  const mod = await freshModule("throws");
+
+  function MockDateTimeFormat() {
+    throw new Error("Intl unavailable");
+  }
+
+  await withMockDateTimeFormat(MockDateTimeFormat as unknown as typeof Intl.DateTimeFormat, () => {
+    assert.equal(mod.localTzAbbr(), "local");
+  });
+});

--- a/apps/web/src/timeFormat.ts
+++ b/apps/web/src/timeFormat.ts
@@ -9,7 +9,7 @@ function parseChUtc(s: string): { date: Date; frac: string } | null {
   const head = dot === -1 ? s : s.slice(0, dot);
   const frac = dot === -1 ? "" : s.slice(dot + 1);
   // Accept both "YYYY-MM-DD HH:MM:SS" and ISO "YYYY-MM-DDTHH:MM:SS".
-  const iso = head.replace(" ", "T") + "Z";
+  const iso = `${head.replace(" ", "T")}Z`;
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return null;
   return { date: d, frac };
@@ -24,13 +24,16 @@ export function formatLocalTimestampMs(s: string): string {
   const p = parseChUtc(s);
   if (!p) return s;
   const { date, frac } = p;
-  const head =
-    `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ` +
-    `${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`;
   const fracN = Number(`0.${frac || "0"}`);
-  const f = Number.isFinite(fracN)
-    ? Math.round(fracN * 100).toString().padStart(2, "0")
-    : "00";
+  const hundredths = Number.isFinite(fracN) ? Math.round(fracN * 100) : 0;
+  const roundedDate = new Date(date);
+  if (hundredths === 100) {
+    roundedDate.setTime(roundedDate.getTime() + 1000);
+  }
+  const f = (hundredths % 100).toString().padStart(2, "0");
+  const head =
+    `${roundedDate.getFullYear()}-${pad2(roundedDate.getMonth() + 1)}-${pad2(roundedDate.getDate())} ` +
+    `${pad2(roundedDate.getHours())}:${pad2(roundedDate.getMinutes())}:${pad2(roundedDate.getSeconds())}`;
   return `${head}.${f}`;
 }
 
@@ -65,5 +68,6 @@ export function localTzAbbr(): string {
   } catch {
     cachedTzAbbr = "local";
   }
-  return cachedTzAbbr!;
+  if (!cachedTzAbbr) cachedTzAbbr = "local";
+  return cachedTzAbbr;
 }


### PR DESCRIPTION
This PR adds coverage for the web timestamp formatting helpers.

The tests cover ClickHouse UTC timestamp strings, ISO-style separators, invalid timestamp fallbacks, local `HH:MM` formatting, fractional-second rounding, and timezone abbreviation caching/fallback behavior.

While adding coverage, I fixed one small edge case where fractions like `.999` could format as `.100` instead of rolling over to the next second with `.00`.

Other changes that don't meaningfully change the behavior of timeFormat are: 

- replaced `cachedTzAbbr!` with an explicit fallback to "local" so the function truly always returns a string without relying on a non-null assertion

- changed string concatenation to a template literal because Biome flagged it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for the web timestamp formatting helpers and fix edge-case rounding in `formatLocalTimestampMs`. Also harden `localTzAbbr()` to always return a string.

- **Bug Fixes**
  - `formatLocalTimestampMs`: round to two digits and roll over the second when rounding hits 100 (e.g., `.999` → next second `.00`); default malformed fractions to `.00`.
  - `localTzAbbr`: cache the short name and fall back to the resolved timezone or `"local"` so it always returns a string.

<sup>Written for commit 4162e7bee594dce6e2ce0244f8a8783fcc76006b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

