### PR TITLE
Close incident PRs by node id

### DIFF
--- a/apps/api/src/github-close-pr.test.ts
+++ b/apps/api/src/github-close-pr.test.ts
@@ -1,0 +1,62 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
+process.env.BETTER_AUTH_SECRET ??= "test-better-auth-secret-with-enough-length";
+
+const { closeGithubPullRequestWithToken } = await import("./github.js");
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+test("closeGithubPullRequestWithToken closes by node id before repo URL fallback", async () => {
+  const calls: string[] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    calls.push(`${init?.method ?? "GET"} ${input.toString()}`);
+    assert.equal(JSON.parse(init?.body as string).variables.pullRequestId, "PR_node_1");
+    return jsonResponse({ data: { closePullRequest: { pullRequest: { id: "PR_node_1" } } } });
+  };
+
+  const result = await closeGithubPullRequestWithToken({
+    token: "token",
+    repoFullName: "old-owner/old-repo",
+    prNumber: 241,
+    prNodeId: "PR_node_1",
+    userAgent: "test",
+    fetchImpl,
+  });
+
+  assert.deepEqual(result, { ok: true });
+  assert.deepEqual(calls, ["POST https://api.github.com/graphql"]);
+});
+
+test("closeGithubPullRequestWithToken falls back to repo URL when node close fails", async () => {
+  const calls: string[] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    calls.push(`${init?.method ?? "GET"} ${input.toString()}`);
+    if (input.toString().endsWith("/graphql")) {
+      return jsonResponse({ errors: [{ message: "not found" }] });
+    }
+    assert.equal(init?.body, JSON.stringify({ state: "closed" }));
+    return jsonResponse({ state: "closed" });
+  };
+
+  const result = await closeGithubPullRequestWithToken({
+    token: "token",
+    repoFullName: "current-owner/current-repo",
+    prNumber: 241,
+    prNodeId: "PR_node_1",
+    userAgent: "test",
+    fetchImpl,
+  });
+
+  assert.deepEqual(result, { ok: true });
+  assert.deepEqual(calls, [
+    "POST https://api.github.com/graphql",
+    "PATCH https://api.github.com/repos/current-owner/current-repo/pulls/241",
+  ]);
+});

--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -708,6 +708,7 @@ async function resolveIncidentForMergedAgentPr(opts: {
           installationId: pr.githubInstallationId,
           repoFullName: pr.repoFullName,
           prNumber: pr.prNumber,
+          prNodeId: pr.prNodeId,
         }),
     });
   }
@@ -1088,28 +1089,84 @@ export async function closeAgentPullRequestOnGithub(opts: {
   installationId: number;
   repoFullName: string;
   prNumber: number;
+  prNodeId?: string | null;
 }): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
     const token = await createInstallationWriteToken(opts.installationId);
