### PR TITLE
worker: add unit tests for result, state, and digest policies

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -36,6 +36,9 @@
     "test:managed-agent-result": "tsx --test src/managed-agent-result.test.ts",
     "test:github-app": "tsx --test src/github-app.test.ts",
     "test:autorecovery-repository": "tsx --test src/autorecovery/repository.integration.test.ts",
+    "test:agent-runs-domain": "tsx --test src/agent-runs/domain.test.ts",
+    "test:digest-policy": "tsx --test src/digest/policy.test.ts",
+    "test:incident-result-policy": "tsx --test src/incident-result-policy.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/worker/src/agent-runs/domain.test.ts
+++ b/apps/worker/src/agent-runs/domain.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  ACTIVE_STATES,
+  type AgentRunState,
+  DORMANT_STATES,
+  IllegalAgentRunTransitionError,
+  TERMINAL_STATES,
+  assertAgentRunSourceState,
+  isActiveState,
+} from "./domain.js";
+
+test("agent run state groups partition the domain states", () => {
+  const all: AgentRunState[] = [...ACTIVE_STATES, ...DORMANT_STATES, ...TERMINAL_STATES];
+  const expected: AgentRunState[] = [
+    "queued",
+    "repo_discovery",
+    "running",
+    "awaiting_human",
+    "pr_retry_queued",
+    "blocked_no_github",
+    "complete",
+    "failed",
+  ];
+
+  assert.deepEqual([...all].sort(), [...expected].sort());
+  assert.equal(new Set(all).size, all.length);
+});
+
+test("isActiveState recognizes tickable states only", () => {
+  for (const state of ACTIVE_STATES) assert.equal(isActiveState(state), true, state);
+  for (const state of DORMANT_STATES) assert.equal(isActiveState(state), false, state);
+  for (const state of TERMINAL_STATES) assert.equal(isActiveState(state), false, state);
+  assert.equal(isActiveState("ready_to_pr"), false);
+  assert.equal(isActiveState("unknown_state"), false);
+});
+
+test("assertAgentRunSourceState allows listed source states", () => {
+  assert.doesNotThrow(() =>
+    assertAgentRunSourceState("startRunning", "repo_discovery", ["repo_discovery"]),
+  );
+});
+
+test("assertAgentRunSourceState throws a descriptive transition error", () => {
+  assert.throws(
+    () => assertAgentRunSourceState("startRunning", "queued", ["repo_discovery"]),
+    (err) => {
+      assert.ok(err instanceof IllegalAgentRunTransitionError);
+      assert.equal(err.name, "IllegalTransitionError");
+      assert.equal(
+        err.message,
+        'startRunning: cannot transition from "queued"; allowed source states: repo_discovery',
+      );
+      return true;
+    },
+  );
+});

--- a/apps/worker/src/digest/policy.test.ts
+++ b/apps/worker/src/digest/policy.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { DEFAULT_DIGEST_POLICY, digestPolicyFromEnv } from "./policy.js";
+
+const ENV_NAMES = [
+  "DIGEST_INTERVAL_MS",
+  "DIGEST_RETRY_COOLDOWN_MS",
+  "DIGEST_CANDIDATE_LOOKBACK_MS",
+  "DIGEST_CANDIDATE_LIMIT",
+] as const;
+
+const ORIGINAL_ENV = Object.fromEntries(
+  ENV_NAMES.map((name) => [name, process.env[name]] as const),
+);
+
+afterEach(() => {
+  for (const name of ENV_NAMES) {
+    const original = ORIGINAL_ENV[name];
+    if (original === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = original;
+    }
+  }
+});
+
+test("digestPolicyFromEnv returns defaults when env values are unset or empty", () => {
+  for (const name of ENV_NAMES) process.env[name] = "";
+
+  assert.deepEqual(digestPolicyFromEnv(), DEFAULT_DIGEST_POLICY);
+});
+
+test("digestPolicyFromEnv applies finite numeric env overrides", () => {
+  process.env.DIGEST_INTERVAL_MS = "1000";
+  process.env.DIGEST_RETRY_COOLDOWN_MS = "2000";
+  process.env.DIGEST_CANDIDATE_LOOKBACK_MS = "3000";
+  process.env.DIGEST_CANDIDATE_LIMIT = "4";
+
+  assert.deepEqual(digestPolicyFromEnv(), {
+    intervalMs: 1000,
+    retryCooldownMs: 2000,
+    candidateLookbackMs: 3000,
+    candidateLimit: 4,
+  });
+});
+
+test("digestPolicyFromEnv falls back per field for non-finite env values", () => {
+  process.env.DIGEST_INTERVAL_MS = "not-a-number";
+  process.env.DIGEST_RETRY_COOLDOWN_MS = "Infinity";
+  process.env.DIGEST_CANDIDATE_LOOKBACK_MS = "5000";
+  process.env.DIGEST_CANDIDATE_LIMIT = "NaN";
+
+  assert.deepEqual(digestPolicyFromEnv(), {
+    ...DEFAULT_DIGEST_POLICY,
+    candidateLookbackMs: 5000,
+  });
+});

