### PR TITLE
Run incident cleanup on stale resolves

### DIFF
--- a/apps/api/src/incidents/resolution-side-effects.test.ts
+++ b/apps/api/src/incidents/resolution-side-effects.test.ts
@@ -3,7 +3,26 @@ import { test } from "node:test";
 import {
   buildResolvedIncidentSlackRoot,
   runResolvedIncidentSideEffects,
+  shouldRunResolvedIncidentSideEffects,
 } from "./resolution-side-effects.js";
+
+test("shouldRunResolvedIncidentSideEffects runs cleanup for stale already-closed resolve requests", () => {
+  assert.equal(
+    shouldRunResolvedIncidentSideEffects({ requestedStatus: "resolved", incidentExists: true }),
+    true,
+  );
+});
+
+test("shouldRunResolvedIncidentSideEffects skips reopen requests and missing incidents", () => {
+  assert.equal(
+    shouldRunResolvedIncidentSideEffects({ requestedStatus: "open", incidentExists: true }),
+    false,
+  );
+  assert.equal(
+    shouldRunResolvedIncidentSideEffects({ requestedStatus: "resolved", incidentExists: false }),
+    false,
+  );
+});
 
 test("runResolvedIncidentSideEffects closes incident PRs through the shared helper and refreshes Slack root", async () => {
   const calls: string[] = [];

--- a/apps/api/src/incidents/resolution-side-effects.ts
+++ b/apps/api/src/incidents/resolution-side-effects.ts
@@ -26,6 +26,13 @@ export type ResolvedIncidentSideEffectDeps = {
   }): Promise<void>;
 };
 
+export function shouldRunResolvedIncidentSideEffects(opts: {
+  requestedStatus: "open" | "resolved";
+  incidentExists: boolean;
+}): boolean {
+  return opts.incidentExists && opts.requestedStatus === "resolved";
+}
+
 export async function runResolvedIncidentSideEffects(opts: {
   incident: ResolvedIncidentSideEffectIncident;
   projectName: string;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -48,7 +48,10 @@ import { mountImpersonation } from "./impersonation.js";
 import { buildIncidentListItem, shouldInlineIncidentListStats } from "./incidents/list.js";
 import { getPrDeliveryRetryEligibility } from "./incidents/pr-retry.js";
 import { buildIncidentPullRequestViews } from "./incidents/pr-view.js";
-import { runResolvedIncidentSideEffectsForIncident } from "./incidents/resolution-side-effects.js";
+import {
+  runResolvedIncidentSideEffectsForIncident,
+  shouldRunResolvedIncidentSideEffects,
+} from "./incidents/resolution-side-effects.js";
 import {
   buildIncidentStatsFromActivityRows,
   buildIncidentStatsFromIssues,
@@ -1334,14 +1337,14 @@ app.patch("/api/projects/:projectId/incidents/:incidentId", async (c) => {
   if (status === "resolved") {
     // Route the dashboard's mark-resolved through the shared helper so the
     // resolved_* columns are populated exactly like every other resolve path.
-    const { resolved } = await resolveIncident({
+    await resolveIncident({
       incidentId,
       kind: "dashboard_manual",
       reasonCode: "dashboard_manual",
       reasonText: `Resolved from the dashboard by user ${c.var.userId}.`,
       resolvedByUserId: c.var.userId,
     });
-    if (resolved) {
+    if (shouldRunResolvedIncidentSideEffects({ requestedStatus: status, incidentExists: true })) {
       await runResolvedIncidentSideEffectsForIncident({
         incidentId,
         closePullRequest: (pr) =>

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -365,12 +365,12 @@ async function handleSlackResolveIncident(
     // resolves. Skip the investigation event to avoid coupling to a possibly-
     // unrelated latest investigation.
   });
+  await runSlackResolvedIncidentSideEffects(incidentId);
+
   if (!resolved) {
     log.info({ incidentId }, "resolve_incident click lost race with concurrent close");
     return;
   }
-
-  await runSlackResolvedIncidentSideEffects(incidentId);
 
   const installation = await installationForIncident({
     pinnedId: incident.slackInstallationId,


### PR DESCRIPTION
## Summary
- Run resolved-incident side effects for valid dashboard resolve requests even when the incident was already closed.
- Refresh Slack resolved side effects before suppressing race-lost Slack resolve replies.
- Add regression coverage for stale resolved requests so incident PR cleanup does not get skipped.

## Tests
- pnpm --dir superlog --filter @superlog/api exec tsx --test src/incidents/resolution-side-effects.test.ts
- pnpm --dir superlog --filter @superlog/api exec tsx --test src/slack.test.ts
- pnpm --dir superlog --filter @superlog/api typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run incident cleanup on stale resolve requests so PRs close and Slack views refresh even if the incident was already closed. Also runs Slack resolved side effects before suppressing race-lost replies.

- **Bug Fixes**
  - Dashboard: use `shouldRunResolvedIncidentSideEffects` to always run cleanup when requesting "resolved" for an existing incident, even if it was already closed.
  - Slack: call `runSlackResolvedIncidentSideEffects` before checking the race outcome to refresh the root view and avoid skipped cleanup.
  - Tests: add coverage for stale resolves and the new guard function to prevent regressions.

<sup>Written for commit fcdf32d78a1d43eec03a35c2d2c9629961790351. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

