### PR TITLE
Agent-run health gauges + per-reason failure fingerprints

### DIFF
--- a/apps/worker/src/agent-run-health-metrics.test.ts
+++ b/apps/worker/src/agent-run-health-metrics.test.ts
@@ -1,0 +1,48 @@
+import "./agent-run.test-env.js";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  type AgentRunHealthCounts,
+  buildAgentRunHealthObservations,
+} from "./agent-run-health-metrics.js";
+
+const COUNTS: AgentRunHealthCounts = {
+  failedRecentByReason: { patch_validation_failed: 7, sync_failed: 2 },
+  completedRecent: 31,
+  stuck: 4,
+  queued: 12,
+  awaitingHuman: 3,
+};
+
+test("health counts map onto the agent_runs gauges", () => {
+  const observations = buildAgentRunHealthObservations(COUNTS);
+
+  const byMetric = new Map(
+    observations.map((o) => [`${o.metric}|${o.attributes?.["failure.reason"] ?? ""}`, o.value]),
+  );
+  assert.equal(byMetric.get("superlog.agent_runs.stuck|"), 4);
+  assert.equal(byMetric.get("superlog.agent_runs.queued|"), 12);
+  assert.equal(byMetric.get("superlog.agent_runs.awaiting_human|"), 3);
+  assert.equal(byMetric.get("superlog.agent_runs.completed_recent|"), 31);
+  assert.equal(byMetric.get("superlog.agent_runs.failed_recent|patch_validation_failed"), 7);
+  assert.equal(byMetric.get("superlog.agent_runs.failed_recent|sync_failed"), 2);
+});
+
+test("zero failures still observe gauges so the series never goes dark", () => {
+  const observations = buildAgentRunHealthObservations({
+    failedRecentByReason: {},
+    completedRecent: 0,
+    stuck: 0,
+    queued: 0,
+    awaitingHuman: 0,
+  });
+  const metrics = observations.map((o) => o.metric);
+  assert.ok(metrics.includes("superlog.agent_runs.stuck"));
+  assert.ok(metrics.includes("superlog.agent_runs.queued"));
+  // A zero-failure pass emits an explicit zero (no reason attribute) so charts
+  // drop to 0 instead of holding the last bad value.
+  const failed = observations.find((o) => o.metric === "superlog.agent_runs.failed_recent");
+  assert.ok(failed);
+  assert.equal(failed.value, 0);
+  assert.equal(failed.attributes?.["failure.reason"], "none");
+});

