### PR TITLE
web: pin dashboard chart x-axis to the query window; bucket-width bars

### DIFF
--- a/apps/web/src/dashboards/widgets/CountChart.tsx
+++ b/apps/web/src/dashboards/widgets/CountChart.tsx
@@ -3,9 +3,16 @@ import type { EChartsOption, SetOptionOpts } from "echarts";
 import type { BarSeriesOption, LineSeriesOption } from "echarts/charts";
 import type * as EChartsCore from "echarts/core";
 import { forwardRef, memo, useEffect, useMemo, useRef, useState } from "react";
+import type { ExploreRange } from "../../api.ts";
 import type { ChartType, LegendPosition } from "../types.ts";
 import { echarts } from "./echarts-setup.ts";
-import { type ChartSeries, type GroupedRow, buildTopNSeries } from "./series-topn.ts";
+import {
+  type BucketGrid,
+  type ChartSeries,
+  type GroupedRow,
+  buildTopNSeries,
+  parseStepMs,
+} from "./series-topn.ts";
 
 type SeriesChartProps<T extends GroupedRow> = {
   rows: T[];
@@ -13,6 +20,14 @@ type SeriesChartProps<T extends GroupedRow> = {
   value: (row: T) => number;
   chartType: ChartType;
   limit: number;
+  /**
+   * Query window. Pins the x-axis to the selected range (instead of the data
+   * extent, which lies about sparse data) and, for bar charts, zero-fills the
+   * bucket grid so bars are always one server bucket wide.
+   */
+  range?: ExploreRange;
+  /** Server bucket step ("5 MINUTE") from the series response. */
+  step?: string;
   showXAxis?: boolean;
   showYAxis?: boolean;
   showLegend: boolean;
@@ -64,20 +79,39 @@ export function CountChart<T extends GroupedRow>({
   value,
   chartType,
   limit,
+  range,
+  step,
   showXAxis = true,
   showYAxis = false,
   showLegend,
   legendPosition,
 }: SeriesChartProps<T>) {
+  const window = useMemo(() => {
+    const sinceMs = range ? Date.parse(range.since) : Number.NaN;
+    const untilMs = range ? Date.parse(range.until) : Number.NaN;
+    if (!Number.isFinite(sinceMs) || !Number.isFinite(untilMs) || untilMs <= sinceMs) {
+      return undefined;
+    }
+    return { sinceMs, untilMs };
+  }, [range]);
+
+  // Bars only: lines connect actual samples, and zero-filling them would draw
+  // false dips wherever the bucket step is finer than the export interval.
+  const grid = useMemo<BucketGrid | undefined>(() => {
+    if (chartType !== "bar" || !window) return undefined;
+    const stepMs = parseStepMs(step);
+    return stepMs ? { ...window, stepMs } : undefined;
+  }, [chartType, window, step]);
+
   const allSeries = useMemo(
     () =>
-      buildTopNSeries(rows, value, limit).map((series, index) => ({
+      buildTopNSeries(rows, value, limit, grid).map((series, index) => ({
         ...series,
         color: series.isOther
           ? OTHER_COLOR
           : (CHART_COLORS[index % CHART_COLORS.length] ?? FIRST_CHART_COLOR),
       })),
-    [rows, value, limit],
+    [rows, value, limit, grid],
   );
   const [hiddenSeries, setHiddenSeries] = useState<Set<string>>(() => new Set());
 
@@ -108,6 +142,8 @@ export function CountChart<T extends GroupedRow>({
       data={visibleSeries}
       type={chartType}
       height="100%"
+      xMin={window?.sinceMs}
+      xMax={window?.untilMs}
       showXAxis={showXAxis}
       showYAxis={showYAxis}
       optionUpdateBehavior={{ notMerge: true, lazyUpdate: true }}
@@ -149,6 +185,8 @@ function KumoLikeTimeseriesChart({
   data,
   type,
   height,
+  xMin,
+  xMax,
   showXAxis,
   showYAxis,
   optionUpdateBehavior,
@@ -156,6 +194,8 @@ function KumoLikeTimeseriesChart({
   data: TimeseriesData[];
   type: ChartType;
   height: number | string;
+  xMin?: number;
+  xMax?: number;
   showXAxis: boolean;
   showYAxis: boolean;
   optionUpdateBehavior?: SetOptionOpts;
@@ -194,6 +234,10 @@ function KumoLikeTimeseriesChart({
       toolbox: { show: false },
       xAxis: {
         type: "time",
+        // Pin the axis to the query window so sparse data sits in honest
+        // empty space instead of stretching to fill the chart.
+        min: xMin,
+        max: xMax,
         splitLine: { show: false },
         axisLine: { show: false },
         axisTick: { show: showXAxis },
@@ -230,7 +274,7 @@ function KumoLikeTimeseriesChart({
       },
       series: transformSeries,
     } satisfies EChartsOption;
-  }, [data, type, showXAxis, showYAxis]);
+  }, [data, type, xMin, xMax, showXAxis, showYAxis]);
 
   const events = useMemo<Partial<ChartEvents>>(
     () => ({

--- a/apps/web/src/dashboards/widgets/TimeseriesCountWidget.tsx
+++ b/apps/web/src/dashboards/widgets/TimeseriesCountWidget.tsx
@@ -28,6 +28,8 @@ export function TimeseriesCountWidget({
       <CountChart
         rows={q.data.rows}
         value={countValue}
+        range={range}
+        step={q.data.step}
         chartType={widget.config.chartType ?? defaultChartType(widget.type)}
         limit={widget.config.limit ?? DEFAULT_TOP_N}
         showXAxis={widget.config.showXAxis ?? true}

--- a/apps/web/src/dashboards/widgets/TimeseriesMetricWidget.tsx
+++ b/apps/web/src/dashboards/widgets/TimeseriesMetricWidget.tsx
@@ -40,6 +40,8 @@ export function TimeseriesMetricWidget({
       <CountChart
         rows={q.data.rows}
         value={metricValue}
+        range={range}
+        step={q.data.step}
         chartType={widget.config.chartType ?? defaultChartType(widget.type)}
         limit={widget.config.limit ?? DEFAULT_TOP_N}
         showXAxis={widget.config.showXAxis ?? true}

--- a/apps/web/src/dashboards/widgets/series-topn.test.ts
+++ b/apps/web/src/dashboards/widgets/series-topn.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { DEFAULT_TOP_N, OTHER_LABEL, buildTopNSeries } from "./series-topn.ts";
+import { DEFAULT_TOP_N, OTHER_LABEL, buildTopNSeries, parseStepMs } from "./series-topn.ts";
 
 const count = (r: { count: number }) => r.count;
 
@@ -175,6 +175,66 @@ test("works with an arbitrary value accessor (metric series use r.value)", () =>
     ["p99", "p50"],
   );
   assert.equal(series[0]?.total, 12.5);
+});
+
+test("parseStepMs parses the API step string", () => {
+  assert.equal(parseStepMs("30 SECOND"), 30_000);
+  assert.equal(parseStepMs("5 MINUTE"), 300_000);
+  assert.equal(parseStepMs("3 HOUR"), 10_800_000);
+  assert.equal(parseStepMs("1 DAY"), 86_400_000);
+  assert.equal(parseStepMs("garbage"), null);
+  assert.equal(parseStepMs(undefined), null);
+});
+
+test("grid fill expands the bucket axis across the whole window with zeros", () => {
+  // Data only in the last two of six 1-minute buckets.
+  const rows = [
+    { bucket: "2026-06-01 00:04:00", group: "a", count: 3 },
+    { bucket: "2026-06-01 00:05:00", group: "a", count: 7 },
+  ];
+  const grid = {
+    sinceMs: Date.parse("2026-06-01T00:00:00Z"),
+    untilMs: Date.parse("2026-06-01T00:05:00Z"),
+    stepMs: 60_000,
+  };
+  const series = buildTopNSeries(rows, count, 10, grid);
+  const a = series.find((s) => s.name === "a");
+  assert.ok(a);
+  // 00:00 through 00:05 inclusive = 6 buckets, zeros where no data.
+  assert.equal(a.data.length, 6);
+  assert.deepEqual(
+    a.data.map((d) => d[1]),
+    [0, 0, 0, 0, 3, 7],
+  );
+  assert.equal(a.data[0]?.[0], Date.parse("2026-06-01T00:00:00Z"));
+  // Totals come from real data only.
+  assert.equal(a.total, 10);
+});
+
+test("grid fill aligns its start to the step and keeps off-grid data buckets", () => {
+  const rows = [{ bucket: "2026-06-01 00:02:30", group: "a", count: 1 }];
+  const grid = {
+    sinceMs: Date.parse("2026-06-01T00:00:30Z"), // mid-bucket window start
+    untilMs: Date.parse("2026-06-01T00:03:00Z"),
+    stepMs: 60_000,
+  };
+  const series = buildTopNSeries(rows, count, 10, grid);
+  const a = series.find((s) => s.name === "a");
+  assert.ok(a);
+  // Grid points 00:00..00:03 (floor-aligned) plus the off-grid 00:02:30 bucket.
+  assert.equal(a.data[0]?.[0], Date.parse("2026-06-01T00:00:00Z"));
+  assert.ok(a.data.some((d) => d[0] === Date.parse("2026-06-01T00:02:30Z") && d[1] === 1));
+});
+
+test("grid fill is skipped when it would explode the bucket count", () => {
+  const rows = [{ bucket: "2026-06-01 00:00:00", group: "a", count: 1 }];
+  const grid = {
+    sinceMs: Date.parse("2026-01-01T00:00:00Z"),
+    untilMs: Date.parse("2026-06-01T00:00:00Z"),
+    stepMs: 1_000, // ~13M buckets — defensive cap kicks in
+  };
+  const series = buildTopNSeries(rows, count, 10, grid);
+  assert.equal(series[0]?.data.length, 1);
 });
 
 test("default top-N is 10", () => {

--- a/apps/web/src/dashboards/widgets/series-topn.ts
+++ b/apps/web/src/dashboards/widgets/series-topn.ts
@@ -13,6 +13,48 @@ export const DEFAULT_TOP_N = 10;
 
 export type GroupedRow = { bucket: string; group: string };
 
+/**
+ * Time grid for bar charts: every `stepMs` bucket across [sinceMs, untilMs]
+ * exists on the axis (zero-filled), so bar band width is always one server
+ * bucket and empty stretches render as empty space instead of bars stretching
+ * to fill the data extent.
+ */
+export type BucketGrid = { sinceMs: number; untilMs: number; stepMs: number };
+
+// Defensive cap: the server targets ~120 buckets per window (pickStep), so a
+// grid bigger than this means mismatched inputs — better to skip the fill
+// than to allocate millions of points.
+const MAX_GRID_POINTS = 2000;
+
+const STEP_UNIT_MS: Record<string, number> = {
+  SECOND: 1_000,
+  MINUTE: 60_000,
+  HOUR: 3_600_000,
+  DAY: 86_400_000,
+};
+
+/** Parse the API's step string ("5 MINUTE") into milliseconds. */
+export function parseStepMs(step: string | undefined): number | null {
+  if (!step) return null;
+  const m = /^(\d+)\s+(SECOND|MINUTE|HOUR|DAY)$/.exec(step.trim());
+  if (!m) return null;
+  const unit = STEP_UNIT_MS[m[2] ?? ""];
+  if (!unit) return null;
+  const ms = Number(m[1]) * unit;
+  return ms > 0 ? ms : null;
+}
+
+// All step-ladder intervals divide evenly into their parent unit, so flooring
+// to the step in epoch ms matches ClickHouse's toStartOfInterval (UTC).
+function gridBucketsMs(grid: BucketGrid): number[] | null {
+  const { sinceMs, untilMs, stepMs } = grid;
+  if (!(stepMs > 0) || !(untilMs >= sinceMs)) return null;
+  if ((untilMs - sinceMs) / stepMs > MAX_GRID_POINTS) return null;
+  const out: number[] = [];
+  for (let t = Math.floor(sinceMs / stepMs) * stepMs; t <= untilMs; t += stepMs) out.push(t);
+  return out;
+}
+
 export type ChartSeries = {
   /** Group value, or "Other" for the rolled-up remainder, "(none)" when empty. */
   name: string;
@@ -43,23 +85,27 @@ function bucketToMs(bucket: string): number {
  * exist, a single "Other" series summing the remainder per bucket.
  *
  * @param limit  max real series before rollup; values < 1 mean "no limit".
+ * @param grid   optional full-window bucket grid to zero-fill (bar charts).
  */
 export function buildTopNSeries<T extends GroupedRow>(
   rows: T[],
   valFn: (r: T) => number,
   limit: number = DEFAULT_TOP_N,
+  grid?: BucketGrid,
 ): ChartSeries[] {
   if (rows.length === 0) return [];
 
-  // Stable, sorted bucket axis shared by every series so points align.
-  const bucketSet = new Set<string>();
+  // Stable, sorted bucket axis (epoch ms) shared by every series so points
+  // align; the optional grid extends it across the whole query window.
+  const bucketSet = new Set<number>();
   const totals = new Map<string, number>();
   for (const r of rows) {
-    bucketSet.add(r.bucket);
+    bucketSet.add(bucketToMs(r.bucket));
     const g = r.group || NONE_LABEL;
     totals.set(g, (totals.get(g) ?? 0) + valFn(r));
   }
-  const buckets = [...bucketSet].sort();
+  if (grid) for (const t of gridBucketsMs(grid) ?? []) bucketSet.add(t);
+  const buckets = [...bucketSet].sort((a, b) => a - b);
   const bucketIndex = new Map(buckets.map((b, i) => [b, i]));
 
   const ranked = [...totals.entries()].sort((a, b) => b[1] - a[1]).map(([g]) => g);
@@ -77,7 +123,7 @@ export function buildTopNSeries<T extends GroupedRow>(
   for (const r of rows) {
     const g = r.group || NONE_LABEL;
     const arr = topGroups.has(g) ? points.get(g) : otherArr;
-    const i = bucketIndex.get(r.bucket);
+    const i = bucketIndex.get(bucketToMs(r.bucket));
     if (!arr || i === undefined) continue;
     arr[i] = (arr[i] ?? 0) + valFn(r);
   }
@@ -87,7 +133,7 @@ export function buildTopNSeries<T extends GroupedRow>(
     const data: [number, number][] = buckets.map((b, i) => {
       const v = arr[i] ?? 0;
       total += v;
-      return [bucketToMs(b), v];
+      return [b, v];
     });
     return { name, total, data, isOther };
   };


### PR DESCRIPTION
Two rendering fixes for dashboard timeseries widgets:

**X-axis pinned to the query window.** The axis previously derived from the data extent, so a metric that has only existed for 15 minutes filled the entire chart even with a 6h window selected. The axis now spans the widget's actual query range; sparse data sits at its real position with honest empty space around it.

**Uniform bucket-width bars.** Sparse bar series used to stretch into wide bars that pretend the data was continuous. Bar charts now zero-fill the full bucket grid using the step the series endpoint already returns, so bar band width is always exactly one server bucket — uniform across all time scales, with empty space where there's no data. Line charts are deliberately left un-filled: zero-filling them would draw false dips wherever the bucket step is finer than the metric's export interval.

Tested: unit tests for the grid fill + step parsing in `series-topn`; typecheck.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the dashboard timeseries x-axis to the selected query window and makes bar charts render one-bucket-wide bars by zero-filling the server bucket grid. Sparse data now shows honest empty space instead of stretching to fill the chart.

- **Bug Fixes**
  - Set `xAxis.min/max` from the widget `range` in `CountChart` to fix stretched timelines.
  - For bar charts, zero-fill the full bucket grid using the API `step` so bars are always one server bucket wide; line charts are not filled.
  - Added `parseStepMs` and window-aligned grid generation with a defensive cap to avoid huge grids; unit tests cover step parsing and grid fill.

<sup>Written for commit 568af82576097be636e22fd03ff36aea37d512ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

