### PR TITLE
api: add unit tests for email bodies and alerts-service

### DIFF
--- a/apps/api/src/alerts-service.test.ts
+++ b/apps/api/src/alerts-service.test.ts
@@ -1,0 +1,190 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { HTTPException } from "hono/http-exception";
+
+// alerts-service.ts transitively imports the db client, which throws at import
+// time without a connection string. Set a dummy URL before the dynamic import
+// (the postgres client connects lazily, so these pure-function tests never open
+// a socket). Same dynamic-import pattern as incidents/detail.test.ts.
+process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
+const { validateAlertInput, alertInputToFilter, summarizeEvaluation } = await import(
+  "./alerts-service.js"
+);
+
+type AlertInput = Parameters<typeof validateAlertInput>[0];
+
+function baseInput(overrides: Partial<AlertInput> = {}): AlertInput {
+  return {
+    name: "test alert",
+    source: "traces",
+    aggregation: "count",
+    comparator: "gt",
+    threshold: 10,
+    ...overrides,
+  } as AlertInput;
+}
+
+function expectBadRequest(fn: () => void, messageMatch: string): void {
+  let err: unknown;
+  try {
+    fn();
+  } catch (caught) {
+    err = caught;
+  }
+  assert.ok(err !== undefined, "expected validateAlertInput to throw");
+  assert.ok(err instanceof HTTPException, "expected an HTTPException");
+  assert.equal(err.status, 400);
+  assert.match(err.message, new RegExp(messageMatch));
+}
+
+test("validateAlertInput accepts a valid logs/traces count alert", () => {
+  assert.doesNotThrow(() => validateAlertInput(baseInput({ source: "traces" })));
+  assert.doesNotThrow(() => validateAlertInput(baseInput({ source: "logs" })));
+});
+
+test("validateAlertInput accepts a valid metric alert", () => {
+  assert.doesNotThrow(() =>
+    validateAlertInput(
+      baseInput({ source: "metric", metricName: "http.server.duration", aggregation: "avg" }),
+    ),
+  );
+});
+
+test("validateAlertInput requires metricName when source = metric", () => {
+  expectBadRequest(
+    () => validateAlertInput(baseInput({ source: "metric", aggregation: "sum", metricName: null })),
+    "metricName required",
+  );
+});
+
+test("validateAlertInput rejects non-count aggregation for logs/traces", () => {
+  expectBadRequest(
+    () => validateAlertInput(baseInput({ source: "logs", aggregation: "sum" })),
+    "must be 'count' for logs/traces",
+  );
+});
+
+test("validateAlertInput rejects count aggregation for metric source", () => {
+  expectBadRequest(
+    () =>
+      validateAlertInput(baseInput({ source: "metric", metricName: "m", aggregation: "count" })),
+    "'sum' or 'avg' for metric",
+  );
+});
+
+test("validateAlertInput requires groupBy when groupMode = per_group", () => {
+  expectBadRequest(
+    () => validateAlertInput(baseInput({ groupMode: "per_group", groupBy: null })),
+    "groupBy required",
+  );
+  assert.doesNotThrow(() =>
+    validateAlertInput(baseInput({ groupMode: "per_group", groupBy: "service.name" })),
+  );
+});
+
+test("alertInputToFilter keeps only the filter fields", () => {
+  const filter = alertInputToFilter(
+    baseInput({
+      groupBy: "service.name",
+      groupMode: "per_group",
+      filter: {
+        resourceAttrs: [{ key: "deployment.environment", value: "prod" }],
+        service: "checkout",
+        severity: "ERROR",
+        spanName: "POST /pay",
+        statusCode: "500",
+        minDurationMs: 250,
+      },
+    }),
+  );
+
+  assert.deepEqual(filter, {
+    resourceAttrs: [{ key: "deployment.environment", value: "prod" }],
+    service: "checkout",
+    severity: "ERROR",
+    spanName: "POST /pay",
+    statusCode: "500",
+    minDurationMs: 250,
+  });
+});
+
+test("alertInputToFilter returns undefined fields when no filter is provided", () => {
+  const filter = alertInputToFilter(baseInput());
+  assert.deepEqual(filter, {
+    resourceAttrs: undefined,
+    service: undefined,
+    severity: undefined,
+    spanName: undefined,
+    statusCode: undefined,
+    minDurationMs: undefined,
+  });
+});
+
+test("summarizeEvaluation single mode reports the total and a 0/1 breach count", () => {
+  const alert = {
+    comparator: "gt" as const,
+    threshold: 10,
+    groupMode: "single" as const,
+    groupBy: null,
+  };
+
+  const below = summarizeEvaluation(alert, { groups: new Map([["", 5]]), total: 5 });
+  assert.deepEqual(below, { mode: "single", value: 5, breaches: 0 });
+
+  const above = summarizeEvaluation(alert, { groups: new Map([["", 15]]), total: 15 });
+  assert.deepEqual(above, { mode: "single", value: 15, breaches: 1 });
+});
+
+test("summarizeEvaluation single mode respects the lt comparator", () => {
+  const alert = {
+    comparator: "lt" as const,
+    threshold: 10,
+    groupMode: "single" as const,
+    groupBy: null,
+  };
+  const result = summarizeEvaluation(alert, { groups: new Map(), total: 5 });
+  assert.deepEqual(result, { mode: "single", value: 5, breaches: 1 });
+});
+
+test("summarizeEvaluation per_group mode sorts by value desc and counts breaches", () => {
+  const alert = {
+    comparator: "gt" as const,
+    threshold: 10,
+    groupMode: "per_group" as const,
+    groupBy: "service.name",
+  };
+  const result = summarizeEvaluation(alert, {
+    groups: new Map([
+      ["g1", 1],
+      ["g2", 50],
+      ["g3", 11],
+    ]),
+    total: 62,
+  });
+
+  assert.equal(result.mode, "per_group");
+  if (result.mode !== "per_group") return; // narrow for TS
+  assert.deepEqual(
+    result.groups.map((g) => g.key),
+    ["g2", "g3", "g1"],
+  );
+  assert.deepEqual(
+    result.groups.map((g) => g.breaching),
+    [true, true, false],
+  );
+  assert.equal(result.breaches, 2);
+});
+
+test("summarizeEvaluation falls back to single mode when groupBy is missing", () => {
+  const alert = {
+    comparator: "gt" as const,
+    threshold: 10,
+    groupMode: "per_group" as const,
+    groupBy: null,
+  };
+  const result = summarizeEvaluation(alert, {
+    groups: new Map([["a", 99]]),
+    total: 99,
+  });
+  assert.deepEqual(result, { mode: "single", value: 99, breaches: 1 });
+});

