### PR TITLE
ci: introduce basic PR checks for typecheck, build and tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: install pnpm 
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a73af047cccdad2823daf8ff3c61dcea65a8a58f # v4.0.0
       - name: Setup Node.js 
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b62b6d0ad9b0af0fb3b1e40be53ce9b9 # v4.2.0
         with:
           node-version: 20
           cache: pnpm
@@ -30,11 +30,11 @@ jobs:
       DATABASE_URL: postgres://postgres:postgres@localhost:5434/superlog
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a73af047cccdad2823daf8ff3c61dcea65a8a58f # v4.0.0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b62b6d0ad9b0af0fb3b1e40be53ce9b9 # v4.2.0
         with:
           node-version: 20
           cache: pnpm
@@ -50,4 +50,4 @@ jobs:
       - name: Run Standard Packages Tests
         run: pnpm -r --if-present test
       - name: Run Database Package Tests
-        run: pnpm --filter @superlog/db exec tsx --test src/**/*.test.ts
+        run: pnpm --filter @superlog/db exec tsx --test src/*.test.ts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,23 +1,31 @@
 name: CI
-on: 
+on:
   pull_request:
-    branches: ["main"] 
-jobs: 
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
   verify:
     name: Typecheck & build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: install pnpm 
-        uses: pnpm/action-setup@v4
-      - name: Setup Node.js 
-        uses: actions/setup-node@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: install pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Check CI workflow security
+        run: pnpm test:ci-workflows
       - name: typecheck
         run: pnpm typecheck
       - name: build
@@ -31,11 +39,13 @@ jobs:
       BETTER_AUTH_SECRET: "a-very-long-dummy-signing-secret-for-ci-testing-purposes"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4
       - name: install pnpm 
-        uses: pnpm/action-setup@a73af047cccdad2823daf8ff3c61dcea65a8a58f # v4.0.0
+        uses: pnpm/action-setup@v4
       - name: Setup Node.js 
-        uses: actions/setup-node@1d0ff469b62b6d0ad9b0af0fb3b1e40be53ce9b9 # v4.2.0
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
@@ -30,11 +30,11 @@ jobs:
       DATABASE_URL: postgres://postgres:postgres@localhost:5434/superlog
     steps:
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4
       - name: install pnpm
-        uses: pnpm/action-setup@a73af047cccdad2823daf8ff3c61dcea65a8a58f # v4.0.0
+        uses: pnpm/action-setup@v4
       - name: Setup Node.js
-        uses: actions/setup-node@1d0ff469b62b6d0ad9b0af0fb3b1e40be53ce9b9 # v4.2.0
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,44 @@
+name: CI
+on: 
+  pull_request:
+    branches: ["main"] 
+jobs: 
+  verify:
+    name: Typecheck & build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: install pnpm 
+        uses: pnpm/action-setup@v4
+      - name: Setup Node.js 
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: typecheck
+        run: pnpm typecheck
+      - name: build
+        run: pnpm build
+  tests:
+    name: Run tests
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run Standard Packages Tests
+        run: pnpm -r --if-present test
+      - name: Run Database Package Tests
+        run: pnpm --filter @superlog/db exec tsx --test src/**/*.test.ts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
     name: Run tests
     needs: verify
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5434/superlog
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -38,6 +40,13 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Start Postgres
+        run: |
+          docker compose up -d postgres
+          until docker compose exec -T postgres pg_isready -U postgres; do
+            echo "Waiting for Postgres to be ready..."
+            sleep 1
+          done
       - name: Run Standard Packages Tests
         run: pnpm -r --if-present test
       - name: Run Database Package Tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DATABASE_URL: postgres://postgres:postgres@localhost:5434/superlog
+      BETTER_AUTH_SECRET: "a-very-long-dummy-signing-secret-for-ci-testing-purposes"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,6 @@ jobs:
             sleep 1
           done
       - name: Run Standard Packages Tests
-        run: pnpm -r --if-present test
+        run: pnpm -r --filter '!@superlog/db' --if-present test
       - name: Run Database Package Tests
-        run: pnpm --filter @superlog/db exec tsx --test src/*.test.ts
+        run: pnpm --filter @superlog/db test

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "tsx watch --import ./tracing.ts src/index.ts",
     "start": "tsx --import ./tracing.ts src/index.ts",
-    "test": "tsx --test src/**/*.test.ts",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "test:mcp-clickhouse-ranges": "tsx scripts/test-mcp-clickhouse-ranges.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "tsx watch --import ./tracing.ts src/index.ts",
     "start": "tsx --import ./tracing.ts src/index.ts",
-    "test": "tsx --test \"src/**/*.test.ts\"",
+    "test": "tsx --test src/*.test.ts src/*/*.test.ts",
     "test:mcp-clickhouse-ranges": "tsx scripts/test-mcp-clickhouse-ranges.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/api/src/github.test.ts
+++ b/apps/api/src/github.test.ts
@@ -78,7 +78,7 @@ test("merged agent PR resolves incident, cascades linked issues, and writes time
     resolvedEvents[0]?.summary,
     `Incident resolved because PR #${fixture.prNumber} was merged.`,
   );
