### PR TITLE
fingerprint: add tsx to lockfile (fixes frozen-lockfile build)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,6 +521,9 @@ importers:
       '@types/node':
         specifier: ^22.10.1
         version: 22.19.17
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
       typescript:
         specifier: ^5.7.2
         version: 5.9.3


### PR DESCRIPTION
Follow-up to #41. That PR added a `tsx`-based `test` script and the `tsx` devDependency to `@superlog/fingerprint` but did not update `pnpm-lock.yaml`, so Docker image builds (`pnpm install --frozen-lockfile`) fail with `ERR_PNPM_OUTDATED_LOCKFILE`.

Adds the missing fingerprint importer entry for `tsx` (already resolved at `4.21.0` for other workspace packages — no new package downloads). Verified locally: `pnpm install --frozen-lockfile` now succeeds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing `tsx` entry for `@superlog/fingerprint` in `pnpm-lock.yaml`, fixing Docker builds that failed with `ERR_PNPM_OUTDATED_LOCKFILE` during `pnpm install --frozen-lockfile`. Reuses the existing workspace resolution `tsx@4.21.0` (no new downloads).

<sup>Written for commit 56b1aa00312f9eaefeedc7ffde50d2a4ebb57662. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