--- a/apps/api/src/email.test.ts
+++ b/apps/api/src/email.test.ts
@@ -1,0 +1,100 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { orgInvitationEmailBody, passwordResetEmailBody, verificationEmailBody } from "./email.js";
+
+test("verificationEmailBody keeps the raw url in text and an escaped copy in html", () => {
+  const url = "https://api.superlog.sh/verify?token=a&b=2";
+  const { text, html } = verificationEmailBody(url);
+
+  // text body carries the raw URL untouched so the link is copy-pasteable
+  assert.ok(text.includes(url));
+  // html escapes the ampersand for both the href and the visible link text
+  assert.ok(html.includes("https://api.superlog.sh/verify?token=a&amp;b=2"));
+  assert.ok(!html.includes("token=a&b=2"));
+});
+
+test("verificationEmailBody escapes html-injection attempts in the url", () => {
+  const url = 'https://api.superlog.sh/x"><script>alert(1)</script>';
+  const { html } = verificationEmailBody(url);
+
+  // none of the dangerous characters survive into the markup
+  assert.ok(!html.includes("<script>"));
+  assert.ok(!html.includes('"><'));
+  assert.ok(html.includes("&quot;"));
+  assert.ok(html.includes("&gt;"));
+  assert.ok(html.includes("&lt;script&gt;"));
+});
+
+test("passwordResetEmailBody mentions expiry and escapes the url", () => {
+  const url = "https://api.superlog.sh/reset?token=x&y=1";
+  const { text, html } = passwordResetEmailBody(url);
+
+  assert.ok(text.includes("expires in 1 hour"));
+  assert.ok(text.includes(url));
+  assert.ok(html.includes("https://api.superlog.sh/reset?token=x&amp;y=1"));
+  assert.ok(!html.includes("token=x&y=1"));
+});
+
+test("orgInvitationEmailBody uses the inviter name when present", () => {
+  const { text, html } = orgInvitationEmailBody({
+    url: "https://api.superlog.sh/invite/abc",
+    orgName: "Acme Inc.",
+    inviterEmail: "alice@example.com",
+    inviterName: "Alice",
+    role: "admin",
+  });
+
+  assert.ok(text.startsWith("Alice invited you to join Acme Inc. on Superlog as admin."));
+  assert.ok(html.includes("Alice invited you to join <strong>Acme Inc.</strong>"));
+  assert.ok(html.includes("as admin."));
+  // the inviter email is not used when a name is available
+  assert.ok(!text.includes("alice@example.com"));
+});
+
+test("orgInvitationEmailBody falls back to inviter email when name is missing or blank", () => {
+  for (const inviterName of [null, undefined, "", "   "]) {
+    const { text, html } = orgInvitationEmailBody({
+      url: "https://api.superlog.sh/invite/abc",
+      orgName: "Acme Inc.",
+      inviterEmail: "alice@example.com",
+      inviterName,
+      role: "member",
+    });
+
+    assert.ok(
+      text.startsWith("alice@example.com invited you to join Acme Inc. on Superlog as member."),
+      `expected email fallback for inviterName=${JSON.stringify(inviterName)}`,
+    );
+    assert.ok(html.includes("alice@example.com invited you to join"));
+  }
+});
+
+test("orgInvitationEmailBody escapes org name, role, and inviter in the html body", () => {
+  const { html } = orgInvitationEmailBody({
+    url: 'https://api.superlog.sh/invite"><img>',
+    orgName: "<b>Evil</b> Corp",
+    inviterEmail: "alice@example.com",
+    inviterName: '<script>alert("x")</script>',
+    role: "<admin>",
+  });
+
+  assert.ok(!html.includes("<script>"));
+  assert.ok(!html.includes("<b>Evil</b>"));
+  assert.ok(!html.includes('"><img>'));
+  assert.ok(html.includes("&lt;b&gt;Evil&lt;/b&gt; Corp"));
+  assert.ok(html.includes("&lt;admin&gt;"));
+  assert.ok(html.includes("&lt;script&gt;"));
+});
+
+test("orgInvitationEmailBody keeps the raw url in the text accept link", () => {
+  const url = "https://api.superlog.sh/invite/abc?ref=email&x=1";
+  const { text } = orgInvitationEmailBody({
+    url,
+    orgName: "Acme",
+    inviterEmail: "a@b.com",
+    inviterName: "A",
+    role: "member",
+  });
+
+  assert.ok(text.includes(`Accept: ${url}`));
+});


### PR DESCRIPTION
## Summary

Adds two new test files covering pure logic that were previously untested:

- `apps/api/src/email.test.ts` (7 tests) — the three email body builders used by Better Auth (verification, password reset, org invite), with focus on the `escape()` helper and the inviter-name → inviter-email fallback.
- `apps/api/src/alerts-service.test.ts` (12 tests) — `validateAlertInput` (all four cross-field guards), `alertInputToFilter`, and `summarizeEvaluation` in `single` and `per_group` modes plus the `groupBy: null` → single fallback.

No production code changes.

## Testing

`pnpm --filter @superlog/api test`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `apps/api/src/email.ts` and `apps/api/src/alerts-service.ts` to lock down HTML escaping and alert logic. Tests cover verification/reset/invite email bodies (XSS-safe escaping and inviter name→email fallback) and alert input validation, filter extraction, and single/per_group summarization; no production code changes.

<sup>Written for commit a39d1ed40898964c963e9592e68d8b19db19e1af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