--- a/apps/worker/src/agent-run-health-metrics.ts
+++ b/apps/worker/src/agent-run-health-metrics.ts
@@ -1,0 +1,145 @@
+import { metrics } from "@opentelemetry/api";
+import { db } from "@superlog/db";
+import { sql } from "drizzle-orm";
+import { logger } from "./logger.js";
+
+// Agent-run health gauges, exported through the worker's own OTel pipeline
+// (same pattern as tenant-metrics.ts). These power dashboards/alerts on
+// investigations piling up in a bad state: failures by reason, runs stuck
+// past their runtime budget, and current queue depth.
+
+const meter = metrics.getMeter("@superlog/worker/agent-runs");
+
+export type AgentRunHealthCounts = {
+  // state='failed' within the recent window, keyed by failure_reason.
+  failedRecentByReason: Record<string, number>;
+  completedRecent: number;
+  // Non-terminal, non-human-gated runs older than the stuck threshold.
+  stuck: number;
+  queued: number;
+  awaitingHuman: number;
+};
+
+export type AgentRunHealthObservation = {
+  metric: string;
+  value: number;
+  attributes?: Record<string, string>;
+};
+
+// The 1h window matches "how bad is it right now" rather than all-time
+// counters; the 2h stuck threshold sits above the 90-minute default
+// maxRuntimeMinutes, so anything non-terminal past it has outlived its own
+// budget. awaiting_human is excluded from stuck — parked on a human is
+// waiting, not stuck — but exposed as its own gauge.
+export async function loadAgentRunHealthCounts(): Promise<AgentRunHealthCounts> {
+  const failedRows = (await db.execute<{ reason: string; count: number }>(sql`
+    SELECT coalesce(nullif(failure_reason, ''), 'unknown') AS reason, count(*)::int AS count
+    FROM agent_runs
+    WHERE state = 'failed' AND updated_at > now() - interval '1 hour'
+    GROUP BY 1
+  `)) as unknown as Array<{ reason: string; count: number }>;
+
+  const gaugeRows = (await db.execute<{
+    completed: number;
+    stuck: number;
+    queued: number;
+    awaiting: number;
+  }>(sql`
+    SELECT
+      count(*) FILTER (WHERE state = 'complete' AND updated_at > now() - interval '1 hour')::int AS completed,
+      count(*) FILTER (
+        WHERE state NOT IN ('complete', 'failed', 'awaiting_human')
+          AND created_at < now() - interval '2 hours'
+      )::int AS stuck,
+      count(*) FILTER (WHERE state = 'queued')::int AS queued,
+      count(*) FILTER (WHERE state = 'awaiting_human')::int AS awaiting
+    FROM agent_runs
+  `)) as unknown as Array<{ completed: number; stuck: number; queued: number; awaiting: number }>;
+
+  const gauges = gaugeRows[0] ?? { completed: 0, stuck: 0, queued: 0, awaiting: 0 };
+  return {
+    failedRecentByReason: Object.fromEntries(failedRows.map((r) => [r.reason, Number(r.count)])),
+    completedRecent: Number(gauges.completed),
+    stuck: Number(gauges.stuck),
+    queued: Number(gauges.queued),
+    awaitingHuman: Number(gauges.awaiting),
+  };
+}
+
+// Pure mapping from counts to gauge observations — kept separate from the OTel
+// callback so it's unit-testable. A zero-failure pass still emits an explicit
+// zero (failure.reason="none") so charts drop to 0 instead of holding the last
+// bad value when a reason's series stops being observed.
+export function buildAgentRunHealthObservations(
+  counts: AgentRunHealthCounts,
+): AgentRunHealthObservation[] {
+  const observations: AgentRunHealthObservation[] = [
+    { metric: "superlog.agent_runs.stuck", value: counts.stuck },
+    { metric: "superlog.agent_runs.queued", value: counts.queued },
+    { metric: "superlog.agent_runs.awaiting_human", value: counts.awaitingHuman },
+    { metric: "superlog.agent_runs.completed_recent", value: counts.completedRecent },
+  ];
+  const reasons = Object.entries(counts.failedRecentByReason);
+  if (reasons.length === 0) {
+    observations.push({
+      metric: "superlog.agent_runs.failed_recent",
+      value: 0,
+      attributes: { "failure.reason": "none" },
+    });
+  }
+  for (const [reason, count] of reasons) {
+    observations.push({
+      metric: "superlog.agent_runs.failed_recent",
+      value: count,
+      attributes: { "failure.reason": reason },
+    });
+  }
+  return observations;
+}
+
+let cached: { at: number; counts: AgentRunHealthCounts } | null = null;
+const CACHE_TTL_MS = 30_000;
+
+async function snapshot(): Promise<AgentRunHealthCounts> {
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return cached.counts;
+  const counts = await loadAgentRunHealthCounts();
+  cached = { at: Date.now(), counts };
+  return counts;
+}
+
+export function registerAgentRunHealthMetrics(): void {
+  const gauges = {
+    "superlog.agent_runs.failed_recent": meter.createObservableGauge(
+      "superlog.agent_runs.failed_recent",
+      { description: "Agent runs that failed in the last hour, by failure.reason." },
+    ),
+    "superlog.agent_runs.stuck": meter.createObservableGauge("superlog.agent_runs.stuck", {
+      description: "Non-terminal agent runs (excluding awaiting_human) older than 2 hours.",
+    }),
+    "superlog.agent_runs.queued": meter.createObservableGauge("superlog.agent_runs.queued", {
+      description: "Agent runs currently queued.",
+    }),
+    "superlog.agent_runs.awaiting_human": meter.createObservableGauge(
+      "superlog.agent_runs.awaiting_human",
+      { description: "Agent runs parked on a human response." },
+    ),
+    "superlog.agent_runs.completed_recent": meter.createObservableGauge(
+      "superlog.agent_runs.completed_recent",
+      { description: "Agent runs that completed in the last hour." },
+    ),
+  } as const;
+
+  meter.addBatchObservableCallback(
+    async (result) => {
+      try {
+        const counts = await snapshot();
+        for (const obs of buildAgentRunHealthObservations(counts)) {
+          result.observe(gauges[obs.metric as keyof typeof gauges], obs.value, obs.attributes);
+        }
+      } catch (err) {
+        logger.error({ err, scope: "agent-run-health-metrics" }, "agent run health observe failed");
+      }
+    },
+    Object.values(gauges),
+  );
+}

--- a/apps/worker/src/agent-runs/status.test.ts
+++ b/apps/worker/src/agent-runs/status.test.ts
@@ -86,3 +86,24 @@ test("exceededWallClockBudget is independent of provider-reported activeSeconds"
     true,
   );
 });
+
+test("failure log messages split log fingerprints per failure reason", async () => {
+  const { fingerprintLog, messageBucketFor } = await import("@superlog/fingerprint");
+  const { agentRunFailureLogMessage } = await import("./status.js");
+
+  const validation = agentRunFailureLogMessage("patch_validation_failed");
+  const sync = agentRunFailureLogMessage("sync_failed");
+
+  // Human-readable, no >=20-char tokens that messageBucketFor would collapse
+  // into <id> (the raw enum `patch_validation_failed` is 23 chars and would).
+  assert.equal(validation, "agent run failed: patch validation failed");
+  assert.equal(sync, "agent run failed: sync failed");
+
+  // Different reasons must land in different issues AND different buckets —
+  // a single shared fingerprint is how the June pileup hid inside a
+  // three-week-old open incident.
+  const fp = (body: string) =>
+    fingerprintLog({ body, severity: "ERROR", service: "superlog-worker" }).hash;
+  assert.notEqual(fp(validation), fp(sync));
+  assert.notEqual(messageBucketFor(validation), messageBucketFor(sync));
+});

