### PR TITLE
Allow configuring the default agent run provider

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,7 +4,6 @@ import { createClient } from "@clickhouse/client";
 import { serve } from "@hono/node-server";
 import { SpanStatusCode, trace } from "@opentelemetry/api";
 import {
-  DEFAULT_AGENT_RUN_PROVIDER,
   type Issue,
   confirmResolutionProposal,
   createIncidentLifecycle,
@@ -13,6 +12,7 @@ import {
   isAgentRunProvider,
   listAccessibleGithubInstallsForProject,
   mintApiKey,
+  resolveDefaultAgentRunProvider,
   resolveIncident,
   runMigrations,
   schema,
@@ -474,7 +474,7 @@ app.post("/api/me/orgs", async (c) => {
           project = createdProject;
           await tx
             .insert(schema.projectAutomationSettings)
-            .values({ projectId: project.id })
+            .values({ projectId: project.id, agentRunProvider: resolveDefaultAgentRunProvider() })
             .onConflictDoNothing({ target: schema.projectAutomationSettings.projectId });
         }
         return {
@@ -503,7 +503,7 @@ app.post("/api/me/orgs", async (c) => {
 
       await tx
         .insert(schema.projectAutomationSettings)
-        .values({ projectId: project.id })
+        .values({ projectId: project.id, agentRunProvider: resolveDefaultAgentRunProvider() })
         .onConflictDoNothing({ target: schema.projectAutomationSettings.projectId });
 
       // Promote the new org to active on every session this user has open, so the
@@ -1131,7 +1131,7 @@ async function getProjectAutomation(projectId: string): Promise<{
   });
   return {
     autoInvestigateIssuesEnabled: row?.autoInvestigateIssuesEnabled ?? true,
-    agentRunProvider: row?.agentRunProvider ?? DEFAULT_AGENT_RUN_PROVIDER,
+    agentRunProvider: row?.agentRunProvider ?? resolveDefaultAgentRunProvider(),
     maxRuntimeMinutes: row?.maxRuntimeMinutes ?? 90,
     maxHumanResumeCount: row?.maxHumanResumeCount ?? 3,
     customInstructions: row?.customInstructions ?? "",

--- a/apps/api/src/management.ts
+++ b/apps/api/src/management.ts
@@ -6,6 +6,7 @@ import {
   isOrgManagementKey,
   mintApiKey,
   mintOrgApiKey,
+  resolveDefaultAgentRunProvider,
   resolveOrgApiKey,
   schema,
 } from "@superlog/db";
@@ -251,6 +252,7 @@ export function mountManagementApi(app: Hono<any>, opts: { ch: ClickHouseClient 
         .insert(schema.projectAutomationSettings)
         .values({
           projectId: project.id,
+          agentRunProvider: resolveDefaultAgentRunProvider(),
           ...(body.automerge_fix_prs !== undefined
             ? { autoMergeFixPrs: body.automerge_fix_prs }
             : {}),
@@ -448,6 +450,7 @@ export function mountManagementApi(app: Hono<any>, opts: { ch: ClickHouseClient 
           .insert(schema.projectAutomationSettings)
           .values({
             projectId: project.id,
+            agentRunProvider: resolveDefaultAgentRunProvider(),
             ...(body.automerge_fix_prs !== undefined
               ? { autoMergeFixPrs: body.automerge_fix_prs }
               : {}),

--- a/apps/api/src/org-context.ts
+++ b/apps/api/src/org-context.ts
@@ -1,4 +1,4 @@
-import { db, schema } from "@superlog/db";
+import { db, resolveDefaultAgentRunProvider, schema } from "@superlog/db";
 import { and, eq } from "drizzle-orm";
 
 // Org context resolution backed by Better Auth's session + organization
@@ -41,7 +41,7 @@ async function ensureProjectForOrg(orgId: string): Promise<SyncedProject> {
 
   await db
     .insert(schema.projectAutomationSettings)
-    .values({ projectId: project.id })
+    .values({ projectId: project.id, agentRunProvider: resolveDefaultAgentRunProvider() })
     .onConflictDoNothing({ target: schema.projectAutomationSettings.projectId });
 
   return project;

--- a/apps/api/src/settings.ts
+++ b/apps/api/src/settings.ts
@@ -1,4 +1,9 @@
-import { db, encryptIntegrationSecret, schema } from "@superlog/db";
+import {
+  db,
+  encryptIntegrationSecret,
+  resolveDefaultAgentRunProvider,
+  schema,
+} from "@superlog/db";
 import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import type { Hono } from "hono";
 import type { Context } from "hono";
@@ -365,7 +370,7 @@ export function mountSettingsAuthed(app: Hono<any>): void {
     if (!project) return c.json({ error: "failed to create project" }, 500);
     await db
       .insert(schema.projectAutomationSettings)
-      .values({ projectId: project.id })
+      .values({ projectId: project.id, agentRunProvider: resolveDefaultAgentRunProvider() })
       .onConflictDoNothing({ target: schema.projectAutomationSettings.projectId });
     return c.json({
       project: {

--- a/apps/worker/src/agent-run-context.ts
+++ b/apps/worker/src/agent-run-context.ts
@@ -1,8 +1,8 @@
 import {
   type AccessibleGithubInstall,
-  DEFAULT_AGENT_RUN_PROVIDER,
   db,
   listAccessibleGithubInstallsForProject,
+  resolveDefaultAgentRunProvider,
   schema,
 } from "@superlog/db";
 import { and, asc, desc, eq, inArray, isNull, ne } from "drizzle-orm";
@@ -108,7 +108,7 @@ export async function getProjectAutomation(projectId: string): Promise<{
   });
   return {
     autoInvestigateIssuesEnabled: row?.autoInvestigateIssuesEnabled ?? true,
-    agentRunProvider: row?.agentRunProvider ?? DEFAULT_AGENT_RUN_PROVIDER,
+    agentRunProvider: row?.agentRunProvider ?? resolveDefaultAgentRunProvider(),
     maxRuntimeMinutes: row?.maxRuntimeMinutes ?? 90,
     maxHumanResumeCount: row?.maxHumanResumeCount ?? 3,
     customInstructions: row?.customInstructions ?? "",

--- a/packages/db/src/agent-runtime.test.ts
+++ b/packages/db/src/agent-runtime.test.ts
@@ -4,10 +4,35 @@ import {
   AGENT_RUN_PROVIDERS,
   DEFAULT_AGENT_RUN_PROVIDER,
   isAgentRunProvider,
+  resolveDefaultAgentRunProvider,
 } from "./agent-runtime.js";
 
 test("agent runtime defaults to the community provider", () => {
   assert.equal(DEFAULT_AGENT_RUN_PROVIDER, "community");
+});
+
+test("resolveDefaultAgentRunProvider falls back to community when env is unset", () => {
+  assert.equal(resolveDefaultAgentRunProvider({}), DEFAULT_AGENT_RUN_PROVIDER);
+  assert.equal(
+    resolveDefaultAgentRunProvider({ DEFAULT_AGENT_RUN_PROVIDER: "" }),
+    DEFAULT_AGENT_RUN_PROVIDER,
+  );
+});
+
+test("resolveDefaultAgentRunProvider honors a valid env override", () => {
+  for (const provider of AGENT_RUN_PROVIDERS) {
+    assert.equal(
+      resolveDefaultAgentRunProvider({ DEFAULT_AGENT_RUN_PROVIDER: provider }),
+      provider,
+    );
+  }
+});
+
+test("resolveDefaultAgentRunProvider rejects invalid env values loudly", () => {
+  assert.throws(
+    () => resolveDefaultAgentRunProvider({ DEFAULT_AGENT_RUN_PROVIDER: "antropic" }),
+    /DEFAULT_AGENT_RUN_PROVIDER must be one of/,
+  );
 });
 
 test("agent runtime validation accepts public and closed-overlay providers", () => {

--- a/packages/db/src/agent-runtime.ts
+++ b/packages/db/src/agent-runtime.ts
@@ -7,3 +7,23 @@ export type AgentRunProvider = (typeof AGENT_RUN_PROVIDERS)[number];
 export function isAgentRunProvider(value: unknown): value is AgentRunProvider {
   return typeof value === "string" && AGENT_RUN_PROVIDERS.includes(value as AgentRunProvider);
 }
+
+/**
+ * Default provider for new projects (and projects without an automation row).
+ * Deployments can override the built-in default with the
+ * DEFAULT_AGENT_RUN_PROVIDER env var — e.g. set it to "disabled" to keep agent
+ * runs off until a project opts in. Invalid values throw so a deploy-config
+ * typo fails loudly instead of silently falling back.
+ */
+export function resolveDefaultAgentRunProvider(
+  env: Record<string, string | undefined> = process.env,
+): AgentRunProvider {
+  const value = env.DEFAULT_AGENT_RUN_PROVIDER;
+  if (value === undefined || value === "") return DEFAULT_AGENT_RUN_PROVIDER;
+  if (!isAgentRunProvider(value)) {
+    throw new Error(
+      `DEFAULT_AGENT_RUN_PROVIDER must be one of: ${AGENT_RUN_PROVIDERS.join(", ")} (got "${value}")`,
+    );
+  }
+  return value;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4,6 +4,7 @@ export {
   AGENT_RUN_PROVIDERS,
   DEFAULT_AGENT_RUN_PROVIDER,
   isAgentRunProvider,
+  resolveDefaultAgentRunProvider,
   type AgentRunProvider,
 } from "./agent-runtime.js";
 export { runMigrations } from "./migrate.js";


### PR DESCRIPTION
## What

Adds `resolveDefaultAgentRunProvider()` to `@superlog/db`: reads the `DEFAULT_AGENT_RUN_PROVIDER` env var, validates it against the known providers, throws on invalid values so a deploy-config typo fails loudly, and falls back to the built-in default when unset.

Applied at:
- every `projectAutomationSettings` insert site in the API (org/project creation, management API, settings)
- the missing-row fallbacks in the API and worker (`getProjectAutomation`)

## Why

The default provider was only expressible as the schema column default, so a deployment couldn't choose a different default for new projects — e.g. setting `DEFAULT_AGENT_RUN_PROVIDER=disabled` to keep agent runs off until a project opts in. With the env var unset, behavior is unchanged.

## Testing

- Unit tests for `resolveDefaultAgentRunProvider` (unset/empty → built-in default, every valid provider honored, invalid value throws)
- `pnpm --filter @superlog/db|api|worker test` pass, typecheck clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets deployments configure the default agent run provider via the `DEFAULT_AGENT_RUN_PROVIDER` env var. Adds a resolver in `@superlog/db` and uses it across API/worker so new projects and missing rows honor the configured default; falls back when unset and throws on invalid values.

- **New Features**
  - Added `resolveDefaultAgentRunProvider()` in `@superlog/db`; validates against `AGENT_RUN_PROVIDERS`, falls back to `DEFAULT_AGENT_RUN_PROVIDER`, throws on invalid.
  - Applied on all `projectAutomationSettings` inserts (org/project creation, management API, settings) and in `getProjectAutomation` fallbacks in API and worker.
  - Unset env keeps current behavior; set to `disabled` to default agent runs off.
  - Added unit tests for resolver behavior.

<sup>Written for commit b89b5c1b9a08b519055a08b221fed44782636a4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

