### PR TITLE
web: surface integration connect errors instead of failing silently

### DIFF
--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -1097,6 +1097,7 @@ function SlackCard() {
   const install = useSlackInstallation();
   const start = useStartSlackInstall();
   const uninstall = useUninstallSlack();
+  const [connectError, setConnectError] = useState<string | null>(null);
 
   const installed = install.data?.installed === true;
 
@@ -1123,9 +1124,14 @@ function SlackCard() {
             size="sm"
             variant={installed ? "secondary" : "primary"}
             loading={start.isPending}
-            onClick={async () => {
-              const { url } = await start.mutateAsync();
-              window.location.href = url;
+            onClick={() => {
+              setConnectError(null);
+              start.mutate(undefined, {
+                onSuccess: ({ url }) => {
+                  window.location.href = url;
+                },
+                onError: (err) => setConnectError(describeIntegrationConnectError(err, "Slack")),
+              });
             }}
           >
             {installed ? "Reinstall" : "Connect Slack"}
@@ -1141,6 +1147,11 @@ function SlackCard() {
             </Btn>
           )}
         </div>
+        {connectError && (
+          <p className="text-[12px] text-danger" role="alert">
+            {connectError}
+          </p>
+        )}
       </div>
     </Tile>
   );

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -79,6 +79,7 @@ import {
 } from "./api";
 import { Dropdown, type DropdownOption } from "./design/Dropdown.tsx";
 import { Btn, Chip, FieldLabel, Input, Label, Tile } from "./design/ui";
+import { describeIntegrationConnectError } from "./integrationError.ts";
 import { AgentMemoriesCard } from "./settings/AgentMemoriesCard.tsx";
 import { BillingCard } from "./settings/BillingCard.tsx";
 import { OrgGeneralCard } from "./settings/OrgGeneralCard.tsx";
@@ -878,6 +879,7 @@ function GithubCard() {
   const startAuthor = useStartGithubAuthorLogin();
   const resetAuthor = useResetGithubCommitAuthor();
   const updateRepoAccess = useUpdateGithubRepoAccess();
+  const [connectError, setConnectError] = useState<string | null>(null);
 
   const installed = install.data?.installed === true;
   const installations = install.data?.installed ? install.data.installations : [];
@@ -918,9 +920,14 @@ function GithubCard() {
             size="sm"
             variant={installed ? "secondary" : "primary"}
             loading={startAccess.isPending}
-            onClick={async () => {
-              const { url } = await startAccess.mutateAsync();
-              window.location.href = url;
+            onClick={() => {
+              setConnectError(null);
+              startAccess.mutate(undefined, {
+                onSuccess: ({ url }) => {
+                  window.location.href = url;
+                },
+                onError: (err) => setConnectError(describeIntegrationConnectError(err, "GitHub")),
+              });
             }}
           >
             {installed ? "Refresh access" : "Connect GitHub"}
@@ -929,14 +936,24 @@ function GithubCard() {
             size="sm"
             variant={needsInstall ? "primary" : "secondary"}
             loading={start.isPending}
-            onClick={async () => {
-              const { url } = await start.mutateAsync();
-              window.location.href = url;
+            onClick={() => {
+              setConnectError(null);
+              start.mutate(undefined, {
+                onSuccess: ({ url }) => {
+                  window.location.href = url;
+                },
+                onError: (err) => setConnectError(describeIntegrationConnectError(err, "GitHub")),
+              });
             }}
           >
             {installed ? "Add repositories" : "Install GitHub App"}
           </Btn>
         </div>
+        {connectError && (
+          <p className="text-[12px] text-danger" role="alert">
+            {connectError}
+          </p>
+        )}
         {installed && (
           <div className="space-y-2 pt-2">
             <FieldLabel>Installed accounts</FieldLabel>

--- a/apps/web/src/integrationError.test.ts
+++ b/apps/web/src/integrationError.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { describeIntegrationConnectError } from "./integrationError.ts";
+
+test("503 explains the integration is not configured on the server", () => {
+  const msg = describeIntegrationConnectError(
+    new Error('503: {"error":"github app not configured"}'),
+    "GitHub",
+  );
+  assert.match(msg, /GitHub isn't configured on this server yet/);
+});
+
+test("503 message is integration-specific", () => {
+  const msg = describeIntegrationConnectError(new Error("503: {}"), "Slack");
+  assert.match(msg, /Slack isn't configured on this server yet/);
+});
+
+test("auth failures suggest signing in again", () => {
+  for (const status of [401, 403]) {
+    const msg = describeIntegrationConnectError(new Error(`${status}: nope`), "GitHub");
+    assert.match(msg, /Try signing in again/);
+  }
+});
+
+test("unknown status surfaces the JSON error detail", () => {
+  const msg = describeIntegrationConnectError(new Error('500: {"error":"boom"}'), "GitHub");
+  assert.equal(msg, "Couldn't start the GitHub connection: boom");
+});
+
+test("non-JSON body is surfaced verbatim", () => {
+  const msg = describeIntegrationConnectError(new Error("500: upstream exploded"), "GitHub");
+  assert.equal(msg, "Couldn't start the GitHub connection: upstream exploded");
+});
+
+test("network error (no status) falls back to a generic retry message", () => {
+  const msg = describeIntegrationConnectError(new Error("Failed to fetch"), "GitHub");
+  assert.equal(msg, "Couldn't start the GitHub connection: Failed to fetch");
+});
+
+test("empty error yields a plain retry message", () => {
+  const msg = describeIntegrationConnectError(new Error(""), "GitHub");
+  assert.equal(msg, "Couldn't start the GitHub connection. Please try again.");
+});
+
+test("non-Error values are coerced safely", () => {
+  const msg = describeIntegrationConnectError("503: down", "GitHub");
+  assert.match(msg, /isn't configured/);
+});

--- a/apps/web/src/integrationError.ts
+++ b/apps/web/src/integrationError.ts
@@ -1,0 +1,43 @@
+// Turns a failed "connect integration" request into a message we can actually
+// show the user. The connect buttons (GitHub, Slack, …) navigate away on
+// success; on failure the mutation rejects and — without this — nothing happens,
+// so the button looks dead. `fetcher` throws `Error("<status>: <body>")`, which
+// we decode here into something human-readable.
+
+export function describeIntegrationConnectError(err: unknown, integration: string): string {
+  const raw = (err instanceof Error ? err.message : String(err)).trim();
+  const match = /^(\d{3}):\s*([\s\S]*)$/.exec(raw);
+  const status = match ? Number(match[1]) : null;
+
+  // 503 = the server has no credentials for this integration. This is the
+  // common self-hosted / local-dev case: the API returns 503 from
+  // /api/<integration>/install-url when the app/OAuth env vars are unset.
+  if (status === 503) {
+    return `${integration} isn't configured on this server yet. The server needs ${integration} credentials set before you can connect.`;
+  }
+  if (status === 401 || status === 403) {
+    return `Your session can't start the ${integration} connection. Try signing in again.`;
+  }
+
+  const detail = extractDetail(match?.[2] ?? raw);
+  return detail
+    ? `Couldn't start the ${integration} connection: ${detail}`
+    : `Couldn't start the ${integration} connection. Please try again.`;
+}
+
+// The error body is usually a JSON envelope like `{"error":"…"}`; pull the
+// message out of it when we can, otherwise fall back to the raw text.
+function extractDetail(body: string): string {
+  const trimmed = body.trim();
+  if (!trimmed) return "";
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (parsed && typeof parsed === "object" && "error" in parsed) {
+      const value = (parsed as { error: unknown }).error;
+      if (typeof value === "string" && value.trim()) return value.trim();
+    }
+  } catch {
+    /* not JSON — use the raw text */
+  }
+  return trimmed;
+}

--- a/apps/web/src/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/onboarding/OnboardingWizard.tsx
@@ -242,7 +242,13 @@ function AgentSetupFlow({
   // always show the install button, even for users who signed in with GitHub.
   const signedInWithGithub = false;
   const [intentId] = useState(() => getSkillOnboardingIntent());
-  const [connectError, setConnectError] = useState<string | null>(null);
+  // Scope the connect error to the integration it came from: the GitHub and
+  // Slack steps share this state, so tagging it prevents a failed GitHub
+  // connect from leaking its message onto the Slack step (or vice versa).
+  const [connectError, setConnectError] = useState<{
+    integration: "GitHub" | "Slack";
+    message: string;
+  } | null>(null);
 
   useEffect(() => {
     if (!githubReady || !slackReady || !intentId || claimIntent.data || claimIntent.isPending)
@@ -263,12 +269,16 @@ function AgentSetupFlow({
         body="Choose the repositories you want Superlog to work with. At least one enabled repo is required."
         loading={githubLoading || startGithub.isPending}
         cta={signedInWithGithub ? "Grant repo access" : "Connect GitHub"}
-        error={connectError}
+        error={connectError?.integration === "GitHub" ? connectError.message : null}
         onNext={() => {
           setConnectError(null);
           startGithub.mutate(undefined, {
             onSuccess: ({ url }) => window.location.assign(url),
-            onError: (err) => setConnectError(describeIntegrationConnectError(err, "GitHub")),
+            onError: (err) =>
+              setConnectError({
+                integration: "GitHub",
+                message: describeIntegrationConnectError(err, "GitHub"),
+              }),
           });
         }}
       />
@@ -284,12 +294,16 @@ function AgentSetupFlow({
         body="After Slack is connected, we'll finish setup and send you back to your agent."
         loading={slackLoading || startSlack.isPending}
         cta="Connect Slack"
-        error={connectError}
+        error={connectError?.integration === "Slack" ? connectError.message : null}
         onNext={() => {
           setConnectError(null);
           startSlack.mutate(undefined, {
             onSuccess: ({ url }) => window.location.assign(url),
-            onError: (err) => setConnectError(describeIntegrationConnectError(err, "Slack")),
+            onError: (err) =>
+              setConnectError({
+                integration: "Slack",
+                message: describeIntegrationConnectError(err, "Slack"),
+              }),
           });
         }}
         onSkip={() => setSlackSkipped(true)}

--- a/apps/web/src/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/onboarding/OnboardingWizard.tsx
@@ -15,6 +15,7 @@ import {
 import { authClient, useSession } from "../auth-client.ts";
 import { Btn, Wordmark } from "../design/ui.tsx";
 import { INSTALL_PROMPT, buildInstallPrompt } from "../installPrompt.ts";
+import { describeIntegrationConnectError } from "../integrationError.ts";
 import { getSkillOnboardingIntent } from "../skillOnboarding.ts";
 import { TruncatedKey } from "./TruncatedKey.tsx";
 import {
@@ -241,6 +242,7 @@ function AgentSetupFlow({
   // always show the install button, even for users who signed in with GitHub.
   const signedInWithGithub = false;
   const [intentId] = useState(() => getSkillOnboardingIntent());
+  const [connectError, setConnectError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!githubReady || !slackReady || !intentId || claimIntent.data || claimIntent.isPending)
@@ -261,11 +263,14 @@ function AgentSetupFlow({
         body="Choose the repositories you want Superlog to work with. At least one enabled repo is required."
         loading={githubLoading || startGithub.isPending}
         cta={signedInWithGithub ? "Grant repo access" : "Connect GitHub"}
-        onNext={() =>
+        error={connectError}
+        onNext={() => {
+          setConnectError(null);
           startGithub.mutate(undefined, {
             onSuccess: ({ url }) => window.location.assign(url),
-          })
-        }
+            onError: (err) => setConnectError(describeIntegrationConnectError(err, "GitHub")),
+          });
+        }}
       />
     );
   }
@@ -279,11 +284,14 @@ function AgentSetupFlow({
         body="After Slack is connected, we'll finish setup and send you back to your agent."
         loading={slackLoading || startSlack.isPending}
         cta="Connect Slack"
-        onNext={() =>
+        error={connectError}
+        onNext={() => {
+          setConnectError(null);
           startSlack.mutate(undefined, {
             onSuccess: ({ url }) => window.location.assign(url),
-          })
-        }
+            onError: (err) => setConnectError(describeIntegrationConnectError(err, "Slack")),
+          });
+        }}
         onSkip={() => setSlackSkipped(true)}
         skipLabel="Skip for now"
       />
@@ -320,6 +328,7 @@ function IntegrationStep({
   onNext,
   onSkip,
   skipLabel,
+  error,
 }: {
   icon: React.ReactNode;
   title: string;
@@ -330,6 +339,7 @@ function IntegrationStep({
   onNext: () => void;
   onSkip?: () => void;
   skipLabel?: string;
+  error?: string | null;
 }) {
   return (
     <>
@@ -345,6 +355,11 @@ function IntegrationStep({
           <p className="m-0 flex-1 text-[13.5px] leading-[1.5] text-muted">{body}</p>
         </div>
       </div>
+      {error && (
+        <p className="mt-3 text-[12px] text-danger" role="alert">
+          {error}
+        </p>
+      )}
       <StepFooter
         onNext={onNext}
         nextLabel={loading ? "Connecting..." : cta}

--- a/apps/web/src/onboarding/SetupTodos.tsx
+++ b/apps/web/src/onboarding/SetupTodos.tsx
@@ -8,6 +8,7 @@ import {
   useStartSlackInstall,
   useStats,
 } from "../api.ts";
+import { describeIntegrationConnectError } from "../integrationError.ts";
 import { DeployDialog } from "./DeployDialog.tsx";
 import { McpInstallDialog } from "./McpInstallDialog.tsx";
 import { TodoCarousel } from "./TodoCarousel.tsx";
@@ -84,6 +85,7 @@ export function SetupTodos({ projectId }: { projectId: string }) {
 
   const [mcpOpen, setMcpOpen] = useState(false);
   const [deployOpen, setDeployOpen] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   // Hold off the first paint until every signal has resolved once — otherwise
   // a fully-onboarded user briefly sees all four todos (every `…Connected`
@@ -110,16 +112,20 @@ export function SetupTodos({ projectId }: { projectId: string }) {
 
   const handleAction = (t: Todo) => {
     if (t.id === "github") {
+      setActionError(null);
       startGithub.mutate(undefined, {
         onSuccess: ({ url }) => {
           window.location.assign(url);
         },
+        onError: (err) => setActionError(describeIntegrationConnectError(err, "GitHub")),
       });
     } else if (t.id === "slack") {
+      setActionError(null);
       startSlack.mutate(undefined, {
         onSuccess: ({ url }) => {
           window.location.assign(url);
         },
+        onError: (err) => setActionError(describeIntegrationConnectError(err, "Slack")),
       });
     } else if (t.id === "mcp") {
       setMcpOpen(true);
@@ -143,6 +149,11 @@ export function SetupTodos({ projectId }: { projectId: string }) {
         completed={completed}
         onAction={handleAction}
       />
+      {actionError && (
+        <p className="mt-2 text-[12px] text-danger" role="alert">
+          {actionError}
+        </p>
+      )}
       {mcpOpen && <McpInstallDialog onClose={() => setMcpOpen(false)} />}
       {deployOpen && <DeployDialog projectId={projectId} onClose={() => setDeployOpen(false)} />}
     </>


### PR DESCRIPTION
## Problem

The **Connect GitHub** / **Connect Slack** buttons navigate away on success, but the click handlers only had `onSuccess` handlers. On failure the mutation rejected and nothing happened — the button looked dead with no feedback.

The most common trigger locally / self-hosted: the API returns `503` from `/api/github/install-url` when the server has no GitHub App credentials configured. The user clicks "Connect GitHub" and nothing happens, with no indication why.

## Screenshot

You clicked Connect Slack, Slack has no credentials configured on the server → the API returned 503 → and
  instead of the button silently doing nothing (the old behavior), our decoder rendered:

` "Slack isn't configured on this server yet. The server needs Slack credentials set before you can connect."`

<img width="1180" height="600" alt="Screenshot 2026-06-15 at 9 54 52 PM" src="https://github.com/user-attachments/assets/8692feea-7dc7-4118-a073-3dc6c5110328" />


## Fix

Add `describeIntegrationConnectError(err, integration)` — a small pure helper that decodes the fetcher's `Error("<status>: <body>")` into a human-readable message:

- **503** → "{integration} isn't configured on this server yet…"
- **401 / 403** → "Your session can't start the {integration} connection. Try signing in again."
- **other status, JSON `{"error":"…"}` body** → "Couldn't start the {integration} connection: {detail}"
- **other status, plain-text body** → surfaces the text verbatim
- **network error (no status)** → "Couldn't start the {integration} connection: {message}"
- **empty / unparseable** → generic "Please try again."

The message renders as a `text-danger` / `role="alert"` line at all three connect entry points, matching the existing error styling in those views:

- the onboarding wizard (GitHub + Slack steps)
- the project Integrations card in Settings (Connect / Refresh access / Install / Add repositories)
- the dashboard setup-todos carousel (GitHub + Slack)

## Tests

`integrationError.test.ts` covers all six branches (8 cases) via the Node test runner — `node --import tsx --test apps/web/src/integrationError.test.ts`.

## Notes

- The decoder is pure (no React/DOM), so it's unit-tested in isolation.
- Web-only; no API or worker changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show clear error messages when Connect GitHub/Slack fails instead of doing nothing. Errors now appear in onboarding, Settings > Integrations, and dashboard setup todos, and are scoped to the correct integration.

- Bug Fixes
  - Added `describeIntegrationConnectError()` to decode errors into friendly messages: 503 not configured, 401/403 sign in again, JSON/text detail, and network/empty fallbacks.
  - Render the message inline next to the button as `text-danger` with `role="alert"` across all entry points; Settings Slack now uses `onError` so failures surface too.
  - Scoped onboarding errors to the matching integration to prevent cross-step leakage; added unit tests covering all branches and non-Error inputs.

<sup>Written for commit 0f4a6c4e70498580d8ba5e9754799c2c03512e72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

