### PR TITLE
web: settings redesign — org/project tabs, grouped sidebar, row-style cards

### DIFF
--- a/apps/web/src/AuthForm.tsx
+++ b/apps/web/src/AuthForm.tsx
@@ -341,7 +341,7 @@ function PrimaryButton({
     <button
       type={type}
       disabled={loading}
-      className="flex h-11 w-full items-center justify-center gap-2 rounded-[8px] bg-accent text-[14px] font-semibold text-accent-ink transition-[filter] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+      className="flex h-11 w-full items-center justify-center gap-2 rounded-md bg-accent text-[14px] font-semibold text-accent-ink shadow-[0_1px_0_0_rgba(255,255,255,0.12)_inset,0_6px_14px_-6px_rgba(72,90,226,0.55)] transition-[filter] hover:brightness-110 active:brightness-95 disabled:cursor-not-allowed disabled:opacity-60"
     >
       <span>{loading ? "…" : children}</span>
       {!loading && (

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -93,6 +93,7 @@ import {
   resolveOrgSection,
   resolveProjectSection,
 } from "./settings/nav.ts";
+import { SettingsCard, SettingsCardFooter, SettingsRow } from "./settings/rows.tsx";
 
 type NavTarget = {
   scope?: SettingsScope;
@@ -653,25 +654,34 @@ function ProjectGeneralCard({ projectId }: { projectId: string | undefined }) {
   const canDelete = projects.length > 1;
 
   return (
-    <Tile>
-      <div className="space-y-4">
-        <div className="grid gap-4 md:grid-cols-2">
-          <div>
-            <span className="mb-1.5 block text-[12px] text-muted">Project name</span>
-            <Input
-              value={nameDraft}
-              disabled={disabled}
-              onChange={(e) => setNameDraft(e.target.value)}
-            />
-          </div>
-          <div>
-            <span className="mb-1.5 block text-[12px] text-muted">Slug</span>
-            <Input value={project?.slug ?? ""} disabled />
-          </div>
-        </div>
-
-        <div className="space-y-2">
-          <FieldLabel>Project context</FieldLabel>
+    <div className="space-y-4">
+      <SettingsCard>
+        <SettingsRow
+          title="Name"
+          description="Shown across the app and in incident threads"
+          control={
+            <div className="w-60">
+              <Input
+                value={nameDraft}
+                disabled={disabled}
+                onChange={(e) => setNameDraft(e.target.value)}
+              />
+            </div>
+          }
+        />
+        <SettingsRow
+          title="Slug"
+          description="Used in URLs — fixed after creation"
+          control={
+            <div className="w-60">
+              <Input className="font-mono text-[12.5px]" value={project?.slug ?? ""} disabled />
+            </div>
+          }
+        />
+        <SettingsRow
+          title="Project context"
+          description="Included as project context for investigations in this project"
+        >
           <textarea
             value={draft}
             disabled={disabled}
@@ -680,17 +690,26 @@ function ProjectGeneralCard({ projectId }: { projectId: string | undefined }) {
             placeholder="e.g. This project is the billing API. Stripe customer IDs are org-scoped. Prefer touching packages/billing before app code."
             className="w-full rounded-sm border border-border bg-surface-2 p-3 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
           />
-          <div className="flex items-center justify-between text-[12px] text-muted">
-            <span>Included as project context for investigations in this project.</span>
-            <span className="font-mono tabular-nums">
-              {draft.length} / {PROJECT_CONTEXT_MAX_LEN}
-            </span>
+          <div className="mt-1 flex justify-end font-mono text-[12px] tabular-nums text-muted">
+            {draft.length} / {PROJECT_CONTEXT_MAX_LEN}
           </div>
-        </div>
-
-        {error && <p className="text-[12px] text-danger">{error}</p>}
-
-        <div className="flex items-center gap-2">
+        </SettingsRow>
+        <SettingsCardFooter>
+          {error && <span className="mr-auto text-[12px] text-danger">{error}</span>}
+          {savedTick && <span className="text-[12px] text-success">Saved</span>}
+          {dirty && (
+            <Btn
+              size="sm"
+              variant="ghost"
+              disabled={update.isPending}
+              onClick={() => {
+                setDraft(value);
+                setNameDraft(project?.name ?? "");
+              }}
+            >
+              Discard
+            </Btn>
+          )}
           <Btn
             size="sm"
             variant="primary"
@@ -719,31 +738,14 @@ function ProjectGeneralCard({ projectId }: { projectId: string | undefined }) {
           >
             Save
           </Btn>
-          {dirty && (
-            <Btn
-              size="sm"
-              variant="ghost"
-              disabled={update.isPending}
-              onClick={() => {
-                setDraft(value);
-                setNameDraft(project?.name ?? "");
-              }}
-            >
-              Discard
-            </Btn>
-          )}
-          {savedTick && <span className="text-[12px] text-success">Saved</span>}
-        </div>
+        </SettingsCardFooter>
+      </SettingsCard>
 
-        <div className="border-t border-border pt-4">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <p className="text-[13px] font-medium text-fg">Delete project</p>
-              <p className="text-[12px] text-muted">
-                Telemetry, API keys, and integrations for this project will be deleted. This
-                cannot be undone.
-              </p>
-            </div>
+      <SettingsCard>
+        <SettingsRow
+          title="Delete project"
+          description="Telemetry, API keys, and integrations for this project will be deleted. This cannot be undone."
+          control={
             <Btn
               size="sm"
               variant="danger"
@@ -766,10 +768,10 @@ function ProjectGeneralCard({ projectId }: { projectId: string | undefined }) {
             >
               Delete
             </Btn>
-          </div>
-        </div>
-      </div>
-    </Tile>
+          }
+        />
+      </SettingsCard>
+    </div>
   );
 }
 
@@ -1141,63 +1143,18 @@ function SlackRoutingCard({ projectId }: { projectId: string | undefined }) {
   }
 
   return (
-    <Tile>
-      <div className="space-y-4">
-        <div>
-          {configured ? (
-            <Chip tone="success" dot>
-              Posting to #{currentChannelName ?? currentChannelId}
-            </Chip>
-          ) : (
-            <Chip tone="muted" dot>
-              Disabled — incidents are not posted to Slack
-            </Chip>
-          )}
-        </div>
-
-        <div className="flex flex-wrap items-end gap-3">
-          <div className="min-w-[260px] flex-1">
-            <FieldLabel>Channel</FieldLabel>
-            <Dropdown
-              value={pendingChannelId}
-              onChange={setPendingChannelId}
-              disabled={!projectId || channels.isLoading || channels.isError}
-              placeholder={
-                channels.isLoading
-                  ? "Loading channels…"
-                  : channels.isError
-                    ? "Failed to load channels"
-                    : "Select a channel…"
-              }
-              emptyLabel="No channels found"
-              options={channelList.map((ch) => ({
-                value: ch.id,
-                searchText: `${ch.isPrivate ? "🔒 " : "#"}${ch.name}`,
-                label: (
-                  <span className="flex items-center gap-1.5">
-                    <span className="text-subtle">{ch.isPrivate ? "🔒" : "#"}</span>
-                    <span>{ch.name}</span>
-                  </span>
-                ),
-              }))}
-            />
-          </div>
-          <Btn
-            size="md"
-            variant="primary"
-            disabled={!projectId || !dirty || setRoute.isPending}
-            loading={setRoute.isPending}
-            onClick={async () => {
-              const ch = channelList.find((c) => c.id === pendingChannelId);
-              if (!ch) return;
-              await setRoute.mutateAsync(ch);
-            }}
-          >
-            {configured ? "Update channel" : "Enable"}
-          </Btn>
-          {configured && (
+    <SettingsCard>
+      <SettingsRow
+        title="Incident threads"
+        description={
+          configured
+            ? `Posting to #${currentChannelName ?? currentChannelId}`
+            : "Disabled — incidents are not posted to Slack"
+        }
+        control={
+          configured ? (
             <Btn
-              size="md"
+              size="sm"
               variant="danger"
               disabled={!projectId || deleteRoute.isPending}
               loading={deleteRoute.isPending}
@@ -1205,24 +1162,68 @@ function SlackRoutingCard({ projectId }: { projectId: string | undefined }) {
             >
               Disable
             </Btn>
-          )}
-        </div>
-
-        {channels.isError ? (
-          <p className="text-[12px] text-muted">
-            Couldn't fetch the channel list — try reconnecting Slack.
-          </p>
-        ) : (
-          <p className="text-[12px] text-muted">
-            Don't see a private channel? Slack only lists private channels the bot belongs to — run{" "}
-            <code className="rounded-sm bg-surface-2 px-1 py-0.5 text-[11px]">
-              /invite @Superlog
-            </code>{" "}
-            in that channel, then reopen this list.
-          </p>
-        )}
-      </div>
-    </Tile>
+          ) : undefined
+        }
+      />
+      <SettingsRow
+        title="Channel"
+        description={
+          channels.isError ? (
+            "Couldn't fetch the channel list — try reconnecting Slack."
+          ) : (
+            <>
+              Private channels only appear once the bot is invited — run{" "}
+              <code className="rounded-sm bg-surface-2 px-1 py-0.5 text-[11px]">
+                /invite @Superlog
+              </code>{" "}
+              there first
+            </>
+          )
+        }
+        control={
+          <>
+            <div className="w-60">
+              <Dropdown
+                value={pendingChannelId}
+                onChange={setPendingChannelId}
+                disabled={!projectId || channels.isLoading || channels.isError}
+                placeholder={
+                  channels.isLoading
+                    ? "Loading channels…"
+                    : channels.isError
+                      ? "Failed to load channels"
+                      : "Select a channel…"
+                }
+                emptyLabel="No channels found"
+                options={channelList.map((ch) => ({
+                  value: ch.id,
+                  searchText: `${ch.isPrivate ? "🔒 " : "#"}${ch.name}`,
+                  label: (
+                    <span className="flex items-center gap-1.5">
+                      <span className="text-subtle">{ch.isPrivate ? "🔒" : "#"}</span>
+                      <span>{ch.name}</span>
+                    </span>
+                  ),
+                }))}
+              />
+            </div>
+            <Btn
+              size="sm"
+              variant="primary"
+              disabled={!projectId || !dirty || setRoute.isPending}
+              loading={setRoute.isPending}
+              onClick={async () => {
+                const ch = channelList.find((c) => c.id === pendingChannelId);
+                if (!ch) return;
+                await setRoute.mutateAsync(ch);
+              }}
+            >
+              {configured ? "Update" : "Enable"}
+            </Btn>
+          </>
+        }
+      />
+    </SettingsCard>
   );
 }
 
@@ -1255,35 +1256,27 @@ function WeeklyDigestCard() {
     : "Never sent";
 
   return (
-    <Tile>
-      <div className="space-y-4">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            {enabled && channelId ? (
-              <Chip tone="success" dot>
-                Posting weekly to #{channelName ?? channelId}
-              </Chip>
-            ) : (
-              <Chip tone="muted" dot>
-                Disabled
-              </Chip>
-            )}
-            <p className="mt-2 text-[12px] text-muted">{lastRunLabel}</p>
-          </div>
-          <label className="flex cursor-pointer items-center gap-2 text-[13px] text-muted">
-            <input
-              type="checkbox"
-              checked={enabled}
-              disabled={save.isPending || (!enabled && !channelId)}
-              onChange={(e) => save.mutate({ enabled: e.target.checked })}
-            />
-            Enabled
-          </label>
-        </div>
-
-        <div className="flex flex-wrap items-end gap-3">
-          <div className="min-w-[260px] flex-1">
-            <FieldLabel>Channel</FieldLabel>
+    <SettingsCard>
+      <SettingsRow
+        title="Post a weekly recap to Slack"
+        description={
+          enabled && channelId
+            ? `Posting to #${channelName ?? channelId} · ${lastRunLabel}`
+            : lastRunLabel
+        }
+        control={
+          <Toggle
+            checked={enabled}
+            disabled={save.isPending || (!enabled && !channelId)}
+            onChange={(v) => save.mutate({ enabled: v })}
+          />
+        }
+      />
+      <SettingsRow
+        title="Channel"
+        description="Use a different channel from incident threads if it's noisy — invite the bot to private channels"
+        control={
+          <div className="w-60">
             <Dropdown
               value={channelId}
               disabled={channels.isLoading || channels.isError || save.isPending}
@@ -1318,24 +1311,24 @@ function WeeklyDigestCard() {
               ]}
             />
           </div>
+        }
+      />
+      <SettingsRow
+        title="Send digest now"
+        description="An LLM ranks the open bug-fix PRs across this org and posts the top 3"
+        control={
           <Btn
-            size="md"
+            size="sm"
             variant="secondary"
             disabled={!channelId || runNow.isPending}
             loading={runNow.isPending}
             onClick={() => runNow.mutate()}
           >
-            Send digest now
+            Send now
           </Btn>
-        </div>
-
-        <p className="text-[12px] text-muted">
-          Each week, an LLM ranks the open bug-fix PRs the agent has produced across this org and
-          posts the top 3. Use a different channel from incident threads if it's noisy. Same Slack
-          install — invite the bot to private channels you want to use.
-        </p>
-      </div>
-    </Tile>
+        }
+      />
+    </SettingsCard>
   );
 }
 

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -218,7 +218,7 @@ function SettingsTabs({
     { value: NEW_PROJECT, label: "+ New project", searchText: "new project" },
   ];
   return (
-    <div className="flex items-center gap-7 border-b border-border">
+    <div className="flex items-end gap-7 border-b border-border">
       <TabButton
         label="Organization"
         active={scope === "org"}

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -83,51 +83,16 @@ import { AgentMemoriesCard } from "./settings/AgentMemoriesCard.tsx";
 import { BillingCard } from "./settings/BillingCard.tsx";
 import { OrgGeneralCard } from "./settings/OrgGeneralCard.tsx";
 import { OrgMembersCard } from "./settings/OrgMembersCard.tsx";
-
-type SettingsScope = "org" | "project";
-
-type OrgSectionId =
-  | "general"
-  | "members"
-  | "billing"
-  | "agent-guidance"
-  | "weekly-digest"
-  | "mgmt-keys"
-  | "github-install";
-type ProjectSectionId =
-  | "general"
-  | "integrations"
-  | "agent"
-  | "agent-memories"
-  | "issue-filter"
-  | "slack-channel"
-  | "api-keys"
-  | "webhooks";
-type SectionId = OrgSectionId | ProjectSectionId;
-
-const ORG_SECTIONS: ReadonlyArray<{ id: OrgSectionId; label: string }> = [
-  { id: "general", label: "General" },
-  { id: "members", label: "Members" },
-  { id: "billing", label: "Billing" },
-  { id: "agent-guidance", label: "Agent guidance" },
-  { id: "weekly-digest", label: "Weekly digest" },
-  { id: "mgmt-keys", label: "Management API keys" },
-  { id: "github-install", label: "GitHub install" },
-];
-
-const PROJECT_SECTIONS: ReadonlyArray<{ id: ProjectSectionId; label: string }> = [
-  { id: "general", label: "General" },
-  { id: "integrations", label: "Integrations" },
-  { id: "agent", label: "Agent" },
-  { id: "agent-memories", label: "Agent memories" },
-  { id: "issue-filter", label: "Issue filter" },
-  { id: "slack-channel", label: "Slack channel" },
-  { id: "api-keys", label: "API keys" },
-  { id: "webhooks", label: "Webhooks" },
-];
-
-const PROJECT_SECTION_IDS = new Set<string>(PROJECT_SECTIONS.map((s) => s.id));
-const ORG_SECTION_IDS = new Set<string>(ORG_SECTIONS.map((s) => s.id));
+import {
+  ORG_NAV_GROUPS,
+  type OrgSectionId,
+  PROJECT_NAV_GROUPS,
+  type ProjectSectionId,
+  type SectionId,
+  type SettingsScope,
+  resolveOrgSection,
+  resolveProjectSection,
+} from "./settings/nav.ts";
 
 type NavTarget = {
   scope?: SettingsScope;
@@ -170,14 +135,7 @@ export function Settings() {
   }, [scope, projectIdParam, projects, defaultProjectId]);
 
   const activeSection: SectionId = useMemo(() => {
-    if (scope === "org") {
-      return sectionParam && ORG_SECTION_IDS.has(sectionParam)
-        ? (sectionParam as OrgSectionId)
-        : ORG_SECTIONS[0]!.id;
-    }
-    return sectionParam && PROJECT_SECTION_IDS.has(sectionParam)
-      ? (sectionParam as ProjectSectionId)
-      : PROJECT_SECTIONS[0]!.id;
+    return scope === "org" ? resolveOrgSection(sectionParam) : resolveProjectSection(sectionParam);
   }, [scope, sectionParam]);
 
   const navigate = (next: NavTarget) => {
@@ -191,8 +149,10 @@ export function Settings() {
     setParams(updated, { replace: true });
   };
 
+  const [creatingProject, setCreatingProject] = useState(false);
+
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       {(linearStatus || githubStatus || githubAuthorStatus) && (
         <header className="space-y-2">
           {linearStatus && <LinearStatusBanner status={linearStatus} />}
@@ -201,15 +161,29 @@ export function Settings() {
         </header>
       )}
 
+      <SettingsTabs
+        scope={scope}
+        projects={projects}
+        activeProjectId={activeProjectId}
+        onNavigate={navigate}
+        onCreateProject={() => setCreatingProject(true)}
+      />
+
       <div className="flex flex-col gap-8 md:flex-row md:items-start">
-        <SettingsSidebar
-          scope={scope}
-          section={activeSection}
-          projects={projects}
-          activeProjectId={activeProjectId}
-          onNavigate={navigate}
-        />
+        <SettingsSideNav scope={scope} section={activeSection} onNavigate={navigate} />
         <div className="min-w-0 flex-1">
+          {creatingProject && (
+            <div className="mb-6 max-w-sm rounded-lg border border-border bg-surface p-3">
+              <p className="mb-2 text-[13px] font-medium text-fg">New project</p>
+              <NewProjectForm
+                onCancel={() => setCreatingProject(false)}
+                onCreated={(p) => {
+                  setCreatingProject(false);
+                  navigate({ scope: "project", projectId: p.id, section: "general" });
+                }}
+              />
+            </div>
+          )}
           {scope === "org" ? (
             <OrgSectionView section={activeSection as OrgSectionId} />
           ) : (
@@ -224,334 +198,227 @@ export function Settings() {
   );
 }
 
-function SettingsSidebar({
+function SettingsTabs({
   scope,
-  section,
   projects,
   activeProjectId,
+  onNavigate,
+  onCreateProject,
+}: {
+  scope: SettingsScope;
+  projects: Array<{ id: string; name: string }>;
+  activeProjectId: string | undefined;
+  onNavigate: (target: NavTarget) => void;
+  onCreateProject: () => void;
+}) {
+  const NEW_PROJECT = "__new_project__";
+  const pickerOptions: DropdownOption[] = [
+    ...projects.map((p) => ({ value: p.id, label: p.name, searchText: p.name })),
+    { value: NEW_PROJECT, label: "+ New project", searchText: "new project" },
+  ];
+  return (
+    <div className="flex items-center gap-7 border-b border-border">
+      <TabButton
+        label="Organization"
+        active={scope === "org"}
+        onClick={() => onNavigate({ scope: "org", section: "general" })}
+      />
+      <TabButton
+        label="Project"
+        active={scope === "project"}
+        onClick={() => onNavigate({ scope: "project", section: "general" })}
+      />
+      <div className="flex-1" />
+      {scope === "project" && projects.length > 0 && (
+        <div className="pb-2">
+          <Dropdown
+            value={activeProjectId ?? ""}
+            onChange={(v) => {
+              if (v === NEW_PROJECT) {
+                onCreateProject();
+                return;
+              }
+              onNavigate({ scope: "project", projectId: v });
+            }}
+            options={pickerOptions}
+            searchable={projects.length > 6}
+            className="w-52"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TabButton({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`-mb-px border-b-2 pb-2.5 pt-1 text-[14px] transition-colors ${
+        active
+          ? "border-fg font-semibold text-fg"
+          : "border-transparent font-medium text-muted hover:text-fg"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+function SettingsSideNav({
+  scope,
+  section,
   onNavigate,
 }: {
   scope: SettingsScope;
   section: SectionId;
-  projects: Array<{ id: string; name: string }>;
-  activeProjectId: string | undefined;
   onNavigate: (target: NavTarget) => void;
 }) {
-  const [creating, setCreating] = useState(false);
-  const projectSection: ProjectSectionId = PROJECT_SECTION_IDS.has(section)
-    ? (section as ProjectSectionId)
-    : "integrations";
+  const groups = scope === "org" ? ORG_NAV_GROUPS : PROJECT_NAV_GROUPS;
   return (
-    <nav className="shrink-0 md:sticky md:top-6 md:w-60">
+    <nav className="shrink-0 md:sticky md:top-6 md:w-56">
       <ul className="flex flex-col gap-0.5">
-        <SidebarItem
-          label="Org"
-          icon={<OrgIcon />}
-          active={scope === "org"}
-          onClick={() =>
-            onNavigate({
-              scope: "org",
-              section: ORG_SECTION_IDS.has(section)
-                ? (section as OrgSectionId)
-                : ORG_SECTIONS[0]!.id,
-            })
-          }
-        />
-        {scope === "org" && (
-          <ul className="ml-[22px] mt-0.5 mb-1 flex flex-col gap-0.5 border-l border-border pl-2">
-            {ORG_SECTIONS.map((s) => (
-              <SidebarLeaf
-                key={s.id}
-                label={s.label}
-                active={section === s.id}
-                onClick={() => onNavigate({ scope: "org", section: s.id })}
-              />
-            ))}
-          </ul>
-        )}
-
-        <li className="mt-3 mb-1 flex items-center justify-between px-3">
-          <span className="text-[11px] uppercase tracking-wider text-muted">Projects</span>
-          <button
-            type="button"
-            onClick={() => setCreating((v) => !v)}
-            aria-label="New project"
-            className="flex h-5 w-5 items-center justify-center rounded-sm text-muted hover:bg-surface-2 hover:text-fg"
-          >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden
-            >
-              <path d="M12 5v14M5 12h14" />
-            </svg>
-          </button>
-        </li>
-        {creating && (
-          <li className="mb-1 px-1">
-            <NewProjectForm
-              onCancel={() => setCreating(false)}
-              onCreated={(p) => {
-                setCreating(false);
-                onNavigate({ scope: "project", projectId: p.id, section: "general" });
-              }}
-            />
+        {groups.map((group, gi) => (
+          <li key={group.label ?? gi}>
+            {group.label && (
+              <p className="mb-1 mt-4 px-3 text-[11px] uppercase tracking-wider text-muted">
+                {group.label}
+              </p>
+            )}
+            <ul className="flex flex-col gap-0.5">
+              {group.items.map((item) => (
+                <li key={item.id}>
+                  <button
+                    type="button"
+                    onClick={() => onNavigate({ scope, section: item.id })}
+                    className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-[13px] transition-colors ${
+                      section === item.id
+                        ? "bg-surface-2 text-fg"
+                        : "text-muted hover:bg-surface-2 hover:text-fg"
+                    }`}
+                  >
+                    <span className="flex h-4 w-4 items-center justify-center" aria-hidden>
+                      <SectionIcon scope={scope} section={item.id} />
+                    </span>
+                    <span className="min-w-0 flex-1 truncate">{item.label}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
           </li>
-        )}
-
-        {projects.map((p) => {
-          const isActive = scope === "project" && activeProjectId === p.id;
-          return (
-            <li key={p.id}>
-              <ProjectRow
-                project={p}
-                active={isActive}
-                canDelete={projects.length > 1}
-                onSelect={() =>
-                  onNavigate({
-                    scope: "project",
-                    projectId: p.id,
-                    section: projectSection,
-                  })
-                }
-                onDeleted={() => {
-                  if (isActive) {
-                    const next = projects.find((q) => q.id !== p.id);
-                    if (next) {
-                      onNavigate({
-                        scope: "project",
-                        projectId: next.id,
-                        section: "integrations",
-                      });
-                    }
-                  }
-                }}
-              />
-              {isActive && (
-                <ul className="ml-[22px] mt-0.5 mb-1 flex flex-col gap-0.5 border-l border-border pl-2">
-                  {PROJECT_SECTIONS.map((s) => (
-                    <SidebarLeaf
-                      key={s.id}
-                      label={s.label}
-                      active={section === s.id}
-                      onClick={() =>
-                        onNavigate({ scope: "project", projectId: p.id, section: s.id })
-                      }
-                    />
-                  ))}
-                </ul>
-              )}
-            </li>
-          );
-        })}
+        ))}
       </ul>
     </nav>
   );
 }
 
-function SidebarItem({
-  label,
-  icon,
-  active,
-  onClick,
-}: {
-  label: string;
-  icon: ReactNode;
-  active: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <li>
-      <button
-        type="button"
-        onClick={onClick}
-        className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-[13px] transition-colors ${
-          active ? "bg-surface-2 text-fg" : "text-muted hover:bg-surface-2 hover:text-fg"
-        }`}
-      >
-        <span className="flex h-4 w-4 items-center justify-center text-current" aria-hidden>
-          {icon}
-        </span>
-        <span className="min-w-0 flex-1 truncate">{label}</span>
-      </button>
-    </li>
-  );
-}
-
-function SidebarLeaf({
-  label,
-  active,
-  onClick,
-}: {
-  label: string;
-  active: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <li>
-      <button
-        type="button"
-        onClick={onClick}
-        className={`flex w-full items-center rounded-md px-2 py-1.5 text-left text-[12.5px] transition-colors ${
-          active ? "bg-surface-2 text-fg" : "text-muted hover:bg-surface-2 hover:text-fg"
-        }`}
-      >
-        <span className="min-w-0 flex-1 truncate">{label}</span>
-      </button>
-    </li>
-  );
-}
-
-function ProjectRow({
-  project,
-  active,
-  canDelete,
-  onSelect,
-  onDeleted,
-}: {
-  project: { id: string; name: string };
-  active: boolean;
-  canDelete: boolean;
-  onSelect: () => void;
-  onDeleted: () => void;
-}) {
-  const [menuOpen, setMenuOpen] = useState(false);
-  const [renaming, setRenaming] = useState(false);
-  const [draft, setDraft] = useState(project.name);
-  const update = useUpdateOrgProject();
-  const del = useDeleteOrgProject();
-
-  useEffect(() => {
-    if (!menuOpen) return;
-    const onDown = () => setMenuOpen(false);
-    window.addEventListener("click", onDown);
-    return () => window.removeEventListener("click", onDown);
-  }, [menuOpen]);
-
-  if (renaming) {
-    const submit = (e: React.FormEvent) => {
-      e.preventDefault();
-      const name = draft.trim();
-      if (!name || name === project.name) {
-        setRenaming(false);
-        setDraft(project.name);
-        return;
-      }
-      update.mutate(
-        { projectId: project.id, patch: { name } },
-        {
-          onSuccess: () => setRenaming(false),
-          onError: () => {
-            setRenaming(false);
-            setDraft(project.name);
-          },
-        },
-      );
-    };
-    return (
-      <form onSubmit={submit} className="flex items-center gap-1 px-3 py-1.5">
-        <input
-          autoFocus
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onBlur={(e) => {
-            // Form's onSubmit may have already fired via Enter; don't issue a
-            // second PATCH while the first is still in flight.
-            if (!update.isPending) submit(e);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Escape") {
-              setRenaming(false);
-              setDraft(project.name);
-            }
-          }}
-          className="h-7 w-full rounded-sm border border-border bg-surface-2 px-2 text-[13px] text-fg focus:border-border-strong focus:outline-none"
-        />
-      </form>
-    );
-  }
-
-  return (
-    <div className="group relative flex items-center">
-      <button
-        type="button"
-        onClick={onSelect}
-        className={`flex min-w-0 flex-1 items-center gap-3 rounded-md px-3 py-2 text-left text-[13px] transition-colors ${
-          active ? "bg-surface-2 text-fg" : "text-muted hover:bg-surface-2 hover:text-fg"
-        }`}
-      >
-        <span className="flex h-4 w-4 items-center justify-center text-current" aria-hidden>
-          <ProjectIcon />
-        </span>
-        <span className="min-w-0 flex-1 truncate">{project.name}</span>
-      </button>
-      <button
-        type="button"
-        aria-label="Project menu"
-        onClick={(e) => {
-          e.stopPropagation();
-          setMenuOpen((v) => !v);
-        }}
-        className={`absolute right-1 flex h-6 w-6 items-center justify-center rounded-sm text-muted hover:bg-surface-3 hover:text-fg ${
-          menuOpen ? "opacity-100" : "opacity-0 group-hover:opacity-100 focus:opacity-100"
-        }`}
-      >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-          <circle cx="5" cy="12" r="1.5" />
-          <circle cx="12" cy="12" r="1.5" />
-          <circle cx="19" cy="12" r="1.5" />
+function SectionIcon({ scope, section }: { scope: SettingsScope; section: SectionId }) {
+  const props = {
+    width: 16,
+    height: 16,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 1.7,
+    strokeLinecap: "round",
+    strokeLinejoin: "round",
+  } as const;
+  const key = `${scope}:${section}`;
+  switch (key) {
+    case "org:general":
+    case "project:general":
+      return (
+        <svg {...props} aria-hidden="true">
+          <line x1="4" y1="8" x2="20" y2="8" />
+          <line x1="4" y1="16" x2="20" y2="16" />
+          <circle cx="9" cy="8" r="2" />
+          <circle cx="15" cy="16" r="2" />
         </svg>
-      </button>
-      {menuOpen && (
-        <div
-          className="absolute right-0 top-full z-10 mt-1 w-32 overflow-hidden rounded-sm border border-border bg-surface-1 shadow-lg"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <button
-            type="button"
-            onClick={() => {
-              setMenuOpen(false);
-              setDraft(project.name);
-              setRenaming(true);
-            }}
-            className="block w-full px-3 py-1.5 text-left text-[12.5px] text-fg hover:bg-surface-2"
-          >
-            Rename
-          </button>
-          <button
-            type="button"
-            disabled={!canDelete || del.isPending}
-            onClick={() => {
-              setMenuOpen(false);
-              if (!canDelete) return;
-              const ok = window.confirm(
-                `Delete project "${project.name}"? Telemetry, API keys, and integrations for this project will be deleted. This cannot be undone.`,
-              );
-              if (!ok) return;
-              del.mutate(project.id, {
-                onSuccess: () => onDeleted(),
-                onError: (err) => {
-                  window.alert(
-                    `Delete failed: ${err instanceof Error ? err.message : String(err)}`,
-                  );
-                },
-              });
-            }}
-            className="block w-full px-3 py-1.5 text-left text-[12.5px] text-danger hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40"
-            title={canDelete ? undefined : "Can't delete the last project in an org"}
-          >
-            Delete
-          </button>
-        </div>
-      )}
-    </div>
-  );
+      );
+    case "org:members":
+      return (
+        <svg {...props} aria-hidden="true">
+          <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+          <circle cx="9" cy="7" r="4" />
+          <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+          <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+        </svg>
+      );
+    case "org:billing":
+      return (
+        <svg {...props} aria-hidden="true">
+          <rect x="1" y="4" width="22" height="16" rx="2" />
+          <line x1="1" y1="10" x2="23" y2="10" />
+        </svg>
+      );
+    case "org:agent-guidance":
+    case "project:agent":
+      return (
+        <svg {...props} aria-hidden="true">
+          <path d="M12 3a7 7 0 0 1 7 7v3a7 7 0 0 1-14 0v-3a7 7 0 0 1 7-7z" />
+          <circle cx="9" cy="12" r="0.5" fill="currentColor" />
+          <circle cx="15" cy="12" r="0.5" fill="currentColor" />
+        </svg>
+      );
+    case "org:mgmt-keys":
+    case "project:api-keys":
+      return (
+        <svg {...props} aria-hidden="true">
+          <circle cx="7.5" cy="15.5" r="5.5" />
+          <path d="m21 2-9.6 9.6" />
+          <path d="m15.5 7.5 3 3L22 7l-3-3" />
+        </svg>
+      );
+    case "org:github-install":
+      return (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+        </svg>
+      );
+    case "project:integrations":
+      return (
+        <svg {...props} aria-hidden="true">
+          <path d="M9 2v6" />
+          <path d="M15 2v6" />
+          <path d="M6 8h12v4a6 6 0 0 1-12 0V8z" />
+          <path d="M12 18v4" />
+        </svg>
+      );
+    case "project:issue-filter":
+      return (
+        <svg {...props} aria-hidden="true">
+          <path d="M22 3H2l8 9.46V19l4 2v-8.54L22 3z" />
+        </svg>
+      );
+    case "project:slack-channel":
+      return (
+        <svg {...props} aria-hidden="true">
+          <line x1="10" y1="3" x2="7" y2="21" />
+          <line x1="17" y1="3" x2="14" y2="21" />
+          <line x1="3" y1="9" x2="21" y2="9" />
+          <line x1="3" y1="15" x2="21" y2="15" />
+        </svg>
+      );
+    case "project:webhooks":
+      return (
+        <svg {...props} aria-hidden="true">
+          <path d="M18 16.98h-5.99c-1.1 0-1.95.94-2.48 1.9A4 4 0 0 1 2 17c.01-.7.2-1.4.57-2" />
+          <path d="m6 17 3.13-5.78c.53-.97.1-2.18-.5-3.1a4 4 0 1 1 6.89-4.06" />
+          <path d="m12 6 3.13 5.73C15.66 12.7 16.9 13 18 13a4 4 0 0 1 0 8" />
+        </svg>
+      );
+    default:
+      return null;
+  }
 }
 
 function NewProjectForm({
@@ -606,55 +473,24 @@ function NewProjectForm({
   );
 }
 
-function OrgIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M3 21h18" />
-      <path d="M5 21V7l8-4v18" />
-      <path d="M19 21V11l-6-4" />
-      <path d="M9 9v.01" />
-      <path d="M9 13v.01" />
-      <path d="M9 17v.01" />
-    </svg>
-  );
-}
-
-function ProjectIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" />
-    </svg>
-  );
-}
-
 function OrgSectionView({ section }: { section: OrgSectionId }) {
   switch (section) {
     case "general":
       return (
-        <Section
-          title="General"
-          subtitle="Organization name and slug. Visible to everyone in the org."
-        >
-          <OrgGeneralCard />
-        </Section>
+        <div className="space-y-10">
+          <Section
+            title="General"
+            subtitle="Organization name and slug. Visible to everyone in the org."
+          >
+            <OrgGeneralCard />
+          </Section>
+          <Section
+            title="Weekly fixes digest"
+            subtitle="A short Slack recap of the top 3 pending bug-fix PRs, ranked by an LLM."
+          >
+            <WeeklyDigestCard />
+          </Section>
+        </div>
       );
     case "members":
       return (
@@ -678,15 +514,6 @@ function OrgSectionView({ section }: { section: OrgSectionId }) {
           subtitle="Prepended to every agent run prompt across all projects in this org."
         >
           <OrgGuidanceCard />
-        </Section>
-      );
-    case "weekly-digest":
-      return (
-        <Section
-          title="Weekly fixes digest"
-          subtitle="A short Slack recap of the top 3 pending bug-fix PRs, ranked by an LLM."
-        >
-          <WeeklyDigestCard />
         </Section>
       );
     case "mgmt-keys":
@@ -800,9 +627,12 @@ const PROJECT_CONTEXT_MAX_LEN = 8000;
 function ProjectGeneralCard({ projectId }: { projectId: string | undefined }) {
   const projectsQ = useOrgProjects();
   const update = useUpdateOrgProject();
-  const project = projectsQ.data?.projects.find((p) => p.id === projectId) ?? null;
+  const del = useDeleteOrgProject();
+  const projects = projectsQ.data?.projects ?? [];
+  const project = projects.find((p) => p.id === projectId) ?? null;
   const value = project?.projectContext ?? "";
   const [draft, setDraft] = useState(value);
+  const [nameDraft, setNameDraft] = useState(project?.name ?? "");
   const [loadedProjectId, setLoadedProjectId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [savedTick, setSavedTick] = useState(false);
@@ -811,13 +641,16 @@ function ProjectGeneralCard({ projectId }: { projectId: string | undefined }) {
     if (!project) return;
     if (loadedProjectId === project.id) return;
     setDraft(project.projectContext);
+    setNameDraft(project.name);
     setLoadedProjectId(project.id);
     setError(null);
   }, [loadedProjectId, project]);
 
   const loaded = !!project && loadedProjectId === project.id;
-  const dirty = loaded && draft !== value;
+  const nameDirty = loaded && nameDraft.trim() !== project.name && nameDraft.trim().length > 0;
+  const dirty = (loaded && draft !== value) || nameDirty;
   const disabled = !loaded || projectsQ.isLoading || update.isPending;
+  const canDelete = projects.length > 1;
 
   return (
     <Tile>
@@ -825,7 +658,11 @@ function ProjectGeneralCard({ projectId }: { projectId: string | undefined }) {
         <div className="grid gap-4 md:grid-cols-2">
           <div>
             <span className="mb-1.5 block text-[12px] text-muted">Project name</span>
-            <Input value={project?.name ?? ""} disabled />
+            <Input
+              value={nameDraft}
+              disabled={disabled}
+              onChange={(e) => setNameDraft(e.target.value)}
+            />
           </div>
           <div>
             <span className="mb-1.5 block text-[12px] text-muted">Slug</span>
@@ -863,7 +700,13 @@ function ProjectGeneralCard({ projectId }: { projectId: string | undefined }) {
               if (!project || !loaded) return;
               setError(null);
               update.mutate(
-                { projectId: project.id, patch: { projectContext: draft } },
+                {
+                  projectId: project.id,
+                  patch: {
+                    projectContext: draft,
+                    ...(nameDirty ? { name: nameDraft.trim() } : {}),
+                  },
+                },
                 {
                   onSuccess: () => {
                     setSavedTick(true);
@@ -874,19 +717,56 @@ function ProjectGeneralCard({ projectId }: { projectId: string | undefined }) {
               );
             }}
           >
-            Save context
+            Save
           </Btn>
           {dirty && (
             <Btn
               size="sm"
               variant="ghost"
               disabled={update.isPending}
-              onClick={() => setDraft(value)}
+              onClick={() => {
+                setDraft(value);
+                setNameDraft(project?.name ?? "");
+              }}
             >
               Discard
             </Btn>
           )}
           {savedTick && <span className="text-[12px] text-success">Saved</span>}
+        </div>
+
+        <div className="border-t border-border pt-4">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-[13px] font-medium text-fg">Delete project</p>
+              <p className="text-[12px] text-muted">
+                Telemetry, API keys, and integrations for this project will be deleted. This
+                cannot be undone.
+              </p>
+            </div>
+            <Btn
+              size="sm"
+              variant="danger"
+              disabled={!project || !canDelete || del.isPending}
+              loading={del.isPending}
+              onClick={() => {
+                if (!project || !canDelete) return;
+                const ok = window.confirm(
+                  `Delete project "${project.name}"? Telemetry, API keys, and integrations for this project will be deleted. This cannot be undone.`,
+                );
+                if (!ok) return;
+                del.mutate(project.id, {
+                  onError: (err) => {
+                    window.alert(
+                      `Delete failed: ${err instanceof Error ? err.message : String(err)}`,
+                    );
+                  },
+                });
+              }}
+            >
+              Delete
+            </Btn>
+          </div>
         </div>
       </div>
     </Tile>

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -90,14 +90,18 @@ import {
   type ProjectSectionId,
   type SectionId,
   type SettingsScope,
+  NEW_PROJECT_OPTION_VALUE,
+  nextProjectIdAfterDelete,
+  projectPickerOptions,
   resolveOrgSection,
   resolveProjectSection,
+  shouldShowProjectPicker,
 } from "./settings/nav.ts";
 import { SettingsCard, SettingsCardFooter, SettingsRow } from "./settings/rows.tsx";
 
 type NavTarget = {
   scope?: SettingsScope;
-  projectId?: string;
+  projectId?: string | null;
   section?: SectionId;
 };
 
@@ -145,7 +149,10 @@ export function Settings() {
       if (next.scope === "project") updated.delete("scope");
       else updated.set("scope", next.scope);
     }
-    if (next.projectId) updated.set("projectId", next.projectId);
+    if (next.projectId !== undefined) {
+      if (next.projectId) updated.set("projectId", next.projectId);
+      else updated.delete("projectId");
+    }
     if (next.section) updated.set("section", next.section);
     setParams(updated, { replace: true });
   };
@@ -191,6 +198,9 @@ export function Settings() {
             <ProjectSectionView
               section={activeSection as ProjectSectionId}
               projectId={activeProjectId}
+              onProjectDeleted={(nextProjectId) => {
+                navigate({ scope: "project", projectId: nextProjectId ?? null, section: "general" });
+              }}
             />
           )}
         </div>
@@ -212,11 +222,7 @@ function SettingsTabs({
   onNavigate: (target: NavTarget) => void;
   onCreateProject: () => void;
 }) {
-  const NEW_PROJECT = "__new_project__";
-  const pickerOptions: DropdownOption[] = [
-    ...projects.map((p) => ({ value: p.id, label: p.name, searchText: p.name })),
-    { value: NEW_PROJECT, label: "+ New project", searchText: "new project" },
-  ];
+  const pickerOptions: DropdownOption[] = projectPickerOptions(projects);
   return (
     <div className="flex items-end gap-7 border-b border-border">
       <TabButton
@@ -230,12 +236,12 @@ function SettingsTabs({
         onClick={() => onNavigate({ scope: "project", section: "general" })}
       />
       <div className="flex-1" />
-      {scope === "project" && projects.length > 0 && (
+      {shouldShowProjectPicker(scope) && (
         <div className="pb-2">
           <Dropdown
             value={activeProjectId ?? ""}
             onChange={(v) => {
-              if (v === NEW_PROJECT) {
+              if (v === NEW_PROJECT_OPTION_VALUE) {
                 onCreateProject();
                 return;
               }
@@ -541,9 +547,11 @@ function OrgSectionView({ section }: { section: OrgSectionId }) {
 function ProjectSectionView({
   section,
   projectId,
+  onProjectDeleted,
 }: {
   section: ProjectSectionId;
   projectId: string | undefined;
+  onProjectDeleted: (nextProjectId: string | undefined) => void;
 }) {
   switch (section) {
     case "general":
@@ -552,7 +560,7 @@ function ProjectSectionView({
           title="General"
           subtitle="Project name, slug, and context available to investigations."
         >
-          <ProjectGeneralCard projectId={projectId} />
+          <ProjectGeneralCard projectId={projectId} onDeleted={onProjectDeleted} />
         </Section>
       );
     case "integrations":
@@ -625,7 +633,13 @@ function ProjectSectionView({
 
 const PROJECT_CONTEXT_MAX_LEN = 8000;
 
-function ProjectGeneralCard({ projectId }: { projectId: string | undefined }) {
+function ProjectGeneralCard({
+  projectId,
+  onDeleted,
+}: {
+  projectId: string | undefined;
+  onDeleted: (nextProjectId: string | undefined) => void;
+}) {
   const projectsQ = useOrgProjects();
   const update = useUpdateOrgProject();
   const del = useDeleteOrgProject();
@@ -757,7 +771,11 @@ function ProjectGeneralCard({ projectId }: { projectId: string | undefined }) {
                   `Delete project "${project.name}"? Telemetry, API keys, and integrations for this project will be deleted. This cannot be undone.`,
                 );
                 if (!ok) return;
+                const nextProjectId = nextProjectIdAfterDelete(projects, project.id);
                 del.mutate(project.id, {
+                  onSuccess: () => {
+                    onDeleted(nextProjectId);
+                  },
                   onError: (err) => {
                     window.alert(
                       `Delete failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -459,7 +459,7 @@ function NewProjectForm({
         }}
         placeholder="Project name"
         disabled={create.isPending}
-        className="h-7 w-full rounded-sm border border-border bg-surface-2 px-2 text-[13px] text-fg focus:border-border-strong focus:outline-none"
+        className="h-7 w-full rounded-lg border border-border bg-surface-2 px-2 text-[13px] text-fg focus:border-border-strong focus:outline-none"
       />
       {error && <span className="px-1 text-[11px] text-danger">{error}</span>}
       <div className="flex items-center gap-1">
@@ -688,7 +688,7 @@ function ProjectGeneralCard({ projectId }: { projectId: string | undefined }) {
             onChange={(e) => setDraft(e.target.value.slice(0, PROJECT_CONTEXT_MAX_LEN))}
             rows={7}
             placeholder="e.g. This project is the billing API. Stripe customer IDs are org-scoped. Prefer touching packages/billing before app code."
-            className="w-full rounded-sm border border-border bg-surface-2 p-3 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
+            className="w-full rounded-lg border border-border bg-surface-2 p-3 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
           />
           <div className="mt-1 flex justify-end font-mono text-[12px] tabular-nums text-muted">
             {draft.length} / {PROJECT_CONTEXT_MAX_LEN}
@@ -1638,7 +1638,7 @@ function OrgGuidanceCard() {
           onChange={(e) => setDraft(e.target.value.slice(0, ORG_GUIDANCE_MAX_LEN))}
           rows={5}
           placeholder="e.g. Always link incidents to the on-call runbook before filing a ticket. Prefer reverts over forward fixes for prod regressions."
-          className="w-full rounded-sm border border-border bg-surface-2 p-3 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
+          className="w-full rounded-lg border border-border bg-surface-2 p-3 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
         />
         <div className="flex items-center justify-between text-[12px] text-muted">
           <span>Prepended to every agent run prompt across all projects in this org.</span>
@@ -2125,7 +2125,7 @@ function IssueFilterBucket({
         <FieldLabel>{meta.label}</FieldLabel>
         <p className="mt-0.5 text-[12px] text-subtle">{meta.subtitle}</p>
       </div>
-      <div className="relative flex min-h-[40px] flex-wrap items-center gap-2 rounded-sm border border-border bg-surface-2 p-2">
+      <div className="relative flex min-h-[40px] flex-wrap items-center gap-2 rounded-lg border border-border bg-surface-2 p-2">
         {clauses.length === 0 && (
           <span className="px-1 text-[12.5px] text-subtle">
             {meta.mode === "include" ? "Any" : "Nothing"} — no constraint.
@@ -2297,7 +2297,7 @@ function IssueFilterPicker({
               }
             }}
             autoFocus
-            className="h-7 w-full rounded-sm border border-border bg-surface-2 px-2 text-[12px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none"
+            className="h-7 w-full rounded-lg border border-border bg-surface-2 px-2 text-[12px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none"
           />
         </div>
         <div className="max-h-72 overflow-y-auto">
@@ -2366,7 +2366,7 @@ function IssueFilterPicker({
             }
           }}
           autoFocus
-          className="h-7 w-full rounded-sm border border-border bg-surface-2 px-2 text-[12px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none"
+          className="h-7 w-full rounded-lg border border-border bg-surface-2 px-2 text-[12px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none"
         />
       </div>
       <div className="max-h-72 overflow-y-auto">
@@ -2778,7 +2778,7 @@ function InstructionsField({
         placeholder={
           "e.g. Prefer one-line fixes when possible. When patching the billing service, run pnpm typecheck before declaring the patch validated."
         }
-        className="w-full rounded-sm border border-border bg-surface-2 p-3 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
+        className="w-full rounded-lg border border-border bg-surface-2 p-3 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
       />
       <div className="flex items-center justify-between text-[12px] text-muted">
         <span>Appended to every agent run prompt for this workspace.</span>
@@ -2980,7 +2980,7 @@ function InstructionForm({
         onChange={(e) => onTextChange(e.target.value)}
         rows={3}
         placeholder="Describe the requirement the agent must follow when filing this ticket…"
-        className="w-full rounded-sm border border-border bg-surface-1 p-2 font-mono text-[12px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
+        className="w-full rounded-lg border border-border bg-surface-1 p-2 font-mono text-[12px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
       />
       <div className="flex items-center gap-2">
         <Btn size="sm" variant="primary" disabled={!title.trim() || disabled} onClick={onSave}>

--- a/apps/web/src/design/DesignLanguage.tsx
+++ b/apps/web/src/design/DesignLanguage.tsx
@@ -39,7 +39,8 @@ import {
 // Design Language — /design
 //
 // Storybook for the primitives in ./ui.tsx. Black canvas · cobalt accent ·
-// sharp edges · bento grids. No deboss; flat hero; split nav.
+// soft corners (10px controls, 10-12px cards) · bento grids. No deboss; flat
+// hero; split nav.
 // ---------------------------------------------------------------------------
 
 export function DesignLanguage() {
@@ -110,7 +111,7 @@ function MainStorybook() {
             id="space"
             n="03"
             title="Space & Radius"
-            subtitle="Eight-pixel rhythm. Near-zero radius."
+            subtitle="Eight-pixel rhythm. Soft radius."
           >
             <SpaceBento />
           </Section>
@@ -561,13 +562,14 @@ function TypeBento() {
 // ---------------------------------------------------------------------------
 
 const spaceSteps = [4, 8, 12, 16, 24, 32, 48, 64];
+// Mirrors the borderRadius scale in tailwind.config.ts — keep in sync.
 const radiusSteps = [
-  { name: "none", px: 0 },
-  { name: "xs", px: 1 },
   { name: "sm", px: 2 },
-  { name: "md", px: 3 },
-  { name: "lg", px: 4 },
-  { name: "xl", px: 5 },
+  { name: "base", px: 4 },
+  { name: "md", px: 6 },
+  { name: "lg", px: 10 },
+  { name: "xl", px: 12 },
+  { name: "2xl", px: 14 },
 ];
 
 function SpaceBento() {
@@ -587,7 +589,7 @@ function SpaceBento() {
         </div>
       </Tile>
 
-      <Tile className="col-span-12 md:col-span-4" label="Radius · near-zero">
+      <Tile className="col-span-12 md:col-span-4" label="Radius · soft">
         <div className="grid grid-cols-3 gap-3">
           {radiusSteps.map((r) => (
             <div key={r.name} className="flex flex-col items-center gap-2">
@@ -672,7 +674,7 @@ function InputsBento() {
         <textarea
           rows={4}
           defaultValue={'error.rate > 0.05 AND service.name == "checkout"'}
-          className="w-full resize-none rounded-sm border border-border bg-surface-2 px-3 py-2 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none"
+          className="w-full resize-none rounded-lg border border-border bg-surface-2 px-3 py-2 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none"
         />
       </Tile>
     </div>

--- a/apps/web/src/design/DesignLanguage.tsx
+++ b/apps/web/src/design/DesignLanguage.tsx
@@ -39,8 +39,8 @@ import {
 // Design Language — /design
 //
 // Storybook for the primitives in ./ui.tsx. Black canvas · cobalt accent ·
-// soft corners (10px controls, 10-12px cards) · bento grids. No deboss; flat
-// hero; split nav.
+// soft corners (6px buttons, 10px inputs, 10-12px cards) · bento grids. No
+// deboss; flat hero; split nav.
 // ---------------------------------------------------------------------------
 
 export function DesignLanguage() {

--- a/apps/web/src/design/Dropdown.tsx
+++ b/apps/web/src/design/Dropdown.tsx
@@ -102,7 +102,7 @@ export function Dropdown({
         aria-haspopup="menu"
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
-        className="flex h-9 w-full items-center gap-2 rounded-sm border border-border bg-surface-2 px-3 text-left text-[13px] text-fg transition-colors hover:border-border-strong focus:border-border-strong focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+        className="flex h-9 w-full items-center gap-2 rounded-lg border border-border bg-surface-2 px-3 text-left text-[13px] text-fg transition-colors hover:border-border-strong focus:border-border-strong focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
       >
         <span className={`flex-1 truncate ${selected ? "text-fg" : "text-subtle"}`}>
           {selected ? (selected.searchText ?? selected.label) : placeholder}

--- a/apps/web/src/design/ui.tsx
+++ b/apps/web/src/design/ui.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState, type ReactNode } from "react";
 
 // ---------------------------------------------------------------------------
 // Shared primitives used across the app and the /design storybook.
-// Dark canvas · cobalt accent · soft corners (10px controls, 10-12px cards) ·
-// bento grids.
+// Dark canvas · cobalt accent · soft corners (6px buttons, 10px inputs,
+// 10-12px cards) · bento grids.
 // ---------------------------------------------------------------------------
 
 export function ShortcutKey({
@@ -104,7 +104,7 @@ export function Btn({
   onClick,
 }: BtnProps) {
   const base =
-    "inline-flex items-center gap-2 rounded-lg font-medium tracking-tight transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 select-none";
+    "inline-flex items-center gap-2 rounded-md font-medium tracking-tight transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 select-none";
   const sizes = {
     sm: "h-7 px-2.5 text-[12px]",
     md: "h-8 px-3 text-[13px]",

--- a/apps/web/src/design/ui.tsx
+++ b/apps/web/src/design/ui.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState, type ReactNode } from "react";
 
 // ---------------------------------------------------------------------------
 // Shared primitives used across the app and the /design storybook.
-// Dark canvas · cobalt accent · sharp edges · bento grids.
+// Dark canvas · cobalt accent · soft corners (10px controls, 10-12px cards) ·
+// bento grids.
 // ---------------------------------------------------------------------------
 
 export function ShortcutKey({
@@ -48,9 +49,7 @@ export function Tile({
 
 export function Label({ children }: { children: ReactNode }) {
   return (
-    <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-subtle">
-      {children}
-    </span>
+    <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-subtle">{children}</span>
   );
 }
 
@@ -105,7 +104,7 @@ export function Btn({
   onClick,
 }: BtnProps) {
   const base =
-    "inline-flex items-center gap-2 rounded-sm font-medium tracking-tight transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 select-none";
+    "inline-flex items-center gap-2 rounded-lg font-medium tracking-tight transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 select-none";
   const sizes = {
     sm: "h-7 px-2.5 text-[12px]",
     md: "h-8 px-3 text-[13px]",
@@ -114,11 +113,9 @@ export function Btn({
   const variants = {
     primary:
       "bg-accent text-accent-ink hover:brightness-110 active:brightness-95 shadow-[0_1px_0_0_rgba(255,255,255,0.12)_inset,0_6px_14px_-6px_rgba(72,90,226,0.55)]",
-    secondary:
-      "bg-transparent text-fg border border-border hover:border-border-strong",
+    secondary: "bg-transparent text-fg border border-border hover:border-border-strong",
     ghost: "bg-transparent text-fg hover:bg-surface-2",
-    danger:
-      "bg-transparent text-danger border border-danger/50 hover:bg-danger/10",
+    danger: "bg-danger/20 text-danger hover:bg-danger/30 active:bg-danger/25",
   };
   return (
     <button
@@ -139,13 +136,7 @@ export function Btn({
 // Chips
 // ---------------------------------------------------------------------------
 
-export type ChipTone =
-  | "neutral"
-  | "success"
-  | "warning"
-  | "danger"
-  | "muted"
-  | "accent";
+export type ChipTone = "neutral" | "success" | "warning" | "danger" | "muted" | "accent";
 
 export function Chip({
   children,
@@ -191,7 +182,7 @@ export function Input(props: React.InputHTMLAttributes<HTMLInputElement>) {
   return (
     <input
       {...rest}
-      className={`h-9 w-full rounded-sm border border-border bg-surface-2 px-3 text-[13px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none ${className}`}
+      className={`h-9 w-full rounded-lg border border-border bg-surface-2 px-3 text-[13px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none ${className}`}
     />
   );
 }
@@ -217,7 +208,7 @@ export function SearchInput({
       </svg>
       <input
         placeholder={placeholder}
-        className="h-9 w-full rounded-sm border border-border bg-surface-2 pl-8 pr-16 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none"
+        className="h-9 w-full rounded-lg border border-border bg-surface-2 pl-8 pr-16 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none"
       />
       <span className="absolute right-2 top-1/2 -translate-y-1/2 rounded-sm border border-border bg-surface-3 px-1.5 py-0.5 font-mono text-[10px] text-muted">
         {shortcut}
@@ -231,7 +222,7 @@ export function Select({ options }: { options: string[] }) {
     <div className="relative">
       <select
         defaultValue={options[0]}
-        className="h-9 w-full appearance-none rounded-sm border border-border bg-surface-2 pl-3 pr-8 text-[13px] text-fg focus:border-border-strong focus:outline-none"
+        className="h-9 w-full appearance-none rounded-lg border border-border bg-surface-2 pl-3 pr-8 text-[13px] text-fg focus:border-border-strong focus:outline-none"
       >
         {options.map((o) => (
           <option key={o} value={o}>
@@ -280,9 +271,7 @@ export function MetricTile({
   return (
     <div className={`relative rounded-2xl border border-border bg-surface p-5 ${className}`}>
       <div className="flex items-center justify-between">
-        <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted">
-          {label}
-        </span>
+        <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted">{label}</span>
         {hasDelta && (
           <span className={`font-mono text-[11px] tabular-nums ${tone}`}>
             {sign}
@@ -313,8 +302,7 @@ export function Sparkline({
   const d = pts
     .map((y, i) => `${i === 0 ? "M" : "L"} ${(i / (pts.length - 1)) * 100} ${40 - (y / max) * 38}`)
     .join(" ");
-  const color =
-    tone === "success" ? "#41D195" : tone === "danger" ? "#EF5A6F" : "#485AE2";
+  const color = tone === "success" ? "#41D195" : tone === "danger" ? "#EF5A6F" : "#485AE2";
   return (
     <svg
       className={className}
@@ -388,9 +376,7 @@ export type Theme = "light" | "dark";
 
 function readTheme(): Theme {
   if (typeof document === "undefined") return "dark";
-  return document.documentElement.getAttribute("data-theme") === "light"
-    ? "light"
-    : "dark";
+  return document.documentElement.getAttribute("data-theme") === "light" ? "light" : "dark";
 }
 
 export function useTheme(): Theme {
@@ -424,12 +410,30 @@ export function ThemeToggle() {
       className="grid h-7 w-7 place-items-center border border-border text-muted transition-colors hover:text-fg"
     >
       {theme === "dark" ? (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
           <circle cx="12" cy="12" r="4" />
           <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
         </svg>
       ) : (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
         </svg>
       )}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -11,25 +11,43 @@
      banner doesn't collide with chrome or force the whole page to scroll. */
   --impersonation-h: 0px;
 
-  --color-bg: #141414;
-  --color-surface: #1c1c1e;
-  --color-surface-2: #232325;
-  --color-surface-3: #2b2b2e;
+  /* Solid colors live as space-separated RGB triplets so tailwind's opacity
+     modifiers (bg-danger/20 etc.) can inject <alpha-value>. The legacy
+     --color-* hex-style vars are derived from them — raw CSS/chart code keeps
+     reading var(--color-x) and stays theme-aware. */
+  --color-bg-rgb: 20 20 20;
+  --color-surface-rgb: 28 28 30;
+  --color-surface-2-rgb: 35 35 37;
+  --color-surface-3-rgb: 43 43 46;
+  --color-fg-rgb: 245 245 246;
+  --color-muted-rgb: 138 138 143;
+  --color-subtle-rgb: 90 90 96;
+  --color-accent-rgb: 72 90 226;
+  --color-accent-ink-rgb: 255 255 255;
+  --color-accent-deep-rgb: 49 64 184;
+  --color-danger-rgb: 239 90 111;
+  --color-warning-rgb: 231 177 90;
+  --color-success-rgb: 65 209 149;
+
+  --color-bg: rgb(var(--color-bg-rgb));
+  --color-surface: rgb(var(--color-surface-rgb));
+  --color-surface-2: rgb(var(--color-surface-2-rgb));
+  --color-surface-3: rgb(var(--color-surface-3-rgb));
   --color-border: rgba(255, 255, 255, 0.07);
   --color-border-strong: rgba(255, 255, 255, 0.12);
 
-  --color-fg: #f5f5f6;
-  --color-muted: #8a8a8f;
-  --color-subtle: #5a5a60;
+  --color-fg: rgb(var(--color-fg-rgb));
+  --color-muted: rgb(var(--color-muted-rgb));
+  --color-subtle: rgb(var(--color-subtle-rgb));
 
-  --color-accent: #485ae2;
-  --color-accent-ink: #ffffff;
+  --color-accent: rgb(var(--color-accent-rgb));
+  --color-accent-ink: rgb(var(--color-accent-ink-rgb));
   --color-accent-soft: rgba(72, 90, 226, 0.14);
-  --color-accent-deep: #3140b8;
+  --color-accent-deep: rgb(var(--color-accent-deep-rgb));
 
-  --color-danger: #ef5a6f;
-  --color-warning: #e7b15a;
-  --color-success: #41d195;
+  --color-danger: rgb(var(--color-danger-rgb));
+  --color-warning: rgb(var(--color-warning-rgb));
+  --color-success: rgb(var(--color-success-rgb));
 
   --dot-color: rgba(245, 245, 246, 0.05);
 }
@@ -37,25 +55,22 @@
 :root[data-theme="light"] {
   color-scheme: light;
 
-  --color-bg: #f5f5f5;
-  --color-surface: #fcfcfc;
-  --color-surface-2: #efefef;
-  --color-surface-3: #e6e6e6;
+  /* Only the RGB triplets need overriding — the derived --color-* vars at
+     :root re-resolve against these at point of use. */
+  --color-bg-rgb: 245 245 245;
+  --color-surface-rgb: 252 252 252;
+  --color-surface-2-rgb: 239 239 239;
+  --color-surface-3-rgb: 230 230 230;
+  --color-fg-rgb: 35 35 35;
+  --color-muted-rgb: 91 94 102;
+  --color-subtle-rgb: 156 159 166;
+  --color-danger-rgb: 214 56 64;
+  --color-warning-rgb: 184 117 3;
+  --color-success-rgb: 31 143 95;
+
   --color-border: rgba(15, 17, 21, 0.08);
   --color-border-strong: rgba(15, 17, 21, 0.16);
-
-  --color-fg: #232323;
-  --color-muted: #5b5e66;
-  --color-subtle: #9c9fa6;
-
-  --color-accent: #485ae2;
-  --color-accent-ink: #ffffff;
   --color-accent-soft: rgba(72, 90, 226, 0.1);
-  --color-accent-deep: #3140b8;
-
-  --color-danger: #d63840;
-  --color-warning: #b87503;
-  --color-success: #1f8f5f;
 
   --dot-color: rgba(0, 0, 0, 0.06);
 }

--- a/apps/web/src/settings/OrgGeneralCard.tsx
+++ b/apps/web/src/settings/OrgGeneralCard.tsx
@@ -2,7 +2,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useMe } from "../api.ts";
 import { authClient } from "../auth-client.ts";
-import { Btn, Input, Tile } from "../design/ui.tsx";
+import { Btn, Input } from "../design/ui.tsx";
+import { SettingsCard, SettingsCardFooter, SettingsRow } from "./rows.tsx";
 
 export function OrgGeneralCard() {
   const me = useMe();
@@ -68,31 +69,39 @@ export function OrgGeneralCard() {
   const dirty = name.trim() !== orgName || slug.trim() !== orgSlug;
 
   return (
-    <Tile>
-      <form onSubmit={submit} className="flex flex-col gap-4">
-        <div>
-          <label className="mb-1.5 block text-[12px] text-muted">Organization name</label>
-          <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Acme" />
-        </div>
-        <div>
-          <label className="mb-1.5 block text-[12px] text-muted">Slug</label>
-          <Input
-            value={slug}
-            onChange={(e) => setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "-"))}
-            placeholder="acme"
-          />
-          <p className="mt-1 text-[11px] text-subtle">
-            Lowercase letters, numbers, and dashes. Used in URLs and emails.
-          </p>
-        </div>
-        {error && <p className="text-[12px] text-danger">{error}</p>}
-        <div className="flex items-center gap-2">
-          <Btn type="submit" loading={update.isPending} disabled={!dirty || !name.trim()}>
+    <form onSubmit={submit}>
+      <SettingsCard>
+        <SettingsRow
+          title="Name"
+          description="Shown across the app and in emails"
+          control={
+            <div className="w-60">
+              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Acme" />
+            </div>
+          }
+        />
+        <SettingsRow
+          title="Slug"
+          description="Used in URLs and emails — lowercase letters, numbers, and dashes"
+          control={
+            <div className="w-60">
+              <Input
+                className="font-mono text-[12.5px]"
+                value={slug}
+                onChange={(e) => setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "-"))}
+                placeholder="acme"
+              />
+            </div>
+          }
+        />
+        <SettingsCardFooter>
+          {error && <span className="mr-auto text-[12px] text-danger">{error}</span>}
+          {savedTick && <span className="text-[12px] text-success">Saved</span>}
+          <Btn type="submit" size="sm" loading={update.isPending} disabled={!dirty || !name.trim()}>
             Save
           </Btn>
-          {savedTick && <span className="text-[12px] text-success">Saved</span>}
-        </div>
-      </form>
-    </Tile>
+        </SettingsCardFooter>
+      </SettingsCard>
+    </form>
   );
 }

--- a/apps/web/src/settings/nav.test.ts
+++ b/apps/web/src/settings/nav.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ORG_NAV_GROUPS,
+  PROJECT_NAV_GROUPS,
+  resolveOrgSection,
+  resolveProjectSection,
+} from "./nav.ts";
+
+test("org nav groups: main group then More group, weekly digest folded into general", () => {
+  const ids: string[] = ORG_NAV_GROUPS.flatMap((g) => g.items.map((i) => i.id));
+  assert.deepEqual(ids, [
+    "general",
+    "members",
+    "billing",
+    "agent-guidance",
+    "mgmt-keys",
+    "github-install",
+  ]);
+  assert.equal(ORG_NAV_GROUPS[0]?.label, undefined);
+  assert.equal(ORG_NAV_GROUPS[1]?.label, "More");
+  assert.ok(!ids.includes("weekly-digest"));
+});
+
+test("project nav groups: agent pages before integrations, keys/webhooks under More", () => {
+  const ids = PROJECT_NAV_GROUPS.flatMap((g) => g.items.map((i) => i.id));
+  assert.deepEqual(ids, [
+    "general",
+    "agent",
+    "agent-memories",
+    "integrations",
+    "issue-filter",
+    "slack-channel",
+    "api-keys",
+    "webhooks",
+  ]);
+  assert.equal(PROJECT_NAV_GROUPS[1]?.label, "More");
+});
+
+test("every org nav id resolves to itself", () => {
+  for (const g of ORG_NAV_GROUPS) {
+    for (const item of g.items) {
+      assert.equal(resolveOrgSection(item.id), item.id);
+    }
+  }
+});
+
+test("every project nav id resolves to itself", () => {
+  for (const g of PROJECT_NAV_GROUPS) {
+    for (const item of g.items) {
+      assert.equal(resolveProjectSection(item.id), item.id);
+    }
+  }
+});
+
+test("legacy weekly-digest URLs land on org general", () => {
+  assert.equal(resolveOrgSection("weekly-digest"), "general");
+});
+
+test("unknown or missing sections fall back to general", () => {
+  assert.equal(resolveOrgSection("nope"), "general");
+  assert.equal(resolveOrgSection(undefined), "general");
+  assert.equal(resolveProjectSection("nope"), "general");
+  assert.equal(resolveProjectSection(undefined), "general");
+});
+
+test("cross-scope section ids don't leak across resolvers", () => {
+  assert.equal(resolveOrgSection("webhooks"), "general");
+  assert.equal(resolveProjectSection("mgmt-keys"), "general");
+});

--- a/apps/web/src/settings/nav.test.ts
+++ b/apps/web/src/settings/nav.test.ts
@@ -3,8 +3,11 @@ import test from "node:test";
 import {
   ORG_NAV_GROUPS,
   PROJECT_NAV_GROUPS,
+  nextProjectIdAfterDelete,
+  projectPickerOptions,
   resolveOrgSection,
   resolveProjectSection,
+  shouldShowProjectPicker,
 } from "./nav.ts";
 
 test("org nav groups: main group then More group, weekly digest folded into general", () => {
@@ -67,4 +70,25 @@ test("unknown or missing sections fall back to general", () => {
 test("cross-scope section ids don't leak across resolvers", () => {
   assert.equal(resolveOrgSection("webhooks"), "general");
   assert.equal(resolveProjectSection("mgmt-keys"), "general");
+});
+
+test("project picker is visible even before the first project exists", () => {
+  assert.equal(shouldShowProjectPicker("project"), true);
+  assert.equal(shouldShowProjectPicker("org"), false);
+  assert.deepEqual(projectPickerOptions([]), [
+    { value: "__new_project__", label: "+ New project", searchText: "new project" },
+  ]);
+});
+
+test("project deletion selects a neighboring project for the URL", () => {
+  const projects = [
+    { id: "p1", name: "One" },
+    { id: "p2", name: "Two" },
+    { id: "p3", name: "Three" },
+  ];
+
+  assert.equal(nextProjectIdAfterDelete(projects, "p2"), "p3");
+  assert.equal(nextProjectIdAfterDelete(projects, "p3"), "p2");
+  assert.equal(nextProjectIdAfterDelete(projects, "p1"), "p2");
+  assert.equal(nextProjectIdAfterDelete([{ id: "p1", name: "One" }], "p1"), undefined);
 });

--- a/apps/web/src/settings/nav.ts
+++ b/apps/web/src/settings/nav.ts
@@ -1,0 +1,93 @@
+// Settings navigation model: two scopes (org / project) rendered as top
+// tabs, each with a grouped icon sidebar. Pure data + resolution logic so
+// the IA is testable without rendering.
+
+export type SettingsScope = "org" | "project";
+
+export type OrgSectionId =
+  | "general"
+  | "members"
+  | "billing"
+  | "agent-guidance"
+  | "mgmt-keys"
+  | "github-install";
+
+export type ProjectSectionId =
+  | "general"
+  | "agent"
+  | "agent-memories"
+  | "integrations"
+  | "issue-filter"
+  | "slack-channel"
+  | "api-keys"
+  | "webhooks";
+
+export type SectionId = OrgSectionId | ProjectSectionId;
+
+export type NavGroup<Id extends string> = {
+  // Undefined for the primary group; "More" for the secondary one.
+  label?: string;
+  items: ReadonlyArray<{ id: Id; label: string }>;
+};
+
+export const ORG_NAV_GROUPS: ReadonlyArray<NavGroup<OrgSectionId>> = [
+  {
+    items: [
+      { id: "general", label: "General" },
+      { id: "members", label: "Members" },
+      { id: "billing", label: "Billing" },
+      { id: "agent-guidance", label: "Agent guidance" },
+    ],
+  },
+  {
+    label: "More",
+    items: [
+      { id: "mgmt-keys", label: "API keys" },
+      { id: "github-install", label: "GitHub" },
+    ],
+  },
+];
+
+export const PROJECT_NAV_GROUPS: ReadonlyArray<NavGroup<ProjectSectionId>> = [
+  {
+    items: [
+      { id: "general", label: "General" },
+      { id: "agent", label: "Agent" },
+      { id: "agent-memories", label: "Agent memories" },
+      { id: "integrations", label: "Integrations" },
+      { id: "issue-filter", label: "Issue filter" },
+      { id: "slack-channel", label: "Slack channel" },
+    ],
+  },
+  {
+    label: "More",
+    items: [
+      { id: "api-keys", label: "API keys" },
+      { id: "webhooks", label: "Webhooks" },
+    ],
+  },
+];
+
+const ORG_SECTION_IDS = new Set<string>(
+  ORG_NAV_GROUPS.flatMap((g) => g.items.map((i) => i.id)),
+);
+const PROJECT_SECTION_IDS = new Set<string>(
+  PROJECT_NAV_GROUPS.flatMap((g) => g.items.map((i) => i.id)),
+);
+
+// Sections that used to be their own page and now live inside another one.
+const LEGACY_ORG_SECTION_ALIASES: Record<string, OrgSectionId> = {
+  "weekly-digest": "general",
+};
+
+export function resolveOrgSection(param: string | undefined): OrgSectionId {
+  if (!param) return "general";
+  const alias = LEGACY_ORG_SECTION_ALIASES[param];
+  if (alias) return alias;
+  return ORG_SECTION_IDS.has(param) ? (param as OrgSectionId) : "general";
+}
+
+export function resolveProjectSection(param: string | undefined): ProjectSectionId {
+  if (!param) return "general";
+  return PROJECT_SECTION_IDS.has(param) ? (param as ProjectSectionId) : "general";
+}

--- a/apps/web/src/settings/nav.ts
+++ b/apps/web/src/settings/nav.ts
@@ -4,6 +4,11 @@
 
 export type SettingsScope = "org" | "project";
 
+export type SettingsProject = {
+  id: string;
+  name: string;
+};
+
 export type OrgSectionId =
   | "general"
   | "members"
@@ -29,6 +34,8 @@ export type NavGroup<Id extends string> = {
   label?: string;
   items: ReadonlyArray<{ id: Id; label: string }>;
 };
+
+export const NEW_PROJECT_OPTION_VALUE = "__new_project__";
 
 export const ORG_NAV_GROUPS: ReadonlyArray<NavGroup<OrgSectionId>> = [
   {
@@ -68,9 +75,7 @@ export const PROJECT_NAV_GROUPS: ReadonlyArray<NavGroup<ProjectSectionId>> = [
   },
 ];
 
-const ORG_SECTION_IDS = new Set<string>(
-  ORG_NAV_GROUPS.flatMap((g) => g.items.map((i) => i.id)),
-);
+const ORG_SECTION_IDS = new Set<string>(ORG_NAV_GROUPS.flatMap((g) => g.items.map((i) => i.id)));
 const PROJECT_SECTION_IDS = new Set<string>(
   PROJECT_NAV_GROUPS.flatMap((g) => g.items.map((i) => i.id)),
 );
@@ -90,4 +95,26 @@ export function resolveOrgSection(param: string | undefined): OrgSectionId {
 export function resolveProjectSection(param: string | undefined): ProjectSectionId {
   if (!param) return "general";
   return PROJECT_SECTION_IDS.has(param) ? (param as ProjectSectionId) : "general";
+}
+
+export function shouldShowProjectPicker(scope: SettingsScope): boolean {
+  return scope === "project";
+}
+
+export function projectPickerOptions(projects: ReadonlyArray<SettingsProject>) {
+  return [
+    ...projects.map((p) => ({ value: p.id, label: p.name, searchText: p.name })),
+    { value: NEW_PROJECT_OPTION_VALUE, label: "+ New project", searchText: "new project" },
+  ];
+}
+
+export function nextProjectIdAfterDelete(
+  projects: ReadonlyArray<SettingsProject>,
+  deletedProjectId: string,
+): string | undefined {
+  const deletedIndex = projects.findIndex((p) => p.id === deletedProjectId);
+  const remaining = projects.filter((p) => p.id !== deletedProjectId);
+  if (remaining.length === 0) return undefined;
+  if (deletedIndex < 0) return remaining[0]?.id;
+  return remaining[Math.min(deletedIndex, remaining.length - 1)]?.id;
 }

--- a/apps/web/src/settings/rows.tsx
+++ b/apps/web/src/settings/rows.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+
+// Row-style settings primitives: a bordered card stacking rows separated by
+// hairline dividers. Each row puts a title + short description on the left
+// and a compact control (input, dropdown, toggle, button) on the right;
+// full-width content (textareas, lists) can sit underneath via children.
+
+export function SettingsCard({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`divide-y divide-border rounded-lg border border-border bg-surface ${className}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function SettingsRow({
+  title,
+  description,
+  control,
+  children,
+}: {
+  title: ReactNode;
+  // Secondary line under the title; keep it to one short sentence.
+  description?: ReactNode;
+  // Compact widget rendered on the right edge of the row.
+  control?: ReactNode;
+  // Optional full-width content below the title/control lane.
+  children?: ReactNode;
+}) {
+  return (
+    <div className="px-5 py-4">
+      <div className="flex items-center justify-between gap-6">
+        <div className="min-w-0">
+          <p className="text-[13.5px] font-medium text-fg">{title}</p>
+          {description && <p className="mt-0.5 text-[12.5px] text-muted">{description}</p>}
+        </div>
+        {control && <div className="flex shrink-0 items-center gap-2">{control}</div>}
+      </div>
+      {children && <div className="mt-3">{children}</div>}
+    </div>
+  );
+}
+
+// Right-aligned action lane (save / discard / status) at the bottom of a card.
+export function SettingsCardFooter({ children }: { children: ReactNode }) {
+  return <div className="flex items-center justify-end gap-2 px-5 py-3">{children}</div>;
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -14,30 +14,27 @@ export default {
           "Roboto",
           "sans-serif",
         ],
-        mono: [
-          "JetBrains Mono",
-          "ui-monospace",
-          "SFMono-Regular",
-          "Menlo",
-          "monospace",
-        ],
+        mono: ["JetBrains Mono", "ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
       },
       colors: {
-        bg: "var(--color-bg)",
-        surface: "var(--color-surface)",
-        "surface-2": "var(--color-surface-2)",
-        "surface-3": "var(--color-surface-3)",
+        // Solid colors use RGB-triplet vars (see index.css) so opacity
+        // modifiers like bg-danger/20 actually work. The rgba-valued tokens
+        // (border, accent-soft) can't take a modifier — use them as-is.
+        bg: "rgb(var(--color-bg-rgb) / <alpha-value>)",
+        surface: "rgb(var(--color-surface-rgb) / <alpha-value>)",
+        "surface-2": "rgb(var(--color-surface-2-rgb) / <alpha-value>)",
+        "surface-3": "rgb(var(--color-surface-3-rgb) / <alpha-value>)",
         border: "var(--color-border)",
         "border-strong": "var(--color-border-strong)",
-        fg: "var(--color-fg)",
-        muted: "var(--color-muted)",
-        subtle: "var(--color-subtle)",
-        accent: "var(--color-accent)",
-        "accent-ink": "var(--color-accent-ink)",
+        fg: "rgb(var(--color-fg-rgb) / <alpha-value>)",
+        muted: "rgb(var(--color-muted-rgb) / <alpha-value>)",
+        subtle: "rgb(var(--color-subtle-rgb) / <alpha-value>)",
+        accent: "rgb(var(--color-accent-rgb) / <alpha-value>)",
+        "accent-ink": "rgb(var(--color-accent-ink-rgb) / <alpha-value>)",
         "accent-soft": "var(--color-accent-soft)",
-        danger: "var(--color-danger)",
-        warning: "var(--color-warning)",
-        success: "var(--color-success)",
+        danger: "rgb(var(--color-danger-rgb) / <alpha-value>)",
+        warning: "rgb(var(--color-warning-rgb) / <alpha-value>)",
+        success: "rgb(var(--color-success-rgb) / <alpha-value>)",
       },
       borderRadius: {
         xs: "1px",
@@ -56,28 +53,26 @@ export default {
       boxShadow: {
         "inset-hairline":
           "inset 0 1px 0 0 rgba(255,255,255,0.04), inset 0 0 0 1px rgba(255,255,255,0.02)",
-        "inset-deep":
-          "inset 0 2px 4px 0 rgba(0,0,0,0.6), inset 0 1px 0 0 rgba(255,255,255,0.03)",
+        "inset-deep": "inset 0 2px 4px 0 rgba(0,0,0,0.6), inset 0 1px 0 0 rgba(255,255,255,0.03)",
         "lift-sm":
           "0 1px 0 0 rgba(255,255,255,0.05) inset, 0 1px 2px 0 rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.04)",
         "lift-md":
           "0 1px 0 0 rgba(255,255,255,0.06) inset, 0 2px 8px -1px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.05)",
-        "glow-accent":
-          "0 0 0 1px rgba(72,90,226,0.35), 0 0 24px -4px rgba(72,90,226,0.42)",
+        "glow-accent": "0 0 0 1px rgba(72,90,226,0.35), 0 0 24px -4px rgba(72,90,226,0.42)",
       },
       keyframes: {
         "pulse-dot": {
           "0%, 100%": { opacity: "0.4", transform: "scale(0.95)" },
           "50%": { opacity: "1", transform: "scale(1.05)" },
         },
-        "scan": {
+        scan: {
           "0%": { transform: "translateX(-100%)" },
           "100%": { transform: "translateX(100%)" },
         },
       },
       animation: {
         "pulse-dot": "pulse-dot 1.6s ease-in-out infinite",
-        "scan": "scan 3s ease-in-out infinite",
+        scan: "scan 3s ease-in-out infinite",
       },
     },
   },


### PR DESCRIPTION
## What

Restructures the settings page and softens the control design language.

**Settings IA** — top-level **Organization / Project** tabs with a grouped icon sidebar (main + "More" group) replacing the old flat sidebar tree. Project picker moved into the tab bar; weekly digest folded into Org → General (legacy `?section=weekly-digest` URLs still resolve). Nav model extracted into a pure `settings/nav.ts` module with node:test coverage.

**Row-style cards** — new `SettingsCard`/`SettingsRow`/`SettingsCardFooter` primitives (title + description left, compact control right, hairline dividers). Org General, Weekly digest, Slack routing, and Project General converted; Project General gains a separate danger card for delete.

**Design language** — buttons `rounded-md` (6px), inputs/dropdowns `rounded-lg` (10px); danger buttons filled red-tint instead of outline; auth Continue button aligned with `Btn` primary (shadow + radius). Color tokens moved to RGB triplets with `<alpha-value>` so tailwind opacity modifiers (`bg-danger/20`, `bg-success/15`, …) actually render — they were silently transparent before. Raw `var(--color-*)` consumers unchanged, both themes covered.

## Testing

- `settings/nav.test.ts` 7/7, typecheck clean, no new biome diagnostics
- Verified headless (Playwright): tab/sidebar navigation, legacy URL redirect, row-card rendering, computed radii/shadows on both themes' tokens

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned Settings with Organization/Project tabs, a grouped icon sidebar, and row-style cards to make navigation clearer and actions faster. Added a project picker with inline create, folded Weekly digest into Org → General, and hardened project navigation and deletion.

- **New Features**
  - Organization/Project tabs with a project picker on Project; “+ New project” inline create; rename/delete moved to Project → General.
  - Grouped sidebar with icons and a “More” group; nav model extracted to `settings/nav.ts` with tests; legacy `?section=weekly-digest` now resolves to Org → General.
  - Row-style primitives `SettingsCard`, `SettingsRow`, `SettingsCardFooter`; converted Org General (+ Weekly digest), Project General (name/context), and Slack routing; separate danger card for delete with neighbor selection and URL update.

- **Refactors**
  - Buttons `rounded-md` (6px); inputs/dropdowns `rounded-lg` (10px); danger buttons use a filled red tint; auth “Continue” matches primary; tab underline bottom-aligned.
  - Color tokens now RGB triplets with `rgb(var(--…)/<alpha-value>)` enabling Tailwind opacity modifiers; config and tokens updated.
  - Navigation hardening: unknown/legacy sections fall back to General; project picker always offers “+ New project”; icons added; tests in `settings/nav.test.ts`.

<sup>Written for commit e0ccadaf8c42596206ac87dde332595488afd37a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

