### PR TITLE
proxy: batch SQS sends and deletes in the ingest queue

### DIFF
--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -459,7 +459,9 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
         resolve();
       }
     });
-    if (ingestQueue && ingestQueueConfig?.consumerEnabled) {
+    // stop() also flushes any sends still waiting on the batching linger, so a
+    // producer-only proxy (consumer disabled) must call it too.
+    if (ingestQueue) {
       await ingestQueue.stop();
     }
   } catch (err) {

--- a/apps/proxy/src/ingest-queue.batch.test.ts
+++ b/apps/proxy/src/ingest-queue.batch.test.ts
@@ -1,0 +1,336 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { IngestQueue, type IngestQueueConfig, getIngestQueueConfig } from "./ingest-queue.js";
+
+const noopLogger = { info: () => {}, warn: () => {}, error: () => {} };
+
+function buildConfig(overrides: Partial<IngestQueueConfig> = {}): IngestQueueConfig {
+  return {
+    queueUrl: "http://localhost/queue",
+    region: "us-west-2",
+    oversizePrefix: "otlp-oversize",
+    maxMessageBytes: 240_000,
+    maxBodyBytes: 64 * 1024 * 1024,
+    consumerEnabled: true,
+    waitTimeSeconds: 20,
+    visibilityTimeoutSeconds: 120,
+    batchSize: 10,
+    consumerConcurrency: 1,
+    sendLingerMs: 5,
+    ...overrides,
+  };
+}
+
+function input(projectId: string, body: Buffer = Buffer.from(`body-${projectId}`)) {
+  return {
+    path: "/v1/logs",
+    projectId,
+    contentType: "application/x-protobuf",
+    body,
+  };
+}
+
+/** Fake SQS for the producer side: accepts SendMessageBatch, records every batch,
+ *  and fails entries whose MessageBody contains `failBodiesContaining`. A plain
+ *  SendMessageCommand is an error — the whole point is that sends are batched. */
+class FakeSendSqs {
+  batchEntries: Array<Array<{ Id: string; MessageBody: string }>> = [];
+  failBodiesContaining: string | null = null;
+
+  // biome-ignore lint/suspicious/noExplicitAny: minimal AWS client test double
+  async send(cmd: any): Promise<unknown> {
+    const name = cmd.constructor.name;
+    if (name === "SendMessageBatchCommand") {
+      const entries = cmd.input.Entries as Array<{ Id: string; MessageBody: string }>;
+      this.batchEntries.push(entries);
+      const marker = this.failBodiesContaining;
+      const failed = marker ? entries.filter((e) => e.MessageBody.includes(marker)) : [];
+      return {
+        Successful: entries.filter((e) => !failed.includes(e)).map((e) => ({ Id: e.Id })),
+        Failed: failed.map((e) => ({
+          Id: e.Id,
+          Code: "InternalError",
+          Message: "simulated entry failure",
+          SenderFault: false,
+        })),
+      };
+    }
+    throw new Error(`unexpected SQS command: ${name}`);
+  }
+}
+
+class FakeS3 {
+  puts: string[] = [];
+  deletes: string[] = [];
+  objects = new Map<string, Buffer>();
+
+  // biome-ignore lint/suspicious/noExplicitAny: minimal AWS client test double
+  async send(cmd: any): Promise<unknown> {
+    const name = cmd.constructor.name;
+    if (name === "PutObjectCommand") {
+      this.puts.push(cmd.input.Key);
+      return {};
+    }
+    if (name === "DeleteObjectCommand") {
+      this.deletes.push(cmd.input.Key);
+      return {};
+    }
+    if (name === "GetObjectCommand") {
+      const body = this.objects.get(cmd.input.Key);
+      if (!body) throw new Error(`no such object: ${cmd.input.Key}`);
+      return { Body: { transformToByteArray: async () => new Uint8Array(body) } };
+    }
+    throw new Error(`unexpected S3 command: ${name}`);
+  }
+}
+
+function buildQueue(overrides: Partial<IngestQueueConfig> = {}) {
+  const queue = new IngestQueue(buildConfig(overrides), noopLogger);
+  const sqs = new FakeSendSqs();
+  const s3 = new FakeS3();
+  (queue as unknown as { sqs: FakeSendSqs }).sqs = sqs;
+  (queue as unknown as { s3: FakeS3 }).s3 = s3;
+  return { queue, sqs, s3 };
+}
+
+test("getIngestQueueConfig reads the send linger with a batching default", () => {
+  const defaults = getIngestQueueConfig({ INGEST_QUEUE_URL: "http://localhost/queue" });
+  assert.equal(defaults?.sendLingerMs, 50);
+
+  const zero = getIngestQueueConfig({
+    INGEST_QUEUE_URL: "http://localhost/queue",
+    INGEST_QUEUE_SEND_LINGER_MS: "0",
+  });
+  assert.equal(zero?.sendLingerMs, 0);
+});
+
+test("enqueue coalesces concurrent sends into one SendMessageBatch", async () => {
+  const { queue, sqs } = buildQueue();
+
+  const results = await Promise.all([1, 2, 3].map((i) => queue.enqueue(input(`p-${i}`))));
+
+  assert.deepEqual(results, ["inline", "inline", "inline"]);
+  assert.equal(sqs.batchEntries.length, 1, "three concurrent sends must share one batch call");
+  assert.equal(sqs.batchEntries[0]?.length, 3);
+});
+
+test("a full batch of 10 flushes immediately without waiting for the linger timer", async () => {
+  const { queue, sqs } = buildQueue({ sendLingerMs: 5_000 });
+
+  const pending = Array.from({ length: 10 }, (_, i) => queue.enqueue(input(`p-${i}`)));
+  // Well under the 5s linger: the batch must already be on the wire.
+  await delay(50);
+  assert.equal(sqs.batchEntries.length, 1);
+  assert.equal(sqs.batchEntries[0]?.length, 10);
+  await Promise.all(pending);
+});
+
+test("splits a flush into multiple batch calls when the 256 KiB payload budget would overflow", async () => {
+  const { queue, sqs } = buildQueue();
+
+  // Three ~107 KiB message bodies (80 KB raw, base64-inflated): two fit in one
+  // 256 KiB SendMessageBatch, the third must roll into a second call.
+  await Promise.all(
+    [1, 2, 3].map((i) => queue.enqueue(input(`p-${i}`, Buffer.alloc(80_000, i)))),
+  );
+
+  assert.equal(sqs.batchEntries.length, 2, "three oversized entries must split into two batches");
+  const totalEntries = sqs.batchEntries.reduce((n, entries) => n + entries.length, 0);
+  assert.equal(totalEntries, 3);
+  for (const entries of sqs.batchEntries) {
+    const bytes = entries.reduce((n, e) => n + Buffer.byteLength(e.MessageBody), 0);
+    assert.ok(bytes <= 256 * 1024, `batch payload ${bytes} exceeds the SQS 256 KiB budget`);
+  }
+});
+
+test("rejects only the entries SQS reports as failed", async () => {
+  const { queue, sqs } = buildQueue();
+  sqs.failBodiesContaining = "p-doomed";
+
+  const ok = queue.enqueue(input("p-fine"));
+  const doomed = queue.enqueue(input("p-doomed"));
+
+  assert.equal(await ok, "inline");
+  await assert.rejects(doomed, /simulated entry failure/);
+});
+
+test("cleans up the uploaded S3 object when its batched send fails", async () => {
+  const { queue, sqs, s3 } = buildQueue({
+    maxMessageBytes: 64, // force the S3 offload path
+    oversizeBucket: "test-bucket",
+  });
+  sqs.failBodiesContaining = "p-doomed";
+
+  await assert.rejects(queue.enqueue(input("p-doomed")), /simulated entry failure/);
+
+  assert.equal(s3.puts.length, 1, "the oversize body must be uploaded before the send");
+  assert.deepEqual(s3.deletes, s3.puts, "the orphaned object must be rolled back");
+});
+
+/** Fake SQS for the consumer side: delivers one fixed batch on the first receive,
+ *  then blocks like a real long-poll until aborted. Deletes must arrive as
+ *  DeleteMessageBatch; entries whose receipt handle is in `failReceipts` fail. */
+class FakeConsumerSqs {
+  deleteBatches: string[][] = [];
+  singleDeletes: string[] = [];
+  failReceipts: string[] = [];
+  private delivered = false;
+
+  constructor(private readonly messages: Array<{ MessageId: string; ReceiptHandle: string; Body: string }>) {}
+
+  // biome-ignore lint/suspicious/noExplicitAny: minimal AWS client test double
+  async send(cmd: any, opts?: { abortSignal?: AbortSignal }): Promise<unknown> {
+    const name = cmd.constructor.name;
+    if (name === "ReceiveMessageCommand") {
+      if (!this.delivered) {
+        this.delivered = true;
+        return { Messages: this.messages };
+      }
+      return await new Promise((_resolve, reject) => {
+        const signal = opts?.abortSignal;
+        const abort = () => {
+          const err = new Error("Request aborted");
+          err.name = "AbortError";
+          reject(err);
+        };
+        if (signal?.aborted) return abort();
+        signal?.addEventListener("abort", abort, { once: true });
+      });
+    }
+    if (name === "DeleteMessageBatchCommand") {
+      const entries = cmd.input.Entries as Array<{ Id: string; ReceiptHandle: string }>;
+      this.deleteBatches.push(entries.map((e) => e.ReceiptHandle));
+      const failed = entries.filter((e) => this.failReceipts.includes(e.ReceiptHandle));
+      return {
+        Successful: entries.filter((e) => !failed.includes(e)).map((e) => ({ Id: e.Id })),
+        Failed: failed.map((e) => ({
+          Id: e.Id,
+          Code: "ReceiptHandleIsInvalid",
+          Message: "simulated delete failure",
+          SenderFault: true,
+        })),
+      };
+    }
+    if (name === "DeleteMessageCommand") {
+      this.singleDeletes.push(cmd.input.ReceiptHandle);
+      return {};
+    }
+    throw new Error(`unexpected SQS command: ${name}`);
+  }
+}
+
+function inlineMessageBody(projectId: string): string {
+  return JSON.stringify({
+    version: 1,
+    kind: "otlp",
+    path: "/v1/logs",
+    projectId,
+    contentType: "application/x-protobuf",
+    receivedAt: new Date().toISOString(),
+    body: { storage: "inline", base64: Buffer.from("hello").toString("base64") },
+  });
+}
+
+function s3MessageBody(projectId: string, key: string): string {
+  return JSON.stringify({
+    version: 1,
+    kind: "otlp",
+    path: "/v1/logs",
+    projectId,
+    contentType: "application/x-protobuf",
+    receivedAt: new Date().toISOString(),
+    body: { storage: "s3", bucket: "test-bucket", key, sizeBytes: 5 },
+  });
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error("timed out waiting for condition");
+    await delay(5);
+  }
+}
+
+async function withCollectorReturning(
+  status: number,
+  run: () => Promise<void>,
+): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(new Uint8Array(0), { status })) as typeof fetch;
+  try {
+    await run();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+test("consumer deletes a processed batch with one DeleteMessageBatch call", async () => {
+  const sqs = new FakeConsumerSqs([
+    { MessageId: "m-1", ReceiptHandle: "r-1", Body: inlineMessageBody("p-1") },
+    { MessageId: "m-2", ReceiptHandle: "r-2", Body: inlineMessageBody("p-2") },
+    { MessageId: "m-3", ReceiptHandle: "r-3", Body: inlineMessageBody("p-3") },
+  ]);
+  const queue = new IngestQueue(buildConfig(), noopLogger);
+  (queue as unknown as { sqs: FakeConsumerSqs }).sqs = sqs;
+
+  await withCollectorReturning(200, async () => {
+    queue.startConsumer("http://collector.local");
+    await waitFor(() => sqs.deleteBatches.length === 1);
+    await queue.stop();
+  });
+
+  assert.deepEqual(sqs.deleteBatches, [["r-1", "r-2", "r-3"]]);
+  assert.equal(sqs.singleDeletes.length, 0, "deletes must be batched, not per-message");
+});
+
+test("poison messages are dropped through the same batched delete", async () => {
+  const sqs = new FakeConsumerSqs([
+    { MessageId: "m-1", ReceiptHandle: "r-1", Body: inlineMessageBody("p-1") },
+    { MessageId: "m-2", ReceiptHandle: "r-2", Body: "not json at all" },
+  ]);
+  const queue = new IngestQueue(buildConfig(), noopLogger);
+  (queue as unknown as { sqs: FakeConsumerSqs }).sqs = sqs;
+
+  await withCollectorReturning(200, async () => {
+    queue.startConsumer("http://collector.local");
+    await waitFor(() => sqs.deleteBatches.length === 1);
+    await queue.stop();
+  });
+
+  assert.deepEqual(sqs.deleteBatches, [["r-1", "r-2"]]);
+});
+
+test("keeps the S3 body when its SQS delete fails so the redelivery can still read it", async () => {
+  const sqs = new FakeConsumerSqs([
+    { MessageId: "m-1", ReceiptHandle: "r-1", Body: s3MessageBody("p-1", "k-1") },
+    { MessageId: "m-2", ReceiptHandle: "r-2", Body: s3MessageBody("p-2", "k-2") },
+  ]);
+  sqs.failReceipts = ["r-2"];
+  const queue = new IngestQueue(buildConfig(), noopLogger);
+  const s3 = new FakeS3();
+  s3.objects.set("k-1", Buffer.from("hello"));
+  s3.objects.set("k-2", Buffer.from("hello"));
+  (queue as unknown as { sqs: FakeConsumerSqs }).sqs = sqs;
+  (queue as unknown as { s3: FakeS3 }).s3 = s3;
+
+  await withCollectorReturning(200, async () => {
+    queue.startConsumer("http://collector.local");
+    await waitFor(() => sqs.deleteBatches.length === 1);
+    await queue.stop();
+  });
+
+  assert.deepEqual(s3.deletes, ["k-1"], "only the successfully-deleted message may purge its body");
+});
+
+test("stop() flushes pending batched sends before resolving", async () => {
+  const { queue, sqs } = buildQueue({ sendLingerMs: 60_000 });
+
+  const pending = queue.enqueue(input("p-1"));
+  // The linger is 60s; stop() must not wait for it.
+  await queue.stop();
+
+  assert.equal(await pending, "inline");
+  assert.equal(sqs.batchEntries.length, 1);
+});

--- a/apps/proxy/src/ingest-queue.shutdown.test.ts
+++ b/apps/proxy/src/ingest-queue.shutdown.test.ts
@@ -16,6 +16,7 @@ const config: IngestQueueConfig = {
   visibilityTimeoutSeconds: 120,
   batchSize: 1,
   consumerConcurrency: 1,
+  sendLingerMs: 0,
 };
 
 const inlineBody = encodeIngestMessage(
@@ -61,9 +62,10 @@ class FakeConsumerSqs {
         signal?.addEventListener("abort", abort, { once: true });
       });
     }
