### PR TITLE
fingerprint: collapse request paths so route-scanner errors group into one issue

### DIFF
--- a/packages/fingerprint/package.json
+++ b/packages/fingerprint/package.json
@@ -8,10 +8,12 @@
     ".": "./src/index.ts"
   },
   "scripts": {
+    "test": "tsx --test src/**/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/node": "^22.10.1",
+    "tsx": "^4.19.2",
     "typescript": "^5.7.2"
   }
 }

--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { fingerprint, messageBucketFor } from "./index.js";
+
+// A single route-scanner error class (e.g. Phoenix NoRouteError) emits one
+// exception per probed path. The stacktrace is identical across all of them —
+// only the request path in the message differs — so without path normalization
+// every probed URL becomes its own issue. One bot sweep then explodes into tens
+// of thousands of distinct fingerprints, which floods issue ingestion. Collapse
+// request paths so the whole sweep groups into a single issue.
+test("messageBucketFor collapses request paths so route-scanner errors group", () => {
+  const a = messageBucketFor("no route found for GET /wp-admin/install.php (AppWeb.Router)");
+  const b = messageBucketFor("no route found for GET /.git/config (AppWeb.Router)");
+  const c = messageBucketFor("no route found for GET /apple-touch-icon.png (AppWeb.Router)");
+  assert.equal(a, b);
+  assert.equal(b, c);
+  assert.match(a, /<path>/);
+});
+
+test("fingerprint groups same-stack route-scanner errors that differ only by path", () => {
+  const stack = "    at AppWeb.Router.call (lib/app_web/router.ex:1:1)";
+  const fp1 = fingerprint({
+    type: "Elixir.Phoenix.Router.NoRouteError",
+    stacktrace: stack,
+    message: "no route found for GET /wp-admin/install.php (AppWeb.Router)",
+  });
+  const fp2 = fingerprint({
+    type: "Elixir.Phoenix.Router.NoRouteError",
+    stacktrace: stack,
+    message: "no route found for GET /.env (AppWeb.Router)",
+  });
+  assert.equal(fp1.hash, fp2.hash);
+});
+
+test("messageBucketFor keeps a bare path token distinct from a real path", () => {
+  // A leading-slash path collapses; an in-word slash (and/or) must not.
+  assert.equal(messageBucketFor("request to /api/v2/users failed"), "request to <path> failed");
+  assert.equal(messageBucketFor("read timeout and/or connection reset"), "read timeout and/or connection reset");
+});
+
+test("messageBucketFor still separates genuinely different messages", () => {
+  assert.notEqual(
+    messageBucketFor("model is not supported"),
+    messageBucketFor("extra inputs are not permitted"),
+  );
+});

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -83,6 +83,7 @@ export function messageBucketFor(message: string | null | undefined): string {
   if (!message) return "";
   let s = unwrapAnthropicErrorMessage(message);
   s = s.replace(/https?:\/\/\S+/gi, "<url>");
+  s = collapseRequestPaths(s);
   s = s.replace(/\b[\w.+-]+@[\w.-]+\.\w+\b/g, "<email>");
   s = s.replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi, "<uuid>");
   s = s.replace(/\b\d{4}-\d{2}-\d{2}[T ][\d:.]+Z?(?:[+-]\d{2}:?\d{2})?\b/g, "<ts>");
@@ -92,6 +93,19 @@ export function messageBucketFor(message: string | null | undefined): string {
   s = s.replace(/\b\d+\b/g, "<n>");
   s = s.replace(/\s+/g, " ").trim().toLowerCase();
   return s.length > MESSAGE_BUCKET_MAX ? s.slice(0, MESSAGE_BUCKET_MAX) : s;
+}
+
+// Collapse leading-slash request paths to a single `<path>` token. A route
+// scanner hammering a server emits one error per probed URL (`/wp-admin`,
+// `/.env`, `/.git/config`, …) that are otherwise identical — same type, same
+// stacktrace. Without this every probed path becomes its own fingerprint, so a
+// single bot sweep explodes into tens of thousands of distinct issues and
+// floods ingestion. We only collapse a slash at a token boundary (start or
+// after whitespace) so in-word slashes like `and/or` or `client/server` stay
+// intact. The HTTP method (`GET`/`POST`) is left alone, so a sweep groups into
+// at most a handful of issues (one per method) instead of thousands.
+function collapseRequestPaths(s: string): string {
+  return s.replace(/(^|\s)\/\S*/g, "$1<path>");
 }
 
 function unwrapAnthropicErrorMessage(raw: string): string {
@@ -104,6 +118,7 @@ function unwrapAnthropicErrorMessage(raw: string): string {
 export function normalizeMessage(body: string): string {
   let s = body;
   s = s.replace(/https?:\/\/\S+/gi, "<url>");
+  s = collapseRequestPaths(s);
   s = s.replace(/\b[\w.+-]+@[\w.-]+\.\w+\b/g, "<email>");
   s = s.replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi, "<uuid>");
   s = s.replace(/\b\d{4}-\d{2}-\d{2}[T ][\d:.]+Z?(?:[+-]\d{2}:?\d{2})?\b/g, "<ts>");


### PR DESCRIPTION
## Problem

A route scanner sweeping a server hits many nonexistent paths and emits one error per probed URL — e.g. a Phoenix `NoRouteError` for `/wp-admin/install.php`, `/.env`, `/.git/config`, `/apple-touch-icon.png`, … These errors all share the **same exception type and the same stacktrace** and differ *only* by the request path embedded in the message.

`messageBucketFor` already strips full URLs, UUIDs, timestamps, IPs, and long IDs, but it never collapsed **bare request paths**. So every probed path produced a distinct message bucket → a distinct fingerprint → its own issue. A single bot sweep can therefore explode into **tens of thousands of distinct issues**, and the per-issue "new issue" handling then dominates a telemetry-ingest pass.

## Fix

Collapse leading-slash request paths to a single `<path>` token in both `messageBucketFor` and `normalizeMessage`.

- Anchored at a token boundary (start of string or after whitespace), so in-word slashes like `and/or` and `client/server` are left intact.
- The HTTP method is untouched, so a sweep groups into at most a handful of issues (one per method, e.g. `GET`/`POST`) instead of thousands.

## Tests

Adds the `@superlog/fingerprint` package's first unit tests and a `test` script:

- route-scanner messages differing only by path now share a fingerprint
- a leading-slash path collapses, but an in-word slash does not
- genuinely different messages still bucket separately

```
pnpm --filter @superlog/fingerprint test
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapse leading-slash request paths to a `<path>` token during fingerprinting so route-scanner errors group into one issue instead of thousands. Adds unit tests and a test script to `@superlog/fingerprint`.

- **Bug Fixes**
  - Normalize leading-slash paths to `<path>` in `messageBucketFor` and `normalizeMessage`; anchored at token boundaries so in-word slashes stay intact; HTTP method unchanged to group by method.

- **Dependencies**
  - Added `tsx` as a dev dependency and a `test` script in `@superlog/fingerprint`.

<sup>Written for commit ede994121fefb7b968aa371e270a9c8fd38a2b42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

