### PR TITLE
Follow-up agent runs: PR comments, feedback, and Slack replies revive the investigation

### DIFF
--- a/apps/api/src/feedback.ts
+++ b/apps/api/src/feedback.ts
@@ -3,6 +3,7 @@ import { and, eq } from "drizzle-orm";
 import type { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { auth } from "./auth.js";
+import { offerFollowUpForFeedback } from "./follow-up-offer.js";
 import { logger } from "./logger.js";
 
 const log = logger.child({ scope: "feedback" });
@@ -192,6 +193,12 @@ export async function recordFeedback(input: {
   if (row) {
     void notifyFeedbackSlack(row).catch((err) => {
       log.warn({ err, feedback_id: row.id }, "feedback slack notify failed");
+    });
+    // Confirm-gated follow-up: offer a "Run follow-up" button in the
+    // incident's Slack thread (no-op for pr_comment feedback, which
+    // auto-triggers from the webhook path instead).
+    void offerFollowUpForFeedback(row).catch((err) => {
+      log.warn({ err, feedback_id: row.id }, "follow-up offer failed");
     });
   }
 }

--- a/apps/api/src/follow-up-offer.ts
+++ b/apps/api/src/follow-up-offer.ts
@@ -1,0 +1,107 @@
+// Confirm-gated follow-up offers for feedback. Feedback is noisier than PR
+// review comments or Slack replies, so instead of auto-running the agent we
+// post a button into the incident's Slack thread and only enqueue when a
+// human clicks it (requestFollowUpAgentRun with confirmed=true — see the
+// follow_up_confirm handler in slack.ts).
+//
+// Lives in its own module because feedback.ts and slack.ts already import
+// from each other's domains; this only depends on @superlog/db.
+import { db, schema } from "@superlog/db";
+import { desc, eq } from "drizzle-orm";
+import { logger } from "./logger.js";
+
+const log = logger.child({ scope: "follow-up-offer" });
+
+// kind=incident → refId is the incident UUID; kind=pr → refId is an
+// agent_pull_requests UUID (when tracked). kind=issue and untracked PR refs
+// don't bind to an incident, so no offer.
+export async function resolveFeedbackIncidentId(
+  feedback: Pick<schema.Feedback, "kind" | "refId">,
+): Promise<string | null> {
+  if (feedback.kind === "incident") {
+    const incident = await db.query.incidents
+      .findFirst({ where: eq(schema.incidents.id, feedback.refId), columns: { id: true } })
+      .catch(() => null);
+    return incident?.id ?? null;
+  }
+  if (feedback.kind === "pr") {
+    const agentPr = await db.query.agentPullRequests
+      .findFirst({
+        where: eq(schema.agentPullRequests.id, feedback.refId),
+        columns: { incidentId: true },
+      })
+      .catch(() => null);
+    return agentPr?.incidentId ?? null;
+  }
+  return null;
+}
+
+// Best-effort: failures are logged and swallowed; the feedback insert must
+// never depend on Slack availability.
+export async function offerFollowUpForFeedback(feedback: schema.Feedback): Promise<void> {
+  // PR-comment feedback already auto-triggers a follow-up run from the
+  // GitHub webhook path — offering a button too would double-trigger.
+  if (feedback.source === "pr_comment") return;
+
+  const incidentId = await resolveFeedbackIncidentId(feedback);
+  if (!incidentId) return;
+
+  const incident = await db.query.incidents.findFirst({
+    where: eq(schema.incidents.id, incidentId),
+  });
+  if (!incident?.slackChannelId || !incident.slackThreadTs) return;
+
+  // Only offer when there is a finished run to follow up on — mirrors the
+  // no_prior_run eligibility check so the button isn't shown when clicking
+  // it could never work.
+  const priorRun = await db.query.agentRuns.findFirst({
+    where: eq(schema.agentRuns.incidentId, incidentId),
+    orderBy: [desc(schema.agentRuns.createdAt)],
+    columns: { state: true },
+  });
+  if (!priorRun || (priorRun.state !== "complete" && priorRun.state !== "failed")) return;
+
+  const installation = incident.slackInstallationId
+    ? await db.query.slackInstallations.findFirst({
+        where: eq(schema.slackInstallations.id, incident.slackInstallationId),
+      })
+    : null;
+  if (!installation?.botAccessToken) return;
+
+  const preview = feedback.body.length > 280 ? `${feedback.body.slice(0, 277)}…` : feedback.body;
+  const text = `New feedback on this incident:\n>${preview}\nWant the agent to run a follow-up investigation that takes it into account?`;
+  try {
+    const res = await fetch("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        authorization: `Bearer ${installation.botAccessToken}`,
+      },
+      body: JSON.stringify({
+        channel: incident.slackChannelId,
+        thread_ts: incident.slackThreadTs,
+        text,
+        blocks: [
+          { type: "section", text: { type: "mrkdwn", text } },
+          {
+            type: "actions",
+            elements: [
+              {
+                type: "button",
+                style: "primary",
+                text: { type: "plain_text", text: "Run follow-up" },
+                action_id: `follow_up_confirm:${feedback.id}`,
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    const data = (await res.json()) as { ok: boolean; error?: string };
+    if (!data.ok) {
+      log.warn({ error: data.error, feedback_id: feedback.id }, "follow-up offer post failed");
+    }
+  } catch (err) {
+    log.warn({ err, feedback_id: feedback.id }, "follow-up offer post threw");
+  }
+}

--- a/apps/api/src/follow-up-offer.ts
+++ b/apps/api/src/follow-up-offer.ts
@@ -12,6 +12,12 @@ import { logger } from "./logger.js";
 
 const log = logger.child({ scope: "follow-up-offer" });
 
+// Slack mrkdwn control characters. User-provided feedback must not be able
+// to inject mentions (<!channel>, <@U…>) or links into the incident thread.
+function escapeSlackText(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 // kind=incident → refId is the incident UUID; kind=pr → refId is an
 // agent_pull_requests UUID (when tracked). kind=issue and untracked PR refs
 // don't bind to an incident, so no offer.
@@ -68,7 +74,9 @@ export async function offerFollowUpForFeedback(feedback: schema.Feedback): Promi
     : null;
   if (!installation?.botAccessToken) return;
 
-  const preview = feedback.body.length > 280 ? `${feedback.body.slice(0, 277)}…` : feedback.body;
+  const preview = escapeSlackText(
+    feedback.body.length > 280 ? `${feedback.body.slice(0, 277)}…` : feedback.body,
+  );
   const text = `New feedback on this incident:\n>${preview}\nWant the agent to run a follow-up investigation that takes it into account?`;
   try {
     const res = await fetch("https://slack.com/api/chat.postMessage", {

--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import {
   db,
   listAccessibleGithubInstallsForProject,
+  requestFollowUpAgentRun,
   resolveIncident,
   schema,
   syncLoopsContactsForOrg,
@@ -361,6 +362,9 @@ type WebhookPayload = {
     user?: GhActor;
     html_url?: string;
     author_association?: string;
+    // pull_request_review_comment only
+    path?: string;
+    line?: number | null;
   };
   review?: {
     id?: number;
@@ -604,6 +608,12 @@ async function handleAgentPrWebhook(
     log.warn({ err, event, agent_pr_id: agentPrRow.id }, "pr comment feedback capture failed");
   });
 
+  // Same best-effort posture: a follow-up enqueue failure must not 500 the
+  // webhook delivery.
+  await maybeRequestPrCommentFollowUp({ event, payload, agentPrRow }).catch((err) => {
+    log.warn({ err, event, agent_pr_id: agentPrRow.id }, "pr comment follow-up enqueue failed");
+  });
+
   const now = new Date();
 
   // Update the parent row when this is a state-changing event.
@@ -713,18 +723,27 @@ async function resolveIncidentForMergedAgentPr(opts: {
   }
 }
 
-async function maybeRecordPrCommentFeedback(opts: {
-  event: string;
-  payload: WebhookPayload;
-  agentPrRow: schema.AgentPullRequest;
-}): Promise<void> {
-  const { event, payload, agentPrRow } = opts;
-  // Only the comment-bearing events count; PR open/close/merge has its
-  // own first-class handling and isn't user feedback.
+type EligiblePrComment = {
+  body: string;
+  actor: GhActor;
+  commentUrl: string | null;
+  path: string | null;
+  line: number | null;
+};
+
+// Shared gate for the comment-bearing PR events: real text from a real
+// (non-bot, repo-associated) human, excluding our own feedback footer.
+// PR open/close/merge has its own first-class handling and isn't a comment.
+function extractEligiblePrComment(
+  event: string,
+  payload: WebhookPayload,
+): EligiblePrComment | null {
   let body: string | null = null;
   let actor: GhActor = null;
   let authorAssociation: string | null = null;
   let commentUrl: string | null = null;
+  let path: string | null = null;
+  let line: number | null = null;
   if (event === "issue_comment" && payload.action === "created") {
     body = payload.comment?.body ?? null;
     actor = payload.comment?.user ?? null;
@@ -735,21 +754,23 @@ async function maybeRecordPrCommentFeedback(opts: {
     actor = payload.comment?.user ?? null;
     authorAssociation = payload.comment?.author_association ?? null;
     commentUrl = payload.comment?.html_url ?? null;
+    path = payload.comment?.path ?? null;
+    line = payload.comment?.line ?? null;
   } else if (event === "pull_request_review" && payload.action === "submitted") {
     body = payload.review?.body ?? null;
     actor = payload.review?.user ?? null;
     authorAssociation = payload.review?.author_association ?? null;
     commentUrl = payload.review?.html_url ?? null;
   } else {
-    return;
+    return null;
   }
-  if (!body || body.trim().length === 0) return;
+  if (!body || body.trim().length === 0) return null;
 
   // Skip our own footer echoed back by the GitHub UI — the PR description
   // itself is rendered into comment-like contexts occasionally (e.g. the
   // squashed merge commit message), and we don't want our own "leave
   // feedback" link surfaced as feedback.
-  if (body.includes(FEEDBACK_PR_FOOTER_MARKER)) return;
+  if (body.includes(FEEDBACK_PR_FOOTER_MARKER)) return null;
 
   if (
     !isFeedbackEligibleCommenter({
@@ -757,8 +778,53 @@ async function maybeRecordPrCommentFeedback(opts: {
       authorAssociation,
     })
   ) {
-    return;
+    return null;
   }
+  return { body, actor, commentUrl, path, line };
+}
+
+// Review feedback on an agent PR revives the agent as a follow-up run that
+// addresses the requested changes on the existing branch. Eligibility (caps,
+// staleness, project gate) is enforced by requestFollowUpAgentRun; comments
+// arriving while a follow-up is still queued append to it, so a review burst
+// becomes one run.
+async function maybeRequestPrCommentFollowUp(opts: {
+  event: string;
+  payload: WebhookPayload;
+  agentPrRow: schema.AgentPullRequest;
+}): Promise<void> {
+  const comment = extractEligiblePrComment(opts.event, opts.payload);
+  if (!comment) return;
+  const result = await requestFollowUpAgentRun(db, {
+    incidentId: opts.agentPrRow.incidentId,
+    trigger: "pr_comment",
+    interaction: {
+      channel: "pr_comment",
+      author: comment.actor?.login ?? null,
+      text: comment.body,
+      url: comment.commentUrl,
+      path: comment.path,
+      line: comment.line,
+      occurredAt: new Date().toISOString(),
+    },
+  });
+  if (result.outcome === "skipped") {
+    log.info(
+      { incident_id: opts.agentPrRow.incidentId, reason: result.reason },
+      "pr comment did not trigger a follow-up run",
+    );
+  }
+}
+
+async function maybeRecordPrCommentFeedback(opts: {
+  event: string;
+  payload: WebhookPayload;
+  agentPrRow: schema.AgentPullRequest;
+}): Promise<void> {
+  const { event, payload, agentPrRow } = opts;
+  const eligible = extractEligiblePrComment(event, payload);
+  if (!eligible) return;
+  const { body, actor, commentUrl } = eligible;
 
   // Resolve org + project via the agent PR's installation so the admin
   // inbox can show which org's PR this feedback is on.

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -13,6 +13,7 @@ import type { Hono } from "hono";
 import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { recordFeedback } from "./feedback.js";
+import { resolveFeedbackIncidentId } from "./follow-up-offer.js";
 import { getDeviceFlow, getSkillDeviceForIntegration } from "./gateway.js";
 import { closeAgentPullRequestOnGithub } from "./github.js";
 import { runResolvedIncidentSideEffectsForIncident } from "./incidents/resolution-side-effects.js";
@@ -236,6 +237,12 @@ async function handleSlackBlockActions(payload: SlackInteractivityPayload): Prom
   if (actionId.startsWith("resolve_incident:")) {
     const incidentId = actionId.slice("resolve_incident:".length);
     if (incidentId) await handleSlackResolveIncident(incidentId, payload);
+    return;
+  }
+
+  if (actionId.startsWith("follow_up_confirm:")) {
+    const feedbackId = actionId.slice("follow_up_confirm:".length);
+    if (feedbackId) await handleFollowUpConfirm(feedbackId, payload);
     return;
   }
 
@@ -499,6 +506,68 @@ async function handleProposalDecision(
   } catch (err) {
     log.warn({ err, proposalId }, "proposal message re-render failed");
   }
+}
+
+// Handle a `follow_up_confirm:<feedbackId>` click from the offer posted by
+// offerFollowUpForFeedback. Enqueues a confirm-gated follow-up run (the
+// confirmed flag bypasses the project's auto-follow-up gate, not the caps)
+// and replies in-thread with the outcome.
+async function handleFollowUpConfirm(
+  feedbackId: string,
+  payload: SlackInteractivityPayload,
+): Promise<void> {
+  const feedback = await db.query.feedback
+    .findFirst({ where: eq(schema.feedback.id, feedbackId) })
+    .catch(() => null);
+  if (!feedback) {
+    log.warn({ feedbackId }, "follow_up_confirm click for unknown feedback");
+    return;
+  }
+  const incidentId = await resolveFeedbackIncidentId(feedback);
+  if (!incidentId) {
+    log.warn({ feedbackId }, "follow_up_confirm feedback does not bind to an incident");
+    return;
+  }
+  const incident = await db.query.incidents.findFirst({
+    where: eq(schema.incidents.id, incidentId),
+  });
+  if (!incident) return;
+
+  const result = await requestFollowUpAgentRun(db, {
+    incidentId,
+    trigger: "feedback",
+    confirmed: true,
+    interaction: {
+      channel: "feedback",
+      author:
+        feedback.authorExternal?.githubLogin ??
+        feedback.authorExternal?.slackUserId ??
+        feedback.authorUserId,
+      text: feedback.body,
+      occurredAt: (feedback.createdAt ?? new Date()).toISOString(),
+    },
+  });
+
+  const installation = await installationForIncident({
+    pinnedId: incident.slackInstallationId,
+    teamId: payload.team?.id ?? "",
+  });
+  if (!installation || !incident.slackChannelId || !incident.slackThreadTs) return;
+  const clickedBy = payload.user?.id ? `<@${payload.user.id}>` : "someone";
+  const text =
+    result.outcome === "skipped"
+      ? result.reason === "follow_up_cap_reached"
+        ? ":no_entry: Can't run another follow-up — this incident reached its follow-up limit."
+        : result.reason === "run_active"
+          ? ":hourglass: An investigation is already running for this incident; the feedback was recorded."
+          : `:no_entry: Follow-up not started (${result.reason.replace(/_/g, " ")}).`
+      : `:mag: Follow-up investigation queued by ${clickedBy} — the agent will take this feedback into account.`;
+  await postSlackThreadReply({
+    botToken: installation.botAccessToken,
+    channel: incident.slackChannelId,
+    threadTs: incident.slackThreadTs,
+    text,
+  });
 }
 
 async function postSlackThreadReply(opts: {

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -3,6 +3,7 @@ import {
   confirmResolutionProposal,
   db,
   dismissResolutionProposal,
+  requestFollowUpAgentRun,
   resolveIncident,
   schema,
   syncLoopsContactsForOrg,
@@ -829,28 +830,50 @@ async function handleSlackEventEnvelope(payload: SlackEventEnvelope): Promise<vo
     where: eq(schema.agentRuns.incidentId, incident.id),
     orderBy: [desc(schema.agentRuns.createdAt)],
   });
-  if (!agentRun || agentRun.state !== "awaiting_human") return;
+  if (!agentRun) return;
 
-  await db
-    .insert(schema.incidentEvents)
-    .values({
-      agentRunId: agentRun.id,
-      kind: "human_reply",
-      summary: event.text.trim(),
-      detail: {
-        slackEventId: payload.event_id ?? null,
-        slackUserId: event.user ?? null,
-        slackChannelId: event.channel,
-        slackThreadTs: event.thread_ts,
-        slackMessageTs: event.ts,
-      },
-      dedupeKey: payload.event_id
-        ? `slack:${payload.event_id}`
-        : `slack:${event.channel}:${event.ts}`,
-    })
-    .onConflictDoNothing({
-      target: [schema.incidentEvents.agentRunId, schema.incidentEvents.dedupeKey],
-    });
+  if (agentRun.state === "awaiting_human") {
+    await db
+      .insert(schema.incidentEvents)
+      .values({
+        agentRunId: agentRun.id,
+        kind: "human_reply",
+        summary: event.text.trim(),
+        detail: {
+          slackEventId: payload.event_id ?? null,
+          slackUserId: event.user ?? null,
+          slackChannelId: event.channel,
+          slackThreadTs: event.thread_ts,
+          slackMessageTs: event.ts,
+        },
+        dedupeKey: payload.event_id
+          ? `slack:${payload.event_id}`
+          : `slack:${event.channel}:${event.ts}`,
+      })
+      .onConflictDoNothing({
+        target: [schema.incidentEvents.agentRunId, schema.incidentEvents.dedupeKey],
+      });
+    return;
+  }
+
+  // A reply after the latest run finished revives the agent as a follow-up
+  // run (eligibility — caps, staleness, project gate — is decided inside).
+  const result = await requestFollowUpAgentRun(db, {
+    incidentId: incident.id,
+    trigger: "slack_reply",
+    interaction: {
+      channel: "slack_reply",
+      author: event.user ?? null,
+      text: event.text.trim(),
+      occurredAt: new Date().toISOString(),
+    },
+  });
+  if (result.outcome === "skipped") {
+    logger.info(
+      { scope: "slack", incident_id: incident.id, reason: result.reason },
+      "slack reply did not trigger a follow-up run",
+    );
+  }
 }
 
 async function resolveUserOrg(

--- a/apps/worker/src/agent-run-context.test.ts
+++ b/apps/worker/src/agent-run-context.test.ts
@@ -1,5 +1,8 @@
+import "./agent-run.test-env.js";
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import type { schema } from "@superlog/db";
+import { buildFollowUpContext } from "./agent-run-context.js";
 import { buildAgentRunInstructions } from "./agent-run-instructions.js";
 
 test("agent run instructions include org guidance, project context, and project instructions", () => {
@@ -17,6 +20,89 @@ test("agent run instructions include org guidance, project context, and project 
       "Run billing tests before opening a PR.",
     ].join("\n\n"),
   );
+});
+
+test("buildFollowUpContext returns null for ordinary incident-triggered runs", () => {
+  const followUp = buildFollowUpContext({
+    trigger: "incident",
+    triggerDetail: null,
+    priorRun: null,
+    events: [],
+  });
+  assert.equal(followUp, null);
+});
+
+test("buildFollowUpContext carries prior findings, handoff notes, PR, and timeline", () => {
+  const priorRun = {
+    state: "complete",
+    selectedRepoFullName: "acme/api",
+    result: {
+      state: "complete",
+      summary: "Fixed the checkout NPE.",
+      rootCause: { text: "Null cart in retry path.", confidence: 8 },
+      handoffNotes: "Examined cart.ts and retry.ts; ruled out the queue (idempotent).",
+      pr: {
+        branchName: "superlog/fix-cart-npe",
+        url: "https://github.com/acme/api/pull/12",
+        validationSummary: "pnpm test passed (212 tests).",
+      },
+    },
+  } as unknown as schema.AgentRun;
+
+  const followUp = buildFollowUpContext({
+    trigger: "pr_comment",
+    triggerDetail: {
+      interactions: [
+        {
+          channel: "pr_comment",
+          author: "alice",
+          text: "Please also guard the empty-cart case.",
+          url: "https://github.com/acme/api/pull/12#discussion_r1",
+          path: "src/cart.ts",
+          line: 42,
+          occurredAt: "2026-06-10T12:00:00Z",
+        },
+      ],
+    },
+    priorRun,
+    events: [
+      { kind: "agent_run_started", summary: "Investigation started across 2 candidate repos." },
+      { kind: "pr_opened", summary: "Opened PR: https://github.com/acme/api/pull/12" },
+      { kind: "noise", summary: null },
+    ],
+  });
+
+  assert.ok(followUp);
+  assert.equal(followUp.trigger, "pr_comment");
+  assert.equal(followUp.interactions.length, 1);
+  assert.equal(followUp.interactions[0]?.path, "src/cart.ts");
+  assert.deepEqual(followUp.priorRun, {
+    state: "complete",
+    summary: "Fixed the checkout NPE.",
+    rootCause: "Null cart in retry path.",
+    handoffNotes: "Examined cart.ts and retry.ts; ruled out the queue (idempotent).",
+    validationSummary: "pnpm test passed (212 tests).",
+    repoFullName: "acme/api",
+    prBranch: "superlog/fix-cart-npe",
+    prUrl: "https://github.com/acme/api/pull/12",
+  });
+  assert.deepEqual(followUp.timeline, [
+    "agent_run_started: Investigation started across 2 candidate repos.",
+    "pr_opened: Opened PR: https://github.com/acme/api/pull/12",
+  ]);
+});
+
+test("buildFollowUpContext tolerates a missing prior run and empty detail", () => {
+  const followUp = buildFollowUpContext({
+    trigger: "slack_reply",
+    triggerDetail: null,
+    priorRun: null,
+    events: [],
+  });
+  assert.ok(followUp);
+  assert.equal(followUp.priorRun, null);
+  assert.deepEqual(followUp.interactions, []);
+  assert.deepEqual(followUp.timeline, []);
 });
 
 test("agent run instructions skip blank project context", () => {

--- a/apps/worker/src/agent-run-context.ts
+++ b/apps/worker/src/agent-run-context.ts
@@ -5,9 +5,10 @@ import {
   listAccessibleGithubInstallsForProject,
   schema,
 } from "@superlog/db";
-import { and, desc, eq, inArray, isNull } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, ne } from "drizzle-orm";
 import { listActiveAgentMemories } from "./agent-memory-tools.js";
 import { buildAgentRunInstructions } from "./agent-run-instructions.js";
+import type { AgentRunnerFollowUp } from "./agent-runner-backend.js";
 import { listInstallationRepositories } from "./infra/github/repositories.js";
 import { logger } from "./logger.js";
 
@@ -45,7 +46,47 @@ export type AgentRunContext = {
   autoMergeMethod: schema.AutoMergeMethod;
   issueRows: Array<schema.Issue>;
   memories: Array<schema.AgentMemory>;
+  // Set for follow-up runs (trigger != incident): the prior run's distilled
+  // context plus the interaction(s) that revived the agent.
+  followUp: AgentRunnerFollowUp | null;
 };
+
+const FOLLOW_UP_TIMELINE_MAX_LINES = 20;
+
+// Pure assembly of the follow-up block from the run row, the latest terminal
+// prior run, and the incident timeline. Returns null for ordinary
+// incident-triggered runs.
+export function buildFollowUpContext(args: {
+  trigger: schema.AgentRunTrigger;
+  triggerDetail: schema.AgentRunTriggerDetail | null;
+  priorRun: schema.AgentRun | null;
+  events: Array<Pick<schema.IncidentEvent, "kind" | "summary">>;
+}): AgentRunnerFollowUp | null {
+  if (args.trigger === "incident") return null;
+  const result = args.priorRun?.result ?? null;
+  const priorState = args.priorRun?.state;
+  return {
+    trigger: args.trigger,
+    interactions: args.triggerDetail?.interactions ?? [],
+    priorRun:
+      args.priorRun && result && (priorState === "complete" || priorState === "failed")
+        ? {
+            state: priorState,
+            summary: result.summary,
+            rootCause: result.rootCause?.text ?? null,
+            handoffNotes: result.handoffNotes ?? null,
+            validationSummary: result.pr?.validationSummary ?? null,
+            repoFullName: args.priorRun.selectedRepoFullName ?? null,
+            prBranch: result.pr?.branchName ?? null,
+            prUrl: result.pr?.url ?? null,
+          }
+        : null,
+    timeline: args.events
+      .filter((event) => typeof event.summary === "string" && event.summary.length > 0)
+      .slice(-FOLLOW_UP_TIMELINE_MAX_LINES)
+      .map((event) => `${event.kind}: ${event.summary}`),
+  };
+}
 
 export async function getProjectAutomation(projectId: string): Promise<{
   autoInvestigateIssuesEnabled: boolean;
@@ -126,6 +167,29 @@ export async function loadAgentRunContext(
     projectInstructions: automation.customInstructions,
   });
   const memories = await listActiveAgentMemories(project.orgId, project.id);
+  let followUp: AgentRunnerFollowUp | null = null;
+  if (agentRun.trigger !== "incident") {
+    const priorRun =
+      (await db.query.agentRuns.findFirst({
+        where: and(
+          eq(schema.agentRuns.incidentId, incident.id),
+          ne(schema.agentRuns.id, agentRun.id),
+          inArray(schema.agentRuns.state, ["complete", "failed"]),
+        ),
+        orderBy: [desc(schema.agentRuns.createdAt)],
+      })) ?? null;
+    const events = await db.query.incidentEvents.findMany({
+      where: eq(schema.incidentEvents.incidentId, incident.id),
+      orderBy: [asc(schema.incidentEvents.createdAt)],
+      columns: { kind: true, summary: true },
+    });
+    followUp = buildFollowUpContext({
+      trigger: agentRun.trigger,
+      triggerDetail: agentRun.triggerDetail,
+      priorRun,
+      events,
+    });
+  }
   return {
     agentRun,
     incident,
@@ -142,6 +206,7 @@ export async function loadAgentRunContext(
     autoMergeMethod: automation.autoMergeMethod,
     issueRows,
     memories,
+    followUp,
   };
 }
 

--- a/apps/worker/src/agent-runner-backend.ts
+++ b/apps/worker/src/agent-runner-backend.ts
@@ -1,6 +1,8 @@
 import type {
   AgentMemoryKind,
+  AgentRunFollowUpInteraction,
   AgentRunResult,
+  AgentRunTrigger,
   LinearTicketInstruction,
   LinearTicketPolicy,
   PrPolicy,
@@ -33,6 +35,26 @@ export type AgentRunnerMemory = {
   body: string;
 };
 
+// Context for a follow-up run revived by a human interaction after a prior
+// investigation finished. The prior session is gone; this block plus the PR
+// branch and project memories is everything the new session inherits.
+export type AgentRunnerFollowUp = {
+  trigger: Exclude<AgentRunTrigger, "incident">;
+  interactions: AgentRunFollowUpInteraction[];
+  priorRun: {
+    state: "complete" | "failed";
+    summary: string;
+    rootCause: string | null;
+    handoffNotes: string | null;
+    validationSummary: string | null;
+    repoFullName: string | null;
+    prBranch: string | null;
+    prUrl: string | null;
+  } | null;
+  // Condensed incident timeline ("kind: summary" lines, oldest first).
+  timeline: string[];
+};
+
 export type AgentRunnerStartInput = {
   incidentId: string;
   projectId: string;
@@ -53,6 +75,8 @@ export type AgentRunnerStartInput = {
   // Durable cross-run facts (terminology, infra, feedback lessons) saved by
   // earlier runs or by users. Injected into the initial prompt in full.
   memories: AgentRunnerMemory[];
+  // Null for ordinary incident-triggered investigations.
+  followUp: AgentRunnerFollowUp | null;
 };
 
 export type AgentRunnerSnapshot = {

--- a/apps/worker/src/agent-runs/pr-delivery.ts
+++ b/apps/worker/src/agent-runs/pr-delivery.ts
@@ -3,16 +3,16 @@ import {
   createIncidentLifecycle,
   db,
   normalizePrBaseBranch,
-  type schema,
+  schema,
 } from "@superlog/db";
-import { eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import {
   type AgentRunContext,
   type InstalledGithubRepo,
   listAccessibleGithubRepositories,
 } from "../agent-run-context.js";
 import { createAgentRunLifecycle } from "../agent-run.js";
-import { mergeAgentPullRequest } from "../github-app.js";
+import { mergeAgentPullRequest, pushPatchToExistingAgentPr } from "../github-app.js";
 import { downloadAgentPatchFile } from "../infra/agent-runner/patch-files.js";
 import { openAgentRunPullRequest } from "../infra/github/pull-requests.js";
 import {
@@ -34,6 +34,29 @@ const DEFAULT_COMMIT_AUTHOR = {
 };
 const agentRunLifecycle = createAgentRunLifecycle(db);
 const incidentLifecycle = createIncidentLifecycle(db);
+
+// Reply posted on the existing PR after a follow-up run pushes new commits.
+function buildFollowUpPrComment(ctx: AgentRunContext, result: AgentRunResult): string {
+  const interactions = ctx.followUp?.interactions ?? [];
+  const authors = [...new Set(interactions.map((i) => i.author).filter((a): a is string => !!a))];
+  const lines = [
+    authors.length > 0
+      ? `Addressed review feedback from ${authors.map((a) => `@${a}`).join(", ")} in a follow-up investigation.`
+      : "Addressed review feedback in a follow-up investigation.",
+    "",
+    result.summary,
+  ];
+  const validation = result.pr?.validationSummary;
+  if (validation) lines.push("", `Validation: ${validation}`);
+  return lines.join("\n");
+}
+
+async function notifyFollowUpPrUpdated(ctx: AgentRunContext, prUrl: string): Promise<void> {
+  await postIncidentThreadMessage(
+    ctx.incident.id,
+    `:arrows_counterclockwise: Follow-up investigation pushed an update to the existing PR: ${prUrl}`,
+  );
+}
 
 export function resolvePullRequestBaseBranch(
   ctx: Pick<AgentRunContext, "prBaseBranch">,
@@ -129,6 +152,115 @@ export async function completeWithPullRequest(
   // later "retry PR" can re-attempt delivery from the patch on record without
   // depending on the agent session (which may have expired) to re-download it.
   const resultWithPatch: AgentRunResult = { ...result, pr: { ...pr, patch, patchFileId } };
+
+  // Follow-up runs deliver onto the prior run's still-open PR: push the patch
+  // as an additional commit on the existing branch and reply on the PR
+  // instead of opening a second one.
+  if (ctx.agentRun.trigger !== "incident") {
+    const existingPr = await db.query.agentPullRequests.findFirst({
+      where: and(
+        eq(schema.agentPullRequests.incidentId, ctx.incident.id),
+        eq(schema.agentPullRequests.repoFullName, pr.selectedRepoFullName),
+        eq(schema.agentPullRequests.state, "open"),
+      ),
+      orderBy: [desc(schema.agentPullRequests.createdAt)],
+    });
+    if (existingPr) {
+      let pushed: { headSha: string };
+      try {
+        pushed = await pushPatchToExistingAgentPr({
+          installationId: repoMeta.installation.installationId,
+          repositoryId: repoMeta.id,
+          repoFullName: pr.selectedRepoFullName,
+          patch,
+          branchName: existingPr.branchName,
+          prNumber: existingPr.prNumber,
+          commitTitle: prTitle,
+          commentBody: buildFollowUpPrComment(ctx, result),
+          commitAuthor:
+            repoMeta.installation.commitAuthorName && repoMeta.installation.commitAuthorEmail
+              ? {
+                  name: repoMeta.installation.commitAuthorName,
+                  email: repoMeta.installation.commitAuthorEmail,
+                }
+              : DEFAULT_COMMIT_AUTHOR,
+        });
+      } catch (err) {
+        await failAgentRun(ctx, "pr_open_failed", summarizePrOpenFailure(err), {
+          existingResult: resultWithPatch,
+          err,
+        });
+        return;
+      }
+
+      const now = new Date();
+      await db
+        .update(schema.agentPullRequests)
+        .set({ headSha: pushed.headSha, lastSyncedAt: now, updatedAt: now })
+        .where(eq(schema.agentPullRequests.id, existingPr.id));
+
+      const followUpResult: AgentRunResult = {
+        ...result,
+        pr: {
+          ...pr,
+          patch,
+          patchFileId,
+          branchName: existingPr.branchName,
+          baseBranch: existingPr.baseBranch,
+          openStatus: "opened",
+          url: existingPr.url,
+        },
+      };
+      await agentRunLifecycle.completeWithPullRequest({
+        id: ctx.agentRun.id,
+        currentState: ctx.agentRun.state,
+        result: followUpResult,
+        selectedRepoFullName: pr.selectedRepoFullName,
+        selectedBaseBranch: existingPr.baseBranch,
+        prUrl: existingPr.url,
+      });
+      await incidentLifecycle
+        .applyAgentRunResult({
+          incident: ctx.incident,
+          agentRunId: ctx.agentRun.id,
+          result: followUpResult,
+        })
+        .catch((err) =>
+          logger.error(
+            {
+              scope: "agent_run.pr_delivery",
+              agent_run_id: ctx.agentRun.id,
+              incident_id: ctx.incident.id,
+              err: err instanceof Error ? err.message : String(err),
+            },
+            "failed to apply incident metadata after updating PR",
+          ),
+        );
+      await enqueueAgentRunCompleted(ctx.agentRun.id).catch((err) =>
+        logger.error(
+          {
+            scope: "webhooks.enqueue",
+            agent_run_id: ctx.agentRun.id,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          "failed to enqueue agent run.completed webhook",
+        ),
+      );
+      await notifyFollowUpPrUpdated(ctx, existingPr.url).catch((err) =>
+        logger.warn(
+          {
+            scope: "agent_run.pr_delivery",
+            agent_run_id: ctx.agentRun.id,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          "failed to post follow-up PR update to Slack",
+        ),
+      );
+      return;
+    }
+    // No open PR to land on (closed meanwhile, or the prior run never opened
+    // one) — fall through to the normal open-a-new-PR path.
+  }
   let opened: Awaited<ReturnType<typeof openAgentRunPullRequest>>;
   try {
     opened = await openAgentRunPullRequest({

--- a/apps/worker/src/agent-runs/pr-delivery.ts
+++ b/apps/worker/src/agent-runs/pr-delivery.ts
@@ -246,6 +246,17 @@ export async function completeWithPullRequest(
           "failed to enqueue agent run.completed webhook",
         ),
       );
+      await recordFiledLinearTicket(ctx, result.linearTicket).catch((err) =>
+        logger.error(
+          {
+            scope: "agent_run.pr_delivery",
+            agent_run_id: ctx.agentRun.id,
+            incident_id: ctx.incident.id,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          "failed to record filed Linear ticket",
+        ),
+      );
       await notifyFollowUpPrUpdated(ctx, existingPr.url).catch((err) =>
         logger.warn(
           {
@@ -255,6 +266,18 @@ export async function completeWithPullRequest(
           },
           "failed to post follow-up PR update to Slack",
         ),
+      );
+      logger.info(
+        {
+          scope: "agent_run",
+          agent_run_id: ctx.agentRun.id,
+          incident_id: ctx.incident.id,
+          session_id: sessionId,
+          runtime_minutes: runtimeMinutes,
+          selected_repo: pr.selectedRepoFullName,
+          pr_url: existingPr.url,
+        },
+        "agent run complete (existing pr updated)",
       );
       return;
     }

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -54,6 +54,7 @@ test("startQueuedAgentRunWorkflow starts runner with capped repo candidates", as
     "prBaseBranch:development",
     "telemetryHint:session.id",
     "memories:0",
+    "followUp:none",
     "startRunning:session-1:1",
     "notifyStarted:1",
   ]);
@@ -137,6 +138,7 @@ function makeDeps(
         calls.push("telemetryHint:session.id");
       }
       calls.push(`memories:${input.memories.length}`);
+      calls.push(`followUp:${input.followUp ? input.followUp.trigger : "none"}`);
       onStart?.(input);
       return { sessionId: "session-1" };
     },
@@ -240,6 +242,7 @@ function makeContext(opts: { githubInstalled?: boolean } = {}): AgentRunContext 
     autoMergeMethod: "squash",
     issueRows: [],
     memories: [],
+    followUp: null,
   };
 }
 

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -240,6 +240,7 @@ async function startRunnerSession(
           title: memory.title,
           body: memory.body,
         })),
+        followUp: ctx.followUp,
       });
       llmSpan.setAttribute("agent_run.session_id", result.sessionId);
       return result;

--- a/apps/worker/src/github-app.ts
+++ b/apps/worker/src/github-app.ts
@@ -544,7 +544,10 @@ export async function applyPatchAndOpenPr(opts: {
     await ensureGitOk(["config", "user.name", gitIdentity.name], { cwd: repoDir });
     await ensureGitOk(["config", "user.email", gitIdentity.email], { cwd: repoDir });
 
-    const patchPath = path.join(repoDir, "superlog.patch");
+    // Written OUTSIDE the repo checkout: an untracked patch file inside
+    // repoDir would make `git status --porcelain` non-empty even when the
+    // patch changed nothing, defeating the no-op detection below.
+    const patchPath = path.join(workdir, "superlog.patch");
     const patchBody = normalizeAgentPatch(opts.patch);
     await writeFile(patchPath, patchBody, "utf8");
     const applyArgs = ["apply", "--index", "--whitespace=nowarn", patchPath];
@@ -675,7 +678,10 @@ export async function pushPatchToExistingAgentPr(opts: {
     await ensureGitOk(["config", "user.name", gitIdentity.name], { cwd: repoDir });
     await ensureGitOk(["config", "user.email", gitIdentity.email], { cwd: repoDir });
 
-    const patchPath = path.join(repoDir, "superlog.patch");
+    // Written OUTSIDE the repo checkout: an untracked patch file inside
+    // repoDir would make `git status --porcelain` non-empty even when the
+    // patch changed nothing, defeating the no-op detection below.
+    const patchPath = path.join(workdir, "superlog.patch");
     const patchBody = normalizeAgentPatch(opts.patch);
     await writeFile(patchPath, patchBody, "utf8");
     const applyArgs = ["apply", "--index", "--whitespace=nowarn", patchPath];

--- a/apps/worker/src/github-app.ts
+++ b/apps/worker/src/github-app.ts
@@ -636,6 +636,88 @@ export async function applyPatchAndOpenPr(opts: {
   }
 }
 
+// Follow-up delivery: apply a new patch as an additional commit on an
+// EXISTING agent PR branch (no new branch, no new PR) and reply on the PR.
+// The patch is expected to be based on the PR branch head — the follow-up
+// prompt instructs the agent to work on that branch. A non-fast-forward
+// push (someone pushed to the branch meanwhile) throws; the caller fails
+// the run rather than guessing at a merge.
+export async function pushPatchToExistingAgentPr(opts: {
+  installationId: number;
+  repositoryId?: number;
+  repoFullName: string;
+  patch: string;
+  branchName: string;
+  prNumber: number;
+  commitTitle: string;
+  commentBody: string | null;
+  commitAuthor?: { name: string; email: string } | null;
+}): Promise<{ headSha: string }> {
+  const workdir = await mkdtemp(path.join(os.tmpdir(), "superlog-pr-update-"));
+  const writeToken = await createGithubWriteToken(opts.installationId, opts.repositoryId);
+  const gitAuthEnv = githubGitAuthEnv(writeToken);
+  const repoDir = path.join(workdir, "repo");
+
+  try {
+    await ensureGitOk(
+      [
+        "clone",
+        "--depth",
+        "1",
+        "--branch",
+        opts.branchName,
+        `https://github.com/${opts.repoFullName}.git`,
+        repoDir,
+      ],
+      { env: gitAuthEnv, suppressOutputOnError: true },
+    );
+    const gitIdentity = resolveGitIdentity(opts.commitAuthor);
+    await ensureGitOk(["config", "user.name", gitIdentity.name], { cwd: repoDir });
+    await ensureGitOk(["config", "user.email", gitIdentity.email], { cwd: repoDir });
+
+    const patchPath = path.join(repoDir, "superlog.patch");
+    const patchBody = normalizeAgentPatch(opts.patch);
+    await writeFile(patchPath, patchBody, "utf8");
+    const applyArgs = ["apply", "--index", "--whitespace=nowarn", patchPath];
+    const applyResult = await runGit(applyArgs, { cwd: repoDir });
+    if (applyResult.code !== 0) {
+      throw gitApplyError(applyArgs, applyResult, patchBody);
+    }
+    const status = await ensureGitOk(["status", "--porcelain"], { cwd: repoDir });
+    if (!status.stdout.trim()) {
+      throw new Error("patch produced no working tree changes");
+    }
+    await ensureGitOk(["commit", "--no-verify", "-m", opts.commitTitle], { cwd: repoDir });
+    await ensureGitPushOk(["push", "origin", `HEAD:refs/heads/${opts.branchName}`], {
+      cwd: repoDir,
+      env: gitAuthEnv,
+      suppressOutputOnError: true,
+    });
+    const headSha = (await ensureGitOk(["rev-parse", "HEAD"], { cwd: repoDir })).stdout.trim();
+
+    if (opts.commentBody) {
+      // Best-effort: the push already landed; a failed comment shouldn't
+      // unwind the delivery.
+      try {
+        await githubRequest(`/repos/${opts.repoFullName}/issues/${opts.prNumber}/comments`, {
+          method: "POST",
+          bearerToken: writeToken,
+          body: { body: opts.commentBody },
+        });
+      } catch (err) {
+        logger.warn(
+          { scope: "github-app", err, pr_number: opts.prNumber, repo: opts.repoFullName },
+          "follow-up PR comment failed",
+        );
+      }
+    }
+
+    return { headSha };
+  } finally {
+    await rm(workdir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
 // Footer appended to every agent-opened PR description so customers can
 // leave feedback in one click. Must contain the marker
 // `/feedback/pr/` because the github webhook handler filters its own
@@ -699,20 +781,17 @@ export async function closeAgentPullRequestOnGithub(opts: {
 }): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
     const token = await createGithubWriteToken(opts.installationId);
-    const res = await fetch(
-      `${GITHUB_API}/repos/${opts.repoFullName}/pulls/${opts.prNumber}`,
-      {
-        method: "PATCH",
-        headers: {
-          accept: "application/vnd.github+json",
-          authorization: `Bearer ${token}`,
-          "content-type": "application/json; charset=utf-8",
-          "x-github-api-version": "2022-11-28",
-          "user-agent": "superlog-worker",
-        },
-        body: JSON.stringify({ state: "closed" }),
+    const res = await fetch(`${GITHUB_API}/repos/${opts.repoFullName}/pulls/${opts.prNumber}`, {
+      method: "PATCH",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json; charset=utf-8",
+        "x-github-api-version": "2022-11-28",
+        "user-agent": "superlog-worker",
       },
-    );
+      body: JSON.stringify({ state: "closed" }),
+    });
     if (res.ok) return { ok: true };
     const text = await res.text().catch(() => "");
     return { ok: false, error: `github PATCH /pulls/${opts.prNumber} ${res.status} ${text}` };

--- a/apps/worker/src/infra/agent-runner/backend.test.ts
+++ b/apps/worker/src/infra/agent-runner/backend.test.ts
@@ -62,6 +62,7 @@ test("getAgentRunnerBackend returns the default community backend", async () => 
         "When an issue sample includes a session.id attribute, use it to query preceding traces and logs.",
       customInstructions: "",
       memories: [],
+      followUp: null,
     });
     const snapshot = await backend.collect(session.sessionId);
 
@@ -109,6 +110,7 @@ test("getAgentRunnerBackend returns a built-in disabled backend for community in
           "When an issue sample includes a session.id attribute, use it to query preceding traces and logs.",
         customInstructions: "",
         memories: [],
+        followUp: null,
       }),
     /disabled/,
   );

--- a/apps/worker/src/managed-agent-result.test.ts
+++ b/apps/worker/src/managed-agent-result.test.ts
@@ -33,6 +33,27 @@ test("accepts minimal well-formed result", () => {
   assert.deepEqual(r.drops, []);
 });
 
+test("normalizes handoffNotes and drops non-string values", () => {
+  const ok = normalizeAgentResult({
+    state: "complete",
+    summary: "x",
+    handoffNotes: "Examined apps/api/src/billing.ts; ruled out the retry path (idempotent).",
+  });
+  assert.equal(ok.ok, true);
+  if (!ok.ok) return;
+  assert.equal(
+    ok.result.handoffNotes,
+    "Examined apps/api/src/billing.ts; ruled out the retry path (idempotent).",
+  );
+  assert.deepEqual(ok.drops, []);
+
+  const bad = normalizeAgentResult({ state: "complete", summary: "x", handoffNotes: 42 });
+  assert.equal(bad.ok, true);
+  if (!bad.ok) return;
+  assert.equal(bad.result.handoffNotes, undefined);
+  assert.deepEqual(bad.drops, ["handoffNotes"]);
+});
+
 test("accepts a fully-populated well-formed result", () => {
   const r = normalizeAgentResult({
     state: "complete",

--- a/apps/worker/src/managed-agent-result.ts
+++ b/apps/worker/src/managed-agent-result.ts
@@ -296,6 +296,8 @@ export function normalizeAgentResult(rawInput: unknown): NormalizeResult {
   const proposedTitle = asString(input.proposedTitle);
   take("proposedTitle", "proposedTitle", proposedTitle);
 
+  take("handoffNotes", "handoffNotes", asString(input.handoffNotes));
+
   const rootCauseConfidence = asString(input.rootCauseConfidence);
   take(
     "rootCauseConfidence",

--- a/packages/db/migrations/0066_youthful_smasher.sql
+++ b/packages/db/migrations/0066_youthful_smasher.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "agent_runs" ADD COLUMN "trigger" text DEFAULT 'incident' NOT NULL;--> statement-breakpoint
+ALTER TABLE "agent_runs" ADD COLUMN "trigger_detail" jsonb;--> statement-breakpoint
+ALTER TABLE "project_automation_settings" ADD COLUMN "auto_follow_up_enabled" boolean DEFAULT true NOT NULL;

--- a/packages/db/migrations/meta/0066_snapshot.json
+++ b/packages/db/migrations/meta/0066_snapshot.json
@@ -1,0 +1,6739 @@
+{
+  "id": "7df9d0f2-3812-42e0-80a5-a36037609fc9",
+  "prevId": "45ff908f-1e6a-4ab8-a042-e724cd42d7cc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_provider_account_idx": {
+          "name": "accounts_provider_account_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_idx": {
+          "name": "accounts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_ticket_events": {
+      "name": "agent_linear_ticket_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_linear_ticket_id": {
+          "name": "agent_linear_ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_linear_id": {
+          "name": "actor_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_ticket_events_ticket_idx": {
+          "name": "agent_linear_ticket_events_ticket_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_ticket_events_provider_event_idx": {
+          "name": "agent_linear_ticket_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk": {
+          "name": "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk",
+          "tableFrom": "agent_linear_ticket_events",
+          "tableTo": "agent_linear_tickets",
+          "columnsFrom": [
+            "agent_linear_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_tickets": {
+      "name": "agent_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_identifier": {
+          "name": "ticket_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_name": {
+          "name": "assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_linear_id": {
+          "name": "assignee_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_tickets_incident_idx": {
+          "name": "agent_linear_tickets_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_agent_run_idx": {
+          "name": "agent_linear_tickets_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_workspace_ticket_idx": {
+          "name": "agent_linear_tickets_workspace_ticket_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_tickets_incident_id_incidents_id_fk": {
+          "name": "agent_linear_tickets_incident_id_incidents_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_linear_tickets_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_installation_id_linear_installations_id_fk": {
+          "name": "agent_linear_tickets_installation_id_linear_installations_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "linear_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memories": {
+      "name": "agent_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source_agent_run_id": {
+          "name": "source_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memories_org_status_idx": {
+          "name": "agent_memories_org_status_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_memories_org_id_orgs_id_fk": {
+          "name": "agent_memories_org_id_orgs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_id_projects_id_fk": {
+          "name": "agent_memories_project_id_projects_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_memories_source_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "source_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_user_id_users_id_fk": {
+          "name": "agent_memories_source_user_id_users_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "source_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_org_fk": {
+          "name": "agent_memories_project_org_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_memories_single_source_check": {
+          "name": "agent_memories_single_source_check",
+          "value": "NOT (source_agent_run_id IS NOT NULL AND source_user_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_pr_events": {
+      "name": "agent_pr_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_pr_id": {
+          "name": "agent_pr_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_login": {
+          "name": "actor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_github_id": {
+          "name": "actor_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pr_events_pr_idx": {
+          "name": "agent_pr_events_pr_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pr_events_provider_event_idx": {
+          "name": "agent_pr_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk": {
+          "name": "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk",
+          "tableFrom": "agent_pr_events",
+          "tableTo": "agent_pull_requests",
+          "columnsFrom": [
+            "agent_pr_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_pull_requests": {
+      "name": "agent_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_node_id": {
+          "name": "pr_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_login": {
+          "name": "merged_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_github_id": {
+          "name": "merged_by_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pull_requests_incident_idx": {
+          "name": "agent_pull_requests_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_agent_run_idx": {
+          "name": "agent_pull_requests_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_repo_pr_idx": {
+          "name": "agent_pull_requests_repo_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pull_requests_incident_id_incidents_id_fk": {
+          "name": "agent_pull_requests_incident_id_incidents_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_pull_requests_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_installation_id_github_installations_id_fk": {
+          "name": "agent_pull_requests_installation_id_github_installations_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'incident'"
+        },
+        "trigger_detail": {
+          "name": "trigger_detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_status": {
+          "name": "provider_session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_full_name": {
+          "name": "selected_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_url": {
+          "name": "selected_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_base_branch": {
+          "name": "selected_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_score": {
+          "name": "selected_repo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cumulative_runtime_minutes": {
+          "name": "cumulative_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resume_count": {
+          "name": "resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_runs_incident_idx": {
+          "name": "agent_runs_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_provider_session_idx": {
+          "name": "agent_runs_provider_session_idx",
+          "columns": [
+            {
+              "expression": "provider_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_incident_id_incidents_id_fk": {
+          "name": "agent_runs_incident_id_incidents_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_firings": {
+      "name": "alert_firings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_value": {
+          "name": "observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluated_at": {
+          "name": "evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_firings_alert_group_idx": {
+          "name": "alert_firings_alert_group_idx",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_firings_alert_id_alerts_id_fk": {
+          "name": "alert_firings_alert_id_alerts_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_firings_issue_id_issues_id_fk": {
+          "name": "alert_firings_issue_id_issues_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_name": {
+          "name": "metric_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "group_by": {
+          "name": "group_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mode": {
+          "name": "group_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single'"
+        },
+        "aggregation": {
+          "name": "aggregation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparator": {
+          "name": "comparator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "evaluation_interval_seconds": {
+          "name": "evaluation_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alerts_project_idx": {
+          "name": "alerts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alerts_enabled_idx": {
+          "name": "alerts_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alerts_project_id_projects_id_fk": {
+          "name": "alerts_project_id_projects_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alerts_created_by_users_id_fk": {
+          "name": "alerts_created_by_users_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions": {
+      "name": "cli_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cli_sessions_user_id_users_id_fk": {
+          "name": "cli_sessions_user_id_users_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_org_id_orgs_id_fk": {
+          "name": "cli_sessions_org_id_orgs_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_sessions_token_hash_unique": {
+          "name": "cli_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_connections": {
+      "name": "cloud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scrape_role_arn": {
+          "name": "scrape_role_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id_ciphertext": {
+          "name": "external_id_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_nonce": {
+          "name": "external_id_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_key_version": {
+          "name": "external_id_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloud_connections_project_idx": {
+          "name": "cloud_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_connections_active_role_idx": {
+          "name": "cloud_connections_active_role_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scrape_role_arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_connections_project_id_projects_id_fk": {
+          "name": "cloud_connections_project_id_projects_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_connections_created_by_users_id_fk": {
+          "name": "cloud_connections_created_by_users_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_resources": {
+      "name": "cloud_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arn": {
+          "name": "arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_fetched_at": {
+          "name": "config_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_resources_project_arn_idx": {
+          "name": "cloud_resources_project_arn_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_project_idx": {
+          "name": "cloud_resources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_connection_idx": {
+          "name": "cloud_resources_connection_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_resources_project_id_projects_id_fk": {
+          "name": "cloud_resources_project_id_projects_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_resources_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_resources_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_widgets": {
+      "name": "dashboard_widgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboard_widgets_dashboard_idx": {
+          "name": "dashboard_widgets_dashboard_idx",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_widgets_dashboard_id_dashboards_id_fk": {
+          "name": "dashboard_widgets_dashboard_id_dashboards_id_fk",
+          "tableFrom": "dashboard_widgets",
+          "tableTo": "dashboards",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboards": {
+      "name": "dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboards_project_slug_idx": {
+          "name": "dashboards_project_slug_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboards_project_idx": {
+          "name": "dashboards_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboards_project_id_projects_id_fk": {
+          "name": "dashboards_project_id_projects_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboards_created_by_users_id_fk": {
+          "name": "dashboards_created_by_users_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_repo": {
+          "name": "ref_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_external": {
+          "name": "author_external",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "triaged_by_user_id": {
+          "name": "triaged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_status_created_idx": {
+          "name": "feedback_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_kind_ref_idx": {
+          "name": "feedback_kind_ref_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_user_id_users_id_fk": {
+          "name": "feedback_author_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_org_id_orgs_id_fk": {
+          "name": "feedback_org_id_orgs_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_project_id_projects_id_fk": {
+          "name": "feedback_project_id_projects_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_triaged_by_user_id_users_id_fk": {
+          "name": "feedback_triaged_by_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triaged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repos": {
+          "name": "repos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_enabled": {
+          "name": "agent_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "repo_access": {
+          "name": "repo_access",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_name": {
+          "name": "commit_author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_email": {
+          "name": "commit_author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_login": {
+          "name": "commit_author_github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_id": {
+          "name": "commit_author_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_avatar_url": {
+          "name": "commit_author_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_by_user_id": {
+          "name": "commit_author_set_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_at": {
+          "name": "commit_author_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_project_installation_idx": {
+          "name": "github_installations_project_installation_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NOT NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_installation_idx": {
+          "name": "github_installations_org_installation_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_idx": {
+          "name": "github_installations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_org_id_orgs_id_fk": {
+          "name": "github_installations_org_id_orgs_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_project_id_projects_id_fk": {
+          "name": "github_installations_project_id_projects_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_commit_author_set_by_user_id_users_id_fk": {
+          "name": "github_installations_commit_author_set_by_user_id_users_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "commit_author_set_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_events": {
+      "name": "incident_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_posted_at": {
+          "name": "slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_events_agent_run_idx": {
+          "name": "incident_events_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_idx": {
+          "name": "incident_events_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_provider_event_idx": {
+          "name": "incident_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_provider_event_idx": {
+          "name": "incident_events_incident_provider_event_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_dedupe_idx": {
+          "name": "incident_events_dedupe_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_dedupe_idx": {
+          "name": "incident_events_incident_dedupe_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_events_agent_run_id_agent_runs_id_fk": {
+          "name": "incident_events_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_events_incident_id_incidents_id_fk": {
+          "name": "incident_events_incident_id_incidents_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "incident_events_parentage_check": {
+          "name": "incident_events_parentage_check",
+          "value": "agent_run_id IS NOT NULL OR incident_id IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.incident_issues": {
+      "name": "incident_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_issues_issue_idx": {
+          "name": "incident_issues_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_issues_incident_idx": {
+          "name": "incident_issues_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_issues_incident_id_incidents_id_fk": {
+          "name": "incident_issues_incident_id_incidents_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_issues_issue_id_issues_id_fk": {
+          "name": "incident_issues_issue_id_issues_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_resolution_proposals": {
+      "name": "incident_resolution_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sweep'"
+        },
+        "proposed_reason_code": {
+          "name": "proposed_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_reason_text": {
+          "name": "proposed_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_at": {
+          "name": "proposed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_slack_user_id": {
+          "name": "decided_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_resolution_proposals_incident_idx": {
+          "name": "incident_resolution_proposals_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proposed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_resolution_proposals_slack_msg_idx": {
+          "name": "incident_resolution_proposals_slack_msg_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_message_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_channel_id IS NOT NULL AND slack_message_ts IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_resolution_proposals_incident_id_incidents_id_fk": {
+          "name": "incident_resolution_proposals_incident_id_incidents_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk": {
+          "name": "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_decided_by_user_id_users_id_fk": {
+          "name": "incident_resolution_proposals_decided_by_user_id_users_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "noise_reason": {
+          "name": "noise_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_resolved_at": {
+          "name": "noise_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_into_id": {
+          "name": "merged_into_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_investigate_suppressed_until": {
+          "name": "auto_investigate_suppressed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autorecovery_last_evaluated_at": {
+          "name": "autorecovery_last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_summary": {
+          "name": "agent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_text": {
+          "name": "root_cause_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_confidence": {
+          "name": "root_cause_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_text": {
+          "name": "estimated_impact_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_confidence": {
+          "name": "estimated_impact_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_severity": {
+          "name": "suggested_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_classification": {
+          "name": "noise_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_classification": {
+          "name": "resolution_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_agent_run_id": {
+          "name": "findings_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_kind": {
+          "name": "resolved_by_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_slack_user_id": {
+          "name": "resolved_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_code": {
+          "name": "resolved_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_text": {
+          "name": "resolved_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incidents_project_status_seen_idx": {
+          "name": "incidents_project_status_seen_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_autorecovery_eval_idx": {
+          "name": "incidents_autorecovery_eval_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "autorecovery_last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_slack_thread_idx": {
+          "name": "incidents_slack_thread_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_project_codename_idx": {
+          "name": "incidents_project_codename_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "codename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "codename <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_project_id_projects_id_fk": {
+          "name": "incidents_project_id_projects_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incidents_merged_into_id_incidents_id_fk": {
+          "name": "incidents_merged_into_id_incidents_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "merged_into_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_slack_installation_id_slack_installations_id_fk": {
+          "name": "incidents_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_findings_agent_run_id_agent_runs_id_fk": {
+          "name": "incidents_findings_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "findings_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_resolved_by_user_id_users_id_fk": {
+          "name": "incidents_resolved_by_user_id_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_org_idx": {
+          "name": "invitations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_org_id_orgs_id_fk": {
+          "name": "invitations_org_id_orgs_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'span'"
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_type": {
+          "name": "exception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_frame": {
+          "name": "top_frame",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_frames": {
+          "name": "normalized_frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_sample": {
+          "name": "last_sample",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "silenced_at": {
+          "name": "silenced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_alerted_at": {
+          "name": "last_alerted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "grouping_state": {
+          "name": "grouping_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'grouped'"
+        },
+        "grouping_source": {
+          "name": "grouping_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_reason": {
+          "name": "grouping_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempted_at": {
+          "name": "grouping_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempt_count": {
+          "name": "grouping_attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_project_fingerprint_idx": {
+          "name": "issues_project_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "silenced_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_grouping_state_idx": {
+          "name": "issues_grouping_state_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grouping_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grouping_state IN ('pending', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_installations": {
+      "name": "linear_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_url_key": {
+          "name": "workspace_url_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_vault_id": {
+          "name": "anthropic_vault_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_credential_id": {
+          "name": "anthropic_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_required_at": {
+          "name": "reauth_required_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_reason": {
+          "name": "reauth_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linear_installations_project_active_idx": {
+          "name": "linear_installations_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_installations_project_id_projects_id_fk": {
+          "name": "linear_installations_project_id_projects_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_installations_actor_user_id_users_id_fk": {
+          "name": "linear_installations_actor_user_id_users_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_codes": {
+      "name": "mcp_oauth_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_codes_client_idx": {
+          "name": "mcp_oauth_codes_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_user_id_users_id_fk": {
+          "name": "mcp_oauth_codes_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_project_id_projects_id_fk": {
+          "name": "mcp_oauth_codes_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_tokens": {
+      "name": "mcp_oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "access_hash": {
+          "name": "access_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_hash": {
+          "name": "refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_tokens_client_idx": {
+          "name": "mcp_oauth_tokens_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_tokens_user_idx": {
+          "name": "mcp_oauth_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_user_id_users_id_fk": {
+          "name": "mcp_oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_project_id_projects_id_fk": {
+          "name": "mcp_oauth_tokens_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_tokens_access_hash_unique": {
+          "name": "mcp_oauth_tokens_access_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_hash"
+          ]
+        },
+        "mcp_oauth_tokens_refresh_hash_unique": {
+          "name": "mcp_oauth_tokens_refresh_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_agent_settings": {
+      "name": "org_agent_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "digest_enabled": {
+          "name": "digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "digest_slack_installation_id": {
+          "name": "digest_slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_id": {
+          "name": "digest_slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_name": {
+          "name": "digest_slack_channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_last_run_at": {
+          "name": "digest_last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_agent_settings_org_idx": {
+          "name": "org_agent_settings_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_agent_settings_org_id_orgs_id_fk": {
+          "name": "org_agent_settings_org_id_orgs_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk": {
+          "name": "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "digest_slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_api_keys": {
+      "name": "org_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_api_keys_org_idx": {
+          "name": "org_api_keys_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_api_keys_org_id_orgs_id_fk": {
+          "name": "org_api_keys_org_id_orgs_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_api_keys_created_by_user_id_users_id_fk": {
+          "name": "org_api_keys_created_by_user_id_users_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_api_keys_key_hash_unique": {
+          "name": "org_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integration_secrets": {
+      "name": "org_integration_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_integration_id": {
+          "name": "org_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_name": {
+          "name": "secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integration_secrets_unique_idx": {
+          "name": "org_integration_secrets_unique_idx",
+          "columns": [
+            {
+              "expression": "org_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integration_secrets_org_integration_id_org_integrations_id_fk": {
+          "name": "org_integration_secrets_org_integration_id_org_integrations_id_fk",
+          "tableFrom": "org_integration_secrets",
+          "tableTo": "org_integrations",
+          "columnsFrom": [
+            "org_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integrations": {
+      "name": "org_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integrations_org_slug_idx": {
+          "name": "org_integrations_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_integrations_org_enabled_idx": {
+          "name": "org_integrations_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integrations_org_id_orgs_id_fk": {
+          "name": "org_integrations_org_id_orgs_id_fk",
+          "tableFrom": "org_integrations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_members_org_user_idx": {
+          "name": "org_members_org_user_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_org_id_orgs_id_fk": {
+          "name": "org_members_org_id_orgs_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_members_user_id_users_id_fk": {
+          "name": "org_members_user_id_users_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_setup_skipped_at": {
+          "name": "github_setup_skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_source": {
+          "name": "signup_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_return_url_hosts": {
+          "name": "allowed_return_url_hosts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_slug_unique": {
+          "name": "orgs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "orgs_clerk_org_id_unique": {
+          "name": "orgs_clerk_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_automation_settings": {
+      "name": "project_automation_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_investigate_issues_enabled": {
+          "name": "auto_investigate_issues_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "agent_run_provider": {
+          "name": "agent_run_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "max_runtime_minutes": {
+          "name": "max_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "max_human_resume_count": {
+          "name": "max_human_resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_follow_up_enabled": {
+          "name": "auto_follow_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "linear_ticket_instructions": {
+          "name": "linear_ticket_instructions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_base_branch": {
+          "name": "pr_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_merge_fix_prs": {
+          "name": "auto_merge_fix_prs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'never'"
+        },
+        "auto_merge_method": {
+          "name": "auto_merge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'squash'"
+        },
+        "issue_filter": {
+          "name": "issue_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "issue_filter_config": {
+          "name": "issue_filter_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"includeLogs\":[],\"includeSpans\":[],\"excludeLogs\":[],\"excludeSpans\":[]}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_automation_settings_project_idx": {
+          "name": "project_automation_settings_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_automation_settings_project_id_projects_id_fk": {
+          "name": "project_automation_settings_project_id_projects_id_fk",
+          "tableFrom": "project_automation_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_github_repos": {
+      "name": "project_github_repos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_full_name": {
+          "name": "github_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_github_repos_project_repo_idx": {
+          "name": "project_github_repos_project_repo_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_github_repos_installation_idx": {
+          "name": "project_github_repos_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_github_repos_project_id_projects_id_fk": {
+          "name": "project_github_repos_project_id_projects_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_github_repos_installation_id_github_installations_id_fk": {
+          "name": "project_github_repos_installation_id_github_installations_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_context": {
+          "name": "project_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_idx": {
+          "name": "projects_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_org_id_orgs_id_fk": {
+          "name": "projects_org_id_orgs_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_id_org_uniq": {
+          "name": "projects_id_org_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_orgs_id_fk": {
+          "name": "sessions_active_organization_id_orgs_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signup_intents": {
+      "name": "signup_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_project_id": {
+          "name": "claimed_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signup_intents_claimed_project_id_projects_id_fk": {
+          "name": "signup_intents_claimed_project_id_projects_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "claimed_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "signup_intents_claimed_by_user_id_users_id_fk": {
+          "name": "signup_intents_claimed_by_user_id_users_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signup_intents_key_hash_unique": {
+          "name": "signup_intents_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slack_installations_project_team_idx": {
+          "name": "slack_installations_project_team_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_project_id_projects_id_fk": {
+          "name": "slack_installations_project_id_projects_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_installations_installed_by_user_id_users_id_fk": {
+          "name": "slack_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_map_artifacts": {
+      "name": "source_map_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dist": {
+          "name": "dist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug_id": {
+          "name": "debug_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_file": {
+          "name": "bundle_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_file": {
+          "name": "map_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_hash": {
+          "name": "source_map_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_bytes": {
+          "name": "source_map_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_bucket": {
+          "name": "storage_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_encoding": {
+          "name": "content_encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gzip'"
+        },
+        "uploaded_by_org_api_key_id": {
+          "name": "uploaded_by_org_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_map_artifacts_project_debug_id_idx": {
+          "name": "source_map_artifacts_project_debug_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "debug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "debug_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_map_artifacts_project_release_idx": {
+          "name": "source_map_artifacts_project_release_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "release",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_map_artifacts_project_id_projects_id_fk": {
+          "name": "source_map_artifacts_project_id_projects_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk": {
+          "name": "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "org_api_keys",
+          "columnsFrom": [
+            "uploaded_by_org_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_project_id": {
+          "name": "active_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_active_project_id_projects_id_fk": {
+          "name": "users_active_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "active_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_status": {
+          "name": "last_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_endpoint_idx": {
+          "name": "webhook_deliveries_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_events": {
+          "name": "enabled_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"agent_run.completed\"]'::jsonb"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_endpoints_project_idx": {
+          "name": "webhook_endpoints_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_endpoints_project_id_projects_id_fk": {
+          "name": "webhook_endpoints_project_id_projects_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_state": {
+      "name": "worker_state",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -463,6 +463,13 @@
       "when": 1781054170075,
       "tag": "0065_nice_ken_ellis",
       "breakpoints": true
+    },
+    {
+      "idx": 66,
+      "version": "7",
+      "when": 1781055868470,
+      "tag": "0066_youthful_smasher",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/agent-follow-up.test.ts
+++ b/packages/db/src/agent-follow-up.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  FOLLOW_UP_MAX_AGE_DAYS,
+  MAX_FOLLOW_UP_RUNS,
+  evaluateFollowUpEligibility,
+} from "./agent-follow-up.js";
+
+const NOW = new Date("2026-06-10T12:00:00Z");
+const RECENT = new Date("2026-06-09T12:00:00Z");
+const STALE = new Date(NOW.getTime() - (FOLLOW_UP_MAX_AGE_DAYS + 1) * 24 * 60 * 60 * 1000);
+
+function input(overrides: Partial<Parameters<typeof evaluateFollowUpEligibility>[0]> = {}) {
+  return {
+    agentRunEnabled: true,
+    autoFollowUpEnabled: true,
+    confirmed: false,
+    priorRun: { state: "complete", completedAt: RECENT },
+    followUpCount: 0,
+    activeRun: null,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+test("eligible interaction on a recently completed run enqueues", () => {
+  assert.deepEqual(evaluateFollowUpEligibility(input()), { action: "enqueue" });
+});
+
+test("failed prior runs are also revivable", () => {
+  const verdict = evaluateFollowUpEligibility(
+    input({ priorRun: { state: "failed", completedAt: RECENT } }),
+  );
+  assert.deepEqual(verdict, { action: "enqueue" });
+});
+
+test("skips when agent runs are disabled for the project", () => {
+  const verdict = evaluateFollowUpEligibility(input({ agentRunEnabled: false }));
+  assert.deepEqual(verdict, { action: "skip", reason: "agent_runs_disabled" });
+});
+
+test("skips when auto follow-up is disabled and the request is not confirmed", () => {
+  const verdict = evaluateFollowUpEligibility(input({ autoFollowUpEnabled: false }));
+  assert.deepEqual(verdict, { action: "skip", reason: "auto_follow_up_disabled" });
+});
+
+test("a confirmed request bypasses the auto-follow-up gate but not the rest", () => {
+  assert.deepEqual(
+    evaluateFollowUpEligibility(input({ autoFollowUpEnabled: false, confirmed: true })),
+    { action: "enqueue" },
+  );
+  assert.deepEqual(
+    evaluateFollowUpEligibility(
+      input({ autoFollowUpEnabled: false, confirmed: true, followUpCount: MAX_FOLLOW_UP_RUNS }),
+    ),
+    { action: "skip", reason: "follow_up_cap_reached" },
+  );
+});
+
+test("skips when there is no terminal prior run", () => {
+  assert.deepEqual(evaluateFollowUpEligibility(input({ priorRun: null })), {
+    action: "skip",
+    reason: "no_prior_run",
+  });
+  assert.deepEqual(
+    evaluateFollowUpEligibility(input({ priorRun: { state: "running", completedAt: null } })),
+    { action: "skip", reason: "no_prior_run" },
+  );
+});
+
+test("skips interactions older than the staleness window", () => {
+  const verdict = evaluateFollowUpEligibility(
+    input({ priorRun: { state: "complete", completedAt: STALE } }),
+  );
+  assert.deepEqual(verdict, { action: "skip", reason: "prior_run_too_old" });
+});
+
+test("skips once the per-incident follow-up cap is reached", () => {
+  const verdict = evaluateFollowUpEligibility(input({ followUpCount: MAX_FOLLOW_UP_RUNS }));
+  assert.deepEqual(verdict, { action: "skip", reason: "follow_up_cap_reached" });
+});
+
+test("appends to a still-queued follow-up run instead of enqueuing a second", () => {
+  const verdict = evaluateFollowUpEligibility(
+    input({ activeRun: { id: "run-2", state: "queued", trigger: "pr_comment" } }),
+  );
+  assert.deepEqual(verdict, { action: "append", runId: "run-2" });
+});
+
+test("skips while a run is actively executing", () => {
+  const verdict = evaluateFollowUpEligibility(
+    input({ activeRun: { id: "run-2", state: "running", trigger: "pr_comment" } }),
+  );
+  assert.deepEqual(verdict, { action: "skip", reason: "run_active" });
+});
+
+test("skips when the active run is the original (non-follow-up) investigation", () => {
+  const verdict = evaluateFollowUpEligibility(
+    input({ activeRun: { id: "run-1", state: "queued", trigger: "incident" } }),
+  );
+  assert.deepEqual(verdict, { action: "skip", reason: "run_active" });
+});

--- a/packages/db/src/agent-follow-up.test.ts
+++ b/packages/db/src/agent-follow-up.test.ts
@@ -80,6 +80,16 @@ test("skips once the per-incident follow-up cap is reached", () => {
   assert.deepEqual(verdict, { action: "skip", reason: "follow_up_cap_reached" });
 });
 
+test("append wins over the cap so review-burst interactions are not dropped", () => {
+  const verdict = evaluateFollowUpEligibility(
+    input({
+      followUpCount: MAX_FOLLOW_UP_RUNS,
+      activeRun: { id: "run-2", state: "queued", trigger: "pr_comment" },
+    }),
+  );
+  assert.deepEqual(verdict, { action: "append", runId: "run-2" });
+});
+
 test("appends to a still-queued follow-up run instead of enqueuing a second", () => {
   const verdict = evaluateFollowUpEligibility(
     input({ activeRun: { id: "run-2", state: "queued", trigger: "pr_comment" } }),

--- a/packages/db/src/agent-follow-up.ts
+++ b/packages/db/src/agent-follow-up.ts
@@ -1,0 +1,195 @@
+// Follow-up agent runs: a human interaction (PR comment, feedback, Slack
+// reply) after a prior investigation finished revives the agent as a NEW
+// agent_runs row on the same incident. Completed provider sessions cannot be
+// resumed, so revival always means a fresh run that carries the prior run's
+// result, handoff notes, and the triggering interaction in its prompt.
+//
+// Shared between the API (webhooks/interactivity enqueue) and the worker
+// (context assembly), hence it lives in the db package next to the other
+// cross-app domain logic.
+import { and, desc, eq } from "drizzle-orm";
+import type { DB } from "./client.js";
+import * as schema from "./schema.js";
+import type {
+  AgentRunFollowUpInteraction,
+  AgentRunTrigger,
+  AgentRunTriggerDetail,
+} from "./schema.js";
+
+export const MAX_FOLLOW_UP_RUNS = 3;
+export const FOLLOW_UP_MAX_AGE_DAYS = 14;
+
+const TERMINAL_PRIOR_STATES = new Set(["complete", "failed"]);
+const EXECUTING_STATES = [
+  "repo_discovery",
+  "running",
+  "awaiting_human",
+  "pr_retry_queued",
+  "blocked_no_github",
+];
+
+export type FollowUpEligibilityInput = {
+  agentRunEnabled: boolean;
+  autoFollowUpEnabled: boolean;
+  // True for explicitly human-confirmed requests (e.g. the feedback
+  // notification button). Bypasses the auto-follow-up project gate only;
+  // caps and staleness still apply.
+  confirmed: boolean;
+  priorRun: { state: string; completedAt: Date | null } | null;
+  followUpCount: number;
+  activeRun: { id: string; state: string; trigger: AgentRunTrigger } | null;
+  now: Date;
+};
+
+export type FollowUpVerdict =
+  | { action: "enqueue" }
+  | { action: "append"; runId: string }
+  | {
+      action: "skip";
+      reason:
+        | "agent_runs_disabled"
+        | "auto_follow_up_disabled"
+        | "no_prior_run"
+        | "prior_run_too_old"
+        | "follow_up_cap_reached"
+        | "run_active";
+    };
+
+export function evaluateFollowUpEligibility(input: FollowUpEligibilityInput): FollowUpVerdict {
+  if (!input.agentRunEnabled) return { action: "skip", reason: "agent_runs_disabled" };
+  if (!input.autoFollowUpEnabled && !input.confirmed) {
+    return { action: "skip", reason: "auto_follow_up_disabled" };
+  }
+  if (input.followUpCount >= MAX_FOLLOW_UP_RUNS) {
+    return { action: "skip", reason: "follow_up_cap_reached" };
+  }
+  if (input.activeRun) {
+    // A queued follow-up absorbs further interactions (a PR review burst is
+    // one run, not one per comment). Anything past queued is already talking
+    // to a session — don't stack a second run behind it.
+    if (input.activeRun.state === "queued" && input.activeRun.trigger !== "incident") {
+      return { action: "append", runId: input.activeRun.id };
+    }
+    return { action: "skip", reason: "run_active" };
+  }
+  if (!input.priorRun || !TERMINAL_PRIOR_STATES.has(input.priorRun.state)) {
+    return { action: "skip", reason: "no_prior_run" };
+  }
+  const completedAt = input.priorRun.completedAt;
+  const maxAgeMs = FOLLOW_UP_MAX_AGE_DAYS * 24 * 60 * 60 * 1000;
+  if (!completedAt || input.now.getTime() - completedAt.getTime() > maxAgeMs) {
+    return { action: "skip", reason: "prior_run_too_old" };
+  }
+  return { action: "enqueue" };
+}
+
+export type RequestFollowUpResult =
+  | { outcome: "enqueued"; agentRunId: string }
+  | { outcome: "appended"; agentRunId: string }
+  | { outcome: "skipped"; reason: Extract<FollowUpVerdict, { action: "skip" }>["reason"] };
+
+// Evaluate and act: insert a queued follow-up run (with a follow_up_queued
+// timeline event), append the interaction to an already-queued follow-up, or
+// skip. Callers pass the interaction from their channel verbatim.
+export async function requestFollowUpAgentRun(
+  db: DB,
+  args: {
+    incidentId: string;
+    trigger: Exclude<AgentRunTrigger, "incident">;
+    interaction: AgentRunFollowUpInteraction;
+    confirmed?: boolean;
+    now?: Date;
+  },
+): Promise<RequestFollowUpResult> {
+  const now = args.now ?? new Date();
+
+  const incident = await db.query.incidents.findFirst({
+    where: eq(schema.incidents.id, args.incidentId),
+    columns: { id: true, projectId: true },
+  });
+  if (!incident) return { outcome: "skipped", reason: "no_prior_run" };
+
+  const automation = await db.query.projectAutomationSettings.findFirst({
+    where: eq(schema.projectAutomationSettings.projectId, incident.projectId),
+    columns: { agentRunEnabled: true, autoFollowUpEnabled: true, agentRunProvider: true },
+  });
+
+  const runs = await db.query.agentRuns.findMany({
+    where: eq(schema.agentRuns.incidentId, args.incidentId),
+    orderBy: [desc(schema.agentRuns.createdAt)],
+    columns: {
+      id: true,
+      state: true,
+      trigger: true,
+      triggerDetail: true,
+      completedAt: true,
+      runtime: true,
+    },
+  });
+  const activeRun =
+    runs.find((run) => run.state === "queued" || EXECUTING_STATES.includes(run.state)) ?? null;
+  const priorRun = runs.find((run) => TERMINAL_PRIOR_STATES.has(run.state)) ?? null;
+  const followUpCount = runs.filter((run) => run.trigger !== "incident").length;
+
+  const verdict = evaluateFollowUpEligibility({
+    agentRunEnabled: automation?.agentRunEnabled ?? true,
+    autoFollowUpEnabled: automation?.autoFollowUpEnabled ?? true,
+    confirmed: args.confirmed ?? false,
+    priorRun: priorRun ? { state: priorRun.state, completedAt: priorRun.completedAt } : null,
+    followUpCount,
+    activeRun: activeRun
+      ? { id: activeRun.id, state: activeRun.state, trigger: activeRun.trigger }
+      : null,
+    now,
+  });
+
+  if (verdict.action === "skip") return { outcome: "skipped", reason: verdict.reason };
+
+  if (verdict.action === "append") {
+    const existing = activeRun?.triggerDetail ?? { interactions: [] };
+    const detail: AgentRunTriggerDetail = {
+      interactions: [...existing.interactions, args.interaction],
+    };
+    await db
+      .update(schema.agentRuns)
+      .set({ triggerDetail: detail, updatedAt: now })
+      .where(and(eq(schema.agentRuns.id, verdict.runId), eq(schema.agentRuns.state, "queued")));
+    return { outcome: "appended", agentRunId: verdict.runId };
+  }
+
+  const runtime = priorRun?.runtime ?? automation?.agentRunProvider;
+  const [created] = await db
+    .insert(schema.agentRuns)
+    .values({
+      incidentId: args.incidentId,
+      ...(runtime ? { runtime } : {}),
+      state: "queued",
+      trigger: args.trigger,
+      triggerDetail: { interactions: [args.interaction] },
+    })
+    .returning({ id: schema.agentRuns.id });
+  if (!created) throw new Error("failed to enqueue follow-up agent run");
+
+  await db.insert(schema.incidentEvents).values({
+    agentRunId: created.id,
+    incidentId: args.incidentId,
+    kind: "follow_up_queued",
+    summary: followUpQueuedSummary(args.trigger),
+    detail: { trigger: args.trigger, interaction: args.interaction },
+    dedupeKey: `follow_up:${created.id}`,
+    processedAt: now,
+  });
+
+  return { outcome: "enqueued", agentRunId: created.id };
+}
+
+function followUpQueuedSummary(trigger: Exclude<AgentRunTrigger, "incident">): string {
+  switch (trigger) {
+    case "pr_comment":
+      return "Follow-up investigation queued from a pull request comment.";
+    case "feedback":
+      return "Follow-up investigation queued from user feedback.";
+    case "slack_reply":
+      return "Follow-up investigation queued from a Slack reply.";
+  }
+}

--- a/packages/db/src/agent-follow-up.ts
+++ b/packages/db/src/agent-follow-up.ts
@@ -60,17 +60,20 @@ export function evaluateFollowUpEligibility(input: FollowUpEligibilityInput): Fo
   if (!input.autoFollowUpEnabled && !input.confirmed) {
     return { action: "skip", reason: "auto_follow_up_disabled" };
   }
-  if (input.followUpCount >= MAX_FOLLOW_UP_RUNS) {
-    return { action: "skip", reason: "follow_up_cap_reached" };
-  }
   if (input.activeRun) {
     // A queued follow-up absorbs further interactions (a PR review burst is
-    // one run, not one per comment). Anything past queued is already talking
-    // to a session — don't stack a second run behind it.
+    // one run, not one per comment). Checked before the cap on purpose:
+    // appending doesn't create a run, so a burst that crosses the cap mid-
+    // review still lands in the queued run instead of being dropped.
+    // Anything past queued is already talking to a session — don't stack a
+    // second run behind it.
     if (input.activeRun.state === "queued" && input.activeRun.trigger !== "incident") {
       return { action: "append", runId: input.activeRun.id };
     }
     return { action: "skip", reason: "run_active" };
+  }
+  if (input.followUpCount >= MAX_FOLLOW_UP_RUNS) {
+    return { action: "skip", reason: "follow_up_cap_reached" };
   }
   if (!input.priorRun || !TERMINAL_PRIOR_STATES.has(input.priorRun.state)) {
     return { action: "skip", reason: "no_prior_run" };
@@ -150,11 +153,18 @@ export async function requestFollowUpAgentRun(
     const detail: AgentRunTriggerDetail = {
       interactions: [...existing.interactions, args.interaction],
     };
-    await db
+    // The state predicate guards against the run leaving `queued` between
+    // our read and this write; .returning() tells us whether we actually
+    // landed the interaction. On a miss the run is already executing — same
+    // outcome as the run_active skip, and the caller should not believe the
+    // interaction was persisted.
+    const [appended] = await db
       .update(schema.agentRuns)
       .set({ triggerDetail: detail, updatedAt: now })
-      .where(and(eq(schema.agentRuns.id, verdict.runId), eq(schema.agentRuns.state, "queued")));
-    return { outcome: "appended", agentRunId: verdict.runId };
+      .where(and(eq(schema.agentRuns.id, verdict.runId), eq(schema.agentRuns.state, "queued")))
+      .returning({ id: schema.agentRuns.id });
+    if (!appended) return { outcome: "skipped", reason: "run_active" };
+    return { outcome: "appended", agentRunId: appended.id };
   }
 
   const runtime = priorRun?.runtime ?? automation?.agentRunProvider;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -64,6 +64,9 @@ export type {
   AgentMemoryKind,
   AgentMemoryStatus,
   NewAgentMemory,
+  AgentRunTrigger,
+  AgentRunFollowUpInteraction,
+  AgentRunTriggerDetail,
   AgentRunResult,
   AgentRunPr,
   AgentRunLinearTicket,
@@ -107,6 +110,15 @@ export {
   generateWebhookSecret,
 } from "./webhooks.js";
 export { generateCodename } from "./codename.js";
+export {
+  evaluateFollowUpEligibility,
+  requestFollowUpAgentRun,
+  FOLLOW_UP_MAX_AGE_DAYS,
+  MAX_FOLLOW_UP_RUNS,
+  type FollowUpEligibilityInput,
+  type FollowUpVerdict,
+  type RequestFollowUpResult,
+} from "./agent-follow-up.js";
 export {
   isActiveIncidentState,
   buildAgentRunIncidentPatch,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -162,6 +162,23 @@ export type AgentRunConfidence = {
   confidence: number;
 };
 
+export type AgentRunTrigger = "incident" | "pr_comment" | "feedback" | "slack_reply";
+
+export type AgentRunFollowUpInteraction = {
+  channel: Exclude<AgentRunTrigger, "incident">;
+  author: string | null;
+  text: string;
+  // PR comments: the comment URL and, for review comments, the file/line.
+  url?: string | null;
+  path?: string | null;
+  line?: number | null;
+  occurredAt: string;
+};
+
+export type AgentRunTriggerDetail = {
+  interactions: AgentRunFollowUpInteraction[];
+};
+
 export type AgentRunResult = {
   state: "complete" | "awaiting_human" | "failed";
   summary: string;
@@ -675,6 +692,10 @@ export const projectAutomationSettings = pgTable(
     maxHumanResumeCount: integer("max_human_resume_count").notNull().default(3),
     customInstructions: text("custom_instructions").notNull().default(""),
     agentRunEnabled: boolean("agent_run_enabled").notNull().default(true),
+    // Gate for follow-up runs auto-triggered by PR comments and Slack
+    // replies after a prior run completed (feedback-triggered follow-ups
+    // are always confirm-gated regardless).
+    autoFollowUpEnabled: boolean("auto_follow_up_enabled").notNull().default(true),
     linearTicketPolicy: text("linear_ticket_policy")
       .$type<"never" | "on_ready_to_pr" | "always">()
       .notNull()
@@ -724,6 +745,14 @@ export const agentRuns = pgTable(
       .references(() => incidents.id, { onDelete: "cascade" }),
     runtime: text("runtime").notNull().default(DEFAULT_AGENT_RUN_PROVIDER),
     state: text("state").notNull().default("queued"),
+    // What started this run. "incident" is the normal investigation kicked
+    // off when the incident opens; the rest are follow-up runs revived by a
+    // human interaction after a prior run finished.
+    trigger: text("trigger").$type<AgentRunTrigger>().notNull().default("incident"),
+    // For follow-up runs: the interaction(s) that triggered it. Multiple
+    // interactions accumulate while the run is still queued (e.g. a PR
+    // review burst becomes one run, not one per comment).
+    triggerDetail: jsonb("trigger_detail").$type<AgentRunTriggerDetail>(),
     providerSessionId: text("provider_session_id"),
     providerThreadId: text("provider_thread_id"),
     providerSessionStatus: text("provider_session_status"),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -175,6 +175,10 @@ export type AgentRunResult = {
   rootCause?: AgentRunConfidence | null;
   estimatedImpact?: AgentRunConfidence | null;
   severity?: IncidentSeverity | null;
+  // Self-authored handover note for future follow-up runs on this incident:
+  // files/areas examined, hypotheses ruled out and why, repo gotchas. Written
+  // at completion when the agent still has full context.
+  handoffNotes?: string | null;
   mobileRegressionTest?: AgentRunMobileRegressionTest | null;
   noiseClassification?: IncidentNoiseClassification | null;
   resolutionClassification?: IncidentResolutionClassification | null;


### PR DESCRIPTION
## Summary

After an investigation finishes, three kinds of human interaction now revive the agent as a **follow-up run** on the same incident (completed provider sessions cannot be resumed, so revival is a fresh run that inherits the prior run's distilled context):

- **`handoffNotes` on the run result** — the agent self-authors a handover note at completion (files examined, hypotheses ruled out, repo gotchas) while it still has full context; follow-up runs read it. Stored in the result jsonb, no migration.
- **Follow-up core** — `agent_runs.trigger` (`incident` | `pr_comment` | `feedback` | `slack_reply`) + `trigger_detail`; shared `evaluateFollowUpEligibility` (pure) + `requestFollowUpAgentRun` in the db package. Guardrails: per-incident cap of 3 follow-ups, 14-day staleness window, new `project_automation_settings.auto_follow_up_enabled` gate, interactions append to a still-queued follow-up so a PR review burst becomes one run, and nothing stacks behind an actively executing run.
- **Context inheritance** — the run context loads the prior run's result (summary, root cause, handoff notes, validation summary, PR branch/url) plus a condensed incident timeline into `AgentRunnerStartInput.followUp`; project memories were already injected.
- **Slack replies** (auto): a thread reply while a run is `awaiting_human` still resumes the live session; once the run is terminal the reply now enqueues a follow-up instead of being dropped.
- **PR review feedback** (auto): comments/reviews on an agent-opened PR (existing non-bot, repo-associated gating) enqueue a follow-up. Delivery pushes the new patch as an **additional commit on the existing PR branch** and replies on the PR — no second PR; falls back to the normal open-PR path when the prior PR is closed.
- **Feedback** (confirm-gated): feedback that binds to an incident with a finished run posts a 'Run follow-up' button into the incident's Slack thread; the click enqueues with `confirmed=true` (bypasses only the auto-follow-up gate, never the caps).

## Testing

- TDD unit tests: eligibility matrix (11 cases), follow-up context builder, result normalization for handoffNotes, start-input threading.
- Integration check against a live dev DB: enqueue → append-on-burst → `follow_up_queued` timeline event → context load with handoffNotes and timeline.
- Full suites: worker 315/315, db 25/25, api 127/128 (the one failure — github.test.ts merged-PR cascade — reproduces identically on the base commit with a fresh database; pre-existing and unrelated).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds follow-up agent runs that revive an investigation when PR comments, feedback, or Slack replies arrive after a run finishes. Follow-ups inherit prior findings and update the existing PR branch instead of opening a new one.

- **New Features**
  - Follow-up core: new `agent_runs.trigger` and `trigger_detail`, with eligibility in `@superlog/db` `requestFollowUpAgentRun` (cap 3 per incident, 14-day window, project gate `project_automation_settings.auto_follow_up_enabled`, append while queued, skip if running). Append is evaluated before the cap and uses a state-guarded `.returning()` update to avoid races.
  - Context inheritance: prior run summary, root cause, `handoffNotes`, validation, PR branch/url, and a condensed timeline passed via `AgentRunnerStartInput.followUp`.
  - Slack replies: resume the live session if `awaiting_human`; otherwise queue a follow-up.
  - PR review feedback: comments/reviews on an agent PR queue a follow-up; interactions capture comment URL and file/line; delivery pushes a new commit to the existing branch, comments on the PR, posts a Slack thread update, records filed Linear tickets, and logs completion. Patch files are written outside the repo checkout to keep no-op detection correct. Falls back to a new PR if the old one closed.
  - Feedback: posts a “Run follow-up” button in the incident’s Slack thread for incident/PR feedback (mrkdwn-escaped preview); clicking enqueues a confirmed follow-up (bypasses only the auto-follow-up gate) and replies in-thread with the outcome.

- **Migration**
  - Run migration 0066. It adds `agent_runs.trigger`, `agent_runs.trigger_detail`, and `project_automation_settings.auto_follow_up_enabled` (defaults to true). No other steps required.

<sup>Written for commit de7a7ec2233c8532b75327314f668ad384a2ff79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

