### PR TITLE
ci: add GitHub Actions checks and Docker image publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+  BETTER_AUTH_SECRET: ci-test-better-auth-secret
+  DATABASE_URL: postgres://postgres:postgres@localhost:5432/superlog
+  NEXT_TELEMETRY_DISABLED: 1
+  TURBO_TELEMETRY_DISABLED: 1
+
+jobs:
+  checks:
+    name: Validate, Typecheck, Test, Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: superlog
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d superlog"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      # TODO: Add back linting once we have it working with Biome
+      - name: Validate package config
+        run: pnpm exec biome check package.json turbo.json apps/*/package.json packages/*/package.json
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,83 @@
+name: Docker
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  images:
+    name: ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: api
+            dockerfile: apps/api/Dockerfile
+          - service: proxy
+            dockerfile: apps/proxy/Dockerfile
+          - service: worker
+            dockerfile: apps/worker/Dockerfile
+          - service: web
+            dockerfile: apps/web/Dockerfile
+          - service: collector
+            dockerfile: infra/collector/Dockerfile
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/superlog-${{ matrix.service }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and publish
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+          build-args: |
+            VITE_API_URL=${{ vars.VITE_API_URL }}
+            VITE_OTEL_EXPORTER_OTLP_ENDPOINT=${{ vars.VITE_OTEL_EXPORTER_OTLP_ENDPOINT }}
+            VITE_OTEL_EXPORTER_OTLP_HEADERS=${{ vars.VITE_OTEL_EXPORTER_OTLP_HEADERS }}
+            VITE_OTEL_SERVICE_NAME=${{ vars.VITE_OTEL_SERVICE_NAME }}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "tsx watch --import ./tracing.ts src/index.ts",
     "start": "tsx --import ./tracing.ts src/index.ts",
-    "test": "tsx --test src/**/*.test.ts",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "test:mcp-clickhouse-ranges": "tsx scripts/test-mcp-clickhouse-ranges.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "tsx watch --import ./tracing.ts src/index.ts",
     "start": "tsx --import ./tracing.ts src/index.ts",
-    "test": "tsx --test \"src/**/*.test.ts\"",
+    "test": "find src -name '*.test.ts' -print | sort | xargs tsx --test",
     "test:mcp-clickhouse-ranges": "tsx scripts/test-mcp-clickhouse-ranges.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/api/src/github.test.ts
+++ b/apps/api/src/github.test.ts
@@ -61,6 +61,7 @@ test("merged agent PR resolves incident, cascades linked issues, and writes time
     where: eq(schema.incidents.id, fixture.incidentId),
   });
   assert.equal(incident?.status, "resolved");
