### PR TITLE
Talk to investigations: continue the same session instead of re-investigating

### DIFF
--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import {
   db,
   listAccessibleGithubInstallsForProject,
-  requestFollowUpAgentRun,
+  recordInboundInteraction,
   resolveIncident,
   schema,
   syncLoopsContactsForOrg,
@@ -785,11 +785,11 @@ function extractEligiblePrComment(
   return { body, actor, commentUrl, path, line };
 }
 
-// Review feedback on an agent PR revives the agent as a follow-up run that
-// addresses the requested changes on the existing branch. Eligibility (caps,
-// staleness, project gate) is enforced by requestFollowUpAgentRun; comments
-// arriving while a follow-up is still queued append to it, so a review burst
-// becomes one run.
+// Review feedback on an agent PR continues the SAME investigation session where
+// one survives (resume / steer, keeping the existing branch mounted), and only
+// cold-starts a fresh run when no session can be resumed. `detail.origin`
+// carries the comment so the worker routes the agent's reply back to the PR.
+// The comment URL is a stable dedupe key against GitHub webhook redelivery.
 async function maybeRequestPrCommentFollowUp(opts: {
   event: string;
   payload: WebhookPayload;
@@ -797,9 +797,8 @@ async function maybeRequestPrCommentFollowUp(opts: {
 }): Promise<void> {
   const comment = extractEligiblePrComment(opts.event, opts.payload);
   if (!comment) return;
-  const result = await requestFollowUpAgentRun(db, {
+  const result = await recordInboundInteraction(db, {
     incidentId: opts.agentPrRow.incidentId,
-    trigger: "pr_comment",
     interaction: {
       channel: "pr_comment",
       author: comment.actor?.login ?? null,
@@ -809,11 +808,14 @@ async function maybeRequestPrCommentFollowUp(opts: {
       line: comment.line,
       occurredAt: new Date().toISOString(),
     },
+    dedupeKey: comment.commentUrl
+      ? `github:${comment.commentUrl}`
+      : `github:${opts.agentPrRow.id}:${Date.now()}`,
   });
   if (result.outcome === "skipped") {
     log.info(
       { incident_id: opts.agentPrRow.incidentId, reason: result.reason },
-      "pr comment did not trigger a follow-up run",
+      "pr comment did not continue the investigation",
     );
   }
 }

--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -731,6 +731,9 @@ type EligiblePrComment = {
   commentUrl: string | null;
   path: string | null;
   line: number | null;
+  // Stable GitHub id of the comment/review — a deterministic dedupe key across
+  // webhook redelivery, used in preference to the URL.
+  sourceId: string | null;
 };
 
 // Shared gate for the comment-bearing PR events: real text from a real
@@ -746,11 +749,13 @@ function extractEligiblePrComment(
   let commentUrl: string | null = null;
   let path: string | null = null;
   let line: number | null = null;
+  let sourceId: string | null = null;
   if (event === "issue_comment" && payload.action === "created") {
     body = payload.comment?.body ?? null;
     actor = payload.comment?.user ?? null;
     authorAssociation = payload.comment?.author_association ?? null;
     commentUrl = payload.comment?.html_url ?? null;
+    sourceId = payload.comment?.id != null ? `issue_comment:${payload.comment.id}` : null;
   } else if (event === "pull_request_review_comment" && payload.action === "created") {
     body = payload.comment?.body ?? null;
     actor = payload.comment?.user ?? null;
@@ -758,11 +763,13 @@ function extractEligiblePrComment(
     commentUrl = payload.comment?.html_url ?? null;
     path = payload.comment?.path ?? null;
     line = payload.comment?.line ?? null;
+    sourceId = payload.comment?.id != null ? `review_comment:${payload.comment.id}` : null;
   } else if (event === "pull_request_review" && payload.action === "submitted") {
     body = payload.review?.body ?? null;
     actor = payload.review?.user ?? null;
     authorAssociation = payload.review?.author_association ?? null;
     commentUrl = payload.review?.html_url ?? null;
+    sourceId = payload.review?.id != null ? `review:${payload.review.id}` : null;
   } else {
     return null;
   }
@@ -782,7 +789,7 @@ function extractEligiblePrComment(
   ) {
     return null;
   }
-  return { body, actor, commentUrl, path, line };
+  return { body, actor, commentUrl, path, line, sourceId };
 }
 
 // Review feedback on an agent PR continues the SAME investigation session where
@@ -808,9 +815,10 @@ async function maybeRequestPrCommentFollowUp(opts: {
       line: comment.line,
       occurredAt: new Date().toISOString(),
     },
-    dedupeKey: comment.commentUrl
-      ? `github:${comment.commentUrl}`
-      : `github:${opts.agentPrRow.id}:${Date.now()}`,
+    // Deterministic across GitHub webhook redelivery: stable comment/review id
+    // first, then the comment URL. Both are stable for a given comment, so a
+    // redelivery dedupes instead of enqueuing twice.
+    dedupeKey: `github:${comment.sourceId ?? comment.commentUrl ?? `${opts.agentPrRow.id}:${comment.body}`}`,
   });
   if (result.outcome === "skipped") {
     log.info(

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -3,6 +3,7 @@ import {
   confirmResolutionProposal,
   db,
   dismissResolutionProposal,
+  recordInboundInteraction,
   requestFollowUpAgentRun,
   resolveIncident,
   schema,
@@ -899,53 +900,52 @@ async function handleSlackEventEnvelope(payload: SlackEventEnvelope): Promise<vo
   });
   if (!incident) return;
 
-  const agentRun = await db.query.agentRuns.findFirst({
-    where: eq(schema.agentRuns.incidentId, incident.id),
-    orderBy: [desc(schema.agentRuns.createdAt)],
-  });
-  if (!agentRun) return;
-
-  if (agentRun.state === "awaiting_human") {
-    await db
-      .insert(schema.incidentEvents)
-      .values({
-        agentRunId: agentRun.id,
-        kind: "human_reply",
-        summary: event.text.trim(),
-        detail: {
-          slackEventId: payload.event_id ?? null,
-          slackUserId: event.user ?? null,
-          slackChannelId: event.channel,
-          slackThreadTs: event.thread_ts,
-          slackMessageTs: event.ts,
-        },
-        dedupeKey: payload.event_id
-          ? `slack:${payload.event_id}`
-          : `slack:${event.channel}:${event.ts}`,
-      })
-      .onConflictDoNothing({
-        target: [schema.incidentEvents.agentRunId, schema.incidentEvents.dedupeKey],
-      });
-    return;
-  }
-
-  // A reply after the latest run finished revives the agent as a follow-up
-  // run (eligibility — caps, staleness, project gate — is decided inside).
-  const result = await requestFollowUpAgentRun(db, {
+  // Talking to the investigation: continue the SAME durable session where we
+  // can (resume / steer), and only spin a fresh run when no session survives.
+  // The shared path records the message, reactivates a terminal run, or
+  // cold-starts — all channels go through it.
+  const result = await recordInboundInteraction(db, {
     incidentId: incident.id,
-    trigger: "slack_reply",
     interaction: {
       channel: "slack_reply",
       author: event.user ?? null,
       text: event.text.trim(),
       occurredAt: new Date().toISOString(),
     },
+    dedupeKey: payload.event_id
+      ? `slack:${payload.event_id}`
+      : `slack:${event.channel}:${event.ts}`,
+    detail: {
+      slackEventId: payload.event_id ?? null,
+      slackUserId: event.user ?? null,
+      slackChannelId: event.channel,
+      slackThreadTs: event.thread_ts,
+      slackMessageTs: event.ts,
+    },
   });
+
+  if (result.outcome === "duplicate") return;
   if (result.outcome === "skipped") {
     logger.info(
       { scope: "slack", incident_id: incident.id, reason: result.reason },
-      "slack reply did not trigger a follow-up run",
+      "slack reply did not continue the investigation",
     );
+    return;
+  }
+
+  // One instant acknowledgement in the originating thread so the human knows
+  // the message landed, rather than silence until the agent replies.
+  const installation = await installationForIncident({
+    pinnedId: incident.slackInstallationId,
+    teamId: payload.team_id ?? "",
+  });
+  if (installation) {
+    await postSlackThreadReply({
+      botToken: installation.botAccessToken,
+      channel: event.channel,
+      threadTs: event.thread_ts,
+      text: ":mag: On it — I'll follow up in this thread.",
+    });
   }
 }
 
@@ -1149,6 +1149,7 @@ type SlackEventEnvelope = {
   type?: string;
   challenge?: string;
   event_id?: string;
+  team_id?: string;
   event?: {
     type?: string;
     subtype?: string;

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -177,15 +177,16 @@ export function mountSlackPublic(app: Hono<any>): void {
     }
     if (payload.type !== "event_callback") return c.json({ ok: true });
 
-    try {
-      await handleSlackEventEnvelope(payload);
-    } catch (err) {
+    // Ack Slack immediately and process out of band: the handler does DB work
+    // and an outbound chat.postMessage, which can exceed Slack's ~3s window and
+    // trigger retries (= duplicate delivery). The handler is idempotent on the
+    // event id, so the rare retry that still arrives is deduped.
+    void handleSlackEventEnvelope(payload).catch((err) =>
       log.error(
         { err, event_type: payload.event?.type, event_id: payload.event_id },
         "slack event handler failed",
-      );
-      throw err;
-    }
+      ),
+    );
     return c.json({ ok: true });
   });
 

--- a/apps/worker/src/agent-run.ts
+++ b/apps/worker/src/agent-run.ts
@@ -139,6 +139,29 @@ export function createAgentRunLifecycle(db: DB) {
     },
 
     /**
+     * `complete | failed → resuming`: a human message arrived after the run
+     * finished. Reactivate so the next tick resumes the durable provider
+     * session in place (continue the same investigation, keep the repo mounted
+     * and the PR branch) rather than starting a new one. Clears the terminal
+     * stamps; the human-visible `resumed` event is emitted by the resume
+     * handler once the session actually accepts the message.
+     */
+    async reactivateForContinuation(opts: {
+      id: string;
+      currentState: AgentRunState | string;
+    }): Promise<void> {
+      assertAgentRunSourceState("reactivateForContinuation", opts.currentState, [
+        "complete",
+        "failed",
+      ]);
+      await repository.updateRun(opts.id, {
+        state: "resuming",
+        failureReason: null,
+        completedAt: null,
+      });
+    },
+
+    /**
      * `queued | repo_discovery → blocked_no_github`, when the project has
      * no GitHub install (or no accessible repos) so the agentRun
      * cannot make progress. Worker stops polling — the row is revived when
@@ -174,15 +197,15 @@ export function createAgentRunLifecycle(db: DB) {
     // shared governed path while the bulk update bypasses it.
 
     /**
-     * `awaiting_human → running`, after the managed session was resumed.
-     * Increments resumeCount. Emits `resumed`.
+     * `awaiting_human | resuming → running`, after the managed session
+     * accepted the human message. Increments resumeCount. Emits `resumed`.
      */
     async resumeRunning(opts: {
       id: string;
       currentState: AgentRunState | string;
       currentResumeCount: number;
     }): Promise<void> {
-      assertAgentRunSourceState("resumeRunning", opts.currentState, ["awaiting_human"]);
+      assertAgentRunSourceState("resumeRunning", opts.currentState, ["awaiting_human", "resuming"]);
       const nextResumeCount = opts.currentResumeCount + 1;
       await repository.updateRun(opts.id, {
         state: "running",
@@ -336,6 +359,7 @@ export function createAgentRunLifecycle(db: DB) {
         "repo_discovery",
         "running",
         "awaiting_human",
+        "resuming",
         "pr_retry_queued",
         "blocked_no_github",
       ]);

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -65,7 +65,12 @@ export async function replyToPrOriginIfNeeded(
       schema.githubInstallations,
       eq(schema.githubInstallations.id, schema.agentPullRequests.installationId),
     )
-    .where(eq(schema.agentPullRequests.incidentId, ctx.incident.id))
+    .where(
+      and(
+        eq(schema.agentPullRequests.incidentId, ctx.incident.id),
+        eq(schema.agentPullRequests.state, "open"),
+      ),
+    )
     .orderBy(desc(schema.agentPullRequests.createdAt))
     .limit(1);
   if (!target) return;

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -5,10 +5,10 @@ import {
   db,
   schema,
 } from "@superlog/db";
-import { eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import type { AgentRunContext } from "../agent-run-context.js";
 import { createAgentRunLifecycle } from "../agent-run.js";
-import { closeAgentPullRequestOnGithub } from "../github-app.js";
+import { closeAgentPullRequestOnGithub, postAgentPrComment } from "../github-app.js";
 import { FIXED_IN_CURRENT_CODE_COOLDOWN_MS } from "../incident-cooldown.js";
 import {
   completedNoiseReason,
@@ -29,6 +29,67 @@ import { isAlertIncident, truncateSlackText } from "./result-metadata.js";
 const WEB_ORIGIN = process.env.WEB_ORIGIN ?? "http://localhost:5173";
 const agentRunLifecycle = createAgentRunLifecycle(db);
 const incidentLifecycle = createIncidentLifecycle(db);
+
+// Channel-in = channel-out: when this turn was triggered by a PR comment, post
+// the agent's reply back onto the PR (in addition to the Slack incident thread,
+// which stays the system of record). The turn's origin is the run's trigger for
+// a cold-start follow-up, or the latest human_reply event for a resumed/steered
+// session. Best-effort — a failed PR post never blocks completion.
+export async function replyToPrOriginIfNeeded(
+  ctx: AgentRunContext,
+  replyText: string,
+): Promise<void> {
+  let isPrOrigin = ctx.agentRun.trigger === "pr_comment";
+  if (!isPrOrigin) {
+    const lastReply = await db.query.incidentEvents.findFirst({
+      where: and(
+        eq(schema.incidentEvents.agentRunId, ctx.agentRun.id),
+        eq(schema.incidentEvents.kind, "human_reply"),
+      ),
+      orderBy: [desc(schema.incidentEvents.createdAt)],
+      columns: { detail: true },
+    });
+    const origin = (lastReply?.detail as { origin?: { channel?: string } } | null)?.origin;
+    isPrOrigin = origin?.channel === "pr_comment";
+  }
+  if (!isPrOrigin) return;
+
+  const [target] = await db
+    .select({
+      prNumber: schema.agentPullRequests.prNumber,
+      repoFullName: schema.agentPullRequests.repoFullName,
+      installationId: schema.githubInstallations.installationId,
+    })
+    .from(schema.agentPullRequests)
+    .innerJoin(
+      schema.githubInstallations,
+      eq(schema.githubInstallations.id, schema.agentPullRequests.installationId),
+    )
+    .where(eq(schema.agentPullRequests.incidentId, ctx.incident.id))
+    .orderBy(desc(schema.agentPullRequests.createdAt))
+    .limit(1);
+  if (!target) return;
+
+  const result = await postAgentPrComment({
+    installationId: target.installationId,
+    repoFullName: target.repoFullName,
+    prNumber: target.prNumber,
+    body: replyText,
+  });
+  if (!result.ok) {
+    logger.warn(
+      {
+        scope: "agent_run",
+        agent_run_id: ctx.agentRun.id,
+        incident_id: ctx.incident.id,
+        repo: target.repoFullName,
+        pr_number: target.prNumber,
+        error: result.error,
+      },
+      "failed to post continuation reply to PR",
+    );
+  }
+}
 
 async function closeOpenPullRequestsForResolvedIncident(incidentId: string): Promise<void> {
   await closeIncidentOpenPullRequestsAfterResolution({
@@ -203,4 +264,5 @@ export async function completeWithoutPullRequest(
       incidentId: ctx.incident.id,
     }),
   );
+  await replyToPrOriginIfNeeded(ctx, result.summary);
 }

--- a/apps/worker/src/agent-runs/domain.ts
+++ b/apps/worker/src/agent-runs/domain.ts
@@ -3,6 +3,7 @@ export type AgentRunState =
   | "repo_discovery"
   | "running"
   | "awaiting_human"
+  | "resuming"
   | "pr_retry_queued"
   | "blocked_no_github"
   | "complete"
@@ -12,12 +13,15 @@ export type AgentRunState =
 // excluded: those rows sit dormant until a GitHub install webhook or manual
 // restart requeues them. `pr_retry_queued` is a failed run that a human asked
 // to re-deliver: the tick re-runs PR delivery from the patch already on record
-// (no re-investigation).
+// (no re-investigation). `resuming` is a previously-terminal run that a human
+// message reactivated: the tick resumes its durable provider session in place
+// (no re-investigation) — the heart of "talking to an investigation".
 export const ACTIVE_STATES: readonly AgentRunState[] = [
   "queued",
   "repo_discovery",
   "running",
   "awaiting_human",
+  "resuming",
   "pr_retry_queued",
 ] as const;
 

--- a/apps/worker/src/agent-runs/pr-delivery.ts
+++ b/apps/worker/src/agent-runs/pr-delivery.ts
@@ -153,10 +153,12 @@ export async function completeWithPullRequest(
   // depending on the agent session (which may have expired) to re-download it.
   const resultWithPatch: AgentRunResult = { ...result, pr: { ...pr, patch, patchFileId } };
 
-  // Follow-up runs deliver onto the prior run's still-open PR: push the patch
-  // as an additional commit on the existing branch and reply on the PR
-  // instead of opening a second one.
-  if (ctx.agentRun.trigger !== "incident") {
+  // Land onto the incident's still-open PR whenever one exists: a resumed or
+  // follow-up turn pushes the patch as an additional commit on the existing
+  // branch and replies on the PR instead of opening a second one. Keyed on the
+  // open PR (not the trigger) because a resumed run keeps its original
+  // `incident` trigger yet must still update its own PR rather than duplicate it.
+  {
     const existingPr = await db.query.agentPullRequests.findFirst({
       where: and(
         eq(schema.agentPullRequests.incidentId, ctx.incident.id),

--- a/apps/worker/src/agent-runs/resume.ts
+++ b/apps/worker/src/agent-runs/resume.ts
@@ -1,44 +1,73 @@
-import { db, schema } from "@superlog/db";
+import {
+  type AgentRunFollowUpInteraction,
+  db,
+  requestFollowUpAgentRun,
+  schema,
+} from "@superlog/db";
 import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { AgentRunContext } from "../agent-run-context.js";
 import { createAgentRunLifecycle } from "../agent-run.js";
 import { getAgentRunnerBackend } from "../infra/agent-runner/backend.js";
-import { postIncidentThreadMessage } from "../infra/slack/incident-messages.js";
 import { logger } from "../logger.js";
 import { failAgentRun, isTransientError } from "./status.js";
 
 const agentRunLifecycle = createAgentRunLifecycle(db);
 
-export async function resumeAwaitingHumanAgentRun(ctx: AgentRunContext): Promise<void> {
+async function loadUnprocessedHumanReplies(agentRunId: string) {
+  return db.query.incidentEvents.findMany({
+    where: and(
+      eq(schema.incidentEvents.agentRunId, agentRunId),
+      eq(schema.incidentEvents.kind, "human_reply"),
+      isNull(schema.incidentEvents.processedAt),
+    ),
+    orderBy: [desc(schema.incidentEvents.createdAt)],
+  });
+}
+
+async function markProcessed(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  await db
+    .update(schema.incidentEvents)
+    .set({ processedAt: new Date() })
+    .where(inArray(schema.incidentEvents.id, ids));
+}
+
+// Resume a run from human input. Handles two source states:
+//   - `awaiting_human`: the agent paused to ask a question (the classic resume).
+//   - `resuming`: a previously-terminal run that an inbound message reactivated
+//     (talking to a finished investigation). The durable provider session is
+//     continued in place — no re-investigation.
+// When the provider session can't be resumed (never created, or reclaimed by
+// the provider after its TTL) we fall back to a cold-start follow-up run that
+// re-seeds the prior context, so the human's message is never silently lost.
+export async function resumeAgentRunFromHumanInput(ctx: AgentRunContext): Promise<void> {
   const sessionId = ctx.agentRun.providerSessionId;
+  const isContinuation = ctx.agentRun.state === "resuming";
+
   if (!sessionId) {
-    // Paused in startQueuedAgentRun before any managed session was created
-    // (repo discovery couldn't pick a candidate). Bounce back to "queued" on a
-    // human reply so the next tick reloads ctx with the repo the human named.
-    const humanReplies = await db.query.incidentEvents.findMany({
-      where: and(
-        eq(schema.incidentEvents.agentRunId, ctx.agentRun.id),
-        eq(schema.incidentEvents.kind, "human_reply"),
-        isNull(schema.incidentEvents.processedAt),
-      ),
-    });
+    // `awaiting_human` paused before any managed session existed (repo
+    // discovery couldn't pick a candidate). Bounce back to "queued" on a human
+    // reply so the next tick reloads ctx with the repo the human named. A
+    // `resuming` run always has a session (we only reactivate when one exists),
+    // but guard with a cold-start fallback in case it doesn't.
+    const humanReplies = await loadUnprocessedHumanReplies(ctx.agentRun.id);
     if (humanReplies.length === 0) return;
+    if (isContinuation) {
+      await coldStartFallback(ctx, humanReplies);
+      return;
+    }
     await agentRunLifecycle.requeueAfterHumanReply({
       id: ctx.agentRun.id,
       currentState: ctx.agentRun.state,
     });
-    await db
-      .update(schema.incidentEvents)
-      .set({ processedAt: new Date() })
-      .where(
-        inArray(
-          schema.incidentEvents.id,
-          humanReplies.map((event) => event.id),
-        ),
-      );
+    await markProcessed(humanReplies.map((event) => event.id));
     return;
   }
-  if (ctx.agentRun.resumeCount >= ctx.automation.maxHumanResumeCount) {
+
+  // The human-resume budget guards a runaway agent that keeps re-pinging the
+  // human; it does not apply to human-initiated continuation, where every
+  // resume is an intentional message.
+  if (!isContinuation && ctx.agentRun.resumeCount >= ctx.automation.maxHumanResumeCount) {
     await failAgentRun(
       ctx,
       "human_resume_budget_exhausted",
@@ -47,14 +76,7 @@ export async function resumeAwaitingHumanAgentRun(ctx: AgentRunContext): Promise
     return;
   }
 
-  const humanReplies = await db.query.incidentEvents.findMany({
-    where: and(
-      eq(schema.incidentEvents.agentRunId, ctx.agentRun.id),
-      eq(schema.incidentEvents.kind, "human_reply"),
-      isNull(schema.incidentEvents.processedAt),
-    ),
-    orderBy: [desc(schema.incidentEvents.createdAt)],
-  });
+  const humanReplies = await loadUnprocessedHumanReplies(ctx.agentRun.id);
   if (humanReplies.length === 0) return;
 
   const combined = humanReplies
@@ -77,20 +99,13 @@ export async function resumeAwaitingHumanAgentRun(ctx: AgentRunContext): Promise
         agent_run_id: ctx.agentRun.id,
         incident_id: ctx.incident.id,
         session_id: sessionId,
+        continuation: isContinuation,
         resume_count: ctx.agentRun.resumeCount + 1,
         reply_count: humanReplies.length,
       },
-      "agent run resumed from human reply",
+      "agent run resumed from human input",
     );
-    await db
-      .update(schema.incidentEvents)
-      .set({ processedAt: new Date() })
-      .where(
-        inArray(
-          schema.incidentEvents.id,
-          humanReplies.map((event) => event.id),
-        ),
-      );
+    await markProcessed(humanReplies.map((event) => event.id));
   } catch (err) {
     if (isTransientError(err)) {
       logger.error(
@@ -108,22 +123,64 @@ export async function resumeAwaitingHumanAgentRun(ctx: AgentRunContext): Promise
       );
       return;
     }
+    // A non-transient resume error on a continuation almost always means the
+    // provider session is gone (TTL-reclaimed). Don't alarm the thread with an
+    // "Investigation failed" card — quietly fall back to a fresh follow-up that
+    // re-seeds the prior context. For the classic awaiting_human pause we keep
+    // the existing hard-fail.
+    if (isContinuation) {
+      logger.warn(
+        {
+          err,
+          scope: "agent_run",
+          agent_run_id: ctx.agentRun.id,
+          incident_id: ctx.incident.id,
+          provider_session_id: sessionId,
+          stage: "resume",
+        },
+        "could not resume durable session; falling back to a cold-start follow-up",
+      );
+      await coldStartFallback(ctx, humanReplies);
+      return;
+    }
     await failAgentRun(ctx, "resume_failed", "Failed to resume agent run.", { err });
-    return;
   }
-  await postIncidentThreadMessage(
-    ctx.incident.id,
-    ":arrow_forward: Investigation resumed with human input.",
-  ).catch((err) =>
-    logger.error(
-      {
-        err,
-        scope: "agent_run",
-        agent_run_id: ctx.agentRun.id,
-        incident_id: ctx.incident.id,
-        stage: "resume_notify",
-      },
-      "failed to post agent run resume notification",
-    ),
-  );
+}
+
+// Session unresumable → mark this run terminal quietly (no failure card) and
+// enqueue a fresh follow-up run that carries the prior context + the human's
+// message, so the conversation continues even across a lost session.
+async function coldStartFallback(
+  ctx: AgentRunContext,
+  humanReplies: Awaited<ReturnType<typeof loadUnprocessedHumanReplies>>,
+): Promise<void> {
+  const combined = humanReplies
+    .map((event) => event.summary ?? "")
+    .filter(Boolean)
+    .reverse()
+    .join("\n\n");
+  const first = humanReplies[humanReplies.length - 1];
+  const origin = (first?.detail as { origin?: AgentRunFollowUpInteraction } | null)?.origin ?? null;
+
+  await agentRunLifecycle.fail({
+    id: ctx.agentRun.id,
+    currentState: ctx.agentRun.state,
+    reason: "resume_failed",
+    summary: "Provider session expired; continuing as a fresh follow-up.",
+    category: "infrastructure",
+    existingResult: ctx.agentRun.result ?? null,
+  });
+
+  await requestFollowUpAgentRun(db, {
+    incidentId: ctx.incident.id,
+    trigger: origin?.channel === "pr_comment" ? "pr_comment" : "slack_reply",
+    interaction: origin ?? {
+      channel: "slack_reply",
+      author: null,
+      text: combined,
+      occurredAt: new Date().toISOString(),
+    },
+  });
+
+  await markProcessed(humanReplies.map((event) => event.id));
 }

--- a/apps/worker/src/agent-runs/resume.ts
+++ b/apps/worker/src/agent-runs/resume.ts
@@ -171,7 +171,7 @@ async function coldStartFallback(
     existingResult: ctx.agentRun.result ?? null,
   });
 
-  await requestFollowUpAgentRun(db, {
+  const result = await requestFollowUpAgentRun(db, {
     incidentId: ctx.incident.id,
     trigger: origin?.channel === "pr_comment" ? "pr_comment" : "slack_reply",
     interaction: origin ?? {
@@ -181,6 +181,23 @@ async function coldStartFallback(
       occurredAt: new Date().toISOString(),
     },
   });
+
+  // Don't silently swallow the human's message: if the fallback couldn't
+  // enqueue (cap reached, gate off, another run already active), surface it
+  // loudly. We still mark the replies processed so the now-failed run doesn't
+  // re-attempt the dead session every tick.
+  if (result.outcome === "skipped") {
+    logger.warn(
+      {
+        scope: "agent_run",
+        agent_run_id: ctx.agentRun.id,
+        incident_id: ctx.incident.id,
+        reason: result.reason,
+        dropped_text: combined.slice(0, 500),
+      },
+      "cold-start fallback could not enqueue; human input not actioned",
+    );
+  }
 
   await markProcessed(humanReplies.map((event) => event.id));
 }

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -1,5 +1,5 @@
 import { type AgentRunResult, db, schema } from "@superlog/db";
-import { and, desc, eq, inArray, isNull } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { AgentRunContext } from "../agent-run-context.js";
 import { createAgentRunLifecycle } from "../agent-run.js";
 import { type AgentRunOutcome, recordAgentRunCompletion } from "../ai-usage.js";
@@ -236,7 +236,8 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         eq(schema.incidentEvents.kind, "human_reply"),
         isNull(schema.incidentEvents.processedAt),
       ),
-      orderBy: [desc(schema.incidentEvents.createdAt)],
+      // Oldest → newest so the steered conversation reads in chronological order.
+      orderBy: [asc(schema.incidentEvents.createdAt)],
     });
     const steeredHuman = await steerIdleRunnerWithPendingContext({
       snapshotStatus: snapshot.status,

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -224,6 +224,38 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
       .set(baseUpdate)
       .where(eq(schema.agentRuns.id, ctx.agentRun.id));
 
+    // A human message that arrived mid-turn (the run was still `running`, so it
+    // was recorded rather than reactivating a terminal run). Steer it into the
+    // live session the moment the runner is idle — even if a result just landed,
+    // so the reply continues the conversation instead of the run completing out
+    // from under it. The inbound channel already ack'd the human, so no extra
+    // thread post here.
+    const pendingHumanReplies = await db.query.incidentEvents.findMany({
+      where: and(
+        eq(schema.incidentEvents.agentRunId, ctx.agentRun.id),
+        eq(schema.incidentEvents.kind, "human_reply"),
+        isNull(schema.incidentEvents.processedAt),
+      ),
+      orderBy: [desc(schema.incidentEvents.createdAt)],
+    });
+    const steeredHuman = await steerIdleRunnerWithPendingContext({
+      snapshotStatus: snapshot.status,
+      pendingContextEvents: pendingHumanReplies,
+      runner,
+      sessionId,
+      incidentId: ctx.incident.id,
+      markEventsProcessed: async (ids) => {
+        await db
+          .update(schema.incidentEvents)
+          .set({ processedAt: new Date() })
+          .where(inArray(schema.incidentEvents.id, ids));
+      },
+      notifySteered: async () => {},
+    });
+    if (steeredHuman) {
+      return;
+    }
+
     if (snapshot.result) {
       if (snapshot.result.state === "complete") {
         let toolLookup: MobileRegressionToolLookupState = "disabled";

--- a/apps/worker/src/agent-runs/tick.ts
+++ b/apps/worker/src/agent-runs/tick.ts
@@ -4,7 +4,7 @@ import { asc, eq, inArray } from "drizzle-orm";
 import { loadAgentRunContext } from "../agent-run-context.js";
 import { ACTIVE_STATES as AGENT_RUN_ACTIVE_STATES } from "../agent-run.js";
 import { retryQueuedPullRequestDelivery } from "./pr-delivery.js";
-import { resumeAwaitingHumanAgentRun } from "./resume.js";
+import { resumeAgentRunFromHumanInput } from "./resume.js";
 import { startQueuedAgentRun } from "./start-run.js";
 import { syncRunningAgentRun } from "./sync.js";
 
@@ -60,8 +60,8 @@ export async function tickAgentRuns(): Promise<number> {
           await syncRunningAgentRun(ctx);
           continue;
         }
-        if (ctx.agentRun.state === "awaiting_human") {
-          await resumeAwaitingHumanAgentRun(ctx);
+        if (ctx.agentRun.state === "awaiting_human" || ctx.agentRun.state === "resuming") {
+          await resumeAgentRunFromHumanInput(ctx);
           continue;
         }
         if (ctx.agentRun.state === "pr_retry_queued") {

--- a/apps/worker/src/github-app.ts
+++ b/apps/worker/src/github-app.ts
@@ -210,6 +210,39 @@ export async function createGithubWriteToken(
   });
 }
 
+// Post a comment on an agent PR — used to route a continuation turn's reply
+// back to the channel it came in on (a PR comment gets a PR answer). Best-effort
+// and idempotency-free: the caller only fires this once per completed turn.
+export async function postAgentPrComment(opts: {
+  installationId: number;
+  repoFullName: string;
+  prNumber: number;
+  body: string;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const token = await createGithubWriteToken(opts.installationId);
+    const res = await fetch(
+      `${GITHUB_API}/repos/${opts.repoFullName}/issues/${opts.prNumber}/comments`,
+      {
+        method: "POST",
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json; charset=utf-8",
+          "x-github-api-version": "2022-11-28",
+          "user-agent": "superlog-worker",
+        },
+        body: JSON.stringify({ body: opts.body }),
+      },
+    );
+    if (res.ok) return { ok: true };
+    const text = await res.text().catch(() => "");
+    return { ok: false, error: `github POST issue comment ${res.status} ${text}` };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 export async function getGithubRepoInfo(
   installationId: number,
   repoFullName: string,

--- a/packages/db/src/agent-follow-up.test.ts
+++ b/packages/db/src/agent-follow-up.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import {
   FOLLOW_UP_MAX_AGE_DAYS,
   MAX_FOLLOW_UP_RUNS,
+  decideInboundContinuation,
   evaluateFollowUpEligibility,
 } from "./agent-follow-up.js";
 
@@ -109,4 +110,98 @@ test("skips when the active run is the original (non-follow-up) investigation", 
     input({ activeRun: { id: "run-1", state: "queued", trigger: "incident" } }),
   );
   assert.deepEqual(verdict, { action: "skip", reason: "run_active" });
+});
+
+// --- Session-continuity routing (decideInboundContinuation) ---
+//
+// The new model: an inbound message continues the SAME durable provider
+// session rather than spinning up a fresh investigation. These tests pin the
+// routing decision; the worker handles the actual resume/steer/fall-back.
+
+function continuation(overrides: Partial<Parameters<typeof decideInboundContinuation>[0]> = {}) {
+  return {
+    agentRunEnabled: true,
+    autoFollowUpEnabled: true,
+    confirmed: false,
+    latestRun: { id: "run-1", state: "complete", providerSessionId: "sess_1" },
+    ...overrides,
+  };
+}
+
+test("a completed run with a live session resumes that session (no new investigation)", () => {
+  assert.deepEqual(decideInboundContinuation(continuation()), {
+    action: "resume",
+    runId: "run-1",
+  });
+});
+
+test("a failed run with a session is still resumable", () => {
+  assert.deepEqual(
+    decideInboundContinuation(
+      continuation({ latestRun: { id: "run-2", state: "failed", providerSessionId: "sess_2" } }),
+    ),
+    { action: "resume", runId: "run-2" },
+  );
+});
+
+test("a terminal run without a session falls back to a cold-start run", () => {
+  assert.deepEqual(
+    decideInboundContinuation(
+      continuation({ latestRun: { id: "run-3", state: "complete", providerSessionId: null } }),
+    ),
+    { action: "cold_start" },
+  );
+});
+
+test("a message arriving mid-turn steers the running session instead of stacking a run", () => {
+  for (const state of ["running", "repo_discovery"]) {
+    assert.deepEqual(
+      decideInboundContinuation(
+        continuation({ latestRun: { id: "run-4", state, providerSessionId: "sess_4" } }),
+      ),
+      { action: "steer", runId: "run-4" },
+      `state=${state}`,
+    );
+  }
+});
+
+test("an awaiting-human run always delivers (worker resumes, or requeues if no session yet)", () => {
+  assert.deepEqual(
+    decideInboundContinuation(
+      continuation({ latestRun: { id: "run-5", state: "awaiting_human", providerSessionId: "s" } }),
+    ),
+    { action: "resume", runId: "run-5" },
+  );
+  assert.deepEqual(
+    decideInboundContinuation(
+      continuation({
+        latestRun: { id: "run-5", state: "awaiting_human", providerSessionId: null },
+      }),
+    ),
+    { action: "resume", runId: "run-5" },
+  );
+});
+
+test("no prior run at all has nothing to continue", () => {
+  assert.deepEqual(decideInboundContinuation(continuation({ latestRun: null })), {
+    action: "skip",
+    reason: "no_prior_run",
+  });
+});
+
+test("project gates still apply: agent runs disabled, auto-follow-up off (unless confirmed)", () => {
+  assert.deepEqual(decideInboundContinuation(continuation({ agentRunEnabled: false })), {
+    action: "skip",
+    reason: "agent_runs_disabled",
+  });
+  assert.deepEqual(decideInboundContinuation(continuation({ autoFollowUpEnabled: false })), {
+    action: "skip",
+    reason: "auto_follow_up_disabled",
+  });
+  // An explicit human confirmation (e.g. the feedback button) bypasses the
+  // auto-follow-up gate and still resumes.
+  assert.deepEqual(
+    decideInboundContinuation(continuation({ autoFollowUpEnabled: false, confirmed: true })),
+    { action: "resume", runId: "run-1" },
+  );
 });

--- a/packages/db/src/agent-follow-up.ts
+++ b/packages/db/src/agent-follow-up.ts
@@ -305,6 +305,19 @@ export async function recordInboundInteraction(
   if (verdict.action === "skip") return { outcome: "skipped", reason: verdict.reason };
 
   if (verdict.action === "cold_start") {
+    // Idempotency for provider/webhook retries: cold-start can append to or
+    // create a run, neither of which is guarded by the dedupe key, so a redelivery
+    // of the same message would double-enqueue. Guard with an incident-scoped
+    // marker — if we've already seen this dedupeKey on the incident, stop.
+    const seen = await db.query.incidentEvents.findFirst({
+      where: and(
+        eq(schema.incidentEvents.incidentId, args.incidentId),
+        eq(schema.incidentEvents.dedupeKey, args.dedupeKey),
+      ),
+      columns: { id: true },
+    });
+    if (seen) return { outcome: "duplicate" };
+
     const result = await requestFollowUpAgentRun(db, {
       incidentId: args.incidentId,
       trigger: args.interaction.channel,
@@ -313,6 +326,23 @@ export async function recordInboundInteraction(
       now,
     });
     if (result.outcome === "skipped") return { outcome: "skipped", reason: result.reason };
+
+    // Record a processed marker so a later redelivery hits the guard above. It's
+    // pre-processed so it never gets re-consumed as a pending human reply.
+    await db
+      .insert(schema.incidentEvents)
+      .values({
+        agentRunId: result.agentRunId,
+        incidentId: args.incidentId,
+        kind: "human_reply",
+        summary: args.interaction.text,
+        detail: { ...(args.detail ?? {}), origin: args.interaction },
+        dedupeKey: args.dedupeKey,
+        processedAt: now,
+      })
+      .onConflictDoNothing({
+        target: [schema.incidentEvents.agentRunId, schema.incidentEvents.dedupeKey],
+      });
     return { outcome: "accepted", action: "cold_start", agentRunId: result.agentRunId };
   }
 

--- a/packages/db/src/agent-follow-up.ts
+++ b/packages/db/src/agent-follow-up.ts
@@ -325,6 +325,12 @@ export async function recordInboundInteraction(
     });
     if (seen) return { outcome: "duplicate" };
 
+    // Claim the dedupe key atomically (the unique (agentRunId, dedupeKey) index
+    // lets only one concurrent racer win). We RELEASE the claim if the enqueue
+    // then fails or is skipped, so the key is only durably consumed once the
+    // follow-up actually exists — a transient failure or a later state change
+    // can be retried instead of silently dropped.
+    let claimId: string | null = null;
     if (latestRun) {
       const [claim] = await db
         .insert(schema.incidentEvents)
@@ -342,16 +348,32 @@ export async function recordInboundInteraction(
         })
         .returning({ id: schema.incidentEvents.id });
       if (!claim) return { outcome: "duplicate" };
+      claimId = claim.id;
     }
 
-    const result = await requestFollowUpAgentRun(db, {
-      incidentId: args.incidentId,
-      trigger: args.interaction.channel,
-      interaction: args.interaction,
-      confirmed: args.confirmed,
-      now,
-    });
-    if (result.outcome === "skipped") return { outcome: "skipped", reason: result.reason };
+    const releaseClaim = async () => {
+      if (claimId) {
+        await db.delete(schema.incidentEvents).where(eq(schema.incidentEvents.id, claimId));
+      }
+    };
+
+    let result: RequestFollowUpResult;
+    try {
+      result = await requestFollowUpAgentRun(db, {
+        incidentId: args.incidentId,
+        trigger: args.interaction.channel,
+        interaction: args.interaction,
+        confirmed: args.confirmed,
+        now,
+      });
+    } catch (err) {
+      await releaseClaim();
+      throw err;
+    }
+    if (result.outcome === "skipped") {
+      await releaseClaim();
+      return { outcome: "skipped", reason: result.reason };
+    }
     return { outcome: "accepted", action: "cold_start", agentRunId: result.agentRunId };
   }
 

--- a/packages/db/src/agent-follow-up.ts
+++ b/packages/db/src/agent-follow-up.ts
@@ -305,10 +305,17 @@ export async function recordInboundInteraction(
   if (verdict.action === "skip") return { outcome: "skipped", reason: verdict.reason };
 
   if (verdict.action === "cold_start") {
-    // Idempotency for provider/webhook retries: cold-start can append to or
-    // create a run, neither of which is guarded by the dedupe key, so a redelivery
-    // of the same message would double-enqueue. Guard with an incident-scoped
-    // marker — if we've already seen this dedupeKey on the incident, stop.
+    // Idempotency for provider/webhook retries: cold-start enqueues/appends a
+    // run, which the dedupe key doesn't otherwise guard. Two layers, both
+    // BEFORE we enqueue so a retry can never double-process one message:
+    //   1. Incident-scoped read — catches a sequential retry whose latest run
+    //      changed (the prior attempt's marker now sits on a different run).
+    //   2. Atomic claim insert against the current latest run — the unique
+    //      (agentRunId, dedupeKey) index lets only one of N concurrent racers
+    //      win; the losers get an empty `.returning()` and bail. cold_start
+    //      only arises when a latest run exists, so there is always a run to
+    //      claim against. The marker is pre-processed so it's never re-consumed
+    //      as a pending human reply.
     const seen = await db.query.incidentEvents.findFirst({
       where: and(
         eq(schema.incidentEvents.incidentId, args.incidentId),
@@ -318,6 +325,25 @@ export async function recordInboundInteraction(
     });
     if (seen) return { outcome: "duplicate" };
 
+    if (latestRun) {
+      const [claim] = await db
+        .insert(schema.incidentEvents)
+        .values({
+          agentRunId: latestRun.id,
+          incidentId: args.incidentId,
+          kind: "human_reply",
+          summary: args.interaction.text,
+          detail: { ...(args.detail ?? {}), origin: args.interaction },
+          dedupeKey: args.dedupeKey,
+          processedAt: now,
+        })
+        .onConflictDoNothing({
+          target: [schema.incidentEvents.agentRunId, schema.incidentEvents.dedupeKey],
+        })
+        .returning({ id: schema.incidentEvents.id });
+      if (!claim) return { outcome: "duplicate" };
+    }
+
     const result = await requestFollowUpAgentRun(db, {
       incidentId: args.incidentId,
       trigger: args.interaction.channel,
@@ -326,23 +352,6 @@ export async function recordInboundInteraction(
       now,
     });
     if (result.outcome === "skipped") return { outcome: "skipped", reason: result.reason };
-
-    // Record a processed marker so a later redelivery hits the guard above. It's
-    // pre-processed so it never gets re-consumed as a pending human reply.
-    await db
-      .insert(schema.incidentEvents)
-      .values({
-        agentRunId: result.agentRunId,
-        incidentId: args.incidentId,
-        kind: "human_reply",
-        summary: args.interaction.text,
-        detail: { ...(args.detail ?? {}), origin: args.interaction },
-        dedupeKey: args.dedupeKey,
-        processedAt: now,
-      })
-      .onConflictDoNothing({
-        target: [schema.incidentEvents.agentRunId, schema.incidentEvents.dedupeKey],
-      });
     return { outcome: "accepted", action: "cold_start", agentRunId: result.agentRunId };
   }
 

--- a/packages/db/src/agent-follow-up.ts
+++ b/packages/db/src/agent-follow-up.ts
@@ -1,13 +1,19 @@
-// Follow-up agent runs: a human interaction (PR comment, feedback, Slack
-// reply) after a prior investigation finished revives the agent as a NEW
-// agent_runs row on the same incident. Completed provider sessions cannot be
-// resumed, so revival always means a fresh run that carries the prior run's
-// result, handoff notes, and the triggering interaction in its prompt.
+// Talking to an investigation: a human interaction (PR comment, feedback,
+// Slack reply) after a run finished should continue the SAME durable provider
+// session — resume it in place, keep the repo mounted, keep committing to the
+// same PR — rather than spinning up a fresh investigation. `decideInboundContinuation`
+// is the routing seam: resume the live session, steer it if it's mid-turn, or
+// fall back to a cold-start run (`requestFollowUpAgentRun`) only when no
+// resumable session exists (never created, or reclaimed by the provider).
 //
-// Shared between the API (webhooks/interactivity enqueue) and the worker
-// (context assembly), hence it lives in the db package next to the other
-// cross-app domain logic.
-import { and, desc, eq } from "drizzle-orm";
+// The cold-start path below carries the prior run's result, handoff notes, and
+// the triggering interaction in its prompt — it is the fallback, not the
+// default.
+//
+// Shared between the API (webhooks/interactivity) and the worker (context
+// assembly), hence it lives in the db package next to the other cross-app
+// domain logic.
+import { and, desc, eq, inArray } from "drizzle-orm";
 import type { DB } from "./client.js";
 import * as schema from "./schema.js";
 import type {
@@ -27,6 +33,60 @@ const EXECUTING_STATES = [
   "pr_retry_queued",
   "blocked_no_github",
 ];
+
+// States where the agent is actively working a turn — a new message should be
+// steered into the live session, not stacked behind it.
+const EXECUTING_LIVE_STATES = new Set(["running", "repo_discovery"]);
+
+export type InboundContinuationInput = {
+  agentRunEnabled: boolean;
+  autoFollowUpEnabled: boolean;
+  // An explicit human confirmation (e.g. the feedback button) bypasses the
+  // auto-follow-up project gate. Continuity has no per-incident cap — talking
+  // to the investigation is the point — so confirmed only matters for the gate.
+  confirmed: boolean;
+  // The most recent run on the incident (any state), or null if none exists.
+  latestRun: { id: string; state: string; providerSessionId: string | null } | null;
+};
+
+export type InboundContinuationVerdict =
+  | { action: "resume"; runId: string }
+  | { action: "steer"; runId: string }
+  | { action: "cold_start" }
+  | {
+      action: "skip";
+      reason: "agent_runs_disabled" | "auto_follow_up_disabled" | "no_prior_run";
+    };
+
+// Route an inbound human message: continue the existing session where possible,
+// fall back to a cold-start run otherwise. Pure — the worker performs the
+// actual resume/steer and converts cold_start into `requestFollowUpAgentRun`.
+export function decideInboundContinuation(
+  input: InboundContinuationInput,
+): InboundContinuationVerdict {
+  if (!input.agentRunEnabled) return { action: "skip", reason: "agent_runs_disabled" };
+  if (!input.autoFollowUpEnabled && !input.confirmed) {
+    return { action: "skip", reason: "auto_follow_up_disabled" };
+  }
+  const run = input.latestRun;
+  if (!run) return { action: "skip", reason: "no_prior_run" };
+
+  // The agent explicitly paused for input — always deliver. The worker resumes
+  // the session, or requeues the run if it paused before a session existed.
+  if (run.state === "awaiting_human") return { action: "resume", runId: run.id };
+
+  if (EXECUTING_LIVE_STATES.has(run.state)) {
+    // Mid-turn: inject into the live session so the agent adapts in real time.
+    // With no session yet (repo discovery still running) there's nothing to
+    // steer — defer to the cold-start path, which itself no-ops while a run is
+    // active, so we never stack a duplicate.
+    return run.providerSessionId ? { action: "steer", runId: run.id } : { action: "cold_start" };
+  }
+
+  // Terminal (or otherwise dormant): resume the durable session in place. Only
+  // when the session is gone do we cold-start a fresh contextful run.
+  return run.providerSessionId ? { action: "resume", runId: run.id } : { action: "cold_start" };
+}
 
 export type FollowUpEligibilityInput = {
   agentRunEnabled: boolean;
@@ -191,6 +251,104 @@ export async function requestFollowUpAgentRun(
   });
 
   return { outcome: "enqueued", agentRunId: created.id };
+}
+
+export type RecordInboundInteractionResult =
+  | { outcome: "accepted"; action: "resume" | "steer" | "cold_start"; agentRunId?: string }
+  | { outcome: "duplicate" }
+  | { outcome: "skipped"; reason: string };
+
+// The shared inbound path for every channel (Slack reply, PR comment/review,
+// feedback): decide whether to continue the durable session or cold-start, then
+// act. For resume/steer it records a `human_reply` event (carrying the channel
+// `origin` so the worker can route the reply back) and reactivates a terminal
+// run into `resuming`; for cold_start it delegates to requestFollowUpAgentRun.
+// `dedupeKey` makes provider/webhook retries idempotent — a swallowed insert
+// returns `duplicate` so the caller neither reactivates twice nor double-acks.
+export async function recordInboundInteraction(
+  db: DB,
+  args: {
+    incidentId: string;
+    interaction: AgentRunFollowUpInteraction;
+    dedupeKey: string;
+    // Channel-specific event detail (Slack ids, etc.); `origin` is merged in.
+    detail?: Record<string, unknown>;
+    confirmed?: boolean;
+    now?: Date;
+  },
+): Promise<RecordInboundInteractionResult> {
+  const now = args.now ?? new Date();
+  const incident = await db.query.incidents.findFirst({
+    where: eq(schema.incidents.id, args.incidentId),
+    columns: { id: true, projectId: true },
+  });
+  if (!incident) return { outcome: "skipped", reason: "no_prior_run" };
+
+  const automation = await db.query.projectAutomationSettings.findFirst({
+    where: eq(schema.projectAutomationSettings.projectId, incident.projectId),
+    columns: { agentRunEnabled: true, autoFollowUpEnabled: true },
+  });
+
+  const latestRun = await db.query.agentRuns.findFirst({
+    where: eq(schema.agentRuns.incidentId, args.incidentId),
+    orderBy: [desc(schema.agentRuns.createdAt)],
+    columns: { id: true, state: true, providerSessionId: true },
+  });
+
+  const verdict = decideInboundContinuation({
+    agentRunEnabled: automation?.agentRunEnabled ?? true,
+    autoFollowUpEnabled: automation?.autoFollowUpEnabled ?? true,
+    confirmed: args.confirmed ?? false,
+    latestRun: latestRun ?? null,
+  });
+
+  if (verdict.action === "skip") return { outcome: "skipped", reason: verdict.reason };
+
+  if (verdict.action === "cold_start") {
+    const result = await requestFollowUpAgentRun(db, {
+      incidentId: args.incidentId,
+      trigger: args.interaction.channel,
+      interaction: args.interaction,
+      confirmed: args.confirmed,
+      now,
+    });
+    if (result.outcome === "skipped") return { outcome: "skipped", reason: result.reason };
+    return { outcome: "accepted", action: "cold_start", agentRunId: result.agentRunId };
+  }
+
+  // resume | steer: record the message against the run, carrying its origin.
+  const [recorded] = await db
+    .insert(schema.incidentEvents)
+    .values({
+      agentRunId: verdict.runId,
+      incidentId: args.incidentId,
+      kind: "human_reply",
+      summary: args.interaction.text,
+      detail: { ...(args.detail ?? {}), origin: args.interaction },
+      dedupeKey: args.dedupeKey,
+    })
+    .onConflictDoNothing({
+      target: [schema.incidentEvents.agentRunId, schema.incidentEvents.dedupeKey],
+    })
+    .returning({ id: schema.incidentEvents.id });
+  if (!recorded) return { outcome: "duplicate" };
+
+  if (verdict.action === "resume") {
+    // Reactivate a terminal run so the tick resumes its session in place. The
+    // state-guarded WHERE is a no-op for awaiting_human (already active) and
+    // TOCTOU-safe if the run moved since we read it.
+    await db
+      .update(schema.agentRuns)
+      .set({ state: "resuming", completedAt: null, failureReason: null, updatedAt: now })
+      .where(
+        and(
+          eq(schema.agentRuns.id, verdict.runId),
+          inArray(schema.agentRuns.state, ["complete", "failed"]),
+        ),
+      );
+  }
+
+  return { outcome: "accepted", action: verdict.action };
 }
 
 function followUpQueuedSummary(trigger: Exclude<AgentRunTrigger, "incident">): string {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -113,11 +113,16 @@ export {
 export { generateCodename } from "./codename.js";
 export {
   evaluateFollowUpEligibility,
+  decideInboundContinuation,
+  recordInboundInteraction,
   requestFollowUpAgentRun,
   FOLLOW_UP_MAX_AGE_DAYS,
   MAX_FOLLOW_UP_RUNS,
   type FollowUpEligibilityInput,
   type FollowUpVerdict,
+  type InboundContinuationInput,
+  type InboundContinuationVerdict,
+  type RecordInboundInteractionResult,
   type RequestFollowUpResult,
 } from "./agent-follow-up.js";
 export {


### PR DESCRIPTION
## What

A human interaction after an investigation finishes — a Slack thread reply, or a PR comment / review — now **continues the same durable agent session in place** rather than spinning up a fresh investigation. The session is resumed, the repo stays mounted, and the agent keeps committing to the same PR. The agent just keeps working; whether a message ends in an answer, a commit, or deeper digging is emergent, not pre-classified. Replies route back to the channel the message came from.

This replaces the previous "every follow-up is a brand-new investigation run" behavior, which re-cloned the repo, re-ran repo discovery, and re-investigated from scratch for what was often just a question.

## How

- **`decideInboundContinuation` + `recordInboundInteraction` (`packages/db`)** — one shared inbound path for every channel. It decides: resume the live session, steer it if it's mid-turn, or cold-start a fresh contextful run only when no session survives (never created, or reclaimed by the provider after its TTL). It records the message with its channel `origin` and reactivates a terminal run.
- **New `resuming` agent-run state** — an inbound message reactivates a terminal run so the worker tick resumes its session. `resume.ts` is generalized to handle both `awaiting_human` and `resuming`, with a quiet cold-start fallback (no "investigation failed" card) when the session can't be resumed.
- **Mid-turn steering (`sync.ts`)** — a message that lands while the run is still working is steered into the live session.
- **PR delivery** lands onto the incident's existing open PR whenever one exists (keyed on the open PR, not the run trigger) so a resumed run updates its own PR instead of opening a duplicate.
- **Channel-in = channel-out** — a PR-originated turn posts the agent's reply back onto the PR (`postAgentPrComment` / `replyToPrOriginIfNeeded`); Slack-originated turns reply in the thread, with an instant ack on inbound.

There is no per-incident cap on continuation — talking to an investigation is the point.

## Notes for review

- The **channel-out reply to a PR** (`postAgentPrComment` posting the agent's answer as a top-level PR comment) is the piece least exercised by unit tests — worth a close look.
- The cold-start fallback fires when a provider session can't be resumed; the warn-log there will tell us empirically how long sessions stay resumable.

## Tests

`decideInboundContinuation` routing is unit-tested. `@superlog/db`, `@superlog/api`, `@superlog/worker` all typecheck; db + slack + worker (state-machine, sync, pr-delivery, completion) suites pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follow-ups on investigations (Slack replies, PR comments/reviews) now continue the same agent session instead of starting a new run, keeping the repo mounted and updating the same PR. Adds race-safe, idempotent inbound handling and resilient Slack/PR delivery.

- **New Features**
  - Shared inbound routing via `decideInboundContinuation` + `recordInboundInteraction` to resume, steer mid-turn, or cold-start only when no session survives.
  - New `resuming` state; `resumeAgentRunFromHumanInput` handles `awaiting_human` and `resuming` with a quiet cold-start fallback if the provider session expired.
  - Mid-turn steering injects human messages into the live session in order (oldest→newest).
  - PR delivery lands on the incident’s existing open PR (keyed on the open PR, not the trigger) to avoid duplicates.
  - Channel-in = channel-out: PR-originated turns post replies back via `postAgentPrComment`; Slack replies continue in-thread with an instant ack.

- **Bug Fixes**
  - Cold-start path is now race-safe and idempotent: incident-scoped dedupe read plus an atomic claim insert (unique `(agentRunId, dedupeKey)`), and the claim is released on failure/skip so the key is only consumed once the follow-up actually exists.
  - Cold-start fallback no longer drops input; logs the reason and a snippet when enqueue is skipped.
  - Deterministic PR-comment dedupe key (stable comment/review id, then URL).
  - PR-origin reply lookup filters to open PRs only.
  - `/slack/events` acks immediately and processes out of band; handler is idempotent on `event_id` to avoid duplicate processing.

<sup>Written for commit 228e5201bd422a873f53430361de8fec87084ada. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

