### PR TITLE
Retry incident PR close with current installs

### DIFF
--- a/apps/api/src/github-close-pr.test.ts
+++ b/apps/api/src/github-close-pr.test.ts
@@ -4,7 +4,9 @@ import { test } from "node:test";
 process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
 process.env.BETTER_AUTH_SECRET ??= "test-better-auth-secret-with-enough-length";
 
-const { closeGithubPullRequestWithToken } = await import("./github.js");
+const { closeGithubPullRequestWithInstallations, closeGithubPullRequestWithToken } = await import(
+  "./github.js"
+);
 
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
@@ -59,4 +61,32 @@ test("closeGithubPullRequestWithToken falls back to repo URL when node close fai
     "POST https://api.github.com/graphql",
     "PATCH https://api.github.com/repos/current-owner/current-repo/pulls/241",
   ]);
+});
+
+test("closeGithubPullRequestWithInstallations tries fallback installations", async () => {
+  const tokenAttempts: number[] = [];
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    assert.equal(
+      init?.headers && new Headers(init.headers).get("authorization"),
+      "Bearer token-202",
+    );
+    return jsonResponse({ data: { closePullRequest: { pullRequest: { id: "PR_node_1" } } } });
+  };
+
+  const result = await closeGithubPullRequestWithInstallations({
+    installationIds: [101, 202],
+    repoFullName: "old-owner/old-repo",
+    prNumber: 241,
+    prNodeId: "PR_node_1",
+    userAgent: "test",
+    fetchImpl,
+    createWriteToken: async (installationId) => {
+      tokenAttempts.push(installationId);
+      if (installationId === 101) throw new Error("github POST /access_tokens failed: 404");
+      return "token-202";
+    },
+  });
+
+  assert.deepEqual(result, { ok: true });
+  assert.deepEqual(tokenAttempts, [101, 202]);
 });