--- a/apps/worker/src/incident-result-policy.test.ts
+++ b/apps/worker/src/incident-result-policy.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { AgentRunResult } from "@superlog/db";
+import {
+  completedNoiseReason,
+  completedResolutionReason,
+  noiseReasonLabel,
+  normalizeNoiseReason,
+  normalizeResolutionReason,
+  normalizeSeverity,
+  resolutionReasonLabel,
+} from "./incident-result-policy.js";
+
+test("normalizeSeverity accepts canonical severities with case and whitespace noise", () => {
+  assert.equal(normalizeSeverity("SEV-1"), "SEV-1");
+  assert.equal(normalizeSeverity(" sev - 2 "), "SEV-2");
+  assert.equal(normalizeSeverity("sev-3"), "SEV-3");
+});
+
+test("normalizeSeverity rejects unknown or non-string inputs", () => {
+  assert.equal(normalizeSeverity("SEV-4"), null);
+  assert.equal(normalizeSeverity("sev2"), null);
+  assert.equal(normalizeSeverity(null), null);
+  assert.equal(normalizeSeverity(2), null);
+});
+
+test("normalizes incident result reason enums from agent output", () => {
+  assert.equal(normalizeNoiseReason(" SELF_TELEMETRY "), "self_telemetry");
+  assert.equal(normalizeNoiseReason("confusing_log_no_impact"), "confusing_log_no_impact");
+  assert.equal(normalizeNoiseReason("not_a_noise_reason"), null);
+  assert.equal(normalizeNoiseReason(undefined), null);
+
+  assert.equal(normalizeResolutionReason(" UPSTREAM_RECOVERED "), "upstream_recovered");
+  assert.equal(
+    normalizeResolutionReason("transient_condition_cleared"),
+    "transient_condition_cleared",
+  );
+  assert.equal(normalizeResolutionReason("not_a_resolution_reason"), null);
+  assert.equal(normalizeResolutionReason({}), null);
+});
+
+test("reason labels stay human-readable for Slack and incident history", () => {
+  assert.equal(noiseReasonLabel("cosmetic_log_only"), "cosmetic log only");
+  assert.equal(noiseReasonLabel("lifecycle_signal"), "lifecycle signal");
+  assert.equal(noiseReasonLabel("self_telemetry"), "self-telemetry");
+  assert.equal(noiseReasonLabel("expected_third_party"), "expected third-party response");
+  assert.equal(noiseReasonLabel("confusing_log_no_impact"), "recovered/no impact");
+
+  assert.equal(resolutionReasonLabel("fixed_in_current_code"), "fixed in current code");
+  assert.equal(
+    resolutionReasonLabel("transient_condition_cleared"),
+    "transient condition cleared",
+  );
+  assert.equal(resolutionReasonLabel("upstream_recovered"), "upstream recovered");
+});
+
+test("completed reason helpers only read classifications from complete results", () => {
+  const complete = {
+    state: "complete",
+    noiseClassification: { reason: "LIFECYCLE_SIGNAL" },
+    resolutionClassification: { reason: "FIXED_IN_CURRENT_CODE" },
+  } as unknown as AgentRunResult;
+  const running = {
+    state: "running",
+    noiseClassification: { reason: "self_telemetry" },
+    resolutionClassification: { reason: "upstream_recovered" },
+  } as unknown as AgentRunResult;
+
+  assert.equal(completedNoiseReason(complete), "lifecycle_signal");
+  assert.equal(completedResolutionReason(complete), "fixed_in_current_code");
+  assert.equal(completedNoiseReason(running), null);
+  assert.equal(completedResolutionReason(running), null);
+});


### PR DESCRIPTION
## Summary

Adds focused unit tests for pure worker policy/domain modules:

- `incident-result-policy.ts`
  - severity normalization
  - noise/resolution reason normalization
  - human-readable reason labels
  - completed-result classification guards

- `agent-runs/domain.ts`
  - agent-run state partition coverage
  - active vs dormant/terminal state checks
  - illegal transition error behavior

- `digest/policy.ts`
  - default policy values from env
  - finite numeric env overrides
  - fallback behavior for invalid env values

## Testing

- `pnpm exec tsx --test apps/worker/src/incident-result-policy.test.ts apps/worker/src/agent-runs/domain.test.ts apps/worker/src/digest/policy.test.ts`
- `pnpm --filter @superlog/worker typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for worker incident-result policy, agent-run state domain, and digest policy to prevent regressions in classification, state transitions, and env parsing.

Tests cover severity/reason normalization and labels, active vs. dormant/terminal checks with clear illegal transition errors, and env-based digest defaults, numeric overrides, and safe fallbacks.

<sup>Written for commit e65ee18e576e994a58d422415b831a1cfe9c67fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