+  assert.equal(incident?.resolvedReasonCode, "agent_pr_merged");
 
   const issue = await db.query.issues.findFirst({
     where: eq(schema.issues.id, fixture.issueId),
@@ -78,7 +79,8 @@ test("merged agent PR resolves incident, cascades linked issues, and writes time
     resolvedEvents[0]?.summary,
     `Incident resolved because PR #${fixture.prNumber} was merged.`,
   );
-  assert.equal(resolvedEvents[0]?.detail?.reason, "agent_pr_merged");
+  assert.equal(resolvedEvents[0]?.detail?.kind, "agent_pr_merged");
+  assert.equal(resolvedEvents[0]?.detail?.reasonCode, "agent_pr_merged");
 
   const prMergedEvent = await db.query.agentPrEvents.findFirst({
     where: and(
@@ -142,6 +144,7 @@ test("closed unmerged agent PR does not resolve incident or linked issue", async
     where: eq(schema.incidents.id, fixture.incidentId),
   });
   assert.equal(incident?.status, "open");
+  assert.equal(incident?.resolvedReasonCode, null);
 
   const issue = await db.query.issues.findFirst({
     where: eq(schema.issues.id, fixture.issueId),
@@ -174,10 +177,7 @@ async function seedAgentPrFixture(label: string): Promise<{
   const installationId = Math.floor(Date.now() / 1000) + Math.floor(Math.random() * 1_000_000);
   const prNumber = Math.floor(Math.random() * 10_000) + 1;
 
-  const [org] = await db
-    .insert(schema.orgs)
-    .values({ name: tag, slug: tag })
-    .returning();
+  const [org] = await db.insert(schema.orgs).values({ name: tag, slug: tag }).returning();
   if (!org) throw new Error("failed to seed org");
   orgIds.push(org.id);
 

--- a/apps/proxy/package.json
+++ b/apps/proxy/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "tsx watch --import ./tracing.ts src/index.ts",
     "start": "tsx --import ./tracing.ts src/index.ts",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "test:ingest-queue": "tsx --test src/ingest-queue.test.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/proxy/package.json
+++ b/apps/proxy/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "tsx watch --import ./tracing.ts src/index.ts",
     "start": "tsx --import ./tracing.ts src/index.ts",
-    "test": "tsx --test \"src/**/*.test.ts\"",
+    "test": "find src -name '*.test.ts' -print | sort | xargs tsx --test",
     "test:ingest-queue": "tsx --test src/ingest-queue.test.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --test \"src/**/*.test.ts\"",
+    "test": "find src -name '*.test.ts' -print | sort | xargs tsx --test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/src/incident-pr-diff-model.test.ts
+++ b/apps/web/src/incident-pr-diff-model.test.ts
@@ -1,6 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { parseIncidentPrPatchFiles, visibleIncidentPrDiffFiles } from "./incident-pr-diff-model.ts";
+
+if (typeof globalThis.navigator === "undefined") {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      maxTouchPoints: 0,
+      platform: "Linux",
+      userAgent: "node.js",
+    },
+  });
+}
+
+const { parseIncidentPrPatchFiles, visibleIncidentPrDiffFiles } = await import(
+  "./incident-pr-diff-model.ts"
+);
 
 const MULTI_FILE_PATCH = `diff --git a/apps/api/src/checkout.ts b/apps/api/src/checkout.ts
 index 4f52110..ab9e031 100644

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -10,7 +10,7 @@
     "backfill:issue-activity-daily": "tsx scripts/backfill-issue-activity-daily.ts",
     "seed:worker-telemetry-dashboard": "tsx scripts/seed-worker-telemetry-dashboard.ts",
     "pgboss:migrate": "tsx scripts/pgboss-migrate.ts",
-    "test": "tsx --test \"src/**/*.test.ts\"",
+    "test": "find src -name '*.test.ts' -print | sort | xargs tsx --test",
     "test:jobs-loader": "tsx --test src/jobs.test.ts",
     "test:jobs-runner": "tsx --test src/jobs/runner.test.ts",
     "test:git-auth-no-argv": "tsx scripts/test-git-auth-no-argv.ts",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -10,6 +10,7 @@
     "backfill:issue-activity-daily": "tsx scripts/backfill-issue-activity-daily.ts",
     "seed:worker-telemetry-dashboard": "tsx scripts/seed-worker-telemetry-dashboard.ts",
     "pgboss:migrate": "tsx scripts/pgboss-migrate.ts",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "test:jobs-loader": "tsx --test src/jobs.test.ts",
     "test:jobs-runner": "tsx --test src/jobs/runner.test.ts",
     "test:git-auth-no-argv": "tsx scripts/test-git-auth-no-argv.ts",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "demo:seed:everything": "tsx scripts/demo/seed-everything.ts",
     "lint": "biome check .",
     "format": "biome format --write .",
+    "test": "turbo run test",
     "typecheck": "turbo run typecheck"
   },
   "devDependencies": {

--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "tsx --test \"src/**/*.test.ts\"",
+    "test": "find src -name '*.test.ts' -print | sort | xargs tsx --test",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "tsx --test src/**/*.test.ts",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "migrate": "tsx src/migrate-cli.ts",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test \"src/**/*.test.ts\"",
+    "test": "find src -name '*.test.ts' -print | sort | xargs tsx --test",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "migrate": "tsx src/migrate-cli.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
     "dev": {
       "cache": false,
@@ -11,6 +11,10 @@
     },
     "typecheck": {
       "dependsOn": ["^build"]
+    },
+    "test": {
+      "env": ["BETTER_AUTH_SECRET", "DATABASE_URL"],
+      "outputs": []
     },
     "lint": {}
   }


### PR DESCRIPTION
This PR adds GitHub Actions so PRs and branch pushes run the basic project checks automatically.

The CI workflow installs pnpm, validates package/Turbo config, runs typechecks, runs the test suite against Postgres, and builds the repo. I also added a Docker workflow that builds the API, proxy, worker, web, and collector images on PRs, and publishes them to GHCR from `main`, tags, or manual runs.

While wiring this up, I added missing package-level `test` scripts so `turbo run test` has a real workspace task to execute, quoted test globs so Node receives them correctly, and tightened Turbo’s test env passthrough to only the values CI needs. 

This file `apps/api/src/github.test.ts` was missed by previous test runs. 

** I have not added linting completely because there were a few linting issues currently. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CI to validate config, typecheck, run tests against Postgres, and build on PRs and pushes. Add Docker image builds and GHCR publishing, and ensure all workspace and web tests run in Node-based CI.

- **New Features**
  - CI: validate package/Turbo config with `biome`, typecheck, test with Postgres service, and build using `pnpm`/`turbo`.
  - Docker: build `api`, `proxy`, `worker`, `web`, and `collector` images; tag via `docker/metadata-action`; publish to `ghcr.io` (non-PRs); cache per-service.

- **Refactors**
  - Replace glob-based `test` scripts with `find | sort | xargs tsx --test` across apps/packages; add root `test` to run `turbo run test`.
  - Update `turbo.json`: pass only `BETTER_AUTH_SECRET` and `DATABASE_URL` to tests; include `.next/**` in build outputs and exclude `.next/cache/**`.
  - Fix `apps/api/src/github.test.ts` assertions for resolved reason fields; minor seed formatting.
  - Shim `navigator` and dynamically import the web diff model in tests to run under Node in CI.

<sup>Written for commit 9552872e96d0cb4ce99298d750814fb4a9741c97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

