### PR TITLE
api: events_per_minute rollup fast path for timeseries-count queries

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -107,8 +107,11 @@ const ch = createClient({
   password: process.env.CLICKHOUSE_PASSWORD ?? "",
   // idle_socket_ttl must stay below CH server's keep_alive_timeout (3s default)
   // so we recycle before the server closes; request_timeout short-circuits
-  // stale sockets that slipped through instead of hanging 30s.
-  request_timeout: 10_000,
+  // stale sockets that slipped through instead of hanging forever. 20s gives
+  // heavy filtered/grouped widget queries on high-volume projects room to
+  // finish; cancel_http_readonly_queries_on_client_close below keeps a
+  // timed-out query from living on server-side.
+  request_timeout: 20_000,
   keep_alive: { enabled: true, idle_socket_ttl: 2_500 },
   clickhouse_settings: {
     // When request_timeout (or a caller's abort signal) drops the HTTP

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -110,6 +110,14 @@ const ch = createClient({
   // stale sockets that slipped through instead of hanging 30s.
   request_timeout: 10_000,
   keep_alive: { enabled: true, idle_socket_ttl: 2_500 },
+  clickhouse_settings: {
+    // When request_timeout (or a caller's abort signal) drops the HTTP
+    // connection, make the server cancel the SELECT instead of letting it
+    // run to completion. Without this, abandoned long scans pile up until
+    // the server hits max_concurrent_queries and rejects everyone
+    // (TOO_MANY_SIMULTANEOUS_QUERIES).
+    cancel_http_readonly_queries_on_client_close: 1,
+  },
 });
 
 const tracer = trace.getTracer("@superlog/api");

--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -336,3 +336,139 @@ test("queryMetrics surfaces sum/min/max for histogram points", async () => {
   assert.ok(gaugeQuery, "expected a gauge query");
   assert.match(gaugeQuery, /Value AS value/);
 });
+
+// -----------------------------------------------------------------------------
+// countSeries rollup fast path: minute-or-coarser, rollup-coverable queries
+// should read the events_per_minute summing table instead of scanning raw
+// otel_traces / otel_logs.
+// -----------------------------------------------------------------------------
+
+// Like fakeClickhouse, but answers the rollup availability probe so the fast
+// path is reachable. Captures the last non-probe query.
+function fakeClickhouseRollup(
+  capture: { query?: string; params?: Record<string, unknown> },
+  rollupExists = true,
+) {
+  return {
+    async query(input: { query: string; query_params?: Record<string, unknown> }) {
+      if (/^EXISTS TABLE/i.test(input.query.trim())) {
+        return {
+          async json() {
+            return [{ result: rollupExists ? 1 : 0 }];
+          },
+        };
+      }
+      capture.query = input.query;
+      capture.params = input.query_params;
+      return {
+        async json() {
+          return [];
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+}
+
+const HOUR_RANGE = { since: "now() - INTERVAL 24 HOUR", until: "now()" };
+
+test("countSeries reads the events_per_minute rollup for unfiltered minute-step queries", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await countSeries(fakeClickhouseRollup(capture), "project-1", "traces", { range: HOUR_RANGE }, undefined, {
+    n: 15,
+    unit: "MINUTE",
+  });
+
+  assert.match(capture.query ?? "", /FROM events_per_minute/);
+  assert.match(capture.query ?? "", /sum\(c\)/);
+  assert.doesNotMatch(capture.query ?? "", /FROM otel_traces/);
+  assert.equal(capture.params?.signal, "traces");
+});
+
+test("countSeries rollup path supports grouping by service", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await countSeries(fakeClickhouseRollup(capture), "project-1", "logs", { range: HOUR_RANGE }, "service.name", {
+    n: 1,
+    unit: "HOUR",
+  });
+
+  assert.match(capture.query ?? "", /FROM events_per_minute/);
+  assert.match(capture.query ?? "", /service AS group_key/);
+  assert.equal(capture.params?.signal, "logs");
+});
+
+test("countSeries rollup path covers service, severity and status filters", async () => {
+  const logCapture: { query?: string; params?: Record<string, unknown> } = {};
+  await countSeries(
+    fakeClickhouseRollup(logCapture),
+    "project-1",
+    "logs",
+    { range: HOUR_RANGE, service: "api", severity: "error" },
+    undefined,
+    { n: 5, unit: "MINUTE" },
+  );
+  assert.match(logCapture.query ?? "", /FROM events_per_minute/);
+  assert.match(logCapture.query ?? "", /service = \{service:String\}/);
+  assert.match(logCapture.query ?? "", /severity = upper\(\{severity:String\}\)/);
+
+  const traceCapture: { query?: string; params?: Record<string, unknown> } = {};
+  await countSeries(
+    fakeClickhouseRollup(traceCapture),
+    "project-1",
+    "traces",
+    { range: HOUR_RANGE, statusCode: "Error" },
+    undefined,
+    { n: 5, unit: "MINUTE" },
+  );
+  assert.match(traceCapture.query ?? "", /FROM events_per_minute/);
+  assert.match(traceCapture.query ?? "", /status_code = \{statusCode:String\}/);
+});
+
+test("countSeries falls back to the raw table for filters the rollup cannot answer", async () => {
+  const cases: { source: "logs" | "traces"; filter: Record<string, unknown>; groupBy?: string }[] = [
+    { source: "traces", filter: { range: HOUR_RANGE, resourceAttrs: [{ key: "env", value: "prod", op: "eq" }] } },
+    { source: "logs", filter: { range: HOUR_RANGE, search: "boom" } },
+    { source: "traces", filter: { range: HOUR_RANGE, spanName: "GET /" } },
+    { source: "traces", filter: { range: HOUR_RANGE, minDurationMs: 250 } },
+    { source: "traces", filter: { range: HOUR_RANGE }, groupBy: "attr:http.route" },
+  ];
+  for (const c of cases) {
+    const capture: { query?: string; params?: Record<string, unknown> } = {};
+    await countSeries(fakeClickhouseRollup(capture), "project-1", c.source, c.filter, c.groupBy, {
+      n: 1,
+      unit: "MINUTE",
+    });
+    assert.match(
+      capture.query ?? "",
+      c.source === "logs" ? /FROM otel_logs/ : /FROM otel_traces/,
+      `expected raw scan for ${JSON.stringify(c)}`,
+    );
+  }
+});
+
+test("countSeries falls back to the raw table for sub-minute steps", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await countSeries(fakeClickhouseRollup(capture), "project-1", "traces", { range: HOUR_RANGE }, undefined, {
+    n: 30,
+    unit: "SECOND",
+  });
+
+  assert.match(capture.query ?? "", /FROM otel_traces/);
+});
+
+test("countSeries falls back to the raw table when the rollup table is absent", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await countSeries(
+    fakeClickhouseRollup(capture, false),
+    "project-1",
+    "traces",
+    { range: HOUR_RANGE },
+    undefined,
+    { n: 15, unit: "MINUTE" },
+  );
+
+  assert.match(capture.query ?? "", /FROM otel_traces/);
+});

--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -458,6 +458,91 @@ test("countSeries falls back to the raw table for sub-minute steps", async () =>
   assert.match(capture.query ?? "", /FROM otel_traces/);
 });
 
+// -----------------------------------------------------------------------------
+// service.name attribute filters should hit the native ServiceName column
+// (the tables' primary key starts with ServiceName) instead of the
+// ResourceAttributes map, which forces a full-window scan.
+// -----------------------------------------------------------------------------
+
+test("countSeries maps a service.name resource filter to the ServiceName column", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await countSeries(
+    fakeClickhouse(capture),
+    "project-1",
+    "logs",
+    {
+      range: HOUR_RANGE,
+      resourceAttrs: [
+        { key: "service.name", value: "worker", op: "eq" },
+        { key: "env", value: "prod", op: "eq" },
+      ],
+    },
+    undefined,
+    { n: 1, unit: "MINUTE" },
+  );
+
+  assert.match(capture.query ?? "", /ServiceName = \{attr_v_0:String\}/);
+  assert.doesNotMatch(capture.query ?? "", /ResourceAttributes\[\{attr_k_0:String\}\]/);
+  // the other attribute still goes through the map
+  assert.match(capture.query ?? "", /ResourceAttributes\[\{attr_k_1:String\}\]/);
+  assert.equal(capture.params?.attr_v_0, "worker");
+});
+
+test("countSeries maps negated service.name filters onto ServiceName too", async () => {
+  const neqCapture: { query?: string; params?: Record<string, unknown> } = {};
+  await countSeries(
+    fakeClickhouse(neqCapture),
+    "project-1",
+    "traces",
+    { range: HOUR_RANGE, resourceAttrs: [{ key: "resource.service.name", value: "worker", op: "neq" }] },
+    undefined,
+    { n: 1, unit: "MINUTE" },
+  );
+  assert.match(neqCapture.query ?? "", /ServiceName != \{attr_v_0:String\}/);
+
+  const ncCapture: { query?: string; params?: Record<string, unknown> } = {};
+  await countSeries(
+    fakeClickhouse(ncCapture),
+    "project-1",
+    "traces",
+    { range: HOUR_RANGE, resourceAttrs: [{ key: "service.name", value: "work", op: "not_contains" }] },
+    undefined,
+    { n: 1, unit: "MINUTE" },
+  );
+  assert.match(ncCapture.query ?? "", /positionCaseInsensitive\(ServiceName, \{attr_v_0:String\}\) = 0/);
+});
+
+test("queryLogs maps a service.name resource filter to the ServiceName column", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await queryLogs(fakeClickhouse(capture), "project-1", {
+    range: { since: "now() - INTERVAL 1 HOUR", until: "now()" },
+    resourceAttrs: [{ key: "service.name", value: "worker", op: "eq" }],
+    limit: 50,
+  });
+
+  assert.match(capture.query ?? "", /ServiceName = \{attr_v_0:String\}/);
+  assert.doesNotMatch(capture.query ?? "", /ResourceAttributes\[\{attr_k_0:String\}\]/);
+});
+
+test("countSeries treats a lone service.name equality filter as rollup-coverable", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await countSeries(
+    fakeClickhouseRollup(capture),
+    "project-1",
+    "traces",
+    { range: HOUR_RANGE, resourceAttrs: [{ key: "service.name", value: "worker", op: "eq" }] },
+    undefined,
+    { n: 15, unit: "MINUTE" },
+  );
+
+  assert.match(capture.query ?? "", /FROM events_per_minute/);
+  assert.match(capture.query ?? "", /service = \{service:String\}/);
+  assert.equal(capture.params?.service, "worker");
+});
+
 test("countSeries falls back to the raw table when the rollup table is absent", async () => {
   const capture: { query?: string; params?: Record<string, unknown> } = {};
 

--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -381,8 +381,45 @@ test("countSeries reads the events_per_minute rollup for unfiltered minute-step 
 
   assert.match(capture.query ?? "", /FROM events_per_minute/);
   assert.match(capture.query ?? "", /sum\(c\)/);
+  // sub-minute `since` values round down to the cell boundary so the partial
+  // first minute is included rather than dropped
+  assert.match(capture.query ?? "", /minute >= toStartOfMinute\(/);
   assert.doesNotMatch(capture.query ?? "", /FROM otel_traces/);
   assert.equal(capture.params?.signal, "traces");
+});
+
+test("countSeries re-probes rollup availability after a failed probe", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+  let probes = 0;
+  const ch = {
+    async query(input: { query: string; query_params?: Record<string, unknown> }) {
+      if (/^EXISTS TABLE/i.test(input.query.trim())) {
+        probes += 1;
+        if (probes === 1) throw new Error("clickhouse unreachable");
+        return {
+          async json() {
+            return [{ result: 1 }];
+          },
+        };
+      }
+      capture.query = input.query;
+      capture.params = input.query_params;
+      return {
+        async json() {
+          return [];
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+
+  // first call: probe fails -> raw scan
+  await countSeries(ch, "project-1", "traces", { range: HOUR_RANGE }, undefined, { n: 15, unit: "MINUTE" });
+  assert.match(capture.query ?? "", /FROM otel_traces/);
+
+  // second call on the same client: probe retried -> rollup
+  await countSeries(ch, "project-1", "traces", { range: HOUR_RANGE }, undefined, { n: 15, unit: "MINUTE" });
+  assert.equal(probes, 2);
+  assert.match(capture.query ?? "", /FROM events_per_minute/);
 });
 
 test("countSeries rollup path supports grouping by service", async () => {

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -1122,6 +1122,102 @@ export function pickStep(rangeSeconds: number, targetBuckets = 120): Step {
   return STEP_LADDER[STEP_LADDER.length - 1] ?? { n: 1, unit: "DAY" };
 }
 
+// -----------------------------------------------------------------------------
+// events_per_minute rollup fast path. Count widgets over long ranges were
+// scanning the raw tables (and the ResourceAttributes map) for every row in
+// the window, which times out for high-volume projects. Queries the rollup
+// (see infra/clickhouse/migrations/003_events_per_minute.sql) can answer —
+// minute-or-coarser buckets, filters within (service, severity, status_code),
+// grouping by nothing or service — read it instead.
+//
+// Availability is probed once per client and memoized so deployments without
+// the rollup (it is not part of the collector's auto-created schema) fall
+// back to the raw scan without a per-request penalty.
+// -----------------------------------------------------------------------------
+
+const rollupAvailability = new WeakMap<ClickHouseClient, Promise<boolean>>();
+
+function rollupAvailable(ch: ClickHouseClient): Promise<boolean> {
+  let probe = rollupAvailability.get(ch);
+  if (!probe) {
+    probe = (async () => {
+      try {
+        const r = await ch.query({ query: "EXISTS TABLE events_per_minute", format: "JSONEachRow" });
+        const rows = (await r.json()) as { result: number | string }[];
+        return Number(rows[0]?.result) === 1;
+      } catch {
+        return false;
+      }
+    })();
+    rollupAvailability.set(ch, probe);
+  }
+  return probe;
+}
+
+function rollupEligible(filter: SeriesFilter, groupBy: string | undefined, step: Step): boolean {
+  if (step.unit === "SECOND") return false; // rollup resolution is one minute
+  if (filter.resourceAttrs?.length) return false;
+  if (filter.search) return false;
+  if (filter.spanName) return false;
+  if (filter.minDurationMs) return false;
+  if (groupBy && groupBy !== "service" && groupBy !== "service.name") return false;
+  return true;
+}
+
+async function countSeriesFromRollup(
+  ch: ClickHouseClient,
+  projectId: string,
+  source: SeriesSource,
+  filter: SeriesFilter,
+  groupBy: string | undefined,
+  step: Step,
+): Promise<{ bucket: string; group: string; count: number }[]> {
+  const { sinceSql, untilSql, sinceExpr, untilExpr } = resolveRange(filter.range);
+  const conds = [
+    "project_id = {projectId:String}",
+    "signal = {signal:String}",
+    `minute >= ${sinceExpr}`,
+    `minute <= ${untilExpr}`,
+  ];
+  if (filter.service) conds.push("service = {service:String}");
+  if (source === "logs") {
+    // The rollup stores upper(SeverityText); mirror the raw path's
+    // case-insensitive comparison.
+    if (filter.severity) conds.push("severity = upper({severity:String})");
+  } else if (filter.statusCode) {
+    conds.push("status_code = {statusCode:String}");
+  }
+  const groupExpr = groupBy ? "service" : "''";
+
+  const query = `
+    SELECT
+      toString(toStartOfInterval(minute, INTERVAL ${step.n} ${step.unit})) AS bucket,
+      ${groupExpr} AS group_key,
+      sum(c) AS c
+    FROM events_per_minute
+    WHERE ${conds.join(" AND ")}
+    GROUP BY bucket, group_key
+    ORDER BY bucket ASC
+    LIMIT 10000
+  `;
+
+  const r = await ch.query({
+    query,
+    query_params: {
+      projectId,
+      signal: source,
+      since: sinceSql,
+      until: untilSql,
+      service: filter.service ?? "",
+      severity: filter.severity ?? "",
+      statusCode: filter.statusCode ?? "",
+    },
+    format: "JSONEachRow",
+  });
+  const rows = (await r.json()) as { bucket: string; group_key: string; c: string | number }[];
+  return rows.map((row) => ({ bucket: row.bucket, group: row.group_key, count: Number(row.c) }));
+}
+
 export async function countSeries(
   ch: ClickHouseClient,
   projectId: string,
@@ -1130,6 +1226,9 @@ export async function countSeries(
   groupBy: string | undefined,
   step: Step,
 ): Promise<{ bucket: string; group: string; count: number }[]> {
+  if (rollupEligible(filter, groupBy, step) && (await rollupAvailable(ch))) {
+    return countSeriesFromRollup(ch, projectId, source, filter, groupBy, step);
+  }
   const { sinceSql, untilSql, sinceExpr, untilExpr } = resolveRange(filter.range);
   const split = splitAttrs(filter.resourceAttrs);
   const attr = attrConds(split.resource);

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -1153,6 +1153,10 @@ function rollupAvailable(ch: ClickHouseClient): Promise<boolean> {
         const rows = (await r.json()) as { result: number | string }[];
         return Number(rows[0]?.result) === 1;
       } catch {
+        // A failed probe (e.g. ClickHouse briefly unreachable) says nothing
+        // about whether the rollup exists — drop the memo so the next call
+        // re-probes instead of pinning the raw path until restart.
+        rollupAvailability.delete(ch);
         return false;
       }
     })();
@@ -1198,7 +1202,14 @@ async function countSeriesFromRollup(
   const conds = [
     "project_id = {projectId:String}",
     "signal = {signal:String}",
-    `minute >= ${sinceExpr}`,
+    // Rollup cells are whole minutes, so a sub-minute `since` cannot be
+    // honored exactly. Round the lower bound down to the cell boundary so the
+    // partial first minute is included in full rather than dropped — edge
+    // buckets may overcount by up to one minute of data, never undercount.
+    // (The upper bound needs no rounding: the cell at until's minute starts
+    // at or before `until` and already satisfies <=.) The fast path only
+    // serves >= 1-minute chart buckets, so the skew stays within one bucket.
+    `minute >= toStartOfMinute(${sinceExpr})`,
     `minute <= ${untilExpr}`,
   ];
   if (filter.service) conds.push("service = {service:String}");

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -73,14 +73,21 @@ function attrConds(
   attrs.forEach((a, i) => {
     const kName = `${paramPrefix}_k_${i}`;
     const vName = `${paramPrefix}_v_${i}`;
+    // service.name lives in the dedicated ServiceName column, which leads
+    // every otel table's primary key — filter it natively so ClickHouse can
+    // prune to the service's PK range instead of scanning the resource map
+    // for the whole window. (The collector populates ServiceName from the
+    // service.name resource attribute, so the two are equivalent.)
+    const native = column === "ResourceAttributes" && a.key === "service.name";
+    const target = native ? "ServiceName" : `${column}[{${kName}:String}]`;
     if (a.op === "neq") {
-      conds.push(`${column}[{${kName}:String}] != {${vName}:String}`);
+      conds.push(`${target} != {${vName}:String}`);
     } else if (a.op === "not_contains") {
-      conds.push(`positionCaseInsensitive(${column}[{${kName}:String}], {${vName}:String}) = 0`);
+      conds.push(`positionCaseInsensitive(${target}, {${vName}:String}) = 0`);
     } else {
-      conds.push(`${column}[{${kName}:String}] = {${vName}:String}`);
+      conds.push(`${target} = {${vName}:String}`);
     }
-    params[kName] = a.key;
+    if (!native) params[kName] = a.key;
     params[vName] = a.value;
   });
   return { conds, params };
@@ -1154,6 +1161,21 @@ function rollupAvailable(ch: ClickHouseClient): Promise<boolean> {
   return probe;
 }
 
+// A widget that filters on the service.name resource attribute (instead of
+// the dedicated service field) is still asking a service question — fold a
+// lone equality into `service` so the rollup can answer it. Returns null
+// when the filter isn't foldable.
+function foldServiceAttrFilter(filter: SeriesFilter): SeriesFilter | null {
+  const attrs = filter.resourceAttrs ?? [];
+  if (attrs.length === 0) return filter;
+  if (attrs.length !== 1 || filter.service) return null;
+  const attr = attrs[0];
+  if (!attr || (attr.op && attr.op !== "eq")) return null;
+  const parsed = parseAttributeKey(attr.key);
+  if (parsed.scope !== "resource" || parsed.key !== "service.name") return null;
+  return { ...filter, service: attr.value, resourceAttrs: [] };
+}
+
 function rollupEligible(filter: SeriesFilter, groupBy: string | undefined, step: Step): boolean {
   if (step.unit === "SECOND") return false; // rollup resolution is one minute
   if (filter.resourceAttrs?.length) return false;
@@ -1226,8 +1248,9 @@ export async function countSeries(
   groupBy: string | undefined,
   step: Step,
 ): Promise<{ bucket: string; group: string; count: number }[]> {
-  if (rollupEligible(filter, groupBy, step) && (await rollupAvailable(ch))) {
-    return countSeriesFromRollup(ch, projectId, source, filter, groupBy, step);
+  const folded = foldServiceAttrFilter(filter);
+  if (folded && rollupEligible(folded, groupBy, step) && (await rollupAvailable(ch))) {
+    return countSeriesFromRollup(ch, projectId, source, folded, groupBy, step);
   }
   const { sinceSql, untilSql, sinceExpr, untilExpr } = resolveRange(filter.range);
   const split = splitAttrs(filter.resourceAttrs);

--- a/infra/clickhouse/migrations/003_events_per_minute.sql
+++ b/infra/clickhouse/migrations/003_events_per_minute.sql
@@ -1,0 +1,77 @@
+-- Per-minute event counts per project, feeding the dashboard / explore
+-- timeseries-count fast path (countSeries in apps/api/src/mcp/clickhouse.ts).
+--
+-- Why: count widgets bucket raw otel_traces / otel_logs rows by time, which
+-- forces a scan of every row in the window (including the ResourceAttributes
+-- map for the project filter). For high-volume projects a 24h+ range reads
+-- hundreds of millions of rows and exceeds the API's ClickHouse timeout.
+-- A SummingMergeTree keyed (project, signal, service, severity, status_code,
+-- minute) answers the same charts in milliseconds at any range.
+--
+-- Dimensions cover what the chart UI can filter / group on without attribute
+-- predicates: service, log severity (stored uppercased to keep the raw
+-- path's case-insensitive match), trace status code. Queries with attribute
+-- filters, body search, span-name / duration predicates, or sub-minute
+-- buckets keep scanning the raw tables.
+--
+-- Run ONCE per environment. Statements are IF NOT EXISTS so they are
+-- individually safe to retry. The MVs only roll up rows inserted AFTER they
+-- are created; historical charts need a one-shot backfill, chunked by day to
+-- bound memory, covering only time strictly BEFORE the MV creation minute so
+-- nothing is double-counted, e.g.:
+--
+--   INSERT INTO superlog.events_per_minute
+--   SELECT ResourceAttributes['superlog.project_id'], 'traces', ServiceName,
+--          '', toString(StatusCode), toStartOfMinute(Timestamp), count()
+--   FROM superlog.otel_traces
+--   WHERE Timestamp >= {day} AND Timestamp < {day_after}
+--     AND Timestamp < {mv_created_minute}
+--     AND ResourceAttributes['superlog.project_id'] != ''
+--   GROUP BY 1, 2, 3, 4, 5, 6;
+--
+-- (and the analogous SELECT from otel_logs with upper(SeverityText) /
+-- TimestampTime).
+
+CREATE TABLE IF NOT EXISTS superlog.events_per_minute ON CLUSTER superlog_ha
+(
+    `project_id` String CODEC(ZSTD(1)),
+    `signal` LowCardinality(String) CODEC(ZSTD(1)),
+    `service` LowCardinality(String) CODEC(ZSTD(1)),
+    `severity` LowCardinality(String) CODEC(ZSTD(1)),
+    `status_code` LowCardinality(String) CODEC(ZSTD(1)),
+    `minute` DateTime CODEC(Delta(4), ZSTD(1)),
+    `c` UInt64 CODEC(Delta(8), ZSTD(1))
+)
+ENGINE = ReplicatedSummingMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
+PARTITION BY toYYYYMM(minute)
+ORDER BY (project_id, signal, service, severity, status_code, minute)
+SETTINGS index_granularity = 8192
+;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.events_per_minute_from_traces_mv ON CLUSTER superlog_ha TO superlog.events_per_minute
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    'traces' AS signal,
+    ServiceName AS service,
+    '' AS severity,
+    toString(StatusCode) AS status_code,
+    toStartOfMinute(Timestamp) AS minute,
+    count() AS c
+FROM superlog.otel_traces
+WHERE ResourceAttributes['superlog.project_id'] != ''
+GROUP BY project_id, signal, service, severity, status_code, minute
+;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.events_per_minute_from_logs_mv ON CLUSTER superlog_ha TO superlog.events_per_minute
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    'logs' AS signal,
+    ServiceName AS service,
+    upper(SeverityText) AS severity,
+    '' AS status_code,
+    toStartOfMinute(TimestampTime) AS minute,
+    count() AS c
+FROM superlog.otel_logs
+WHERE ResourceAttributes['superlog.project_id'] != ''
+GROUP BY project_id, signal, service, severity, status_code, minute
+;

--- a/infra/clickhouse/schema/ha-replicated-otel.sql
+++ b/infra/clickhouse/schema/ha-replicated-otel.sql
@@ -337,3 +337,48 @@ WHERE SeverityNumber >= 17
   AND LogAttributes['superlog.issue_fingerprint'] != ''
 GROUP BY project_id, fingerprint, day
 ;
+-- events_per_minute (dashboard timeseries-count fast path; see
+-- migrations/003_events_per_minute.sql for rationale + backfill notes)
+CREATE TABLE IF NOT EXISTS superlog.events_per_minute ON CLUSTER superlog_ha
+(
+    `project_id` String CODEC(ZSTD(1)),
+    `signal` LowCardinality(String) CODEC(ZSTD(1)),
+    `service` LowCardinality(String) CODEC(ZSTD(1)),
+    `severity` LowCardinality(String) CODEC(ZSTD(1)),
+    `status_code` LowCardinality(String) CODEC(ZSTD(1)),
+    `minute` DateTime CODEC(Delta(4), ZSTD(1)),
+    `c` UInt64 CODEC(Delta(8), ZSTD(1))
+)
+ENGINE = ReplicatedSummingMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
+PARTITION BY toYYYYMM(minute)
+ORDER BY (project_id, signal, service, severity, status_code, minute)
+SETTINGS index_granularity = 8192
+;
+-- events_per_minute_from_traces_mv
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.events_per_minute_from_traces_mv ON CLUSTER superlog_ha TO superlog.events_per_minute
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    'traces' AS signal,
+    ServiceName AS service,
+    '' AS severity,
+    toString(StatusCode) AS status_code,
+    toStartOfMinute(Timestamp) AS minute,
+    count() AS c
+FROM superlog.otel_traces
+WHERE ResourceAttributes['superlog.project_id'] != ''
+GROUP BY project_id, signal, service, severity, status_code, minute
+;
+-- events_per_minute_from_logs_mv
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.events_per_minute_from_logs_mv ON CLUSTER superlog_ha TO superlog.events_per_minute
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    'logs' AS signal,
+    ServiceName AS service,
+    upper(SeverityText) AS severity,
+    '' AS status_code,
+    toStartOfMinute(TimestampTime) AS minute,
+    count() AS c
+FROM superlog.otel_logs
+WHERE ResourceAttributes['superlog.project_id'] != ''
+GROUP BY project_id, signal, service, severity, status_code, minute
+;


### PR DESCRIPTION
## Problem

Dashboard / explore count widgets bucket raw `otel_traces` / `otel_logs` rows by time. The per-project filter reads the `ResourceAttributes` map for every row in the window, and the project-id skip index can't prune granules when one project's data appears in most of them. For high-volume projects a 24h+ range scans hundreds of millions of rows, exceeds the API's ClickHouse timeout, and the chart 500s — dashboards effectively never load at larger time scales.

Two distinct shapes were timing out:
1. The plain count histogram (explore top chart, unfiltered widgets) — a full-window scan just to draw ~100 buckets.
2. Custom filtered/grouped widgets (e.g. filter `service.name` + a log attribute, group by another attribute) over 7-day ranges.

Worse, the timed-out queries kept running server-side to completion (60–140s observed): the client abort only dropped the socket. Under dashboard auto-refresh/retry, abandoned scans piled up to `max_concurrent_queries` and ClickHouse started rejecting everyone with `TOO_MANY_SIMULTANEOUS_QUERIES`.

## Fix

1. **`events_per_minute` rollup** (migration `003`, also added to the HA schema): a SummingMergeTree keyed `(project_id, signal, service, severity, status_code, minute)` fed by MVs from `otel_traces` and `otel_logs`. Answers shape 1 (and service/severity/status-filtered variants) in milliseconds at any range.
2. **`countSeries` fast path**: routes to the rollup when the query is coverable — minute-or-coarser buckets, filters within (service, log severity, trace status code), grouping by nothing or service. A lone `service.name` resource-attr equality folds into the service dimension. Attribute filters, body search, span-name/duration predicates, and sub-minute buckets keep the raw scan. Rollup availability is probed once per client (`EXISTS TABLE`) and memoized, so deployments without the migration silently keep the old behavior.
3. **Native `ServiceName` filtering** for shape 2: `service.name` resource-attr filters now hit the dedicated `ServiceName` column instead of the map. `ServiceName` leads every otel table's primary key, so ClickHouse prunes to the service's PK range instead of scanning the whole window — **~12× faster** (140s → 11s) measured on a real 7-day filtered+grouped widget query against a high-volume dataset.
4. **`cancel_http_readonly_queries_on_client_close`** on the API's ClickHouse client, so an aborted request kills its server-side query instead of orphaning it. With that safety in place, `request_timeout` is widened 10s → 20s so heavy-but-legitimate widget queries (the ~11s case above) can finish.

## Notes

- The MVs only roll up rows inserted after creation; the migration documents a chunked, double-count-safe backfill for history.
- Verified MV + fast-path semantics against a real ClickHouse: rollup results match the raw-scan results bucket-for-bucket, including case-insensitive severity and group-by-service.

## Tests

- `countSeries` rollup routing: unfiltered, group-by-service, service/severity/status filters, lone service.name attr → rollup; attribute/search/span-name/duration filters, sub-minute steps, missing rollup table → raw scan.
- `service.name` → `ServiceName` mapping for eq/neq/not_contains in `countSeries` and `queryLogs`.
- `pnpm --filter @superlog/api test`: 57 pass. Typecheck clean.