### PR TITLE
worker: agent-run health gauges — stuck allow-list, blocked gauge, per-org grouping

### DIFF
--- a/apps/worker/src/agent-run-health-metrics.test.ts
+++ b/apps/worker/src/agent-run-health-metrics.test.ts
@@ -2,11 +2,13 @@ import "./agent-run.test-env.js";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
-  type AgentRunHealthCounts,
+  type AgentRunOrgHealthCounts,
   buildAgentRunHealthObservations,
 } from "./agent-run-health-metrics.js";
 
-const COUNTS: AgentRunHealthCounts = {
+const ACME: AgentRunOrgHealthCounts = {
+  orgId: "org-acme",
+  orgName: "Acme",
   failedRecentByReason: { patch_validation_failed: 7, sync_failed: 2 },
   completedRecent: 31,
   stuck: 4,
@@ -15,37 +17,67 @@ const COUNTS: AgentRunHealthCounts = {
   blocked: 5,
 };
 
-test("health counts map onto the agent_runs gauges", () => {
-  const observations = buildAgentRunHealthObservations(COUNTS);
+const GLOBEX: AgentRunOrgHealthCounts = {
+  orgId: "org-globex",
+  orgName: "Globex",
+  failedRecentByReason: {},
+  completedRecent: 0,
+  stuck: 0,
+  queued: 1,
+  awaitingHuman: 0,
+  blocked: 0,
+};
 
-  const byMetric = new Map(
-    observations.map((o) => [`${o.metric}|${o.attributes?.["failure.reason"] ?? ""}`, o.value]),
-  );
-  assert.equal(byMetric.get("superlog.agent_runs.stuck|"), 4);
-  assert.equal(byMetric.get("superlog.agent_runs.queued|"), 12);
-  assert.equal(byMetric.get("superlog.agent_runs.awaiting_human|"), 3);
-  assert.equal(byMetric.get("superlog.agent_runs.blocked|"), 5);
-  assert.equal(byMetric.get("superlog.agent_runs.completed_recent|"), 31);
-  assert.equal(byMetric.get("superlog.agent_runs.failed_recent|patch_validation_failed"), 7);
-  assert.equal(byMetric.get("superlog.agent_runs.failed_recent|sync_failed"), 2);
+function key(o: { metric: string; attributes?: Record<string, string> }): string {
+  return [
+    o.metric,
+    o.attributes?.["tenant.org.name"] ?? "",
+    o.attributes?.["failure.reason"] ?? "",
+  ].join("|");
+}
+
+test("per-org counts map onto gauges with tenant org attributes", () => {
+  const observations = buildAgentRunHealthObservations([ACME, GLOBEX]);
+  const byKey = new Map(observations.map((o) => [key(o), o.value]));
+
+  assert.equal(byKey.get("superlog.agent_runs.stuck|Acme|"), 4);
+  assert.equal(byKey.get("superlog.agent_runs.queued|Acme|"), 12);
+  assert.equal(byKey.get("superlog.agent_runs.awaiting_human|Acme|"), 3);
+  assert.equal(byKey.get("superlog.agent_runs.blocked|Acme|"), 5);
+  assert.equal(byKey.get("superlog.agent_runs.completed_recent|Acme|"), 31);
+  assert.equal(byKey.get("superlog.agent_runs.failed_recent|Acme|patch_validation_failed"), 7);
+  assert.equal(byKey.get("superlog.agent_runs.failed_recent|Acme|sync_failed"), 2);
+
+  // Zero gauges still emit per org so a recovered org drops to 0 instead of
+  // its series freezing at the last bad value.
+  assert.equal(byKey.get("superlog.agent_runs.stuck|Globex|"), 0);
+  assert.equal(byKey.get("superlog.agent_runs.queued|Globex|"), 1);
+
+  // Both org id and name ride along for grouping/filtering.
+  const acmeStuck = observations.find((o) => key(o) === "superlog.agent_runs.stuck|Acme|");
+  assert.equal(acmeStuck?.attributes?.["tenant.org.id"], "org-acme");
 });
 
-test("zero failures still observe gauges so the series never goes dark", () => {
-  const observations = buildAgentRunHealthObservations({
-    failedRecentByReason: {},
-    completedRecent: 0,
-    stuck: 0,
-    queued: 0,
-    awaitingHuman: 0,
-    blocked: 0,
-  });
+test("zero failures across all orgs still observe an explicit failed_recent zero", () => {
+  const observations = buildAgentRunHealthObservations([GLOBEX]);
+  const failed = observations.filter((o) => o.metric === "superlog.agent_runs.failed_recent");
+  assert.equal(failed.length, 1);
+  assert.equal(failed[0]?.value, 0);
+  assert.equal(failed[0]?.attributes?.["failure.reason"], "none");
+});
+
+test("no orgs at all still observes every gauge so the series never goes dark", () => {
+  const observations = buildAgentRunHealthObservations([]);
   const metrics = observations.map((o) => o.metric);
-  assert.ok(metrics.includes("superlog.agent_runs.stuck"));
-  assert.ok(metrics.includes("superlog.agent_runs.queued"));
-  // A zero-failure pass emits an explicit zero (no reason attribute) so charts
-  // drop to 0 instead of holding the last bad value.
-  const failed = observations.find((o) => o.metric === "superlog.agent_runs.failed_recent");
-  assert.ok(failed);
-  assert.equal(failed.value, 0);
-  assert.equal(failed.attributes?.["failure.reason"], "none");
+  for (const m of [
+    "superlog.agent_runs.stuck",
+    "superlog.agent_runs.queued",
+    "superlog.agent_runs.awaiting_human",
+    "superlog.agent_runs.blocked",
+    "superlog.agent_runs.completed_recent",
+    "superlog.agent_runs.failed_recent",
+  ]) {
+    assert.ok(metrics.includes(m), `missing ${m}`);
+  }
+  for (const o of observations) assert.equal(o.value, 0);
 });

--- a/apps/worker/src/agent-run-health-metrics.test.ts
+++ b/apps/worker/src/agent-run-health-metrics.test.ts
@@ -12,6 +12,7 @@ const COUNTS: AgentRunHealthCounts = {
   stuck: 4,
   queued: 12,
   awaitingHuman: 3,
+  blocked: 5,
 };
 
 test("health counts map onto the agent_runs gauges", () => {
@@ -23,6 +24,7 @@ test("health counts map onto the agent_runs gauges", () => {
   assert.equal(byMetric.get("superlog.agent_runs.stuck|"), 4);
   assert.equal(byMetric.get("superlog.agent_runs.queued|"), 12);
   assert.equal(byMetric.get("superlog.agent_runs.awaiting_human|"), 3);
+  assert.equal(byMetric.get("superlog.agent_runs.blocked|"), 5);
   assert.equal(byMetric.get("superlog.agent_runs.completed_recent|"), 31);
   assert.equal(byMetric.get("superlog.agent_runs.failed_recent|patch_validation_failed"), 7);
   assert.equal(byMetric.get("superlog.agent_runs.failed_recent|sync_failed"), 2);
@@ -35,6 +37,7 @@ test("zero failures still observe gauges so the series never goes dark", () => {
     stuck: 0,
     queued: 0,
     awaitingHuman: 0,
+    blocked: 0,
   });
   const metrics = observations.map((o) => o.metric);
   assert.ok(metrics.includes("superlog.agent_runs.stuck"));

--- a/apps/worker/src/agent-run-health-metrics.test.ts
+++ b/apps/worker/src/agent-run-health-metrics.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import {
   type AgentRunOrgHealthCounts,
   buildAgentRunHealthObservations,
+  withRecoveryZeros,
 } from "./agent-run-health-metrics.js";
 
 const ACME: AgentRunOrgHealthCounts = {
@@ -64,6 +65,27 @@ test("zero failures across all orgs still observe an explicit failed_recent zero
   assert.equal(failed.length, 1);
   assert.equal(failed[0]?.value, 0);
   assert.equal(failed[0]?.attributes?.["failure.reason"], "none");
+});
+
+test("orgs that drop out of the snapshot get one explicit all-zero pass", () => {
+  // Globex emitted last pass but has nothing to report now (e.g. its only
+  // stuck run got superseded). It must emit zeros once so its series ends at
+  // 0 instead of freezing at the last bad value.
+  const previous = new Map([
+    ["org-acme", "Acme"],
+    ["org-globex", "Globex"],
+  ]);
+  const out = withRecoveryZeros([ACME], previous);
+  assert.equal(out.length, 2);
+  const globex = out.find((o) => o.orgId === "org-globex");
+  assert.ok(globex);
+  assert.equal(globex.orgName, "Globex");
+  assert.equal(globex.stuck, 0);
+  assert.equal(globex.queued, 0);
+  assert.equal(globex.blocked, 0);
+  assert.deepEqual(globex.failedRecentByReason, {});
+  // Orgs still present are passed through untouched.
+  assert.equal(out.find((o) => o.orgId === "org-acme"), ACME);
 });
 
 test("no orgs at all still observes every gauge so the series never goes dark", () => {

--- a/apps/worker/src/agent-run-health-metrics.ts
+++ b/apps/worker/src/agent-run-health-metrics.ts
@@ -148,6 +148,33 @@ export async function loadAgentRunHealthCounts(): Promise<AgentRunOrgHealthCount
   );
 }
 
+// An org that emitted last pass but dropped out of the snapshot (e.g. its
+// only stuck run got superseded) gets one explicit all-zero entry so its
+// series ends at 0 instead of freezing at the last bad value. It only lives
+// for one pass — `previous` tracks the orgs the *snapshot* contained, so the
+// recovery zeros don't keep themselves alive.
+export function withRecoveryZeros(
+  current: AgentRunOrgHealthCounts[],
+  previous: ReadonlyMap<string, string>,
+): AgentRunOrgHealthCounts[] {
+  const seen = new Set(current.map((o) => o.orgId));
+  const out = [...current];
+  for (const [orgId, orgName] of previous) {
+    if (seen.has(orgId)) continue;
+    out.push({
+      orgId,
+      orgName,
+      failedRecentByReason: {},
+      completedRecent: 0,
+      stuck: 0,
+      queued: 0,
+      awaitingHuman: 0,
+      blocked: 0,
+    });
+  }
+  return out;
+}
+
 // Pure mapping from counts to gauge observations — kept separate from the OTel
 // callback so it's unit-testable. Orgs in the snapshot emit every gauge
 // (including zeros) so a recovered org drops to 0 instead of freezing at its
@@ -200,12 +227,15 @@ export function buildAgentRunHealthObservations(
 
 let cached: { at: number; counts: AgentRunOrgHealthCounts[] } | null = null;
 const CACHE_TTL_MS = 30_000;
+let previousSnapshotOrgs = new Map<string, string>();
 
 async function snapshot(): Promise<AgentRunOrgHealthCounts[]> {
   if (cached && Date.now() - cached.at < CACHE_TTL_MS) return cached.counts;
   const counts = await loadAgentRunHealthCounts();
-  cached = { at: Date.now(), counts };
-  return counts;
+  const withZeros = withRecoveryZeros(counts, previousSnapshotOrgs);
+  previousSnapshotOrgs = new Map(counts.map((o) => [o.orgId, o.orgName]));
+  cached = { at: Date.now(), counts: withZeros };
+  return withZeros;
 }
 
 export function registerAgentRunHealthMetrics(): void {

--- a/apps/worker/src/agent-run-health-metrics.ts
+++ b/apps/worker/src/agent-run-health-metrics.ts
@@ -6,11 +6,15 @@ import { logger } from "./logger.js";
 // Agent-run health gauges, exported through the worker's own OTel pipeline
 // (same pattern as tenant-metrics.ts). These power dashboards/alerts on
 // investigations piling up in a bad state: failures by reason, runs stuck
-// past their runtime budget, and current queue depth.
+// past their runtime budget, and current queue depth. Every observation
+// carries tenant.org.id / tenant.org.name (the tenant-metrics convention) so
+// dashboards can group by org.
 
 const meter = metrics.getMeter("@superlog/worker/agent-runs");
 
-export type AgentRunHealthCounts = {
+export type AgentRunOrgHealthCounts = {
+  orgId: string;
+  orgName: string;
   // state='failed' within the recent window, keyed by failure_reason.
   failedRecentByReason: Record<string, number>;
   completedRecent: number;
@@ -40,15 +44,33 @@ export type AgentRunHealthObservation = {
 // maxRuntimeMinutes, so any active run past it has outlived its own budget.
 // Parked states are not stuck: awaiting_human and blocked runs each get their
 // own gauge instead.
-export async function loadAgentRunHealthCounts(): Promise<AgentRunHealthCounts> {
-  const failedRows = (await db.execute<{ reason: string; count: number }>(sql`
-    SELECT coalesce(nullif(failure_reason, ''), 'unknown') AS reason, count(*)::int AS count
-    FROM agent_runs
-    WHERE state = 'failed' AND updated_at > now() - interval '1 hour'
-    GROUP BY 1
-  `)) as unknown as Array<{ reason: string; count: number }>;
+//
+// Orgs whose runs are all in old terminal states (every gauge zero, no recent
+// failures) are dropped: emitting permanent zeros for every org that ever ran
+// an investigation would grow export volume without adding information.
+export async function loadAgentRunHealthCounts(): Promise<AgentRunOrgHealthCounts[]> {
+  const failedRows = (await db.execute<{
+    org_id: string;
+    org_name: string;
+    reason: string;
+    count: number;
+  }>(sql`
+    SELECT
+      o.id AS org_id,
+      o.name AS org_name,
+      coalesce(nullif(ar.failure_reason, ''), 'unknown') AS reason,
+      count(*)::int AS count
+    FROM agent_runs ar
+    JOIN incidents i ON i.id = ar.incident_id
+    JOIN projects p ON p.id = i.project_id
+    JOIN orgs o ON o.id = p.org_id
+    WHERE ar.state = 'failed' AND ar.updated_at > now() - interval '1 hour'
+    GROUP BY 1, 2, 3
+  `)) as unknown as Array<{ org_id: string; org_name: string; reason: string; count: number }>;
 
   const gaugeRows = (await db.execute<{
+    org_id: string;
+    org_name: string;
     completed: number;
     stuck: number;
     queued: number;
@@ -56,19 +78,27 @@ export async function loadAgentRunHealthCounts(): Promise<AgentRunHealthCounts> 
     blocked: number;
   }>(sql`
     SELECT
-      count(*) FILTER (WHERE state = 'complete' AND updated_at > now() - interval '1 hour')::int AS completed,
+      o.id AS org_id,
+      o.name AS org_name,
+      count(*) FILTER (WHERE ar.state = 'complete' AND ar.updated_at > now() - interval '1 hour')::int AS completed,
       count(*) FILTER (
-        WHERE state IN (${sql.join(
+        WHERE ar.state IN (${sql.join(
           ACTIVE_RUN_STATES.map((s) => sql`${s}`),
           sql`, `,
         )})
-          AND created_at < now() - interval '2 hours'
+          AND ar.created_at < now() - interval '2 hours'
       )::int AS stuck,
-      count(*) FILTER (WHERE state = 'queued')::int AS queued,
-      count(*) FILTER (WHERE state = 'awaiting_human')::int AS awaiting,
-      count(*) FILTER (WHERE state LIKE 'blocked_%')::int AS blocked
-    FROM agent_runs
+      count(*) FILTER (WHERE ar.state = 'queued')::int AS queued,
+      count(*) FILTER (WHERE ar.state = 'awaiting_human')::int AS awaiting,
+      count(*) FILTER (WHERE ar.state LIKE 'blocked_%')::int AS blocked
+    FROM agent_runs ar
+    JOIN incidents i ON i.id = ar.incident_id
+    JOIN projects p ON p.id = i.project_id
+    JOIN orgs o ON o.id = p.org_id
+    GROUP BY 1, 2
   `)) as unknown as Array<{
+    org_id: string;
+    org_name: string;
     completed: number;
     stuck: number;
     queued: number;
@@ -76,53 +106,102 @@ export async function loadAgentRunHealthCounts(): Promise<AgentRunHealthCounts> 
     blocked: number;
   }>;
 
-  const gauges = gaugeRows[0] ?? { completed: 0, stuck: 0, queued: 0, awaiting: 0, blocked: 0 };
-  return {
-    failedRecentByReason: Object.fromEntries(failedRows.map((r) => [r.reason, Number(r.count)])),
-    completedRecent: Number(gauges.completed),
-    stuck: Number(gauges.stuck),
-    queued: Number(gauges.queued),
-    awaitingHuman: Number(gauges.awaiting),
-    blocked: Number(gauges.blocked),
+  const byOrg = new Map<string, AgentRunOrgHealthCounts>();
+  const orgEntry = (orgId: string, orgName: string): AgentRunOrgHealthCounts => {
+    let entry = byOrg.get(orgId);
+    if (!entry) {
+      entry = {
+        orgId,
+        orgName,
+        failedRecentByReason: {},
+        completedRecent: 0,
+        stuck: 0,
+        queued: 0,
+        awaitingHuman: 0,
+        blocked: 0,
+      };
+      byOrg.set(orgId, entry);
+    }
+    return entry;
   };
+
+  for (const r of gaugeRows) {
+    const entry = orgEntry(r.org_id, r.org_name);
+    entry.completedRecent = Number(r.completed);
+    entry.stuck = Number(r.stuck);
+    entry.queued = Number(r.queued);
+    entry.awaitingHuman = Number(r.awaiting);
+    entry.blocked = Number(r.blocked);
+  }
+  for (const r of failedRows) {
+    orgEntry(r.org_id, r.org_name).failedRecentByReason[r.reason] = Number(r.count);
+  }
+
+  return [...byOrg.values()].filter(
+    (o) =>
+      o.completedRecent > 0 ||
+      o.stuck > 0 ||
+      o.queued > 0 ||
+      o.awaitingHuman > 0 ||
+      o.blocked > 0 ||
+      Object.keys(o.failedRecentByReason).length > 0,
+  );
 }
 
 // Pure mapping from counts to gauge observations — kept separate from the OTel
-// callback so it's unit-testable. A zero-failure pass still emits an explicit
-// zero (failure.reason="none") so charts drop to 0 instead of holding the last
-// bad value when a reason's series stops being observed.
+// callback so it's unit-testable. Orgs in the snapshot emit every gauge
+// (including zeros) so a recovered org drops to 0 instead of freezing at its
+// last bad value. When nothing is failing anywhere, an explicit zero with
+// failure.reason="none" keeps the failed_recent series alive; an empty
+// snapshot does the same for every gauge.
 export function buildAgentRunHealthObservations(
-  counts: AgentRunHealthCounts,
+  orgs: AgentRunOrgHealthCounts[],
 ): AgentRunHealthObservation[] {
-  const observations: AgentRunHealthObservation[] = [
-    { metric: "superlog.agent_runs.stuck", value: counts.stuck },
-    { metric: "superlog.agent_runs.queued", value: counts.queued },
-    { metric: "superlog.agent_runs.awaiting_human", value: counts.awaitingHuman },
-    { metric: "superlog.agent_runs.blocked", value: counts.blocked },
-    { metric: "superlog.agent_runs.completed_recent", value: counts.completedRecent },
-  ];
-  const reasons = Object.entries(counts.failedRecentByReason);
-  if (reasons.length === 0) {
+  const observations: AgentRunHealthObservation[] = [];
+  let failedObserved = 0;
+
+  for (const org of orgs) {
+    const attrs = { "tenant.org.id": org.orgId, "tenant.org.name": org.orgName };
+    observations.push(
+      { metric: "superlog.agent_runs.stuck", value: org.stuck, attributes: attrs },
+      { metric: "superlog.agent_runs.queued", value: org.queued, attributes: attrs },
+      { metric: "superlog.agent_runs.awaiting_human", value: org.awaitingHuman, attributes: attrs },
+      { metric: "superlog.agent_runs.blocked", value: org.blocked, attributes: attrs },
+      { metric: "superlog.agent_runs.completed_recent", value: org.completedRecent, attributes: attrs },
+    );
+    for (const [reason, count] of Object.entries(org.failedRecentByReason)) {
+      failedObserved++;
+      observations.push({
+        metric: "superlog.agent_runs.failed_recent",
+        value: count,
+        attributes: { ...attrs, "failure.reason": reason },
+      });
+    }
+  }
+
+  if (orgs.length === 0) {
+    observations.push(
+      { metric: "superlog.agent_runs.stuck", value: 0 },
+      { metric: "superlog.agent_runs.queued", value: 0 },
+      { metric: "superlog.agent_runs.awaiting_human", value: 0 },
+      { metric: "superlog.agent_runs.blocked", value: 0 },
+      { metric: "superlog.agent_runs.completed_recent", value: 0 },
+    );
+  }
+  if (failedObserved === 0) {
     observations.push({
       metric: "superlog.agent_runs.failed_recent",
       value: 0,
       attributes: { "failure.reason": "none" },
     });
   }
-  for (const [reason, count] of reasons) {
-    observations.push({
-      metric: "superlog.agent_runs.failed_recent",
-      value: count,
-      attributes: { "failure.reason": reason },
-    });
-  }
   return observations;
 }
 
-let cached: { at: number; counts: AgentRunHealthCounts } | null = null;
+let cached: { at: number; counts: AgentRunOrgHealthCounts[] } | null = null;
 const CACHE_TTL_MS = 30_000;
 
-async function snapshot(): Promise<AgentRunHealthCounts> {
+async function snapshot(): Promise<AgentRunOrgHealthCounts[]> {
   if (cached && Date.now() - cached.at < CACHE_TTL_MS) return cached.counts;
   const counts = await loadAgentRunHealthCounts();
   cached = { at: Date.now(), counts };
@@ -133,24 +212,24 @@ export function registerAgentRunHealthMetrics(): void {
   const gauges = {
     "superlog.agent_runs.failed_recent": meter.createObservableGauge(
       "superlog.agent_runs.failed_recent",
-      { description: "Agent runs that failed in the last hour, by failure.reason." },
+      { description: "Agent runs that failed in the last hour, by org and failure.reason." },
     ),
     "superlog.agent_runs.stuck": meter.createObservableGauge("superlog.agent_runs.stuck", {
-      description: "Non-terminal agent runs (excluding awaiting_human) older than 2 hours.",
+      description: "Actively-moving agent runs older than 2 hours, by org.",
     }),
     "superlog.agent_runs.queued": meter.createObservableGauge("superlog.agent_runs.queued", {
-      description: "Agent runs currently queued.",
+      description: "Agent runs currently queued, by org.",
     }),
     "superlog.agent_runs.awaiting_human": meter.createObservableGauge(
       "superlog.agent_runs.awaiting_human",
-      { description: "Agent runs parked on a human response." },
+      { description: "Agent runs parked on a human response, by org." },
     ),
     "superlog.agent_runs.blocked": meter.createObservableGauge("superlog.agent_runs.blocked", {
-      description: "Agent runs parked on missing prerequisites (e.g. no GitHub connected).",
+      description: "Agent runs parked on missing prerequisites (e.g. no GitHub connected), by org.",
     }),
     "superlog.agent_runs.completed_recent": meter.createObservableGauge(
       "superlog.agent_runs.completed_recent",
-      { description: "Agent runs that completed in the last hour." },
+      { description: "Agent runs that completed in the last hour, by org." },
     ),
   } as const;
 

--- a/apps/worker/src/agent-run-health-metrics.ts
+++ b/apps/worker/src/agent-run-health-metrics.ts
@@ -14,11 +14,20 @@ export type AgentRunHealthCounts = {
   // state='failed' within the recent window, keyed by failure_reason.
   failedRecentByReason: Record<string, number>;
   completedRecent: number;
-  // Non-terminal, non-human-gated runs older than the stuck threshold.
+  // Actively-moving states that stopped moving (older than the stuck threshold).
   stuck: number;
   queued: number;
   awaitingHuman: number;
+  // Runs parked on missing prerequisites (e.g. no GitHub connected).
+  blocked: number;
 };
+
+// States that should always be progressing on their own. Anything here older
+// than the stuck threshold has genuinely wedged. Deliberately an allow-list:
+// parked states (awaiting_human, blocked_no_github, superseded, and whatever
+// gets added next) accumulate by design — counting them as stuck pins the
+// gauge at a permanently-elevated baseline and makes it unreadable.
+const ACTIVE_RUN_STATES = ["queued", "repo_discovery", "running", "pr_retry_queued"] as const;
 
 export type AgentRunHealthObservation = {
   metric: string;
@@ -28,9 +37,9 @@ export type AgentRunHealthObservation = {
 
 // The 1h window matches "how bad is it right now" rather than all-time
 // counters; the 2h stuck threshold sits above the 90-minute default
-// maxRuntimeMinutes, so anything non-terminal past it has outlived its own
-// budget. awaiting_human is excluded from stuck — parked on a human is
-// waiting, not stuck — but exposed as its own gauge.
+// maxRuntimeMinutes, so any active run past it has outlived its own budget.
+// Parked states are not stuck: awaiting_human and blocked runs each get their
+// own gauge instead.
 export async function loadAgentRunHealthCounts(): Promise<AgentRunHealthCounts> {
   const failedRows = (await db.execute<{ reason: string; count: number }>(sql`
     SELECT coalesce(nullif(failure_reason, ''), 'unknown') AS reason, count(*)::int AS count
@@ -44,25 +53,37 @@ export async function loadAgentRunHealthCounts(): Promise<AgentRunHealthCounts> 
     stuck: number;
     queued: number;
     awaiting: number;
+    blocked: number;
   }>(sql`
     SELECT
       count(*) FILTER (WHERE state = 'complete' AND updated_at > now() - interval '1 hour')::int AS completed,
       count(*) FILTER (
-        WHERE state NOT IN ('complete', 'failed', 'awaiting_human')
+        WHERE state IN (${sql.join(
+          ACTIVE_RUN_STATES.map((s) => sql`${s}`),
+          sql`, `,
+        )})
           AND created_at < now() - interval '2 hours'
       )::int AS stuck,
       count(*) FILTER (WHERE state = 'queued')::int AS queued,
-      count(*) FILTER (WHERE state = 'awaiting_human')::int AS awaiting
+      count(*) FILTER (WHERE state = 'awaiting_human')::int AS awaiting,
+      count(*) FILTER (WHERE state LIKE 'blocked_%')::int AS blocked
     FROM agent_runs
-  `)) as unknown as Array<{ completed: number; stuck: number; queued: number; awaiting: number }>;
+  `)) as unknown as Array<{
+    completed: number;
+    stuck: number;
+    queued: number;
+    awaiting: number;
+    blocked: number;
+  }>;
 
-  const gauges = gaugeRows[0] ?? { completed: 0, stuck: 0, queued: 0, awaiting: 0 };
+  const gauges = gaugeRows[0] ?? { completed: 0, stuck: 0, queued: 0, awaiting: 0, blocked: 0 };
   return {
     failedRecentByReason: Object.fromEntries(failedRows.map((r) => [r.reason, Number(r.count)])),
     completedRecent: Number(gauges.completed),
     stuck: Number(gauges.stuck),
     queued: Number(gauges.queued),
     awaitingHuman: Number(gauges.awaiting),
+    blocked: Number(gauges.blocked),
   };
 }
 
@@ -77,6 +98,7 @@ export function buildAgentRunHealthObservations(
     { metric: "superlog.agent_runs.stuck", value: counts.stuck },
     { metric: "superlog.agent_runs.queued", value: counts.queued },
     { metric: "superlog.agent_runs.awaiting_human", value: counts.awaitingHuman },
+    { metric: "superlog.agent_runs.blocked", value: counts.blocked },
     { metric: "superlog.agent_runs.completed_recent", value: counts.completedRecent },
   ];
   const reasons = Object.entries(counts.failedRecentByReason);
@@ -123,6 +145,9 @@ export function registerAgentRunHealthMetrics(): void {
       "superlog.agent_runs.awaiting_human",
       { description: "Agent runs parked on a human response." },
     ),
+    "superlog.agent_runs.blocked": meter.createObservableGauge("superlog.agent_runs.blocked", {
+      description: "Agent runs parked on missing prerequisites (e.g. no GitHub connected).",
+    }),
     "superlog.agent_runs.completed_recent": meter.createObservableGauge(
       "superlog.agent_runs.completed_recent",
       { description: "Agent runs that completed in the last hour." },


### PR DESCRIPTION
Two fixes to the agent-run health gauges:

**Stuck counts only actively-moving states.** The stuck gauge filtered \`state NOT IN ('complete','failed','awaiting_human')\`, which counted parked states (\`blocked_no_github\`, \`superseded\`) as stuck — pinning the gauge at a permanently-elevated baseline. It now uses an allow-list of states that should always be progressing (\`queued\`, \`repo_discovery\`, \`running\`, \`pr_retry_queued\`), so new parked states added later can't silently re-inflate it. Blocked runs get their own gauge (\`superlog.agent_runs.blocked\`) since "N projects have investigations waiting on a GitHub connection" is a real signal — just a different one.

**Per-org grouping.** Every observation now carries \`tenant.org.id\` / \`tenant.org.name\` (same convention as tenant-metrics) so dashboards can group by org. Orgs whose gauges are all zero with no recent failures are dropped from the export to bound volume; orgs present in the snapshot emit explicit zeros so a recovered org drops to 0 instead of freezing at its last bad value.

Tested: unit tests for the observation mapping (per-org attrs, zero-org and zero-failure liveness rows); typecheck.