### PR TITLE
Add demo data mode: shared read-only sample-data overlay for new users

### DIFF
--- a/apps/api/src/dashboards.ts
+++ b/apps/api/src/dashboards.ts
@@ -19,11 +19,17 @@ import {
   updateDashboardLayout,
   updateDashboardWidget,
 } from "./dashboards-service.js";
+import { resolveEffectiveReadProjectId } from "./demo.js";
 import { resolveActiveOrgContext } from "./org-context.js";
 
-type Vars = { userId: string; orgId: string | null };
+type Vars = { userId: string; orgId: string | null; demoReadProjectId?: string };
 
 export function mountDashboards(app: Hono<{ Variables: Vars }>) {
+  // Authorizes against the real project and also returns `readProjectId` — the
+  // demo project's id when the real project hasn't ingested yet (read-only
+  // overlay), else the real id. GET handlers read from `readProjectId`; writes
+  // keep using the real `projectId` (and are blocked in demo mode by the
+  // demoReadOnly middleware in index.ts).
   const requireAccess = async (c: Context<{ Variables: Vars }>, projectId: string) => {
     const project = await db.query.projects.findFirst({
       where: eq(schema.projects.id, projectId),
@@ -34,13 +40,15 @@ export function mountDashboards(app: Hono<{ Variables: Vars }>) {
       preferredOrgId: c.var.orgId,
     });
     if (project.orgId !== ctx.org.id) throw new HTTPException(403, { message: "forbidden" });
-    return { project, user: ctx.user };
+    const readProjectId =
+      c.var.demoReadProjectId ?? (await resolveEffectiveReadProjectId(projectId)).id;
+    return { project, user: ctx.user, readProjectId };
   };
 
   app.get("/api/projects/:projectId/dashboards", async (c) => {
     const projectId = c.req.param("projectId");
-    await requireAccess(c, projectId);
-    return c.json(await listDashboardsForProject(projectId));
+    const { readProjectId } = await requireAccess(c, projectId);
+    return c.json(await listDashboardsForProject(readProjectId));
   });
 
   app.post("/api/projects/:projectId/dashboards", async (c) => {
@@ -55,8 +63,8 @@ export function mountDashboards(app: Hono<{ Variables: Vars }>) {
   app.get("/api/projects/:projectId/dashboards/:id", async (c) => {
     const projectId = c.req.param("projectId");
     const id = c.req.param("id");
-    await requireAccess(c, projectId);
-    const dashboard = await getDashboardWithWidgets(projectId, id);
+    const { readProjectId } = await requireAccess(c, projectId);
+    const dashboard = await getDashboardWithWidgets(readProjectId, id);
     if (!dashboard) throw new HTTPException(404, { message: "dashboard not found" });
     return c.json(dashboard);
   });

--- a/apps/api/src/demo.test.ts
+++ b/apps/api/src/demo.test.ts
@@ -1,0 +1,194 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+// demo.ts transitively imports the db client, which throws at import time
+// without a connection string. Set a dummy URL before the dynamic import (the
+// postgres client connects lazily, so these pure-function tests never open a
+// socket). Same pattern as alerts-service.test.ts / incidents/detail.test.ts.
+process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
+const { demoProjectId, isDemoBlockedWrite, pickReadProjectId } = await import("./demo.js");
+
+test("demoProjectId only accepts a canonical UUID (fail-safe on misconfig)", () => {
+  const prev = process.env.DEMO_PROJECT_ID;
+  try {
+    process.env.DEMO_PROJECT_ID = "47966735-416b-4f3d-8ed1-6a96379d75fd";
+    assert.equal(demoProjectId(), "47966735-416b-4f3d-8ed1-6a96379d75fd");
+    process.env.DEMO_PROJECT_ID = "  47966735-416b-4f3d-8ed1-6a96379d75fd  ";
+    assert.equal(demoProjectId(), "47966735-416b-4f3d-8ed1-6a96379d75fd");
+    for (const bad of ["", "   ", "not-a-uuid", "47966735", "demo-project"]) {
+      process.env.DEMO_PROJECT_ID = bad;
+      assert.equal(demoProjectId(), undefined, `"${bad}" should disable demo mode`);
+    }
+    process.env.DEMO_PROJECT_ID = undefined;
+    assert.equal(demoProjectId(), undefined);
+  } finally {
+    if (prev === undefined) process.env.DEMO_PROJECT_ID = undefined;
+    else process.env.DEMO_PROJECT_ID = prev;
+  }
+});
+
+test("pickReadProjectId substitutes the demo project for a fresh, un-ingested project", () => {
+  assert.deepEqual(
+    pickReadProjectId({ realProjectId: "real-1", demoProjectId: "demo-x", hasIngested: false }),
+    { id: "demo-x", demo: true },
+  );
+});
+
+test("pickReadProjectId returns the real project once it has ingested", () => {
+  assert.deepEqual(
+    pickReadProjectId({ realProjectId: "real-1", demoProjectId: "demo-x", hasIngested: true }),
+    { id: "real-1", demo: false },
+  );
+});
+
+test("pickReadProjectId is a no-op when demo mode is off (no DEMO_PROJECT_ID)", () => {
+  assert.deepEqual(
+    pickReadProjectId({ realProjectId: "real-1", demoProjectId: undefined, hasIngested: false }),
+    { id: "real-1", demo: false },
+  );
+});
+
+test("pickReadProjectId never overlays the demo project onto itself", () => {
+  assert.deepEqual(
+    pickReadProjectId({ realProjectId: "demo-x", demoProjectId: "demo-x", hasIngested: false }),
+    { id: "demo-x", demo: false },
+  );
+});
+
+test("isDemoBlockedWrite blocks writes to demo-overlaid resources", () => {
+  for (const [method, path] of [
+    ["POST", "/api/projects/p1/dashboards"],
+    ["PATCH", "/api/projects/p1/dashboards/d1/layout"],
+    ["DELETE", "/api/projects/p1/dashboards/d1/widgets/w1"],
+    ["PATCH", "/api/projects/p1/incidents/inc1"],
+    ["POST", "/api/projects/p1/incidents/inc1/agent-run/restart"],
+    ["POST", "/api/projects/p1/alerts"],
+    ["DELETE", "/api/projects/p1/alerts/a1"],
+    ["POST", "/api/projects/p1/issues/i1/silence"],
+  ] as const) {
+    assert.equal(isDemoBlockedWrite({ method, path }), true, `${method} ${path} should be blocked`);
+  }
+});
+
+test("isDemoBlockedWrite never blocks the install / integration path (how users leave demo)", () => {
+  for (const [method, path] of [
+    ["POST", "/api/projects/p1/keys"],
+    ["DELETE", "/api/projects/p1/keys/k1"],
+    ["PATCH", "/api/projects/p1/automation"],
+    ["POST", "/api/projects/p1/cloud-connections"],
+    ["POST", "/api/projects/p1/cloud-connections/c1/sync"],
+    ["POST", "/api/projects/p1/webhooks"],
+    ["PUT", "/api/projects/p1/slack-route"],
+    ["POST", "/api/projects/p1/symbolication/log"],
+  ] as const) {
+    assert.equal(
+      isDemoBlockedWrite({ method, path }),
+      false,
+      `${method} ${path} should be allowed`,
+    );
+  }
+});
+
+test("isDemoBlockedWrite never blocks POST-for-read endpoints (explorer / previews)", () => {
+  for (const path of [
+    "/api/projects/p1/explore/logs",
+    "/api/projects/p1/explore/traces",
+    "/api/projects/p1/explore/metric-series",
+    "/api/projects/p1/issues/lookup",
+    "/api/projects/p1/issue-filter/preview",
+    "/api/projects/p1/alerts/preview",
+  ]) {
+    assert.equal(
+      isDemoBlockedWrite({ method: "POST", path }),
+      false,
+      `POST ${path} is a read and must stay allowed`,
+    );
+  }
+});
+
+test("isDemoBlockedWrite ignores non-mutating methods and non-project routes", () => {
+  assert.equal(isDemoBlockedWrite({ method: "GET", path: "/api/projects/p1/dashboards" }), false);
+  assert.equal(isDemoBlockedWrite({ method: "POST", path: "/api/me/orgs" }), false);
+});
+
+// Regression guard / living checklist: EVERY mutating /api/projects/:projectId/*
+// route in the codebase, classified as block (mutates demo-overlaid data, must be
+// 403 in demo mode) or allow (install / integration path or POST-for-read — must
+// stay open so a user can leave demo mode). If you add a mutating project route,
+// add it here with its intent. Keep in sync with the route inventory in index.ts
+// (grep: `.(post|put|patch|delete)("/api/projects/:projectId`).
+test("isDemoBlockedWrite matches the full mutating project-route inventory", () => {
+  const ROUTES: Array<{ method: string; path: string; block: boolean }> = [
+    // demo-overlaid data → blocked
+    { method: "POST", path: "/api/projects/p1/dashboards", block: true },
+    { method: "PATCH", path: "/api/projects/p1/dashboards/d1", block: true },
+    { method: "DELETE", path: "/api/projects/p1/dashboards/d1", block: true },
+    { method: "POST", path: "/api/projects/p1/dashboards/d1/widgets", block: true },
+    { method: "PATCH", path: "/api/projects/p1/dashboards/d1/widgets/w1", block: true },
+    { method: "DELETE", path: "/api/projects/p1/dashboards/d1/widgets/w1", block: true },
+    { method: "PATCH", path: "/api/projects/p1/dashboards/d1/layout", block: true },
+    { method: "PATCH", path: "/api/projects/p1/incidents/i1", block: true },
+    { method: "POST", path: "/api/projects/p1/incidents/i1/agent-run/restart", block: true },
+    { method: "POST", path: "/api/projects/p1/incidents/i1/agent-run/retry-pr", block: true },
+    { method: "POST", path: "/api/projects/p1/incidents/i1/pull-requests/pr1/merge", block: true },
+    { method: "POST", path: "/api/projects/p1/alerts", block: true },
+    { method: "PATCH", path: "/api/projects/p1/alerts/a1", block: true },
+    { method: "DELETE", path: "/api/projects/p1/alerts/a1", block: true },
+    { method: "POST", path: "/api/projects/p1/alerts/a1/test", block: true },
+    { method: "POST", path: "/api/projects/p1/issues/i1/silence", block: true },
+    { method: "POST", path: "/api/projects/p1/issues/i1/unsilence", block: true },
+    // install / integration path → must stay OPEN (how a user leaves demo mode)
+    { method: "POST", path: "/api/projects/p1/keys", block: false },
+    { method: "DELETE", path: "/api/projects/p1/keys/k1", block: false },
+    { method: "PATCH", path: "/api/projects/p1/automation", block: false },
+    { method: "POST", path: "/api/projects/p1/cloud-connections", block: false },
+    { method: "DELETE", path: "/api/projects/p1/cloud-connections/c1", block: false },
+    { method: "POST", path: "/api/projects/p1/cloud-connections/c1/sync", block: false },
+    { method: "POST", path: "/api/projects/p1/cloud-connections/c1/verify", block: false },
+    { method: "POST", path: "/api/projects/p1/cloud-connections/c1/logs-stream", block: false },
+    { method: "POST", path: "/api/projects/p1/cloud-connections/c1/metrics-stream", block: false },
+    { method: "POST", path: "/api/projects/p1/webhooks", block: false },
+    { method: "PATCH", path: "/api/projects/p1/webhooks/h1", block: false },
+    { method: "DELETE", path: "/api/projects/p1/webhooks/h1", block: false },
+    { method: "POST", path: "/api/projects/p1/webhooks/h1/rotate-secret", block: false },
+    { method: "POST", path: "/api/projects/p1/webhooks/h1/test", block: false },
+    { method: "PUT", path: "/api/projects/p1/slack-route", block: false },
+    { method: "DELETE", path: "/api/projects/p1/slack-route", block: false },
+    { method: "POST", path: "/api/projects/p1/symbolication/log", block: false },
+    // POST-for-read (query in body) → must stay OPEN
+    { method: "POST", path: "/api/projects/p1/explore/logs", block: false },
+    { method: "POST", path: "/api/projects/p1/explore/traces", block: false },
+    { method: "POST", path: "/api/projects/p1/explore/traces-aggregated", block: false },
+    { method: "POST", path: "/api/projects/p1/explore/series", block: false },
+    { method: "POST", path: "/api/projects/p1/explore/metric-series", block: false },
+    { method: "POST", path: "/api/projects/p1/explore/metrics", block: false },
+    { method: "POST", path: "/api/projects/p1/issues/lookup", block: false },
+    { method: "POST", path: "/api/projects/p1/issue-filter/preview", block: false },
+    { method: "POST", path: "/api/projects/p1/alerts/preview", block: false },
+  ];
+  for (const r of ROUTES) {
+    assert.equal(
+      isDemoBlockedWrite({ method: r.method, path: r.path }),
+      r.block,
+      `${r.method} ${r.path} expected block=${r.block}`,
+    );
+  }
+});
+
+test("isDemoBlockedWrite is not fooled by path/method variations", () => {
+  // trailing slash, query string, lowercase method, extra depth on a blocked seg
+  assert.equal(isDemoBlockedWrite({ method: "post", path: "/api/projects/p1/dashboards" }), true);
+  assert.equal(
+    isDemoBlockedWrite({ method: "POST", path: "/api/projects/p1/dashboards?x=1" }),
+    true,
+  );
+  assert.equal(
+    isDemoBlockedWrite({ method: "DELETE", path: "/api/projects/p1/incidents/i1/anything" }),
+    true,
+  );
+  // an explore path with a query string is still a read
+  assert.equal(
+    isDemoBlockedWrite({ method: "POST", path: "/api/projects/p1/explore/logs?limit=5" }),
+    false,
+  );
+});

--- a/apps/api/src/demo.ts
+++ b/apps/api/src/demo.ts
@@ -1,0 +1,179 @@
+import { db, schema } from "@superlog/db";
+import { and, eq, isNotNull } from "drizzle-orm";
+import type { Context } from "hono";
+import { createMiddleware } from "hono/factory";
+import { HTTPException } from "hono/http-exception";
+
+// ---------------------------------------------------------------------------
+// Demo data overlay
+//
+// A brand-new user whose project has never ingested telemetry transparently
+// READS a single shared, hidden demo project's data (incidents, dashboards,
+// traces, logs, metrics) so they can evaluate the product before instrumenting
+// their own app. The substitution is server-side and read-only:
+//
+//   effectiveReadProjectId = hasIngested ? realProjectId : DEMO_PROJECT_ID
+//
+// The moment their real telemetry lands, the proxy stamps api_keys.last_used_at,
+// `hasIngested` flips true, and every read switches back to their own project.
+//
+// The whole feature is gated on the DEMO_PROJECT_ID env var. When unset (the
+// open-core / self-host default) every helper below is a no-op and behaviour is
+// exactly as before — no extra queries, no overlay.
+// ---------------------------------------------------------------------------
+
+type Vars = {
+  userId: string;
+  orgId: string | null;
+  // Set by the demoOverlay middleware: the project id reads should target for
+  // this request (the demo project when overlaying, else the real id). Lets
+  // requireProjectAccess reuse the decision instead of recomputing it.
+  demoReadProjectId?: string;
+};
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * The configured shared demo project id, or undefined when demo mode is off.
+ * Requires a canonical UUID: a misconfigured (wrong-length / typo) value
+ * disables demo mode rather than risking a malformed response rewrite — the
+ * fail-safe direction.
+ */
+export function demoProjectId(): string | undefined {
+  const id = process.env.DEMO_PROJECT_ID?.trim();
+  return id && UUID_RE.test(id) ? id : undefined;
+}
+
+/**
+ * Pure decision: which project id should the read path query, and is this an
+ * overlay read? We never substitute when the caller IS the demo project (the
+ * demo owner viewing it directly) or once the real project has ingested.
+ */
+export function pickReadProjectId(args: {
+  realProjectId: string;
+  demoProjectId: string | undefined;
+  hasIngested: boolean;
+}): { id: string; demo: boolean } {
+  const { realProjectId, demoProjectId, hasIngested } = args;
+  if (demoProjectId && !hasIngested && demoProjectId !== realProjectId) {
+    return { id: demoProjectId, demo: true };
+  }
+  return { id: realProjectId, demo: false };
+}
+
+/**
+ * Has this project ever ingested telemetry? Derived from api_keys.last_used_at,
+ * which the proxy stamps on every successful ingest auth (no ClickHouse hit).
+ */
+export async function projectHasIngested(projectId: string): Promise<boolean> {
+  const row = await db.query.apiKeys.findFirst({
+    columns: { id: true },
+    where: and(eq(schema.apiKeys.projectId, projectId), isNotNull(schema.apiKeys.lastUsedAt)),
+  });
+  return row !== undefined;
+}
+
+/**
+ * Resolve the effective read project id for a real project. Returns the real id
+ * untouched (and skips the hasIngested query entirely) when demo mode is off.
+ */
+export async function resolveEffectiveReadProjectId(
+  realProjectId: string,
+): Promise<{ id: string; demo: boolean }> {
+  const demo = demoProjectId();
+  if (!demo || demo === realProjectId) return { id: realProjectId, demo: false };
+  const hasIngested = await projectHasIngested(realProjectId);
+  return pickReadProjectId({ realProjectId, demoProjectId: demo, hasIngested });
+}
+
+/** Is this project currently served demo data? (demo configured && not ingested) */
+export async function isProjectInDemoMode(realProjectId: string): Promise<boolean> {
+  return (await resolveEffectiveReadProjectId(realProjectId)).demo;
+}
+
+// ---------------------------------------------------------------------------
+// Read-only enforcement (framework level)
+// ---------------------------------------------------------------------------
+
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+// Demo-overlaid resources are read-only while a project is in demo mode. We use
+// an explicit set rather than "block every mutating method" because several
+// READ endpoints are POST (they carry query filters in the body) — blocking
+// those would break the demo trace/log/metric explorer. Equally, the install /
+// integration path (keys, automation, cloud-connections, webhooks, slack-route,
+// symbolication) must stay OPEN — minting an ingest key and connecting an app
+// are exactly how a user leaves demo mode.
+const READ_ONLY_SEGMENTS = new Set(["dashboards", "incidents", "alerts", "issues"]);
+
+// POST-for-read endpoints under the protected segments above — never blocked.
+const POST_READ_SUBPATHS = new Set(["issues/lookup", "issue-filter/preview", "alerts/preview"]);
+
+/**
+ * Pure: should this request be rejected as a write against demo-overlaid data?
+ * Only true for mutating methods targeting a demo-overlaid resource, excluding
+ * the POST-for-read endpoints. Callers still gate this on actual demo mode.
+ */
+export function isDemoBlockedWrite(args: { method: string; path: string }): boolean {
+  if (!MUTATING_METHODS.has(args.method.toUpperCase())) return false;
+  const m = args.path.match(/^\/api\/projects\/[^/]+\/(.+?)(?:\?.*)?$/);
+  const sub = m?.[1];
+  if (!sub) return false;
+  if (POST_READ_SUBPATHS.has(sub) || sub.startsWith("explore/")) return false;
+  return READ_ONLY_SEGMENTS.has(sub.split("/")[0] ?? "");
+}
+
+/**
+ * Hono middleware for the demo overlay. Mount on `/api/projects/:projectId/*`.
+ * It is the single place the per-request overlay decision is made:
+ *  - decides whether this project is currently served demo data (one cheap
+ *    hasIngested lookup) and stashes the read target in `c.var.demoReadProjectId`
+ *    so requireProjectAccess can reuse it;
+ *  - enforces read-only by rejecting writes to demo-overlaid resources (403);
+ *  - rewrites the demo project id back to the real one in the JSON response, so
+ *    the client never sees the demo id and routes sub-resource calls (incident
+ *    stats, PRs, …) to its own project (which re-overlays server-side). Both ids
+ *    are 36-char UUIDs, so Content-Length stays valid.
+ * No-op (and no extra query) when DEMO_PROJECT_ID is unset.
+ */
+export function demoOverlay() {
+  return createMiddleware<{ Variables: Vars }>(async (c: Context<{ Variables: Vars }>, next) => {
+    const demo = demoProjectId();
+    const realProjectId = c.req.param("projectId");
+    if (!demo || !realProjectId || realProjectId === demo) {
+      await next();
+      return;
+    }
+
+    const overlaying = !(await projectHasIngested(realProjectId));
+    c.set("demoReadProjectId", overlaying ? demo : realProjectId);
+
+    if (overlaying && isDemoBlockedWrite({ method: c.req.method, path: c.req.path })) {
+      throw new HTTPException(403, { message: "demo_read_only" });
+    }
+
+    await next();
+
+    if (!overlaying) return;
+    const res = c.res;
+    const ct = res.headers.get("content-type") ?? "";
+    if (!ct.includes("application/json")) return;
+    try {
+      // Read from a clone so the original body is never disturbed if we bail.
+      const body = await res.clone().text();
+      if (!body.includes(demo)) return;
+      const headers = new Headers(res.headers);
+      // Let the runtime recompute the length. demo→real are equal-length UUIDs
+      // so it's unchanged today, but not coupling to that keeps the rewrite
+      // robust if the body length ever shifts.
+      headers.delete("content-length");
+      c.res = new Response(body.split(demo).join(realProjectId), {
+        status: res.status,
+        statusText: res.statusText,
+        headers,
+      });
+    } catch {
+      // Rewriting is best-effort; never let it turn a good response into a 500.
+    }
+  });
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -32,6 +32,12 @@ import { auth } from "./auth.js";
 import { shouldRunMigrationsOnBoot } from "./boot-migrations.js";
 import { mountCloudConnectionsAuthed } from "./cloud-connections.js";
 import { mountDashboards } from "./dashboards.js";
+import {
+  demoOverlay,
+  demoProjectId,
+  projectHasIngested,
+  resolveEffectiveReadProjectId,
+} from "./demo.js";
 import { mountFeedbackAuthed, mountFeedbackPublic } from "./feedback.js";
 import { type GatewayVars, mountGateway } from "./gateway.js";
 import { prBaseBranchExists } from "./github-branches.js";
@@ -131,6 +137,9 @@ type Vars = {
   userId: string;
   orgId: string | null;
   impersonating?: boolean;
+  // Set by the demoOverlay middleware (apps/api/src/demo.ts): the project id
+  // reads should target this request (demo project when overlaying, else real).
+  demoReadProjectId?: string;
 } & Partial<GatewayVars>;
 const app = new Hono<{ Variables: Vars }>();
 const incidentLifecycle = createIncidentLifecycle(db);
@@ -287,6 +296,13 @@ app.use("/api/*", async (c, next) => {
   await next();
 });
 
+// Demo overlay (framework level): decides demo-vs-real per request, enforces
+// read-only on demo-overlaid resources, and rewrites the demo project id back to
+// the real one in responses so the client never sees it. No-op when
+// DEMO_PROJECT_ID is unset. The install / integration write path is never
+// blocked. See apps/api/src/demo.ts.
+app.use("/api/projects/:projectId/*", demoOverlay());
+
 mountMcpAuthed(app);
 mountPersonalAccessTokens(app);
 mountGithubAuthed(app);
@@ -359,15 +375,14 @@ app.get("/api/me", async (c) => {
   const accessibleInstalls = await listAccessibleGithubInstallsForProject(project.id);
   const githubSetupNeeded = accessibleInstalls.length === 0 && !org.githubSetupSkippedAt;
 
-  // `hasIngested` decides whether OnboardingGate shows the install wizard. Reading
-  // it from api_keys.last_used_at (set by proxy/src/index.ts on every successful
-  // auth) avoids 6 ClickHouse count() queries per page load — the previous gate
-  // derived this from /stats and was firing on every navigation forever.
-  const ingestedKey = await db.query.apiKeys.findFirst({
-    columns: { id: true },
-    where: and(eq(schema.apiKeys.projectId, project.id), isNotNull(schema.apiKeys.lastUsedAt)),
-  });
-  const hasIngested = ingestedKey !== undefined;
+  // `hasIngested` decides whether OnboardingGate shows the install wizard. It's
+  // derived from api_keys.last_used_at (set by proxy/src/index.ts on every
+  // successful auth) — no ClickHouse count() queries per page load.
+  const hasIngested = await projectHasIngested(project.id);
+  // `demoMode` is true when a shared demo project is configured and this project
+  // hasn't ingested yet, i.e. the server is serving it demo data. The web uses it
+  // to render the read-only sample-data experience + the persistent install nudge.
+  const demoMode = demoProjectId() !== undefined && !hasIngested;
 
   return c.json({
     user: {
@@ -379,6 +394,7 @@ app.get("/api/me", async (c) => {
     },
     org: { id: org.id, name: org.name, slug: org.slug, githubSetupNeeded },
     project: { id: project.id, name: project.name, slug: project.slug, hasIngested },
+    demoMode,
     billingEnforcement,
   });
 });
@@ -717,8 +733,7 @@ app.get("/api/projects/:projectId/mcp-status", async (c) => {
 });
 
 app.get("/api/projects/:projectId/stats", async (c) => {
-  const projectId = c.req.param("projectId");
-  await requireProjectAccess(c, projectId);
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const [traces, logs, metrics, issueRows] = await Promise.all([
     chCount("otel_traces", "Timestamp", projectId),
     chCount("otel_logs", "Timestamp", projectId),
@@ -788,8 +803,7 @@ app.post("/api/me/billing/cancel", async (c) => {
 });
 
 app.get("/api/projects/:projectId/explore/attribute-keys", async (c) => {
-  const projectId = c.req.param("projectId");
-  await requireProjectAccess(c, projectId);
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const { since, until } = parseRangeQuery(c);
   const rows = await listAttributeKeys(
     ch,
@@ -801,8 +815,7 @@ app.get("/api/projects/:projectId/explore/attribute-keys", async (c) => {
 });
 
 app.get("/api/projects/:projectId/explore/attribute-values", async (c) => {
-  const projectId = c.req.param("projectId");
-  await requireProjectAccess(c, projectId);
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const key = c.req.query("key");
   if (!key) throw new HTTPException(400, { message: "key is required" });
   const { since, until } = parseRangeQuery(c);
@@ -818,16 +831,14 @@ app.get("/api/projects/:projectId/explore/attribute-values", async (c) => {
 });
 
 app.get("/api/projects/:projectId/explore/services", async (c) => {
-  const projectId = c.req.param("projectId");
-  await requireProjectAccess(c, projectId);
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const { since, until } = parseRangeQuery(c);
   const services = await listServices(ch, projectId, { since, until });
   return c.json(services);
 });
 
 app.post("/api/projects/:projectId/explore/logs", async (c) => {
-  const projectId = c.req.param("projectId");
-  await requireProjectAccess(c, projectId);
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   return tracer.startActiveSpan("explore.query_logs", async (span) => {
     span.setAttribute("tenant.project_id", projectId);
     try {
@@ -858,8 +869,7 @@ app.post("/api/projects/:projectId/explore/logs", async (c) => {
 });
 
 app.post("/api/projects/:projectId/explore/traces", async (c) => {
-  const projectId = c.req.param("projectId");
-  await requireProjectAccess(c, projectId);
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const body = (await c.req.json().catch(() => ({}))) as ExploreListBody;
   const limit = clampLimit(body.limit, 100, 500);
   const rows = await queryTraces(ch, projectId, {
@@ -875,8 +885,7 @@ app.post("/api/projects/:projectId/explore/traces", async (c) => {
 });
 
 app.post("/api/projects/:projectId/explore/traces-aggregated", async (c) => {
-  const projectId = c.req.param("projectId");
-  await requireProjectAccess(c, projectId);
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const body = (await c.req.json().catch(() => ({}))) as ExploreListBody;
   const limit = clampLimit(body.limit, 100, 500);
   const rows = await queryTracesAggregated(ch, projectId, {
@@ -892,9 +901,8 @@ app.post("/api/projects/:projectId/explore/traces-aggregated", async (c) => {
 });
 
 app.get("/api/projects/:projectId/explore/traces/:traceId", async (c) => {
-  const projectId = c.req.param("projectId");
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const traceId = c.req.param("traceId");
-  await requireProjectAccess(c, projectId);
   if (!/^[a-fA-F0-9]{1,64}$/.test(traceId)) {
     throw new HTTPException(400, { message: "invalid trace id" });
   }
@@ -903,8 +911,7 @@ app.get("/api/projects/:projectId/explore/traces/:traceId", async (c) => {
 });
 
 app.post("/api/projects/:projectId/explore/series", async (c) => {
-  const projectId = c.req.param("projectId");
-  await requireProjectAccess(c, projectId);
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const body = (await c.req.json().catch(() => ({}))) as ExploreSeriesBody;
   const source: SeriesSource = body.source === "traces" ? "traces" : "logs";
   const filter = body.filter ?? {};
@@ -931,16 +938,14 @@ app.post("/api/projects/:projectId/explore/series", async (c) => {
 });
 
 app.get("/api/projects/:projectId/explore/metric-names", async (c) => {
-  const projectId = c.req.param("projectId");
-  await requireProjectAccess(c, projectId);
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const { since, until } = parseRangeQuery(c);
   const names = await listMetricNames(ch, projectId, { since, until });
   return c.json(names);
 });
 
 app.post("/api/projects/:projectId/explore/metric-series", async (c) => {
-  const projectId = c.req.param("projectId");
-  await requireProjectAccess(c, projectId);
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const body = (await c.req.json().catch(() => ({}))) as MetricSeriesBody;
   const metricName = typeof body.metricName === "string" ? body.metricName : "";
   const filter = body.filter ?? {};
@@ -968,8 +973,7 @@ app.post("/api/projects/:projectId/explore/metric-series", async (c) => {
 });
 
 app.post("/api/projects/:projectId/explore/metrics", async (c) => {
-  const projectId = c.req.param("projectId");
-  await requireProjectAccess(c, projectId);
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const body = (await c.req.json().catch(() => ({}))) as ExploreListBody & { metricName?: string };
   const limit = clampLimit(body.limit, 100, 500);
   const rows = await queryMetrics(ch, projectId, {
@@ -1095,10 +1099,15 @@ async function chMetricsCount(projectId: string): Promise<number> {
   });
 }
 
+// Authorizes the user for `projectId` (always their REAL project) and returns
+// the project id the READ path should query. For a project that has never
+// ingested, that's the shared demo project (server-side overlay, read-only);
+// otherwise it's the real id unchanged. Writes pass the real id and ignore the
+// return value. No-op (returns the real id, no extra query) when demo mode off.
 async function requireProjectAccess(
   c: Context<{ Variables: Vars }>,
   projectId: string,
-): Promise<void> {
+): Promise<string> {
   return tracer.startActiveSpan("project.authorize", async (span) => {
     span.setAttribute("tenant.project_id", projectId);
     span.setAttribute("superlog.user_id", c.var.userId);
@@ -1114,6 +1123,12 @@ async function requireProjectAccess(
       });
       if (project.orgId !== ctx.org.id) throw new HTTPException(403, { message: "forbidden" });
       span.setAttribute("superlog.org_id", ctx.org.id);
+      // Reuse the demoOverlay middleware's decision when present (it runs on all
+      // /api/projects/:projectId/* routes); fall back to computing it directly.
+      const readProjectId =
+        c.var.demoReadProjectId ?? (await resolveEffectiveReadProjectId(projectId)).id;
+      if (readProjectId !== projectId) span.setAttribute("superlog.demo_overlay", true);
+      return readProjectId;
     } catch (err) {
       span.recordException(err as Error);
       span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
@@ -1211,8 +1226,7 @@ async function getLatestAgentRun(incidentId: string) {
 }
 
 app.get("/api/projects/:projectId/issues", async (c) => {
-  const projectId = c.req.param("projectId");
-  await requireProjectAccess(c, projectId);
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const silencedParam = c.req.query("silenced") ?? "active";
   const limit = clampLimit(Number(c.req.query("limit") ?? 50), 50, 200);
   const projectFilter = eq(schema.issues.projectId, projectId);
@@ -1231,9 +1245,8 @@ app.get("/api/projects/:projectId/issues", async (c) => {
 });
 
 app.get("/api/projects/:projectId/issues/:issueId", async (c) => {
-  const projectId = c.req.param("projectId");
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const issueId = c.req.param("issueId");
-  await requireProjectAccess(c, projectId);
   const issue = await db.query.issues.findFirst({
     where: and(eq(schema.issues.id, issueId), eq(schema.issues.projectId, projectId)),
   });
@@ -1251,8 +1264,7 @@ app.get("/api/projects/:projectId/issues/:issueId", async (c) => {
 });
 
 app.post("/api/projects/:projectId/issues/lookup", async (c) => {
-  const projectId = c.req.param("projectId");
-  await requireProjectAccess(c, projectId);
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const body = (await c.req.json().catch(() => ({}))) as {
     kind?: "log" | "span";
     service?: string | null;
@@ -1308,9 +1320,8 @@ app.post("/api/projects/:projectId/symbolication/log", async (c) => {
 });
 
 app.get("/api/projects/:projectId/issues/:issueId/agent-run", async (c) => {
-  const projectId = c.req.param("projectId");
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const issueId = c.req.param("issueId");
-  await requireProjectAccess(c, projectId);
 
   const issue = await db.query.issues.findFirst({
     where: and(eq(schema.issues.id, issueId), eq(schema.issues.projectId, projectId)),
@@ -1778,8 +1789,7 @@ app.patch("/api/projects/:projectId/automation", async (c) => {
 });
 
 app.get("/api/projects/:projectId/incidents", async (c) => {
-  const projectId = c.req.param("projectId");
-  await requireProjectAccess(c, projectId);
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const limit = clampLimit(Number(c.req.query("limit") ?? 50), 50, 200);
   const status = c.req.query("status");
   const incidentStatus = status && status !== "all" && isIncidentStatus(status) ? status : null;
@@ -1986,9 +1996,8 @@ async function loadIncidentsBucketStats(
 }
 
 app.get("/api/projects/:projectId/incidents/:incidentId", async (c) => {
-  const projectId = c.req.param("projectId");
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const incidentId = c.req.param("incidentId");
-  await requireProjectAccess(c, projectId);
 
   const incident = await getProjectIncident(projectId, incidentId);
   if (!incident) throw new HTTPException(404, { message: "incident not found" });
@@ -2036,9 +2045,8 @@ app.get("/api/projects/:projectId/incidents/:incidentId", async (c) => {
 });
 
 app.get("/api/projects/:projectId/incidents/:incidentId/pull-requests", async (c) => {
-  const projectId = c.req.param("projectId");
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const incidentId = c.req.param("incidentId");
-  await requireProjectAccess(c, projectId);
 
   const incident = await getProjectIncident(projectId, incidentId);
   if (!incident) throw new HTTPException(404, { message: "incident not found" });
@@ -2340,9 +2348,8 @@ async function fetchIncidentTimeseriesPairs(args: {
 
 // Daily event counts + impacted-user count for an incident's underlying telemetry.
 app.get("/api/projects/:projectId/incidents/:incidentId/stats", async (c) => {
-  const projectId = c.req.param("projectId");
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const incidentId = c.req.param("incidentId");
-  await requireProjectAccess(c, projectId);
 
   const incident = await getProjectIncident(projectId, incidentId);
   if (!incident) throw new HTTPException(404, { message: "incident not found" });
@@ -2670,9 +2677,8 @@ type PendingResolutionProposal = {
 // Back-compat: returns the same {agentRun, events} shape the web client
 // used pre-merge. The main `/incidents/:id` GET now folds this in.
 app.get("/api/projects/:projectId/incidents/:incidentId/agent-run", async (c) => {
-  const projectId = c.req.param("projectId");
+  const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const incidentId = c.req.param("incidentId");
-  await requireProjectAccess(c, projectId);
 
   const incident = await getProjectIncident(projectId, incidentId);
   if (!incident) throw new HTTPException(404, { message: "incident not found" });

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -8,6 +8,12 @@ export type Me = {
   // The onboarding wizard's create-org step posts to /api/me/orgs to fix that.
   org: { id: string; name: string; slug: string; githubSetupNeeded: boolean } | null;
   project: { id: string; name: string; slug: string; hasIngested: boolean } | null;
+  // True when a shared demo project is configured and this project hasn't
+  // ingested yet — the server is serving it read-only sample data. Drives the
+  // demo-explore experience + the persistent install nudge. Flips false the
+  // instant real telemetry lands (hasIngested), teleporting the user to their
+  // own project.
+  demoMode?: boolean;
   // Whether billing hard-blocks are enforced. Metering runs regardless; this
   // gates the "Ingest paused" bar so we don't show it when nothing is blocked.
   billingEnforcement?: boolean;

--- a/apps/web/src/onboarding/InstallNudge.tsx
+++ b/apps/web/src/onboarding/InstallNudge.tsx
@@ -1,0 +1,36 @@
+import { Btn } from "../design/ui.tsx";
+import { ArrowIcon } from "./icons.tsx";
+
+// Persistent, always-on nudge shown over the app while the user is exploring
+// demo (sample) data. It is deliberately prominent and NOT dismissable — the
+// whole point of demo mode is to keep pushing the user toward instrumenting
+// their own app. Clicking "Connect your app" drops the demo-exploring opt-in,
+// which sends them back to the install wizard. It disappears on its own the
+// moment real telemetry lands (the gate stops rendering it).
+export function InstallNudge({ onConnect }: { onConnect: () => void }) {
+  return (
+    <div className="fixed bottom-5 right-5 z-50 w-[320px] overflow-hidden rounded-[14px] border border-[rgba(140,152,240,0.35)] bg-[#0f1014] shadow-[0_12px_40px_rgba(0,0,0,0.5)]">
+      <div className="flex items-start gap-2.5 border-b border-[rgba(255,255,255,0.07)] px-[18px] py-[14px]">
+        <span className="mt-1 h-2 w-2 flex-shrink-0 animate-pulse rounded-full bg-[#8C98F0]" />
+        <div className="flex-1">
+          <p className="m-0 text-[13.5px] font-semibold text-fg">You're exploring sample data</p>
+          <p className="m-0 mt-1 text-[12.5px] leading-[1.5] text-muted">
+            These incidents, dashboards and traces are a demo. Connect your own app to see your real
+            data here — it takes a couple of minutes.
+          </p>
+        </div>
+      </div>
+      <div className="px-[18px] py-[12px]">
+        <Btn
+          variant="primary"
+          size="md"
+          onClick={onConnect}
+          className="!h-[36px] w-full !justify-center !rounded-[8px] !px-[14px] !text-[13px]"
+        >
+          Connect your app
+          <ArrowIcon />
+        </Btn>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/onboarding/OnboardingGate.tsx
+++ b/apps/web/src/onboarding/OnboardingGate.tsx
@@ -54,13 +54,15 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
   }, [skillMode, hasIngested]);
 
   // Teleport: once the user's own telemetry arrives, demo mode is over — drop
-  // the local opt-in so refreshes land straight on their real data.
+  // the local opt-in so refreshes land straight on their real data. Gate on
+  // `me.data` being loaded: before it resolves, `demoMode` defaults to false,
+  // and acting on that would wipe a returning explorer's opt-in on every refresh.
   useEffect(() => {
-    if (!demoMode && exploring) {
+    if (me.data && !demoMode && exploring) {
       setExploring(false);
       writeDemoExploring(false);
     }
-  }, [demoMode, exploring]);
+  }, [me.data, demoMode, exploring]);
 
   const startExploring = () => {
     setExploring(true);

--- a/apps/web/src/onboarding/OnboardingGate.tsx
+++ b/apps/web/src/onboarding/OnboardingGate.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useEffect, useState } from "react";
 import { useMe } from "../api.ts";
 import { CenteredShell } from "../design/ui.tsx";
 import { finishSkillOnboarding, isSkillOnboardingPending } from "../skillOnboarding.ts";
+import { InstallNudge } from "./InstallNudge.tsx";
 import { OnboardingWizard } from "./OnboardingWizard.tsx";
 
 // Pre-empts the dashboard for new users until they've finished the install +
@@ -10,18 +11,65 @@ import { OnboardingWizard } from "./OnboardingWizard.tsx";
 // We auto-pass-through once the project has ever ingested. `hasIngested` is
 // derived from api_keys.last_used_at (the proxy stamps it on every successful
 // auth), so this gate stays cheap: no ClickHouse queries per page load.
+//
+// Demo overlay: when the server is serving sample data (`me.demoMode`), the
+// install wizard stays the default landing, but the user can opt to "Explore
+// with sample data" — which renders the populated app (reading the shared demo
+// project, read-only) with a persistent InstallNudge. The opt-in is local-only
+// and is dropped the instant real telemetry lands (demoMode flips false).
+
+const DEMO_EXPLORING_KEY = "superlog.demo_exploring";
+
+function readDemoExploring(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(DEMO_EXPLORING_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeDemoExploring(on: boolean) {
+  if (typeof window === "undefined") return;
+  try {
+    if (on) window.localStorage.setItem(DEMO_EXPLORING_KEY, "1");
+    else window.localStorage.removeItem(DEMO_EXPLORING_KEY);
+  } catch {
+    /* ignore */
+  }
+}
 
 export function OnboardingGate({ children }: { children: ReactNode }) {
   const me = useMe();
 
   const [dismissed, setDismissed] = useState(false);
+  const [exploring, setExploring] = useState(readDemoExploring);
 
   const hasIngested = me.data?.project?.hasIngested ?? false;
+  const demoMode = me.data?.demoMode ?? false;
   const skillMode = isSkillOnboardingPending();
 
   useEffect(() => {
     if (skillMode && hasIngested) finishSkillOnboarding();
   }, [skillMode, hasIngested]);
+
+  // Teleport: once the user's own telemetry arrives, demo mode is over — drop
+  // the local opt-in so refreshes land straight on their real data.
+  useEffect(() => {
+    if (!demoMode && exploring) {
+      setExploring(false);
+      writeDemoExploring(false);
+    }
+  }, [demoMode, exploring]);
+
+  const startExploring = () => {
+    setExploring(true);
+    writeDemoExploring(true);
+  };
+  const stopExploring = () => {
+    setExploring(false);
+    writeDemoExploring(false);
+  };
 
   if (me.isLoading || !me.data) {
     return (
@@ -67,6 +115,17 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
     return <>{children}</>;
   }
 
+  // Opted into the demo: render the populated app (server serves demo data,
+  // read-only) with a persistent nudge to connect their own app.
+  if (demoMode && exploring) {
+    return (
+      <>
+        {children}
+        <InstallNudge onConnect={stopExploring} />
+      </>
+    );
+  }
+
   return (
     <OnboardingWizard
       projectId={me.data.project.id}
@@ -75,6 +134,7 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
       onComplete={() => {
         setDismissed(true);
       }}
+      onExploreDemo={demoMode ? startExploring : undefined}
     />
   );
 }

--- a/apps/web/src/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/onboarding/OnboardingWizard.tsx
@@ -58,6 +58,7 @@ export function OnboardingWizard({
   userName,
   userEmail,
   onComplete,
+  onExploreDemo,
 }: {
   mode?: Mode;
   // Null until the user has created their first org. While null, the wizard
@@ -66,6 +67,9 @@ export function OnboardingWizard({
   userName: string;
   userEmail: string;
   onComplete: () => void;
+  // Present only when a shared demo project is configured. Lets the user skip
+  // ahead and explore sample data instead of instrumenting first.
+  onExploreDemo?: () => void;
 }) {
   const [step, setStep] = useState<Step>("install");
 
@@ -126,12 +130,14 @@ export function OnboardingWizard({
               minting={createKey.isPending && !createKey.data}
               error={createKey.error ? String(createKey.error) : null}
               onNext={() => setStep("deploy")}
+              onExploreDemo={onExploreDemo}
             />
           ) : (
             <DeployStep
               eventsArrived={eventsArrived}
               onBack={() => setStep("install")}
               onDone={onComplete}
+              onExploreDemo={onExploreDemo}
             />
           )}
         </div>
@@ -413,10 +419,7 @@ export function AgentKeyStep({
             {slackSkipped ? (
               <SkippedPill icon={<SlackIcon size={13} />} label="Slack skipped" />
             ) : (
-              <StatusPill
-                icon={<SlackIcon size={13} />}
-                label={slackLabel ?? "Slack connected"}
-              />
+              <StatusPill icon={<SlackIcon size={13} />} label={slackLabel ?? "Slack connected"} />
             )}
           </div>
           <div className="px-[22px] py-[18px]">
@@ -612,11 +615,13 @@ function InstallStep({
   minting,
   error,
   onNext,
+  onExploreDemo,
 }: {
   apiKey: string | null;
   minting: boolean;
   error: string | null;
   onNext: () => void;
+  onExploreDemo?: () => void;
 }) {
   const [copied, setCopied] = useState(false);
   const prompt = apiKey ? buildInstallPrompt(apiKey) : INSTALL_PROMPT;
@@ -687,7 +692,26 @@ function InstallStep({
       </div>
 
       <StepFooter onNext={onNext} nextLabel="The agent is done" />
+      <ExploreDemoLink onExploreDemo={onExploreDemo} />
     </>
+  );
+}
+
+// Subtle escape hatch shown only when a shared demo project is configured: lets
+// a new user explore sample data before instrumenting. The install wizard stays
+// the primary path; this is a secondary, lower-emphasis action.
+function ExploreDemoLink({ onExploreDemo }: { onExploreDemo?: () => void }) {
+  if (!onExploreDemo) return null;
+  return (
+    <div className="mt-3 text-right">
+      <button
+        type="button"
+        onClick={onExploreDemo}
+        className="pr-1 text-[12.5px] font-medium text-muted underline-offset-4 transition-colors hover:text-fg hover:underline"
+      >
+        Not ready yet? Explore with sample data first →
+      </button>
+    </div>
   );
 }
 
@@ -695,10 +719,12 @@ function DeployStep({
   eventsArrived,
   onBack,
   onDone,
+  onExploreDemo,
 }: {
   eventsArrived: boolean;
   onBack: () => void;
   onDone: () => void;
+  onExploreDemo?: () => void;
 }) {
   return (
     <>
@@ -742,6 +768,7 @@ function DeployStep({
         nextLabel={eventsArrived ? "Continue" : "I've deployed"}
         nextDisabled={!eventsArrived}
       />
+      {!eventsArrived && <ExploreDemoLink onExploreDemo={onExploreDemo} />}
     </>
   );
 }

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -12,6 +12,7 @@
     "pgboss:migrate": "tsx scripts/pgboss-migrate.ts",
     "test:jobs-loader": "tsx --test src/jobs.test.ts",
     "test:jobs-runner": "tsx --test src/jobs/runner.test.ts",
+    "test:demo-feed": "tsx --test src/jobs/demo-feed.test.ts",
     "test:git-auth-no-argv": "tsx scripts/test-git-auth-no-argv.ts",
     "test:patch-normalization": "tsx scripts/test-patch-normalization.ts",
     "test:slack-pinning": "tsx --test src/slack-pinning.test.ts",

--- a/apps/worker/src/jobs.ts
+++ b/apps/worker/src/jobs.ts
@@ -17,7 +17,9 @@ import { logger } from "./logger.js";
 // only when a real job needs more.
 export type JobDeps = {
   db: DB;
-  clickhouse: Pick<ClickHouseClient, "query">;
+  // `command` is exposed alongside `query` so jobs can run lightweight DDL/DML
+  // (e.g. the demo-feed job's ALTER … DELETE retention trim).
+  clickhouse: Pick<ClickHouseClient, "query" | "command">;
 };
 
 // The unit of work for a scheduled job: run once per fire. pg-boss owns the

--- a/apps/worker/src/jobs/demo-feed.test.ts
+++ b/apps/worker/src/jobs/demo-feed.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { buildDemoBatch } from "./demo-feed.js";
+
+type LogRecord = { severityNumber: number };
+type Span = { status?: { code?: number }; events?: unknown[] };
+
+function allLogs(batch: ReturnType<typeof buildDemoBatch>): LogRecord[] {
+  const rl = (batch.logs as { resourceLogs: { scopeLogs: { logRecords: LogRecord[] }[] }[] })
+    .resourceLogs;
+  return rl.flatMap((r) => r.scopeLogs.flatMap((s) => s.logRecords));
+}
+
+function allSpans(batch: ReturnType<typeof buildDemoBatch>): Span[] {
+  const rs = (batch.traces as { resourceSpans: { scopeSpans: { spans: Span[] }[] }[] })
+    .resourceSpans;
+  return rs.flatMap((r) => r.scopeSpans.flatMap((s) => s.spans));
+}
+
+test("demo feed never emits ERROR logs (would mint competing issues)", () => {
+  const logs = allLogs(buildDemoBatch(1_700_000_000_000));
+  assert.ok(logs.length > 0);
+  // Issues are minted from SeverityNumber >= 17 (ERROR). The feed must stay below.
+  for (const l of logs) assert.ok(l.severityNumber < 17, `severity ${l.severityNumber} >= ERROR`);
+});
+
+test("demo feed never emits error-status spans or exception events", () => {
+  const spans = allSpans(buildDemoBatch(1_700_000_000_000));
+  assert.ok(spans.length > 0);
+  for (const s of spans) {
+    assert.notEqual(s.status?.code, 2, "span status must not be Error (2)");
+    assert.ok(!s.events || s.events.length === 0, "span must carry no exception events");
+  }
+});
+
+test("demo feed stamps timestamps near the provided now (recent data)", () => {
+  const now = 1_700_000_000_000;
+  const logs = buildDemoBatch(now) as {
+    logs: { resourceLogs: { scopeLogs: { logRecords: { timeUnixNano: string }[] }[] }[] };
+  };
+  const records = logs.logs.resourceLogs.flatMap((r) => r.scopeLogs.flatMap((s) => s.logRecords));
+  for (const rec of records) {
+    const ms = Number(BigInt(rec.timeUnixNano) / 1_000_000n);
+    assert.ok(ms <= now && ms >= now - 120_000, "log timestamp should be within the last ~2m");
+  }
+});

--- a/apps/worker/src/jobs/demo-feed.ts
+++ b/apps/worker/src/jobs/demo-feed.ts
@@ -1,0 +1,205 @@
+// Rolling telemetry feed for the shared demo project.
+//
+// Demo mode lets a brand-new user explore a populated product before they
+// instrument anything: the API serves them a hidden, curated demo project's
+// data (read-only). This job keeps that project's telemetry feeling LIVE —
+// every couple of minutes it appends a fresh burst of traces / INFO-WARN logs /
+// gauge metrics (timestamped ~now) and trims rows past the retention window, so
+// charts move and "last 1h" views stay populated.
+//
+// Deliberately emits NO span `exception` events and NO ERROR/SeverityNumber>=17
+// logs: issues/incidents are minted only from those, and the demo's incidents
+// are a curated, hand-written set (see scripts/demo/provision-demo-project.ts).
+// Keeping the live feed clean means the worker never manufactures competing
+// low-quality issues on top of the curated set.
+//
+// Opt-in: the job only schedules when DEMO_PROJECT_ID and DEMO_COLLECTOR_URL are
+// set, so stock / self-host builds schedule nothing.
+
+import type { JobDefinition, JobDeps } from "../jobs.js";
+import { logger } from "../logger.js";
+
+const SERVICES = ["checkout-api", "catalog-api", "payments-api", "web", "worker"] as const;
+const REGIONS = ["us-east-1", "us-west-2", "eu-west-1"] as const;
+const SPAN_NAMES = ["GET /cart", "POST /checkout", "GET /products", "POST /pay", "GET /health"];
+const LOG_LINES = [
+  "request completed",
+  "cache hit",
+  "order placed",
+  "payment authorized",
+  "inventory reserved",
+  "rate limit near threshold",
+];
+const METRICS = [
+  { name: "http.server.duration", unit: "ms", base: 120, spread: 80 },
+  { name: "http.server.requests", unit: "1", base: 40, spread: 30 },
+  { name: "process.memory.usage", unit: "By", base: 256_000_000, spread: 40_000_000 },
+] as const;
+// Retention window for demo telemetry — anything older is trimmed each tick.
+const RETENTION_HOURS = 24;
+
+const HEX = "0123456789abcdef";
+function hex(len: number): string {
+  let s = "";
+  for (let i = 0; i < len; i++) s += HEX[Math.floor(Math.random() * 16)];
+  return s;
+}
+const nanos = (ms: number) => String(Math.trunc(ms) * 1_000_000);
+const attr = (key: string, value: string) => ({ key, value: { stringValue: value } });
+const pick = <T>(xs: readonly T[]): T => xs[Math.floor(Math.random() * xs.length)] as T;
+
+function resourceFor(service: string) {
+  return {
+    attributes: [
+      attr("service.name", service),
+      attr("cloud.region", pick(REGIONS)),
+      attr("deployment.environment", "production"),
+    ],
+  };
+}
+
+export type DemoBatch = {
+  traces: unknown;
+  logs: unknown;
+  metrics: unknown;
+};
+
+// Pure: build one fresh burst of OTLP/HTTP JSON payloads anchored at `nowMs`.
+// `superlog.project_id` is intentionally NOT set here — the collector promotes
+// it from the x-superlog-project-id ingest header (anti-spoofing).
+export function buildDemoBatch(nowMs: number, perService = 6): DemoBatch {
+  const resourceSpans = SERVICES.map((service) => ({
+    resource: resourceFor(service),
+    scopeSpans: [
+      {
+        scope: { name: "demo.feed" },
+        spans: Array.from({ length: perService }, () => {
+          const start = nowMs - Math.floor(Math.random() * 60_000);
+          const durationMs = 20 + Math.floor(Math.random() * 400);
+          return {
+            traceId: hex(32),
+            spanId: hex(16),
+            name: pick(SPAN_NAMES),
+            kind: 2, // SERVER
+            startTimeUnixNano: nanos(start),
+            endTimeUnixNano: nanos(start + durationMs),
+            attributes: [
+              attr("http.method", pick(["GET", "POST"])),
+              attr("http.status_code", pick(["200", "200", "200", "201", "204"])),
+            ],
+            status: { code: 1 }, // OK — never Error, never an exception event
+          };
+        }),
+      },
+    ],
+  }));
+
+  const resourceLogs = SERVICES.map((service) => ({
+    resource: resourceFor(service),
+    scopeLogs: [
+      {
+        scope: { name: "demo.feed" },
+        logRecords: Array.from({ length: perService }, () => {
+          // INFO (9) most of the time, WARN (13) occasionally. Never >= 17 (ERROR).
+          const warn = Math.random() < 0.15;
+          return {
+            timeUnixNano: nanos(nowMs - Math.floor(Math.random() * 60_000)),
+            severityNumber: warn ? 13 : 9,
+            severityText: warn ? "WARN" : "INFO",
+            body: { stringValue: pick(LOG_LINES) },
+            attributes: [attr("http.route", pick(SPAN_NAMES))],
+          };
+        }),
+      },
+    ],
+  }));
+
+  const resourceMetrics = SERVICES.map((service) => ({
+    resource: resourceFor(service),
+    scopeMetrics: [
+      {
+        scope: { name: "demo.feed" },
+        metrics: METRICS.map((m) => ({
+          name: m.name,
+          unit: m.unit,
+          gauge: {
+            dataPoints: [
+              {
+                timeUnixNano: nanos(nowMs),
+                asDouble: m.base + (Math.random() - 0.5) * m.spread,
+                attributes: [attr("http.method", pick(["GET", "POST"]))],
+              },
+            ],
+          },
+        })),
+      },
+    ],
+  }));
+
+  return {
+    traces: { resourceSpans },
+    logs: { resourceLogs },
+    metrics: { resourceMetrics },
+  };
+}
+
+async function postSignal(
+  collectorUrl: string,
+  projectId: string,
+  signal: "traces" | "logs" | "metrics",
+  payload: unknown,
+): Promise<void> {
+  const res = await fetch(`${collectorUrl.replace(/\/$/, "")}/v1/${signal}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-superlog-project-id": projectId,
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error(`collector ${signal} ingest failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+async function trimOldTelemetry(deps: JobDeps, projectId: string): Promise<void> {
+  const cutoff = `now() - INTERVAL ${RETENTION_HOURS} HOUR`;
+  const tables: Array<{ table: string; tsCol: string }> = [
+    { table: "otel_traces", tsCol: "Timestamp" },
+    { table: "otel_logs", tsCol: "Timestamp" },
+    { table: "otel_metrics_gauge", tsCol: "TimeUnix" },
+  ];
+  for (const { table, tsCol } of tables) {
+    await deps.clickhouse.command({
+      query: `ALTER TABLE ${table} DELETE WHERE ResourceAttributes['superlog.project_id'] = {projectId:String} AND ${tsCol} < ${cutoff}`,
+      query_params: { projectId },
+    });
+  }
+}
+
+export const job: JobDefinition = {
+  name: "demo-feed",
+  // Every 2 minutes — fine-grained enough that "last 5m" / "last 1h" views stay
+  // alive without flooding the project.
+  schedule: "*/2 * * * *",
+  create: (deps: JobDeps) => {
+    const projectId = process.env.DEMO_PROJECT_ID?.trim();
+    const collectorUrl = process.env.DEMO_COLLECTOR_URL?.trim();
+    if (!projectId || !collectorUrl) return null; // opt out: not a demo deployment
+
+    return async () => {
+      const batch = buildDemoBatch(Date.now());
+      await postSignal(collectorUrl, projectId, "traces", batch.traces);
+      await postSignal(collectorUrl, projectId, "logs", batch.logs);
+      await postSignal(collectorUrl, projectId, "metrics", batch.metrics);
+      await trimOldTelemetry(deps, projectId).catch((err) => {
+        // Trim is best-effort: a failed retention pass must not fail the feed.
+        logger.warn(
+          { scope: "jobs.demo-feed", err: err instanceof Error ? err.message : String(err) },
+          "demo-feed retention trim failed",
+        );
+      });
+      logger.info({ scope: "jobs.demo-feed", projectId }, "demo telemetry feed tick complete");
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "demo:seed:acme": "tsx scripts/demo/seed-acme-telemetry.ts",
     "demo:seed:rich": "tsx scripts/demo/seed-rich-telemetry.ts",
     "demo:seed:everything": "tsx scripts/demo/seed-everything.ts",
+    "demo:provision": "tsx scripts/demo/provision-demo-project.ts",
+    "demo:verify-isolation": "tsx scripts/demo/verify-demo-isolation.ts",
     "lint": "biome check .",
     "format": "biome format --write .",
     "typecheck": "turbo run typecheck"

--- a/scripts/demo/provision-demo-project.ts
+++ b/scripts/demo/provision-demo-project.ts
@@ -224,7 +224,19 @@ async function main(): Promise<void> {
 
   // ── Org (NO org_members — keeps the project invisible to real users) ─────
   let org = await db.query.orgs.findFirst({ where: eq(schema.orgs.slug, DEMO.orgSlug) });
-  if (!org) {
+  if (org) {
+    // Safety guard: never seed demo data into a REAL org that merely collides on
+    // the slug. The demo org is defined by having ZERO members; any org with a
+    // member is a real tenant, so refuse rather than corrupt it.
+    const member = await db.query.orgMembers.findFirst({
+      where: eq(schema.orgMembers.orgId, org.id),
+    });
+    if (member) {
+      throw new Error(
+        `refusing to seed demo data: an org with slug "${DEMO.orgSlug}" already exists and has members — that is a real org, not the hidden demo org`,
+      );
+    }
+  } else {
     org = (
       await db.insert(schema.orgs).values({ name: DEMO.orgName, slug: DEMO.orgSlug }).returning()
     )[0];
@@ -293,61 +305,66 @@ async function main(): Promise<void> {
     });
     if (existing) continue;
 
-    const issue = (
-      await db
-        .insert(schema.issues)
-        .values({
-          projectId,
-          fingerprint,
-          kind: "span",
-          service: inc.service,
-          exceptionType: inc.exceptionType,
-          title: inc.title,
-          message: inc.agentSummary,
-          topFrame: inc.topFrame,
-          firstSeen,
-          lastSeen,
-          eventCount: inc.eventCount,
-        })
-        .returning()
-    )[0];
-    if (!issue) throw new Error(`failed to insert issue for ${inc.codename}`);
+    // Atomic: issue + incident + link commit together, so a mid-loop failure
+    // can't leave an orphan incident (no linked issue) that the codename
+    // idempotency check above would then skip forever on re-runs.
+    await db.transaction(async (tx) => {
+      const issue = (
+        await tx
+          .insert(schema.issues)
+          .values({
+            projectId,
+            fingerprint,
+            kind: "span",
+            service: inc.service,
+            exceptionType: inc.exceptionType,
+            title: inc.title,
+            message: inc.agentSummary,
+            topFrame: inc.topFrame,
+            firstSeen,
+            lastSeen,
+            eventCount: inc.eventCount,
+          })
+          .returning()
+      )[0];
+      if (!issue) throw new Error(`failed to insert issue for ${inc.codename}`);
 
-    const incidentRow = (
-      await db
-        .insert(schema.incidents)
-        .values({
-          projectId,
-          service: inc.service,
-          environment: inc.environment,
-          title: inc.title,
-          codename: inc.codename,
-          severity: inc.severity,
-          status: inc.status,
-          firstSeen,
-          lastSeen,
-          issueCount: 1,
-          agentSummary: inc.agentSummary,
-          rootCauseText: inc.rootCauseText,
-          rootCauseConfidence: 80,
-          estimatedImpactText: inc.estimatedImpactText,
-          estimatedImpactConfidence: 70,
-          ...(inc.status === "resolved"
-            ? {
-                resolvedAt: lastSeen,
-                resolvedByKind: "agent_classification" as const,
-                resolvedReasonCode: "fixed_in_current_code",
-                resolvedReasonText: "Fix deployed; no recurrence since.",
-              }
-            : {}),
-        })
-        .returning()
-    )[0];
-    if (!incidentRow) throw new Error(`failed to insert incident ${inc.codename}`);
+      const incidentRow = (
+        await tx
+          .insert(schema.incidents)
+          .values({
+            projectId,
+            service: inc.service,
+            environment: inc.environment,
+            title: inc.title,
+            codename: inc.codename,
+            severity: inc.severity,
+            status: inc.status,
+            firstSeen,
+            lastSeen,
+            issueCount: 1,
+            agentSummary: inc.agentSummary,
+            rootCauseText: inc.rootCauseText,
+            rootCauseConfidence: 80,
+            estimatedImpactText: inc.estimatedImpactText,
+            estimatedImpactConfidence: 70,
+            ...(inc.status === "resolved"
+              ? {
+                  resolvedAt: lastSeen,
+                  resolvedByKind: "agent_classification" as const,
+                  resolvedReasonCode: "fixed_in_current_code",
+                  resolvedReasonText: "Fix deployed; no recurrence since.",
+                }
+              : {}),
+          })
+          .returning()
+      )[0];
+      if (!incidentRow) throw new Error(`failed to insert incident ${inc.codename}`);
 
-    await db
-      .insert(schema.incidentIssues)
-      .values({ incidentId: incidentRow.id, issueId: issue.id });
+      await tx
+        .insert(schema.incidentIssues)
+        .values({ incidentId: incidentRow.id, issueId: issue.id });
+    });
     incidentCount++;
   }
 

--- a/scripts/demo/provision-demo-project.ts
+++ b/scripts/demo/provision-demo-project.ts
@@ -1,0 +1,402 @@
+// Provision the shared demo project that powers demo mode.
+//
+// Demo mode (see apps/api/src/demo.ts) lets a brand-new user explore a populated
+// product before instrumenting anything: until their own project ingests, the
+// API serves them THIS project's data, read-only. This script creates that
+// project and seeds a curated, hand-written set of incidents (with agent-style
+// root-cause writeups) + dashboards. Live telemetry is layered on separately by
+// the worker's demo-feed job (apps/worker/src/jobs/demo-feed.ts), which keeps
+// traces/logs/metrics flowing so charts move and the explorer stays populated.
+//
+// The project is hidden from real users by having NO org_members on its org —
+// resolveActiveOrgContext gates on membership, so nobody can navigate to it; the
+// overlay reads it server-side by id only. Print the resulting project id and
+// set it as DEMO_PROJECT_ID on the api + worker.
+//
+// Idempotent. Pass --reset to wipe previously-seeded demo data before reseeding.
+//
+//   DATABASE_URL=... pnpm tsx scripts/demo/provision-demo-project.ts [--reset]
+
+import process from "node:process";
+import { and, eq, like } from "drizzle-orm";
+
+const DEMO = {
+  ownerEmail: "demo@superlog.internal",
+  orgName: "Acme (demo)",
+  orgSlug: "acme-demo",
+  projectName: "Acme Storefront",
+  projectSlug: "acme-storefront",
+};
+
+// Curated incidents. Each gets one linked issue. The "investigation" the user
+// reads is the agentSummary / rootCause / impact text on the incident row —
+// exactly where the worker writes real agent findings.
+type SeedIncident = {
+  codename: string;
+  service: string;
+  environment: string;
+  title: string;
+  severity: "SEV-1" | "SEV-2" | "SEV-3";
+  status: "open" | "resolved";
+  ageDays: number; // firstSeen = now - ageDays
+  agentSummary: string;
+  rootCauseText: string;
+  estimatedImpactText: string;
+  exceptionType: string;
+  topFrame: string;
+  eventCount: number;
+};
+
+const INCIDENTS: SeedIncident[] = [
+  {
+    codename: "amber-otter",
+    service: "payments-api",
+    environment: "production",
+    title: "Checkout 500s on payment capture",
+    severity: "SEV-1",
+    status: "open",
+    ageDays: 0,
+    agentSummary:
+      "A null `paymentIntent.customer` reaches `capturePayment()` for guest checkouts, throwing before the charge is created. ~6% of checkouts affected since the 14:20 deploy.",
+    rootCauseText:
+      "The guest-checkout path skips customer creation, so `customer` is undefined. `capturePayment()` dereferences `customer.defaultSource` without a guard (payments-api/src/capture.ts:88).",
+    estimatedImpactText:
+      "≈ 6% of checkout attempts (guest users) failing. Revenue impact rising with evening traffic.",
+    exceptionType: "TypeError",
+    topFrame: "capturePayment (payments-api/src/capture.ts:88:17)",
+    eventCount: 412,
+  },
+  {
+    codename: "brisk-finch",
+    service: "catalog-api",
+    environment: "production",
+    title: "Product search p95 latency spike",
+    severity: "SEV-2",
+    status: "open",
+    ageDays: 1,
+    agentSummary:
+      "Search p95 jumped from 180ms to 1.4s. A missing index on `products.search_vector` forces a sequential scan under the new fuzzy-match query.",
+    rootCauseText:
+      "The fuzzy-search feature shipped without the GIN index on `search_vector`; Postgres falls back to a seq scan on the 2.1M-row products table.",
+    estimatedImpactText: "All search requests slow; visible cart-abandonment uptick on mobile.",
+    exceptionType: "SlowQueryWarning",
+    topFrame: "searchProducts (catalog-api/src/search.ts:54:11)",
+    eventCount: 88,
+  },
+  {
+    codename: "calm-heron",
+    service: "checkout-api",
+    environment: "production",
+    title: "Cart total wrong for stacked discounts",
+    severity: "SEV-2",
+    status: "resolved",
+    ageDays: 4,
+    agentSummary:
+      "When two percentage discounts stacked, they were applied additively instead of multiplicatively, undercharging by up to 12%. Fixed and deployed.",
+    rootCauseText:
+      "`applyDiscounts()` summed discount rates rather than composing them. Corrected to fold sequentially (checkout-api/src/pricing.ts:120).",
+    estimatedImpactText: "~340 orders undercharged over 2 days before the fix.",
+    exceptionType: "AssertionError",
+    topFrame: "applyDiscounts (checkout-api/src/pricing.ts:120:9)",
+    eventCount: 51,
+  },
+  {
+    codename: "dapper-lynx",
+    service: "web",
+    environment: "production",
+    title: "Intermittent 404s on product images",
+    severity: "SEV-3",
+    status: "open",
+    ageDays: 2,
+    agentSummary:
+      "A CDN cache-key change drops the `?v=` asset hash for ~3% of image URLs, yielding sporadic 404s on first load.",
+    rootCauseText:
+      "The image proxy strips query strings it doesn't recognize; the new versioned-asset param isn't in its allowlist (web/src/img-proxy.ts:33).",
+    estimatedImpactText: "Cosmetic; broken thumbnails on a small fraction of product cards.",
+    exceptionType: "NotFoundError",
+    topFrame: "resolveAsset (web/src/img-proxy.ts:33:5)",
+    eventCount: 73,
+  },
+  {
+    codename: "eager-marten",
+    service: "payments-api",
+    environment: "production",
+    title: "Duplicate charges on network retry",
+    severity: "SEV-1",
+    status: "resolved",
+    ageDays: 6,
+    agentSummary:
+      "A client retry on timeout created a second charge because the idempotency key was regenerated per attempt. Now derived from the order id. Resolved.",
+    rootCauseText:
+      "Idempotency key used a per-request UUID; retries got fresh keys. Switched to `order:<id>:capture` (payments-api/src/capture.ts:142).",
+    estimatedImpactText: "29 customers double-charged before mitigation; all refunded.",
+    exceptionType: "DuplicateChargeError",
+    topFrame: "capturePayment (payments-api/src/capture.ts:142:13)",
+    eventCount: 31,
+  },
+  {
+    codename: "fleet-osprey",
+    service: "worker",
+    environment: "production",
+    title: "Inventory sync job timing out",
+    severity: "SEV-3",
+    status: "open",
+    ageDays: 3,
+    agentSummary:
+      "The nightly inventory sync exceeds its 5-minute budget as the supplier feed grew; the job is killed mid-batch, leaving stock counts stale.",
+    rootCauseText:
+      "Sync fetches all SKUs in one request and processes serially. Needs pagination + batched upserts (worker/src/jobs/inventory-sync.ts:61).",
+    estimatedImpactText: "Stock levels up to a day stale for ~8% of SKUs.",
+    exceptionType: "TimeoutError",
+    topFrame: "syncInventory (worker/src/jobs/inventory-sync.ts:61:7)",
+    eventCount: 12,
+  },
+];
+
+// Two dashboards over the metric names the demo-feed job emits, grouped by
+// service. NB groupBy must be "service.name" (resolves to ServiceName); the
+// older seeders used "resource:service.name" which looks up a non-existent key.
+const DASHBOARDS = [
+  {
+    name: "Service overview",
+    slug: "service-overview",
+    widgets: [
+      {
+        type: "timeseries_metric" as const,
+        title: "Request rate by service",
+        config: {
+          metricName: "http.server.requests",
+          groupBy: "service.name",
+          filter: { resourceAttrs: [] as never[] },
+        },
+        layout: { x: 0, y: 0, w: 6, h: 4 },
+      },
+      {
+        type: "timeseries_metric" as const,
+        title: "Latency (p50) by service",
+        config: {
+          metricName: "http.server.duration",
+          groupBy: "service.name",
+          filter: { resourceAttrs: [] as never[] },
+        },
+        layout: { x: 6, y: 0, w: 6, h: 4 },
+      },
+    ],
+  },
+  {
+    name: "Capacity",
+    slug: "capacity",
+    widgets: [
+      {
+        type: "timeseries_metric" as const,
+        title: "Memory usage by service",
+        config: {
+          metricName: "process.memory.usage",
+          groupBy: "service.name",
+          filter: { resourceAttrs: [] as never[] },
+        },
+        layout: { x: 0, y: 0, w: 12, h: 4 },
+      },
+    ],
+  },
+];
+
+function daysAgo(days: number): Date {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
+
+async function main(): Promise<void> {
+  const reset = process.argv.includes("--reset");
+  if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL is required");
+
+  const [{ db }, schema, agentRuntime] = await Promise.all([
+    import("../../packages/db/src/client.js"),
+    import("../../packages/db/src/schema.js"),
+    import("../../packages/db/src/agent-runtime.js"),
+  ]);
+
+  // ── Owner user (created_by for dashboards; never logs in) ────────────────
+  let user = await db.query.users.findFirst({ where: eq(schema.users.email, DEMO.ownerEmail) });
+  if (!user) {
+    user = (await db.insert(schema.users).values({ email: DEMO.ownerEmail }).returning())[0];
+  }
+  if (!user) throw new Error("failed to provision demo owner user");
+
+  // ── Org (NO org_members — keeps the project invisible to real users) ─────
+  let org = await db.query.orgs.findFirst({ where: eq(schema.orgs.slug, DEMO.orgSlug) });
+  if (!org) {
+    org = (
+      await db.insert(schema.orgs).values({ name: DEMO.orgName, slug: DEMO.orgSlug }).returning()
+    )[0];
+  }
+  if (!org) throw new Error("failed to provision demo org");
+
+  // ── Project ──────────────────────────────────────────────────────────────
+  let project = await db.query.projects.findFirst({
+    where: and(eq(schema.projects.orgId, org.id), eq(schema.projects.slug, DEMO.projectSlug)),
+  });
+  if (!project) {
+    project = (
+      await db
+        .insert(schema.projects)
+        .values({ orgId: org.id, name: DEMO.projectName, slug: DEMO.projectSlug })
+        .returning()
+    )[0];
+  }
+  if (!project) throw new Error("failed to provision demo project");
+  const projectId = project.id;
+
+  // ── Automation OFF: no agent runs, no auto-investigation on demo data ─────
+  await db
+    .insert(schema.projectAutomationSettings)
+    .values({
+      projectId,
+      autoInvestigateIssuesEnabled: false,
+      agentRunEnabled: false,
+      agentRunProvider: agentRuntime.DEFAULT_AGENT_RUN_PROVIDER,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: schema.projectAutomationSettings.projectId,
+      set: { autoInvestigateIssuesEnabled: false, agentRunEnabled: false, updatedAt: new Date() },
+    });
+
+  // ── Reset prior demo content ──────────────────────────────────────────────
+  if (reset) {
+    // incident_issues cascades from incidents; issues are deleted explicitly.
+    await db.delete(schema.incidents).where(eq(schema.incidents.projectId, projectId));
+    await db
+      .delete(schema.issues)
+      .where(
+        and(
+          eq(schema.issues.projectId, projectId),
+          like(schema.issues.fingerprint, "demo-incident-%"),
+        ),
+      );
+    await db.delete(schema.dashboards).where(eq(schema.dashboards.projectId, projectId));
+    console.log("✓ reset prior demo content");
+  }
+
+  // ── Curated incidents + issues ────────────────────────────────────────────
+  let incidentCount = 0;
+  for (const [i, inc] of INCIDENTS.entries()) {
+    const fingerprint = `demo-incident-${i + 1}`;
+    const firstSeen = daysAgo(inc.ageDays);
+    const lastSeen = inc.status === "resolved" ? daysAgo(Math.max(0, inc.ageDays - 1)) : new Date();
+
+    // Skip if this incident already exists (idempotent without --reset).
+    const existing = await db.query.incidents.findFirst({
+      where: and(
+        eq(schema.incidents.projectId, projectId),
+        eq(schema.incidents.codename, inc.codename),
+      ),
+    });
+    if (existing) continue;
+
+    const issue = (
+      await db
+        .insert(schema.issues)
+        .values({
+          projectId,
+          fingerprint,
+          kind: "span",
+          service: inc.service,
+          exceptionType: inc.exceptionType,
+          title: inc.title,
+          message: inc.agentSummary,
+          topFrame: inc.topFrame,
+          firstSeen,
+          lastSeen,
+          eventCount: inc.eventCount,
+        })
+        .returning()
+    )[0];
+    if (!issue) throw new Error(`failed to insert issue for ${inc.codename}`);
+
+    const incidentRow = (
+      await db
+        .insert(schema.incidents)
+        .values({
+          projectId,
+          service: inc.service,
+          environment: inc.environment,
+          title: inc.title,
+          codename: inc.codename,
+          severity: inc.severity,
+          status: inc.status,
+          firstSeen,
+          lastSeen,
+          issueCount: 1,
+          agentSummary: inc.agentSummary,
+          rootCauseText: inc.rootCauseText,
+          rootCauseConfidence: 80,
+          estimatedImpactText: inc.estimatedImpactText,
+          estimatedImpactConfidence: 70,
+          ...(inc.status === "resolved"
+            ? {
+                resolvedAt: lastSeen,
+                resolvedByKind: "agent_classification" as const,
+                resolvedReasonCode: "fixed_in_current_code",
+                resolvedReasonText: "Fix deployed; no recurrence since.",
+              }
+            : {}),
+        })
+        .returning()
+    )[0];
+    if (!incidentRow) throw new Error(`failed to insert incident ${inc.codename}`);
+
+    await db
+      .insert(schema.incidentIssues)
+      .values({ incidentId: incidentRow.id, issueId: issue.id });
+    incidentCount++;
+  }
+
+  // ── Dashboards + widgets ──────────────────────────────────────────────────
+  for (const d of DASHBOARDS) {
+    let dashboard = await db.query.dashboards.findFirst({
+      where: and(eq(schema.dashboards.projectId, projectId), eq(schema.dashboards.slug, d.slug)),
+    });
+    if (!dashboard) {
+      dashboard = (
+        await db
+          .insert(schema.dashboards)
+          .values({ projectId, name: d.name, slug: d.slug, createdBy: user.id })
+          .returning()
+      )[0];
+    }
+    if (!dashboard) throw new Error(`failed to insert dashboard ${d.slug}`);
+    const dashboardId = dashboard.id;
+    await db
+      .delete(schema.dashboardWidgets)
+      .where(eq(schema.dashboardWidgets.dashboardId, dashboardId));
+    await db.insert(schema.dashboardWidgets).values(
+      d.widgets.map((w, i) => ({
+        dashboardId,
+        type: w.type,
+        title: w.title,
+        config: w.config,
+        layout: w.layout,
+        position: i,
+      })),
+    );
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        demoProjectId: projectId,
+        org: { id: org.id, slug: DEMO.orgSlug },
+        seeded: { incidents: incidentCount, dashboards: DASHBOARDS.length },
+        next: "Set DEMO_PROJECT_ID=<demoProjectId> on api + worker, and DEMO_COLLECTOR_URL on worker.",
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/demo/verify-demo-isolation.ts
+++ b/scripts/demo/verify-demo-isolation.ts
@@ -1,0 +1,191 @@
+// Adversarial integration check for demo-mode tenant isolation.
+//
+// Demo mode serves un-ingested users a shared, hidden demo project's data via a
+// server-side read-only overlay (see apps/api/src/demo.ts). The invariant this
+// script defends: a real user can NEVER read or write the demo project directly,
+// mint credentials scoped to it, join its org, reach it via the management API,
+// or learn its id from a response. The only way to see demo data is the overlay
+// on your OWN un-ingested project.
+//
+// Unlike the pure unit tests (apps/api/src/demo.test.ts), these invariants depend
+// on org membership + Better Auth + the management API, so this runs against the
+// LIVE stack. Run from a seeded worktree:
+//
+//   DEMO_PROJECT_ID=<id> API_URL=<https://api...> DATABASE_URL=<pg> \
+//     pnpm tsx scripts/demo/verify-demo-isolation.ts
+//
+// Exits non-zero (and prints BREACH) if any vector succeeds. Read-only probing.
+
+import process from "node:process";
+
+// Worktree API uses a self-signed cert.
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+const API = (process.env.API_URL ?? "https://api.gifted-beechnut.superlog.localhost:1355").replace(
+  /\/$/,
+  "",
+);
+const ORIGIN = process.env.WEB_ORIGIN ?? API.replace("://api.", "://");
+const DEMO_PROJECT = process.env.DEMO_PROJECT_ID;
+if (!DEMO_PROJECT) throw new Error("DEMO_PROJECT_ID is required");
+
+// --- tiny cookie jar over fetch ------------------------------------------------
+const jar = new Map<string, string>();
+function storeCookies(res: Response) {
+  // node returns folded set-cookie via getSetCookie()
+  const raw = (res.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie?.() ?? [];
+  for (const c of raw) {
+    const [pair] = c.split(";");
+    const eq = pair?.indexOf("=") ?? -1;
+    if (pair && eq > 0) jar.set(pair.slice(0, eq), pair.slice(eq + 1));
+  }
+}
+function cookieHeader(): string {
+  return [...jar.entries()].map(([k, v]) => `${k}=${v}`).join("; ");
+}
+async function req(
+  method: string,
+  path: string,
+  opts: { body?: unknown; bearer?: string; auth?: boolean } = {},
+): Promise<{ status: number; text: string }> {
+  const headers: Record<string, string> = { "content-type": "application/json", origin: ORIGIN };
+  if (opts.auth !== false && jar.size) headers.cookie = cookieHeader();
+  if (opts.bearer) headers.authorization = `Bearer ${opts.bearer}`;
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers,
+    body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
+  });
+  storeCookies(res);
+  return { status: res.status, text: await res.text() };
+}
+
+// --- assertions ----------------------------------------------------------------
+let failures = 0;
+const denied = (s: number) => s === 401 || s === 403 || s === 404;
+function check(name: string, ok: boolean, detail: string) {
+  console.log(`${ok ? "PASS" : "BREACH"}  ${name} — ${detail}`);
+  if (!ok) failures++;
+}
+
+async function demoOrgId(): Promise<string | null> {
+  if (!process.env.DATABASE_URL) return null;
+  const { db } = await import("../../packages/db/src/client.js");
+  const schema = await import("../../packages/db/src/schema.js");
+  const { eq } = await import("drizzle-orm");
+  const p = await db.query.projects.findFirst({ where: eq(schema.projects.id, DEMO_PROJECT) });
+  return p?.orgId ?? null;
+}
+
+async function main(): Promise<void> {
+  const demoOrg = await demoOrgId();
+
+  // Fresh attacker with their own (un-ingested → demoMode) project.
+  const email = `isolation-probe-${Date.now()}@example.com`;
+  await req("POST", "/api/auth/sign-up/email", {
+    body: { email, password: "adminadmin", name: "Probe" },
+  });
+  await req("POST", "/api/me/orgs", { body: { name: "Probe Co" } });
+  const me = JSON.parse((await req("GET", "/api/me")).text) as {
+    demoMode?: boolean;
+    project?: { id: string };
+  };
+  const myProject = me.project?.id;
+  if (!myProject) throw new Error("probe user has no project");
+  check("baseline: attacker is in demo mode", me.demoMode === true, `demoMode=${me.demoMode}`);
+
+  // 1. Direct reads of the demo project by id.
+  for (const sub of ["incidents", "dashboards", "issues"]) {
+    const r = await req("GET", `/api/projects/${DEMO_PROJECT}/${sub}`);
+    check(`direct read demo ${sub}`, denied(r.status), `http=${r.status}`);
+  }
+  const exploreLogs = await req("POST", `/api/projects/${DEMO_PROJECT}/explore/logs`, { body: {} });
+  check("direct read demo explore/logs", denied(exploreLogs.status), `http=${exploreLogs.status}`);
+
+  // 2. Direct writes to the demo project by id.
+  for (const [m, sub, body] of [
+    ["POST", "keys", '"x"'],
+    ["POST", "dashboards", { name: "x", slug: "x" }],
+  ] as const) {
+    const r = await req(m, `/api/projects/${DEMO_PROJECT}/${sub}`, { body });
+    check(`direct write demo ${sub}`, denied(r.status), `http=${r.status}`);
+  }
+
+  // 3. Mint credentials scoped to the demo project.
+  const k = await req("POST", `/api/projects/${DEMO_PROJECT}/keys`, { body: '"x"' });
+  check("mint ingest key for demo project", denied(k.status), `http=${k.status}`);
+  const t = await req("POST", "/api/me/mcp-tokens", {
+    body: { projectId: DEMO_PROJECT, name: "x" },
+  });
+  check("mint MCP token for demo project", denied(t.status), `http=${t.status}`);
+
+  // 4. Activate / join the demo org.
+  const act = await req("PUT", "/api/me/active-project", { body: { projectId: DEMO_PROJECT } });
+  check("set active project to demo", denied(act.status), `http=${act.status}`);
+  if (demoOrg) {
+    const sa = await req("POST", "/api/auth/organization/set-active", {
+      body: { organizationId: demoOrg },
+    });
+    check("Better Auth set-active demo org", denied(sa.status), `http=${sa.status}`);
+    const inv = await req("POST", "/api/auth/organization/invite-member", {
+      body: { organizationId: demoOrg, email, role: "owner" },
+    });
+    check(
+      "Better Auth invite-self to demo org",
+      !(inv.status >= 200 && inv.status < 300),
+      `http=${inv.status}`,
+    );
+  }
+
+  // 5. Management API: own key must not reach the demo project.
+  const mk = await req("POST", "/api/org/api-keys", { body: { name: "mk" } });
+  let mgmtToken: string | undefined;
+  try {
+    mgmtToken = JSON.parse(mk.text)?.key?.plaintext;
+  } catch {
+    /* ignore */
+  }
+  if (mgmtToken) {
+    const sane = await req("GET", "/api/v1/projects", { bearer: mgmtToken, auth: false });
+    check("mgmt key reads own projects (sanity)", sane.status === 200, `http=${sane.status}`);
+    const breach = await req("GET", `/api/v1/projects/${DEMO_PROJECT}/api-keys`, {
+      bearer: mgmtToken,
+      auth: false,
+    });
+    check("mgmt key reaches demo project", denied(breach.status), `http=${breach.status}`);
+  } else {
+    check("obtained management key", false, "could not parse management key");
+  }
+
+  // 6. Demo id must never leak into overlaid responses on the attacker's project.
+  for (const path of [
+    `/api/projects/${myProject}/incidents`,
+    `/api/projects/${myProject}/dashboards`,
+    "/api/me",
+  ]) {
+    const r = await req("GET", path);
+    check(`no demo-id leak in ${path}`, !r.text.includes(DEMO_PROJECT), `http=${r.status}`);
+  }
+
+  // 7. Read-only enforcement on the attacker's own (demo-overlaid) project.
+  const w = await req("POST", `/api/projects/${myProject}/dashboards`, {
+    body: { name: "x", slug: "x" },
+  });
+  check("write to own demo-overlaid dashboards is blocked", w.status === 403, `http=${w.status}`);
+  const ok = await req("POST", `/api/projects/${myProject}/keys`, { body: '"leave-demo"' });
+  check(
+    "install path (mint own key) stays open",
+    ok.status >= 200 && ok.status < 300,
+    `http=${ok.status}`,
+  );
+
+  console.log(
+    `\n${failures === 0 ? "✓ all isolation checks passed" : `✗ ${failures} BREACH(es) found`}`,
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/demo/verify-demo-isolation.ts
+++ b/scripts/demo/verify-demo-isolation.ts
@@ -18,9 +18,6 @@
 
 import process from "node:process";
 
-// Worktree API uses a self-signed cert.
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-
 const API = (process.env.API_URL ?? "https://api.gifted-beechnut.superlog.localhost:1355").replace(
   /\/$/,
   "",
@@ -28,6 +25,20 @@ const API = (process.env.API_URL ?? "https://api.gifted-beechnut.superlog.localh
 const ORIGIN = process.env.WEB_ORIGIN ?? API.replace("://api.", "://");
 const DEMO_PROJECT = process.env.DEMO_PROJECT_ID;
 if (!DEMO_PROJECT) throw new Error("DEMO_PROJECT_ID is required");
+
+// This is a DEV-ONLY isolation probe against the local portless API, which
+// serves a self-signed cert. Accept that cert ONLY for loopback / *.localhost
+// targets — never for a real host — so this can't weaken a production
+// connection. The script refuses to run against a non-local API over HTTPS.
+const apiHost = new URL(API).hostname;
+const isLocalHost = apiHost === "127.0.0.1" || apiHost === "localhost" || apiHost.endsWith(".localhost");
+if (API.startsWith("https://") && !isLocalHost) {
+  throw new Error(`refusing to disable TLS verification for non-local host: ${apiHost}`);
+}
+if (isLocalHost) {
+  // codeql[js/disabling-certificate-validation] -- localhost-only dev probe vs self-signed portless cert
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
 
 // --- tiny cookie jar over fetch ------------------------------------------------
 const jar = new Map<string, string>();


### PR DESCRIPTION
## What

New users sign up to an empty account and are blocked behind the install wizard until telemetry arrives — so they can't evaluate the product before doing any work. This adds an optional **demo mode**: a brand-new user whose project has never ingested transparently **reads** a single shared, hidden demo project (curated incidents with root-cause writeups, dashboards, and a live telemetry feed), **read-only**, and is teleported to their own data the instant they ingest.

The entire feature is gated on the **`DEMO_PROJECT_ID`** env var. Unset (the default) is a complete no-op — no extra queries, no behavior change — so self-hosted deployments are unaffected.

## How

- **Server-side overlay** (`apps/api/src/demo.ts`): `requireProjectAccess` now returns an effective read id — `hasIngested ? realProject : DEMO_PROJECT_ID`. The substitution is keyed off the user's own session state, never user input.
- **`demoOverlay()` middleware** on `/api/projects/:projectId/*`:
  - enforces read-only on demo-overlaid resources (dashboards/incidents/alerts/issues) with `403 demo_read_only`. The install/integration write path (keys, automation, integrations) stays open — that's how a user leaves demo mode;
  - rewrites the demo project id back to the user's real id in JSON responses, so the client never sees the demo id and all sub-resource routing resolves to the user's own (re-overlaid) project.
- **Web**: the install wizard stays the default landing; an "Explore with sample data" opt-in renders the populated app with a persistent install nudge. Teleports out the moment real telemetry lands.
- **Worker** (`apps/worker/src/jobs/demo-feed.ts`): a pg-boss cron job keeps the demo project's telemetry flowing (INFO/WARN logs + traces + gauge metrics, no exceptions/ERRORs — so it never mints competing issues). Opts out unless `DEMO_PROJECT_ID` + `DEMO_COLLECTOR_URL` are set.
- **Scripts**: `scripts/demo/provision-demo-project.ts` seeds the curated demo org/project/incidents/dashboards (automation off; the org has zero members so it's unreachable by normal users). `scripts/demo/verify-demo-isolation.ts` is a runnable adversarial check.

## Security

Isolation rests on two orthogonal gates: org-membership authorization (the demo project's org has **zero members**, so it's directly unreachable by any credential) and the server-side read-substitution that scrubs the demo id from responses. All writes use the real `projectId` param, never the substituted id.

Adversarially verified — direct id read/write, key/MCP-token minting, org join/invite/set-active, management API, id-leak hunting, read-only path-trick bypass, and collector header-spoofing all denied.

## Tests

- `apps/api/src/demo.test.ts` — 11 unit tests incl. a route-inventory regression guard (every mutating project route classified block/allow) and UUID-validation fail-safe.
- `apps/worker/src/jobs/demo-feed.test.ts` — asserts the live feed never emits issue-spawning telemetry.
- `scripts/demo/verify-demo-isolation.ts` — 19 live-stack isolation checks.

Typecheck (api/web/worker), unit tests, and the isolation suite all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add demo data mode so brand-new projects transparently read a shared, hidden sample dataset (read-only) until their first ingest. It flips to real data instantly and is a no‑op unless `DEMO_PROJECT_ID` is set.

- **New Features**
  - API: server-side overlay via `demoOverlay()` picks the effective read project id, enforces read-only on demo-overlaid resources, and rewrites the demo id back to the real id; POST-for-read + install/integration writes stay allowed.
  - Web: onboarding adds “Explore with sample data” and a persistent `InstallNudge`; users auto-teleport to real data on first ingest; hardened to clear the opt‑in only after `/api/me` loads.
  - Worker: `demo-feed` pg-boss job streams live traces/logs/metrics (no ERRORs/exceptions) and trims old rows; enabled only with `DEMO_PROJECT_ID` + `DEMO_COLLECTOR_URL`.
  - Scripts: `demo:provision` seeds a curated demo org/project/incidents/dashboards, refuses seeding into an org that has members, and wraps each incident’s inserts in a transaction; `demo:verify-isolation` adversarially checks the demo project is unreachable and limits its dev-only TLS bypass to localhost.
  - Tests: API unit tests cover overlay decisions and write blocking; worker tests ensure the feed never emits issue-spawning telemetry.

- **Migration**
  - Seed the demo project: run `pnpm demo:provision` (use `--reset` to reseed).
  - Configure env vars: set `DEMO_PROJECT_ID` on API and worker; set `DEMO_COLLECTOR_URL` on the worker.
  - Optional: run `pnpm demo:verify-isolation` against your stack.

<sup>Written for commit ba1b14eea830bec3ed8b3522a38310e0b536dfec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