-    const res = await fetch(
-      `https://api.github.com/repos/${opts.repoFullName}/pulls/${opts.prNumber}`,
-      {
-        method: "PATCH",
-        headers: {
-          accept: "application/vnd.github+json",
-          authorization: `Bearer ${token}`,
-          "content-type": "application/json; charset=utf-8",
-          "x-github-api-version": "2022-11-28",
-          "user-agent": "superlog-api",
-        },
-        body: JSON.stringify({ state: "closed" }),
-      },
-    );
-    if (res.ok) return { ok: true };
-    const text = await res.text().catch(() => "");
-    return { ok: false, error: `github PATCH /pulls/${opts.prNumber} ${res.status} ${text}` };
+    return closeGithubPullRequestWithToken({
+      token,
+      repoFullName: opts.repoFullName,
+      prNumber: opts.prNumber,
+      prNodeId: opts.prNodeId,
+      userAgent: "superlog-api",
+    });
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function closeGithubPullRequestWithToken(opts: {
+  token: string;
+  repoFullName: string;
+  prNumber: number;
+  prNodeId?: string | null;
+  userAgent: string;
+  fetchImpl?: typeof fetch;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const errors: string[] = [];
+  if (opts.prNodeId) {
+    const res = await fetchImpl("https://api.github.com/graphql", {
+      method: "POST",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${opts.token}`,
+        "content-type": "application/json; charset=utf-8",
+        "x-github-api-version": "2022-11-28",
+        "user-agent": opts.userAgent,
+      },
+      body: JSON.stringify({
+        query: `mutation ClosePullRequest($pullRequestId: ID!) {
+          closePullRequest(input: { pullRequestId: $pullRequestId }) {
+            pullRequest { id closed }
+          }
+        }`,
+        variables: { pullRequestId: opts.prNodeId },
+      }),
+    });
+    const text = await res.text().catch(() => "");
+    if (res.ok) {
+      const data = text ? parseGithubGraphqlResponse(text) : {};
+      if (!data.errors?.length) return { ok: true };
+    }
+    errors.push(`github GraphQL closePullRequest ${res.status} ${text}`);
+  }
+
+  const res = await fetchImpl(
+    `https://api.github.com/repos/${opts.repoFullName}/pulls/${opts.prNumber}`,
+    {
+      method: "PATCH",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${opts.token}`,
+        "content-type": "application/json; charset=utf-8",
+        "x-github-api-version": "2022-11-28",
+        "user-agent": opts.userAgent,
+      },
+      body: JSON.stringify({ state: "closed" }),
+    },
+  );
+  if (res.ok) return { ok: true };
+  const text = await res.text().catch(() => "");
+  errors.push(`github PATCH /pulls/${opts.prNumber} ${res.status} ${text}`);
+  return { ok: false, error: errors.join("; ") };
+}
+
+function parseGithubGraphqlResponse(text: string): { errors?: unknown[] } {
+  try {
+    return JSON.parse(text) as { errors?: unknown[] };
+  } catch {
+    return { errors: [{ message: "invalid json response" }] };
   }
 }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1352,6 +1352,7 @@ app.patch("/api/projects/:projectId/incidents/:incidentId", async (c) => {
             installationId: pr.githubInstallationId,
             repoFullName: pr.repoFullName,
             prNumber: pr.prNumber,
+            prNodeId: pr.prNodeId,
           }),
       });
     }
@@ -1433,6 +1434,7 @@ async function decideResolutionProposal(
           installationId: pr.githubInstallationId,
           repoFullName: pr.repoFullName,
           prNumber: pr.prNumber,
+          prNodeId: pr.prNodeId,
         }),
     });
   }

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -398,6 +398,7 @@ async function runSlackResolvedIncidentSideEffects(incidentId: string): Promise<
         installationId: pr.githubInstallationId,
         repoFullName: pr.repoFullName,
         prNumber: pr.prNumber,
+        prNodeId: pr.prNodeId,
       }),
   });
 }
@@ -438,6 +439,7 @@ async function handleProposalDecision(
           installationId: pr.githubInstallationId,
           repoFullName: pr.repoFullName,
           prNumber: pr.prNumber,
+          prNodeId: pr.prNodeId,
         }),
     });
   }

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -38,6 +38,7 @@ async function closeOpenPullRequestsForResolvedIncident(incidentId: string): Pro
         installationId: pr.githubInstallationId,
         repoFullName: pr.repoFullName,
         prNumber: pr.prNumber,
+        prNodeId: pr.prNodeId,
       }),
     onCloseFailure: ({ pr, error }) =>
       logger.warn(

--- a/apps/worker/src/github-app.ts
+++ b/apps/worker/src/github-app.ts
@@ -696,28 +696,81 @@ export async function closeAgentPullRequestOnGithub(opts: {
   installationId: number;
   repoFullName: string;
   prNumber: number;
+  prNodeId?: string | null;
 }): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
     const token = await createGithubWriteToken(opts.installationId);
-    const res = await fetch(
-      `${GITHUB_API}/repos/${opts.repoFullName}/pulls/${opts.prNumber}`,
-      {
-        method: "PATCH",
-        headers: {
-          accept: "application/vnd.github+json",
-          authorization: `Bearer ${token}`,
-          "content-type": "application/json; charset=utf-8",
-          "x-github-api-version": "2022-11-28",
-          "user-agent": "superlog-worker",
-        },
-        body: JSON.stringify({ state: "closed" }),
-      },
-    );
-    if (res.ok) return { ok: true };
-    const text = await res.text().catch(() => "");
-    return { ok: false, error: `github PATCH /pulls/${opts.prNumber} ${res.status} ${text}` };
+    return closeGithubPullRequestWithToken({
+      token,
+      repoFullName: opts.repoFullName,
+      prNumber: opts.prNumber,
+      prNodeId: opts.prNodeId,
+      userAgent: "superlog-worker",
+    });
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+async function closeGithubPullRequestWithToken(opts: {
+  token: string;
+  repoFullName: string;
+  prNumber: number;
+  prNodeId?: string | null;
+  userAgent: string;
+  fetchImpl?: typeof fetch;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const errors: string[] = [];
+  if (opts.prNodeId) {
+    const res = await fetchImpl(`${GITHUB_API}/graphql`, {
+      method: "POST",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${opts.token}`,
+        "content-type": "application/json; charset=utf-8",
+        "x-github-api-version": "2022-11-28",
+        "user-agent": opts.userAgent,
+      },
+      body: JSON.stringify({
+        query: `mutation ClosePullRequest($pullRequestId: ID!) {
+          closePullRequest(input: { pullRequestId: $pullRequestId }) {
+            pullRequest { id closed }
+          }
+        }`,
+        variables: { pullRequestId: opts.prNodeId },
+      }),
+    });
+    const text = await res.text().catch(() => "");
+    if (res.ok) {
+      const data = text ? parseGithubGraphqlResponse(text) : {};
+      if (!data.errors?.length) return { ok: true };
+    }
+    errors.push(`github GraphQL closePullRequest ${res.status} ${text}`);
+  }
+
+  const res = await fetchImpl(`${GITHUB_API}/repos/${opts.repoFullName}/pulls/${opts.prNumber}`, {
+    method: "PATCH",
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${opts.token}`,
+      "content-type": "application/json; charset=utf-8",
+      "x-github-api-version": "2022-11-28",
+      "user-agent": opts.userAgent,
+    },
+    body: JSON.stringify({ state: "closed" }),
+  });
+  if (res.ok) return { ok: true };
+  const text = await res.text().catch(() => "");
+  errors.push(`github PATCH /pulls/${opts.prNumber} ${res.status} ${text}`);
+  return { ok: false, error: errors.join("; ") };
+}
+
+function parseGithubGraphqlResponse(text: string): { errors?: unknown[] } {
+  try {
+    return JSON.parse(text) as { errors?: unknown[] };
+  } catch {
+    return { errors: [{ message: "invalid json response" }] };
   }
 }
 

--- a/packages/db/src/incident-pr-resolution.test.ts
+++ b/packages/db/src/incident-pr-resolution.test.ts
@@ -58,8 +58,20 @@ function recordingDb(rows: IncidentOpenPullRequestToClose[]): { db: DB; calls: R
 test("closeIncidentOpenPullRequestsAfterResolution closes open PRs and records events", async () => {
   const closedAt = new Date("2026-06-07T01:02:03.000Z");
   const { db, calls } = recordingDb([
-    { id: "pr-1", githubInstallationId: 101, repoFullName: "acme/api", prNumber: 12 },
-    { id: "pr-2", githubInstallationId: 202, repoFullName: "acme/web", prNumber: 34 },
+    {
+      id: "pr-1",
+      githubInstallationId: 101,
+      repoFullName: "acme/api",
+      prNumber: 12,
+      prNodeId: "PR_node_1",
+    },
+    {
+      id: "pr-2",
+      githubInstallationId: 202,
+      repoFullName: "acme/web",
+      prNumber: 34,
+      prNodeId: null,
+    },
   ]);
   const closed: string[] = [];
 
@@ -68,13 +80,13 @@ test("closeIncidentOpenPullRequestsAfterResolution closes open PRs and records e
     database: db,
     now: () => closedAt,
     closePullRequest: async (pr) => {
-      closed.push(`${pr.repoFullName}#${pr.prNumber}`);
+      closed.push(`${pr.repoFullName}#${pr.prNumber}:${pr.prNodeId ?? "no-node"}`);
       return { ok: true };
     },
   });
 
   assert.deepEqual(result, { closedPullRequestCount: 2, failedPullRequestCount: 0 });
-  assert.deepEqual(closed, ["acme/api#12", "acme/web#34"]);
+  assert.deepEqual(closed, ["acme/api#12:PR_node_1", "acme/web#34:no-node"]);
   const updates = calls.filter((call) => call.op === "update");
   assert.equal(updates.length, 2);
   assert.equal(updates[0]?.table, schema.agentPullRequests);
@@ -88,7 +100,13 @@ test("closeIncidentOpenPullRequestsAfterResolution closes open PRs and records e
 
 test("closeIncidentOpenPullRequestsAfterResolution leaves failed PRs open", async () => {
   const { db, calls } = recordingDb([
-    { id: "pr-1", githubInstallationId: 101, repoFullName: "acme/api", prNumber: 12 },
+    {
+      id: "pr-1",
+      githubInstallationId: 101,
+      repoFullName: "acme/api",
+      prNumber: 12,
+      prNodeId: "PR_node_1",
+    },
   ]);
   const failures: string[] = [];
 

--- a/packages/db/src/incident-pr-resolution.ts
+++ b/packages/db/src/incident-pr-resolution.ts
@@ -7,6 +7,7 @@ export type IncidentOpenPullRequestToClose = {
   githubInstallationId: number;
   repoFullName: string;
   prNumber: number;
+  prNodeId: string | null;
 };
 
 export type CloseIncidentPullRequest = (
@@ -32,6 +33,7 @@ export async function closeIncidentOpenPullRequestsAfterResolution(opts: {
       id: schema.agentPullRequests.id,
       repoFullName: schema.agentPullRequests.repoFullName,
       prNumber: schema.agentPullRequests.prNumber,
+      prNodeId: schema.agentPullRequests.prNodeId,
       githubInstallationId: schema.githubInstallations.installationId,
     })
     .from(schema.agentPullRequests)


### PR DESCRIPTION
## Summary
- Pass stored GitHub pull request node IDs into incident PR cleanup.
- Prefer GraphQL close by node ID, then fall back to the repo/number REST close.
- Covers renamed repositories where old repo names redirect in the browser but return 404 from write APIs.

## Tests
- pnpm --dir superlog --filter @superlog/db exec tsx --test src/incident-pr-resolution.test.ts
- pnpm --dir superlog --filter @superlog/api exec tsx --test src/github-close-pr.test.ts
- pnpm --dir superlog --filter @superlog/db typecheck
- pnpm --dir superlog --filter @superlog/api typecheck
- pnpm --dir superlog --filter @superlog/worker typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close incident PRs via GitHub GraphQL using stored pull request node IDs, with REST fallback. Fixes 404s when repos are renamed.

- **Bug Fixes**
  - Pass `prNodeId` through incident resolution in `@superlog/api`, `@superlog/worker`, and Slack side effects.
  - Add `closeGithubPullRequestWithToken` to close by node ID first, then fall back to repo/number REST.
  - Select `prNodeId` in DB incident PR queries in `@superlog/db`.
  - Add tests in `@superlog/api` and `@superlog/db` to cover node-ID close and fallback.

<sup>Written for commit 00ee0c3a2d3773a1776ad917e907079250e27432. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