--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -706,6 +706,7 @@ async function resolveIncidentForMergedAgentPr(opts: {
       closePullRequest: (pr) =>
         closeAgentPullRequestOnGithub({
           installationId: pr.githubInstallationId,
+          fallbackInstallationIds: pr.fallbackGithubInstallationIds,
           repoFullName: pr.repoFullName,
           prNumber: pr.prNumber,
           prNodeId: pr.prNodeId,
@@ -1087,22 +1088,51 @@ export async function mergeGithubPullRequest(opts: {
 
 export async function closeAgentPullRequestOnGithub(opts: {
   installationId: number;
+  fallbackInstallationIds?: number[];
   repoFullName: string;
   prNumber: number;
   prNodeId?: string | null;
 }): Promise<{ ok: true } | { ok: false; error: string }> {
-  try {
-    const token = await createInstallationWriteToken(opts.installationId);
-    return closeGithubPullRequestWithToken({
-      token,
-      repoFullName: opts.repoFullName,
-      prNumber: opts.prNumber,
-      prNodeId: opts.prNodeId,
-      userAgent: "superlog-api",
-    });
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  return closeGithubPullRequestWithInstallations({
+    installationIds: [opts.installationId, ...(opts.fallbackInstallationIds ?? [])],
+    repoFullName: opts.repoFullName,
+    prNumber: opts.prNumber,
+    prNodeId: opts.prNodeId,
+    userAgent: "superlog-api",
+    createWriteToken: createInstallationWriteToken,
+  });
+}
+
+export async function closeGithubPullRequestWithInstallations(opts: {
+  installationIds: number[];
+  repoFullName: string;
+  prNumber: number;
+  prNodeId?: string | null;
+  userAgent: string;
+  fetchImpl?: typeof fetch;
+  createWriteToken: (installationId: number) => Promise<string>;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  const errors: string[] = [];
+  for (const installationId of dedupeInstallationIds(opts.installationIds)) {
+    try {
+      const token = await opts.createWriteToken(installationId);
+      const result = await closeGithubPullRequestWithToken({
+        token,
+        repoFullName: opts.repoFullName,
+        prNumber: opts.prNumber,
+        prNodeId: opts.prNodeId,
+        userAgent: opts.userAgent,
+        fetchImpl: opts.fetchImpl,
+      });
+      if (result.ok) return result;
+      errors.push(`installation ${installationId}: ${result.error}`);
+    } catch (err) {
+      errors.push(
+        `installation ${installationId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
+  return { ok: false, error: errors.join("; ") || "no github installations available" };
 }
 
 export async function closeGithubPullRequestWithToken(opts: {
@@ -1168,6 +1198,10 @@ function parseGithubGraphqlResponse(text: string): { errors?: unknown[] } {
   } catch {
     return { errors: [{ message: "invalid json response" }] };
   }
+}
+
+function dedupeInstallationIds(values: number[]): number[] {
+  return [...new Set(values)];
 }
 
 // Safety ceiling on paginated GitHub list calls: 100 pages × 100 per page =

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1350,6 +1350,7 @@ app.patch("/api/projects/:projectId/incidents/:incidentId", async (c) => {
         closePullRequest: (pr) =>
           closeAgentPullRequestOnGithub({
             installationId: pr.githubInstallationId,
+            fallbackInstallationIds: pr.fallbackGithubInstallationIds,
             repoFullName: pr.repoFullName,
             prNumber: pr.prNumber,
             prNodeId: pr.prNodeId,
@@ -1432,6 +1433,7 @@ async function decideResolutionProposal(
       closePullRequest: (pr) =>
         closeAgentPullRequestOnGithub({
           installationId: pr.githubInstallationId,
+          fallbackInstallationIds: pr.fallbackGithubInstallationIds,
           repoFullName: pr.repoFullName,
           prNumber: pr.prNumber,
           prNodeId: pr.prNodeId,

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -396,6 +396,7 @@ async function runSlackResolvedIncidentSideEffects(incidentId: string): Promise<
     closePullRequest: (pr) =>
       closeAgentPullRequestOnGithub({
         installationId: pr.githubInstallationId,
+        fallbackInstallationIds: pr.fallbackGithubInstallationIds,
         repoFullName: pr.repoFullName,
         prNumber: pr.prNumber,
         prNodeId: pr.prNodeId,
@@ -437,6 +438,7 @@ async function handleProposalDecision(
       closePullRequest: (pr) =>
         closeAgentPullRequestOnGithub({
           installationId: pr.githubInstallationId,
+          fallbackInstallationIds: pr.fallbackGithubInstallationIds,
           repoFullName: pr.repoFullName,
           prNumber: pr.prNumber,
           prNodeId: pr.prNodeId,

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -36,6 +36,7 @@ async function closeOpenPullRequestsForResolvedIncident(incidentId: string): Pro
     closePullRequest: (pr) =>
       closeAgentPullRequestOnGithub({
         installationId: pr.githubInstallationId,
+        fallbackInstallationIds: pr.fallbackGithubInstallationIds,
         repoFullName: pr.repoFullName,
         prNumber: pr.prNumber,
         prNodeId: pr.prNodeId,

--- a/apps/worker/src/github-app.ts
+++ b/apps/worker/src/github-app.ts
@@ -694,22 +694,34 @@ export async function getObsPrMerged(
 
 export async function closeAgentPullRequestOnGithub(opts: {
   installationId: number;
+  fallbackInstallationIds?: number[];
   repoFullName: string;
   prNumber: number;
   prNodeId?: string | null;
 }): Promise<{ ok: true } | { ok: false; error: string }> {
-  try {
-    const token = await createGithubWriteToken(opts.installationId);
-    return closeGithubPullRequestWithToken({
-      token,
-      repoFullName: opts.repoFullName,
-      prNumber: opts.prNumber,
-      prNodeId: opts.prNodeId,
-      userAgent: "superlog-worker",
-    });
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  const errors: string[] = [];
+  for (const installationId of dedupeInstallationIds([
+    opts.installationId,
+    ...(opts.fallbackInstallationIds ?? []),
+  ])) {
+    try {
+      const token = await createGithubWriteToken(installationId);
+      const result = await closeGithubPullRequestWithToken({
+        token,
+        repoFullName: opts.repoFullName,
+        prNumber: opts.prNumber,
+        prNodeId: opts.prNodeId,
+        userAgent: "superlog-worker",
+      });
+      if (result.ok) return result;
+      errors.push(`installation ${installationId}: ${result.error}`);
+    } catch (err) {
+      errors.push(
+        `installation ${installationId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
+  return { ok: false, error: errors.join("; ") || "no github installations available" };
 }
 
 async function closeGithubPullRequestWithToken(opts: {
@@ -772,6 +784,10 @@ function parseGithubGraphqlResponse(text: string): { errors?: unknown[] } {
   } catch {
     return { errors: [{ message: "invalid json response" }] };
   }
+}
+
+function dedupeInstallationIds(values: number[]): number[] {
+  return [...new Set(values)];
 }
 
 export type AutoMergeMethod = "squash" | "merge" | "rebase";

--- a/packages/db/src/incident-pr-resolution.test.ts
+++ b/packages/db/src/incident-pr-resolution.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { type DB } from "./client.js";
+import type { DB } from "./client.js";
 import {
-  closeIncidentOpenPullRequestsAfterResolution,
   type IncidentOpenPullRequestToClose,
+  closeIncidentOpenPullRequestsAfterResolution,
 } from "./incident-pr-resolution.js";
 import * as schema from "./schema.js";
 
@@ -11,8 +11,19 @@ type RecordedCall =
   | { op: "update"; table: unknown; values: Record<string, unknown> }
   | { op: "insert"; table: unknown; values: Record<string, unknown> };
 
-function recordingDb(rows: IncidentOpenPullRequestToClose[]): { db: DB; calls: RecordedCall[] } {
+type OpenPullRequestTestRow = IncidentOpenPullRequestToClose & { projectId?: string | null };
+
+function recordingDb(opts: {
+  openPullRequests: OpenPullRequestTestRow[];
+  projectInstallationIds?: Array<{ projectId: string; githubInstallationId: number }>;
+  projectRepoInstallationIds?: Array<{ projectId: string; githubInstallationId: number }>;
+}): { db: DB; calls: RecordedCall[] } {
   const calls: RecordedCall[] = [];
+  const selectRows = [
+    opts.openPullRequests,
+    opts.projectInstallationIds ?? [],
+    opts.projectRepoInstallationIds ?? [],
+  ];
   const db = {
     select() {
       return {
@@ -21,9 +32,19 @@ function recordingDb(rows: IncidentOpenPullRequestToClose[]): { db: DB; calls: R
             innerJoin() {
               return {
                 async where() {
-                  return rows;
+                  return selectRows.shift() ?? [];
+                },
+                innerJoin() {
+                  return {
+                    async where() {
+                      return selectRows.shift() ?? [];
+                    },
+                  };
                 },
               };
+            },
+            async where() {
+              return selectRows.shift() ?? [];
             },
           };
         },
@@ -57,22 +78,26 @@ function recordingDb(rows: IncidentOpenPullRequestToClose[]): { db: DB; calls: R
 
 test("closeIncidentOpenPullRequestsAfterResolution closes open PRs and records events", async () => {
   const closedAt = new Date("2026-06-07T01:02:03.000Z");
-  const { db, calls } = recordingDb([
-    {
-      id: "pr-1",
-      githubInstallationId: 101,
-      repoFullName: "acme/api",
-      prNumber: 12,
-      prNodeId: "PR_node_1",
-    },
-    {
-      id: "pr-2",
-      githubInstallationId: 202,
-      repoFullName: "acme/web",
-      prNumber: 34,
-      prNodeId: null,
-    },
-  ]);
+  const { db, calls } = recordingDb({
+    openPullRequests: [
+      {
+        id: "pr-1",
+        githubInstallationId: 101,
+        fallbackGithubInstallationIds: [],
+        repoFullName: "acme/api",
+        prNumber: 12,
+        prNodeId: "PR_node_1",
+      },
+      {
+        id: "pr-2",
+        githubInstallationId: 202,
+        fallbackGithubInstallationIds: [],
+        repoFullName: "acme/web",
+        prNumber: 34,
+        prNodeId: null,
+      },
+    ],
+  });
   const closed: string[] = [];
 
   const result = await closeIncidentOpenPullRequestsAfterResolution({
@@ -99,15 +124,18 @@ test("closeIncidentOpenPullRequestsAfterResolution closes open PRs and records e
 });
 
 test("closeIncidentOpenPullRequestsAfterResolution leaves failed PRs open", async () => {
-  const { db, calls } = recordingDb([
-    {
-      id: "pr-1",
-      githubInstallationId: 101,
-      repoFullName: "acme/api",
-      prNumber: 12,
-      prNodeId: "PR_node_1",
-    },
-  ]);
+  const { db, calls } = recordingDb({
+    openPullRequests: [
+      {
+        id: "pr-1",
+        githubInstallationId: 101,
+        fallbackGithubInstallationIds: [],
+        repoFullName: "acme/api",
+        prNumber: 12,
+        prNodeId: "PR_node_1",
+      },
+    ],
+  });
   const failures: string[] = [];
 
   const result = await closeIncidentOpenPullRequestsAfterResolution({
@@ -120,4 +148,37 @@ test("closeIncidentOpenPullRequestsAfterResolution leaves failed PRs open", asyn
   assert.deepEqual(result, { closedPullRequestCount: 0, failedPullRequestCount: 1 });
   assert.deepEqual(failures, ["pr-1:rate_limited"]);
   assert.equal(calls.length, 0);
+});
+
+test("closeIncidentOpenPullRequestsAfterResolution offers current project installations as fallback", async () => {
+  const { db } = recordingDb({
+    openPullRequests: [
+      {
+        id: "pr-1",
+        projectId: "project-1",
+        githubInstallationId: 101,
+        fallbackGithubInstallationIds: [],
+        repoFullName: "old-owner/api",
+        prNumber: 12,
+        prNodeId: "PR_node_1",
+      },
+    ],
+    projectInstallationIds: [
+      { projectId: "project-1", githubInstallationId: 303 },
+      { projectId: "project-1", githubInstallationId: 101 },
+    ],
+    projectRepoInstallationIds: [{ projectId: "project-1", githubInstallationId: 404 }],
+  });
+  const attempted: number[][] = [];
+
+  await closeIncidentOpenPullRequestsAfterResolution({
+    incidentId: "inc-1",
+    database: db,
+    closePullRequest: async (pr) => {
+      attempted.push([pr.githubInstallationId, ...pr.fallbackGithubInstallationIds]);
+      return { ok: true };
+    },
+  });
+
+  assert.deepEqual(attempted, [[101, 303, 404]]);
 });

--- a/packages/db/src/incident-pr-resolution.ts
+++ b/packages/db/src/incident-pr-resolution.ts
@@ -1,13 +1,21 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import type { DB } from "./client.js";
 import * as schema from "./schema.js";
 
 export type IncidentOpenPullRequestToClose = {
   id: string;
   githubInstallationId: number;
+  fallbackGithubInstallationIds: number[];
   repoFullName: string;
   prNumber: number;
   prNodeId: string | null;
+};
+
+type IncidentOpenPullRequestRow = Omit<
+  IncidentOpenPullRequestToClose,
+  "fallbackGithubInstallationIds"
+> & {
+  projectId: string | null;
 };
 
 export type CloseIncidentPullRequest = (
@@ -28,9 +36,10 @@ export async function closeIncidentOpenPullRequestsAfterResolution(opts: {
 }): Promise<CloseIncidentOpenPullRequestsResult> {
   const database = opts.database ?? (await import("./client.js")).db;
   const now = opts.now ?? (() => new Date());
-  const rows = await database
+  const rows = (await database
     .select({
       id: schema.agentPullRequests.id,
+      projectId: schema.incidents.projectId,
       repoFullName: schema.agentPullRequests.repoFullName,
       prNumber: schema.agentPullRequests.prNumber,
       prNodeId: schema.agentPullRequests.prNodeId,
@@ -41,16 +50,30 @@ export async function closeIncidentOpenPullRequestsAfterResolution(opts: {
       schema.githubInstallations,
       eq(schema.githubInstallations.id, schema.agentPullRequests.installationId),
     )
+    .innerJoin(schema.incidents, eq(schema.incidents.id, schema.agentPullRequests.incidentId))
     .where(
       and(
         eq(schema.agentPullRequests.incidentId, opts.incidentId),
         eq(schema.agentPullRequests.state, "open"),
       ),
-    );
+    )) as IncidentOpenPullRequestRow[];
+
+  const fallbackInstallationIdsByProjectId = await loadFallbackInstallationIdsByProjectId(
+    database,
+    rows,
+  );
 
   let closedPullRequestCount = 0;
   let failedPullRequestCount = 0;
-  for (const pr of rows) {
+  for (const row of rows) {
+    const { projectId, ...prWithoutProject } = row;
+    const fallbackGithubInstallationIds = dedupeInstallationIds(
+      fallbackInstallationIdsByProjectId.get(projectId ?? "") ?? [],
+    ).filter((installationId) => installationId !== row.githubInstallationId);
+    const pr: IncidentOpenPullRequestToClose = {
+      ...prWithoutProject,
+      fallbackGithubInstallationIds,
+    };
     const closedAt = now();
     const result = await opts.closePullRequest(pr);
     if (!result.ok) {
@@ -85,4 +108,65 @@ export async function closeIncidentOpenPullRequestsAfterResolution(opts: {
   }
 
   return { closedPullRequestCount, failedPullRequestCount };
+}
+
+async function loadFallbackInstallationIdsByProjectId(
+  database: DB,
+  rows: IncidentOpenPullRequestRow[],
+): Promise<Map<string, number[]>> {
+  const projectIds = dedupeStrings(rows.map((row) => row.projectId).filter((id) => id !== null));
+  const result = new Map<string, number[]>();
+  if (projectIds.length === 0) return result;
+
+  const projectInstallations = await database
+    .select({
+      projectId: schema.githubInstallations.projectId,
+      githubInstallationId: schema.githubInstallations.installationId,
+    })
+    .from(schema.githubInstallations)
+    .where(
+      and(
+        inArray(schema.githubInstallations.projectId, projectIds),
+        isNull(schema.githubInstallations.revokedAt),
+      ),
+    );
+
+  const projectRepoInstallations = await database
+    .select({
+      projectId: schema.projectGithubRepos.projectId,
+      githubInstallationId: schema.githubInstallations.installationId,
+    })
+    .from(schema.projectGithubRepos)
+    .innerJoin(
+      schema.githubInstallations,
+      eq(schema.githubInstallations.id, schema.projectGithubRepos.installationId),
+    )
+    .where(
+      and(
+        inArray(schema.projectGithubRepos.projectId, projectIds),
+        isNull(schema.githubInstallations.revokedAt),
+      ),
+    );
+
+  for (const row of [...projectInstallations, ...projectRepoInstallations]) {
+    if (!row.projectId) continue;
+    const installationIds = result.get(row.projectId) ?? [];
+    installationIds.push(row.githubInstallationId);
+    result.set(row.projectId, installationIds);
+  }
+  return result;
+}
+
+function dedupeStrings(values: (string | null)[]): string[] {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (value) seen.add(value);
+  }
+  return [...seen];
+}
+
+function dedupeInstallationIds(values: number[]): number[] {
+  const seen = new Set<number>();
+  for (const value of values) seen.add(value);
+  return [...seen];
 }


### PR DESCRIPTION
When an incident is resolved, open incident PRs now carry fallback GitHub installation ids from the incident project. The API and worker close paths try the original installation first, then active project installations, so stale install rows do not leave PRs open. Added focused DB and GitHub adapter tests.\n\nChecks: pnpm --filter @superlog/db exec tsx --test src/incident-pr-resolution.test.ts; pnpm --filter @superlog/api exec tsx --test src/github-close-pr.test.ts; pnpm --filter @superlog/db typecheck; pnpm --filter @superlog/api typecheck; pnpm --filter @superlog/worker typecheck; biome check on touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Incident PRs now retry closure using current project GitHub installations when the original install is stale or revoked. This prevents resolved incidents from leaving PRs open.

- **Bug Fixes**
  - DB: `closeIncidentOpenPullRequestsAfterResolution` now attaches `fallbackGithubInstallationIds` from active project-level and repo-level installs (deduped, excluding the primary).
  - API/Worker: added a retry path that tries the original install, then fallbacks (`closeGithubPullRequestWithInstallations`); all resolution entry points now pass fallback IDs (`@superlog/api`, `@superlog/worker`, Slack handlers).
  - Tests: added focused tests in `@superlog/db` and `@superlog/api` covering fallback selection and PR close retries.

<sup>Written for commit deac6c9b2f7ae9e45469afd31fb8e61b821c8a13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