-    if (name === "DeleteMessageCommand") {
-      this.deleted.push(cmd.input.ReceiptHandle);
-      return {};
+    if (name === "DeleteMessageBatchCommand") {
+      const entries = cmd.input.Entries as Array<{ Id: string; ReceiptHandle: string }>;
+      for (const entry of entries) this.deleted.push(entry.ReceiptHandle);
+      return { Successful: entries.map((entry) => ({ Id: entry.Id })), Failed: [] };
     }
     throw new Error(`unexpected SQS command: ${name}`);
   }

--- a/apps/proxy/src/ingest-queue.stream.test.ts
+++ b/apps/proxy/src/ingest-queue.stream.test.ts
@@ -7,11 +7,12 @@ class FakeSqs {
   sent: string[] = [];
   // biome-ignore lint/suspicious/noExplicitAny: test double for the AWS client surface
   async send(cmd: any): Promise<unknown> {
-    if (cmd.constructor.name !== "SendMessageCommand") {
+    if (cmd.constructor.name !== "SendMessageBatchCommand") {
       throw new Error(`unexpected SQS command: ${cmd.constructor.name}`);
     }
-    this.sent.push(cmd.input.MessageBody);
-    return { MessageId: "m-1" };
+    const entries = cmd.input.Entries as Array<{ Id: string; MessageBody: string }>;
+    for (const entry of entries) this.sent.push(entry.MessageBody);
+    return { Successful: entries.map((entry) => ({ Id: entry.Id })), Failed: [] };
   }
 }
 
@@ -52,6 +53,7 @@ function buildQueue(overrides: Partial<IngestQueueConfig> = {}): {
     visibilityTimeoutSeconds: 120,
     batchSize: 10,
     consumerConcurrency: 4,
+    sendLingerMs: 0,
     ...overrides,
   };
   const sinks: RecordingSink[] = [];

--- a/apps/proxy/src/ingest-queue.ts
+++ b/apps/proxy/src/ingest-queue.ts
@@ -9,12 +9,12 @@ import {
   S3Client,
 } from "@aws-sdk/client-s3";
 import {
-  DeleteMessageCommand,
+  DeleteMessageBatchCommand,
   type Message,
   ReceiveMessageCommand,
   type ReceiveMessageCommandOutput,
   SQSClient,
-  SendMessageCommand,
+  SendMessageBatchCommand,
 } from "@aws-sdk/client-sqs";
 import { Upload } from "@aws-sdk/lib-storage";
 import { type SpillSink, captureBody } from "./body-capture.js";
@@ -37,6 +37,15 @@ const DEFAULT_VISIBILITY_TIMEOUT_SECONDS = 120;
 const DEFAULT_BATCH_SIZE = 10;
 const DEFAULT_CONSUMER_CONCURRENCY = 4;
 const MAX_COLLECTOR_ERROR_BODY_CHARS = 1_000;
+// SQS hard limits on a single SendMessageBatch/DeleteMessageBatch call: at most
+// 10 entries, and (for sends) at most 256 KiB of total payload across entries.
+const SQS_BATCH_MAX_ENTRIES = 10;
+const SQS_BATCH_MAX_PAYLOAD_BYTES = 256 * 1024;
+// How long a pending send may wait for batch-mates before it is flushed anyway.
+// Each SQS request is billed individually, so coalescing sends into
+// SendMessageBatch cuts the request bill up to 10x; the linger is the latency
+// ceiling that coalescing may add to an ingest ack.
+const DEFAULT_SEND_LINGER_MS = 50;
 
 type LoggerLike = {
   info: (obj: Record<string, unknown>, msg: string) => void;
@@ -56,6 +65,7 @@ export type IngestQueueConfig = {
   visibilityTimeoutSeconds: number;
   batchSize: number;
   consumerConcurrency: number;
+  sendLingerMs: number;
 };
 
 export type IngestQueueInput = {
@@ -138,6 +148,7 @@ export function getIngestQueueConfig(env: NodeJS.ProcessEnv): IngestQueueConfig 
       readPositiveInt(env.INGEST_QUEUE_CONSUMER_CONCURRENCY, DEFAULT_CONSUMER_CONCURRENCY),
       32,
     ),
+    sendLingerMs: readNonNegativeInt(env.INGEST_QUEUE_SEND_LINGER_MS, DEFAULT_SEND_LINGER_MS),
   };
 }
 
