### PR TITLE
Make the default agent run provider deployment-configurable

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,7 +4,6 @@ import { createClient } from "@clickhouse/client";
 import { serve } from "@hono/node-server";
 import { SpanStatusCode, trace } from "@opentelemetry/api";
 import {
-  DEFAULT_AGENT_RUN_PROVIDER,
   type Issue,
   confirmResolutionProposal,
   createIncidentLifecycle,
@@ -13,6 +12,7 @@ import {
   isAgentRunProvider,
   listAccessibleGithubInstallsForProject,
   mintApiKey,
+  resolveDefaultAgentRunProvider,
   resolveIncident,
   runMigrations,
   schema,
@@ -474,7 +474,7 @@ app.post("/api/me/orgs", async (c) => {
           project = createdProject;
           await tx
             .insert(schema.projectAutomationSettings)
-            .values({ projectId: project.id })
+            .values({ projectId: project.id, agentRunProvider: resolveDefaultAgentRunProvider() })
             .onConflictDoNothing({ target: schema.projectAutomationSettings.projectId });
         }
         return {
@@ -503,7 +503,7 @@ app.post("/api/me/orgs", async (c) => {
 
       await tx
         .insert(schema.projectAutomationSettings)
-        .values({ projectId: project.id })
+        .values({ projectId: project.id, agentRunProvider: resolveDefaultAgentRunProvider() })
         .onConflictDoNothing({ target: schema.projectAutomationSettings.projectId });
 
       // Promote the new org to active on every session this user has open, so the
@@ -1131,7 +1131,7 @@ async function getProjectAutomation(projectId: string): Promise<{
   });
   return {
     autoInvestigateIssuesEnabled: row?.autoInvestigateIssuesEnabled ?? true,
-    agentRunProvider: row?.agentRunProvider ?? DEFAULT_AGENT_RUN_PROVIDER,
+    agentRunProvider: row?.agentRunProvider ?? resolveDefaultAgentRunProvider(),
     maxRuntimeMinutes: row?.maxRuntimeMinutes ?? 90,
     maxHumanResumeCount: row?.maxHumanResumeCount ?? 3,
     customInstructions: row?.customInstructions ?? "",

--- a/apps/api/src/management.ts
+++ b/apps/api/src/management.ts
@@ -6,6 +6,7 @@ import {
   isOrgManagementKey,
   mintApiKey,
   mintOrgApiKey,
+  resolveDefaultAgentRunProvider,
   resolveOrgApiKey,
   schema,
 } from "@superlog/db";
@@ -251,6 +252,7 @@ export function mountManagementApi(app: Hono<any>, opts: { ch: ClickHouseClient 
         .insert(schema.projectAutomationSettings)
         .values({
           projectId: project.id,
+          agentRunProvider: resolveDefaultAgentRunProvider(),
           ...(body.automerge_fix_prs !== undefined
             ? { autoMergeFixPrs: body.automerge_fix_prs }
             : {}),
@@ -448,6 +450,7 @@ export function mountManagementApi(app: Hono<any>, opts: { ch: ClickHouseClient 
           .insert(schema.projectAutomationSettings)
           .values({
             projectId: project.id,
+            agentRunProvider: resolveDefaultAgentRunProvider(),
             ...(body.automerge_fix_prs !== undefined
               ? { autoMergeFixPrs: body.automerge_fix_prs }
               : {}),

--- a/apps/api/src/org-context.ts
+++ b/apps/api/src/org-context.ts
@@ -1,4 +1,4 @@
-import { db, schema } from "@superlog/db";
+import { db, resolveDefaultAgentRunProvider, schema } from "@superlog/db";
 import { and, eq } from "drizzle-orm";
 
 // Org context resolution backed by Better Auth's session + organization
@@ -41,7 +41,7 @@ async function ensureProjectForOrg(orgId: string): Promise<SyncedProject> {
 
   await db
     .insert(schema.projectAutomationSettings)
-    .values({ projectId: project.id })
+    .values({ projectId: project.id, agentRunProvider: resolveDefaultAgentRunProvider() })
     .onConflictDoNothing({ target: schema.projectAutomationSettings.projectId });
 
   return project;

--- a/apps/api/src/settings.ts
+++ b/apps/api/src/settings.ts
@@ -1,4 +1,9 @@
-import { db, encryptIntegrationSecret, schema } from "@superlog/db";
+import {
+  db,
+  encryptIntegrationSecret,
+  resolveDefaultAgentRunProvider,
+  schema,
+} from "@superlog/db";
 import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import type { Hono } from "hono";
 import type { Context } from "hono";
@@ -365,7 +370,7 @@ export function mountSettingsAuthed(app: Hono<any>): void {
     if (!project) return c.json({ error: "failed to create project" }, 500);
     await db
       .insert(schema.projectAutomationSettings)
-      .values({ projectId: project.id })
+      .values({ projectId: project.id, agentRunProvider: resolveDefaultAgentRunProvider() })
       .onConflictDoNothing({ target: schema.projectAutomationSettings.projectId });
     return c.json({
       project: {

--- a/apps/worker/src/agent-run-context.ts
+++ b/apps/worker/src/agent-run-context.ts
@@ -1,8 +1,8 @@
 import {
   type AccessibleGithubInstall,
-  DEFAULT_AGENT_RUN_PROVIDER,
   db,
   listAccessibleGithubInstallsForProject,
+  resolveDefaultAgentRunProvider,
   schema,
 } from "@superlog/db";
 import { and, asc, desc, eq, inArray, isNull, ne } from "drizzle-orm";
@@ -108,7 +108,7 @@ export async function getProjectAutomation(projectId: string): Promise<{
   });
   return {
     autoInvestigateIssuesEnabled: row?.autoInvestigateIssuesEnabled ?? true,
-    agentRunProvider: row?.agentRunProvider ?? DEFAULT_AGENT_RUN_PROVIDER,
+    agentRunProvider: row?.agentRunProvider ?? resolveDefaultAgentRunProvider(),
     maxRuntimeMinutes: row?.maxRuntimeMinutes ?? 90,
     maxHumanResumeCount: row?.maxHumanResumeCount ?? 3,
     customInstructions: row?.customInstructions ?? "",

--- a/packages/db/src/agent-runtime.test.ts
+++ b/packages/db/src/agent-runtime.test.ts
@@ -4,10 +4,37 @@ import {
   AGENT_RUN_PROVIDERS,
   DEFAULT_AGENT_RUN_PROVIDER,
   isAgentRunProvider,
+  resolveDefaultAgentRunProvider,
 } from "./agent-runtime.js";
 
 test("agent runtime defaults to the community provider", () => {
   assert.equal(DEFAULT_AGENT_RUN_PROVIDER, "community");
+});
+
+test("resolveDefaultAgentRunProvider falls back to community when env is unset", () => {
+  assert.equal(resolveDefaultAgentRunProvider({}), DEFAULT_AGENT_RUN_PROVIDER);
+  assert.equal(
+    resolveDefaultAgentRunProvider({ DEFAULT_AGENT_RUN_PROVIDER: "" }),
+    DEFAULT_AGENT_RUN_PROVIDER,
+  );
+});
+
+test("resolveDefaultAgentRunProvider honors a valid env override", () => {
+  assert.equal(
+    resolveDefaultAgentRunProvider({ DEFAULT_AGENT_RUN_PROVIDER: "anthropic" }),
+    "anthropic",
+  );
+  assert.equal(
+    resolveDefaultAgentRunProvider({ DEFAULT_AGENT_RUN_PROVIDER: "disabled" }),
+    "disabled",
+  );
+});
+
+test("resolveDefaultAgentRunProvider rejects invalid env values loudly", () => {
+  assert.throws(
+    () => resolveDefaultAgentRunProvider({ DEFAULT_AGENT_RUN_PROVIDER: "antropic" }),
+    /DEFAULT_AGENT_RUN_PROVIDER must be one of/,
+  );
 });
 
 test("agent runtime validation accepts public and closed-overlay providers", () => {

--- a/packages/db/src/agent-runtime.ts
+++ b/packages/db/src/agent-runtime.ts
@@ -7,3 +7,23 @@ export type AgentRunProvider = (typeof AGENT_RUN_PROVIDERS)[number];
 export function isAgentRunProvider(value: unknown): value is AgentRunProvider {
   return typeof value === "string" && AGENT_RUN_PROVIDERS.includes(value as AgentRunProvider);
 }
+
+/**
+ * Deployment-level default for new projects (and projects without an
+ * automation row). Set the DEFAULT_AGENT_RUN_PROVIDER env var to override the
+ * built-in community default — e.g. a hosted deployment that runs every
+ * project on a managed runner. Invalid values throw so a typo in deploy config
+ * fails loudly instead of silently reverting to community.
+ */
+export function resolveDefaultAgentRunProvider(
+  env: Record<string, string | undefined> = process.env,
+): AgentRunProvider {
+  const value = env.DEFAULT_AGENT_RUN_PROVIDER;
+  if (value === undefined || value === "") return DEFAULT_AGENT_RUN_PROVIDER;
+  if (!isAgentRunProvider(value)) {
+    throw new Error(
+      `DEFAULT_AGENT_RUN_PROVIDER must be one of: ${AGENT_RUN_PROVIDERS.join(", ")} (got "${value}")`,
+    );
+  }
+  return value;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4,6 +4,7 @@ export {
   AGENT_RUN_PROVIDERS,
   DEFAULT_AGENT_RUN_PROVIDER,
   isAgentRunProvider,
+  resolveDefaultAgentRunProvider,
   type AgentRunProvider,
 } from "./agent-runtime.js";
 export { runMigrations } from "./migrate.js";


### PR DESCRIPTION
## What

Adds `resolveDefaultAgentRunProvider()` to `@superlog/db`: reads the `DEFAULT_AGENT_RUN_PROVIDER` env var, validates it against the known providers (`community`, `anthropic`, `disabled`), throws on invalid values so a deploy-config typo fails loudly, and falls back to the built-in `community` default when unset.

Applied at:
- every `projectAutomationSettings` insert site in the API (org/project creation, management API, settings), so new projects pick up the deployment default instead of the bare schema default
- the missing-row fallbacks in the API and worker (`getProjectAutomation`)

## Why

The default provider was hardcoded to `community` via the schema column default. A hosted deployment that wants every new project on a managed runner (e.g. `anthropic`) had no way to configure that. Self-hosted setups are unaffected: with the env var unset, behavior is identical to today.

## Testing

- New unit tests for `resolveDefaultAgentRunProvider` (unset/empty → community, valid override honored, invalid value throws)
- `pnpm --filter @superlog/db test`, `--filter @superlog/api test`, `--filter @superlog/worker test` all pass
- Typecheck clean across db/api/worker

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the default agent run provider deployment-configurable so new projects use your chosen provider. `@superlog/db` adds `resolveDefaultAgentRunProvider()` to read and validate the DEFAULT_AGENT_RUN_PROVIDER env, and the API/worker use it for inserts and fallbacks.

- **New Features**
  - `@superlog/db`: added `resolveDefaultAgentRunProvider()`; validates against `community`, `anthropic`, `disabled`; throws on invalid; falls back to `community` when unset.
  - API: applies the resolved default on project automation inserts (`index.ts`, `org-context.ts`, `management.ts`, `settings.ts`).
  - Worker: uses the resolved default when automation settings are missing.
  - Tests: unit tests for the resolver; typecheck clean across `@superlog/db`, `@superlog/api`, `@superlog/worker`.

<sup>Written for commit de85e79055dabe0f15da5dc9e1c86a4edf70193a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

