### PR TITLE
Fix: match the partial dedupe index in recordInboundInteraction ON CONFLICT

### DIFF
--- a/packages/db/src/agent-follow-up.ts
+++ b/packages/db/src/agent-follow-up.ts
@@ -13,7 +13,7 @@
 // Shared between the API (webhooks/interactivity) and the worker (context
 // assembly), hence it lives in the db package next to the other cross-app
 // domain logic.
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import type { DB } from "./client.js";
 import * as schema from "./schema.js";
 import type {
@@ -344,7 +344,11 @@ export async function recordInboundInteraction(
           processedAt: now,
         })
         .onConflictDoNothing({
+          // Matches the PARTIAL unique index incident_events_dedupe_idx
+          // (WHERE agent_run_id IS NOT NULL) — Postgres only binds ON CONFLICT
+          // to a partial index when the predicate is repeated here.
           target: [schema.incidentEvents.agentRunId, schema.incidentEvents.dedupeKey],
+          where: sql`${schema.incidentEvents.agentRunId} is not null`,
         })
         .returning({ id: schema.incidentEvents.id });
       if (!claim) return { outcome: "duplicate" };
@@ -389,7 +393,11 @@ export async function recordInboundInteraction(
       dedupeKey: args.dedupeKey,
     })
     .onConflictDoNothing({
+      // Matches the PARTIAL unique index incident_events_dedupe_idx
+      // (WHERE agent_run_id IS NOT NULL); the predicate must be repeated for
+      // Postgres to bind ON CONFLICT to a partial index.
       target: [schema.incidentEvents.agentRunId, schema.incidentEvents.dedupeKey],
+      where: sql`${schema.incidentEvents.agentRunId} is not null`,
     })
     .returning({ id: schema.incidentEvents.id });
   if (!recorded) return { outcome: "duplicate" };


### PR DESCRIPTION
## Bug

Every inbound interaction (Slack thread reply, PR comment) errored out in production with:

```
PostgresError: there is no unique or exclusion constraint matching the ON CONFLICT specification
on conflict ("agent_run_id","dedupe_key") do nothing
```

so no `human_reply` was recorded, the run was never reactivated, and no ack was posted — the human got silence.

## Cause

`incident_events_dedupe_idx` is a **partial** unique index:

```sql
CREATE UNIQUE INDEX incident_events_dedupe_idx ON incident_events (agent_run_id, dedupe_key) WHERE (agent_run_id IS NOT NULL)
```

Postgres only binds `ON CONFLICT (agent_run_id, dedupe_key)` to a partial index when the conflict clause repeats the index predicate. Both `onConflictDoNothing` inserts in `recordInboundInteraction` omitted it. This never surfaced before because the insert path had never actually run in prod.

## Fix

Add the matching `where: sql\`agent_run_id is not null\`` predicate to both inserts.

Verified against prod with `EXPLAIN` — the statement now binds to `incident_events_dedupe_idx` (`Conflict Arbiter Indexes: incident_events_dedupe_idx`), no error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inbound interaction failures by matching the partial unique index in the ON CONFLICT clause. Adds the missing `where` predicate so inserts bind to `incident_events_dedupe_idx`, restoring human reply recording and run reactivation.

- **Bug Fixes**
  - Add `where: sql\`${schema.incidentEvents.agentRunId} is not null\`` to both `onConflictDoNothing` calls in `recordInboundInteraction`.
  - Verified with EXPLAIN: binds to `incident_events_dedupe_idx`; resolves “no unique or exclusion constraint” errors.

<sup>Written for commit 514398f466d330be70489d62490d51cea0fc10a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