@@ -276,6 +287,22 @@ export type SpillSinkFactory = (params: {
   contentType: string;
 }) => SpillSink;
 
+type PendingSend = {
+  messageBody: string;
+  bytes: number;
+  resolve: () => void;
+  reject: (err: unknown) => void;
+};
+
+/** Outcome of processing one received message: whether the consume loop should
+ *  delete it from the queue, and which offloaded S3 body to purge once that
+ *  delete has succeeded. */
+type ProcessedMessage = {
+  message: Message;
+  shouldDelete: boolean;
+  s3Cleanup?: { bucket: string; key: string };
+};
+
 export class IngestQueue {
   private readonly sqs: SQSClient;
   private readonly s3: S3Client;
@@ -326,12 +353,7 @@ export class IngestQueue {
         );
       }
 
-      await this.sqs.send(
-        new SendMessageCommand({
-          QueueUrl: this.config.queueUrl,
-          MessageBody: encoded.messageBody,
-        }),
-      );
+      await this.sendToQueue(encoded.messageBody);
       return encoded.storage;
     } catch (err) {
       if (uploadedObject) {
@@ -397,9 +419,7 @@ export class IngestQueue {
       body: { storage: "s3", bucket, key, sizeBytes: result.totalBytes },
     };
     try {
-      await this.sqs.send(
-        new SendMessageCommand({ QueueUrl: this.config.queueUrl, MessageBody: JSON.stringify(message) }),
-      );
+      await this.sendToQueue(JSON.stringify(message));
     } catch (err) {
       // The object already landed; clean up the orphan so a failed enqueue does
       // not leak S3 storage, mirroring enqueue()'s rollback.
@@ -467,6 +487,104 @@ export class IngestQueue {
     };
   }
 
+  // Producer-side micro-batching: pending sends accumulate here until a flush
+  // (10 entries, the 256 KiB payload budget, or the linger timer) groups them
+  // into SendMessageBatch calls. Every SQS request is billed individually, so at
+  // ingest volume this cuts the request bill up to 10x for the price of at most
+  // sendLingerMs of added ack latency.
+  private pendingSends: PendingSend[] = [];
+  private pendingSendBytes = 0;
+  private sendFlushTimer: NodeJS.Timeout | null = null;
+  private readonly inFlightSends = new Set<Promise<void>>();
+
+  /** Resolves once this message body has been accepted by SQS (its batch entry
+   *  succeeded); rejects with the entry/batch failure otherwise. */
+  private sendToQueue(messageBody: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const bytes = Buffer.byteLength(messageBody);
+      this.pendingSends.push({ messageBody, bytes, resolve, reject });
+      this.pendingSendBytes += bytes;
+      if (
+        this.pendingSends.length >= SQS_BATCH_MAX_ENTRIES ||
+        this.pendingSendBytes >= SQS_BATCH_MAX_PAYLOAD_BYTES
+      ) {
+        this.flushPendingSends();
+      } else if (!this.sendFlushTimer) {
+        this.sendFlushTimer = setTimeout(() => this.flushPendingSends(), this.config.sendLingerMs);
+        // Never keep the process alive just for a pending flush; shutdown
+        // flushes explicitly via stop().
+        this.sendFlushTimer.unref?.();
+      }
+    });
+  }
+
+  private flushPendingSends(): void {
+    if (this.sendFlushTimer) {
+      clearTimeout(this.sendFlushTimer);
+      this.sendFlushTimer = null;
+    }
+    const pending = this.pendingSends;
+    this.pendingSends = [];
+    this.pendingSendBytes = 0;
+    if (pending.length === 0) return;
+
+    // Greedy chunking under both SQS batch limits. A single message can be at
+    // most maxMessageBytes (< the payload budget), so every entry fits somewhere.
+    const chunks: PendingSend[][] = [];
+    let current: PendingSend[] = [];
+    let currentBytes = 0;
+    for (const entry of pending) {
+      if (
+        current.length > 0 &&
+        (current.length >= SQS_BATCH_MAX_ENTRIES ||
+          currentBytes + entry.bytes > SQS_BATCH_MAX_PAYLOAD_BYTES)
+      ) {
+        chunks.push(current);
+        current = [];
+        currentBytes = 0;
+      }
+      current.push(entry);
+      currentBytes += entry.bytes;
+    }
+    if (current.length > 0) chunks.push(current);
+
+    for (const chunk of chunks) {
+      const sendPromise: Promise<void> = this.sendBatchChunk(chunk).finally(() => {
+        this.inFlightSends.delete(sendPromise);
+      });
+      this.inFlightSends.add(sendPromise);
+    }
+  }
+
+  private async sendBatchChunk(chunk: PendingSend[]): Promise<void> {
+    try {
+      const result = await this.sqs.send(
+        new SendMessageBatchCommand({
+          QueueUrl: this.config.queueUrl,
+          Entries: chunk.map((entry, index) => ({
+            Id: String(index),
+            MessageBody: entry.messageBody,
+          })),
+        }),
+      );
+      const failed = new Map((result.Failed ?? []).map((failure) => [failure.Id, failure]));
+      chunk.forEach((entry, index) => {
+        const failure = failed.get(String(index));
+        if (failure) {
+          entry.reject(
+            new Error(
+              `SQS batch entry failed: ${failure.Code ?? "unknown"}: ${failure.Message ?? "no message"}`,
+            ),
+          );
+        } else {
+          entry.resolve();
+        }
+      });
+    } catch (err) {
+      for (const entry of chunk) entry.reject(err);
+    }
+  }
+
   // Set by stop(); flips the consume loops out of their receive cycle so a
   // rolling deploy can drain cleanly instead of abandoning in-flight messages.
   private shuttingDown = false;
