### PR TITLE
Fix pricing slider tick labels not aligning with the track

### DIFF
--- a/apps/web/src/Pricing.tsx
+++ b/apps/web/src/Pricing.tsx
@@ -412,7 +412,11 @@ function ScaleSlider(props: {
           {props.formatValue(props.value)}
         </span>
       </div>
-      <div className="mt-1 flex justify-between text-[11px] text-subtle">
+      {/* Pad right by the value readout (w-[88px]) + the row's gap-3 (12px) so the
+          tick labels line up with the slider track instead of the full card width.
+          Without this the track is ~100px narrower than the ticks and they drift
+          apart — most visibly on a narrow (mobile) card. */}
+      <div className="mt-1 flex justify-between pr-[100px] text-[11px] text-subtle">
         {props.anchors.map((a) => (
           <span key={a}>{props.formatTick(a)}</span>
         ))}


### PR DESCRIPTION
## What

On the pricing page, the pay-as-you-go sliders' scale labels (`0 / 25 / 75 / 150 / 300`, `0 / 1M / 10M / 50M / 250M`) didn't line up with the slider track. The track ended well short of the rightmost label, so the numbers under it were meaningless — most obvious on a narrow / mobile-width card.

## Why

In `ScaleSlider` (`apps/web/src/Pricing.tsx`), the range `<input>` shares a flex row with a fixed-width value readout (`w-[88px]`) plus the row's `gap-3` (12px), so the track is ~100px narrower than the card. The tick-label row underneath, though, spanned the **full** card width with `justify-between`. Track width ≠ label-row width, so the two drift apart. On a wide card the ~100px gap is a small fraction and barely shows; on a narrow card it's glaring.

## Fix

Pad the tick row's right edge by the readout width + gap (`pr-[100px]`) so it spans exactly the track width and the labels realign with the track.

One-line, CSS-only change — no behavior or value changes.

## Verification

Rendered `/pricing` at mobile (390px) and tablet (768px) widths and confirmed the ticks now sit under their track positions, with the value readout still to the right.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misaligned tick labels on the pricing sliders by adding right padding to the tick row so its width matches the slider track. Labels now align correctly across viewports, with no behavior changes.

<sup>Written for commit e9c23c06fe51def7aa202a789c7be6fb0795785c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