-  assert.equal(resolvedEvents[0]?.detail?.reason, "agent_pr_merged");
+  assert.equal(resolvedEvents[0]?.detail?.reasonCode, "agent_pr_merged");
 
   const prMergedEvent = await db.query.agentPrEvents.findFirst({
     where: and(

--- a/apps/api/src/ingest-filters.test.ts
+++ b/apps/api/src/ingest-filters.test.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { strict as assert } from "node:assert";
 import { after, before, test } from "node:test";
 import { closeDb, db, runMigrations, schema } from "@superlog/db";

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "demo:seed:everything": "tsx scripts/demo/seed-everything.ts",
     "demo:provision": "tsx scripts/demo/provision-demo-project.ts",
     "demo:verify-isolation": "tsx scripts/demo/verify-demo-isolation.ts",
+    "test:ci-workflows": "tsx --test scripts/ci-workflow-security.test.ts",
     "lint": "biome check .",
     "format": "biome format --write .",
     "typecheck": "turbo run typecheck"

--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "tsx --test \"src/**/*.test.ts\"",
+    "test": "tsx --test src/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "tsx --test src/**/*.test.ts",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,7 +17,8 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "db:seed": "tsx src/seed.ts",
-    "test:migrations": "tsx --test src/migrations.test.ts"
+    "test:migrations": "tsx --test src/migrations.test.ts",
+    "test": "tsx --test src/*.test.ts"
   },
   "dependencies": {
     "better-auth": "^1.6.11",

--- a/packages/fingerprint/package.json
+++ b/packages/fingerprint/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "tsx --test \"src/**/*.test.ts\"",
+    "test": "tsx --test src/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/fingerprint/package.json
+++ b/packages/fingerprint/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "tsx --test src/**/*.test.ts",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/scripts/ci-workflow-security.test.ts
+++ b/scripts/ci-workflow-security.test.ts
@@ -1,0 +1,32 @@
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const workflow = readFileSync(new URL("../.github/workflows/ci.yaml", import.meta.url), "utf8");
+
+test("CI workflow uses least-privilege repository token permissions", () => {
+  assert.match(workflow, /^permissions:\n {2}contents: read$/m);
+  assert.doesNotMatch(workflow, /^permissions:\s*write-all$/m);
+});
+
+test("CI workflow pins third-party actions to immutable commit SHAs", () => {
+  const actionRefs = [...workflow.matchAll(/^\s*uses:\s*([^@\s]+)@([^\s#]+)/gm)];
+
+  assert.ok(actionRefs.length > 0, "expected workflow to use at least one action");
+
+  for (const [, action, ref] of actionRefs) {
+    assert.match(ref, /^[a-f0-9]{40}$/, `${action} is not pinned to a full commit SHA`);
+  }
+});
+
+test("CI workflow checkout steps do not persist GitHub token credentials", () => {
+  const checkoutBlocks = workflow
+    .split(/\n(?=\s+- name: )/)
+    .filter((block) => block.includes("uses: actions/checkout@"));
+
+  assert.ok(checkoutBlocks.length > 0, "expected workflow to use checkout");
+
+  for (const block of checkoutBlocks) {
+    assert.match(block, /\n\s+persist-credentials:\s*false\b/);
+  }
+});


### PR DESCRIPTION
## What & why

Introduced the repository's first GitHub Actions CI workflow under `.github/workflows/ci.yaml` to automatically validate pull requests. The workflow splits validation into a `verify` job (typecheck & build) and a dependent `tests` job (package & database tests), ensuring that tests only run if the build compiles successfully.

## How to test
1. Open a pull request targeting the `main` branch with this changes to trigger the new CI workflow.
2. Verify that the `verify` and `tests` jobs execute sequentially and complete successfully.
3. To run these validation steps locally, execute:
   ```bash
   pnpm typecheck
   pnpm build
   pnpm -r --if-present test
   pnpm --filter @superlog/db exec tsx --test src/**/*.test.ts

## AI assistance

<!-- If you used generative AI (Claude, Cursor, Copilot, etc.) to draft code, tests, or copy in this PR, disclose it briefly. See CONTRIBUTING.md → "Generative AI policy" for what counts. Skip this section if no AI was used. -->

- [ ] None
- [x] Used AI for: brainstorming an initial GitHub Actions workflow and validating CI design decisions

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / cleanup

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm format` has been run on changed files
- [ ] Added or updated tests where it makes sense
- [x] Branch is up to date with `main`
- [ ] PR title follows the area-prefix style for the area being changed (e.g. `worker: …`, `fix(slack): …`)
- [x] Read [CONTRIBUTING.md](https://github.com/superloglabs/superlog/blob/main/CONTRIBUTING.md) (skim counts)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI workflow for PRs that typechecks, builds, runs tests, and enforces workflow security. Tests wait for a successful build; DB tests run against local Postgres, and auth-dependent tests use a dummy `BETTER_AUTH_SECRET`.

- **New Features**
  - Adds `.github/workflows/ci.yaml` with `verify` (Node 20, install, security checks, typecheck, build) and `tests` (needs `verify`, starts Postgres, sets `BETTER_AUTH_SECRET`, runs `pnpm -r --filter '!@superlog/db' --if-present test`, then `pnpm --filter @superlog/db test`).
  - Hardens CI: least-privilege token (`permissions: contents: read`), `actions/checkout` with `persist-credentials: false`, and all actions (`actions/checkout`, `pnpm/action-setup`, `actions/setup-node`) pinned to immutable commit SHAs. Adds `test:ci-workflows` and `scripts/ci-workflow-security.test.ts` to enforce.

- **Bug Fixes**
  - Standardizes `tsx` test globs: `apps/api` uses `src/*.test.ts src/*/*.test.ts`; `packages/billing`, `packages/fingerprint`, and `@superlog/db` use `src/*.test.ts`.
  - Fixes API tests by importing `dotenv/config`; updates webhook test to assert `detail.reasonCode`.

<sup>Written for commit c324374818b65e73e7f8072306624e121e16ede3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

