### PR TITLE
One-step AWS connect: scrape role + metrics + logs in a single stack

### DIFF
--- a/apps/api/src/cloud-connections-service.test.ts
+++ b/apps/api/src/cloud-connections-service.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import {
   type StsVerifier,
+  buildCombinedConnectLaunchUrl,
   buildConnectQuickCreateUrl,
   buildLogsStreamLaunchUrl,
   buildMetricsStreamLaunchUrl,
@@ -105,6 +106,67 @@ test("buildLogsStreamLaunchUrl targets the logs stack with the same params", () 
   assert.equal(frag.get("param_IntakeUrl"), "https://intake.example.com/aws/firehose/logs");
   assert.equal(frag.get("param_IngestKey"), "sl_public_xyz");
   assert.equal(frag.get("param_ConnectionId"), "conn-9");
+});
+
+test("buildCombinedConnectLaunchUrl carries scrape + both streams in one stack", () => {
+  const url = buildCombinedConnectLaunchUrl({
+    region: "us-west-2",
+    templateUrl: "https://superlog-cfn.s3.amazonaws.com/connect-stack.yaml",
+    superlogAccountId: "123456789012",
+    externalId: "ext-abc",
+    connectionId: "conn-1",
+    serviceToken: "arn:aws:sns:us-west-2:123456789012:superlog-connect",
+    metricsIntakeUrl: "https://intake.example.com/aws/firehose/metrics",
+    logsIntakeUrl: "https://intake.example.com/aws/firehose/logs",
+    metricsIngestKey: "sl_public_metrics",
+    logsIngestKey: "sl_public_logs",
+  });
+
+  const u = new URL(url);
+  assert.equal(u.host, "us-west-2.console.aws.amazon.com");
+  const frag = new URLSearchParams(u.hash.slice(u.hash.indexOf("?") + 1));
+  // One stack — same name as the baseline connect stack.
+  assert.equal(frag.get("stackName"), "superlog-connect");
+  assert.equal(frag.get("templateURL"), "https://superlog-cfn.s3.amazonaws.com/connect-stack.yaml");
+  assert.equal(frag.get("param_SuperlogAccountId"), "123456789012");
+  assert.equal(frag.get("param_ExternalId"), "ext-abc");
+  assert.equal(frag.get("param_ConnectionId"), "conn-1");
+  assert.equal(
+    frag.get("param_SuperlogServiceToken"),
+    "arn:aws:sns:us-west-2:123456789012:superlog-connect",
+  );
+  // Streaming on by default, both intake URLs + dedicated keys present.
+  assert.equal(frag.get("param_EnableMetrics"), "true");
+  assert.equal(frag.get("param_EnableLogs"), "true");
+  assert.equal(
+    frag.get("param_MetricsIntakeUrl"),
+    "https://intake.example.com/aws/firehose/metrics",
+  );
+  assert.equal(frag.get("param_LogsIntakeUrl"), "https://intake.example.com/aws/firehose/logs");
+  assert.equal(frag.get("param_MetricsIngestKey"), "sl_public_metrics");
+  assert.equal(frag.get("param_LogsIngestKey"), "sl_public_logs");
+});
+
+test("buildCombinedConnectLaunchUrl can disable a stream and pass a log filter", () => {
+  const url = buildCombinedConnectLaunchUrl({
+    region: "eu-central-1",
+    templateUrl: "https://cfn.example/connect-stack.yaml",
+    superlogAccountId: "123456789012",
+    externalId: "ext-xyz",
+    connectionId: "conn-2",
+    metricsIntakeUrl: "https://intake.example.com/aws/firehose/metrics",
+    logsIntakeUrl: "https://intake.example.com/aws/firehose/logs",
+    metricsIngestKey: "sl_public_m",
+    logsIngestKey: "sl_public_l",
+    enableMetrics: false,
+    logsFilterPattern: "?ERROR ?WARN",
+  });
+  const frag = new URLSearchParams(new URL(url).hash.slice(new URL(url).hash.indexOf("?") + 1));
+  assert.equal(frag.get("param_EnableMetrics"), "false");
+  assert.equal(frag.get("param_EnableLogs"), "true");
+  assert.equal(frag.get("param_LogsFilterPattern"), "?ERROR ?WARN");
+  // No SNS topic supplied → no zero-paste param (manual paste fallback).
+  assert.equal(frag.get("param_SuperlogServiceToken"), null);
 });
 
 test("buildMetricsStreamLaunchUrl rejects a hostname-hijacking region", () => {

--- a/apps/api/src/cloud-connections-service.ts
+++ b/apps/api/src/cloud-connections-service.ts
@@ -94,6 +94,62 @@ export function buildLogsStreamLaunchUrl(input: StreamLaunchInput): string {
   return buildStreamLaunchUrl("superlog-logs-stream", input);
 }
 
+export type CombinedConnectLaunchInput = {
+  /** Region the stack (and its regional stream/Firehose resources) is created in. */
+  region: string;
+  /** Public HTTPS URL of the combined `superlog-connect-stack.cfn.yaml` template. */
+  templateUrl: string;
+  /** Superlog AWS account id allowed to assume the scrape role. */
+  superlogAccountId: string;
+  /** Confused-deputy nonce for the scrape role's trust policy. */
+  externalId: string;
+  /** Connection this stack completes (zero-paste callback + reporting). */
+  connectionId: string;
+  /** Our SNS topic ARN for zero-paste reporting. Omitted → manual role-ARN paste. */
+  serviceToken?: string;
+  /** Firehose intake URLs (proxy `/aws/firehose/*` routes). */
+  metricsIntakeUrl: string;
+  logsIntakeUrl: string;
+  /** Dedicated per-signal ingest keys the two Firehoses authenticate with. */
+  metricsIngestKey: string;
+  logsIngestKey: string;
+  /** Stream toggles — default on. Off connects inventory only / skips that signal. */
+  enableMetrics?: boolean;
+  enableLogs?: boolean;
+  /** CloudWatch Logs filter pattern (default everything). */
+  logsFilterPattern?: string;
+};
+
+/**
+ * Build the one-step "Connect AWS" launch link for the combined stack
+ * (`superlog-connect-stack.cfn.yaml`): scrape role + metric streaming + log
+ * streaming in a single CloudFormation stack named `superlog-connect`. Streaming
+ * defaults on but each signal toggles off via a parameter. Everything
+ * prod-specific (account id, intake URLs, ingest keys, SNS topic) is a parameter
+ * value, never baked into the committed template.
+ */
+export function buildCombinedConnectLaunchUrl(input: CombinedConnectLaunchInput): string {
+  const params: Record<string, string> = {
+    SuperlogAccountId: input.superlogAccountId,
+    ExternalId: input.externalId,
+    ConnectionId: input.connectionId,
+    EnableMetrics: (input.enableMetrics ?? true) ? "true" : "false",
+    EnableLogs: (input.enableLogs ?? true) ? "true" : "false",
+    MetricsIntakeUrl: input.metricsIntakeUrl,
+    LogsIntakeUrl: input.logsIntakeUrl,
+    MetricsIngestKey: input.metricsIngestKey,
+    LogsIngestKey: input.logsIngestKey,
+  };
+  if (input.serviceToken) params.SuperlogServiceToken = input.serviceToken;
+  if (input.logsFilterPattern) params.LogsFilterPattern = input.logsFilterPattern;
+  return buildConnectQuickCreateUrl({
+    region: input.region,
+    templateUrl: input.templateUrl,
+    stackName: "superlog-connect",
+    params,
+  });
+}
+
 /**
  * Name of the dedicated ingest key minted for a stream. Stable + regional so the
  * streaming-status read can find the key that the setup route created — keep the

--- a/apps/api/src/cloud-connections.test.ts
+++ b/apps/api/src/cloud-connections.test.ts
@@ -67,7 +67,23 @@ async function seedProject() {
   return { org, user, project };
 }
 
-function appFor(userId: string, orgId: string, sts: StsVerifier, resourceLister?: ResourceLister) {
+// Fully-configured one-step connect: combined template + both Firehose intakes.
+const COMBINED_CONFIG: CloudConnectConfig = {
+  superlogAccountId: "123456789012",
+  templateUrl: "https://cfn.example/aws-connect.yaml",
+  connectStackTemplateUrl: "https://cfn.example/connect-stack.yaml",
+  metricsIntakeUrl: "https://intake.example.com/aws/firehose/metrics",
+  logsIntakeUrl: "https://intake.example.com/aws/firehose/logs",
+  serviceToken: "arn:aws:sns:us-west-2:123456789012:superlog-connect",
+};
+
+function appWith(
+  userId: string,
+  orgId: string,
+  sts: StsVerifier,
+  config: CloudConnectConfig,
+  resourceLister?: ResourceLister,
+) {
   const app = new Hono<{ Variables: { userId: string; orgId: string | null } }>();
   app.use("*", (c, next) => {
     c.set("userId", userId);
@@ -77,7 +93,7 @@ function appFor(userId: string, orgId: string, sts: StsVerifier, resourceLister?
   // No-op config fetcher so tests never reach real AWS Cloud Control.
   mountCloudConnectionsAuthed(app, {
     sts,
-    config: CONFIG,
+    config,
     resourceLister,
     configFetcher: {
       async get() {
@@ -87,6 +103,13 @@ function appFor(userId: string, orgId: string, sts: StsVerifier, resourceLister?
   });
   return app;
 }
+
+function appFor(userId: string, orgId: string, sts: StsVerifier, resourceLister?: ResourceLister) {
+  return appWith(userId, orgId, sts, CONFIG, resourceLister);
+}
+
+const fragOf = (url: string) =>
+  new URLSearchParams(new URL(url).hash.slice(new URL(url).hash.indexOf("?") + 1));
 
 const okSts = (accountId: string): StsVerifier => ({
   async verifyAssumeRole() {
@@ -393,6 +416,84 @@ test("metrics-stream is 501 when metric streaming isn't configured", async () =>
     { method: "POST" },
   );
   assert.equal(res.status, 501);
+});
+
+test("one-step connect launches the combined stack + mints both stream keys", async () => {
+  const { org, user, project } = await seedProject();
+  const app = appWith(user.id, org.id, okSts("210987654321"), COMBINED_CONFIG);
+
+  const created = await asConn(
+    await app.request(`/api/projects/${project.id}/cloud-connections`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ region: "us-west-2" }),
+    }),
+  );
+
+  assert.ok(created.launchUrl, "expected a launch url");
+  const frag = fragOf(created.launchUrl);
+  // One combined stack, streaming on by default, with both intakes + the SNS topic.
+  assert.equal(frag.get("templateURL"), "https://cfn.example/connect-stack.yaml");
+  assert.equal(frag.get("stackName"), "superlog-connect");
+  assert.equal(frag.get("param_EnableMetrics"), "true");
+  assert.equal(frag.get("param_EnableLogs"), "true");
+  assert.equal(
+    frag.get("param_MetricsIntakeUrl"),
+    "https://intake.example.com/aws/firehose/metrics",
+  );
+  assert.equal(frag.get("param_LogsIntakeUrl"), "https://intake.example.com/aws/firehose/logs");
+  assert.equal(
+    frag.get("param_SuperlogServiceToken"),
+    "arn:aws:sns:us-west-2:123456789012:superlog-connect",
+  );
+  // Dedicated per-signal keys, distinct, both embedded in the launch URL.
+  const mKey = frag.get("param_MetricsIngestKey");
+  const lKey = frag.get("param_LogsIngestKey");
+  assert.ok(mKey && lKey && mKey !== lKey, "expected two distinct ingest keys");
+
+  // Both stream keys persisted up front (so reconciliation tracks each signal).
+  const sk = await db.query.cloudStreamKeys.findMany({
+    where: eq(schema.cloudStreamKeys.connectionId, created.id),
+  });
+  assert.equal(sk.length, 2);
+  assert.deepEqual(sk.map((r) => r.kind).sort(), ["logs", "metrics"]);
+});
+
+test("one-step re-launch (metrics-stream) reuses the same combined stack + keys", async () => {
+  const { org, user, project } = await seedProject();
+  const app = appWith(user.id, org.id, okSts("210987654321"), COMBINED_CONFIG);
+
+  const created = await asConn(
+    await app.request(`/api/projects/${project.id}/cloud-connections`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ region: "us-west-2" }),
+    }),
+  );
+  assert.ok(created.launchUrl, "expected a launch url");
+  const keyAtConnect = fragOf(created.launchUrl).get("param_MetricsIngestKey");
+  // Verify, then "Re-launch metric streaming" → must return the SAME combined
+  // stack with the SAME key (no new key, no parallel stack).
+  await app.request(`/api/projects/${project.id}/cloud-connections/${created.id}/verify`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ scrapeRoleArn: "arn:aws:iam::210987654321:role/SuperlogScrapeRole" }),
+  });
+  const relaunch = (await (
+    await app.request(
+      `/api/projects/${project.id}/cloud-connections/${created.id}/metrics-stream`,
+      { method: "POST" },
+    )
+  ).json()) as { launchUrl: string; keyPrefix: string };
+  const frag = fragOf(relaunch.launchUrl);
+  assert.equal(frag.get("stackName"), "superlog-connect");
+  assert.equal(frag.get("param_MetricsIngestKey"), keyAtConnect);
+
+  // Still exactly two stream keys — re-launch minted nothing new.
+  const sk = await db.query.cloudStreamKeys.findMany({
+    where: eq(schema.cloudStreamKeys.connectionId, created.id),
+  });
+  assert.equal(sk.length, 2);
 });
 
 test("reconnecting a role already active in the project revokes the old row (no 500)", async () => {

--- a/apps/api/src/cloud-connections.test.ts
+++ b/apps/api/src/cloud-connections.test.ts
@@ -496,6 +496,68 @@ test("one-step re-launch (metrics-stream) reuses the same combined stack + keys"
   assert.equal(sk.length, 2);
 });
 
+test("re-launch re-mints a stream key whose api key was revoked", async () => {
+  const { org, user, project } = await seedProject();
+  const app = appWith(user.id, org.id, okSts("210987654321"), COMBINED_CONFIG);
+
+  const created = await asConn(
+    await app.request(`/api/projects/${project.id}/cloud-connections`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ region: "us-west-2" }),
+    }),
+  );
+  await app.request(`/api/projects/${project.id}/cloud-connections/${created.id}/verify`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ scrapeRoleArn: "arn:aws:iam::210987654321:role/SuperlogScrapeRole" }),
+  });
+
+  // Revoke the metrics signal's api key out from under the stored stream key.
+  const before = await db.query.cloudStreamKeys.findFirst({
+    where: and(
+      eq(schema.cloudStreamKeys.connectionId, created.id),
+      eq(schema.cloudStreamKeys.kind, "metrics"),
+    ),
+  });
+  assert.ok(before);
+  await db
+    .update(schema.apiKeys)
+    .set({ revokedAt: new Date() })
+    .where(eq(schema.apiKeys.id, before.apiKeyId));
+
+  // Re-launch must NOT hand back the dead key — it re-mints in place.
+  const relaunch = (await (
+    await app.request(
+      `/api/projects/${project.id}/cloud-connections/${created.id}/metrics-stream`,
+      { method: "POST" },
+    )
+  ).json()) as { launchUrl: string };
+
+  const after = await db.query.cloudStreamKeys.findFirst({
+    where: and(
+      eq(schema.cloudStreamKeys.connectionId, created.id),
+      eq(schema.cloudStreamKeys.kind, "metrics"),
+    ),
+  });
+  assert.ok(after);
+  assert.notEqual(after.apiKeyId, before.apiKeyId);
+  const newKey = await db.query.apiKeys.findFirst({
+    where: eq(schema.apiKeys.id, after.apiKeyId),
+  });
+  assert.equal(newKey?.revokedAt, null);
+  // Still one metrics row (re-minted in place, not duplicated).
+  const all = await db.query.cloudStreamKeys.findMany({
+    where: and(
+      eq(schema.cloudStreamKeys.connectionId, created.id),
+      eq(schema.cloudStreamKeys.kind, "metrics"),
+    ),
+  });
+  assert.equal(all.length, 1);
+  // Launch URL carries the live key (and not the revoked prefix).
+  assert.ok(fragOf(relaunch.launchUrl).get("param_MetricsIngestKey"));
+});
+
 test("reconnecting a role already active in the project revokes the old row (no 500)", async () => {
   const { org, user, project } = await seedProject();
   const roleArn = "arn:aws:iam::210987654321:role/SuperlogScrapeRole";

--- a/apps/api/src/cloud-connections.ts
+++ b/apps/api/src/cloud-connections.ts
@@ -12,6 +12,7 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 import {
   type StsVerifier,
+  buildCombinedConnectLaunchUrl,
   buildConnectQuickCreateUrl,
   buildLogsStreamLaunchUrl,
   buildMetricsStreamLaunchUrl,
@@ -64,7 +65,24 @@ export type CloudConnectConfig = {
   logsTemplateUrl?: string;
   /** Firehose intake URL CloudWatch Logs deliver to — the proxy's `/aws/firehose/logs`. */
   logsIntakeUrl?: string;
+  /**
+   * Public HTTPS URL of the combined one-step template
+   * (`superlog-connect-stack.cfn.yaml`): scrape role + metric + log streaming in
+   * a single stack. When set alongside both intake URLs, "Connect AWS" provisions
+   * everything in one launch; otherwise it falls back to the scrape-role-only
+   * template and per-signal stream setup.
+   */
+  connectStackTemplateUrl?: string;
 };
+
+/** True when the one-step combined connect (scrape + both streams) is fully configured. */
+function combinedConnectReady(config: CloudConnectConfig): config is CloudConnectConfig & {
+  connectStackTemplateUrl: string;
+  metricsIntakeUrl: string;
+  logsIntakeUrl: string;
+} {
+  return Boolean(config.connectStackTemplateUrl && config.metricsIntakeUrl && config.logsIntakeUrl);
+}
 
 export function cloudConnectConfigFromEnv(
   env: NodeJS.ProcessEnv = process.env,
@@ -80,6 +98,7 @@ export function cloudConnectConfigFromEnv(
     metricsIntakeUrl: env.AWS_FIREHOSE_METRICS_INTAKE_URL || undefined,
     logsTemplateUrl: env.AWS_LOGS_TEMPLATE_URL || undefined,
     logsIntakeUrl: env.AWS_FIREHOSE_LOGS_INTAKE_URL || undefined,
+    connectStackTemplateUrl: env.AWS_CONNECT_STACK_TEMPLATE_URL || undefined,
   };
 }
 
@@ -199,6 +218,74 @@ export function mountCloudConnectionsAuthed(
     return { project, user: ctx.user };
   };
 
+  // Decrypt a persisted stream key + look up its prefix for display.
+  const loadStreamKey = async (sk: typeof schema.cloudStreamKeys.$inferSelect) => {
+    const ingestKey = decryptIntegrationSecret({
+      ciphertext: sk.keyCiphertext,
+      nonce: sk.keyNonce,
+      keyVersion: sk.keyKeyVersion,
+    });
+    const keyRow = await db.query.apiKeys.findFirst({
+      where: eq(schema.apiKeys.id, sk.apiKeyId),
+    });
+    return { ingestKey, keyPrefix: keyRow?.keyPrefix ?? "" };
+  };
+
+  // Idempotently get (or first-time mint) the dedicated ingest key for one
+  // signal of a connection. A dedicated key per stream keeps it independently
+  // revocable and makes attribution obvious in the key list. Reused by both the
+  // one-step connect (mints both up front) and per-signal stream setup, so a
+  // re-launch carries the *same* IngestKey instead of minting a new one each
+  // click. The insert is guarded against a concurrent first mint (unique
+  // connection+kind): if we lose the race we revoke the orphan key and reuse the
+  // winner's, so two parallel callers don't 500 or leave duplicate keys.
+  const ensureStreamKey = async (
+    connectionId: string,
+    projectId: string,
+    region: string,
+    kind: "metrics" | "logs",
+  ): Promise<{ ingestKey: string; keyPrefix: string }> => {
+    const existing = await db.query.cloudStreamKeys.findFirst({
+      where: and(
+        eq(schema.cloudStreamKeys.connectionId, connectionId),
+        eq(schema.cloudStreamKeys.kind, kind),
+      ),
+    });
+    if (existing) return loadStreamKey(existing);
+
+    const minted = await mintApiKey({ projectId, name: streamKeyName(kind, region) });
+    const cipher = encryptIntegrationSecret(minted.plaintext);
+    const [inserted] = await db
+      .insert(schema.cloudStreamKeys)
+      .values({
+        connectionId,
+        kind,
+        apiKeyId: minted.id,
+        keyCiphertext: cipher.ciphertext,
+        keyNonce: cipher.nonce,
+        keyKeyVersion: cipher.keyVersion,
+      })
+      .onConflictDoNothing({
+        target: [schema.cloudStreamKeys.connectionId, schema.cloudStreamKeys.kind],
+      })
+      .returning();
+
+    if (inserted) return { ingestKey: minted.plaintext, keyPrefix: minted.keyPrefix };
+
+    await db
+      .update(schema.apiKeys)
+      .set({ revokedAt: new Date() })
+      .where(eq(schema.apiKeys.id, minted.id));
+    const winner = await db.query.cloudStreamKeys.findFirst({
+      where: and(
+        eq(schema.cloudStreamKeys.connectionId, connectionId),
+        eq(schema.cloudStreamKeys.kind, kind),
+      ),
+    });
+    if (!winner) throw new HTTPException(500, { message: "failed to persist stream key" });
+    return loadStreamKey(winner);
+  };
+
   app.get("/api/projects/:projectId/cloud-connections", async (c) => {
     const projectId = c.req.param("projectId");
     await requireAccess(c, projectId);
@@ -236,21 +323,43 @@ export function mountCloudConnectionsAuthed(
       .returning();
     if (!row) throw new HTTPException(500, { message: "failed to create connection" });
 
-    const params: Record<string, string> = {
-      ExternalId: externalId,
-      SuperlogAccountId: config.superlogAccountId,
-      ConnectionId: row.id,
-    };
-    // When we have an SNS topic, pass it so the template's custom resource reports
-    // the role ARN back automatically (zero-paste). Otherwise the customer pastes.
-    if (config.serviceToken) params.SuperlogServiceToken = config.serviceToken;
-
-    const launchUrl = buildConnectQuickCreateUrl({
-      region: parsed.data.region,
-      templateUrl: config.templateUrl,
-      stackName: "superlog-connect",
-      params,
-    });
+    let launchUrl: string;
+    if (combinedConnectReady(config)) {
+      // One-step connect: mint both signal keys up front and launch a single
+      // stack that creates the scrape role + metric + log streaming together.
+      const [metricsKey, logsKey] = await Promise.all([
+        ensureStreamKey(row.id, projectId, row.region, "metrics"),
+        ensureStreamKey(row.id, projectId, row.region, "logs"),
+      ]);
+      launchUrl = buildCombinedConnectLaunchUrl({
+        region: row.region,
+        templateUrl: config.connectStackTemplateUrl,
+        superlogAccountId: config.superlogAccountId,
+        externalId,
+        connectionId: row.id,
+        serviceToken: config.serviceToken,
+        metricsIntakeUrl: config.metricsIntakeUrl,
+        logsIntakeUrl: config.logsIntakeUrl,
+        metricsIngestKey: metricsKey.ingestKey,
+        logsIngestKey: logsKey.ingestKey,
+      });
+    } else {
+      // Legacy: scrape-role-only stack; streaming is set up later per signal.
+      const params: Record<string, string> = {
+        ExternalId: externalId,
+        SuperlogAccountId: config.superlogAccountId,
+        ConnectionId: row.id,
+      };
+      // When we have an SNS topic, pass it so the template's custom resource reports
+      // the role ARN back automatically (zero-paste). Otherwise the customer pastes.
+      if (config.serviceToken) params.SuperlogServiceToken = config.serviceToken;
+      launchUrl = buildConnectQuickCreateUrl({
+        region: parsed.data.region,
+        templateUrl: config.templateUrl,
+        stackName: "superlog-connect",
+        params,
+      });
+    }
     // externalId returned once so the UI can show it; it's also in the launch URL.
     return c.json({ ...toPublic(row), launchUrl, externalId });
   });
@@ -277,10 +386,12 @@ export function mountCloudConnectionsAuthed(
     return c.json(toPublic(updated));
   });
 
-  // Set up CloudWatch metric/log streaming for a verified connection. Mints a
-  // dedicated project ingest key (the stream authenticates with it) and returns
-  // the launch URL for the corresponding stack. POST, not GET: each call mints a
-  // key, so it must be an explicit user action, not something the UI polls.
+  // Set up (or re-launch) CloudWatch metric/log streaming for a verified
+  // connection. Returns the launch URL for the stack that carries this signal.
+  // In one-step (combined) mode every signal lives in the single `superlog-connect`
+  // stack, so both signals' buttons return the *same* combined launch URL — a
+  // re-launch updates that one stack rather than creating a parallel one. POST,
+  // not GET: it can mint a key, so it must be an explicit user action, not polled.
   const handleStreamSetup = async (
     c: Context<{ Variables: Vars }>,
     projectId: string,
@@ -288,9 +399,16 @@ export function mountCloudConnectionsAuthed(
     kind: "metrics" | "logs",
   ) => {
     await requireAccess(c, projectId);
-    const templateUrl = kind === "metrics" ? config?.metricsTemplateUrl : config?.logsTemplateUrl;
-    const intakeUrl = kind === "metrics" ? config?.metricsIntakeUrl : config?.logsIntakeUrl;
-    if (!templateUrl || !intakeUrl) {
+
+    // Configuration check first (independent of the specific connection): in
+    // legacy mode this signal's template + intake URL must be set, else 501.
+    // One-step mode is always "configured" once the combined template + intakes
+    // exist, so it skips this.
+    const combined = config != null && combinedConnectReady(config);
+    const legacyTemplateUrl =
+      kind === "metrics" ? config?.metricsTemplateUrl : config?.logsTemplateUrl;
+    const legacyIntakeUrl = kind === "metrics" ? config?.metricsIntakeUrl : config?.logsIntakeUrl;
+    if (!combined && (!legacyTemplateUrl || !legacyIntakeUrl)) {
       throw new HTTPException(501, { message: `${kind} streaming is not configured` });
     }
 
@@ -306,80 +424,46 @@ export function mountCloudConnectionsAuthed(
       throw new HTTPException(409, { message: "connection is not verified" });
     }
 
-    // Decrypt a persisted stream key + look up its prefix for display.
-    const loadKey = async (sk: typeof schema.cloudStreamKeys.$inferSelect) => {
-      const ingestKey = decryptIntegrationSecret({
-        ciphertext: sk.keyCiphertext,
-        nonce: sk.keyNonce,
-        keyVersion: sk.keyKeyVersion,
+    // One-step mode: re-open the single combined stack with both signals' keys.
+    if (combined && config) {
+      const externalId = decryptIntegrationSecret({
+        ciphertext: row.externalIdCiphertext,
+        nonce: row.externalIdNonce,
+        keyVersion: row.externalIdKeyVersion,
       });
-      const keyRow = await db.query.apiKeys.findFirst({
-        where: eq(schema.apiKeys.id, sk.apiKeyId),
+      const [metricsKey, logsKey] = await Promise.all([
+        ensureStreamKey(row.id, projectId, row.region, "metrics"),
+        ensureStreamKey(row.id, projectId, row.region, "logs"),
+      ]);
+      const launchUrl = buildCombinedConnectLaunchUrl({
+        region: row.region,
+        templateUrl: config.connectStackTemplateUrl,
+        superlogAccountId: config.superlogAccountId,
+        externalId,
+        connectionId: row.id,
+        serviceToken: config.serviceToken,
+        metricsIntakeUrl: config.metricsIntakeUrl,
+        logsIntakeUrl: config.logsIntakeUrl,
+        metricsIngestKey: metricsKey.ingestKey,
+        logsIngestKey: logsKey.ingestKey,
       });
-      return { ingestKey, keyPrefix: keyRow?.keyPrefix ?? "" };
-    };
-
-    // Idempotent: reuse the stream's persisted key if setup already ran, so a
-    // re-launch ("repair") carries the *same* IngestKey instead of minting a new
-    // one each click. Only mint + store on first setup.
-    const existing = await db.query.cloudStreamKeys.findFirst({
-      where: and(
-        eq(schema.cloudStreamKeys.connectionId, row.id),
-        eq(schema.cloudStreamKeys.kind, kind),
-      ),
-    });
-
-    let ingestKey: string;
-    let keyPrefix: string;
-    if (existing) {
-      ({ ingestKey, keyPrefix } = await loadKey(existing));
-    } else {
-      // A dedicated ingest key per stream keeps it independently revocable and
-      // makes attribution obvious in the project's key list. The insert is
-      // guarded against a concurrent first setup (unique connection+kind): if we
-      // lose the race we revoke the orphan key we just minted and reuse the
-      // winner's, so two parallel clicks don't 500 or leave duplicate keys.
-      const minted = await mintApiKey({ projectId, name: streamKeyName(kind, row.region) });
-      const cipher = encryptIntegrationSecret(minted.plaintext);
-      const [inserted] = await db
-        .insert(schema.cloudStreamKeys)
-        .values({
-          connectionId: row.id,
-          kind,
-          apiKeyId: minted.id,
-          keyCiphertext: cipher.ciphertext,
-          keyNonce: cipher.nonce,
-          keyKeyVersion: cipher.keyVersion,
-        })
-        .onConflictDoNothing({
-          target: [schema.cloudStreamKeys.connectionId, schema.cloudStreamKeys.kind],
-        })
-        .returning();
-
-      if (inserted) {
-        ingestKey = minted.plaintext;
-        keyPrefix = minted.keyPrefix;
-      } else {
-        await db
-          .update(schema.apiKeys)
-          .set({ revokedAt: new Date() })
-          .where(eq(schema.apiKeys.id, minted.id));
-        const winner = await db.query.cloudStreamKeys.findFirst({
-          where: and(
-            eq(schema.cloudStreamKeys.connectionId, row.id),
-            eq(schema.cloudStreamKeys.kind, kind),
-          ),
-        });
-        if (!winner) throw new HTTPException(500, { message: "failed to persist stream key" });
-        ({ ingestKey, keyPrefix } = await loadKey(winner));
-      }
+      return c.json({
+        launchUrl,
+        keyPrefix: (kind === "metrics" ? metricsKey : logsKey).keyPrefix,
+      });
     }
 
+    // Legacy: a dedicated per-signal stack. (Both URLs are non-null here — the
+    // 501 guard above already rejected the unconfigured case.)
+    if (!legacyTemplateUrl || !legacyIntakeUrl) {
+      throw new HTTPException(501, { message: `${kind} streaming is not configured` });
+    }
+    const { ingestKey, keyPrefix } = await ensureStreamKey(row.id, projectId, row.region, kind);
     const build = kind === "metrics" ? buildMetricsStreamLaunchUrl : buildLogsStreamLaunchUrl;
     const launchUrl = build({
       region: row.region,
-      templateUrl,
-      intakeUrl,
+      templateUrl: legacyTemplateUrl,
+      intakeUrl: legacyIntakeUrl,
       ingestKey,
       connectionId: row.id,
     });

--- a/apps/api/src/cloud-connections.ts
+++ b/apps/api/src/cloud-connections.ts
@@ -218,7 +218,9 @@ export function mountCloudConnectionsAuthed(
     return { project, user: ctx.user };
   };
 
-  // Decrypt a persisted stream key + look up its prefix for display.
+  // Decrypt a persisted stream key + look up its prefix for display. `revoked`
+  // is true when the underlying api key is missing or has been revoked, so the
+  // stored secret would no longer authenticate and must be re-minted.
   const loadStreamKey = async (sk: typeof schema.cloudStreamKeys.$inferSelect) => {
     const ingestKey = decryptIntegrationSecret({
       ciphertext: sk.keyCiphertext,
@@ -228,33 +230,36 @@ export function mountCloudConnectionsAuthed(
     const keyRow = await db.query.apiKeys.findFirst({
       where: eq(schema.apiKeys.id, sk.apiKeyId),
     });
-    return { ingestKey, keyPrefix: keyRow?.keyPrefix ?? "" };
+    return {
+      ingestKey,
+      keyPrefix: keyRow?.keyPrefix ?? "",
+      revoked: !keyRow || keyRow.revokedAt != null,
+    };
   };
 
-  // Idempotently get (or first-time mint) the dedicated ingest key for one
-  // signal of a connection. A dedicated key per stream keeps it independently
-  // revocable and makes attribution obvious in the key list. Reused by both the
-  // one-step connect (mints both up front) and per-signal stream setup, so a
-  // re-launch carries the *same* IngestKey instead of minting a new one each
-  // click. The insert is guarded against a concurrent first mint (unique
-  // connection+kind): if we lose the race we revoke the orphan key and reuse the
-  // winner's, so two parallel callers don't 500 or leave duplicate keys.
-  const ensureStreamKey = async (
+  // Mint a fresh ingest key, encrypt it, and point a stream-key row at it. Used
+  // for both the first-ever mint and re-minting after the prior key was revoked.
+  const mintAndStoreStreamKey = async (
+    streamKeyId: string | null,
     connectionId: string,
     projectId: string,
     region: string,
     kind: "metrics" | "logs",
   ): Promise<{ ingestKey: string; keyPrefix: string }> => {
-    const existing = await db.query.cloudStreamKeys.findFirst({
-      where: and(
-        eq(schema.cloudStreamKeys.connectionId, connectionId),
-        eq(schema.cloudStreamKeys.kind, kind),
-      ),
-    });
-    if (existing) return loadStreamKey(existing);
-
     const minted = await mintApiKey({ projectId, name: streamKeyName(kind, region) });
     const cipher = encryptIntegrationSecret(minted.plaintext);
+    if (streamKeyId) {
+      await db
+        .update(schema.cloudStreamKeys)
+        .set({
+          apiKeyId: minted.id,
+          keyCiphertext: cipher.ciphertext,
+          keyNonce: cipher.nonce,
+          keyKeyVersion: cipher.keyVersion,
+        })
+        .where(eq(schema.cloudStreamKeys.id, streamKeyId));
+      return { ingestKey: minted.plaintext, keyPrefix: minted.keyPrefix };
+    }
     const [inserted] = await db
       .insert(schema.cloudStreamKeys)
       .values({
@@ -269,9 +274,10 @@ export function mountCloudConnectionsAuthed(
         target: [schema.cloudStreamKeys.connectionId, schema.cloudStreamKeys.kind],
       })
       .returning();
-
     if (inserted) return { ingestKey: minted.plaintext, keyPrefix: minted.keyPrefix };
 
+    // Lost a concurrent first-insert race: revoke our orphan key and reuse the
+    // winner's row (re-minting it too if that one is already revoked).
     await db
       .update(schema.apiKeys)
       .set({ revokedAt: new Date() })
@@ -283,7 +289,36 @@ export function mountCloudConnectionsAuthed(
       ),
     });
     if (!winner) throw new HTTPException(500, { message: "failed to persist stream key" });
-    return loadStreamKey(winner);
+    const loaded = await loadStreamKey(winner);
+    if (!loaded.revoked) return { ingestKey: loaded.ingestKey, keyPrefix: loaded.keyPrefix };
+    return mintAndStoreStreamKey(winner.id, connectionId, projectId, region, kind);
+  };
+
+  // Idempotently get (or first-time mint) the dedicated ingest key for one
+  // signal of a connection. A dedicated key per stream keeps it independently
+  // revocable and makes attribution obvious in the key list. Reused by both the
+  // one-step connect (mints both up front) and per-signal stream setup, so a
+  // re-launch carries the *same* IngestKey instead of minting a new one each
+  // click — unless the stored key has since been revoked, in which case we
+  // re-mint in place so the launch URL never carries a dead key.
+  const ensureStreamKey = async (
+    connectionId: string,
+    projectId: string,
+    region: string,
+    kind: "metrics" | "logs",
+  ): Promise<{ ingestKey: string; keyPrefix: string }> => {
+    const existing = await db.query.cloudStreamKeys.findFirst({
+      where: and(
+        eq(schema.cloudStreamKeys.connectionId, connectionId),
+        eq(schema.cloudStreamKeys.kind, kind),
+      ),
+    });
+    if (existing) {
+      const loaded = await loadStreamKey(existing);
+      if (!loaded.revoked) return { ingestKey: loaded.ingestKey, keyPrefix: loaded.keyPrefix };
+      return mintAndStoreStreamKey(existing.id, connectionId, projectId, region, kind);
+    }
+    return mintAndStoreStreamKey(null, connectionId, projectId, region, kind);
   };
 
   app.get("/api/projects/:projectId/cloud-connections", async (c) => {

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -596,8 +596,15 @@ async function forwardFirehose(
     } catch (err) {
       span.recordException(err as Error);
       span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+      // Keep the detailed error server-side only — the errorMessage we return is
+      // echoed by AWS into the customer's Firehose error logs / S3 error bucket,
+      // so it must not carry internal exception text (collector URLs, stack info).
+      logger.error({ err, signal, requestId }, "firehose proxy request failed");
       // 500 (retriable) with a Firehose-shaped body so AWS backs off and retries.
-      return c.json(firehoseResponseBody(requestId ?? "unknown", (err as Error).message), 500);
+      return c.json(
+        firehoseResponseBody(requestId ?? "unknown", "internal error processing firehose request"),
+        500,
+      );
     } finally {
       span.end();
     }

--- a/infra/aws-connect/superlog-connect-stack.cfn.yaml
+++ b/infra/aws-connect/superlog-connect-stack.cfn.yaml
@@ -182,8 +182,10 @@ Resources:
     Condition: CreateMetrics
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
+    # No explicit BucketName: with DeletionPolicy Retain, a hard-coded name would
+    # be orphaned when EnableMetrics is toggled off, then collide when toggled
+    # back on. A CloudFormation-generated name keeps the stack re-enableable.
     Properties:
-      BucketName: !Sub "superlog-metrics-backup-${AWS::AccountId}-${AWS::Region}"
       LifecycleConfiguration:
         Rules:
           - Id: expire-backups
@@ -244,7 +246,9 @@ Resources:
               - Sid: DeliveryErrorLogs
                 Effect: Allow
                 Action: "logs:PutLogEvents"
-                Resource: !GetAtt MetricsFirehoseLogGroup.Arn
+                # PutLogEvents authorizes against the log *stream* ARN, not the
+                # log-group ARN, so scope to the group's streams explicitly.
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/kinesisfirehose/superlog-metrics:log-stream:*"
 
   MetricsDeliveryStream:
     Type: AWS::KinesisFirehose::DeliveryStream
@@ -338,8 +342,9 @@ Resources:
     Condition: CreateLogs
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
+    # No explicit BucketName — see MetricsBackupBucket: keeps the stack
+    # re-enableable after a toggle-off retains the bucket.
     Properties:
-      BucketName: !Sub "superlog-logs-backup-${AWS::AccountId}-${AWS::Region}"
       LifecycleConfiguration:
         Rules:
           - Id: expire-backups
@@ -400,7 +405,9 @@ Resources:
               - Sid: DeliveryErrorLogs
                 Effect: Allow
                 Action: "logs:PutLogEvents"
-                Resource: !GetAtt LogsFirehoseLogGroup.Arn
+                # PutLogEvents authorizes against the log *stream* ARN, not the
+                # log-group ARN, so scope to the group's streams explicitly.
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/kinesisfirehose/superlog-logs:log-stream:*"
 
   LogsDeliveryStream:
     Type: AWS::KinesisFirehose::DeliveryStream
@@ -445,6 +452,13 @@ Resources:
             Principal:
               Service: !Sub "logs.${AWS::Region}.amazonaws.com"
             Action: "sts:AssumeRole"
+            # Confused-deputy guard: only this account's CloudWatch Logs in this
+            # region may assume the role.
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref "AWS::AccountId"
+              ArnLike:
+                aws:SourceArn: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
       Policies:
         - PolicyName: SuperlogLogsToFirehose
           PolicyDocument:

--- a/infra/aws-connect/superlog-connect-stack.cfn.yaml
+++ b/infra/aws-connect/superlog-connect-stack.cfn.yaml
@@ -1,0 +1,487 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Superlog AWS connect — one-step integration stack. Creates the read-only
+  scrape/inventory role AND (by default) CloudWatch metric streaming + an
+  account-level CloudWatch Logs subscription, all delivered to Superlog through
+  Amazon Data Firehose. Metric streaming and log streaming each toggle off via
+  the EnableMetrics / EnableLogs parameters — they incur CloudWatch Metric
+  Streams + Firehose (and, for logs, CloudWatch Logs delivery) charges on YOUR
+  AWS bill, so the namespace set and log FilterPattern below are the cost levers.
+  The scrape role itself is read-only and free.
+
+# Lets the logs subscription PolicyDocument be built with Fn::ToJsonString
+# instead of hand-interpolating the FilterPattern into a JSON string.
+Transform: AWS::LanguageExtensions
+
+Parameters:
+  # --- Connection (scrape role) ---------------------------------------------
+  SuperlogAccountId:
+    Type: String
+    Description: The Superlog AWS account allowed to assume the scrape role.
+    AllowedPattern: "^[0-9]{12}$"
+  ExternalId:
+    Type: String
+    Description: >-
+      Unique external ID Superlog presents when assuming the role (confused-deputy
+      nonce). Not NoEcho: the quick-create link drops NoEcho params and it's
+      already in the launch URL, not a password.
+    MinLength: 16
+  RoleName:
+    Type: String
+    Description: Name for the created scrape role.
+    Default: SuperlogScrapeRole
+  ConnectionId:
+    Type: String
+    Description: Superlog connection this stack completes (used by the callback).
+    Default: ""
+  SuperlogServiceToken:
+    Type: String
+    Description: >-
+      Superlog SNS topic ARN. When set, this stack reports the new role ARN back
+      to Superlog automatically (zero-paste). Leave blank to paste the ScrapeRoleArn
+      output by hand.
+    Default: ""
+
+  # --- Streaming toggles + delivery -----------------------------------------
+  EnableMetrics:
+    Type: String
+    Description: >-
+      Stream CloudWatch metrics to Superlog. "true" creates a Metric Stream +
+      Firehose (billable). Set to "false" to connect inventory only.
+    Default: "true"
+    AllowedValues: ["true", "false"]
+  EnableLogs:
+    Type: String
+    Description: >-
+      Forward CloudWatch Logs to Superlog via an account-level subscription +
+      Firehose (billable). Set to "false" to skip log streaming.
+    Default: "true"
+    AllowedValues: ["true", "false"]
+  MetricsIngestKey:
+    Type: String
+    Description: >-
+      Superlog ingest key the metric stream authenticates with (sl_public_…).
+      Provided by Superlog in the launch link. Ignored when EnableMetrics=false.
+    Default: ""
+  LogsIngestKey:
+    Type: String
+    Description: >-
+      Superlog ingest key the log subscription authenticates with (sl_public_…).
+      Provided by Superlog in the launch link. Ignored when EnableLogs=false.
+    Default: ""
+  MetricsIntakeUrl:
+    Type: String
+    Description: Superlog Firehose intake URL for metrics (https). From the launch link.
+    Default: ""
+  LogsIntakeUrl:
+    Type: String
+    Description: Superlog Firehose intake URL for logs (https). From the launch link.
+    Default: ""
+  LogsFilterPattern:
+    Type: String
+    Description: >-
+      CloudWatch Logs filter pattern. Empty forwards everything; narrow it (e.g.
+      ?ERROR ?WARN) to cut log volume and cost. Embedded safely via Fn::ToJsonString.
+    Default: ""
+
+Conditions:
+  # Auto-report only when both the SNS topic and a connection id are supplied.
+  ReportBack: !And
+    - !Not [!Equals [!Ref SuperlogServiceToken, ""]]
+    - !Not [!Equals [!Ref ConnectionId, ""]]
+  CreateMetrics: !Equals [!Ref EnableMetrics, "true"]
+  CreateLogs: !Equals [!Ref EnableLogs, "true"]
+
+Resources:
+  # ===========================================================================
+  # Connection — read-only scrape/inventory role (always created)
+  # ===========================================================================
+  ScrapeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref RoleName
+      Description: Read-only role Superlog assumes to inventory AWS resources.
+      MaxSessionDuration: 3600
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${SuperlogAccountId}:root"
+            Action: "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                "sts:ExternalId": !Ref ExternalId
+      Policies:
+        - PolicyName: SuperlogScrapeReadOnly
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: ResourceInventory
+                Effect: Allow
+                Action:
+                  - "tag:GetResources"
+                  - "tag:GetTagKeys"
+                  - "tag:GetTagValues"
+                Resource: "*"
+              - Sid: MetricCatalog
+                Effect: Allow
+                Action:
+                  - "cloudwatch:ListMetrics"
+                Resource: "*"
+              - Sid: ConfigRead
+                Effect: Allow
+                Action:
+                  - "cloudformation:GetResource"
+                  - "cloudformation:ListResources"
+                  - "ec2:Describe*"
+                  - "rds:Describe*"
+                  - "rds:ListTagsForResource"
+                  - "lambda:GetFunction"
+                  - "lambda:GetFunctionConfiguration"
+                  - "lambda:ListFunctions"
+                  - "elasticloadbalancing:Describe*"
+                  - "ecs:Describe*"
+                  - "ecs:List*"
+                  - "autoscaling:Describe*"
+                  - "ssm:ListAssociations"
+                  - "ssm:DescribeInstanceInformation"
+                Resource: "*"
+              - Sid: DenySensitiveReads
+                Effect: Deny
+                Action:
+                  - "secretsmanager:GetSecretValue"
+                  - "kms:Decrypt"
+                  - "kms:GenerateDataKey"
+                  - "ssm:GetParameter"
+                  - "ssm:GetParameters"
+                  - "ssm:GetParametersByPath"
+                  - "s3:GetObject"
+                  - "dynamodb:GetItem"
+                  - "dynamodb:BatchGetItem"
+                  - "dynamodb:Query"
+                  - "dynamodb:Scan"
+                Resource: "*"
+
+  RegisterWithSuperlog:
+    Type: Custom::SuperlogConnect
+    Condition: ReportBack
+    Properties:
+      ServiceToken: !Ref SuperlogServiceToken
+      RoleArn: !GetAtt ScrapeRole.Arn
+      AccountId: !Ref "AWS::AccountId"
+      Region: !Ref "AWS::Region"
+      ConnectionId: !Ref ConnectionId
+      ExternalId: !Ref ExternalId
+
+  # ===========================================================================
+  # Metric streaming — CloudWatch Metric Stream → Firehose (Condition: CreateMetrics)
+  # ===========================================================================
+  MetricsBackupBucket:
+    Type: AWS::S3::Bucket
+    Condition: CreateMetrics
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub "superlog-metrics-backup-${AWS::AccountId}-${AWS::Region}"
+      LifecycleConfiguration:
+        Rules:
+          - Id: expire-backups
+            Status: Enabled
+            ExpirationInDays: 7
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  MetricsFirehoseLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: CreateMetrics
+    Properties:
+      LogGroupName: "/aws/kinesisfirehose/superlog-metrics"
+      RetentionInDays: 7
+
+  MetricsFirehoseLogStream:
+    Type: AWS::Logs::LogStream
+    Condition: CreateMetrics
+    Properties:
+      LogGroupName: !Ref MetricsFirehoseLogGroup
+      LogStreamName: HttpEndpointDelivery
+
+  MetricsFirehoseRole:
+    Type: AWS::IAM::Role
+    Condition: CreateMetrics
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: firehose.amazonaws.com
+            Action: "sts:AssumeRole"
+      Policies:
+        - PolicyName: SuperlogMetricsFirehoseDelivery
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: BackupBucketWrite
+                Effect: Allow
+                Action:
+                  - "s3:AbortMultipartUpload"
+                  - "s3:GetBucketLocation"
+                  - "s3:GetObject"
+                  - "s3:ListBucket"
+                  - "s3:ListBucketMultipartUploads"
+                  - "s3:PutObject"
+                Resource:
+                  - !GetAtt MetricsBackupBucket.Arn
+                  - !Sub "${MetricsBackupBucket.Arn}/*"
+              - Sid: DeliveryErrorLogs
+                Effect: Allow
+                Action: "logs:PutLogEvents"
+                Resource: !GetAtt MetricsFirehoseLogGroup.Arn
+
+  MetricsDeliveryStream:
+    Type: AWS::KinesisFirehose::DeliveryStream
+    Condition: CreateMetrics
+    Properties:
+      DeliveryStreamName: "superlog-metrics-stream"
+      DeliveryStreamType: DirectPut
+      HttpEndpointDestinationConfiguration:
+        EndpointConfiguration:
+          Url: !Ref MetricsIntakeUrl
+          Name: Superlog
+          AccessKey: !Ref MetricsIngestKey
+        RequestConfiguration:
+          ContentEncoding: GZIP
+        BufferingHints:
+          IntervalInSeconds: 60
+          SizeInMBs: 4
+        RetryOptions:
+          DurationInSeconds: 300
+        S3BackupMode: FailedDataOnly
+        CloudWatchLoggingOptions:
+          Enabled: true
+          LogGroupName: !Ref MetricsFirehoseLogGroup
+          LogStreamName: !Ref MetricsFirehoseLogStream
+        RoleARN: !GetAtt MetricsFirehoseRole.Arn
+        S3Configuration:
+          BucketARN: !GetAtt MetricsBackupBucket.Arn
+          RoleARN: !GetAtt MetricsFirehoseRole.Arn
+          CompressionFormat: GZIP
+          BufferingHints:
+            IntervalInSeconds: 300
+            SizeInMBs: 5
+
+  MetricStreamRole:
+    Type: AWS::IAM::Role
+    Condition: CreateMetrics
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: streams.metrics.cloudwatch.amazonaws.com
+            Action: "sts:AssumeRole"
+      Policies:
+        - PolicyName: SuperlogMetricStreamToFirehose
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "firehose:PutRecord"
+                  - "firehose:PutRecordBatch"
+                Resource: !GetAtt MetricsDeliveryStream.Arn
+
+  MetricStream:
+    Type: AWS::CloudWatch::MetricStream
+    Condition: CreateMetrics
+    Properties:
+      Name: "superlog-metrics-stream"
+      FirehoseArn: !GetAtt MetricsDeliveryStream.Arn
+      RoleArn: !GetAtt MetricStreamRole.Arn
+      OutputFormat: opentelemetry1.0
+      # Cost lever: stream only dashboard-relevant namespaces. ECS +
+      # ECS/ContainerInsights are intentionally included (service/task metrics
+      # power the ECS dashboards) but are the highest-cardinality entries —
+      # trim them here if your account runs many tasks and the bill matters.
+      IncludeFilters:
+        - Namespace: AWS/EC2
+        - Namespace: AWS/EBS
+        - Namespace: AWS/RDS
+        - Namespace: AWS/ApplicationELB
+        - Namespace: AWS/NetworkELB
+        - Namespace: AWS/ELB
+        - Namespace: AWS/Lambda
+        - Namespace: AWS/ECS
+        - Namespace: ECS/ContainerInsights
+        - Namespace: AWS/DynamoDB
+        - Namespace: AWS/SQS
+        - Namespace: AWS/SNS
+        - Namespace: AWS/S3
+        - Namespace: AWS/ElastiCache
+        - Namespace: AWS/ApiGateway
+        - Namespace: AWS/CloudFront
+
+  # ===========================================================================
+  # Log streaming — account-level subscription → Firehose (Condition: CreateLogs)
+  # ===========================================================================
+  LogsBackupBucket:
+    Type: AWS::S3::Bucket
+    Condition: CreateLogs
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub "superlog-logs-backup-${AWS::AccountId}-${AWS::Region}"
+      LifecycleConfiguration:
+        Rules:
+          - Id: expire-backups
+            Status: Enabled
+            ExpirationInDays: 7
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  LogsFirehoseLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: CreateLogs
+    Properties:
+      LogGroupName: "/aws/kinesisfirehose/superlog-logs"
+      RetentionInDays: 7
+
+  LogsFirehoseLogStream:
+    Type: AWS::Logs::LogStream
+    Condition: CreateLogs
+    Properties:
+      LogGroupName: !Ref LogsFirehoseLogGroup
+      LogStreamName: HttpEndpointDelivery
+
+  LogsFirehoseRole:
+    Type: AWS::IAM::Role
+    Condition: CreateLogs
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: firehose.amazonaws.com
+            Action: "sts:AssumeRole"
+      Policies:
+        - PolicyName: SuperlogLogsFirehoseDelivery
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: BackupBucketWrite
+                Effect: Allow
+                Action:
+                  - "s3:AbortMultipartUpload"
+                  - "s3:GetBucketLocation"
+                  - "s3:GetObject"
+                  - "s3:ListBucket"
+                  - "s3:ListBucketMultipartUploads"
+                  - "s3:PutObject"
+                Resource:
+                  - !GetAtt LogsBackupBucket.Arn
+                  - !Sub "${LogsBackupBucket.Arn}/*"
+              - Sid: DeliveryErrorLogs
+                Effect: Allow
+                Action: "logs:PutLogEvents"
+                Resource: !GetAtt LogsFirehoseLogGroup.Arn
+
+  LogsDeliveryStream:
+    Type: AWS::KinesisFirehose::DeliveryStream
+    Condition: CreateLogs
+    Properties:
+      DeliveryStreamName: "superlog-logs-stream"
+      DeliveryStreamType: DirectPut
+      HttpEndpointDestinationConfiguration:
+        EndpointConfiguration:
+          Url: !Ref LogsIntakeUrl
+          Name: Superlog
+          AccessKey: !Ref LogsIngestKey
+        RequestConfiguration:
+          ContentEncoding: GZIP
+        BufferingHints:
+          IntervalInSeconds: 60
+          SizeInMBs: 4
+        RetryOptions:
+          DurationInSeconds: 300
+        S3BackupMode: FailedDataOnly
+        CloudWatchLoggingOptions:
+          Enabled: true
+          LogGroupName: !Ref LogsFirehoseLogGroup
+          LogStreamName: !Ref LogsFirehoseLogStream
+        RoleARN: !GetAtt LogsFirehoseRole.Arn
+        S3Configuration:
+          BucketARN: !GetAtt LogsBackupBucket.Arn
+          RoleARN: !GetAtt LogsFirehoseRole.Arn
+          CompressionFormat: GZIP
+          BufferingHints:
+            IntervalInSeconds: 300
+            SizeInMBs: 5
+
+  CwlToFirehoseRole:
+    Type: AWS::IAM::Role
+    Condition: CreateLogs
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: !Sub "logs.${AWS::Region}.amazonaws.com"
+            Action: "sts:AssumeRole"
+      Policies:
+        - PolicyName: SuperlogLogsToFirehose
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "firehose:PutRecord"
+                  - "firehose:PutRecordBatch"
+                Resource: !GetAtt LogsDeliveryStream.Arn
+
+  # One account-level subscription covers every log group, current and future.
+  # SelectionCriteria excludes the Firehose's own delivery-error log group so a
+  # delivery error can't log into a group that re-subscribes it — the classic
+  # account-level recursion trap.
+  LogsSubscription:
+    Type: AWS::Logs::AccountPolicy
+    Condition: CreateLogs
+    Properties:
+      PolicyName: "superlog-logs-subscription"
+      PolicyType: SUBSCRIPTION_FILTER_POLICY
+      Scope: ALL
+      SelectionCriteria: 'LogGroupName NOT IN ["/aws/kinesisfirehose/superlog-logs"]'
+      PolicyDocument:
+        Fn::ToJsonString:
+          DestinationArn: !GetAtt LogsDeliveryStream.Arn
+          RoleArn: !GetAtt CwlToFirehoseRole.Arn
+          FilterPattern: !Ref LogsFilterPattern
+          Distribution: Random
+
+Outputs:
+  ScrapeRoleArn:
+    Description: >-
+      The scrape role ARN. With zero-paste enabled it's reported automatically;
+      otherwise copy this into Superlog to finish connecting.
+    Value: !GetAtt ScrapeRole.Arn
+  MetricStreamArn:
+    Condition: CreateMetrics
+    Description: ARN of the created CloudWatch Metric Stream.
+    Value: !GetAtt MetricStream.Arn

--- a/infra/aws-connect/superlog-logs-stream.cfn.yaml
+++ b/infra/aws-connect/superlog-logs-stream.cfn.yaml
@@ -31,7 +31,9 @@ Parameters:
     Type: String
     Description: Name prefix for the Firehose, backup bucket, log group, and roles.
     Default: superlog-logs
-    AllowedPattern: "^[a-z0-9-]{3,40}$"
+    # Bounded so "<prefix>-backup-<account>-<region>" stays within the 63-char S3
+    # bucket-name limit, and must start alphanumeric (S3 bucket-name rule).
+    AllowedPattern: "^[a-z0-9][a-z0-9-]{2,24}$"
   FilterPattern:
     Type: String
     Description: >-
@@ -113,7 +115,10 @@ Resources:
               - Sid: DeliveryErrorLogs
                 Effect: Allow
                 Action: "logs:PutLogEvents"
-                Resource: !GetAtt FirehoseLogGroup.Arn
+                # PutLogEvents authorizes against the log *stream*. (GetAtt
+                # LogGroup.Arn already ends in ":*", so this is the same scope made
+                # explicit / least-privilege.)
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/kinesisfirehose/${ResourcePrefix}:log-stream:*"
 
   DeliveryStream:
     Type: AWS::KinesisFirehose::DeliveryStream
@@ -159,6 +164,13 @@ Resources:
             Principal:
               Service: !Sub "logs.${AWS::Region}.amazonaws.com"
             Action: "sts:AssumeRole"
+            # Confused-deputy guard: only this account's CloudWatch Logs in this
+            # region may assume the role.
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref "AWS::AccountId"
+              ArnLike:
+                aws:SourceArn: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
       Policies:
         - PolicyName: SuperlogLogsToFirehose
           PolicyDocument:

--- a/infra/aws-connect/superlog-metrics-stream.cfn.yaml
+++ b/infra/aws-connect/superlog-metrics-stream.cfn.yaml
@@ -28,7 +28,9 @@ Parameters:
     Type: String
     Description: Name prefix for the stream, Firehose, backup bucket, and roles.
     Default: superlog-metrics
-    AllowedPattern: "^[a-z0-9-]{3,40}$"
+    # Bounded so "<prefix>-backup-<account>-<region>" stays within the 63-char S3
+    # bucket-name limit, and must start alphanumeric (S3 bucket-name rule).
+    AllowedPattern: "^[a-z0-9][a-z0-9-]{2,24}$"
   ConnectionId:
     Type: String
     Description: Superlog connection this stack belongs to (reserved for reporting).
@@ -106,7 +108,10 @@ Resources:
               - Sid: DeliveryErrorLogs
                 Effect: Allow
                 Action: "logs:PutLogEvents"
-                Resource: !GetAtt FirehoseLogGroup.Arn
+                # PutLogEvents authorizes against the log *stream*. (GetAtt
+                # LogGroup.Arn already ends in ":*", so this is the same scope made
+                # explicit / least-privilege.)
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/kinesisfirehose/${ResourcePrefix}:log-stream:*"
 
   DeliveryStream:
     Type: AWS::KinesisFirehose::DeliveryStream


### PR DESCRIPTION
Collapses the three-launch AWS connect flow (scrape role → metric stream → log subscription) into a single CloudFormation stack.

## What
- **New combined template** `infra/aws-connect/superlog-connect-stack.cfn.yaml` — scrape role + custom-resource callback + CloudWatch metric streaming + account-level log subscription + both Firehoses, each streaming section gated by an `EnableMetrics` / `EnableLogs` parameter (default `true`). `Transform: AWS::LanguageExtensions` for the logs `PolicyDocument` (`Fn::ToJsonString`, so any FilterPattern is embedded safely).
- **One-step connect endpoint** — when a combined-template URL + both Firehose intake URLs are configured, `POST /cloud-connections` mints both per-signal ingest keys up front and returns the combined launch URL. Per-signal stream setup re-opens that same `superlog-connect` stack (no parallel stacks, reuses the stored keys). Falls back to the scrape-role-only template + separate stream stacks when unconfigured.
- Idempotent key mint/store/race logic factored into a shared `ensureStreamKey` helper.

## Cost note
Streaming defaults on but is toggleable per signal. The metric namespace set keeps `AWS/ECS` + `ECS/ContainerInsights` (service/task metrics power the ECS dashboards) and flags them as the highest-cardinality cost lever; `EnableMetrics=false` or trimming the namespace list controls it.

## Tests
`buildCombinedConnectLaunchUrl` (toggles + log filter), one-step connect mints both keys + launches the combined stack, per-signal re-launch reuses the same stack/keys. 35 service + integration tests green. Combined template validated via `create-change-set` (both toggles on, and metrics/logs off).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses the three-step AWS connect flow into a single CloudFormation stack and adds agentless CloudWatch metrics and logs ingest via Firehose. Also hardens IAM policies, stream templates, and Firehose proxy errors to prevent name collisions, confused-deputy, dead keys, and info leaks.

- **New Features**
  - One-step connect: returns a combined-stack launch URL and mints both per-signal ingest keys up front; reuses the same stack/keys on re-launch; re-mints in place if a stored key was revoked; falls back to the old multi-stack flow when unconfigured.
  - Combined CloudFormation template `infra/aws-connect/superlog-connect-stack.cfn.yaml` with `EnableMetrics`/`EnableLogs` (default true), optional `LogsFilterPattern`, safe logs PolicyDocument via `Transform: AWS::LanguageExtensions` + `Fn::ToJsonString`; backup buckets use CloudFormation-generated names with Retain; Firehose `logs:PutLogEvents` scoped to the log-stream ARN; CloudWatch Logs → Firehose role includes `aws:SourceAccount`/`aws:SourceArn` guards.
  - Firehose ingest path: proxy `POST /aws/firehose/{metrics,logs}` authenticates via `x-amz-firehose-access-key`, enforces quota, stamps tenant header, forwards to the collector, and returns a generic error message on 500 to avoid leaking details into customer logs.
  - Collector receivers: `awsfirehose/metrics` (OTLP v1 on :4433) and `awsfirehose/logs` (CloudWatch Logs JSON on :4434) wired into existing pipelines.
  - Stream templates: `infra/aws-connect/superlog-metrics-stream.cfn.yaml` and `infra/aws-connect/superlog-logs-stream.cfn.yaml` for per-signal setup/repair, with bounded `ResourcePrefix` (`^[a-z0-9][a-z0-9-]{2,24}$`), `logs:PutLogEvents` scoped to the log-stream ARN, and (logs) `aws:SourceAccount`/`aws:SourceArn` trust guards.
  - UI: stack health panel showing connection/metrics/logs states with quick setup/relaunch actions; new APIs to fetch stack health and set up streams.
  - Persistence: `cloud_stream_keys` table and idempotent key mint/store logic in `@superlog/db` to keep stable per-signal ingest keys and re-mint them in place if revoked.

- **Migration**
  - Apply DB migration 0069.
  - Deploy the collector with the new `awsfirehose/{metrics,logs}` receivers and open ports 4433 and 4434 (configs updated).
  - Provide the combined-template URL and both Firehose intake URLs to enable the one-step flow; otherwise the API will use the legacy multi-stack flow.

<sup>Written for commit 210275780e19a9abc01515c0a02c43ba63c6971c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