--- a/apps/worker/src/agent-runs/status.ts
+++ b/apps/worker/src/agent-runs/status.ts
@@ -67,6 +67,16 @@ export function agentRunErrorLogMeta(err: unknown): Record<string, string> | nul
   return Object.keys(meta).length > 0 ? meta : null;
 }
 
+// Failure log message with the reason inlined as plain words. The reason must
+// be in the message body (not only in structured attrs) because log issues
+// fingerprint on the normalized body — a constant "agent run failed" string
+// collapses every failure mode into one issue forever, so a brand-new failure
+// mode never produces a new issue/incident/investigation. Spaces instead of
+// underscores keep messageBucketFor from collapsing long enum tokens to <id>.
+export function agentRunFailureLogMessage(reason: schema.AgentRunFailureReason): string {
+  return `agent run failed: ${reason.replaceAll("_", " ")}`;
+}
+
 export async function failAgentRun(
   ctx: AgentRunContext,
   reason: schema.AgentRunFailureReason,
@@ -89,7 +99,7 @@ export async function failAgentRun(
       runtime_minutes: ctx.agentRun.cumulativeRuntimeMinutes,
       resume_count: ctx.agentRun.resumeCount,
     },
-    "agent run failed",
+    agentRunFailureLogMessage(reason),
   );
   await agentRunLifecycle.fail({
     id: ctx.agentRun.id,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,6 +1,7 @@
 import "./env.js";
 import { createClient } from "@clickhouse/client";
 import { db } from "@superlog/db";
+import { registerAgentRunHealthMetrics } from "./agent-run-health-metrics.js";
 import { initAiUsageSink } from "./ai-usage.js";
 import { createUsageMeterTicker } from "./billing/usage-meter-ticker.js";
 import { handleIssueTransition } from "./incidents/workflow.js";
@@ -19,6 +20,7 @@ logger.info({ scope: "boot" }, "env loaded");
 await initAiUsageSink();
 
 registerTenantMetrics();
+registerAgentRunHealthMetrics();
 
 const CLICKHOUSE_URL = process.env.CLICKHOUSE_URL ?? "http://localhost:8123";
 const CLICKHOUSE_DB = process.env.CLICKHOUSE_DB ?? "superlog";


### PR DESCRIPTION
## What

**1. Per-reason failure fingerprints.** `failAgentRun` logged the constant message `"agent run failed"`, so log-issue fingerprinting collapsed every failure mode into a single issue forever. Once that issue's incident was open, a burst of a brand-new failure mode only bumped event counts on the old incident — no new issue, no new incident, no investigation. The message now inlines the reason as plain words (`agent run failed: patch validation failed`), so each failure mode fingerprints into its own issue and a new mode surfaces as a new incident. Spaces (not underscores) keep `messageBucketFor` from collapsing long enum tokens into `<id>`.

**2. Agent-run health gauges** on the worker meter (same pattern as `tenant-metrics.ts`), exported through the worker's normal OTel pipeline:

- `superlog.agent_runs.failed_recent` — failed in the last hour, by `failure.reason`; emits an explicit zero (`reason=none`) on clean passes so charts drop to 0 instead of holding the last bad value
- `superlog.agent_runs.stuck` — non-terminal runs older than 2h (above the 90-min default runtime budget; `awaiting_human` excluded)
- `superlog.agent_runs.queued`, `superlog.agent_runs.awaiting_human`, `superlog.agent_runs.completed_recent`

Since they ride the existing exporter, dashboards and alerts on investigation pileups can be built in Superlog itself.

## Testing

- TDD: fingerprint-split test asserts distinct `fingerprintLog` hashes AND distinct `messageBucketFor` buckets per reason; gauge-mapping tests cover per-reason attributes and the explicit-zero case
- Full `@superlog/worker` suite passes; typecheck clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds agent-run health gauges in the worker and updates failure log messages to fingerprint by reason. This surfaces new failure modes as new incidents and enables dashboards/alerts on run health.

- **New Features**
  - Expose gauges via the worker’s OTel pipeline: superlog.agent_runs.failed_recent (1h, by failure.reason), .stuck (>2h, excludes awaiting_human), .queued, .awaiting_human, .completed_recent.
  - Emit an explicit zero for failed_recent when there are no failures (failure.reason=none) so charts drop to 0.

- **Bug Fixes**
  - Failure logs now inline the reason as plain words (e.g., "agent run failed: patch validation failed") to create distinct fingerprints and buckets per reason.
  - Uses spaces instead of underscores to avoid messageBucketFor collapsing long enum tokens into <id>.

<sup>Written for commit f2f3c8ed2464b3b4abfe74ca9e9a834492f494cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

