### PR TITLE
demo: fix demo-feed retention trim (deterministic) + isolation-probe TLS guard

### DIFF
--- a/apps/worker/src/jobs/demo-feed.ts
+++ b/apps/worker/src/jobs/demo-feed.ts
@@ -163,7 +163,12 @@ async function postSignal(
 }
 
 async function trimOldTelemetry(deps: JobDeps, projectId: string): Promise<void> {
-  const cutoff = `now() - INTERVAL ${RETENTION_HOURS} HOUR`;
+  // Compute the cutoff in JS and pass it as a literal. ALTER ... DELETE on a
+  // ReplicatedMergeTree (prod) rejects non-deterministic functions, so we can't
+  // use now() in the predicate — fromUnixTimestamp64Milli of a fixed value is
+  // deterministic. (otel_traces also has a 30d table TTL; otel_logs/metrics have
+  // none, so this trim is what bounds them for the demo project.)
+  const cutoffMs = Date.now() - RETENTION_HOURS * 60 * 60 * 1000;
   const tables: Array<{ table: string; tsCol: string }> = [
     { table: "otel_traces", tsCol: "Timestamp" },
     { table: "otel_logs", tsCol: "Timestamp" },
@@ -171,8 +176,8 @@ async function trimOldTelemetry(deps: JobDeps, projectId: string): Promise<void>
   ];
   for (const { table, tsCol } of tables) {
     await deps.clickhouse.command({
-      query: `ALTER TABLE ${table} DELETE WHERE ResourceAttributes['superlog.project_id'] = {projectId:String} AND ${tsCol} < ${cutoff}`,
-      query_params: { projectId },
+      query: `ALTER TABLE ${table} DELETE WHERE ResourceAttributes['superlog.project_id'] = {projectId:String} AND ${tsCol} < fromUnixTimestamp64Milli({cutoffMs:Int64})`,
+      query_params: { projectId, cutoffMs },
     });
   }
 }

--- a/scripts/demo/verify-demo-isolation.ts
+++ b/scripts/demo/verify-demo-isolation.ts
@@ -26,15 +26,13 @@ const ORIGIN = process.env.WEB_ORIGIN ?? API.replace("://api.", "://");
 const DEMO_PROJECT = process.env.DEMO_PROJECT_ID;
 if (!DEMO_PROJECT) throw new Error("DEMO_PROJECT_ID is required");
 
-// This is a DEV-ONLY isolation probe against the local portless API, which
-// serves a self-signed cert. Accept that cert ONLY for loopback / *.localhost
-// targets — never for a real host — so this can't weaken a production
-// connection. The script refuses to run against a non-local API over HTTPS.
+// The local portless API serves a self-signed cert, so accept it — but ONLY for
+// loopback / *.localhost targets, never for a real host (so this can't weaken a
+// production TLS connection). Against a real host (e.g. api.superlog.sh) we do
+// nothing and let fetch verify the cert normally.
 const apiHost = new URL(API).hostname;
-const isLocalHost = apiHost === "127.0.0.1" || apiHost === "localhost" || apiHost.endsWith(".localhost");
-if (API.startsWith("https://") && !isLocalHost) {
-  throw new Error(`refusing to disable TLS verification for non-local host: ${apiHost}`);
-}
+const isLocalHost =
+  apiHost === "127.0.0.1" || apiHost === "localhost" || apiHost.endsWith(".localhost");
 if (isLocalHost) {
   // codeql[js/disabling-certificate-validation] -- localhost-only dev probe vs self-signed portless cert
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";


### PR DESCRIPTION
Two small follow-ups to demo data mode, both surfaced while running it in prod.

## 1. demo-feed retention trim — deterministic cutoff
`trimOldTelemetry` used `now()` inside `ALTER … DELETE`. On a ReplicatedMergeTree, mutations may only use deterministic functions, so the trim failed every tick:
```
demo-feed retention trim failed: … ALTER DELETE statements must use only deterministic functions. Function 'now' is non-deterministic.
```
The feed itself was unaffected (best-effort, caught), but `otel_logs` / `otel_metrics_*` have **no table TTL** (only `otel_traces` has a 30d TTL), so the demo project's logs/metrics were never pruned. Fix: compute the cutoff in JS and pass `fromUnixTimestamp64Milli({cutoffMs:Int64})` — deterministic, so the mutation is accepted.

## 2. verify-demo-isolation.ts — don't refuse real hosts
The TLS guard threw on any non-local HTTPS host, which blocked running the isolation suite against prod. The self-signed-cert bypass only needs to apply to loopback/`*.localhost`; against a real host (valid cert) just let `fetch` verify normally.

Typecheck + demo-feed unit tests green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make demo-feed retention trimming deterministic and limit the isolation probe’s TLS bypass to localhost so the suite can run against prod safely.

- **Bug Fixes**
  - Retention trim: compute cutoff time in JS and pass it via `fromUnixTimestamp64Milli` to satisfy ClickHouse deterministic mutation rules, ensuring demo `otel_logs` and `otel_metrics_*` are pruned.
  - Isolation probe: only disable TLS verification for loopback/`*.localhost`; allow real hosts to use normal cert checks so tests can run against production.

<sup>Written for commit 48bf72bf7317a83e414d354a93711df66b651fda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

