### PR TITLE
fix(auth): don't require email verification to accept org invitations

### DIFF
--- a/apps/api/src/auth-invitation.test.ts
+++ b/apps/api/src/auth-invitation.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+// auth.ts throws at import if BETTER_AUTH_SECRET is unset, and @superlog/db
+// needs DATABASE_URL (the postgres client connects lazily, so a dummy is
+// enough). Mirror the other auth-adjacent tests and provide both before import.
+process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
+process.env.BETTER_AUTH_SECRET ??= "test-better-auth-secret";
+
+test("organization plugin does not gate invitations on email verification", async () => {
+  const { auth } = await import("./auth.js");
+  const plugins = auth.options.plugins as Array<{ id: string; options?: Record<string, unknown> }>;
+  const orgPlugin = plugins.find((p) => p.id === "organization");
+  assert.ok(orgPlugin, "organization plugin should be registered");
+
+  // Better Auth defaults requireEmailVerificationOnInvitation to `true`. That
+  // contradicts emailAndPassword.requireEmailVerification:false — sign-ups land
+  // logged-in but unverified (the default state), and the default would lock
+  // those users out of getInvitation/acceptInvitation with a FORBIDDEN that the
+  // UI renders as a misleading "Invitation not found" (looks like a 404). Pin it
+  // false so the invite flow matches the app's "verification is optional" stance.
+  assert.equal(orgPlugin.options?.requireEmailVerificationOnInvitation, false);
+});

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -169,6 +169,14 @@ export const auth = betterAuth({
   },
   plugins: [
     organization({
+      // Better Auth defaults this to `true`, which would gate getInvitation /
+      // acceptInvitation / rejectInvitation on a verified email. But sign-ups
+      // land logged-in while still unverified (emailAndPassword
+      // .requireEmailVerification is false above), so the default locks the
+      // typical invitee out of accepting — Better Auth throws FORBIDDEN and the
+      // accept page surfaces it as a misleading "Invitation not found" (looks
+      // like a 404). Keep the invite flow as permissive as the rest of the app.
+      requireEmailVerificationOnInvitation: false,
       schema: {
         // Our `org_members` table uses `orgId` (TS) / `org_id` (SQL) instead
         // of Better Auth's expected `organizationId`. Same for `invitations`.


### PR DESCRIPTION
## Problem

A freshly-invited teammate could not accept an org invitation — the accept page showed an "Invitation not found" error (effectively a 404) even though the invite was valid and pending.

Root cause: Better Auth's `organization` plugin defaults `requireEmailVerificationOnInvitation` to `true`, which gates `getInvitation` / `acceptInvitation` / `rejectInvitation` on a **verified** email address. But our email+password config sets `requireEmailVerification: false`, so sign-ups land logged-in while still **unverified** (the default state). Those users hit a `FORBIDDEN`, which the accept-invitation page renders as a generic "Invitation not found" — indistinguishable from a 404 to the invitee.

Net effect: the common case (invitee signs up via email+password, doesn't separately verify) is locked out of joining.

## Fix

Set `requireEmailVerificationOnInvitation: false` on the `organization` plugin so the invite flow is as permissive as the rest of the app's auth.

## Test

Adds `auth-invitation.test.ts`, which imports the configured `auth` instance and asserts the wired-up `organization` plugin option is `false` (catches a regression to the Better Auth default). Red before the change, green after; `tsc --noEmit` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow invitees to accept org invitations without verifying email. Sets `requireEmailVerificationOnInvitation: false` in the `organization` plugin to fix the misleading “Invitation not found” error for unverified users.

- **Bug Fixes**
  - Disabled email verification requirement for invitation endpoints (`requireEmailVerificationOnInvitation: false` in `apps/api/src/auth.ts`).
  - Added `auth-invitation.test.ts` to assert the option stays `false`.

<sup>Written for commit 029ba9f6c0f6e813f3c121fd15858a1b383175c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