@@ -512,6 +630,12 @@ export class IngestQueue {
       { queueUrl: this.config.queueUrl },
       "ingest queue consumer draining in-flight messages",
     );
+    // Flush any sends still waiting on the linger timer so a producer-only
+    // proxy doesn't drop the tail of accepted requests on SIGTERM. The entry
+    // promises are awaited by their HTTP handlers; allSettled only waits for
+    // the wire calls to finish.
+    this.flushPendingSends();
+    await Promise.allSettled([...this.inFlightSends]);
     // consumersDone never rejects (see startConsumer); a loop failure is logged
     // and surfaced as a non-zero exit there.
     await this.consumersDone;
@@ -555,7 +679,10 @@ export class IngestQueue {
       const messages = result.Messages ?? [];
       if (messages.length === 0) continue;
 
-      await Promise.all(messages.map((message) => this.processMessage(message, collectorUrl)));
+      const processed = await Promise.all(
+        messages.map((message) => this.processMessage(message, collectorUrl)),
+      );
+      await this.deleteProcessedMessages(processed.filter((outcome) => outcome.shouldDelete));
     }
 
     this.logger.info(
@@ -564,9 +691,16 @@ export class IngestQueue {
     );
   }
 
-  private async processMessage(message: Message, collectorUrl: string): Promise<void> {
+  /**
+   * Forward one received message to the collector and report whether it should
+   * be deleted from the queue. Deletion itself happens in batch back in the
+   * consume loop (see {@link deleteProcessedMessages}); the optional s3Cleanup
+   * is only acted on once the SQS delete for this message actually succeeded,
+   * so a redelivered message can still read its offloaded body.
+   */
+  private async processMessage(message: Message, collectorUrl: string): Promise<ProcessedMessage> {
     const startedAt = performance.now();
-    if (!message.Body) return;
+    if (!message.Body) return { message, shouldDelete: false };
 
     let parsed: IngestQueueMessage | undefined;
     let collectorFailure: CollectorFailureDescription | undefined;
@@ -607,18 +741,6 @@ export class IngestQueue {
         throw new Error(collectorFailure.message);
       }
 
-      if (!message.ReceiptHandle) throw new Error("SQS message is missing receipt handle");
-      await this.sqs.send(
-        new DeleteMessageCommand({
-          QueueUrl: this.config.queueUrl,
-          ReceiptHandle: message.ReceiptHandle,
-        }),
-      );
-
-      if (parsed.body.storage === "s3") {
-        await this.deleteS3Object(parsed.body.bucket, parsed.body.key);
-      }
-
       proxyOperationalRecorder.recordQueueDelivery({
         path: parsed.path,
         projectId: parsed.projectId,
@@ -638,6 +760,15 @@ export class IngestQueue {
         },
         "delivered queued ingest payload",
       );
+
+      return {
+        message,
+        shouldDelete: true,
+        s3Cleanup:
+          parsed.body.storage === "s3"
+            ? { bucket: parsed.body.bucket, key: parsed.body.key }
+            : undefined,
+      };
     } catch (err) {
       const poison = isPoisonMessageError(err);
       // A collector 4xx (other than 408/429) rejects these exact bytes permanently, so it
@@ -684,30 +815,79 @@ export class IngestQueue {
       // An undeliverable message (poison envelope or permanent collector 4xx) can never
       // succeed; leaving it in place means 50 redeliveries (15-min visibility each) before
       // it reaches the DLQ, which pins oldest-message-age into a sawtooth and keeps the bad
-      // payload churning in-flight. Delete it immediately so it stops cycling.
-      if (drop && message.ReceiptHandle) {
-        const sqsDeleted = await this.sqs
-          .send(
-            new DeleteMessageCommand({
-              QueueUrl: this.config.queueUrl,
-              ReceiptHandle: message.ReceiptHandle,
-            }),
-          )
-          .then(() => true)
-          .catch((deleteErr: unknown) => {
-            this.logger.warn(
-              { err: deleteErr, messageId: message.MessageId },
-              "failed to delete undeliverable ingest message",
-            );
-            return false;
-          });
-        // Only purge the S3 body once the queue message is actually gone. If the SQS delete
-        // failed, the message will be redelivered after the visibility timeout and still needs
-        // its body — deleting it here would strand the retry with a missing object until the DLQ.
-        if (sqsDeleted && parsed?.body?.storage === "s3" && parsed.body.bucket && parsed.body.key) {
-          await this.deleteS3Object(parsed.body.bucket, parsed.body.key).catch(() => {});
-        }
+      // payload churning in-flight. Mark it for deletion so it stops cycling; the S3 body
+      // is only purged once the SQS delete actually succeeded (see deleteProcessedMessages).
+      return {
+        message,
+        shouldDelete: drop,
+        s3Cleanup:
+          drop && parsed?.body?.storage === "s3" && parsed.body.bucket && parsed.body.key
+            ? { bucket: parsed.body.bucket, key: parsed.body.key }
+            : undefined,
+      };
+    }
+  }
+
+  /**
+   * Delete a processed batch of messages with DeleteMessageBatch (one billed
+   * request per 10 messages instead of one per message). A failed entry is only
+   * logged — the message redelivers after its visibility timeout, which at worst
+   * forwards the same payload to the collector twice; its offloaded S3 body is
+   * kept so the retry can still read it.
+   */
+  private async deleteProcessedMessages(outcomes: ProcessedMessage[]): Promise<void> {
+    const deletable = outcomes.filter((outcome) => {
+      if (outcome.message.ReceiptHandle) return true;
+      this.logger.warn(
+        { messageId: outcome.message.MessageId },
+        "SQS message is missing receipt handle; it cannot be deleted",
+      );
+      return false;
+    });
+
+    for (let offset = 0; offset < deletable.length; offset += SQS_BATCH_MAX_ENTRIES) {
+      const chunk = deletable.slice(offset, offset + SQS_BATCH_MAX_ENTRIES);
+      let failedIds: Set<string | undefined>;
+      try {
+        const result = await this.sqs.send(
+          new DeleteMessageBatchCommand({
+            QueueUrl: this.config.queueUrl,
+            Entries: chunk.map((outcome, index) => ({
+              Id: String(index),
+              ReceiptHandle: outcome.message.ReceiptHandle,
+            })),
+          }),
+        );
+        failedIds = new Set((result.Failed ?? []).map((failure) => failure.Id));
+      } catch (err) {
+        this.logger.warn(
+          { err, count: chunk.length },
+          "failed to delete processed ingest messages; they will be redelivered",
+        );
+        continue;
       }
+
+      await Promise.all(
+        chunk.map(async (outcome, index) => {
+          if (failedIds.has(String(index))) {
+            this.logger.warn(
+              { messageId: outcome.message.MessageId },
+              "failed to delete processed ingest message; it will be redelivered",
+            );
+            return;
+          }
+          if (outcome.s3Cleanup) {
+            await this.deleteS3Object(outcome.s3Cleanup.bucket, outcome.s3Cleanup.key).catch(
+              (err) => {
+                this.logger.warn(
+                  { err, ...outcome.s3Cleanup },
+                  "failed to delete oversize ingest object after delivery",
+                );
+              },
+            );
+          }
+        }),
+      );
     }
   }
 
@@ -773,6 +953,12 @@ function readPositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readNonNegativeInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
 function trimSlashes(value: string): string {


### PR DESCRIPTION
## Why

Every SQS request is billed individually, and the ingest path currently makes three per message: one `SendMessage` from the proxy edge, a share of a `ReceiveMessage`, and one `DeleteMessage` from the consumer. At millions of ingest messages per day the request count — not payload size — dominates the queue bill. Batching sends and deletes cuts those calls by up to 10x with no change to delivery semantics.

## What

**Producer (send) side** — `enqueue()` / `enqueueStream()` now hand their encoded message to a micro-batcher instead of calling `SendMessage` directly:
- Flushes into `SendMessageBatch` when 10 entries are pending, when the 256 KiB batch payload budget would overflow, or when a linger timer fires (`INGEST_QUEUE_SEND_LINGER_MS`, default 50 ms — the max latency batching may add to an ingest ack).
- Per-entry failures reject only their own `enqueue()` promise; the caller's existing error handling (5xx → client retry) is unchanged.
- An uploaded oversize S3 body is still rolled back when its batched send fails.

**Consumer (delete) side** — `processMessage()` now returns a delete decision instead of deleting inline, and the consume loop deletes each received batch with one `DeleteMessageBatch` call:
- Poison messages and permanent collector 4xx drops flow through the same batched delete.
- An entry whose delete fails just redelivers after the visibility timeout (same as a failed single delete before); its offloaded S3 body is kept so the retry can still read it.
- One behavior fix in passing: a successful delivery whose delete fails now records a `delivered` metric (it was delivered) instead of `delivery_error`.

**Shutdown** — `stop()` flushes pending batched sends before resolving, and the proxy now calls `stop()` on SIGTERM even when the consumer is disabled, so a producer-only deployment never drops the tail of accepted requests.

## Testing

- New `ingest-queue.batch.test.ts`: coalescing, full-batch immediate flush, 256 KiB budget splitting, per-entry failure isolation, S3 rollback on batched-send failure, batched consumer deletes, poison-drop via batched delete, S3-body retention on per-entry delete failure, and flush-on-stop.
- Updated the stream/shutdown test fakes for the batch commands.
- `tsx --test` over all four ingest-queue test files: 27/27 pass; `tsc --noEmit` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch SQS sends and deletes in the ingest queue to reduce per-request costs by up to 10x while keeping delivery semantics the same. Adds at most 50 ms of optional ack latency for better coalescing.

- **New Features**
  - Send micro-batching: `enqueue()`/`enqueueStream()` coalesce into `SendMessageBatch`; flush on 10 entries, 256 KiB, or a linger (`INGEST_QUEUE_SEND_LINGER_MS`, default 50 ms).
  - Failure handling: only failed batch entries reject; oversize S3 bodies are rolled back if their send fails.
  - Batched deletes: `processMessage()` returns a delete decision; the loop uses `DeleteMessageBatch`. Failed deletes redeliver; S3 bodies are kept until the delete succeeds.
  - Shutdown: `stop()` flushes pending sends; the proxy now calls `stop()` on SIGTERM even when the consumer is disabled.

- **Bug Fixes**
  - Successful deliveries whose delete fails now record `delivered` instead of `delivery_error`.

<sup>Written for commit cbf70f96bbe8f3b755f5c856036e8c34b3c94839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

