### PR TITLE
investigations: dedupe by fix target and steer instead of re-investigating

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -32,6 +32,8 @@
     "test:digest-domain": "tsx --test src/digest/domain.test.ts",
     "test:digest-run": "tsx --test src/digest/run.test.ts",
     "test:incident-intake": "tsx --test src/incidents/intake.test.ts",
+    "test:issue-routing": "tsx --test src/incidents/issue-routing.test.ts",
+    "test:merge-agent-run": "tsx --test src/merge-agent-run.test.ts",
     "test:incident-state": "tsx --test src/incident-state.test.ts",
     "test:managed-agent-result": "tsx --test src/managed-agent-result.test.ts",
     "test:github-app": "tsx --test src/github-app.test.ts",

--- a/apps/worker/src/agent-runs/merge.ts
+++ b/apps/worker/src/agent-runs/merge.ts
@@ -22,14 +22,30 @@ type MergeCandidateRow = {
   representative: LinkedIncidentIssue | null;
   summary: string | null;
   proposedTitle: string | null;
+  fixTargets: string[] | null;
+  priorPrState: "open" | "closed" | "merged" | null;
 };
+
+function changedFilesFromResult(result: unknown): string[] | null {
+  const pr = (result as { pr?: { changedFiles?: unknown } | null } | null)?.pr ?? null;
+  const files = pr?.changedFiles;
+  if (!Array.isArray(files)) return null;
+  const cleaned = files.filter((f): f is string => typeof f === "string" && f.length > 0);
+  return cleaned.length > 0 ? cleaned : null;
+}
 
 async function loadMergeCandidates(
   projectId: string,
   excludeIncidentId: string,
 ): Promise<MergeCandidateRow[]> {
+  // Include resolved incidents, not just open ones: if the same root cause was
+  // already investigated and fixed (or its PR closed), a new lookalike should be
+  // recognized as a duplicate and merged in rather than spawning a fresh PR.
   const incidents = await db.query.incidents.findMany({
-    where: and(eq(schema.incidents.projectId, projectId), eq(schema.incidents.status, "open")),
+    where: and(
+      eq(schema.incidents.projectId, projectId),
+      inArray(schema.incidents.status, ["open", "resolved"]),
+    ),
     orderBy: [desc(schema.incidents.lastSeen)],
     limit: INCIDENT_GROUPING_CANDIDATE_LIMIT,
   });
@@ -61,7 +77,7 @@ async function loadMergeCandidates(
     .orderBy(desc(schema.agentRuns.startedAt));
   const summaryByIncident = new Map<
     string,
-    { summary: string | null; proposedTitle: string | null }
+    { summary: string | null; proposedTitle: string | null; fixTargets: string[] | null }
   >();
   for (const inv of agentRuns) {
     if (summaryByIncident.has(inv.incidentId)) continue;
@@ -69,8 +85,33 @@ async function loadMergeCandidates(
     summaryByIncident.set(inv.incidentId, {
       summary: r?.summary ?? null,
       proposedTitle: r?.proposedTitle ?? null,
+      fixTargets: changedFilesFromResult(inv.result),
     });
   }
+
+  // Latest PR state per candidate incident, so the judge can weigh "this
+  // incident already proposed a fix here" — including closed PRs.
+  const prs = await db
+    .select({
+      incidentId: schema.agentPullRequests.incidentId,
+      state: schema.agentPullRequests.state,
+      createdAt: schema.agentPullRequests.createdAt,
+    })
+    .from(schema.agentPullRequests)
+    .where(
+      inArray(
+        schema.agentPullRequests.incidentId,
+        others.map((i) => i.id),
+      ),
+    )
+    .orderBy(desc(schema.agentPullRequests.createdAt));
+  const prStateByIncident = new Map<string, "open" | "closed" | "merged">();
+  for (const pr of prs) {
+    if (pr.incidentId && !prStateByIncident.has(pr.incidentId)) {
+      prStateByIncident.set(pr.incidentId, pr.state as "open" | "closed" | "merged");
+    }
+  }
+
   return others.map((incident) => {
     const inv = summaryByIncident.get(incident.id);
     return {
@@ -78,6 +119,8 @@ async function loadMergeCandidates(
       representative: (linkedByIncident.get(incident.id) ?? [])[0] ?? null,
       summary: inv?.summary ?? null,
       proposedTitle: inv?.proposedTitle ?? null,
+      fixTargets: inv?.fixTargets ?? null,
+      priorPrState: prStateByIncident.get(incident.id) ?? null,
     };
   });
 }
@@ -93,6 +136,8 @@ function buildMergeCandidate(row: MergeCandidateRow): MergeCandidateIncident | n
     issueCount: row.incident.issueCount,
     proposedTitle: row.proposedTitle,
     summary: row.summary,
+    fixTargets: row.fixTargets,
+    priorPrState: row.priorPrState,
     representative: {
       exceptionType: row.representative.exceptionType,
       message: row.representative.message,
@@ -131,6 +176,10 @@ export async function tryMergeAfterAgentRun(
         issueCount: ctx.incident.issueCount,
         proposedTitle: result.proposedTitle ?? null,
         summary: result.summary,
+        // The source run just finished; its validated patch isn't a PR yet, so
+        // priorPrState is null. Its fixTargets are the files that patch changes.
+        fixTargets: changedFilesFromResult(result),
+        priorPrState: null,
         representative: {
           exceptionType: sourceRep.exceptionType,
           message: sourceRep.message,

--- a/apps/worker/src/incidents/issue-routing.test.ts
+++ b/apps/worker/src/incidents/issue-routing.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { decideIssueArrivalRouting } from "./issue-routing.js";
+
+const base = {
+  createdIncident: false,
+  reopenedIncident: false,
+  suppressed: false,
+  latestRunIsTerminal: true,
+};
+
+test("steers when a new signature joins an already-investigated open incident", () => {
+  assert.equal(decideIssueArrivalRouting(base), "steer");
+});
+
+test("investigates a brand-new incident (nothing to steer)", () => {
+  assert.equal(decideIssueArrivalRouting({ ...base, createdIncident: true }), "investigate");
+});
+
+test("investigates a reopened incident (keeps reopen behavior)", () => {
+  assert.equal(decideIssueArrivalRouting({ ...base, reopenedIncident: true }), "investigate");
+});
+
+test("investigates when there is no terminal run yet (none/active/dormant)", () => {
+  assert.equal(decideIssueArrivalRouting({ ...base, latestRunIsTerminal: false }), "investigate");
+});
+
+test("does not steer while suppressed by a fixed_in_current_code cooldown", () => {
+  assert.equal(decideIssueArrivalRouting({ ...base, suppressed: true }), "investigate");
+});

--- a/apps/worker/src/incidents/issue-routing.ts
+++ b/apps/worker/src/incidents/issue-routing.ts
@@ -1,0 +1,36 @@
+// When a new error signature joins an incident, decide whether to start a fresh
+// investigation or steer the one that already ran.
+//
+// Background: a single root cause is a "fingerprint factory" — one bug surfaces
+// as many distinct issues (per vendor, per log layer). Issue-grouping correctly
+// folds them into one incident, but every new signature joining an incident
+// re-armed the investigation trigger, so a still-firing incident was
+// investigated again and again, opening a duplicate PR each time. Once an
+// incident has already been investigated, a new signature should continue that
+// investigation (it can confirm the existing fix already covers it, or extend
+// it) instead of starting over.
+
+export type IssueArrivalAction = "investigate" | "steer";
+
+export type IssueArrivalRoutingInput = {
+  // A brand-new incident was opened for this issue — there is nothing to steer.
+  createdIncident: boolean;
+  // A previously-resolved incident regressed. Keep the existing reopen behavior
+  // (fresh look + reopen messaging) rather than steering.
+  reopenedIncident: boolean;
+  // The incident's auto-investigation is on a `fixed_in_current_code` cooldown.
+  // Route to the normal investigate path, which no-ops under suppression — we
+  // must not bypass that guard by steering.
+  suppressed: boolean;
+  // The incident's most recent run finished (complete/failed). Only then is
+  // there a durable investigation to continue. No run, an active run, or a
+  // dormant (blocked) run all take the existing investigate path.
+  latestRunIsTerminal: boolean;
+};
+
+export function decideIssueArrivalRouting(input: IssueArrivalRoutingInput): IssueArrivalAction {
+  if (input.createdIncident || input.reopenedIncident) return "investigate";
+  if (!input.latestRunIsTerminal) return "investigate";
+  if (input.suppressed) return "investigate";
+  return "steer";
+}

--- a/apps/worker/src/incidents/workflow.ts
+++ b/apps/worker/src/incidents/workflow.ts
@@ -1,12 +1,13 @@
-import { type DB, db, schema } from "@superlog/db";
+import { type DB, db, recordInboundInteraction, schema } from "@superlog/db";
 import { and, desc, eq, inArray } from "drizzle-orm";
 import { getProjectAutomation } from "../agent-run-context.js";
-import { investigationGate } from "../billing/investigation-gate.js";
 import {
   ACTIVE_STATES as AGENT_RUN_ACTIVE_STATES,
   createAgentRunLifecycle,
   isActiveState as isActiveAgentRunState,
 } from "../agent-run.js";
+import { TERMINAL_STATES as AGENT_RUN_TERMINAL_STATES } from "../agent-runs/domain.js";
+import { investigationGate } from "../billing/investigation-gate.js";
 import { isAutoAgentRunSuppressed } from "../incident-cooldown.js";
 import { ensureIncidentForIssue } from "../incident-intake.js";
 import { buildReopenedIncidentSlackUpdate } from "../incident-slack.js";
@@ -17,6 +18,7 @@ import {
   updateIncidentMainMessage,
 } from "../infra/slack/incident-messages.js";
 import { logger } from "../logger.js";
+import { decideIssueArrivalRouting } from "./issue-routing.js";
 
 const WEB_ORIGIN = process.env.WEB_ORIGIN ?? "http://localhost:5173";
 const agentRunLifecycle = createAgentRunLifecycle(db);
@@ -108,6 +110,38 @@ async function queueAgentRunIfNeeded(incident: schema.Incident): Promise<{
   });
 }
 
+// Steer the incident's existing investigation with a newly-arrived error
+// signature. Routes through the same shared continuation path as human channels
+// (Slack/PR comments): resume the durable session, or cold-start a context-
+// carrying follow-up when the session is gone. Returns false when nothing was
+// actioned (no resumable run, follow-ups disabled, or the follow-up budget is
+// spent) so the caller can fall back to the normal investigate path.
+async function steerInvestigationWithNewSignature(
+  incident: schema.Incident,
+  issue: schema.Issue,
+  transition: IssueTransition,
+): Promise<boolean> {
+  const label = transition === "new" ? "New" : "Regressed";
+  const result = await recordInboundInteraction(db, {
+    incidentId: incident.id,
+    interaction: {
+      channel: "issue_joined",
+      author: null,
+      text: `${label} error signature joined this incident: ${issue.title}. If your existing analysis or open PR already covers this, no new change is needed; if it reveals a code path your fix misses, extend the existing PR rather than opening another.`,
+      occurredAt: new Date().toISOString(),
+    },
+    dedupeKey: `issue_joined:${issue.id}:${transition}`,
+  });
+  if (result.outcome === "skipped") return false;
+  if (result.outcome === "accepted") {
+    await postIncidentThreadMessage(
+      incident.id,
+      `:repeat: ${label} signal *${issue.title}* folded into this investigation.`,
+    );
+  }
+  return true;
+}
+
 export async function handleIssueTransition(
   issue: schema.Issue,
   transition: IssueTransition,
@@ -125,6 +159,31 @@ export async function handleIssueTransition(
       firstIssue: issue,
     });
   }
+
+  // If this incident has already been investigated, a new error signature should
+  // steer that investigation rather than launch a fresh one (which is what
+  // produced duplicate PRs for one root cause). Falls through to the normal
+  // investigate path when there's nothing resumable to steer.
+  const latestRun = await db.query.agentRuns.findFirst({
+    where: eq(schema.agentRuns.incidentId, incident.id),
+    orderBy: [desc(schema.agentRuns.createdAt)],
+    columns: { state: true },
+  });
+  const routing = decideIssueArrivalRouting({
+    createdIncident,
+    reopenedIncident,
+    suppressed: isAutoAgentRunSuppressed(incident, new Date()),
+    latestRunIsTerminal: latestRun
+      ? (AGENT_RUN_TERMINAL_STATES as readonly string[]).includes(latestRun.state)
+      : false,
+  });
+  if (
+    routing === "steer" &&
+    (await steerInvestigationWithNewSignature(incident, issue, transition))
+  ) {
+    return;
+  }
+
   const { agentRun, queueStatus } = await queueAgentRunIfNeeded(incident);
   if (reopenedIncident) {
     const update = buildReopenedIncidentSlackUpdate({

--- a/apps/worker/src/merge-agent-run.test.ts
+++ b/apps/worker/src/merge-agent-run.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { type MergeCandidateIncident, buildUserMessage } from "./merge-agent-run.js";
+
+const representative = {
+  exceptionType: "RuntimeError",
+  message: "Failed to get NET32 session: Invalid username or password",
+  topFrame: "worker.py:1362",
+  normalizedFrames: ["worker.py:1362"],
+};
+
+const candidate: MergeCandidateIncident = {
+  id: "incident-canonical",
+  title: "DentalCity order history retries indefinitely on invalid credentials",
+  service: "websites-api-worker",
+  firstSeen: "2026-06-11T00:00:00.000Z",
+  lastSeen: "2026-06-14T00:00:00.000Z",
+  issueCount: 12,
+  proposedTitle: null,
+  summary: "Order history SQS message is never deleted on invalid credentials.",
+  fixTargets: ["worker.py"],
+  priorPrState: "closed",
+  representative,
+};
+
+test("buildUserMessage surfaces fix targets so the judge can match same-file fixes", () => {
+  const message = buildUserMessage({
+    projectName: "Alara",
+    source: {
+      title: "NET32 order history retries indefinitely",
+      service: "websites-api-worker",
+      firstSeen: "2026-06-12T00:00:00.000Z",
+      lastSeen: "2026-06-14T00:00:00.000Z",
+      issueCount: 9,
+      proposedTitle: null,
+      summary: "Invalid-credential SQS messages retry forever; delete them instead.",
+      fixTargets: ["worker.py"],
+      priorPrState: null,
+      representative,
+    },
+    candidates: [candidate],
+  });
+
+  // Both incidents' fix touches worker.py — the message must carry that signal.
+  assert.match(message, /fixTargets/);
+  assert.match(message, /worker\.py/);
+  // A closed prior PR is still surfaced (not dropped).
+  assert.match(message, /"priorPrState": "closed"/);
+});

--- a/apps/worker/src/merge-agent-run.ts
+++ b/apps/worker/src/merge-agent-run.ts
@@ -13,6 +13,15 @@ export type MergeCandidateIncident = {
   issueCount: number;
   proposedTitle: string | null;
   summary: string | null;
+  // Files the incident's investigation proposed changing (the validated patch's
+  // changed files). May already be in an open/closed/merged PR. Two incidents
+  // whose fixes touch the same files are strong evidence of one root cause —
+  // even when their surface symptoms (vendor, exception text) differ.
+  fixTargets: string[] | null;
+  // The state of the most recent PR the incident produced, if any. A closed PR
+  // is NOT a reason to ignore the incident: it still means "we already proposed
+  // this fix here", so a same-root-cause source should merge in, not re-open.
+  priorPrState: "open" | "closed" | "merged" | null;
   representative: {
     exceptionType: string;
     message: string | null;
@@ -36,6 +45,8 @@ const SYSTEM_PROMPT = [
   "  - Both summaries identify the same upstream dependency, external API, database object, or migration as the cause.",
   "  - Both summaries describe the same code path, the same misconfiguration, or the same fix.",
   "  - One incident is the canonical fault and the other is a documented downstream symptom of it (per the summaries themselves).",
+  "Fix targets are decisive evidence. Each incident may include `fixTargets`: the files the agent's validated fix would change. If the source and a candidate would change the SAME file(s) (especially the same function), treat that as strong positive evidence of one shared root cause and prefer 'merge' — even if the vendor, exception class, or error text differ (e.g. per-vendor symptoms of one shared handler bug).",
+  "A candidate's `priorPrState` tells you it already produced a PR. A 'closed' (unmerged) PR is NOT a reason to skip it: it means a fix for this root cause was already proposed there, so a same-root-cause source should merge into it rather than open a duplicate PR.",
   "Examples that do NOT justify merging:",
   "  - Same exception class but different root causes per the summaries.",
   "  - Same service, unrelated bugs.",
@@ -47,7 +58,7 @@ const SYSTEM_PROMPT = [
   '{"decision":"standalone","evidence":"<short reason or null>"}',
 ].join("\n");
 
-function buildUserMessage(input: {
+export function buildUserMessage(input: {
   projectName: string;
   source: MergeSourceIncident;
   candidates: MergeCandidateIncident[];
@@ -96,9 +107,7 @@ function parseVerdict(raw: string, candidateIds: Set<string>): MergeVerdict {
     return { decision: "standalone", evidence: null };
   }
   const evidence =
-    typeof obj.evidence === "string" && obj.evidence.trim().length > 0
-      ? obj.evidence.trim()
-      : null;
+    typeof obj.evidence === "string" && obj.evidence.trim().length > 0 ? obj.evidence.trim() : null;
   return { decision: "standalone", evidence };
 }
 

--- a/packages/db/src/agent-follow-up.ts
+++ b/packages/db/src/agent-follow-up.ts
@@ -428,5 +428,7 @@ function followUpQueuedSummary(trigger: Exclude<AgentRunTrigger, "incident">): s
       return "Follow-up investigation queued from user feedback.";
     case "slack_reply":
       return "Follow-up investigation queued from a Slack reply.";
+    case "issue_joined":
+      return "Follow-up investigation queued: a new error signature joined this incident.";
   }
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -162,7 +162,16 @@ export type AgentRunConfidence = {
   confidence: number;
 };
 
-export type AgentRunTrigger = "incident" | "pr_comment" | "feedback" | "slack_reply";
+// "issue_joined" is a machine-originated follow-up: a new error signature joined
+// an already-investigated incident. Instead of starting a fresh investigation
+// (which produced duplicate PRs for the same root cause), it steers the existing
+// investigation — same continuation path as the human channels below.
+export type AgentRunTrigger =
+  | "incident"
+  | "pr_comment"
+  | "feedback"
+  | "slack_reply"
+  | "issue_joined";
 
 export type AgentRunFollowUpInteraction = {
   channel: Exclude<AgentRunTrigger, "incident">;


### PR DESCRIPTION
## Problem

A single root cause often surfaces as many distinct issues — one per integration and one per log layer (the raise, the catch, the wrapper, the traceback, the retry line). Issue-grouping correctly folds them into one incident, but two gaps still produced near-duplicate PRs for the same fix:

1. **Re-investigation.** Every new signature joining an incident re-armed the investigation trigger. The only guards were "a run is already active" and the `fixed_in_current_code` cooldown, so a still-firing incident was investigated from scratch repeatedly — opening a new PR each time.
2. **Weak merge recall.** The post-run merge judge that consolidates same-root-cause incidents compared only prose summaries, and only against other *open* incidents. Two incidents whose fixes touch the same code but whose surface symptoms differ (different integration, different exception text) were judged standalone, so each opened its own PR.

## Changes

**Merge judge is now fix-aware** (`merge-agent-run.ts`, `agent-runs/merge.ts`)
- Each incident carries `fixTargets` (the validated patch's `changedFiles`) and `priorPrState`. Same-file fixes are treated as strong evidence of one root cause even when symptoms differ; a closed (unmerged) PR no longer hides a candidate — a same-root-cause source merges into it rather than re-proposing.
- Merge candidates now include `resolved` incidents, so an already-fixed root cause is recognized as a duplicate instead of re-opened.

**Steer instead of re-investigate** (`schema.ts`, `agent-follow-up.ts`, `incidents/workflow.ts`, new `incidents/issue-routing.ts`)
- New `issue_joined` trigger. A new signature joining an already-investigated incident now steers that investigation through the existing inbound-continuation path used by PR comments and chat replies (resume the durable session, or cold-start a context-carrying follow-up), instead of launching a fresh one.
- Routing is a pure function (`decideIssueArrivalRouting`): it only steers when the latest run is terminal and not suppressed, and falls back to the normal investigate path otherwise, so existing behavior is preserved. The follow-up cap and age limit bound runaway.

## Tests
- New: `issue-routing.test.ts` (routing decision), `merge-agent-run.test.ts` (merge prompt carries fix targets / closed-PR state).
- Existing follow-up, incident-intake, and agent-run-sync suites still pass.
- `pnpm -r typecheck` clean across all workspaces.

No schema/migration change — `issue_joined` is a TS union member on the existing `trigger` text column.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops duplicate PRs for the same root cause by steering new error signatures into the existing investigation and making the merge judge fix-aware so same-file fixes merge even when symptoms differ.

- **New Features**
  - Merge judge now considers `fixTargets` (validated patch changed files) and `priorPrState`, and also scans `resolved` incidents. Same-file fixes are treated as one root cause, including when a prior PR was closed.
  - Added `issue_joined` trigger with `decideIssueArrivalRouting` to steer only when the latest run is terminal and not suppressed; resumes the durable session or queues a follow-up, otherwise falls back to a fresh investigation.

<sup>Written for commit 0d12dc2f9390a56027e4315a6dc58d5317a772d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

