### PR TITLE
Service map: infrastructure topology with AI service grouping

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -32,6 +32,7 @@ import { auth } from "./auth.js";
 import { shouldRunMigrationsOnBoot } from "./boot-migrations.js";
 import { mountCloudConnectionsAuthed } from "./cloud-connections.js";
 import { mountDashboards } from "./dashboards.js";
+import { mountTopology } from "./topology.js";
 import {
   demoOverlay,
   demoProjectId,
@@ -314,6 +315,7 @@ mountOrgKeyManagementAuthed(app);
 mountDashboards(app);
 mountCloudConnectionsAuthed(app);
 mountIngestFilters(app);
+mountTopology(app);
 mountAlerts(app, { ch });
 mountWebhooks(app);
 mountFeedbackAuthed(app);

--- a/apps/api/src/topology.ts
+++ b/apps/api/src/topology.ts
@@ -1,0 +1,60 @@
+import { db, schema } from "@superlog/db";
+import { eq } from "drizzle-orm";
+import type { Context, Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { resolveEffectiveReadProjectId } from "./demo.js";
+import { resolveActiveOrgContext } from "./org-context.js";
+
+type Vars = { userId: string; orgId: string | null; demoReadProjectId?: string };
+
+// Serves the project's persisted service map and lets the UI request a (re)build.
+// The actual build+enrich runs in the worker's `build-topologies` job; the API
+// only reads the row and flips `refreshRequestedAt`, so they stay decoupled.
+export function mountTopology(app: Hono<{ Variables: Vars }>) {
+  const requireAccess = async (c: Context<{ Variables: Vars }>, projectId: string) => {
+    const project = await db.query.projects.findFirst({ where: eq(schema.projects.id, projectId) });
+    if (!project) throw new HTTPException(404, { message: "project not found" });
+    const ctx = await resolveActiveOrgContext({
+      userId: c.var.userId,
+      preferredOrgId: c.var.orgId,
+    });
+    if (project.orgId !== ctx.org.id) throw new HTTPException(403, { message: "forbidden" });
+    const readProjectId =
+      c.var.demoReadProjectId ?? (await resolveEffectiveReadProjectId(projectId)).id;
+    return { project, readProjectId };
+  };
+
+  app.get("/api/projects/:projectId/topology", async (c) => {
+    const projectId = c.req.param("projectId");
+    const { readProjectId } = await requireAccess(c, projectId);
+    const row = await db.query.projectTopologies.findFirst({
+      where: eq(schema.projectTopologies.projectId, readProjectId),
+    });
+    if (!row)
+      return c.json({ status: "empty" as const, graph: null, enrichment: null, generatedAt: null });
+    return c.json({
+      status: row.status,
+      graph: row.graph,
+      enrichment: row.enrichment,
+      generatedAt: row.generatedAt,
+      error: row.error,
+    });
+  });
+
+  // Request a (re)build. Idempotent: upserts the row and marks it pending so the
+  // worker job picks it up on its next pass. Uses the real projectId (writes are
+  // blocked in demo mode by the demoReadOnly middleware).
+  app.post("/api/projects/:projectId/topology/generate", async (c) => {
+    const projectId = c.req.param("projectId");
+    await requireAccess(c, projectId);
+    const now = new Date();
+    await db
+      .insert(schema.projectTopologies)
+      .values({ projectId, status: "generating", refreshRequestedAt: now })
+      .onConflictDoUpdate({
+        target: schema.projectTopologies.projectId,
+        set: { status: "generating", refreshRequestedAt: now, updatedAt: now },
+      });
+    return c.json({ status: "generating" as const });
+  });
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
+    "@superlog/topology": "workspace:*",
     "@git-diff-view/file": "^0.1.3",
     "@git-diff-view/react": "^0.1.3",
     "@hugeicons/core-free-icons": "^4.1.4",

--- a/apps/web/src/Overview.tsx
+++ b/apps/web/src/Overview.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from "react-router-dom";
 import { IncidentRow } from "./Issues.tsx";
-import { useIncidents, useMe } from "./api.ts";
+import { useCloudConnections, useIncidents, useMe } from "./api.ts";
 import { SetupTodos } from "./onboarding/SetupTodos.tsx";
+import { ServiceMap } from "./service-map/ServiceMap.tsx";
 
 const ACTIVE_INCIDENT_WINDOW_MS = 24 * 60 * 60 * 1000;
 const ACTIVE_INCIDENT_LIMIT = 5;
@@ -24,8 +25,17 @@ export function Overview() {
     <div className="flex flex-col gap-10">
       <SetupTodos projectId={projectId} />
       <ActiveIncidentsSection projectId={projectId} />
+      <ServiceMapSection projectId={projectId} />
     </div>
   );
+}
+
+// Only surface the map for projects that have connected AWS — it's meaningless
+// (and noise) without an inventory to draw from.
+function ServiceMapSection({ projectId }: { projectId: string }) {
+  const connections = useCloudConnections(projectId);
+  if (!connections.data || connections.data.length === 0) return null;
+  return <ServiceMap projectId={projectId} />;
 }
 
 function ActiveIncidentsSection({ projectId }: { projectId: string }) {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -980,6 +980,39 @@ export function useSetIngestFilters(projectId: string) {
   });
 }
 
+// --- Service map / topology -------------------------------------------------
+
+export type TopologyDoc = {
+  status: "empty" | "idle" | "generating" | "error";
+  graph: import("@superlog/topology").Topology | null;
+  enrichment: import("@superlog/topology").TopologyEnrichment | null;
+  generatedAt: string | null;
+  error?: string | null;
+};
+
+export function useTopology(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  return useQuery({
+    queryKey: ["topology", projectId],
+    enabled: !!projectId,
+    queryFn: () => fetcher<TopologyDoc>(`/api/projects/${projectId}/topology`),
+    // While a build is in flight, poll so the map appears when it lands.
+    refetchInterval: (q) => (q.state.data?.status === "generating" ? 4000 : false),
+  });
+}
+
+export function useGenerateTopology(projectId: string) {
+  const fetcher = useFetcher();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      fetcher<{ status: string }>(`/api/projects/${projectId}/topology/generate`, {
+        method: "POST",
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["topology", projectId] }),
+  });
+}
+
 export type LinearInstallation =
   | { installed: false }
   | {

--- a/apps/web/src/design/service-map/Playground.tsx
+++ b/apps/web/src/design/service-map/Playground.tsx
@@ -1,788 +1,202 @@
-import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
-import { Btn } from "../ui.tsx";
+import { applyEnrichment, groupPath, viewTopology } from "@superlog/topology";
+import type { Density } from "@superlog/topology";
+import { type ReactNode, useMemo, useState } from "react";
+import { TopologyEmptyState } from "../../service-map/EmptyState.tsx";
+import { EdgeLegend, TopologyCanvas } from "../../service-map/TopologyCanvas.tsx";
+import { sampleEnrichment } from "./enrichment.fixtures.ts";
+import { rawTopology } from "./fixtures.ts";
 
 // ---------------------------------------------------------------------------
 // Service Map — /design/service-map
 //
-// A react-flow-flavored canvas for laying out services. Dotted background,
-// draggable nodes, curved edges, services bucketed into groups, and up to
-// three signal badges per service (cost · security · performance).
-//
-// Aesthetic: soft rounded cards with a double-outline halo, sans-serif
-// normal-case type, a hairline header divider, and dashed leader rows that
-// pair a label with a solid / soft pill (echoing the Cloudflare node card).
-// Storybook only — all data is mocked below.
+// Two-level map of Superlog's OWN prod infra. The LLM groups resources into a
+// few logical *services by intent* (Web app · API & backend · Telemetry pipeline
+// · External integrations) — that's the top level. Click a service to explode it
+// into the resources it's made of, with faded stubs to the services it talks to.
+// Data is real (./fixtures.ts); the grouping is the baked AI pass
+// (./enrichment.fixtures.ts).
 // ---------------------------------------------------------------------------
 
-const NODE_W = 248;
-const HEADER_H = 54; // icon + name row, down to the hairline divider
-const BADGE_ROW_H = 42; // compact badge row
-
-type BadgeKind = "cost" | "security" | "performance";
-
-type Badge = { kind: BadgeKind; count: number };
-
-type ServiceStatus = "healthy" | "degraded" | "down";
-
-type ServiceNode = {
-  id: string;
-  name: string;
-  kind: string;
-  status: ServiceStatus;
-  group: string;
-  x: number;
-  y: number;
-  badges: Badge[];
-};
-
-type Group = {
-  id: string;
-  name: string;
-  tone: "accent" | "success" | "warning" | "neutral";
-};
-
-type Edge = { from: string; to: string };
-
-// ---------------------------------------------------------------------------
-// Mock topology
-// ---------------------------------------------------------------------------
-
-const GROUPS: Group[] = [
-  { id: "edge", name: "Edge", tone: "accent" },
-  { id: "core", name: "Core services", tone: "neutral" },
-  { id: "data", name: "Data plane", tone: "success" },
-];
-
-const INITIAL_NODES: ServiceNode[] = [
-  {
-    id: "proxy",
-    name: "intake-proxy",
-    kind: "edge",
-    status: "healthy",
-    group: "edge",
-    x: 40,
-    y: 130,
-    badges: [{ kind: "performance", count: 1 }],
-  },
-  {
-    id: "web",
-    name: "web",
-    kind: "static",
-    status: "healthy",
-    group: "edge",
-    x: 40,
-    y: 300,
-    badges: [],
-  },
-  {
-    id: "api",
-    name: "checkout-api",
-    kind: "service",
-    status: "degraded",
-    group: "core",
-    x: 392,
-    y: 96,
-    badges: [
-      { kind: "security", count: 2 },
-      { kind: "performance", count: 3 },
-    ],
-  },
-  {
-    id: "worker",
-    name: "payments-worker",
-    kind: "worker",
-    status: "down",
-    group: "core",
-    x: 392,
-    y: 300,
-    badges: [
-      { kind: "cost", count: 1 },
-      { kind: "security", count: 1 },
-      { kind: "performance", count: 2 },
-    ],
-  },
-  {
-    id: "auth",
-    name: "auth",
-    kind: "service",
-    status: "healthy",
-    group: "core",
-    x: 392,
-    y: 480,
-    badges: [{ kind: "security", count: 1 }],
-  },
-  {
-    id: "pg",
-    name: "postgres",
-    kind: "database",
-    status: "healthy",
-    group: "data",
-    x: 760,
-    y: 150,
-    badges: [{ kind: "cost", count: 2 }],
-  },
-  {
-    id: "clickhouse",
-    name: "clickhouse",
-    kind: "database",
-    status: "degraded",
-    group: "data",
-    x: 760,
-    y: 332,
-    badges: [
-      { kind: "cost", count: 1 },
-      { kind: "performance", count: 1 },
-    ],
-  },
-];
-
-const EDGES: Edge[] = [
-  { from: "proxy", to: "api" },
-  { from: "web", to: "api" },
-  { from: "worker", to: "auth" },
-  { from: "api", to: "worker" },
-  { from: "api", to: "pg" },
-  { from: "worker", to: "clickhouse" },
-  { from: "worker", to: "pg" },
-];
-
-// ---------------------------------------------------------------------------
-// Badge metadata
-// ---------------------------------------------------------------------------
-
-const BADGE_META: Record<
-  BadgeKind,
-  {
-    label: string;
-    color: string;
-    ink: string; // readable text color when used as a solid fill
-    icon: ReactNode;
-    blurb: (n: number) => string;
-  }
-> = {
-  cost: {
-    label: "Cost anomalies",
-    color: "var(--color-warning)",
-    ink: "#1a1505",
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M12 1v22M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
-      </svg>
-    ),
-    blurb: (n) => `Spend spiked vs. the 7-day baseline in ${n} ${n === 1 ? "area" : "areas"}.`,
-  },
-  security: {
-    label: "Security issues",
-    color: "var(--color-danger)",
-    ink: "#fff",
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-      </svg>
-    ),
-    blurb: (n) => `${n} exposed ${n === 1 ? "surface" : "surfaces"} or unpatched dependency flagged.`,
-  },
-  performance: {
-    label: "Performance",
-    color: "var(--color-accent)",
-    ink: "#fff",
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" />
-      </svg>
-    ),
-    blurb: (n) => `${n} ${n === 1 ? "endpoint" : "endpoints"} above the latency SLO.`,
-  },
-};
-
-const BADGE_ORDER: BadgeKind[] = ["cost", "security", "performance"];
-
-const STATUS_COLOR: Record<ServiceStatus, string> = {
-  healthy: "var(--color-success)",
-  degraded: "var(--color-warning)",
-  down: "var(--color-danger)",
-};
-
-const STATUS_LABEL: Record<ServiceStatus, string> = {
-  healthy: "Healthy",
-  degraded: "Degraded",
-  down: "Down",
-};
-
-const GROUP_TONE: Record<Group["tone"], { border: string; bg: string; label: string }> = {
-  accent: { border: "rgba(72,90,226,0.32)", bg: "rgba(72,90,226,0.05)", label: "var(--color-accent)" },
-  success: { border: "rgba(65,209,149,0.28)", bg: "rgba(65,209,149,0.045)", label: "var(--color-success)" },
-  warning: { border: "rgba(231,177,90,0.28)", bg: "rgba(231,177,90,0.045)", label: "var(--color-warning)" },
-  neutral: { border: "rgba(255,255,255,0.12)", bg: "rgba(255,255,255,0.02)", label: "var(--color-muted)" },
-};
-
-const KIND_ICON: Record<string, ReactNode> = {
-  edge: (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
-      <circle cx="12" cy="12" r="9" />
-      <path d="M3 12h18M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18z" />
-    </svg>
-  ),
-  service: (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
-      <path d="m8 7-5 5 5 5M16 7l5 5-5 5" />
-    </svg>
-  ),
-  worker: (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M12 2v3M12 19v3M5 12H2M22 12h-3M5 5l2 2M17 17l2 2M5 19l2-2M17 7l2-2" />
-      <circle cx="12" cy="12" r="3.5" />
-    </svg>
-  ),
-  database: (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-      <ellipse cx="12" cy="5" rx="8" ry="3" />
-      <path d="M4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3" />
-    </svg>
-  ),
-  static: (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="3" y="4" width="18" height="16" rx="1.5" />
-      <path d="M3 9h18" />
-    </svg>
-  ),
-};
-
-// ---------------------------------------------------------------------------
-// Geometry helpers
-// ---------------------------------------------------------------------------
-
-// Edges anchor at the header row so expanding a node doesn't shift its ports.
-const PORT_Y = 27;
-
-function nodeHeight(node: ServiceNode): number {
-  return HEADER_H + (node.badges.length === 0 ? 36 : BADGE_ROW_H);
-}
-
-// Gap so the line + arrowhead clear each card's outer halo ring (~5px) rather
-// than being painted over by it.
-const PORT_GAP = 9;
-// Minimum horizontal separation before we route side-to-side; below it the
-// nodes are effectively stacked and we route top/bottom instead.
-const LR_THRESHOLD = 24;
-
-// Orthogonal "step" connector with sharp right-angle corners. Picks exit/entry
-// sides from geometry so the arrowhead always points *into* the target card
-// rather than back out of it.
-function edgePath(a: ServiceNode, b: ServiceNode, ha: number, hb: number): string {
-  const G = PORT_GAP;
-  const aRight = a.x + NODE_W;
-
-  if (b.x >= aRight + LR_THRESHOLD) {
-    // Left → right: exit a's right edge, enter b's left edge.
-    const sx = aRight + G;
-    const sy = a.y + PORT_Y;
-    const tx = b.x - G;
-    const ty = b.y + PORT_Y;
-    const midX = sx + (tx - sx) / 2;
-    return `M ${sx} ${sy} L ${midX} ${sy} L ${midX} ${ty} L ${tx} ${ty}`;
-  }
-
-  // Stacked: route vertically between the facing edges.
-  const sx = a.x + NODE_W / 2;
-  const tx = b.x + NODE_W / 2;
-  if (b.y >= a.y) {
-    // b below a: exit a's bottom, enter b's top.
-    const sy = a.y + ha + G;
-    const ty = b.y - G;
-    const midY = sy + (ty - sy) / 2;
-    return `M ${sx} ${sy} L ${sx} ${midY} L ${tx} ${midY} L ${tx} ${ty}`;
-  }
-  // b above a: exit a's top, enter b's bottom.
-  const sy = a.y - G;
-  const ty = b.y + hb + G;
-  const midY = sy + (ty - sy) / 2;
-  return `M ${sx} ${sy} L ${sx} ${midY} L ${tx} ${midY} L ${tx} ${ty}`;
-}
-
-function groupBounds(nodes: ServiceNode[]) {
-  const xs = nodes.map((n) => n.x);
-  const ys = nodes.map((n) => n.y);
-  const minX = Math.min(...xs);
-  const minY = Math.min(...ys);
-  const maxX = Math.max(...xs.map((x) => x + NODE_W));
-  const maxY = Math.max(...nodes.map((n) => n.y + nodeHeight(n)));
-  const padX = 22;
-  const padTop = 60; // room for the group label tab plus a gap above the first card
-  const padBottom = 22;
-  return {
-    x: minX - padX,
-    y: minY - padTop,
-    w: maxX - minX + padX * 2,
-    h: maxY - minY + padTop + padBottom,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Page
-// ---------------------------------------------------------------------------
+type View = "map" | "empty";
 
 export function ServiceMapPlayground() {
-  const [nodes, setNodes] = useState<ServiceNode[]>(INITIAL_NODES);
-  const [selectedId, setSelectedId] = useState<string | null>("api");
-  const [showGroups, setShowGroups] = useState(true);
-  const [showDots, setShowDots] = useState(true);
-  const [pan, setPan] = useState({ x: 0, y: 0 });
-  const [panning, setPanning] = useState(false);
-  const viewport = useRef<HTMLDivElement>(null);
-  const drag = useRef<
-    | { mode: "node"; id: string; startX: number; startY: number; originX: number; originY: number; moved: boolean }
-    | { mode: "pan"; startX: number; startY: number; originX: number; originY: number; moved: boolean }
-    | null
-  >(null);
-
-  const byId = useMemo(() => Object.fromEntries(nodes.map((n) => [n.id, n])), [nodes]);
-  const selected = selectedId ? byId[selectedId] ?? null : null;
-
-  // Drag on a node moves the node.
-  const onNodePointerDown = useCallback((e: React.PointerEvent, node: ServiceNode) => {
-    e.preventDefault();
-    e.stopPropagation();
-    viewport.current?.setPointerCapture?.(e.pointerId);
-    drag.current = {
-      mode: "node",
-      id: node.id,
-      startX: e.clientX,
-      startY: e.clientY,
-      originX: node.x,
-      originY: node.y,
-      moved: false,
-    };
-  }, []);
-
-  // Drag on the empty canvas pans the whole map.
-  const onCanvasPointerDown = useCallback(
-    (e: React.PointerEvent) => {
-      viewport.current?.setPointerCapture?.(e.pointerId);
-      setPanning(true);
-      drag.current = { mode: "pan", startX: e.clientX, startY: e.clientY, originX: pan.x, originY: pan.y, moved: false };
-    },
-    [pan.x, pan.y],
+  const [view, setView] = useState<View>("map");
+  // Deep-linkable: /design/service-map?service=backend opens that service directly.
+  const [focused, setFocused] = useState<string | null>(() =>
+    new URLSearchParams(window.location.search).get("service"),
   );
+  const [density, setDensity] = useState<Density>("comfortable");
+  const [showDots, setShowDots] = useState(true);
 
-  const onPointerMove = useCallback((e: React.PointerEvent) => {
-    const d = drag.current;
-    if (!d) return;
-    const dx = e.clientX - d.startX;
-    const dy = e.clientY - d.startY;
-    if (d.mode === "pan") {
-      if (Math.abs(dx) + Math.abs(dy) >= 3) d.moved = true;
-      setPan({ x: d.originX + dx, y: d.originY + dy });
-      return;
-    }
-    if (!d.moved && Math.abs(dx) + Math.abs(dy) < 3) return;
-    d.moved = true;
-    const nx = Math.max(0, d.originX + dx);
-    const ny = Math.max(0, d.originY + dy);
-    setNodes((prev) => prev.map((n) => (n.id === d.id ? { ...n, x: nx, y: ny } : n)));
-  }, []);
-
-  const onPointerUp = useCallback(() => {
-    const d = drag.current;
-    if (d?.mode === "node" && !d.moved) setSelectedId((cur) => (cur === d.id ? null : d.id));
-    if (d?.mode === "pan") {
-      if (!d.moved) setSelectedId(null);
-      setPanning(false);
-    }
-    drag.current = null;
-  }, []);
-
-  const groupBoxes = useMemo(() => {
-    return GROUPS.map((g) => {
-      const members = nodes.filter((n) => n.group === g.id);
-      if (members.length === 0) return null;
-      return { group: g, bounds: groupBounds(members) };
-    }).filter((b): b is { group: Group; bounds: ReturnType<typeof groupBounds> } => b !== null);
-  }, [nodes]);
-
-  const extent = useMemo(() => {
-    const maxX = Math.max(1040, ...nodes.map((n) => n.x + NODE_W + 80));
-    const maxY = Math.max(680, ...nodes.map((n) => n.y + nodeHeight(n) + 80));
-    return { w: maxX, h: maxY };
-  }, [nodes]);
+  // Services require the AI grouping pass, so we always enrich the raw graph.
+  const enriched = useMemo(() => applyEnrichment(rawTopology, sampleEnrichment), []);
+  const focusedGroup = focused ? enriched.groups.find((g) => g.id === focused) : undefined;
+  const topology = useMemo(() => viewTopology(enriched, focused), [enriched, focused]);
+  const path = useMemo(() => groupPath(enriched, focused), [enriched, focused]);
 
   return (
     <div className="relative min-h-screen bg-bg font-sans text-fg">
       <SubpageNav crumb="Service map" />
-
       <main className="mx-auto max-w-7xl px-6 pb-24 pt-8">
-        <header className="mb-6 flex flex-wrap items-end justify-between gap-4">
+        <header className="mb-5 flex flex-wrap items-end justify-between gap-4">
           <div>
-            <span className="text-[13px] font-medium text-muted">Storybook</span>
+            <span className="text-[13px] font-medium text-muted">Storybook · real data</span>
             <h1 className="mt-1.5 text-[30px] font-semibold tracking-tight text-fg">Service map</h1>
-            <p className="mt-1.5 max-w-xl text-[14px] leading-relaxed text-muted">
-              Drag a service to rearrange, click to expand it. Each service carries up to three
-              signal badges — cost anomalies, security issues, and performance regressions — and
-              lives inside a group.
+            <p className="mt-1.5 max-w-2xl text-[14px] leading-relaxed text-muted">
+              An LLM groups our infrastructure into a few logical services by intent. Click a
+              service to explode it into the resources it's built from.
             </p>
           </div>
-          <div className="flex items-center gap-3">
-            <Legend kind="cost" />
-            <Legend kind="security" />
-            <Legend kind="performance" />
-            <span className="mx-0.5 h-5 w-px bg-border" />
-            <button
-              type="button"
-              onClick={() => setShowGroups((s) => !s)}
-              className={`rounded-lg border px-3 py-1.5 text-[13px] font-medium transition-colors ${
-                showGroups ? "border-border-strong text-fg" : "border-border text-muted hover:text-fg"
-              }`}
-            >
-              Groups
-            </button>
-            <button
-              type="button"
-              onClick={() => setShowDots((s) => !s)}
-              className={`rounded-lg border px-3 py-1.5 text-[13px] font-medium transition-colors ${
-                showDots ? "border-border-strong text-fg" : "border-border text-muted hover:text-fg"
-              }`}
-            >
-              Dots
-            </button>
-          </div>
+          <Segmented
+            value={view}
+            onChange={setView}
+            options={[
+              { value: "map", label: "Map" },
+              { value: "empty", label: "Empty state" },
+            ]}
+          />
         </header>
 
-        <div className="relative h-[680px]">
-          {/* Canvas — fills the full canonical width */}
-          <div
-            ref={viewport}
-            className={`absolute inset-0 overflow-hidden rounded-2xl border border-border ${
-              panning ? "cursor-grabbing" : "cursor-grab"
-            }`}
-            style={{
-              backgroundImage: showDots
-                ? "radial-gradient(var(--dot-color) 1.25px, transparent 1.25px)"
-                : undefined,
-              backgroundSize: "22px 22px",
-              backgroundPosition: `${pan.x - 1}px ${pan.y - 1}px`,
-            }}
-            onPointerDown={onCanvasPointerDown}
-            onPointerMove={onPointerMove}
-            onPointerUp={onPointerUp}
-          >
-            <div
-              className="absolute left-0 top-0"
-              style={{ width: extent.w, height: extent.h, transform: `translate(${pan.x}px, ${pan.y}px)` }}
-            >
-                {/* Group containers */}
-                {showGroups &&
-                  groupBoxes.map(({ group, bounds }) => {
-                    const tone = GROUP_TONE[group.tone];
-                    return (
-                      <div
-                        key={group.id}
-                        className="pointer-events-none absolute rounded-2xl"
-                        style={{
-                          left: bounds.x,
-                          top: bounds.y,
-                          width: bounds.w,
-                          height: bounds.h,
-                          border: `1px dashed ${tone.border}`,
-                          background: tone.bg,
-                        }}
-                      >
-                        <span
-                          className="absolute left-3 top-3 rounded-md border bg-surface px-2 py-0.5 text-[12px] font-medium"
-                          style={{ color: tone.label, borderColor: tone.border }}
-                        >
-                          {group.name}
-                        </span>
-                      </div>
-                    );
-                  })}
-
-                {/* Edges */}
-                <svg className="pointer-events-none absolute inset-0" width={extent.w} height={extent.h}>
-                  <defs>
-                    <marker
-                      id="sm-arrow"
-                      viewBox="0 0 10 10"
-                      refX="8"
-                      refY="5"
-                      markerWidth="6"
-                      markerHeight="6"
-                      orient="auto-start-reverse"
-                    >
-                      <path d="M0 0 L10 5 L0 10 z" fill="var(--color-subtle)" />
-                    </marker>
-                  </defs>
-                  {EDGES.map((e) => {
-                    const a = byId[e.from];
-                    const b = byId[e.to];
-                    if (!a || !b) return null;
-                    const active = selectedId === e.from || selectedId === e.to;
-                    return (
-                      <path
-                        key={`${e.from}-${e.to}`}
-                        d={edgePath(a, b, nodeHeight(a), nodeHeight(b))}
-                        fill="none"
-                        stroke={active ? "var(--color-accent)" : "var(--color-subtle)"}
-                        strokeWidth={active ? 1.75 : 1.25}
-                        strokeOpacity={active ? 0.9 : 0.5}
-                        markerEnd="url(#sm-arrow)"
-                      />
-                    );
-                  })}
-                </svg>
-
-                {/* Nodes */}
-                {nodes.map((node) => (
-                  <ServiceCard
-                    key={node.id}
-                    node={node}
-                    selected={selectedId === node.id}
-                    onPointerDown={(e) => onNodePointerDown(e, node)}
-                  />
-                ))}
+        {view === "empty" ? (
+          <TopologyEmptyState />
+        ) : (
+          <>
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+              <Breadcrumb path={path} onNavigate={setFocused} />
+              <div className="flex items-center gap-2">
+                <Segmented
+                  value={density}
+                  onChange={setDensity}
+                  options={[
+                    { value: "comfortable", label: "Comfortable" },
+                    { value: "compact", label: "Compact" },
+                  ]}
+                />
+                <Toggle on={showDots} onClick={() => setShowDots((v) => !v)} label="Dots" />
+              </div>
             </div>
-          </div>
 
-          {/* Inspector — floats over the canvas */}
-          {selected && (
-            <div className="pointer-events-none absolute inset-y-3 right-3 z-10 w-[340px] max-w-[calc(100%-24px)]">
-              <Inspector node={selected} onClose={() => setSelectedId(null)} />
-            </div>
-          )}
-        </div>
+            {focused ? (
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <p className="text-[13px] text-muted">
+                  {focusedGroup?.intent}
+                  <span className="text-subtle">
+                    {" "}
+                    · dashed cards are neighbouring services — click to hop
+                  </span>
+                </p>
+                <EdgeLegend />
+              </div>
+            ) : (
+              sampleEnrichment.summary && (
+                <div className="mb-3 flex items-start gap-2 rounded-xl border border-border bg-surface-2 px-3.5 py-2.5">
+                  <span className="mt-0.5 text-accent">
+                    <svg viewBox="0 0 24 24" fill="currentColor" className="h-3.5 w-3.5">
+                      <path d="M12 2l1.6 4.8L18 8l-4.4 1.2L12 14l-1.6-4.8L6 8l4.4-1.2L12 2z" />
+                    </svg>
+                  </span>
+                  <span className="text-[12.5px] leading-relaxed text-muted">
+                    {sampleEnrichment.summary}
+                  </span>
+                </div>
+              )
+            )}
+
+            <TopologyCanvas
+              key={focused ?? "overview"}
+              topology={topology}
+              density={density}
+              showGroups={false}
+              showDots={showDots}
+              fitHeight
+              fitWidth
+              lockNodes
+              onNodeOpen={(serviceId) => setFocused(serviceId)}
+            />
+          </>
+        )}
       </main>
     </div>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Service card (node)
-// ---------------------------------------------------------------------------
+// ---- small controls --------------------------------------------------------
 
-function ServiceCard({
-  node,
-  selected,
-  onPointerDown,
-}: {
-  node: ServiceNode;
-  selected: boolean;
-  onPointerDown: (e: React.PointerEvent) => void;
-}) {
+function Breadcrumb({
+  path,
+  onNavigate,
+}: { path: { id: string; label: string }[]; onNavigate: (id: string | null) => void }) {
   return (
-    <div
-      onPointerDown={onPointerDown}
-      className="absolute cursor-grab touch-none select-none rounded-2xl bg-surface-2 transition-shadow active:cursor-grabbing"
-      style={{
-        left: node.x,
-        top: node.y,
-        width: NODE_W,
-        // Double-outline halo: crisp inner border, a bg gap, then a faint ring.
-        boxShadow: selected
-          ? "0 0 0 1px var(--color-accent), 0 0 0 4px var(--color-surface), 0 0 0 5px rgba(72,90,226,0.35), 0 16px 32px -16px rgba(72,90,226,0.5)"
-          : "0 0 0 1px var(--color-border-strong), 0 0 0 4px var(--color-surface), 0 0 0 5px rgba(255,255,255,0.04), 0 10px 24px -16px rgba(0,0,0,0.8)",
-      }}
-    >
-      {/* Header */}
-      <div className="flex items-center gap-2.5 px-4 pt-3.5 pb-3">
-        <span className="h-[18px] w-[18px] shrink-0 text-muted">{KIND_ICON[node.kind] ?? KIND_ICON.service}</span>
-        <span className="truncate text-[15px] font-semibold tracking-tight text-fg">{node.name}</span>
-      </div>
-
-      <div className="h-px bg-border" />
-
-      {node.badges.length === 0 ? (
-        <div className="px-4 py-2.5">
-          <span className="text-[12.5px] text-subtle">No active signals</span>
-        </div>
-      ) : (
-        <div className="flex flex-wrap items-center gap-1.5 px-4 py-2.5">
-          {node.badges.map((b) => (
-            <CompactBadge key={b.kind} badge={b} />
-          ))}
-        </div>
-      )}
+    <div className="flex items-center gap-2 text-[14px]">
+      <button
+        type="button"
+        onClick={() => onNavigate(null)}
+        className={`font-medium transition-colors ${path.length === 0 ? "text-fg" : "text-muted hover:text-fg"}`}
+      >
+        All services
+      </button>
+      {path.map((seg, i) => {
+        const last = i === path.length - 1;
+        return (
+          <span key={seg.id} className="flex items-center gap-2">
+            <span className="text-subtle">/</span>
+            <button
+              type="button"
+              onClick={() => onNavigate(seg.id)}
+              disabled={last}
+              className={`font-medium transition-colors ${last ? "text-fg" : "text-muted hover:text-fg"}`}
+            >
+              {seg.label}
+            </button>
+          </span>
+        );
+      })}
     </div>
   );
 }
 
-// A dashed leader row: label · · · · · · value.
-function LeaderRow({ label, right }: { label: ReactNode; right: ReactNode }) {
+function Segmented<T extends string>({
+  value,
+  onChange,
+  options,
+}: { value: T; onChange: (v: T) => void; options: { value: T; label: string }[] }) {
   return (
-    <div className="flex items-center gap-3">
-      <span className="shrink-0 text-[13.5px] text-fg">{label}</span>
-      <span className="h-px flex-1 self-center border-t border-dashed border-border-strong" />
-      <span className="shrink-0">{right}</span>
-    </div>
-  );
-}
-
-// Solid pill when a signal is present (echoes the black "Enabled" pill),
-// soft gray "Clear" pill otherwise (echoes the muted "Disabled" pill).
-function SignalPill({ kind, count }: { kind: BadgeKind; count: number }) {
-  const meta = BADGE_META[kind];
-  if (count === 0) {
-    return (
-      <span className="inline-flex items-center rounded-full bg-surface-3 px-2.5 py-0.5 text-[12px] font-medium text-subtle">
-        Clear
-      </span>
-    );
-  }
-  return (
-    <span
-      className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[12px] font-semibold tabular-nums"
-      style={{ background: meta.color, color: meta.ink }}
-    >
-      <span className="h-3 w-3">{meta.icon}</span>
-      {count}
-    </span>
-  );
-}
-
-function CompactBadge({ badge }: { badge: Badge }) {
-  const meta = BADGE_META[badge.kind];
-  return (
-    <span
-      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[12px] font-medium tabular-nums"
-      style={{ color: meta.color, background: `color-mix(in srgb, ${meta.color} 16%, transparent)` }}
-      title={`${meta.label}: ${badge.count}`}
-    >
-      <span className="h-3 w-3">{meta.icon}</span>
-      {badge.count}
-    </span>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Inspector panel
-// ---------------------------------------------------------------------------
-
-function Inspector({ node, onClose }: { node: ServiceNode | null; onClose: () => void }) {
-  if (!node) return null;
-  const group = GROUPS.find((g) => g.id === node.group);
-  const totalSignals = node.badges.reduce((sum, b) => sum + b.count, 0);
-
-  return (
-    <div className="pointer-events-auto flex h-full flex-col overflow-hidden rounded-2xl border border-border-strong bg-surface shadow-[0_24px_60px_-20px_rgba(0,0,0,0.75)]">
-      <div className="flex items-center gap-2.5 px-5 py-4">
-        <span className="h-[18px] w-[18px] shrink-0 text-muted">{KIND_ICON[node.kind] ?? KIND_ICON.service}</span>
-        <div className="min-w-0">
-          <div className="truncate text-[15px] font-semibold tracking-tight text-fg">{node.name}</div>
-          <div className="text-[12.5px] text-subtle">{node.kind}</div>
-        </div>
-        <span
-          className="ml-auto inline-flex items-center gap-1.5 rounded-full bg-surface-2 px-2.5 py-1 text-[12.5px] font-medium"
-          style={{ color: STATUS_COLOR[node.status] }}
-        >
-          <span className="h-2 w-2 rounded-full" style={{ background: STATUS_COLOR[node.status] }} />
-          {STATUS_LABEL[node.status]}
-        </span>
+    <div className="inline-flex rounded-lg border border-border p-0.5">
+      {options.map((o) => (
         <button
+          key={o.value}
           type="button"
-          onClick={onClose}
-          aria-label="Close"
-          className="grid h-7 w-7 shrink-0 place-items-center rounded-lg text-subtle transition-colors hover:bg-surface-2 hover:text-fg"
+          onClick={() => onChange(o.value)}
+          className={`rounded-md px-2.5 py-1 text-[12.5px] font-medium transition-colors ${value === o.value ? "bg-surface-3 text-fg" : "text-muted hover:text-fg"}`}
         >
-          <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-            <path d="M6 6 18 18M18 6 6 18" />
-          </svg>
+          {o.label}
         </button>
-      </div>
-
-      <div className="h-px bg-border" />
-
-      <div className="flex-1 space-y-5 overflow-y-auto px-5 py-4">
-        <LeaderRow
-          label={<span className="text-[13.5px] text-muted">Group</span>}
-          right={
-            group ? (
-              <span
-                className="rounded-md border px-2 py-0.5 text-[12.5px] font-medium"
-                style={{ color: GROUP_TONE[group.tone].label, background: GROUP_TONE[group.tone].bg, borderColor: GROUP_TONE[group.tone].border }}
-              >
-                {group.name}
-              </span>
-            ) : null
-          }
-        />
-
-        <div>
-          <div className="mb-2.5 flex items-baseline justify-between">
-            <span className="text-[13px] font-medium text-muted">Signals</span>
-            <span className="text-[12.5px] tabular-nums text-subtle">{totalSignals} open</span>
-          </div>
-          <div className="space-y-2">
-            {BADGE_ORDER.map((kind) => {
-              const meta = BADGE_META[kind];
-              const count = node.badges.find((b) => b.kind === kind)?.count ?? 0;
-              const present = count > 0;
-              return (
-                <div
-                  key={kind}
-                  className="flex items-start gap-3 rounded-xl border border-border bg-surface-2 p-3"
-                  style={{ opacity: present ? 1 : 0.6 }}
-                >
-                  <span
-                    className="mt-0.5 grid h-7 w-7 shrink-0 place-items-center rounded-lg"
-                    style={{ color: meta.color, background: `color-mix(in srgb, ${meta.color} 16%, transparent)` }}
-                  >
-                    <span className="h-4 w-4">{meta.icon}</span>
-                  </span>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="text-[13.5px] font-medium text-fg">{meta.label}</span>
-                      <span className="ml-auto shrink-0">
-                        <SignalPill kind={kind} count={count} />
-                      </span>
-                    </div>
-                    <p className="mt-1 text-[12.5px] leading-relaxed text-muted">
-                      {present ? meta.blurb(count) : "No findings in this category."}
-                    </p>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      </div>
-
-      <div className="h-px bg-border" />
-      <div className="flex gap-2 px-5 py-4">
-        <Btn size="sm" variant="primary">
-          Open service
-        </Btn>
-        <Btn size="sm" variant="ghost">
-          Add badge
-        </Btn>
-      </div>
+      ))}
     </div>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Legend
-// ---------------------------------------------------------------------------
-
-function Legend({ kind }: { kind: BadgeKind }) {
-  const meta = BADGE_META[kind];
+function Toggle({ on, onClick, label }: { on: boolean; onClick: () => void; label: string }) {
   return (
-    <span className="inline-flex items-center gap-1.5 text-[13px] text-muted">
-      <span className="h-3.5 w-3.5" style={{ color: meta.color }}>
-        {meta.icon}
-      </span>
-      {meta.label}
-    </span>
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-lg border px-3 py-1.5 text-[13px] font-medium transition-colors ${on ? "border-border-strong text-fg" : "border-border text-muted hover:text-fg"}`}
+    >
+      {label}
+    </button>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Subpage nav (mirrors the shared /design chrome)
-// ---------------------------------------------------------------------------
-
-function SubpageNav({ crumb }: { crumb: string }) {
+function SubpageNav({ crumb }: { crumb: string }): ReactNode {
   return (
     <header className="relative z-10">
       <div className="px-6">
         <nav className="flex items-center justify-start gap-3 py-5">
-          <a href="/design" className="text-[14px] font-medium text-muted transition-opacity hover:text-fg">
+          <a
+            href="/design"
+            className="text-[14px] font-medium text-muted transition-opacity hover:text-fg"
+          >
             ← Design
           </a>
           <span className="text-[14px] text-subtle">/</span>

--- a/apps/web/src/design/service-map/enrichment.fixtures.ts
+++ b/apps/web/src/design/service-map/enrichment.fixtures.ts
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------
+// Hand-authored "as-if-from-the-LLM" enrichment of the real snapshot.
+//
+// The model's job: identify a handful of logical *services by intent* (not infra
+// tiers), assign every resource to one, clean names, and infer the links
+// telemetry didn't capture. This is the TARGET output the production Anthropic
+// pass must produce. Each group here becomes a top-level service node that
+// explodes into its member resources on click (see services.ts). Every entry is
+// a reviewable suggestion — applyEnrichment flags them for accept/reject.
+// ---------------------------------------------------------------------------
+
+import type { TopologyEnrichment } from "@superlog/topology";
+
+export const sampleEnrichment: TopologyEnrichment = {
+  summary:
+    "Identified 3 services by intent — Web app, API & backend, Telemetry pipeline — and inferred the datastore links the API & workers don't emit spans for.",
+  groups: [
+    {
+      id: "web",
+      label: "Web app",
+      tone: "accent",
+      intent: "Customer-facing dashboard, delivered via CDN",
+    },
+    {
+      id: "backend",
+      label: "API & backend",
+      tone: "neutral",
+      intent: "Serves the API, runs investigations, owns the app database",
+    },
+    {
+      id: "telemetry",
+      label: "Telemetry pipeline",
+      tone: "warning",
+      intent: "Ingests, processes & stores observability data",
+    },
+  ],
+  nodePatches: [
+    // Web app
+    { id: "web", label: "Web frontend", group: "web" },
+    // API & backend
+    { id: "alb", label: "Load balancer", group: "backend" },
+    { id: "ecs:api", label: "API", group: "backend" },
+    { id: "ecs:admin-api", label: "Admin API", group: "backend" },
+    { id: "ecs:worker", label: "Investigation worker", group: "backend" },
+    { id: "rds:postgres", label: "Postgres", group: "backend" },
+    // Telemetry pipeline
+    { id: "ecs:proxy", label: "Ingest proxy", group: "telemetry" },
+    { id: "sqs:ingest", label: "Ingest queue", group: "telemetry" },
+    { id: "ecs:ingest-consumer", label: "Ingest consumer", group: "telemetry" },
+    { id: "ecs:collector", label: "OTel collector", group: "telemetry" },
+    { id: "clickhouse", label: "ClickHouse", group: "telemetry" },
+  ],
+  // Links the deterministic graph is missing (no client-span instrumentation),
+  // but which obviously exist — the model proposes them for review.
+  suggestedEdges: [
+    { from: "ecs:api", to: "rds:postgres", kind: "reads", label: "inferred" },
+    { from: "ecs:api", to: "clickhouse", kind: "reads", label: "inferred" },
+    { from: "ecs:worker", to: "clickhouse", kind: "reads", label: "inferred" },
+    { from: "ecs:admin-api", to: "rds:postgres", kind: "reads", label: "inferred" },
+  ],
+};

--- a/apps/web/src/design/service-map/fixtures.ts
+++ b/apps/web/src/design/service-map/fixtures.ts
@@ -1,0 +1,157 @@
+// ---------------------------------------------------------------------------
+// Real-data fixtures
+//
+// A snapshot of Superlog's OWN prod infrastructure (AWS account us-west-2) plus
+// the cross-service call graph observed in our OWN dogfood telemetry. Captured
+// read-only via `aws` describe calls + ClickHouse SELECTs so the storybook shows
+// a real, recognizable map rather than invented boxes. The same provider →
+// merge → layout path runs here as it will in the worker, so iterating on these
+// fixtures is iterating on the production data contract.
+//
+// Deterministic edges below = solid facts (load-balancer wiring, queue plumbing,
+// and *observed* client spans). Edges the data did NOT surface — e.g. api↔Postgres
+// (the API's PG client spans aren't instrumented) — are intentionally LEFT OUT so
+// the LLM enrichment pass (enrichment.fixtures.ts) can demonstrate "create links."
+// ---------------------------------------------------------------------------
+
+import {
+  type AwsInfraSnapshot,
+  type ServiceGraph,
+  awsInfraProvider,
+  mergeTopologies,
+  telemetryProvider,
+} from "@superlog/topology";
+
+// Internal collector NLB host as it appears in client spans (server.address).
+const COLLECTOR_HOST = "superlog-prod-collector-28757fa87820e028.elb.us-west-2.amazonaws.com";
+
+export const awsSnapshot: AwsInfraSnapshot = {
+  resources: [
+    {
+      id: "alb",
+      kind: "edge",
+      label: "superlog-prod-app",
+      sublabel: "ALB · internet-facing",
+      service: "elb",
+    },
+    {
+      id: "ecs:api",
+      kind: "compute",
+      label: "superlog-api",
+      sublabel: "ECS Fargate · :4100",
+      service: "ecs",
+    },
+    {
+      id: "ecs:proxy",
+      kind: "compute",
+      label: "superlog-proxy",
+      sublabel: "ECS Fargate · :4000",
+      service: "ecs",
+    },
+    {
+      id: "ecs:admin-api",
+      kind: "compute",
+      label: "superlog-admin-api",
+      sublabel: "ECS Fargate · :4200",
+      service: "ecs",
+    },
+    {
+      id: "ecs:worker",
+      kind: "compute",
+      label: "superlog-worker",
+      sublabel: "ECS Fargate",
+      service: "ecs",
+    },
+    {
+      id: "ecs:ingest-consumer",
+      kind: "compute",
+      label: "superlog-ingest-consumer",
+      sublabel: "ECS Fargate",
+      service: "ecs",
+    },
+    {
+      id: "ecs:collector",
+      kind: "compute",
+      label: "superlog-collector",
+      sublabel: "ECS Fargate · otelcol",
+      service: "ecs",
+    },
+    {
+      id: "web",
+      kind: "edge",
+      label: "@superlog/web",
+      sublabel: "S3 + CloudFront",
+      service: "cloudfront",
+    },
+    {
+      id: "sqs:ingest",
+      kind: "queue",
+      label: "superlog-prod-app-ingest",
+      sublabel: "SQS (+ DLQ)",
+      service: "sqs",
+    },
+    {
+      id: "rds:postgres",
+      kind: "database",
+      label: "superlog-prod-postgres",
+      sublabel: "RDS · db.m6g.large · Multi-AZ",
+      service: "rds",
+    },
+    {
+      id: "clickhouse",
+      kind: "database",
+      label: "superlog-prod-clickhouse-ha",
+      sublabel: "EC2 · 3 replicas + 3 keeper",
+      service: "ec2",
+    },
+  ],
+  // Solid, inferable wiring (load balancer targets + queue plumbing + collector write path).
+  relationships: [
+    { from: "alb", to: "ecs:api", kind: "routes", label: ":4100" },
+    { from: "alb", to: "ecs:proxy", kind: "routes", label: ":4000" },
+    { from: "alb", to: "ecs:admin-api", kind: "routes", label: ":4200" },
+    { from: "ecs:proxy", to: "sqs:ingest", kind: "enqueues" },
+    { from: "sqs:ingest", to: "ecs:ingest-consumer", kind: "consumes" },
+    { from: "ecs:ingest-consumer", to: "ecs:collector", kind: "writes", label: "forwards OTLP" },
+    { from: "ecs:collector", to: "clickhouse", kind: "writes" },
+  ],
+};
+
+// Observed in our own traces (last 6h, dogfood project). Counts are real.
+export const serviceGraph: ServiceGraph = {
+  services: [
+    { name: "superlog-proxy", spans: 992721 },
+    { name: "superlog-ingest-consumer", spans: 343770 },
+    { name: "superlog-worker", spans: 131869 },
+    { name: "superlog-api", spans: 47427 },
+    { name: "@superlog/web", spans: 3895 },
+  ],
+  edges: [{ from: "@superlog/web", to: "superlog-api", calls: 1373 }],
+  // Only deps that resolve to an internal node we model (collector NLB, Postgres).
+  // The third-party SaaS deps (Anthropic/GitHub/Slack/…) are intentionally omitted —
+  // external integrations aren't part of the system map.
+  externalDeps: [
+    { from: "superlog-ingest-consumer", target: COLLECTOR_HOST, peerKind: "http", calls: 219511 },
+    { from: "superlog-worker", target: "postgresql", peerKind: "db", calls: 13583 },
+    { from: "superlog-worker", target: COLLECTOR_HOST, peerKind: "http", calls: 120 },
+    { from: "superlog-proxy", target: COLLECTOR_HOST, peerKind: "http", calls: 12 },
+  ],
+};
+
+// Reconcile telemetry-native ids (svc:/ext:) onto the canonical AWS resource ids
+// so a service and its ECS task collapse into one node.
+export const aliases: Record<string, string> = {
+  "svc:superlog-api": "ecs:api",
+  "svc:superlog-proxy": "ecs:proxy",
+  "svc:superlog-worker": "ecs:worker",
+  "svc:superlog-ingest-consumer": "ecs:ingest-consumer",
+  "svc:@superlog/web": "web",
+  "ext:postgresql": "rds:postgres",
+  [`ext:${COLLECTOR_HOST}`]: "ecs:collector",
+};
+
+/** The deterministic, trustworthy unified topology — before any LLM refinement. */
+export const rawTopology = mergeTopologies(
+  [awsInfraProvider(awsSnapshot), telemetryProvider(serviceGraph)],
+  aliases,
+);

--- a/apps/web/src/service-map/EmptyState.tsx
+++ b/apps/web/src/service-map/EmptyState.tsx
@@ -1,0 +1,121 @@
+import type { ReactNode } from "react";
+import { Btn } from "../design/ui.tsx";
+
+// ---------------------------------------------------------------------------
+// TopologyEmptyState
+//
+// Shown on the main page when a project has telemetry but no map has been built
+// yet (OnboardingGate already blocks the truly-empty, pre-ingest case). A faint
+// "ghost" topology sits behind the call-to-action so the canvas reads as a map
+// the moment data lands, rather than a blank rectangle.
+// ---------------------------------------------------------------------------
+
+export function TopologyEmptyState({
+  onConnectAws,
+  onBuildFromTelemetry,
+  height = 680,
+}: {
+  onConnectAws?: () => void;
+  onBuildFromTelemetry?: () => void;
+  height?: number | string;
+}) {
+  return (
+    <div
+      className="relative w-full overflow-hidden rounded-2xl border border-border"
+      style={{ height }}
+    >
+      {/* dotted canvas backdrop */}
+      <div
+        className="absolute inset-0"
+        style={{
+          backgroundImage: "radial-gradient(var(--dot-color) 1.25px, transparent 1.25px)",
+          backgroundSize: "22px 22px",
+        }}
+      />
+      {/* ghost map */}
+      <GhostMap />
+      {/* fade + centered CTA */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(120% 80% at 50% 45%, color-mix(in srgb, var(--color-bg) 78%, transparent), color-mix(in srgb, var(--color-bg) 30%, transparent))",
+        }}
+      />
+      <div className="absolute inset-0 grid place-items-center px-6">
+        <div className="max-w-md text-center">
+          <div className="mx-auto mb-4 grid h-12 w-12 place-items-center rounded-2xl border border-border-strong bg-surface text-muted">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              className="h-6 w-6"
+            >
+              <circle cx="5" cy="6" r="2.5" />
+              <circle cx="19" cy="6" r="2.5" />
+              <circle cx="12" cy="18" r="2.5" />
+              <path d="M7 7.5 10.5 16M17 7.5 13.5 16M7.5 6h9" />
+            </svg>
+          </div>
+          <h2 className="text-[20px] font-semibold tracking-tight text-fg">Map your system</h2>
+          <p className="mx-auto mt-2 max-w-sm text-[13.5px] leading-relaxed text-muted">
+            Build a live map of your services and infrastructure — drawn from the telemetry you
+            already send, then enriched with the resources behind it. An assistant proposes the
+            groupings and links; you adjust anything.
+          </p>
+          <div className="mt-5 flex items-center justify-center gap-2.5">
+            <Btn size="md" variant="primary" onClick={onBuildFromTelemetry}>
+              Build from telemetry
+            </Btn>
+            <Btn size="md" variant="secondary" onClick={onConnectAws}>
+              Connect AWS
+            </Btn>
+          </div>
+          <p className="mt-3 text-[12px] text-subtle">
+            Takes a few seconds · you can edit or regenerate any time
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// A faint, non-interactive sample graph so the empty canvas still reads as a map.
+function GhostMap() {
+  const ghostNode = (x: number, y: number, w = 120): ReactNode => (
+    <rect
+      x={x}
+      y={y}
+      width={w}
+      height={44}
+      rx={12}
+      fill="var(--color-surface-2)"
+      stroke="var(--color-border)"
+      strokeWidth={1}
+    />
+  );
+  return (
+    <svg
+      className="absolute inset-0 h-full w-full opacity-50"
+      viewBox="0 0 900 560"
+      preserveAspectRatio="xMidYMid slice"
+    >
+      {/* edges */}
+      <g stroke="var(--color-subtle)" strokeWidth={1.25} strokeOpacity={0.5} fill="none">
+        <path d="M170 130 L320 130 L320 110 L470 110" />
+        <path d="M170 230 L320 230 L320 250 L470 250" />
+        <path d="M590 110 L740 130" />
+        <path d="M590 250 L740 250" />
+        <path d="M530 170 L530 250" />
+      </g>
+      {/* nodes */}
+      {ghostNode(60, 108)}
+      {ghostNode(60, 208)}
+      {ghostNode(470, 88)}
+      {ghostNode(470, 228)}
+      {ghostNode(740, 108)}
+      {ghostNode(740, 228)}
+    </svg>
+  );
+}

--- a/apps/web/src/service-map/ServiceMap.tsx
+++ b/apps/web/src/service-map/ServiceMap.tsx
@@ -1,0 +1,223 @@
+import {
+  type Topology,
+  type TopologyEnrichment,
+  applyEnrichment,
+  groupPath,
+  viewTopology,
+} from "@superlog/topology";
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { type TopologyDoc, useGenerateTopology, useTopology } from "../api.ts";
+import { TopologyEmptyState } from "./EmptyState.tsx";
+import { EdgeLegend, TopologyCanvas } from "./TopologyCanvas.tsx";
+
+// Production service map on the Overview page. Reads the persisted topology, applies
+// the LLM grouping, and shows the two-level drill (services → resources). The build
+// itself runs in the worker; here we just render + request (re)builds.
+export function ServiceMap({ projectId }: { projectId: string }) {
+  const { data, isLoading } = useTopology(projectId);
+  const generate = useGenerateTopology(projectId);
+  const navigate = useNavigate();
+  const [focused, setFocused] = useState<string | null>(null);
+
+  const graph = data?.graph ?? null;
+  const enrichment = (data?.enrichment ?? null) as TopologyEnrichment | null;
+
+  // Apply the AI grouping (if any), then collapse to services. Degrades to the flat
+  // resource graph when the enrichment pass hasn't run.
+  const enriched = useMemo<Topology | null>(
+    () => (graph ? (enrichment ? applyEnrichment(graph, enrichment) : graph) : null),
+    [graph, enrichment],
+  );
+  const hasServices = (enriched?.groups.length ?? 0) > 0;
+  const focusedGroup =
+    focused && enriched ? enriched.groups.find((g) => g.id === focused) : undefined;
+  // One call renders any level of the hierarchy (root, a parent service, a leaf).
+  const shown = useMemo(
+    () => (enriched ? viewTopology(enriched, focused) : null),
+    [enriched, focused],
+  );
+  const path = useMemo(() => (enriched ? groupPath(enriched, focused) : []), [enriched, focused]);
+
+  const empty = !graph || enriched?.nodes.length === 0;
+
+  return (
+    <section>
+      <Header
+        generatedAt={data?.generatedAt ?? null}
+        status={data?.status}
+        generating={generate.isPending || data?.status === "generating"}
+        onRegenerate={() => generate.mutate()}
+        showRegenerate={!empty}
+      />
+
+      {isLoading ? (
+        <Skeleton />
+      ) : empty ? (
+        <TopologyEmptyState
+          height={420}
+          onBuildFromTelemetry={() => generate.mutate()}
+          onConnectAws={() => navigate("/settings?scope=project&section=integrations")}
+        />
+      ) : (
+        <>
+          {hasServices && (
+            <MapNav
+              path={path}
+              intent={focusedGroup?.intent}
+              showLegend={!!focused}
+              onNavigate={setFocused}
+            />
+          )}
+          {shown && (
+            <TopologyCanvas
+              key={focused ?? "overview"}
+              topology={shown}
+              showGroups={false}
+              showDots
+              fitHeight
+              fitWidth
+              lockNodes
+              onNodeOpen={(serviceId) => setFocused(serviceId)}
+              frame={
+                focused && focusedGroup
+                  ? {
+                      label: focusedGroup.label,
+                      tone: focusedGroup.tone,
+                      aiProposed: focusedGroup.aiProposed,
+                    }
+                  : undefined
+              }
+            />
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+function Header({
+  generatedAt,
+  status,
+  generating,
+  onRegenerate,
+  showRegenerate,
+}: {
+  generatedAt: string | null;
+  status?: TopologyDoc["status"];
+  generating: boolean;
+  onRegenerate: () => void;
+  showRegenerate: boolean;
+}) {
+  return (
+    <div className="mb-4 flex items-end justify-between gap-4">
+      <div>
+        <h2 className="text-[18px] font-semibold tracking-tight text-fg">Service map</h2>
+        <p className="mt-0.5 text-[12.5px] text-muted">
+          {generating
+            ? "Building from your infrastructure & telemetry…"
+            : status === "error"
+              ? "Last build failed — try again."
+              : generatedAt
+                ? `Updated ${timeAgo(generatedAt)}`
+                : "Your services, grouped by what they do."}
+        </p>
+      </div>
+      {showRegenerate && (
+        <button
+          type="button"
+          onClick={onRegenerate}
+          disabled={generating}
+          className="shrink-0 rounded-lg border border-border px-3 py-1.5 text-[13px] font-medium text-muted transition-colors hover:text-fg disabled:opacity-50"
+        >
+          {generating ? "Building…" : "Regenerate"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// Navigation layer above the map: back control + breadcrumb path + the current
+// level's intent, with the edge legend on the right.
+function MapNav({
+  path,
+  intent,
+  showLegend,
+  onNavigate,
+}: {
+  path: { id: string; label: string }[];
+  intent?: string;
+  showLegend: boolean;
+  onNavigate: (id: string | null) => void;
+}) {
+  const parent = path.length >= 2 ? path[path.length - 2]!.id : null;
+  const canGoBack = path.length > 0;
+  return (
+    <div className="mb-3 rounded-xl border border-border bg-surface px-3 py-2.5">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <button
+            type="button"
+            onClick={() => onNavigate(parent)}
+            disabled={!canGoBack}
+            aria-label="Back"
+            className="grid h-6 w-6 shrink-0 place-items-center rounded-md border border-border text-muted transition-colors enabled:hover:text-fg disabled:opacity-40"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              className="h-3.5 w-3.5"
+            >
+              <path d="m15 6-6 6 6 6" />
+            </svg>
+          </button>
+          <nav className="flex min-w-0 items-center gap-2 text-[13.5px]">
+            <button
+              type="button"
+              onClick={() => onNavigate(null)}
+              className={`font-medium transition-colors ${path.length === 0 ? "text-fg" : "text-muted hover:text-fg"}`}
+            >
+              All groups
+            </button>
+            {path.map((seg, i) => {
+              const last = i === path.length - 1;
+              return (
+                <span key={seg.id} className="flex min-w-0 items-center gap-2">
+                  <span className="text-subtle">/</span>
+                  <button
+                    type="button"
+                    onClick={() => onNavigate(seg.id)}
+                    disabled={last}
+                    className={`truncate font-medium transition-colors ${last ? "text-fg" : "text-muted hover:text-fg"}`}
+                  >
+                    {seg.label}
+                  </button>
+                </span>
+              );
+            })}
+          </nav>
+        </div>
+        {showLegend && <EdgeLegend />}
+      </div>
+      {intent && <p className="mt-1.5 pl-[34px] text-[12.5px] text-muted">{intent}</p>}
+    </div>
+  );
+}
+
+function Skeleton() {
+  return (
+    <div className="h-[420px] w-full animate-pulse rounded-2xl border border-border bg-surface-2" />
+  );
+}
+
+function timeAgo(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const m = Math.round(ms / 60000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.round(h / 24)}d ago`;
+}

--- a/apps/web/src/service-map/ServiceMap.tsx
+++ b/apps/web/src/service-map/ServiceMap.tsx
@@ -5,7 +5,7 @@ import {
   groupPath,
   viewTopology,
 } from "@superlog/topology";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { type TopologyDoc, useGenerateTopology, useTopology } from "../api.ts";
 import { TopologyEmptyState } from "./EmptyState.tsx";
@@ -30,14 +30,18 @@ export function ServiceMap({ projectId }: { projectId: string }) {
     [graph, enrichment],
   );
   const hasServices = (enriched?.groups.length ?? 0) > 0;
+  // A rebuild can change group ids; a `focused` id that no longer exists would
+  // render an empty map. Treat a stale focus as the root, and reset the state so
+  // the breadcrumb/back control don't carry it forward.
   const focusedGroup =
     focused && enriched ? enriched.groups.find((g) => g.id === focused) : undefined;
+  const focus = focused && focusedGroup ? focused : null;
+  useEffect(() => {
+    if (focused && enriched && !focusedGroup) setFocused(null);
+  }, [focused, enriched, focusedGroup]);
   // One call renders any level of the hierarchy (root, a parent service, a leaf).
-  const shown = useMemo(
-    () => (enriched ? viewTopology(enriched, focused) : null),
-    [enriched, focused],
-  );
-  const path = useMemo(() => (enriched ? groupPath(enriched, focused) : []), [enriched, focused]);
+  const shown = useMemo(() => (enriched ? viewTopology(enriched, focus) : null), [enriched, focus]);
+  const path = useMemo(() => (enriched ? groupPath(enriched, focus) : []), [enriched, focus]);
 
   const empty = !graph || enriched?.nodes.length === 0;
 
@@ -65,13 +69,13 @@ export function ServiceMap({ projectId }: { projectId: string }) {
             <MapNav
               path={path}
               intent={focusedGroup?.intent}
-              showLegend={!!focused}
+              showLegend={!!focus}
               onNavigate={setFocused}
             />
           )}
           {shown && (
             <TopologyCanvas
-              key={focused ?? "overview"}
+              key={focus ?? "overview"}
               topology={shown}
               showGroups={false}
               showDots
@@ -80,7 +84,7 @@ export function ServiceMap({ projectId }: { projectId: string }) {
               lockNodes
               onNodeOpen={(serviceId) => setFocused(serviceId)}
               frame={
-                focused && focusedGroup
+                focus && focusedGroup
                   ? {
                       label: focusedGroup.label,
                       tone: focusedGroup.tone,

--- a/apps/web/src/service-map/TopologyCanvas.tsx
+++ b/apps/web/src/service-map/TopologyCanvas.tsx
@@ -1,0 +1,1257 @@
+import { type Density, NODE_W, layoutTopology, nodeCardHeight } from "@superlog/topology";
+import type {
+  EdgeSource,
+  NodeKind,
+  Signal,
+  SignalKind,
+  Topology,
+  TopologyEdge,
+  TopologyGroup,
+  TopologyNode,
+} from "@superlog/topology";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Btn } from "../design/ui.tsx";
+
+// ---------------------------------------------------------------------------
+// TopologyCanvas — a data-driven renderer for the generic `Topology` model.
+//
+// Knows nothing about AWS/telemetry. It takes a Topology, auto-lays it out
+// (overridable by dragging), and draws nodes, grouped containers, and edges
+// styled by provenance: telemetry = solid (observed), infra = hairline
+// (inferred), suggested = dashed + AI-marked (review me), manual = dashed.
+// Pan + drag + an inspector are carried over from the original storyboard.
+// ---------------------------------------------------------------------------
+
+const HEADER_H = 56;
+const BADGE_ROW_H = 40;
+const PORT_Y = 28;
+const PORT_GAP = 9;
+const LR_THRESHOLD = 24;
+
+// Focus-frame geometry: padding inside the boundary, room for its label tab, and
+// the horizontal gap that pushes neighbour stubs clear of the frame.
+const FRAME_PAD = 26;
+const FRAME_LABEL_H = 16;
+const STUB_GAP = 72;
+
+type XY = { x: number; y: number };
+
+function nodeHeight(node: TopologyNode): number {
+  // Service + boundary cards are sized by the shared layout helper (member list /
+  // stub), so renderer geometry and layout stacking never drift apart.
+  if (node.kind === "service") return nodeCardHeight(node);
+  const hasSignals = (node.signals?.length ?? 0) > 0;
+  const hasSub = !!node.sublabel;
+  return HEADER_H + (hasSub ? 16 : 0) + (hasSignals ? BADGE_ROW_H : 14);
+}
+
+// ---- visual tokens ---------------------------------------------------------
+
+const KIND_ICON: Record<string, ReactNode> = {
+  service: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="3" y="3" width="8" height="8" rx="1.5" />
+      <rect x="13" y="3" width="8" height="8" rx="1.5" />
+      <rect x="3" y="13" width="8" height="8" rx="1.5" />
+      <rect x="13" y="13" width="8" height="8" rx="1.5" />
+    </svg>
+  ),
+  edge: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M3 12h18M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18z" />
+    </svg>
+  ),
+  compute: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="4" y="4" width="16" height="16" rx="2" />
+      <rect x="9" y="9" width="6" height="6" rx="1" />
+      <path d="M9 1v3M15 1v3M9 20v3M15 20v3M1 9h3M1 15h3M20 9h3M20 15h3" />
+    </svg>
+  ),
+  queue: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="3" y="7" width="4" height="10" rx="1" />
+      <rect x="10" y="7" width="4" height="10" rx="1" />
+      <rect x="17" y="7" width="4" height="10" rx="1" />
+    </svg>
+  ),
+  database: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <ellipse cx="12" cy="5" rx="8" ry="3" />
+      <path d="M4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3" />
+    </svg>
+  ),
+  cache: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" />
+    </svg>
+  ),
+  storage: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 7c0-1.7 4-3 9-3s9 1.3 9 3-4 3-9 3-9-1.3-9-3z" />
+      <path d="M3 7v10c0 1.7 4 3 9 3s9-1.3 9-3V7" />
+    </svg>
+  ),
+  external: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+      <path d="M15 3h6v6M10 14 21 3" />
+    </svg>
+  ),
+};
+const iconFor = (kind: NodeKind): ReactNode => KIND_ICON[kind] ?? KIND_ICON.compute;
+
+const GROUP_TONE: Record<TopologyGroup["tone"], { border: string; bg: string; label: string }> = {
+  accent: {
+    border: "rgba(72,90,226,0.32)",
+    bg: "rgba(72,90,226,0.05)",
+    label: "var(--color-accent)",
+  },
+  success: {
+    border: "rgba(65,209,149,0.28)",
+    bg: "rgba(65,209,149,0.045)",
+    label: "var(--color-success)",
+  },
+  warning: {
+    border: "rgba(231,177,90,0.28)",
+    bg: "rgba(231,177,90,0.045)",
+    label: "var(--color-warning)",
+  },
+  danger: {
+    border: "rgba(226,72,72,0.30)",
+    bg: "rgba(226,72,72,0.05)",
+    label: "var(--color-danger)",
+  },
+  neutral: {
+    border: "rgba(255,255,255,0.12)",
+    bg: "rgba(255,255,255,0.02)",
+    label: "var(--color-muted)",
+  },
+};
+
+const SIGNAL_META: Record<SignalKind, { color: string; label: string }> = {
+  cost: { color: "var(--color-warning)", label: "Cost" },
+  security: { color: "var(--color-danger)", label: "Security" },
+  performance: { color: "var(--color-accent)", label: "Performance" },
+};
+
+// Edge styling keyed on provenance — the trust signal of the whole map.
+const EDGE_STYLE: Record<
+  EdgeSource,
+  { stroke: string; width: number; opacity: number; dash?: string }
+> = {
+  telemetry: { stroke: "var(--color-accent)", width: 1.7, opacity: 0.85 },
+  infra: { stroke: "var(--color-subtle)", width: 1.25, opacity: 0.5 },
+  suggested: { stroke: "var(--color-accent)", width: 1.5, opacity: 0.7, dash: "5 4" },
+  manual: { stroke: "var(--color-fg)", width: 1.4, opacity: 0.6, dash: "2 3" },
+};
+
+// Cards must be OPAQUE so edges routed behind them don't bleed through (the
+// surface tokens are low-alpha overlays). Compose the surface tint over the page
+// background so the fill is solid regardless of the token's alpha.
+const CARD_BG =
+  "linear-gradient(0deg, var(--color-surface-2), var(--color-surface-2)), var(--color-bg)";
+
+// ---- geometry --------------------------------------------------------------
+
+function edgePath(a: XY, b: XY, ha: number, hb: number): string {
+  const G = PORT_GAP;
+  const aRight = a.x + NODE_W;
+  if (b.x >= aRight + LR_THRESHOLD) {
+    const sx = aRight + G;
+    const sy = a.y + PORT_Y;
+    const tx = b.x - G;
+    const ty = b.y + PORT_Y;
+    const midX = sx + (tx - sx) / 2;
+    return `M ${sx} ${sy} L ${midX} ${sy} L ${midX} ${ty} L ${tx} ${ty}`;
+  }
+  const sx = a.x + NODE_W / 2;
+  const tx = b.x + NODE_W / 2;
+  if (b.y >= a.y) {
+    const sy = a.y + ha + G;
+    const ty = b.y - G;
+    const midY = sy + (ty - sy) / 2;
+    return `M ${sx} ${sy} L ${sx} ${midY} L ${tx} ${midY} L ${tx} ${ty}`;
+  }
+  const sy = a.y - G;
+  const ty = b.y + hb + G;
+  const midY = sy + (ty - sy) / 2;
+  return `M ${sx} ${sy} L ${sx} ${midY} L ${tx} ${midY} L ${tx} ${ty}`;
+}
+
+function groupBounds(positions: Map<string, XY>, nodes: TopologyNode[]) {
+  const pts = nodes.map((n) => ({ p: positions.get(n.id)!, h: nodeHeight(n) })).filter((x) => x.p);
+  const minX = Math.min(...pts.map((x) => x.p.x));
+  const minY = Math.min(...pts.map((x) => x.p.y));
+  const maxX = Math.max(...pts.map((x) => x.p.x + NODE_W));
+  const maxY = Math.max(...pts.map((x) => x.p.y + x.h));
+  const padX = 22;
+  const padTop = 56;
+  const padBottom = 22;
+  return {
+    x: minX - padX,
+    y: minY - padTop,
+    w: maxX - minX + padX * 2,
+    h: maxY - minY + padTop + padBottom,
+  };
+}
+
+// ---- component -------------------------------------------------------------
+
+export function TopologyCanvas({
+  topology,
+  density = "comfortable",
+  showGroups = true,
+  showDots = true,
+  height = 680,
+  fitHeight = false,
+  fitWidth = false,
+  onNodeOpen,
+  lockNodes = false,
+  frame,
+}: {
+  topology: Topology;
+  density?: Density;
+  showGroups?: boolean;
+  showDots?: boolean;
+  height?: number | string;
+  /**
+   * When drilled into a group, the boundary frame to draw around the group's own
+   * contents. Connected neighbour groups (boundary stubs) are pushed OUTSIDE this
+   * frame so cross-group edges visibly cross the boundary.
+   */
+  frame?: { label: string; tone: TopologyGroup["tone"]; aiProposed?: boolean };
+  /** Size the canvas to the laid-out content (clamped) instead of a fixed height. */
+  fitHeight?: boolean;
+  /** Zoom-to-fit the content to the canvas width (never upscaling) and centre it. */
+  fitWidth?: boolean;
+  /**
+   * Called when a `service`-kind node is clicked, with the target service id
+   * (from `node.meta.serviceId`). Used to drill into / hop between services.
+   * Non-service nodes still open the inspector.
+   */
+  onNodeOpen?: (serviceId: string) => void;
+  /** Pin nodes in their laid-out positions — clicks still work, dragging doesn't. */
+  lockNodes?: boolean;
+}) {
+  const [viewportW, setViewportW] = useState(0);
+  // Inside a frame, lay out ONLY the group's own contents — the neighbour stubs are
+  // positioned outside the frame afterwards (see `display`), so they must not
+  // inflate the inside DAG's width/spread.
+  const layoutTopo = useMemo(() => {
+    if (!frame) return topology;
+    const stubIds = new Set(topology.nodes.filter((n) => n.meta?.boundary).map((n) => n.id));
+    if (stubIds.size === 0) return topology;
+    return {
+      nodes: topology.nodes.filter((n) => !stubIds.has(n.id)),
+      edges: topology.edges.filter((e) => !stubIds.has(e.from) && !stubIds.has(e.to)),
+      groups: topology.groups,
+    };
+  }, [frame, topology]);
+  // Wrap long chains to the canvas width (at full node size — no scaling). Inside a
+  // frame, leave room for the outside stub columns + frame padding so the group's
+  // contents wrap to fit rather than spilling under the neighbours / off-screen.
+  const layoutMaxWidth = useMemo(() => {
+    if (!fitWidth || viewportW <= 0) return undefined;
+    if (!frame) return viewportW;
+    const reserve = (NODE_W + STUB_GAP) * 2 + FRAME_PAD * 2 + 16;
+    return Math.max(NODE_W + 80, viewportW - reserve);
+  }, [fitWidth, viewportW, frame]);
+  const layout = useMemo(
+    () =>
+      layoutTopology(layoutTopo, {
+        density,
+        lanes: showGroups,
+        maxWidth: layoutMaxWidth,
+      }),
+    [layoutTopo, density, showGroups, layoutMaxWidth],
+  );
+  // node-id signature so positions reset when the graph (not just a drag) changes
+  const sig = useMemo(
+    () => topology.nodes.map((n) => n.id).join("|") + density + showGroups + viewportW,
+    [topology, density, showGroups, viewportW],
+  );
+
+  const [positions, setPositions] = useState<Map<string, XY>>(() => new Map(layout.positions));
+  useEffect(() => setPositions(new Map(layout.positions)), [sig, layout.positions]);
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [pan, setPan] = useState<XY>({ x: 0, y: 0 });
+  const [panning, setPanning] = useState(false);
+  const viewport = useRef<HTMLDivElement>(null);
+
+  // Track the canvas width so we can wrap + centre content.
+  useEffect(() => {
+    const el = viewport.current;
+    if (!el) return;
+    const update = () => setViewportW(el.clientWidth);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  const drag = useRef<{
+    mode: "node" | "pan";
+    id?: string;
+    startX: number;
+    startY: number;
+    originX: number;
+    originY: number;
+    moved: boolean;
+  } | null>(null);
+
+  const byId = useMemo(() => new Map(topology.nodes.map((n) => [n.id, n])), [topology]);
+
+  // Display positions: when a frame is set, relocate the neighbour boundary stubs
+  // to columns just OUTSIDE the group's content bbox — upstream (something →
+  // inside) on the left, downstream (inside → something) on the right — so the
+  // frame encloses only the group's own resources and cross-group edges cross it.
+  const display = useMemo(() => {
+    if (!frame) return positions;
+    const stubs = topology.nodes.filter((n) => n.meta?.boundary);
+    if (stubs.length === 0) return positions;
+    const inside = topology.nodes.filter((n) => !n.meta?.boundary);
+    let minX = Number.POSITIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+    for (const n of inside) {
+      const p = positions.get(n.id);
+      if (!p) continue;
+      minX = Math.min(minX, p.x);
+      minY = Math.min(minY, p.y);
+      maxX = Math.max(maxX, p.x + NODE_W);
+      maxY = Math.max(maxY, p.y + nodeHeight(n));
+    }
+    if (!Number.isFinite(minX)) return positions;
+    const cy = (minY + maxY) / 2;
+    const left: string[] = [];
+    const right: string[] = [];
+    for (const s of stubs) {
+      // downstream = the group depends on it (inside → stub) → place on the right.
+      const downstream = topology.edges.some((e) => e.to === s.id);
+      (downstream ? right : left).push(s.id);
+    }
+    const m = new Map(positions);
+    const STUB_H = 48;
+    const place = (ids: string[], x: number) => {
+      const step = STUB_H + 18;
+      let y = cy - (ids.length * step - 18) / 2;
+      for (const id of ids) {
+        m.set(id, { x, y });
+        y += step;
+      }
+    };
+    place(left, minX - STUB_GAP - NODE_W);
+    place(right, maxX + STUB_GAP);
+    // Left stubs (and the frame label) can land at negative coordinates; the edge
+    // SVG starts at (0,0), so shift everything non-negative or its edges get clipped.
+    let gMinX = Number.POSITIVE_INFINITY;
+    let gMinY = Number.POSITIVE_INFINITY;
+    for (const p of m.values()) {
+      gMinX = Math.min(gMinX, p.x);
+      gMinY = Math.min(gMinY, p.y);
+    }
+    const dx = gMinX < FRAME_PAD ? FRAME_PAD - gMinX : 0;
+    const dy = gMinY < FRAME_PAD + FRAME_LABEL_H ? FRAME_PAD + FRAME_LABEL_H - gMinY : 0;
+    if (dx || dy) for (const [k, p] of m) m.set(k, { x: p.x + dx, y: p.y + dy });
+    return m;
+  }, [frame, positions, topology.nodes, topology.edges]);
+
+  // The frame rectangle around the group's own contents (boundary stubs excluded).
+  const frameBox = useMemo(() => {
+    if (!frame) return null;
+    let minX = Number.POSITIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+    for (const n of topology.nodes) {
+      if (n.meta?.boundary) continue;
+      const p = display.get(n.id);
+      if (!p) continue;
+      minX = Math.min(minX, p.x);
+      minY = Math.min(minY, p.y);
+      maxX = Math.max(maxX, p.x + NODE_W);
+      maxY = Math.max(maxY, p.y + nodeHeight(n));
+    }
+    if (!Number.isFinite(minX)) return null;
+    return {
+      x: minX - FRAME_PAD,
+      y: minY - FRAME_PAD - FRAME_LABEL_H,
+      w: maxX - minX + FRAME_PAD * 2,
+      h: maxY - minY + FRAME_PAD * 2 + FRAME_LABEL_H,
+    };
+  }, [frame, display, topology.nodes]);
+
+  // Cross-boundary links connect a neighbour to the GROUP as a whole, not to the
+  // individual member it happens to touch — anything else looks like the outside
+  // group reaches inside the box. So we collapse every edge that crosses the frame
+  // into a single connection per (neighbour, direction), drawn stub ↔ frame edge.
+  const crossings = useMemo(() => {
+    if (!frame || !frameBox) return [];
+    const SOURCE_RANK: Record<EdgeSource, number> = {
+      manual: 4,
+      telemetry: 3,
+      infra: 2,
+      suggested: 1,
+    };
+    const byStub = new Map<string, { stubId: string; inbound: boolean; source: EdgeSource }>();
+    for (const e of topology.edges) {
+      const fromB = !!byId.get(e.from)?.meta?.boundary;
+      const toB = !!byId.get(e.to)?.meta?.boundary;
+      if (fromB === toB) continue; // both inside (real intra edge) or both stubs — skip
+      const stubId = fromB ? e.from : e.to;
+      const inbound = fromB; // stub is the source → arrow points into the group
+      const key = `${stubId}:${inbound}`;
+      const cur = byStub.get(key);
+      if (!cur || SOURCE_RANK[e.source] > SOURCE_RANK[cur.source])
+        byStub.set(key, { stubId, inbound, source: e.source });
+    }
+    return [...byStub.values()];
+  }, [frame, frameBox, topology.edges, byId]);
+
+  const selected = selectedId ? (byId.get(selectedId) ?? null) : null;
+  const neighbors = useMemo(() => {
+    if (!selectedId) return new Set<string>();
+    const s = new Set<string>();
+    for (const e of topology.edges) {
+      if (e.from === selectedId) s.add(e.to);
+      if (e.to === selectedId) s.add(e.from);
+    }
+    return s;
+  }, [selectedId, topology.edges]);
+
+  const onNodePointerDown = useCallback(
+    (e: React.PointerEvent, node: TopologyNode) => {
+      e.preventDefault();
+      e.stopPropagation();
+      viewport.current?.setPointerCapture?.(e.pointerId);
+      const p = positions.get(node.id) ?? { x: 0, y: 0 };
+      drag.current = {
+        mode: "node",
+        id: node.id,
+        startX: e.clientX,
+        startY: e.clientY,
+        originX: p.x,
+        originY: p.y,
+        moved: false,
+      };
+    },
+    [positions],
+  );
+
+  const onCanvasPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      viewport.current?.setPointerCapture?.(e.pointerId);
+      setPanning(true);
+      drag.current = {
+        mode: "pan",
+        startX: e.clientX,
+        startY: e.clientY,
+        originX: pan.x,
+        originY: pan.y,
+        moved: false,
+      };
+    },
+    [pan.x, pan.y],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      const d = drag.current;
+      if (!d) return;
+      const dx = e.clientX - d.startX;
+      const dy = e.clientY - d.startY;
+      if (d.mode === "pan") {
+        if (Math.abs(dx) + Math.abs(dy) >= 3) d.moved = true;
+        setPan({ x: d.originX + dx, y: d.originY + dy });
+        return;
+      }
+      if (lockNodes) return; // nodes are pinned — drag is a no-op (click still fires on up)
+      if (!d.moved && Math.abs(dx) + Math.abs(dy) < 3) return;
+      d.moved = true;
+      const nx = Math.max(0, d.originX + dx);
+      const ny = Math.max(0, d.originY + dy);
+      setPositions((prev) => new Map(prev).set(d.id!, { x: nx, y: ny }));
+    },
+    [lockNodes],
+  );
+
+  const onPointerUp = useCallback(() => {
+    const d = drag.current;
+    if (d?.mode === "node" && !d.moved && d.id) {
+      const node = byId.get(d.id);
+      // Containers drill on the map: a group reveals its services, a service reveals
+      // its resources, a boundary stub hops to that neighbour — all via onNodeOpen.
+      // A leaf resource has nothing to drill into, so it opens the detail drawer.
+      if (node?.kind === "service" && onNodeOpen) {
+        const target = (node.meta?.serviceId as string | undefined) ?? node.id;
+        onNodeOpen(target);
+      } else {
+        setSelectedId((cur) => (cur === d.id ? null : (d.id ?? null)));
+      }
+    }
+    if (d?.mode === "pan") {
+      if (!d.moved) setSelectedId(null);
+      setPanning(false);
+    }
+    drag.current = null;
+  }, [byId, onNodeOpen]);
+
+  const groupBoxes = useMemo(() => {
+    if (!showGroups) return [];
+    return topology.groups
+      .map((g) => {
+        const members = topology.nodes.filter((n) => n.group === g.id && positions.get(n.id));
+        if (members.length === 0) return null;
+        return { group: g, bounds: groupBounds(positions, members) };
+      })
+      .filter(
+        (b): b is { group: TopologyGroup; bounds: ReturnType<typeof groupBounds> } => b !== null,
+      );
+  }, [showGroups, topology.groups, topology.nodes, positions]);
+
+  // True bounding box of the laid-out nodes (no padding floor) — drives zoom-to-fit
+  // and centring.
+  const content = useMemo(() => {
+    let minX = Number.POSITIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+    for (const n of topology.nodes) {
+      const p = display.get(n.id);
+      if (!p) continue;
+      minX = Math.min(minX, p.x);
+      minY = Math.min(minY, p.y);
+      maxX = Math.max(maxX, p.x + NODE_W);
+      maxY = Math.max(maxY, p.y + nodeHeight(n));
+    }
+    // Include the frame so a group whose stubs sit only on one side stays centred.
+    if (frameBox) {
+      minX = Math.min(minX, frameBox.x);
+      minY = Math.min(minY, frameBox.y);
+      maxX = Math.max(maxX, frameBox.x + frameBox.w);
+      maxY = Math.max(maxY, frameBox.y + frameBox.h);
+    }
+    if (!Number.isFinite(minX)) return { minX: 0, minY: 0, w: 0, h: 0 };
+    return { minX, minY, w: maxX - minX, h: maxY - minY };
+  }, [topology.nodes, display, frameBox]);
+
+  // The scrollable inner-layer size (kept generous so the SVG/background cover pans).
+  const extent = useMemo(
+    () => ({
+      w: Math.max(1040, content.minX + content.w + 80),
+      h: Math.max(600, content.minY + content.h + 80),
+    }),
+    [content],
+  );
+
+  // No scaling — content is wrapped to fit width at full size, then centred.
+  const resolvedHeight = fitHeight
+    ? Math.min(1640, Math.max(360, Math.round(content.h + 96)))
+    : height;
+  const vh = typeof resolvedHeight === "number" ? resolvedHeight : content.h + 96;
+  // Centre the content box when it fits; once it's wider than the viewport, pin the
+  // chain's left edge to a small pad instead (centring would push the start of a
+  // left-to-right map off-screen — the user pans right to follow it).
+  const PAD_X = 24;
+  const baseX =
+    content.w <= viewportW - PAD_X * 2
+      ? (viewportW - content.w) / 2 - content.minX
+      : PAD_X - content.minX;
+  const baseY = (vh - content.h) / 2 - content.minY;
+
+  return (
+    <div className="relative w-full" style={{ height: resolvedHeight }}>
+      <div
+        ref={viewport}
+        className={`absolute inset-0 overflow-hidden rounded-2xl border border-border ${panning ? "cursor-grabbing" : "cursor-grab"}`}
+        style={{
+          backgroundImage: showDots
+            ? "radial-gradient(var(--dot-color) 1.25px, transparent 1.25px)"
+            : undefined,
+          backgroundSize: "22px 22px",
+          backgroundPosition: `${pan.x - 1}px ${pan.y - 1}px`,
+        }}
+        onPointerDown={onCanvasPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+      >
+        <div
+          className="absolute left-0 top-0"
+          style={{
+            width: extent.w,
+            height: extent.h,
+            transform: `translate(${baseX + pan.x}px, ${baseY + pan.y}px)`,
+            transformOrigin: "0 0",
+          }}
+        >
+          {/* Focus frame: the boundary around the drilled group's own contents.
+              Neighbour stubs are positioned outside it; edges cross the border. */}
+          {frame && frameBox && (
+            <div
+              className="pointer-events-none absolute rounded-[20px]"
+              style={{
+                left: frameBox.x,
+                top: frameBox.y,
+                width: frameBox.w,
+                height: frameBox.h,
+                border: `1.5px dashed ${GROUP_TONE[frame.tone].border}`,
+                background: GROUP_TONE[frame.tone].bg,
+              }}
+            >
+              <span
+                className="absolute left-3 top-0 inline-flex -translate-y-1/2 items-center gap-1.5 rounded-md border bg-surface px-2 py-0.5 text-[12px] font-medium"
+                style={{
+                  color: GROUP_TONE[frame.tone].label,
+                  borderColor: GROUP_TONE[frame.tone].border,
+                }}
+              >
+                {frame.label}
+                {frame.aiProposed && <AiDot />}
+              </span>
+            </div>
+          )}
+
+          {/* Group containers */}
+          {groupBoxes.map(({ group, bounds }) => {
+            const tone = GROUP_TONE[group.tone];
+            return (
+              <div
+                key={group.id}
+                className="pointer-events-none absolute rounded-2xl"
+                style={{
+                  left: bounds.x,
+                  top: bounds.y,
+                  width: bounds.w,
+                  height: bounds.h,
+                  border: `1px dashed ${tone.border}`,
+                  background: tone.bg,
+                }}
+              >
+                <span
+                  className="absolute left-3 top-3 inline-flex items-center gap-1.5 rounded-md border bg-surface px-2 py-0.5 text-[12px] font-medium"
+                  style={{ color: tone.label, borderColor: tone.border }}
+                >
+                  {group.label}
+                  {group.aiProposed && <AiDot />}
+                </span>
+              </div>
+            );
+          })}
+
+          {/* Edges */}
+          <svg className="pointer-events-none absolute inset-0" width={extent.w} height={extent.h}>
+            <defs>
+              <marker
+                id="tc-arrow"
+                viewBox="0 0 10 10"
+                refX="8"
+                refY="5"
+                markerWidth="6"
+                markerHeight="6"
+                orient="auto-start-reverse"
+              >
+                <path d="M0 0 L10 5 L0 10 z" fill="var(--color-subtle)" />
+              </marker>
+              <marker
+                id="tc-arrow-active"
+                viewBox="0 0 10 10"
+                refX="8"
+                refY="5"
+                markerWidth="6.5"
+                markerHeight="6.5"
+                orient="auto-start-reverse"
+              >
+                <path d="M0 0 L10 5 L0 10 z" fill="var(--color-accent)" />
+              </marker>
+            </defs>
+            {topology.edges
+              // In a framed view the boundary-crossing edges are drawn separately
+              // (stub ↔ frame); the normal pass handles only the group's own
+              // internal wiring. At the root nothing is a stub, so all edges pass.
+              .filter((e) => {
+                if (!frame) return true;
+                const fromB = !!byId.get(e.from)?.meta?.boundary;
+                const toB = !!byId.get(e.to)?.meta?.boundary;
+                return fromB === toB;
+              })
+              .map((e) => {
+                const a = display.get(e.from);
+                const b = display.get(e.to);
+                const na = byId.get(e.from);
+                const nb = byId.get(e.to);
+                if (!a || !b || !na || !nb) return null;
+                const active = selectedId === e.from || selectedId === e.to;
+                const style = EDGE_STYLE[e.source];
+                return (
+                  <g key={e.id}>
+                    <path
+                      d={edgePath(a, b, nodeHeight(na), nodeHeight(nb))}
+                      fill="none"
+                      stroke={active ? "var(--color-accent)" : style.stroke}
+                      strokeWidth={active ? style.width + 0.6 : style.width}
+                      strokeOpacity={active ? 1 : selectedId ? 0.18 : style.opacity}
+                      strokeDasharray={style.dash}
+                      markerEnd={active ? "url(#tc-arrow-active)" : "url(#tc-arrow)"}
+                    />
+                  </g>
+                );
+              })}
+
+            {/* Boundary crossings: connect each neighbour to the frame edge itself. */}
+            {frame &&
+              frameBox &&
+              crossings.map((c) => {
+                const sp = display.get(c.stubId);
+                if (!sp) return null;
+                const stub = byId.get(c.stubId);
+                const stubH = stub ? nodeHeight(stub) : 48;
+                const leftSide = sp.x < frameBox.x;
+                const stubInner = leftSide ? sp.x + NODE_W : sp.x;
+                const frameX = leftSide ? frameBox.x : frameBox.x + frameBox.w;
+                // Land on the frame edge at the neighbour's height, clamped to the
+                // frame so the arrow always meets the border.
+                const y = Math.max(
+                  frameBox.y + 12,
+                  Math.min(frameBox.y + frameBox.h - 12, sp.y + stubH / 2),
+                );
+                const start = c.inbound ? stubInner : frameX;
+                const end = c.inbound ? frameX : stubInner;
+                const style = EDGE_STYLE[c.source];
+                return (
+                  <path
+                    key={`${c.stubId}:${c.inbound}`}
+                    d={`M ${start} ${y} L ${end} ${y}`}
+                    fill="none"
+                    stroke={style.stroke}
+                    strokeWidth={style.width}
+                    strokeOpacity={selectedId ? 0.18 : style.opacity}
+                    strokeDasharray={style.dash}
+                    markerEnd="url(#tc-arrow)"
+                  />
+                );
+              })}
+          </svg>
+
+          {/* Nodes */}
+          {topology.nodes.map((node) => {
+            const p = display.get(node.id);
+            if (!p) return null;
+            const dimmed = !!selectedId && selectedId !== node.id && !neighbors.has(node.id);
+            return (
+              <NodeCard
+                key={node.id}
+                node={node}
+                pos={p}
+                selected={selectedId === node.id}
+                dimmed={dimmed}
+                locked={lockNodes}
+                onPointerDown={(e) => onNodePointerDown(e, node)}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      {selected && (
+        <div className="pointer-events-none absolute inset-y-3 right-3 z-10 w-[340px] max-w-[calc(100%-24px)]">
+          <Inspector node={selected} topology={topology} onClose={() => setSelectedId(null)} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---- node card -------------------------------------------------------------
+
+function NodeCard({
+  node,
+  pos,
+  selected,
+  dimmed,
+  locked,
+  onPointerDown,
+}: {
+  node: TopologyNode;
+  pos: XY;
+  selected: boolean;
+  dimmed: boolean;
+  locked?: boolean;
+  onPointerDown: (e: React.PointerEvent) => void;
+}) {
+  if (node.kind === "service")
+    return <ServiceCard node={node} pos={pos} dimmed={dimmed} onPointerDown={onPointerDown} />;
+  return (
+    <div
+      onPointerDown={onPointerDown}
+      className={`absolute touch-none select-none rounded-2xl transition-[box-shadow,opacity] ${locked ? "cursor-default" : "cursor-grab active:cursor-grabbing"}`}
+      style={{
+        left: pos.x,
+        top: pos.y,
+        width: NODE_W,
+        background: CARD_BG,
+        opacity: dimmed ? 0.35 : 1,
+        boxShadow: selected
+          ? "0 0 0 1px var(--color-accent), 0 0 0 4px var(--color-surface), 0 0 0 5px rgba(72,90,226,0.35), 0 16px 32px -16px rgba(72,90,226,0.5)"
+          : "0 0 0 1px var(--color-border-strong), 0 0 0 4px var(--color-surface), 0 0 0 5px rgba(255,255,255,0.04), 0 10px 24px -16px rgba(0,0,0,0.8)",
+      }}
+    >
+      <div className="flex items-center gap-2.5 px-4 pt-3.5 pb-2.5">
+        <span className="h-[18px] w-[18px] shrink-0 text-muted">{iconFor(node.kind)}</span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <span className="truncate text-[14.5px] font-semibold tracking-tight text-fg">
+              {node.label}
+            </span>
+            {node.aiProposed && <AiDot />}
+            {node.status && node.status !== "unknown" && <StatusDot status={node.status} />}
+          </div>
+          {node.sublabel && (
+            <div className="truncate text-[11.5px] text-subtle">{node.sublabel}</div>
+          )}
+        </div>
+        {typeof node.meta?.console === "string" && (
+          <a
+            href={node.meta.console}
+            target="_blank"
+            rel="noreferrer"
+            onPointerDown={(e) => e.stopPropagation()}
+            title="Open in AWS console"
+            className="grid h-6 w-6 shrink-0 place-items-center rounded-md text-subtle transition-colors hover:bg-surface-2 hover:text-fg"
+          >
+            <ExtLink />
+          </a>
+        )}
+      </div>
+
+      <div className="h-px bg-border" />
+
+      {node.signals && node.signals.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-1.5 px-4 py-2.5">
+          {node.signals.map((s) => (
+            <SignalBadge key={s.kind} signal={s} />
+          ))}
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 px-4 py-2">
+          <span className="text-[11.5px] capitalize text-subtle">{node.kind}</span>
+          {typeof node.meta?.badge === "string" && (
+            <span className="ml-auto shrink-0 rounded-full bg-surface-3 px-1.5 py-0.5 text-[10.5px] font-medium tabular-nums text-muted">
+              {node.meta.badge}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Distinct rendering for collapsed services + boundary stubs (the top level and
+// the "talks to →" markers inside an exploded service).
+function ServiceCard({
+  node,
+  pos,
+  dimmed,
+  onPointerDown,
+}: {
+  node: TopologyNode;
+  pos: XY;
+  dimmed: boolean;
+  onPointerDown: (e: React.PointerEvent) => void;
+}) {
+  const tone = (node.meta?.tone as TopologyGroup["tone"] | undefined) ?? "neutral";
+  const t = GROUP_TONE[tone];
+  const boundary = !!node.meta?.boundary;
+
+  if (boundary) {
+    // Faded via muted colours + dashed border, NOT via opacity — an opacity on the
+    // whole card makes its background translucent, letting edges bleed through it.
+    return (
+      <div
+        onPointerDown={onPointerDown}
+        className="absolute flex cursor-pointer touch-none select-none items-center gap-2 rounded-xl border border-dashed px-3 py-2.5"
+        style={{
+          left: pos.x,
+          top: pos.y,
+          width: NODE_W,
+          background: CARD_BG,
+          borderColor: t.border,
+          opacity: dimmed ? 0.35 : 1,
+        }}
+        title={`Open ${node.label}`}
+      >
+        <span className="h-[16px] w-[16px] shrink-0 opacity-70" style={{ color: t.label }}>
+          {iconFor("service")}
+        </span>
+        <span className="truncate text-[13px] font-medium text-subtle">{node.label}</span>
+        <span className="ml-auto shrink-0 text-subtle">
+          <Chevron />
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      onPointerDown={onPointerDown}
+      className="absolute cursor-pointer touch-none select-none rounded-2xl transition-[box-shadow,opacity] hover:brightness-110"
+      style={{
+        left: pos.x,
+        top: pos.y,
+        width: NODE_W,
+        background: CARD_BG,
+        opacity: dimmed ? 0.35 : 1,
+        boxShadow: `0 0 0 1px ${t.border}, 0 0 0 4px var(--color-surface), 0 0 0 5px ${t.bg}, 0 12px 28px -16px rgba(0,0,0,0.85)`,
+      }}
+    >
+      <div className="flex items-center gap-2.5 px-4 pt-3.5 pb-3">
+        <span
+          className="grid h-7 w-7 shrink-0 place-items-center rounded-lg"
+          style={{ color: t.label, background: t.bg }}
+        >
+          <span className="h-[16px] w-[16px]">{iconFor("service")}</span>
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <span className="truncate text-[15px] font-semibold tracking-tight text-fg">
+              {node.label}
+            </span>
+            {node.aiProposed && <AiDot />}
+          </div>
+          {node.sublabel && (
+            <div className="line-clamp-2 text-[11.5px] leading-snug text-subtle">
+              {node.sublabel}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="h-px bg-border" />
+
+      {/* No counts on the card — you open it to see what's inside. */}
+      <div className="flex items-center px-4 py-2.5">
+        <span className="ml-auto inline-flex items-center gap-1 text-[11.5px] text-muted">
+          Open
+          <Chevron />
+        </span>
+      </div>
+
+      {node.signals && node.signals.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5 px-4 pb-2.5">
+          {node.signals.map((s) => (
+            <SignalBadge key={s.kind} signal={s} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ExtLink() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-3 w-3"
+    >
+      <path d="M15 3h6v6M10 14 21 3M18 13v8H3V6h8" />
+    </svg>
+  );
+}
+
+function Chevron() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className="h-3.5 w-3.5"
+    >
+      <path d="m9 6 6 6-6 6" />
+    </svg>
+  );
+}
+
+function StatusDot({ status }: { status: NonNullable<TopologyNode["status"]> }) {
+  const color =
+    status === "healthy"
+      ? "var(--color-success)"
+      : status === "degraded"
+        ? "var(--color-warning)"
+        : "var(--color-danger)";
+  return (
+    <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: color }} title={status} />
+  );
+}
+
+function AiDot() {
+  return (
+    <span
+      className="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center text-accent"
+      title="AI suggestion — review"
+    >
+      <svg viewBox="0 0 24 24" fill="currentColor" className="h-3.5 w-3.5">
+        <path d="M12 2l1.6 4.8L18 8l-4.4 1.2L12 14l-1.6-4.8L6 8l4.4-1.2L12 2z" />
+      </svg>
+    </span>
+  );
+}
+
+function SignalBadge({ signal }: { signal: Signal }) {
+  const meta = SIGNAL_META[signal.kind];
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[12px] font-medium tabular-nums"
+      style={{
+        color: meta.color,
+        background: `color-mix(in srgb, ${meta.color} 16%, transparent)`,
+      }}
+      title={`${meta.label}: ${signal.count}`}
+    >
+      <span className="h-1.5 w-1.5 rounded-full" style={{ background: meta.color }} />
+      {signal.count}
+    </span>
+  );
+}
+
+// ---- inspector -------------------------------------------------------------
+
+function Inspector({
+  node,
+  topology,
+  onClose,
+}: { node: TopologyNode; topology: Topology; onClose: () => void }) {
+  const group = topology.groups.find((g) => g.id === node.group);
+  const inbound = topology.edges.filter((e) => e.to === node.id);
+  const outbound = topology.edges.filter((e) => e.from === node.id);
+  const labelFor = (id: string) => topology.nodes.find((n) => n.id === id)?.label ?? id;
+  const facts = (node.meta?.facts as { label: string; value: string }[] | undefined) ?? [];
+  const console_ = typeof node.meta?.console === "string" ? node.meta.console : undefined;
+
+  return (
+    <div className="pointer-events-auto flex h-full flex-col overflow-hidden rounded-2xl border border-border-strong bg-surface shadow-[0_24px_60px_-20px_rgba(0,0,0,0.75)]">
+      <div className="flex items-center gap-2.5 px-5 py-4">
+        <span className="h-[18px] w-[18px] shrink-0 text-muted">{iconFor(node.kind)}</span>
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className="truncate text-[15px] font-semibold tracking-tight text-fg">
+              {node.label}
+            </span>
+            {node.aiProposed && <AiDot />}
+          </div>
+          <div className="text-[12px] text-subtle">
+            <span className="capitalize">{node.kind}</span>
+            <span className="text-subtle"> · {node.provider}</span>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="ml-auto grid h-7 w-7 shrink-0 place-items-center rounded-lg text-subtle transition-colors hover:bg-surface-2 hover:text-fg"
+        >
+          <svg
+            className="h-4 w-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          >
+            <path d="M6 6 18 18M18 6 6 18" />
+          </svg>
+        </button>
+      </div>
+      <div className="h-px bg-border" />
+      <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+        {group && (
+          <Row label="Group">
+            <span
+              className="rounded-md border px-2 py-0.5 text-[12px] font-medium"
+              style={{
+                color: GROUP_TONE[group.tone].label,
+                background: GROUP_TONE[group.tone].bg,
+                borderColor: GROUP_TONE[group.tone].border,
+              }}
+            >
+              {group.label}
+            </span>
+          </Row>
+        )}
+        {node.sublabel && (
+          <Row label="Detail">
+            <span className="text-[12.5px] text-fg">{node.sublabel}</span>
+          </Row>
+        )}
+        {facts.map((f) => (
+          <Row key={f.label} label={f.label}>
+            <span className="text-[12.5px] text-fg">{f.value}</span>
+          </Row>
+        ))}
+        <EdgeList title="Depends on" edges={outbound} dir="out" labelFor={labelFor} />
+        <EdgeList title="Used by" edges={inbound} dir="in" labelFor={labelFor} />
+      </div>
+      <div className="h-px bg-border" />
+      <div className="flex gap-2 px-5 py-4">
+        {console_ ? (
+          <a
+            href={console_}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-lg bg-accent px-3 py-1.5 text-[13px] font-medium text-white transition-opacity hover:opacity-90"
+          >
+            Open in AWS
+            <ExtLink />
+          </a>
+        ) : (
+          <Btn size="sm" variant="primary">
+            Open
+          </Btn>
+        )}
+        <Btn size="sm" variant="ghost">
+          Reassign group
+        </Btn>
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="shrink-0 text-[13px] text-muted">{label}</span>
+      <span className="h-px flex-1 self-center border-t border-dashed border-border-strong" />
+      <span className="shrink-0">{children}</span>
+    </div>
+  );
+}
+
+const EDGE_SOURCE_LABEL: Record<EdgeSource, string> = {
+  telemetry: "observed",
+  infra: "inferred",
+  suggested: "AI",
+  manual: "manual",
+};
+
+function EdgeList({
+  title,
+  edges,
+  dir,
+  labelFor,
+}: { title: string; edges: TopologyEdge[]; dir: "in" | "out"; labelFor: (id: string) => string }) {
+  if (edges.length === 0) return null;
+  return (
+    <div>
+      <div className="mb-2 text-[12px] font-medium text-muted">{title}</div>
+      <div className="space-y-1.5">
+        {edges.map((e) => (
+          <div
+            key={e.id}
+            className="flex items-center gap-2 rounded-lg border border-border bg-surface-2 px-2.5 py-1.5"
+          >
+            <span className="truncate text-[12.5px] text-fg">
+              {labelFor(dir === "out" ? e.to : e.from)}
+            </span>
+            {e.label && <span className="shrink-0 text-[11px] text-subtle">{e.label}</span>}
+            <span className="ml-auto shrink-0 rounded-full bg-surface-3 px-1.5 py-0.5 text-[10.5px] uppercase tracking-wide text-subtle">
+              {EDGE_SOURCE_LABEL[e.source]}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---- shared legend (exported for the playground header) --------------------
+
+export function EdgeLegend() {
+  const items: { source: EdgeSource; label: string }[] = [
+    { source: "telemetry", label: "Observed" },
+    { source: "infra", label: "Inferred" },
+    { source: "suggested", label: "AI suggested" },
+  ];
+  return (
+    <div className="flex items-center gap-3">
+      {items.map((it) => {
+        const s = EDGE_STYLE[it.source];
+        return (
+          <span
+            key={it.source}
+            className="inline-flex items-center gap-1.5 text-[12.5px] text-muted"
+          >
+            <svg width="22" height="6" viewBox="0 0 22 6">
+              <line
+                x1="0"
+                y1="3"
+                x2="22"
+                y2="3"
+                stroke={s.stroke}
+                strokeWidth={s.width + 0.4}
+                strokeOpacity={Math.max(s.opacity, 0.7)}
+                strokeDasharray={s.dash}
+              />
+            </svg>
+            {it.label}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -57,6 +57,7 @@
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@superlog/db": "workspace:*",
     "@superlog/fingerprint": "workspace:*",
+    "@superlog/topology": "workspace:*",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
     "pg-boss": "^12.0.0",

--- a/apps/worker/src/ai-usage.ts
+++ b/apps/worker/src/ai-usage.ts
@@ -20,7 +20,7 @@ export type TokenUsage = {
 // Where in the worker a model call originated. These mirror the worker's own
 // feature modules (digest.ts, grouping.ts, …), so they disclose nothing the
 // file layout doesn't already.
-export type CallSite = "agent_run" | "digest" | "grouping" | "merge" | "autorecovery";
+export type CallSite = "agent_run" | "digest" | "grouping" | "merge" | "autorecovery" | "topology";
 
 export type AgentRunOutcome = "complete_with_pr" | "complete_no_pr" | "failed" | "awaiting_human";
 

--- a/apps/worker/src/jobs/build-topologies.ts
+++ b/apps/worker/src/jobs/build-topologies.ts
@@ -6,7 +6,7 @@
 
 import { schema } from "@superlog/db";
 import type { Topology } from "@superlog/topology";
-import { and, eq, isNull, lt, or, sql } from "drizzle-orm";
+import { and, eq, exists, isNull, lt, or, sql } from "drizzle-orm";
 import type { JobDefinition, JobDeps } from "../jobs.js";
 import { logger } from "../logger.js";
 import { buildProjectTopology } from "../topology/build.js";
@@ -27,6 +27,20 @@ async function selectCandidates(db: JobDeps["db"], now: Date): Promise<string[]>
     .where(
       and(
         sql`${schema.projectTopologies.status} <> 'generating'`,
+        // Only rebuild while the project still has a connected source — a
+        // disconnected project's inventory is empty, so a rebuild is wasted work
+        // (and would crowd out connected projects on the bounded tick).
+        exists(
+          db
+            .select({ one: sql`1` })
+            .from(schema.cloudConnections)
+            .where(
+              and(
+                eq(schema.cloudConnections.projectId, schema.projectTopologies.projectId),
+                eq(schema.cloudConnections.status, "connected"),
+              ),
+            ),
+        ),
         or(
           isNull(schema.projectTopologies.generatedAt),
           sql`${schema.projectTopologies.refreshRequestedAt} > ${schema.projectTopologies.generatedAt}`,

--- a/apps/worker/src/jobs/build-topologies.ts
+++ b/apps/worker/src/jobs/build-topologies.ts
@@ -1,0 +1,134 @@
+// Scheduled job: (re)build the service-map topology for projects. Picks up rows a
+// user asked to refresh (refreshRequestedAt > generatedAt), connected projects
+// that have no map yet, and maps older than a day. For each: build the
+// deterministic graph from inventory + telemetry, run the LLM grouping pass, and
+// persist. The handler does one bounded pass; pg-boss owns the schedule.
+
+import { schema } from "@superlog/db";
+import type { Topology } from "@superlog/topology";
+import { and, eq, isNull, lt, or, sql } from "drizzle-orm";
+import type { JobDefinition, JobDeps } from "../jobs.js";
+import { logger } from "../logger.js";
+import { buildProjectTopology } from "../topology/build.js";
+import { serviceGraphFromClickHouse } from "../topology/clickhouse.js";
+import { enrichProjectTopology } from "../topology/enrich.js";
+
+const MAX_PER_TICK = 8;
+const STALE_AFTER_HOURS = 24;
+const scope = "jobs.build-topologies";
+
+async function selectCandidates(db: JobDeps["db"], now: Date): Promise<string[]> {
+  const staleBefore = new Date(now.getTime() - STALE_AFTER_HOURS * 3600_000);
+
+  // 1) Existing rows that need a (re)build and aren't already in flight.
+  const pending = await db
+    .select({ projectId: schema.projectTopologies.projectId })
+    .from(schema.projectTopologies)
+    .where(
+      and(
+        sql`${schema.projectTopologies.status} <> 'generating'`,
+        or(
+          isNull(schema.projectTopologies.generatedAt),
+          sql`${schema.projectTopologies.refreshRequestedAt} > ${schema.projectTopologies.generatedAt}`,
+          lt(schema.projectTopologies.generatedAt, staleBefore),
+        ),
+      ),
+    )
+    .limit(MAX_PER_TICK);
+
+  // 2) Connected projects that have no topology row at all → seed them.
+  const connected = await db
+    .selectDistinct({ projectId: schema.cloudConnections.projectId })
+    .from(schema.cloudConnections)
+    .leftJoin(
+      schema.projectTopologies,
+      eq(schema.projectTopologies.projectId, schema.cloudConnections.projectId),
+    )
+    .where(
+      and(eq(schema.cloudConnections.status, "connected"), isNull(schema.projectTopologies.id)),
+    )
+    .limit(MAX_PER_TICK);
+
+  const ids = new Set<string>();
+  for (const r of [...pending, ...connected]) ids.add(r.projectId);
+  return [...ids].slice(0, MAX_PER_TICK);
+}
+
+async function buildOne(deps: JobDeps, projectId: string): Promise<void> {
+  const project = await deps.db.query.projects.findFirst({
+    where: eq(schema.projects.id, projectId),
+  });
+  if (!project) return;
+
+  // Claim the row (insert if missing) and mark in-flight.
+  await deps.db
+    .insert(schema.projectTopologies)
+    .values({ projectId, status: "generating" })
+    .onConflictDoUpdate({
+      target: schema.projectTopologies.projectId,
+      set: { status: "generating", updatedAt: new Date() },
+    });
+
+  try {
+    const graph: Topology = await buildProjectTopology(
+      {
+        listResources: async (pid) => {
+          const rows = await deps.db.query.cloudResources.findMany({
+            where: and(
+              eq(schema.cloudResources.projectId, pid),
+              isNull(schema.cloudResources.removedAt),
+            ),
+          });
+          return rows.map((r) => ({
+            arn: r.arn,
+            service: r.service,
+            resourceType: r.resourceType,
+            name: r.name,
+            region: r.region,
+            accountId: r.accountId,
+            config: r.config as Record<string, unknown> | null,
+          }));
+        },
+        serviceGraph: (pid) => serviceGraphFromClickHouse(deps.clickhouse, pid),
+      },
+      projectId,
+    );
+
+    const enrichment = await enrichProjectTopology(graph, { orgId: project.orgId, projectId });
+
+    await deps.db
+      .update(schema.projectTopologies)
+      .set({
+        graph,
+        enrichment,
+        status: "idle",
+        error: null,
+        generatedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.projectTopologies.projectId, projectId));
+    logger.info(
+      { scope, projectId, nodes: graph.nodes.length, enriched: !!enrichment },
+      "topology built",
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await deps.db
+      .update(schema.projectTopologies)
+      .set({ status: "error", error: message, updatedAt: new Date() })
+      .where(eq(schema.projectTopologies.projectId, projectId))
+      .catch(() => {});
+    logger.warn({ scope, projectId, err: message }, "topology build failed");
+  }
+}
+
+export const job: JobDefinition = {
+  name: "build-topologies",
+  schedule: "*/5 * * * *",
+  create: (deps: JobDeps) => async () => {
+    const candidates = await selectCandidates(deps.db, new Date());
+    for (const projectId of candidates) await buildOne(deps, projectId);
+    if (candidates.length > 0)
+      logger.info({ scope, count: candidates.length }, "topology build pass complete");
+  },
+};

--- a/apps/worker/src/topology/build.test.ts
+++ b/apps/worker/src/topology/build.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ServiceGraph } from "@superlog/topology";
+import {
+  type ResourceRow,
+  assembleTopology,
+  buildProjectTopology,
+  isMappableResource,
+  resourceId,
+  resourcesToSnapshot,
+} from "./build.js";
+
+const rows: ResourceRow[] = [
+  {
+    arn: "arn:aws:ecs:us-west-2:1:service/superlog-prod-app/superlog-prod-api",
+    service: "ecs",
+    resourceType: "service",
+    name: "superlog-prod-api",
+    region: "us-west-2",
+  },
+  {
+    arn: "arn:aws:ecs:us-west-2:1:service/superlog-prod-app/superlog-prod-worker",
+    service: "ecs",
+    resourceType: "service",
+    name: "superlog-prod-worker",
+    region: "us-west-2",
+  },
+  {
+    arn: "arn:aws:rds:us-west-2:1:db:superlog-prod-postgres",
+    service: "rds",
+    resourceType: "db",
+    name: "superlog-prod-postgres",
+    region: "us-west-2",
+  },
+  {
+    arn: "arn:aws:sqs:us-west-2:1:superlog-prod-app-ingest",
+    service: "sqs",
+    resourceType: null,
+    name: "superlog-prod-app-ingest",
+    region: "us-west-2",
+  },
+];
+
+const graph: ServiceGraph = {
+  services: [
+    { name: "superlog-api", spans: 100 },
+    { name: "superlog-worker", spans: 50 },
+  ],
+  edges: [{ from: "superlog-api", to: "superlog-worker", calls: 10 }],
+  externalDeps: [
+    { from: "superlog-worker", target: "postgresql", peerKind: "db", calls: 20 },
+    { from: "superlog-worker", target: "api.anthropic.com", peerKind: "http", calls: 5 },
+  ],
+};
+
+test("resourcesToSnapshot maps services to node kinds", () => {
+  const snap = resourcesToSnapshot(rows);
+  const kindOf = (id: string) => snap.resources.find((r) => r.id === id)?.kind;
+  assert.equal(kindOf(resourceId(rows[0]!)), "compute"); // ecs
+  assert.equal(kindOf(resourceId(rows[2]!)), "database"); // rds
+  assert.equal(kindOf(resourceId(rows[3]!)), "queue"); // sqs
+  assert.equal(snap.relationships.length, 0);
+});
+
+test("assembleTopology reconciles telemetry service.name onto its ECS resource", () => {
+  const t = assembleTopology(rows, graph);
+  // "superlog-api" tokens ⊆ "superlog-prod-api" → collapsed onto the ECS node, not a stray svc: node
+  assert.ok(!t.nodes.some((n) => n.id === "svc:superlog-api"));
+  const apiNode = t.nodes.find((n) => n.id === resourceId(rows[0]!));
+  assert.ok(apiNode, "api ECS node present");
+  assert.equal(apiNode?.provider, "merged");
+  // the observed api→worker edge now connects the two ECS resource ids
+  assert.ok(
+    t.edges.some(
+      (e) =>
+        e.from === resourceId(rows[0]!) &&
+        e.to === resourceId(rows[1]!) &&
+        e.source === "telemetry",
+    ),
+  );
+});
+
+test("assembleTopology keeps the db peer (folded onto RDS) and drops unmatched SaaS", () => {
+  const t = assembleTopology(rows, graph);
+  // postgresql db peer reconciles onto the RDS resource
+  assert.ok(!t.nodes.some((n) => n.label === "postgresql"));
+  assert.ok(
+    t.edges.some((e) => e.to === resourceId(rows[2]!)),
+    "worker→postgres edge folded onto RDS",
+  );
+  // anthropic http SaaS is dropped — not part of the system map
+  assert.ok(!t.nodes.some((n) => n.id === "ext:api.anthropic.com"));
+});
+
+test("an http peer is NOT folded onto a resource just because a leading label matches", () => {
+  // "api.resend.com" must not collapse onto the "superlog-prod-api" service.
+  const g: ServiceGraph = {
+    services: [{ name: "superlog-api", spans: 10 }],
+    edges: [],
+    externalDeps: [{ from: "superlog-api", target: "api.resend.com", peerKind: "http", calls: 3 }],
+  };
+  const t = assembleTopology(rows, g);
+  assert.ok(!t.nodes.some((n) => n.label.includes("resend")), "resend dropped, not folded");
+  assert.ok(
+    !t.edges.some(
+      (e) => e.to === resourceId(rows[0]!) && e.label === undefined && e.source === "telemetry",
+    ),
+  );
+});
+
+test("isMappableResource keeps system building-blocks and drops plumbing", () => {
+  const keep = (service: string, resourceType: string | null): ResourceRow => ({
+    arn: `arn:aws:${service}:r:1:x`,
+    service,
+    resourceType,
+    name: null,
+    region: null,
+  });
+  assert.ok(isMappableResource(keep("ecs", "service")));
+  assert.ok(isMappableResource(keep("rds", "db")));
+  assert.ok(isMappableResource(keep("ec2", "instance")));
+  assert.ok(isMappableResource(keep("elasticloadbalancing", "loadbalancer")));
+  assert.ok(isMappableResource(keep("sqs", null)));
+  // plumbing → dropped
+  assert.ok(!isMappableResource(keep("ec2", "security-group-rule")));
+  assert.ok(!isMappableResource(keep("ec2", "snapshot")));
+  assert.ok(!isMappableResource(keep("secretsmanager", "secret")));
+  assert.ok(!isMappableResource(keep("ecs", "task-definition")));
+  assert.ok(!isMappableResource(keep("elasticloadbalancing", "targetgroup")));
+  assert.ok(!isMappableResource(keep("logs", "log-group")));
+});
+
+test("assembleTopology filters plumbing out of the node set", () => {
+  const noisy: ResourceRow[] = [
+    ...rows,
+    {
+      arn: "arn:aws:ec2:us-west-2:1:security-group-rule/sgr-1",
+      service: "ec2",
+      resourceType: "security-group-rule",
+      name: null,
+      region: "us-west-2",
+    },
+    {
+      arn: "arn:aws:secretsmanager:us-west-2:1:secret:foo",
+      service: "secretsmanager",
+      resourceType: "secret",
+      name: "foo",
+      region: "us-west-2",
+    },
+  ];
+  const t = assembleTopology(noisy, { services: [], edges: [], externalDeps: [] });
+  assert.ok(!t.nodes.some((n) => n.id.includes("security-group-rule")));
+  assert.ok(!t.nodes.some((n) => n.id.includes("secret")));
+});
+
+test("buildProjectTopology wires the readers", async () => {
+  const t = await buildProjectTopology(
+    { listResources: async () => rows, serviceGraph: async () => graph },
+    "p1",
+  );
+  assert.ok(t.nodes.length >= rows.length);
+});

--- a/apps/worker/src/topology/build.ts
+++ b/apps/worker/src/topology/build.ts
@@ -87,8 +87,11 @@ const lastArnSegment = (arn: string): string => {
 // Short, stable, human-ish node id — NOT the full ARN. The LLM has to echo these
 // back in its nodePatches, and it can't reliably reproduce a 90-char ARN, so a
 // full-ARN id silently breaks the whole enrichment. The ARN is preserved in meta.
+// Region-qualified so the same `service:name` in two regions (a project may have
+// several connections) can't collapse into one node; the suffix stays short enough
+// for the LLM to echo. Single-region inventories just get a stable `:region` tail.
 export const resourceId = (r: ResourceRow): string =>
-  `${r.service}:${r.name ?? lastArnSegment(r.arn)}`;
+  `${r.service}:${r.name ?? lastArnSegment(r.arn)}${r.region ? `@${r.region}` : ""}`;
 const resourceLabel = (r: ResourceRow): string => r.name ?? (lastArnSegment(r.arn) || r.service);
 
 export function resourcesToSnapshot(rows: ResourceRow[]): AwsInfraSnapshot {

--- a/apps/worker/src/topology/build.ts
+++ b/apps/worker/src/topology/build.ts
@@ -1,0 +1,259 @@
+// Build a deterministic project topology from live data: the AWS resource
+// inventory (Postgres `cloud_resources`) for nodes, and the observed
+// cross-service call graph (ClickHouse `otel_traces`) for edges. Pure assembly
+// lives here (testable with injected rows); IO is behind the `TopologyReaders`
+// port. The LLM grouping pass runs separately (enrich.ts).
+
+import {
+  type AwsInfraSnapshot,
+  type AwsResource,
+  type NodeKind,
+  type ServiceGraph,
+  type Topology,
+  awsInfraProvider,
+  mergeTopologies,
+  telemetryProvider,
+} from "@superlog/topology";
+import { resourceDetail } from "./resource-detail.js";
+
+/** The columns we read from `cloud_resources`. */
+export type ResourceRow = {
+  arn: string;
+  service: string;
+  resourceType: string | null;
+  name: string | null;
+  region: string | null;
+  accountId?: string | null;
+  /** Cloud Control configuration (best-effort; null for types we don't enrich). */
+  config?: Record<string, unknown> | null;
+};
+
+export type TopologyReaders = {
+  /** Active (non-removed) resources for the project. */
+  listResources: (projectId: string) => Promise<ResourceRow[]>;
+  /** Observed service call-graph + outbound peers from telemetry. */
+  serviceGraph: (projectId: string) => Promise<ServiceGraph>;
+};
+
+// AWS service short-name → node kind. Unknown services fall back to "compute".
+const SERVICE_KIND: Record<string, NodeKind> = {
+  ecs: "compute",
+  lambda: "compute",
+  ec2: "compute",
+  rds: "database",
+  dynamodb: "database",
+  elasticache: "cache",
+  sqs: "queue",
+  sns: "queue",
+  kinesis: "queue",
+  s3: "storage",
+  elasticloadbalancing: "edge",
+  cloudfront: "edge",
+  apigateway: "edge",
+};
+
+// Which (service, resourceType) pairs are worth putting on a system map. The raw
+// tag inventory is ~90% plumbing — security-group rules, secrets, snapshots, task
+// definitions, listeners, subnets, alarms — which would bury the few resources a
+// human cares about. We keep the building blocks of a running system and drop the
+// rest. `"all"` keeps every type for that service.
+const MAPPABLE: Record<string, "all" | Set<string>> = {
+  ecs: new Set(["service"]),
+  rds: new Set(["db", "cluster"]),
+  ec2: new Set(["instance"]),
+  elasticloadbalancing: new Set(["loadbalancer"]),
+  lambda: new Set(["function"]),
+  dynamodb: new Set(["table"]),
+  elasticache: new Set(["cluster", "replicationgroup"]),
+  sqs: "all",
+  cloudfront: "all",
+  // S3 deliberately omitted: our buckets (tfstate, alb-logs, backups, source-maps,
+  // cfn-templates) are all infra plumbing, never app-meaningful nodes. Re-add a
+  // curated subset if real app buckets show up.
+};
+
+export function isMappableResource(r: ResourceRow): boolean {
+  const allow = MAPPABLE[r.service];
+  if (!allow) return false;
+  if (allow === "all") return true;
+  return r.resourceType ? allow.has(r.resourceType) : false;
+}
+
+const lastArnSegment = (arn: string): string => {
+  const tail = arn.split(":").pop() ?? arn;
+  return tail.split("/").pop() ?? tail;
+};
+
+// Short, stable, human-ish node id — NOT the full ARN. The LLM has to echo these
+// back in its nodePatches, and it can't reliably reproduce a 90-char ARN, so a
+// full-ARN id silently breaks the whole enrichment. The ARN is preserved in meta.
+export const resourceId = (r: ResourceRow): string =>
+  `${r.service}:${r.name ?? lastArnSegment(r.arn)}`;
+const resourceLabel = (r: ResourceRow): string => r.name ?? (lastArnSegment(r.arn) || r.service);
+
+export function resourcesToSnapshot(rows: ResourceRow[]): AwsInfraSnapshot {
+  const resources: AwsResource[] = rows.map((r) => {
+    // Polymorphic per-kind detail: console deep-link + headline badge + facts,
+    // folded into the node's generic meta so the renderer stays AWS-agnostic.
+    const detail = resourceDetail(r);
+    return {
+      id: resourceId(r),
+      kind: SERVICE_KIND[r.service] ?? "compute",
+      label: resourceLabel(r),
+      sublabel: r.resourceType ? `${r.service} · ${r.resourceType}` : r.service,
+      arn: r.arn,
+      service: r.service,
+      meta: {
+        region: r.region ?? undefined,
+        accountId: r.accountId ?? undefined,
+        resourceType: r.resourceType ?? undefined,
+        console: detail.consoleUrl,
+        badge: detail.badge,
+        facts: detail.facts.length ? detail.facts : undefined,
+      },
+    };
+  });
+  // No reliable relationships come from tag-based inventory alone, so infra edges
+  // are left to telemetry (observed) + the LLM's suggested links.
+  return { resources, relationships: [] };
+}
+
+// --- reconciliation: telemetry service.name / peer host ↔ inventory resource ---
+
+const tokenize = (s: string): Set<string> =>
+  new Set(
+    s
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length > 1),
+  );
+
+const isSubset = (a: Set<string>, b: Set<string>): boolean => {
+  if (a.size === 0) return false;
+  for (const t of a) if (!b.has(t)) return false;
+  return true;
+};
+
+/**
+ * Match a telemetry name (service.name or a peer host's leading label) to the
+ * inventory resource it most likely *is*. Heuristic: the name's tokens must be a
+ * subset of the resource's tokens; ties broken toward the most specific (fewest
+ * extra tokens) resource.
+ */
+function matchResource(name: string, rows: ResourceRow[]): string | null {
+  const want = tokenize(name);
+  if (want.size === 0) return null;
+  let best: { id: string; extra: number } | null = null;
+  for (const r of rows) {
+    const have = tokenize(`${r.name ?? ""} ${r.arn}`);
+    if (!isSubset(want, have)) continue;
+    const extra = have.size - want.size;
+    if (!best || extra < best.extra) best = { id: resourceId(r), extra };
+  }
+  return best?.id ?? null;
+}
+
+/**
+ * Fold a telemetry peer HOST onto an inventory resource only when the resource's
+ * NAME tokens all appear in the host — e.g. internal NLB host
+ * `superlog-prod-collector-xyz.elb…` contains every token of `superlog-prod-collector`.
+ * This deliberately does NOT match on a single leading label, so `api.resend.com`
+ * does not get folded onto our `superlog-prod-api` service. Requires ≥2 name tokens
+ * to avoid weak matches.
+ */
+function matchHostToResource(host: string, rows: ResourceRow[]): string | null {
+  const hostTokens = tokenize(host);
+  let best: { id: string; score: number } | null = null;
+  for (const r of rows) {
+    const nameTokens = tokenize(r.name ?? "");
+    if (nameTokens.size < 2) continue;
+    if (![...nameTokens].every((t) => hostTokens.has(t))) continue;
+    if (!best || nameTokens.size > best.score) best = { id: resourceId(r), score: nameTokens.size };
+  }
+  return best?.id ?? null;
+}
+
+// `db.system` values are generic engine names, not resource names, so they don't
+// token-match. Map the engine → AWS service and fold onto that resource when the
+// project has exactly one of them.
+const DB_SYSTEM_SERVICE: Record<string, string> = {
+  postgresql: "rds",
+  postgres: "rds",
+  mysql: "rds",
+  mariadb: "rds",
+  aurora: "rds",
+  dynamodb: "dynamodb",
+  redis: "elasticache",
+  memcached: "elasticache",
+};
+
+function matchDbEngine(engine: string, rows: ResourceRow[]): string | null {
+  const service = DB_SYSTEM_SERVICE[engine.toLowerCase()];
+  if (!service) return null;
+  const candidates = rows.filter((r) => r.service === service);
+  return candidates.length === 1 ? resourceId(candidates[0]!) : null;
+}
+
+/**
+ * Assemble nodes (inventory) + edges (telemetry) into one topology. External
+ * HTTP peers (third-party SaaS) are dropped unless they resolve to a known
+ * resource — only internal infra (datastores, queues, our own hosts) stays.
+ */
+export function assembleTopology(allRows: ResourceRow[], graph: ServiceGraph): Topology {
+  // Drop infrastructure plumbing before anything else — both the nodes we draw
+  // and the telemetry↔resource reconciliation work off the curated set.
+  const rows = allRows.filter(isMappableResource);
+  const snapshot = resourcesToSnapshot(rows);
+
+  const aliases: Record<string, string> = {};
+  for (const svc of graph.services) {
+    const id = matchResource(svc.name, rows);
+    if (id) aliases[`svc:${svc.name}`] = id;
+  }
+
+  // Keep db/messaging peers (infra) and any http peer that maps to a resource;
+  // drop unmatched http SaaS so the map stays about the customer's own system.
+  const keptDeps = graph.externalDeps.filter((dep) => {
+    if (dep.peerKind === "db" || dep.peerKind === "messaging") return true;
+    const id = matchHostToResource(dep.target, rows);
+    if (id) {
+      aliases[`ext:${dep.target}`] = id;
+      return true;
+    }
+    return false; // unmatched third-party SaaS → dropped
+  });
+  // db/messaging peers may still alias onto a resource (e.g. "postgresql" → RDS).
+  for (const dep of keptDeps) {
+    if (aliases[`ext:${dep.target}`]) continue;
+    let id = matchHostToResource(dep.target, rows);
+    if (!id && dep.peerKind === "db") id = matchDbEngine(dep.target, rows);
+    if (id) aliases[`ext:${dep.target}`] = id;
+  }
+
+  const filteredGraph: ServiceGraph = { ...graph, externalDeps: keptDeps };
+  const merged = mergeTopologies(
+    [awsInfraProvider(snapshot), telemetryProvider(filteredGraph)],
+    aliases,
+  );
+
+  // External integrations (third-party SaaS) don't belong on a system map — drop
+  // any external-kind node that slipped through, and edges touching it.
+  const keep = merged.nodes.filter((n) => n.kind !== "external");
+  const keepIds = new Set(keep.map((n) => n.id));
+  return {
+    nodes: keep,
+    edges: merged.edges.filter((e) => keepIds.has(e.from) && keepIds.has(e.to)),
+    groups: merged.groups,
+  };
+}
+
+export async function buildProjectTopology(
+  readers: TopologyReaders,
+  projectId: string,
+): Promise<Topology> {
+  const [rows, graph] = await Promise.all([
+    readers.listResources(projectId),
+    readers.serviceGraph(projectId),
+  ]);
+  return assembleTopology(rows, graph);
+}

--- a/apps/worker/src/topology/clickhouse.ts
+++ b/apps/worker/src/topology/clickhouse.ts
@@ -1,0 +1,96 @@
+// ClickHouse reads for topology building: the observed cross-service call graph
+// and outbound client-span peers, scoped to a project. Mirrors the query shape
+// in apps/api/src/mcp/clickhouse.ts (parameterised, project_id + time window).
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import type { ServiceGraph } from "@superlog/topology";
+
+type Ch = Pick<ClickHouseClient, "query">;
+
+const PROJECT_FILTER = "ResourceAttributes['superlog.project_id'] = {projectId:String}";
+
+async function rows<T>(ch: Ch, query: string, params: Record<string, unknown>): Promise<T[]> {
+  const r = await ch.query({ query, query_params: params, format: "JSONEachRow" });
+  return r.json<T>();
+}
+
+/**
+ * Build a ServiceGraph from telemetry: distinct emitting services, observed
+ * cross-service calls (parent.ServiceName → child.ServiceName), and outbound
+ * client-span peers (db / messaging / http). Bounded windows + row limits keep
+ * it cheap.
+ */
+export async function serviceGraphFromClickHouse(
+  ch: Ch,
+  projectId: string,
+  opts: { sinceHours?: number } = {},
+): Promise<ServiceGraph> {
+  // Default to a short window: the cross-service self-join is O(spans²)-ish and
+  // times out over 24h on high-volume projects. A few hours is plenty to observe
+  // the live service graph.
+  const sinceHours = opts.sinceHours ?? 6;
+  const params = { projectId, sinceHours };
+
+  const services = await rows<{ name: string; spans: string }>(
+    ch,
+    `SELECT ServiceName AS name, count() AS spans
+       FROM otel_traces
+      WHERE Timestamp > now() - INTERVAL {sinceHours:UInt32} HOUR
+        AND ${PROJECT_FILTER} AND ServiceName != ''
+      GROUP BY name ORDER BY spans DESC LIMIT 200`,
+    params,
+  );
+
+  const edges = await rows<{ src: string; dst: string; calls: string }>(
+    ch,
+    `SELECT p.ServiceName AS src, c.ServiceName AS dst, count() AS calls
+       FROM otel_traces AS c
+       INNER JOIN otel_traces AS p ON c.TraceId = p.TraceId AND c.ParentSpanId = p.SpanId
+      WHERE c.Timestamp > now() - INTERVAL {sinceHours:UInt32} HOUR
+        AND p.Timestamp > now() - INTERVAL {sinceHours:UInt32} HOUR
+        AND c.${PROJECT_FILTER} AND p.${PROJECT_FILTER}
+        AND c.ServiceName != p.ServiceName AND c.ServiceName != '' AND p.ServiceName != ''
+      GROUP BY src, dst ORDER BY calls DESC LIMIT 500
+      SETTINGS max_execution_time = 25`,
+    params,
+  );
+
+  const peerRows = await rows<{
+    from: string;
+    db: string;
+    msg: string;
+    peer: string;
+    calls: string;
+  }>(
+    ch,
+    `SELECT ServiceName AS from,
+            SpanAttributes['db.system'] AS db,
+            SpanAttributes['messaging.system'] AS msg,
+            SpanAttributes['server.address'] AS peer,
+            count() AS calls
+       FROM otel_traces
+      WHERE Timestamp > now() - INTERVAL {sinceHours:UInt32} HOUR
+        AND ${PROJECT_FILTER} AND SpanKind = 'Client'
+        AND (SpanAttributes['db.system'] != '' OR SpanAttributes['messaging.system'] != '' OR SpanAttributes['server.address'] != '')
+      GROUP BY from, db, msg, peer ORDER BY calls DESC LIMIT 500`,
+    params,
+  );
+
+  const externalDeps: ServiceGraph["externalDeps"] = [];
+  for (const r of peerRows) {
+    if (!r.from) continue;
+    const [target, peerKind] = r.db
+      ? [r.db, "db" as const]
+      : r.msg
+        ? [r.msg, "messaging" as const]
+        : [r.peer, "http" as const];
+    if (!target) continue;
+    externalDeps.push({ from: r.from, target, peerKind, calls: Number(r.calls) });
+  }
+
+  return {
+    services: services.map((s) => ({ name: s.name, spans: Number(s.spans) })),
+    edges: edges.map((e) => ({ from: e.src, to: e.dst, calls: Number(e.calls) })),
+    externalDeps,
+  };
+}

--- a/apps/worker/src/topology/enrich.test.ts
+++ b/apps/worker/src/topology/enrich.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { Topology } from "@superlog/topology";
+import {
+  type EnrichLLMClient,
+  enrichTopologyWithClient,
+  parseEnrichmentToolInput,
+} from "./enrich.js";
+
+const known = new Set(["a", "b", "db"]);
+
+test("parseEnrichmentToolInput keeps valid groups/patches/edges, drops unknown refs", () => {
+  const out = parseEnrichmentToolInput(
+    {
+      summary: "grouped",
+      groups: [
+        { id: "app", label: "App", intent: "serves traffic", tone: "neutral" },
+        { id: "bad" }, // missing label → dropped
+      ],
+      nodePatches: [
+        { id: "a", label: "A", group: "app" },
+        { id: "ghost", group: "app" }, // unknown node → dropped
+        { id: "b", group: "missing" }, // unknown group → dropped
+      ],
+      suggestedEdges: [
+        { from: "a", to: "db", kind: "reads" },
+        { from: "a", to: "ghost" }, // unknown endpoint → dropped
+      ],
+    },
+    known,
+  )!;
+  assert.equal(out.groups?.length, 1);
+  assert.equal(out.groups?.[0]?.id, "app");
+  assert.deepEqual(out.nodePatches, [{ id: "a", label: "A", group: "app" }]);
+  assert.equal(out.suggestedEdges?.length, 1);
+  assert.equal(out.suggestedEdges?.[0]?.from, "a");
+});
+
+test("parseEnrichmentToolInput defaults an invalid tone to neutral and rejects empty", () => {
+  const out = parseEnrichmentToolInput(
+    { groups: [{ id: "g", label: "G", tone: "rainbow" }], nodePatches: [] },
+    known,
+  )!;
+  assert.equal(out.groups?.[0]?.tone, "neutral");
+  assert.equal(parseEnrichmentToolInput({ groups: [] }, known), null);
+  assert.equal(parseEnrichmentToolInput("nope", known), null);
+});
+
+test("enrichTopologyWithClient forces the tool and parses its input", async () => {
+  const topology: Topology = {
+    nodes: [
+      { id: "a", kind: "compute", label: "svc-a", provider: "infra" },
+      { id: "db", kind: "database", label: "pg", provider: "infra" },
+    ],
+    edges: [],
+    groups: [],
+  };
+  let sawToolChoice = false;
+  const client: EnrichLLMClient = {
+    messages: {
+      // biome-ignore lint/suspicious/noExplicitAny: minimal stub of the SDK surface
+      create: (async (req: any) => {
+        sawToolChoice = req.tool_choice?.name === "propose_services";
+        return {
+          content: [
+            {
+              type: "tool_use",
+              name: "propose_services",
+              id: "t1",
+              input: {
+                groups: [{ id: "core", label: "Core" }],
+                nodePatches: [{ id: "a", group: "core" }],
+              },
+            },
+          ],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        };
+      }) as any,
+    } as any,
+  };
+  const { enrichment } = await enrichTopologyWithClient(client, topology);
+  assert.ok(sawToolChoice, "forces propose_services tool");
+  assert.equal(enrichment?.groups?.[0]?.id, "core");
+  assert.deepEqual(enrichment?.nodePatches, [{ id: "a", label: undefined, group: "core" }]);
+});
+
+test("enrichTopologyWithClient returns null for an empty topology without calling the model", async () => {
+  let called = false;
+  const client: EnrichLLMClient = {
+    // biome-ignore lint/suspicious/noExplicitAny: stub
+    messages: {
+      create: (async () => {
+        called = true;
+        return {} as any;
+      }) as any,
+    } as any,
+  };
+  const { enrichment } = await enrichTopologyWithClient(client, {
+    nodes: [],
+    edges: [],
+    groups: [],
+  });
+  assert.equal(enrichment, null);
+  assert.equal(called, false);
+});

--- a/apps/worker/src/topology/enrich.test.ts
+++ b/apps/worker/src/topology/enrich.test.ts
@@ -36,6 +36,26 @@ test("parseEnrichmentToolInput keeps valid groups/patches/edges, drops unknown r
   assert.equal(out.suggestedEdges?.[0]?.from, "a");
 });
 
+test("parseEnrichmentToolInput breaks parent cycles so no group is orphaned", () => {
+  // A→B→A: both parents would be valid per-edge, but the cycle would hide both
+  // groups from every rendered level. The parser must drop the cyclic links.
+  const out = parseEnrichmentToolInput(
+    {
+      groups: [
+        { id: "a", label: "A", tone: "neutral", parent: "b" },
+        { id: "b", label: "B", tone: "neutral", parent: "a" },
+        { id: "c", label: "C", tone: "neutral", parent: "a" }, // acyclic child of A
+      ],
+      nodePatches: [],
+    },
+    known,
+  )!;
+  const byId = new Map(out.groups?.map((g) => [g.id, g]));
+  assert.equal(byId.get("a")?.parent, undefined); // cycle cut
+  assert.equal(byId.get("b")?.parent, undefined); // cycle cut
+  assert.equal(byId.get("c")?.parent, "a"); // healthy link preserved
+});
+
 test("parseEnrichmentToolInput defaults an invalid tone to neutral and rejects empty", () => {
   const out = parseEnrichmentToolInput(
     { groups: [{ id: "g", label: "G", tone: "rainbow" }], nodePatches: [] },

--- a/apps/worker/src/topology/enrich.ts
+++ b/apps/worker/src/topology/enrich.ts
@@ -1,0 +1,228 @@
+// LLM enrichment: given a deterministic topology, ask Claude once to organize it
+// into a few logical *services by intent*, clean node labels, and suggest links
+// the telemetry missed. Returns a `TopologyEnrichment` (the same shape the spike
+// baked by hand) or null when the model is unavailable/unusable. Mirrors the
+// inline-Anthropic pattern in grouping.ts; structured output via a single forced
+// tool call, validated by a pure parser (repo has no zod in the worker).
+
+import Anthropic from "@anthropic-ai/sdk";
+import type {
+  GroupTone,
+  NodePatch,
+  ProposedGroup,
+  SuggestedEdge,
+  Topology,
+  TopologyEnrichment,
+} from "@superlog/topology";
+import { recordTokenUsage } from "../ai-usage.js";
+
+const MODEL = process.env.ANTHROPIC_TOPOLOGY_MODEL ?? "claude-sonnet-4-6";
+const TONES: GroupTone[] = ["accent", "success", "warning", "neutral", "danger"];
+
+const SYSTEM_PROMPT = [
+  "You organize a cloud system's resources into a HIERARCHY of logical SERVICES BY INTENT —",
+  "what each group is *for* (e.g. 'Web app', 'API & backend', 'Telemetry pipeline'), NOT by infra tier.",
+  "Keep the TOP level small (2–5 services). Use NESTING (a group's `parent`) for natural sub-systems:",
+  "e.g. a 'Telemetry pipeline' service containing a 'ClickHouse cluster' sub-group that holds the",
+  "replica/keeper nodes. Assign every node to exactly one LEAF group. Give each group a 3–8 word intent.",
+  "Relabel nodes to clean, human names (drop env prefixes/suffixes).",
+  "Do NOT create an 'external integrations'/'third-party' group — those resources are not on this map.",
+  "Suggest a few links that clearly exist but aren't in the observed edges (e.g. an API reads its database).",
+  "Only reference node ids that were given. Call propose_services exactly once.",
+].join(" ");
+
+const PROPOSE_SERVICES_TOOL: Anthropic.Messages.Tool = {
+  name: "propose_services",
+  description:
+    "Your final grouping of the system into logical services, node relabels, and suggested links.",
+  input_schema: {
+    type: "object",
+    properties: {
+      summary: { type: "string", description: "One sentence describing the grouping you chose." },
+      groups: {
+        type: "array",
+        description: "The logical services (2–6).",
+        items: {
+          type: "object",
+          properties: {
+            id: { type: "string", description: "short slug, e.g. 'backend'" },
+            label: { type: "string" },
+            intent: { type: "string" },
+            tone: { type: "string", enum: TONES },
+            parent: {
+              type: "string",
+              description:
+                "optional id of the parent group, for nesting (omit for a top-level service)",
+            },
+          },
+          required: ["id", "label"],
+        },
+      },
+      nodePatches: {
+        type: "array",
+        description: "Per-node relabel + service assignment. One entry per node id.",
+        items: {
+          type: "object",
+          properties: {
+            id: { type: "string", description: "an existing node id" },
+            label: { type: "string" },
+            group: { type: "string", description: "id of one of the proposed groups" },
+          },
+          required: ["id", "group"],
+        },
+      },
+      suggestedEdges: {
+        type: "array",
+        description: "Links that obviously exist but weren't observed.",
+        items: {
+          type: "object",
+          properties: {
+            from: { type: "string" },
+            to: { type: "string" },
+            kind: { type: "string" },
+          },
+          required: ["from", "to"],
+        },
+      },
+    },
+    required: ["groups", "nodePatches"],
+  },
+};
+
+const asStr = (v: unknown): string | undefined =>
+  typeof v === "string" && v.trim() ? v.trim() : undefined;
+
+/**
+ * Validate a `propose_services` tool input into a TopologyEnrichment. Pure: filters
+ * out malformed entries and anything referencing unknown nodes/groups rather than
+ * throwing, so a partially-good answer is still usable.
+ */
+export function parseEnrichmentToolInput(
+  input: unknown,
+  knownNodeIds: Set<string>,
+): TopologyEnrichment | null {
+  if (!input || typeof input !== "object") return null;
+  const obj = input as Record<string, unknown>;
+  const arr = (v: unknown): Record<string, unknown>[] =>
+    Array.isArray(v) ? (v as Record<string, unknown>[]) : [];
+
+  const rawGroups: {
+    id: string;
+    label: string;
+    intent?: string;
+    tone: GroupTone;
+    parent?: string;
+  }[] = [];
+  for (const g of arr(obj.groups)) {
+    const id = asStr(g.id);
+    const label = asStr(g.label);
+    if (!id || !label) continue;
+    const tone: GroupTone = TONES.includes(g.tone as GroupTone) ? (g.tone as GroupTone) : "neutral";
+    rawGroups.push({ id, label, intent: asStr(g.intent), tone, parent: asStr(g.parent) });
+  }
+  if (rawGroups.length === 0) return null;
+  const groupIds = new Set(rawGroups.map((g) => g.id));
+  // Keep a parent only when it references another proposed group and isn't a self/loop.
+  const groups: ProposedGroup[] = rawGroups.map((g) => ({
+    id: g.id,
+    label: g.label,
+    intent: g.intent,
+    tone: g.tone,
+    parent: g.parent && g.parent !== g.id && groupIds.has(g.parent) ? g.parent : undefined,
+  }));
+
+  const nodePatches: NodePatch[] = [];
+  for (const p of arr(obj.nodePatches)) {
+    const id = asStr(p.id);
+    const group = asStr(p.group);
+    if (!id || !knownNodeIds.has(id) || !group || !groupIds.has(group)) continue;
+    nodePatches.push({ id, label: asStr(p.label), group });
+  }
+
+  const suggestedEdges: SuggestedEdge[] = [];
+  for (const e of arr(obj.suggestedEdges)) {
+    const from = asStr(e.from);
+    const to = asStr(e.to);
+    if (!from || !to || from === to || !knownNodeIds.has(from) || !knownNodeIds.has(to)) continue;
+    suggestedEdges.push({ from, to, kind: asStr(e.kind) });
+  }
+
+  return { summary: asStr(obj.summary), groups, nodePatches, suggestedEdges };
+}
+
+function buildUserMessage(topology: Topology): string {
+  const nodes = topology.nodes.map((n) => ({
+    id: n.id,
+    label: n.label,
+    kind: n.kind,
+    sublabel: n.sublabel,
+  }));
+  const edges = topology.edges.map((e) => ({
+    from: e.from,
+    to: e.to,
+    kind: e.kind,
+    source: e.source,
+  }));
+  return [
+    "Here is the system's resource graph. Group it into logical services by intent.",
+    `Nodes:\n${JSON.stringify(nodes, null, 0)}`,
+    `Observed edges:\n${JSON.stringify(edges, null, 0)}`,
+  ].join("\n\n");
+}
+
+export type EnrichLLMClient = Pick<Anthropic, "messages">;
+
+export async function enrichTopologyWithClient(
+  client: EnrichLLMClient,
+  topology: Topology,
+): Promise<{ enrichment: TopologyEnrichment | null; usage: Anthropic.Messages.Usage | undefined }> {
+  if (topology.nodes.length === 0) return { enrichment: null, usage: undefined };
+  const message = await client.messages.create({
+    model: MODEL,
+    max_tokens: 2000,
+    temperature: 0,
+    system: SYSTEM_PROMPT,
+    tools: [PROPOSE_SERVICES_TOOL],
+    tool_choice: { type: "tool", name: "propose_services" },
+    messages: [{ role: "user", content: buildUserMessage(topology) }],
+  });
+  const toolUse = message.content.find(
+    (b): b is Anthropic.Messages.ToolUseBlock => b.type === "tool_use",
+  );
+  const known = new Set(topology.nodes.map((n) => n.id));
+  const enrichment = toolUse ? parseEnrichmentToolInput(toolUse.input, known) : null;
+  return { enrichment, usage: message.usage };
+}
+
+/**
+ * Run the enrichment against the real Anthropic API. Opts out (returns null) when
+ * `ANTHROPIC_API_KEY` is absent, so stock builds without the key stay inert.
+ */
+export async function enrichProjectTopology(
+  topology: Topology,
+  ctx: { orgId: string; projectId: string },
+): Promise<TopologyEnrichment | null> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return null;
+  const client = new Anthropic({ apiKey });
+  const { enrichment, usage } = await enrichTopologyWithClient(client, topology);
+  if (usage) {
+    try {
+      await recordTokenUsage({
+        orgId: ctx.orgId,
+        projectId: ctx.projectId,
+        model: MODEL,
+        callSite: "topology",
+        usage: {
+          inputTokens: usage.input_tokens ?? 0,
+          outputTokens: usage.output_tokens ?? 0,
+          cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+          cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+        },
+      });
+    } catch {
+      // best-effort accounting
+    }
+  }
+  return enrichment;
+}

--- a/apps/worker/src/topology/enrich.ts
+++ b/apps/worker/src/topology/enrich.ts
@@ -15,6 +15,7 @@ import type {
   TopologyEnrichment,
 } from "@superlog/topology";
 import { recordTokenUsage } from "../ai-usage.js";
+import { logger } from "../logger.js";
 
 const MODEL = process.env.ANTHROPIC_TOPOLOGY_MODEL ?? "claude-sonnet-4-6";
 const TONES: GroupTone[] = ["accent", "success", "warning", "neutral", "danger"];
@@ -122,13 +123,36 @@ export function parseEnrichmentToolInput(
   }
   if (rawGroups.length === 0) return null;
   const groupIds = new Set(rawGroups.map((g) => g.id));
-  // Keep a parent only when it references another proposed group and isn't a self/loop.
+  // A parent is valid only when it references another proposed group (not self).
+  const directParent = new Map<string, string | undefined>(
+    rawGroups.map((g) => [
+      g.id,
+      g.parent && g.parent !== g.id && groupIds.has(g.parent) ? g.parent : undefined,
+    ]),
+  );
+  // Cut a parent link only when walking up from it returns to the group itself —
+  // that's the back-edge of a cycle (A→B→A would otherwise orphan A and B from
+  // every rendered level). A group that merely points INTO a cycle keeps its link
+  // (the cycle gets cut at its own back-edge instead).
+  const acyclicParent = (id: string): string | undefined => {
+    const p0 = directParent.get(id);
+    if (!p0) return undefined;
+    const seen = new Set<string>();
+    let p: string | undefined = p0;
+    while (p) {
+      if (p === id) return undefined; // cycle through `id` → cut its link
+      if (seen.has(p)) return p0; // downstream cycle, not through `id` → keep link
+      seen.add(p);
+      p = directParent.get(p);
+    }
+    return p0;
+  };
   const groups: ProposedGroup[] = rawGroups.map((g) => ({
     id: g.id,
     label: g.label,
     intent: g.intent,
     tone: g.tone,
-    parent: g.parent && g.parent !== g.id && groupIds.has(g.parent) ? g.parent : undefined,
+    parent: acyclicParent(g.id),
   }));
 
   const nodePatches: NodePatch[] = [];
@@ -205,7 +229,19 @@ export async function enrichProjectTopology(
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) return null;
   const client = new Anthropic({ apiKey });
-  const { enrichment, usage } = await enrichTopologyWithClient(client, topology);
+  // Enrichment is best-effort: a transient Anthropic failure must NOT sink the
+  // build — the deterministic graph still persists, just without AI grouping.
+  let enrichment: TopologyEnrichment | null;
+  let usage: Anthropic.Messages.Usage | undefined;
+  try {
+    ({ enrichment, usage } = await enrichTopologyWithClient(client, topology));
+  } catch (err) {
+    logger.warn(
+      { projectId: ctx.projectId, err: err instanceof Error ? err.message : String(err) },
+      "topology enrichment failed — persisting deterministic graph only",
+    );
+    return null;
+  }
   if (usage) {
     try {
       await recordTokenUsage({

--- a/apps/worker/src/topology/resource-detail.test.ts
+++ b/apps/worker/src/topology/resource-detail.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ResourceRow } from "./build.js";
+import { resourceDetail } from "./resource-detail.js";
+
+const row = (over: Partial<ResourceRow>): ResourceRow => ({
+  arn: "arn:aws:ecs:us-west-2:121638211609:service/superlog-prod/api",
+  service: "ecs",
+  resourceType: "service",
+  name: "api",
+  region: "us-west-2",
+  accountId: "121638211609",
+  config: null,
+  ...over,
+});
+
+test("ECS service surfaces running/desired task counts + a console link", () => {
+  const d = resourceDetail(
+    row({
+      config: { ServiceName: "api", Cluster: "superlog-prod", DesiredCount: 3, RunningCount: 3, LaunchType: "FARGATE" },
+    }),
+  );
+  assert.equal(d.badge, "3/3 tasks");
+  assert.ok(d.facts.some((f) => f.label === "Tasks" && f.value === "3 running / 3 desired"));
+  assert.ok(d.facts.some((f) => f.label === "Launch type" && f.value === "FARGATE"));
+  assert.ok(d.consoleUrl?.includes("/ecs/v2/clusters/superlog-prod/services/api/"));
+  assert.ok(d.consoleUrl?.includes("us-west-2.console.aws.amazon.com"));
+});
+
+test("ECS with only desired count degrades to '<n> tasks'", () => {
+  const d = resourceDetail(row({ config: { ServiceName: "api", Cluster: "c", DesiredCount: 1 } }));
+  assert.equal(d.badge, "1 task");
+});
+
+test("RDS instance surfaces class + engine and a database deep-link", () => {
+  const d = resourceDetail(
+    row({
+      arn: "arn:aws:rds:us-west-2:121638211609:db:superlog-prod-postgres",
+      service: "rds",
+      resourceType: "db",
+      name: "superlog-prod-postgres",
+      config: { DBInstanceIdentifier: "superlog-prod-postgres", DBInstanceClass: "db.t4g.medium", Engine: "postgres", MultiAZ: true },
+    }),
+  );
+  assert.equal(d.badge, "db.t4g.medium");
+  assert.ok(d.facts.some((f) => f.label === "Multi-AZ" && f.value === "yes"));
+  assert.ok(d.consoleUrl?.includes("#database:id=superlog-prod-postgres"));
+});
+
+test("region falls back to the ARN when the column is null", () => {
+  const d = resourceDetail(row({ region: null, config: { ServiceName: "api", Cluster: "c", DesiredCount: 2 } }));
+  assert.ok(d.consoleUrl?.includes("us-west-2"));
+});
+
+test("ECS console link works from the ARN alone (no config yet, no task badge)", () => {
+  const d = resourceDetail(
+    row({
+      arn: "arn:aws:ecs:us-west-2:121638211609:service/superlog-prod-app/superlog-prod-api",
+      name: "superlog-prod-api",
+      config: null,
+    }),
+  );
+  assert.equal(d.badge, undefined); // no config → no task count
+  assert.ok(d.consoleUrl?.includes("/clusters/superlog-prod-app/services/superlog-prod-api/"));
+});
+
+test("unknown / un-enriched resource yields an empty detail, no throw", () => {
+  const d = resourceDetail(row({ service: "kms", resourceType: "key", config: null }));
+  assert.deepEqual(d.facts, []);
+  assert.equal(d.badge, undefined);
+});

--- a/apps/worker/src/topology/resource-detail.test.ts
+++ b/apps/worker/src/topology/resource-detail.test.ts
@@ -17,14 +17,20 @@ const row = (over: Partial<ResourceRow>): ResourceRow => ({
 test("ECS service surfaces running/desired task counts + a console link", () => {
   const d = resourceDetail(
     row({
-      config: { ServiceName: "api", Cluster: "superlog-prod", DesiredCount: 3, RunningCount: 3, LaunchType: "FARGATE" },
+      config: {
+        ServiceName: "api",
+        Cluster: "superlog-prod",
+        DesiredCount: 3,
+        RunningCount: 3,
+        LaunchType: "FARGATE",
+      },
     }),
   );
   assert.equal(d.badge, "3/3 tasks");
   assert.ok(d.facts.some((f) => f.label === "Tasks" && f.value === "3 running / 3 desired"));
   assert.ok(d.facts.some((f) => f.label === "Launch type" && f.value === "FARGATE"));
+  assert.ok(d.consoleUrl?.startsWith("https://us-west-2.console.aws.amazon.com/"));
   assert.ok(d.consoleUrl?.includes("/ecs/v2/clusters/superlog-prod/services/api/"));
-  assert.ok(d.consoleUrl?.includes("us-west-2.console.aws.amazon.com"));
 });
 
 test("ECS with only desired count degrades to '<n> tasks'", () => {
@@ -39,7 +45,12 @@ test("RDS instance surfaces class + engine and a database deep-link", () => {
       service: "rds",
       resourceType: "db",
       name: "superlog-prod-postgres",
-      config: { DBInstanceIdentifier: "superlog-prod-postgres", DBInstanceClass: "db.t4g.medium", Engine: "postgres", MultiAZ: true },
+      config: {
+        DBInstanceIdentifier: "superlog-prod-postgres",
+        DBInstanceClass: "db.t4g.medium",
+        Engine: "postgres",
+        MultiAZ: true,
+      },
     }),
   );
   assert.equal(d.badge, "db.t4g.medium");
@@ -48,7 +59,9 @@ test("RDS instance surfaces class + engine and a database deep-link", () => {
 });
 
 test("region falls back to the ARN when the column is null", () => {
-  const d = resourceDetail(row({ region: null, config: { ServiceName: "api", Cluster: "c", DesiredCount: 2 } }));
+  const d = resourceDetail(
+    row({ region: null, config: { ServiceName: "api", Cluster: "c", DesiredCount: 2 } }),
+  );
   assert.ok(d.consoleUrl?.includes("us-west-2"));
 });
 
@@ -62,6 +75,18 @@ test("ECS console link works from the ARN alone (no config yet, no task badge)",
   );
   assert.equal(d.badge, undefined); // no config → no task count
   assert.ok(d.consoleUrl?.includes("/clusters/superlog-prod-app/services/superlog-prod-api/"));
+});
+
+test("ECS cluster from a slash-less ARN config value resolves its trailing name", () => {
+  // config.Cluster as a colon-only ARN (no slash) must yield the cluster name, not
+  // the whole ARN — regression for lastSegment's missing ':' fallback.
+  const d = resourceDetail(
+    row({
+      config: { ServiceName: "api", Cluster: "arn:aws:ecs:us-west-2:121638211609:superlog-prod" },
+    }),
+  );
+  assert.ok(d.facts.some((f) => f.label === "Cluster" && f.value === "superlog-prod"));
+  assert.ok(d.consoleUrl?.includes("/clusters/superlog-prod/"));
 });
 
 test("unknown / un-enriched resource yields an empty detail, no throw", () => {

--- a/apps/worker/src/topology/resource-detail.ts
+++ b/apps/worker/src/topology/resource-detail.ts
@@ -1,0 +1,195 @@
+// Polymorphic per-resource detail for the service map. A `cloud_resources` row is
+// generic (arn / service / type / name / Cloud Control `config`); here we turn it
+// into the kind-specific facts a human wants on the card — ECS task counts, the
+// RDS instance class, a Lambda's runtime — plus a deep-link into the AWS console.
+//
+// This is the one place that knows AWS specifics. Everything downstream (the
+// topology model, the renderer) stays domain-agnostic: we fold the result into the
+// node's generic `meta` bag (`badge`, `facts`, `console`) and the UI just displays
+// whatever is there. Add a new resource type by adding a case below, nothing else.
+
+import type { ResourceRow } from "./build.js";
+
+export type ResourceFact = { label: string; value: string };
+
+export type ResourceDetail = {
+  /** AWS console deep-link for this exact resource, when we can build one. */
+  consoleUrl?: string;
+  /** Single headline fact for the card (e.g. "3/3 tasks", "db.t4g.medium"). */
+  badge?: string;
+  /** Full key/value detail for the inspector. */
+  facts: ResourceFact[];
+};
+
+const str = (v: unknown): string | undefined =>
+  typeof v === "string" && v.length > 0 ? v : undefined;
+const num = (v: unknown): number | undefined =>
+  typeof v === "number"
+    ? v
+    : typeof v === "string" && v.trim() !== "" && !Number.isNaN(Number(v))
+      ? Number(v)
+      : undefined;
+
+// Cluster / load-balancer / etc. identifiers often arrive as ARNs; the console
+// wants the trailing name.
+const lastSegment = (s: string): string => s.split("/").pop() ?? s.split(":").pop() ?? s;
+
+// ECS service ARN: `arn:…:service/<cluster>/<service>` (new long-ARN format).
+// Returns [cluster, service] when present.
+function ecsClusterService(arn: string): [string | undefined, string | undefined] {
+  const rest = arn.split(":").slice(5).join(":"); // e.g. "service/cluster/svc"
+  const parts = rest.split("/");
+  if (parts[0] === "service" && parts.length >= 3) return [parts[1], parts[2]];
+  return [undefined, undefined];
+}
+
+/** Best-effort region: the row's column, else parsed from the ARN's 4th field. */
+function regionOf(r: ResourceRow): string | undefined {
+  if (r.region) return r.region;
+  const parts = r.arn.split(":");
+  return parts.length > 3 && parts[3] ? parts[3] : undefined;
+}
+
+function consoleBase(region: string): string {
+  return `https://${region}.console.aws.amazon.com`;
+}
+
+/** Resolve the resource detail. Falls back to an empty (no-badge) detail. */
+export function resourceDetail(r: ResourceRow): ResourceDetail {
+  const builder = BUILDERS[`${r.service}:${r.resourceType ?? ""}`] ?? BUILDERS[r.service];
+  const detail = builder?.(r, regionOf(r)) ?? { facts: [] };
+  return detail;
+}
+
+type Builder = (r: ResourceRow, region?: string) => ResourceDetail;
+
+const BUILDERS: Record<string, Builder> = {
+  "ecs:service": (r, region) => {
+    const cfg = r.config ?? {};
+    const desired = num(cfg.DesiredCount);
+    const running = num(cfg.RunningCount);
+    const launch = str(cfg.LaunchType);
+    // The cluster + service are in the ARN's resource id (`service/<cluster>/<svc>`),
+    // so the console link works even before Cloud Control config is fetched.
+    const [arnCluster, arnService] = ecsClusterService(r.arn);
+    const cfgCluster = str(cfg.Cluster);
+    const cluster = cfgCluster ? lastSegment(cfgCluster) : arnCluster;
+    const service = str(cfg.ServiceName) ?? arnService ?? r.name ?? undefined;
+    const facts: ResourceFact[] = [];
+    if (desired != null)
+      facts.push({
+        label: "Tasks",
+        value: running != null ? `${running} running / ${desired} desired` : `${desired} desired`,
+      });
+    if (launch) facts.push({ label: "Launch type", value: launch });
+    if (cluster) facts.push({ label: "Cluster", value: cluster });
+    // Headline: running/desired if we have both, else the desired count.
+    const badge =
+      desired != null
+        ? running != null
+          ? `${running}/${desired} tasks`
+          : `${desired} ${desired === 1 ? "task" : "tasks"}`
+        : undefined;
+    const consoleUrl =
+      region && cluster && service
+        ? `${consoleBase(region)}/ecs/v2/clusters/${enc(cluster)}/services/${enc(service)}/health?region=${region}`
+        : undefined;
+    return { consoleUrl, badge, facts };
+  },
+
+  "rds:db": (r, region) => {
+    const cfg = r.config ?? {};
+    const cls = str(cfg.DBInstanceClass);
+    const engine = str(cfg.Engine);
+    const multiAz = typeof cfg.MultiAZ === "boolean" ? cfg.MultiAZ : undefined;
+    const facts: ResourceFact[] = [];
+    if (engine) facts.push({ label: "Engine", value: engine });
+    if (cls) facts.push({ label: "Class", value: cls });
+    if (multiAz != null) facts.push({ label: "Multi-AZ", value: multiAz ? "yes" : "no" });
+    const id = str(cfg.DBInstanceIdentifier) ?? r.name ?? undefined;
+    const consoleUrl =
+      region && id
+        ? `${consoleBase(region)}/rds/home?region=${region}#database:id=${enc(id)};is-cluster=false`
+        : undefined;
+    return { consoleUrl, badge: cls, facts };
+  },
+
+  "rds:cluster": (r, region) => {
+    const cfg = r.config ?? {};
+    const engine = str(cfg.Engine);
+    const id = str(cfg.DBClusterIdentifier) ?? r.name ?? undefined;
+    const facts: ResourceFact[] = engine ? [{ label: "Engine", value: engine }] : [];
+    const consoleUrl =
+      region && id
+        ? `${consoleBase(region)}/rds/home?region=${region}#database:id=${enc(id)};is-cluster=true`
+        : undefined;
+    return { consoleUrl, badge: engine, facts };
+  },
+
+  "ec2:instance": (r, region) => {
+    const cfg = r.config ?? {};
+    const type = str(cfg.InstanceType);
+    const az = str(cfg.AvailabilityZone);
+    const id = str(cfg.InstanceId) ?? r.name ?? lastSegment(r.arn);
+    const facts: ResourceFact[] = [];
+    if (type) facts.push({ label: "Instance type", value: type });
+    if (az) facts.push({ label: "AZ", value: az });
+    const consoleUrl =
+      region && id
+        ? `${consoleBase(region)}/ec2/home?region=${region}#InstanceDetails:instanceId=${enc(id)}`
+        : undefined;
+    return { consoleUrl, badge: type, facts };
+  },
+
+  "lambda:function": (r, region) => {
+    const cfg = r.config ?? {};
+    const runtime = str(cfg.Runtime);
+    const mem = num(cfg.MemorySize);
+    const name = str(cfg.FunctionName) ?? r.name ?? undefined;
+    const facts: ResourceFact[] = [];
+    if (runtime) facts.push({ label: "Runtime", value: runtime });
+    if (mem != null) facts.push({ label: "Memory", value: `${mem} MB` });
+    const consoleUrl =
+      region && name
+        ? `${consoleBase(region)}/lambda/home?region=${region}#/functions/${enc(name)}`
+        : undefined;
+    return { consoleUrl, badge: runtime, facts };
+  },
+
+  "elasticloadbalancing:loadbalancer": (r, region) => {
+    const cfg = r.config ?? {};
+    const type = str(cfg.Type); // application | network | gateway
+    const scheme = str(cfg.Scheme);
+    const facts: ResourceFact[] = [];
+    if (type) facts.push({ label: "Type", value: type });
+    if (scheme) facts.push({ label: "Scheme", value: scheme });
+    const name = r.name ?? lastSegment(r.arn);
+    const consoleUrl = region
+      ? `${consoleBase(region)}/ec2/home?region=${region}#LoadBalancers:search=${enc(name)}`
+      : undefined;
+    const badge = type ? type.toUpperCase().slice(0, 3) : undefined; // ALB / NET / GAT
+    return { consoleUrl, badge, facts };
+  },
+
+  "dynamodb:table": (r, region) => {
+    const name = str(r.config?.TableName) ?? r.name ?? lastSegment(r.arn);
+    const consoleUrl = region
+      ? `${consoleBase(region)}/dynamodbv2/home?region=${region}#table?name=${enc(name)}`
+      : undefined;
+    return { consoleUrl, facts: [] };
+  },
+
+  sqs: (r, region) => {
+    const name = r.name ?? lastSegment(r.arn);
+    const consoleUrl = region
+      ? `${consoleBase(region)}/sqs/v3/home?region=${region}#/queues`
+      : undefined;
+    return {
+      consoleUrl,
+      badge: name.endsWith("-dlq") || name.endsWith("-dead-letter") ? "DLQ" : undefined,
+      facts: [],
+    };
+  },
+};
+
+const enc = encodeURIComponent;

--- a/apps/worker/src/topology/resource-detail.ts
+++ b/apps/worker/src/topology/resource-detail.ts
@@ -31,8 +31,13 @@ const num = (v: unknown): number | undefined =>
       : undefined;
 
 // Cluster / load-balancer / etc. identifiers often arrive as ARNs; the console
-// wants the trailing name.
-const lastSegment = (s: string): string => s.split("/").pop() ?? s.split(":").pop() ?? s;
+// wants the trailing name. Slash-delimited wins (e.g. `…cluster/name`), else fall
+// back to the colon-delimited tail (e.g. a slash-less `arn:…:queue-name`).
+const lastSegment = (s: string): string => {
+  if (s.includes("/")) return s.slice(s.lastIndexOf("/") + 1);
+  if (s.includes(":")) return s.slice(s.lastIndexOf(":") + 1);
+  return s;
+};
 
 // ECS service ARN: `arn:…:service/<cluster>/<service>` (new long-ARN format).
 // Returns [cluster, service] when present.

--- a/packages/db/migrations/0072_loving_magdalene.sql
+++ b/packages/db/migrations/0072_loving_magdalene.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "project_topologies" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"project_id" uuid NOT NULL,
+	"graph" jsonb,
+	"enrichment" jsonb,
+	"status" text DEFAULT 'idle' NOT NULL,
+	"error" text,
+	"generated_at" timestamp with time zone,
+	"refresh_requested_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "project_topologies" ADD CONSTRAINT "project_topologies_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "project_topologies_project_idx" ON "project_topologies" USING btree ("project_id");

--- a/packages/db/migrations/meta/0072_snapshot.json
+++ b/packages/db/migrations/meta/0072_snapshot.json
@@ -1,0 +1,7257 @@
+{
+  "id": "b29122f7-1fdf-43e5-b317-814039e0987a",
+  "prevId": "f0af9edf-17d8-427f-b4f8-3e97e1d7b719",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_provider_account_idx": {
+          "name": "accounts_provider_account_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_idx": {
+          "name": "accounts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_ticket_events": {
+      "name": "agent_linear_ticket_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_linear_ticket_id": {
+          "name": "agent_linear_ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_linear_id": {
+          "name": "actor_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_ticket_events_ticket_idx": {
+          "name": "agent_linear_ticket_events_ticket_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_ticket_events_provider_event_idx": {
+          "name": "agent_linear_ticket_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk": {
+          "name": "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk",
+          "tableFrom": "agent_linear_ticket_events",
+          "tableTo": "agent_linear_tickets",
+          "columnsFrom": [
+            "agent_linear_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_tickets": {
+      "name": "agent_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_identifier": {
+          "name": "ticket_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_name": {
+          "name": "assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_linear_id": {
+          "name": "assignee_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_tickets_incident_idx": {
+          "name": "agent_linear_tickets_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_agent_run_idx": {
+          "name": "agent_linear_tickets_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_workspace_ticket_idx": {
+          "name": "agent_linear_tickets_workspace_ticket_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_tickets_incident_id_incidents_id_fk": {
+          "name": "agent_linear_tickets_incident_id_incidents_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_linear_tickets_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_installation_id_linear_installations_id_fk": {
+          "name": "agent_linear_tickets_installation_id_linear_installations_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "linear_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memories": {
+      "name": "agent_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source_agent_run_id": {
+          "name": "source_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memories_org_status_idx": {
+          "name": "agent_memories_org_status_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_memories_org_id_orgs_id_fk": {
+          "name": "agent_memories_org_id_orgs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_id_projects_id_fk": {
+          "name": "agent_memories_project_id_projects_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_memories_source_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "source_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_user_id_users_id_fk": {
+          "name": "agent_memories_source_user_id_users_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "source_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_org_fk": {
+          "name": "agent_memories_project_org_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_memories_single_source_check": {
+          "name": "agent_memories_single_source_check",
+          "value": "NOT (source_agent_run_id IS NOT NULL AND source_user_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_pr_events": {
+      "name": "agent_pr_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_pr_id": {
+          "name": "agent_pr_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_login": {
+          "name": "actor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_github_id": {
+          "name": "actor_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pr_events_pr_idx": {
+          "name": "agent_pr_events_pr_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pr_events_provider_event_idx": {
+          "name": "agent_pr_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk": {
+          "name": "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk",
+          "tableFrom": "agent_pr_events",
+          "tableTo": "agent_pull_requests",
+          "columnsFrom": [
+            "agent_pr_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_pull_requests": {
+      "name": "agent_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_node_id": {
+          "name": "pr_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_login": {
+          "name": "merged_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_github_id": {
+          "name": "merged_by_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pull_requests_incident_idx": {
+          "name": "agent_pull_requests_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_agent_run_idx": {
+          "name": "agent_pull_requests_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_repo_pr_idx": {
+          "name": "agent_pull_requests_repo_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pull_requests_incident_id_incidents_id_fk": {
+          "name": "agent_pull_requests_incident_id_incidents_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_pull_requests_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_installation_id_github_installations_id_fk": {
+          "name": "agent_pull_requests_installation_id_github_installations_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'incident'"
+        },
+        "trigger_detail": {
+          "name": "trigger_detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_status": {
+          "name": "provider_session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_full_name": {
+          "name": "selected_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_url": {
+          "name": "selected_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_base_branch": {
+          "name": "selected_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_score": {
+          "name": "selected_repo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cumulative_runtime_minutes": {
+          "name": "cumulative_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resume_count": {
+          "name": "resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_runs_incident_idx": {
+          "name": "agent_runs_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_provider_session_idx": {
+          "name": "agent_runs_provider_session_idx",
+          "columns": [
+            {
+              "expression": "provider_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_incident_id_incidents_id_fk": {
+          "name": "agent_runs_incident_id_incidents_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_firings": {
+      "name": "alert_firings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_value": {
+          "name": "observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluated_at": {
+          "name": "evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_firings_alert_group_idx": {
+          "name": "alert_firings_alert_group_idx",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_firings_alert_id_alerts_id_fk": {
+          "name": "alert_firings_alert_id_alerts_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_firings_issue_id_issues_id_fk": {
+          "name": "alert_firings_issue_id_issues_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_name": {
+          "name": "metric_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "group_by": {
+          "name": "group_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mode": {
+          "name": "group_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single'"
+        },
+        "aggregation": {
+          "name": "aggregation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparator": {
+          "name": "comparator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "evaluation_interval_seconds": {
+          "name": "evaluation_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alerts_project_idx": {
+          "name": "alerts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alerts_enabled_idx": {
+          "name": "alerts_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alerts_project_id_projects_id_fk": {
+          "name": "alerts_project_id_projects_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alerts_created_by_users_id_fk": {
+          "name": "alerts_created_by_users_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions": {
+      "name": "cli_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cli_sessions_user_id_users_id_fk": {
+          "name": "cli_sessions_user_id_users_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_org_id_orgs_id_fk": {
+          "name": "cli_sessions_org_id_orgs_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_sessions_token_hash_unique": {
+          "name": "cli_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_connections": {
+      "name": "cloud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scrape_role_arn": {
+          "name": "scrape_role_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id_ciphertext": {
+          "name": "external_id_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_nonce": {
+          "name": "external_id_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_key_version": {
+          "name": "external_id_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloud_connections_project_idx": {
+          "name": "cloud_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_connections_active_role_idx": {
+          "name": "cloud_connections_active_role_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scrape_role_arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_connections_project_id_projects_id_fk": {
+          "name": "cloud_connections_project_id_projects_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_connections_created_by_users_id_fk": {
+          "name": "cloud_connections_created_by_users_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_resources": {
+      "name": "cloud_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arn": {
+          "name": "arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_fetched_at": {
+          "name": "config_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_resources_project_arn_idx": {
+          "name": "cloud_resources_project_arn_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_project_idx": {
+          "name": "cloud_resources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_connection_idx": {
+          "name": "cloud_resources_connection_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_resources_project_id_projects_id_fk": {
+          "name": "cloud_resources_project_id_projects_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_resources_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_resources_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_stream_keys": {
+      "name": "cloud_stream_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_ciphertext": {
+          "name": "key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_nonce": {
+          "name": "key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_key_version": {
+          "name": "key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_stream_keys_connection_kind_idx": {
+          "name": "cloud_stream_keys_connection_kind_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_stream_keys_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_stream_keys_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_stream_keys",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_stream_keys_api_key_id_api_keys_id_fk": {
+          "name": "cloud_stream_keys_api_key_id_api_keys_id_fk",
+          "tableFrom": "cloud_stream_keys",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_widgets": {
+      "name": "dashboard_widgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboard_widgets_dashboard_idx": {
+          "name": "dashboard_widgets_dashboard_idx",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_widgets_dashboard_id_dashboards_id_fk": {
+          "name": "dashboard_widgets_dashboard_id_dashboards_id_fk",
+          "tableFrom": "dashboard_widgets",
+          "tableTo": "dashboards",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboards": {
+      "name": "dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboards_project_slug_idx": {
+          "name": "dashboards_project_slug_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboards_project_idx": {
+          "name": "dashboards_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboards_project_id_projects_id_fk": {
+          "name": "dashboards_project_id_projects_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboards_created_by_users_id_fk": {
+          "name": "dashboards_created_by_users_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_repo": {
+          "name": "ref_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_external": {
+          "name": "author_external",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "triaged_by_user_id": {
+          "name": "triaged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_status_created_idx": {
+          "name": "feedback_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_kind_ref_idx": {
+          "name": "feedback_kind_ref_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_user_id_users_id_fk": {
+          "name": "feedback_author_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_org_id_orgs_id_fk": {
+          "name": "feedback_org_id_orgs_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_project_id_projects_id_fk": {
+          "name": "feedback_project_id_projects_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_triaged_by_user_id_users_id_fk": {
+          "name": "feedback_triaged_by_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triaged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repos": {
+          "name": "repos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_enabled": {
+          "name": "agent_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "repo_access": {
+          "name": "repo_access",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_name": {
+          "name": "commit_author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_email": {
+          "name": "commit_author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_login": {
+          "name": "commit_author_github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_id": {
+          "name": "commit_author_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_avatar_url": {
+          "name": "commit_author_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_by_user_id": {
+          "name": "commit_author_set_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_at": {
+          "name": "commit_author_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_project_installation_idx": {
+          "name": "github_installations_project_installation_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NOT NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_installation_idx": {
+          "name": "github_installations_org_installation_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_idx": {
+          "name": "github_installations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_org_id_orgs_id_fk": {
+          "name": "github_installations_org_id_orgs_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_project_id_projects_id_fk": {
+          "name": "github_installations_project_id_projects_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_commit_author_set_by_user_id_users_id_fk": {
+          "name": "github_installations_commit_author_set_by_user_id_users_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "commit_author_set_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_events": {
+      "name": "incident_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_posted_at": {
+          "name": "slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_events_agent_run_idx": {
+          "name": "incident_events_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_idx": {
+          "name": "incident_events_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_provider_event_idx": {
+          "name": "incident_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_provider_event_idx": {
+          "name": "incident_events_incident_provider_event_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_dedupe_idx": {
+          "name": "incident_events_dedupe_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_dedupe_idx": {
+          "name": "incident_events_incident_dedupe_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_events_agent_run_id_agent_runs_id_fk": {
+          "name": "incident_events_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_events_incident_id_incidents_id_fk": {
+          "name": "incident_events_incident_id_incidents_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "incident_events_parentage_check": {
+          "name": "incident_events_parentage_check",
+          "value": "agent_run_id IS NOT NULL OR incident_id IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.incident_issues": {
+      "name": "incident_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_issues_issue_idx": {
+          "name": "incident_issues_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_issues_incident_idx": {
+          "name": "incident_issues_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_issues_incident_id_incidents_id_fk": {
+          "name": "incident_issues_incident_id_incidents_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_issues_issue_id_issues_id_fk": {
+          "name": "incident_issues_issue_id_issues_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_resolution_proposals": {
+      "name": "incident_resolution_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sweep'"
+        },
+        "proposed_reason_code": {
+          "name": "proposed_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_reason_text": {
+          "name": "proposed_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_at": {
+          "name": "proposed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_slack_user_id": {
+          "name": "decided_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_resolution_proposals_incident_idx": {
+          "name": "incident_resolution_proposals_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proposed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_resolution_proposals_slack_msg_idx": {
+          "name": "incident_resolution_proposals_slack_msg_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_message_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_channel_id IS NOT NULL AND slack_message_ts IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_resolution_proposals_incident_id_incidents_id_fk": {
+          "name": "incident_resolution_proposals_incident_id_incidents_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk": {
+          "name": "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_decided_by_user_id_users_id_fk": {
+          "name": "incident_resolution_proposals_decided_by_user_id_users_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "noise_reason": {
+          "name": "noise_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_resolved_at": {
+          "name": "noise_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_into_id": {
+          "name": "merged_into_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_investigate_suppressed_until": {
+          "name": "auto_investigate_suppressed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autorecovery_last_evaluated_at": {
+          "name": "autorecovery_last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_summary": {
+          "name": "agent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_text": {
+          "name": "root_cause_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_confidence": {
+          "name": "root_cause_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_text": {
+          "name": "estimated_impact_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_confidence": {
+          "name": "estimated_impact_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_severity": {
+          "name": "suggested_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_classification": {
+          "name": "noise_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_classification": {
+          "name": "resolution_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_agent_run_id": {
+          "name": "findings_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_kind": {
+          "name": "resolved_by_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_slack_user_id": {
+          "name": "resolved_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_code": {
+          "name": "resolved_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_text": {
+          "name": "resolved_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incidents_project_status_seen_idx": {
+          "name": "incidents_project_status_seen_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_autorecovery_eval_idx": {
+          "name": "incidents_autorecovery_eval_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "autorecovery_last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_slack_thread_idx": {
+          "name": "incidents_slack_thread_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_project_codename_idx": {
+          "name": "incidents_project_codename_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "codename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "codename <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_project_id_projects_id_fk": {
+          "name": "incidents_project_id_projects_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incidents_merged_into_id_incidents_id_fk": {
+          "name": "incidents_merged_into_id_incidents_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "merged_into_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_slack_installation_id_slack_installations_id_fk": {
+          "name": "incidents_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_findings_agent_run_id_agent_runs_id_fk": {
+          "name": "incidents_findings_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "findings_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_resolved_by_user_id_users_id_fk": {
+          "name": "incidents_resolved_by_user_id_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_org_idx": {
+          "name": "invitations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_org_id_orgs_id_fk": {
+          "name": "invitations_org_id_orgs_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'span'"
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_type": {
+          "name": "exception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_frame": {
+          "name": "top_frame",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_frames": {
+          "name": "normalized_frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_sample": {
+          "name": "last_sample",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "silenced_at": {
+          "name": "silenced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_alerted_at": {
+          "name": "last_alerted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "grouping_state": {
+          "name": "grouping_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'grouped'"
+        },
+        "grouping_source": {
+          "name": "grouping_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_reason": {
+          "name": "grouping_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempted_at": {
+          "name": "grouping_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempt_count": {
+          "name": "grouping_attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_project_fingerprint_idx": {
+          "name": "issues_project_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "silenced_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_grouping_state_idx": {
+          "name": "issues_grouping_state_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grouping_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grouping_state IN ('pending', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_installations": {
+      "name": "linear_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_url_key": {
+          "name": "workspace_url_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_vault_id": {
+          "name": "anthropic_vault_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_credential_id": {
+          "name": "anthropic_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_required_at": {
+          "name": "reauth_required_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_reason": {
+          "name": "reauth_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linear_installations_project_active_idx": {
+          "name": "linear_installations_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_installations_project_id_projects_id_fk": {
+          "name": "linear_installations_project_id_projects_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_installations_actor_user_id_users_id_fk": {
+          "name": "linear_installations_actor_user_id_users_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_codes": {
+      "name": "mcp_oauth_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_codes_client_idx": {
+          "name": "mcp_oauth_codes_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_user_id_users_id_fk": {
+          "name": "mcp_oauth_codes_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_project_id_projects_id_fk": {
+          "name": "mcp_oauth_codes_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_tokens": {
+      "name": "mcp_oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "access_hash": {
+          "name": "access_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_hash": {
+          "name": "refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_tokens_client_idx": {
+          "name": "mcp_oauth_tokens_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_tokens_user_idx": {
+          "name": "mcp_oauth_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_user_id_users_id_fk": {
+          "name": "mcp_oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_project_id_projects_id_fk": {
+          "name": "mcp_oauth_tokens_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_tokens_access_hash_unique": {
+          "name": "mcp_oauth_tokens_access_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_hash"
+          ]
+        },
+        "mcp_oauth_tokens_refresh_hash_unique": {
+          "name": "mcp_oauth_tokens_refresh_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_agent_settings": {
+      "name": "org_agent_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "digest_enabled": {
+          "name": "digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "digest_slack_installation_id": {
+          "name": "digest_slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_id": {
+          "name": "digest_slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_name": {
+          "name": "digest_slack_channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_last_run_at": {
+          "name": "digest_last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_agent_settings_org_idx": {
+          "name": "org_agent_settings_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_agent_settings_org_id_orgs_id_fk": {
+          "name": "org_agent_settings_org_id_orgs_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk": {
+          "name": "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "digest_slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_api_keys": {
+      "name": "org_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_api_keys_org_idx": {
+          "name": "org_api_keys_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_api_keys_org_id_orgs_id_fk": {
+          "name": "org_api_keys_org_id_orgs_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_api_keys_created_by_user_id_users_id_fk": {
+          "name": "org_api_keys_created_by_user_id_users_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_api_keys_key_hash_unique": {
+          "name": "org_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integration_secrets": {
+      "name": "org_integration_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_integration_id": {
+          "name": "org_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_name": {
+          "name": "secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integration_secrets_unique_idx": {
+          "name": "org_integration_secrets_unique_idx",
+          "columns": [
+            {
+              "expression": "org_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integration_secrets_org_integration_id_org_integrations_id_fk": {
+          "name": "org_integration_secrets_org_integration_id_org_integrations_id_fk",
+          "tableFrom": "org_integration_secrets",
+          "tableTo": "org_integrations",
+          "columnsFrom": [
+            "org_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integrations": {
+      "name": "org_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integrations_org_slug_idx": {
+          "name": "org_integrations_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_integrations_org_enabled_idx": {
+          "name": "org_integrations_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integrations_org_id_orgs_id_fk": {
+          "name": "org_integrations_org_id_orgs_id_fk",
+          "tableFrom": "org_integrations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_members_org_user_idx": {
+          "name": "org_members_org_user_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_org_id_orgs_id_fk": {
+          "name": "org_members_org_id_orgs_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_members_user_id_users_id_fk": {
+          "name": "org_members_user_id_users_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_setup_skipped_at": {
+          "name": "github_setup_skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_source": {
+          "name": "signup_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_return_url_hosts": {
+          "name": "allowed_return_url_hosts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_slug_unique": {
+          "name": "orgs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "orgs_clerk_org_id_unique": {
+          "name": "orgs_clerk_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personal_access_tokens_user_idx": {
+          "name": "personal_access_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personal_access_tokens_project_idx": {
+          "name": "personal_access_tokens_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_users_id_fk": {
+          "name": "personal_access_tokens_user_id_users_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personal_access_tokens_project_id_projects_id_fk": {
+          "name": "personal_access_tokens_project_id_projects_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_automation_settings": {
+      "name": "project_automation_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_investigate_issues_enabled": {
+          "name": "auto_investigate_issues_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "agent_run_provider": {
+          "name": "agent_run_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "max_runtime_minutes": {
+          "name": "max_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "max_human_resume_count": {
+          "name": "max_human_resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_follow_up_enabled": {
+          "name": "auto_follow_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "linear_ticket_instructions": {
+          "name": "linear_ticket_instructions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_base_branch": {
+          "name": "pr_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_merge_fix_prs": {
+          "name": "auto_merge_fix_prs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'never'"
+        },
+        "auto_merge_method": {
+          "name": "auto_merge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'squash'"
+        },
+        "issue_filter": {
+          "name": "issue_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "issue_filter_config": {
+          "name": "issue_filter_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"includeLogs\":[],\"includeSpans\":[],\"excludeLogs\":[],\"excludeSpans\":[]}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_automation_settings_project_idx": {
+          "name": "project_automation_settings_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_automation_settings_project_id_projects_id_fk": {
+          "name": "project_automation_settings_project_id_projects_id_fk",
+          "tableFrom": "project_automation_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_github_repos": {
+      "name": "project_github_repos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_full_name": {
+          "name": "github_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_github_repos_project_repo_idx": {
+          "name": "project_github_repos_project_repo_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_github_repos_installation_idx": {
+          "name": "project_github_repos_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_github_repos_project_id_projects_id_fk": {
+          "name": "project_github_repos_project_id_projects_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_github_repos_installation_id_github_installations_id_fk": {
+          "name": "project_github_repos_installation_id_github_installations_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_ingest_filters": {
+      "name": "project_ingest_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal": {
+          "name": "signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_ingest_filters_project_source_signal_idx": {
+          "name": "project_ingest_filters_project_source_signal_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_ingest_filters_project_id_projects_id_fk": {
+          "name": "project_ingest_filters_project_id_projects_id_fk",
+          "tableFrom": "project_ingest_filters",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_topologies": {
+      "name": "project_topologies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment": {
+          "name": "enrichment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_requested_at": {
+          "name": "refresh_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_topologies_project_idx": {
+          "name": "project_topologies_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_topologies_project_id_projects_id_fk": {
+          "name": "project_topologies_project_id_projects_id_fk",
+          "tableFrom": "project_topologies",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_context": {
+          "name": "project_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_idx": {
+          "name": "projects_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_org_id_orgs_id_fk": {
+          "name": "projects_org_id_orgs_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_id_org_uniq": {
+          "name": "projects_id_org_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_orgs_id_fk": {
+          "name": "sessions_active_organization_id_orgs_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signup_intents": {
+      "name": "signup_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_project_id": {
+          "name": "claimed_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signup_intents_claimed_project_id_projects_id_fk": {
+          "name": "signup_intents_claimed_project_id_projects_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "claimed_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "signup_intents_claimed_by_user_id_users_id_fk": {
+          "name": "signup_intents_claimed_by_user_id_users_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signup_intents_key_hash_unique": {
+          "name": "signup_intents_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slack_installations_project_team_idx": {
+          "name": "slack_installations_project_team_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_project_id_projects_id_fk": {
+          "name": "slack_installations_project_id_projects_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_installations_installed_by_user_id_users_id_fk": {
+          "name": "slack_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_map_artifacts": {
+      "name": "source_map_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dist": {
+          "name": "dist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug_id": {
+          "name": "debug_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_file": {
+          "name": "bundle_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_file": {
+          "name": "map_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_hash": {
+          "name": "source_map_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_bytes": {
+          "name": "source_map_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_bucket": {
+          "name": "storage_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_encoding": {
+          "name": "content_encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gzip'"
+        },
+        "uploaded_by_org_api_key_id": {
+          "name": "uploaded_by_org_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_map_artifacts_project_debug_id_idx": {
+          "name": "source_map_artifacts_project_debug_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "debug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "debug_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_map_artifacts_project_release_idx": {
+          "name": "source_map_artifacts_project_release_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "release",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_map_artifacts_project_id_projects_id_fk": {
+          "name": "source_map_artifacts_project_id_projects_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk": {
+          "name": "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "org_api_keys",
+          "columnsFrom": [
+            "uploaded_by_org_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_project_id": {
+          "name": "active_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_org_id": {
+          "name": "active_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_org_id": {
+          "name": "favorite_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_project_id": {
+          "name": "favorite_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_active_project_id_projects_id_fk": {
+          "name": "users_active_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "active_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_active_org_id_orgs_id_fk": {
+          "name": "users_active_org_id_orgs_id_fk",
+          "tableFrom": "users",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_favorite_org_id_orgs_id_fk": {
+          "name": "users_favorite_org_id_orgs_id_fk",
+          "tableFrom": "users",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "favorite_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_favorite_project_id_projects_id_fk": {
+          "name": "users_favorite_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "favorite_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_status": {
+          "name": "last_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_endpoint_idx": {
+          "name": "webhook_deliveries_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_events": {
+          "name": "enabled_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"agent_run.completed\"]'::jsonb"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_endpoints_project_idx": {
+          "name": "webhook_endpoints_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_endpoints_project_id_projects_id_fk": {
+          "name": "webhook_endpoints_project_id_projects_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_state": {
+      "name": "worker_state",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -505,6 +505,13 @@
       "when": 1781912549129,
       "tag": "0071_good_roxanne_simpson",
       "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1782302382240,
+      "tag": "0072_loving_magdalene",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1924,6 +1924,37 @@ export const projectIngestFilters = pgTable(
 );
 
 export type ProjectIngestFilter = typeof projectIngestFilters.$inferSelect;
+
+// The generated service map for a project. One row per project. `graph` is the
+// deterministic topology (AWS inventory + observed telemetry edges); `enrichment`
+// is the LLM's reviewable grouping/relabel/suggested-links pass on top. The whole
+// map is regenerated wholesale by a worker job, so it's stored as JSON blobs
+// rather than normalized node/edge tables. `refreshRequestedAt > generatedAt`
+// (or a null graph) is the worker's "(re)build me" signal.
+export const projectTopologies = pgTable(
+  "project_topologies",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    projectId: uuid("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    // Deterministic Topology { nodes, edges, groups } from @superlog/topology.
+    graph: jsonb("graph"),
+    // TopologyEnrichment { groups, nodePatches, suggestedEdges } from the LLM pass.
+    enrichment: jsonb("enrichment"),
+    status: text("status").$type<"idle" | "generating" | "error">().default("idle").notNull(),
+    error: text("error"),
+    generatedAt: timestamp("generated_at", { withTimezone: true }),
+    refreshRequestedAt: timestamp("refresh_requested_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    projectUniq: uniqueIndex("project_topologies_project_idx").on(t.projectId),
+  }),
+);
+
+export type ProjectTopology = typeof projectTopologies.$inferSelect;
 export type Org = typeof orgs.$inferSelect;
 export type User = typeof users.$inferSelect;
 export type Project = typeof projects.$inferSelect;

--- a/packages/topology/package.json
+++ b/packages/topology/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "tsx --test src/**/*.test.ts",
+    "test": "tsx --test src/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/topology/package.json
+++ b/packages/topology/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@superlog/topology",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "tsx --test src/**/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/topology/src/enrich.test.ts
+++ b/packages/topology/src/enrich.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { type TopologyEnrichment, applyEnrichment } from "./enrich.js";
+import type { Topology } from "./topology.js";
+
+const base: Topology = {
+  nodes: [
+    { id: "ecs:api", kind: "compute", label: "superlog-api", provider: "merged" },
+    { id: "sqs:ingest", kind: "queue", label: "superlog-prod-app-ingest", provider: "infra" },
+    { id: "ecs:proxy", kind: "compute", label: "superlog-proxy", provider: "merged" },
+  ],
+  edges: [
+    {
+      id: "ecs:proxy->ecs:api",
+      from: "ecs:proxy",
+      to: "ecs:api",
+      source: "telemetry",
+      kind: "calls",
+    },
+  ],
+  groups: [],
+};
+
+const enrichment: TopologyEnrichment = {
+  summary: "Grouped by tier; linked proxy→queue.",
+  groups: [{ id: "ingest", label: "Ingest pipeline", tone: "accent" }],
+  nodePatches: [
+    { id: "ecs:api", label: "API", group: "app" },
+    { id: "sqs:ingest", label: "Ingest queue", group: "ingest" },
+  ],
+  suggestedEdges: [
+    { from: "ecs:proxy", to: "sqs:ingest", kind: "enqueues", label: "infers enqueue" },
+  ],
+};
+
+test("applyEnrichment renames + regroups via nodePatches and flags them aiProposed", () => {
+  const out = applyEnrichment(base, enrichment);
+  const api = out.nodes.find((n) => n.id === "ecs:api")!;
+  assert.equal(api.label, "API");
+  assert.equal(api.group, "app");
+  assert.equal(api.aiProposed, true);
+  assert.ok(out.groups.some((g) => g.id === "ingest" && g.aiProposed));
+});
+
+test("suggested links are added with source 'suggested', existing edges untouched", () => {
+  const out = applyEnrichment(base, enrichment);
+  const suggested = out.edges.find((e) => e.from === "ecs:proxy" && e.to === "sqs:ingest");
+  assert.equal(suggested?.source, "suggested");
+  // the deterministic telemetry edge is still present and still telemetry-sourced
+  const det = out.edges.find((e) => e.from === "ecs:proxy" && e.to === "ecs:api");
+  assert.equal(det?.source, "telemetry");
+  assert.equal(out.edges.length, base.edges.length + 1);
+});
+
+test("toggling a capability off makes that part a no-op", () => {
+  const noRename = applyEnrichment(base, enrichment, { rename: false });
+  assert.equal(noRename.nodes.find((n) => n.id === "ecs:api")!.label, "superlog-api");
+  // regroup still applied
+  assert.equal(noRename.nodes.find((n) => n.id === "ecs:api")!.group, "app");
+
+  const noLinks = applyEnrichment(base, enrichment, { suggestLinks: false });
+  assert.equal(noLinks.edges.length, base.edges.length);
+
+  const noGroup = applyEnrichment(base, enrichment, { regroup: false });
+  assert.equal(noGroup.groups.length, 0);
+  assert.equal(noGroup.nodes.find((n) => n.id === "ecs:api")!.group, undefined);
+});
+
+test("never duplicates a known pair and never drops a deterministic edge", () => {
+  const dupAttempt: TopologyEnrichment = {
+    suggestedEdges: [{ from: "ecs:proxy", to: "ecs:api", kind: "depends" }],
+  };
+  const out = applyEnrichment(base, dupAttempt);
+  assert.equal(out.edges.length, base.edges.length, "no duplicate pair added");
+  assert.equal(out.edges[0]?.source, "telemetry", "original edge preserved");
+});
+
+test("suggested edge to a missing node is skipped", () => {
+  const out = applyEnrichment(base, { suggestedEdges: [{ from: "ecs:proxy", to: "ghost" }] });
+  assert.equal(out.edges.length, base.edges.length);
+});

--- a/packages/topology/src/enrich.ts
+++ b/packages/topology/src/enrich.ts
@@ -69,7 +69,13 @@ export function applyEnrichment(
   enrichment: TopologyEnrichment,
   toggles: EnrichmentToggles = ALL_ON,
 ): Topology {
-  const t = { ...ALL_ON, ...toggles };
+  // Nullish-coalesce each toggle so an explicit `undefined` (e.g. `{rename: someVar}`
+  // where the var is unset) doesn't silently disable a capability — only `false` does.
+  const t = {
+    rename: toggles.rename ?? true,
+    regroup: toggles.regroup ?? true,
+    suggestLinks: toggles.suggestLinks ?? true,
+  };
   const patchById = new Map((enrichment.nodePatches ?? []).map((p) => [p.id, p]));
 
   const nodes = topology.nodes.map((n) => {

--- a/packages/topology/src/enrich.ts
+++ b/packages/topology/src/enrich.ts
@@ -1,0 +1,144 @@
+// ---------------------------------------------------------------------------
+// LLM refinement contract
+//
+// The deterministic graph (providers + merge) is the source of truth. An LLM is
+// asked to produce a `TopologyEnrichment` — a set of *reviewable suggestions*:
+// cleaner names + reclassifications, logical groupings, and links telemetry
+// didn't capture. `applyEnrichment` folds those onto a topology in a strictly
+// ADDITIVE way:
+//
+//   • it never deletes a node or a deterministic edge,
+//   • everything it touches is flagged (`aiProposed` on nodes/groups,
+//     `source:"suggested"` on edges) so the UI can render it as "review me",
+//   • each of the three capabilities is independently toggleable.
+//
+// So the worst an LLM can do is propose — a human (or the renderer's accept/reject
+// affordance) decides. This same value shape is what the production worker's
+// Anthropic pass must emit, which is why it lives here and is unit-tested against
+// the baked fixtures.
+// ---------------------------------------------------------------------------
+
+import {
+  type EdgeKind,
+  type GroupTone,
+  type NodeKind,
+  type Topology,
+  type TopologyEdge,
+  edgeId,
+} from "./topology.js";
+
+export type ProposedGroup = {
+  id: string;
+  label: string;
+  tone: GroupTone;
+  intent?: string;
+  parent?: string;
+};
+
+export type NodePatch = {
+  id: string;
+  label?: string;
+  sublabel?: string;
+  kind?: NodeKind;
+  group?: string;
+};
+
+export type SuggestedEdge = { from: string; to: string; kind?: EdgeKind; label?: string };
+
+export type TopologyEnrichment = {
+  /** A one-line rationale the LLM gives for the overall arrangement (shown in UI). */
+  summary?: string;
+  groups?: ProposedGroup[];
+  nodePatches?: NodePatch[];
+  suggestedEdges?: SuggestedEdge[];
+};
+
+export type EnrichmentToggles = {
+  /** Apply label / sublabel / kind reclassification from nodePatches. */
+  rename?: boolean;
+  /** Apply group assignment + add proposed groups. */
+  regroup?: boolean;
+  /** Add suggestedEdges as dashed "review me" links. */
+  suggestLinks?: boolean;
+};
+
+const ALL_ON: Required<EnrichmentToggles> = { rename: true, regroup: true, suggestLinks: true };
+
+export function applyEnrichment(
+  topology: Topology,
+  enrichment: TopologyEnrichment,
+  toggles: EnrichmentToggles = ALL_ON,
+): Topology {
+  const t = { ...ALL_ON, ...toggles };
+  const patchById = new Map((enrichment.nodePatches ?? []).map((p) => [p.id, p]));
+
+  const nodes = topology.nodes.map((n) => {
+    const patch = patchById.get(n.id);
+    if (!patch) return n;
+    const next = { ...n };
+    let touched = false;
+    if (t.rename) {
+      if (patch.label && patch.label !== n.label) {
+        next.label = patch.label;
+        touched = true;
+      }
+      if (patch.sublabel !== undefined && patch.sublabel !== n.sublabel) {
+        next.sublabel = patch.sublabel;
+        touched = true;
+      }
+      if (patch.kind && patch.kind !== n.kind) {
+        next.kind = patch.kind;
+        touched = true;
+      }
+    }
+    if (t.regroup && patch.group !== undefined && patch.group !== n.group) {
+      next.group = patch.group;
+      touched = true;
+    }
+    return touched ? { ...next, aiProposed: true } : n;
+  });
+
+  const groups = t.regroup
+    ? dedupeGroups([
+        ...topology.groups,
+        ...(enrichment.groups ?? []).map((g) => ({
+          id: g.id,
+          label: g.label,
+          tone: g.tone,
+          intent: g.intent,
+          parentId: g.parent,
+          aiProposed: true,
+        })),
+      ])
+    : topology.groups;
+
+  // Additive only: keep every existing edge; append suggestions that don't
+  // duplicate a pair the deterministic graph already knows about.
+  const edges: TopologyEdge[] = [...topology.edges];
+  if (t.suggestLinks && enrichment.suggestedEdges?.length) {
+    const known = new Set(edges.map((e) => `${e.from} ${e.to}`));
+    const present = new Set(topology.nodes.map((n) => n.id));
+    for (const s of enrichment.suggestedEdges) {
+      const key = `${s.from} ${s.to}`;
+      if (s.from === s.to || known.has(key)) continue;
+      if (!present.has(s.from) || !present.has(s.to)) continue;
+      known.add(key);
+      edges.push({
+        id: edgeId(s.from, s.to, s.kind),
+        from: s.from,
+        to: s.to,
+        kind: s.kind,
+        source: "suggested",
+        label: s.label,
+      });
+    }
+  }
+
+  return { nodes, edges, groups };
+}
+
+function dedupeGroups(groups: Topology["groups"]): Topology["groups"] {
+  const by = new Map<string, Topology["groups"][number]>();
+  for (const g of groups) by.set(g.id, by.get(g.id) ?? g);
+  return [...by.values()];
+}

--- a/packages/topology/src/index.ts
+++ b/packages/topology/src/index.ts
@@ -1,0 +1,11 @@
+// @superlog/topology — framework-agnostic topology model + builders.
+//
+// Pure, dependency-free logic shared by the worker (builds a topology from live
+// inventory + telemetry, then runs the LLM enrichment) and the web renderer. The
+// React canvas itself lives in apps/web; everything here is plain data + functions.
+
+export * from "./topology.js";
+export * from "./providers.js";
+export * from "./services.js";
+export * from "./enrich.js";
+export * from "./layout.js";

--- a/packages/topology/src/layout.test.ts
+++ b/packages/topology/src/layout.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { assignLayers, layoutTopology } from "./layout.js";
+import type { Topology } from "./topology.js";
+
+const node = (id: string) => ({
+  id,
+  kind: "compute" as const,
+  label: id,
+  provider: "infra" as const,
+});
+const edge = (from: string, to: string) => ({
+  id: `${from}->${to}`,
+  from,
+  to,
+  source: "infra" as const,
+});
+
+// alb → api → postgres ; alb → proxy ; proxy → queue → consumer
+const t: Topology = {
+  nodes: ["alb", "api", "postgres", "proxy", "queue", "consumer"].map(node),
+  edges: [
+    edge("alb", "api"),
+    edge("api", "postgres"),
+    edge("alb", "proxy"),
+    edge("proxy", "queue"),
+    edge("queue", "consumer"),
+  ],
+  groups: [],
+};
+
+test("sources land in layer 0 and depth increases along edges", () => {
+  const layers = assignLayers(t);
+  assert.equal(layers.get("alb"), 0);
+  assert.equal(layers.get("api"), 1);
+  assert.equal(layers.get("postgres"), 2);
+  assert.equal(layers.get("proxy"), 1);
+  assert.equal(layers.get("queue"), 2);
+  assert.equal(layers.get("consumer"), 3);
+});
+
+test("layout is deterministic and places later layers further right", () => {
+  const a = layoutTopology(t);
+  const b = layoutTopology(t);
+  assert.deepEqual([...a.positions.entries()].sort(), [...b.positions.entries()].sort());
+  const alb = a.positions.get("alb")!;
+  const api = a.positions.get("api")!;
+  const postgres = a.positions.get("postgres")!;
+  assert.ok(api.x > alb.x, "api right of alb");
+  assert.ok(postgres.x > api.x, "postgres right of api");
+});
+
+test("cycles terminate (no infinite layering) and stay bounded", () => {
+  const cyclic: Topology = {
+    nodes: ["a", "b", "c"].map(node),
+    edges: [edge("a", "b"), edge("b", "c"), edge("c", "a")],
+    groups: [],
+  };
+  const layers = assignLayers(cyclic);
+  for (const v of layers.values())
+    assert.ok(v < cyclic.nodes.length, "layer stays bounded under a cycle");
+});
+
+test("extent grows with the widest layer", () => {
+  const { extent } = layoutTopology(t);
+  assert.ok(extent.w > 0 && extent.h > 0);
+});
+
+test("swimlane mode keeps each group in a non-overlapping vertical band", () => {
+  const grouped: Topology = {
+    nodes: [
+      { ...node("alb"), group: "edge" },
+      { ...node("api"), group: "app" }, // layer 1
+      { ...node("worker"), group: "app" }, // layer 1 (also fed by alb) → same column as api
+      { ...node("pg"), group: "data" },
+    ],
+    edges: [edge("alb", "api"), edge("alb", "worker"), edge("api", "pg"), edge("worker", "pg")],
+    groups: [
+      { id: "edge", label: "Edge", tone: "accent" },
+      { id: "app", label: "App", tone: "neutral" },
+      { id: "data", label: "Data", tone: "success" },
+    ],
+  };
+  const { positions } = layoutTopology(grouped, { lanes: true });
+  const yOf = (id: string) => positions.get(id)!.y;
+  // lane order edge < app < data means every edge node sits above every app node, etc.
+  assert.ok(yOf("alb") < yOf("api"), "edge lane above app lane");
+  assert.ok(yOf("alb") < yOf("worker"));
+  assert.ok(Math.max(yOf("api"), yOf("worker")) < yOf("pg"), "app lane above data lane");
+  // api & worker share a lane AND a dependency layer → they stack vertically, not overlap
+  assert.notEqual(yOf("api"), yOf("worker"));
+});

--- a/packages/topology/src/layout.ts
+++ b/packages/topology/src/layout.ts
@@ -1,0 +1,263 @@
+// ---------------------------------------------------------------------------
+// Layered auto-layout (Sugiyama-lite), dependency-free.
+//
+// Our topologies are mostly left-to-right DAGs (edge → compute → data → external),
+// so a longest-path layering + a couple of barycenter ordering sweeps gives a
+// clean, deterministic arrangement without pulling in dagre/elk. Cycles (which a
+// telemetry graph can contain) are tolerated: the layering is capped so it always
+// terminates, and back-edges simply don't push their target further right.
+//
+// Output positions are top-left corners in canvas px. They are a STARTING point —
+// once productionized, a user drag becomes a saved per-node override that wins
+// over the computed value.
+// ---------------------------------------------------------------------------
+
+import type { Topology, TopologyNode } from "./topology.js";
+
+export const NODE_W = 248;
+export const NODE_H = 96; // header + one badge/empty row, matches the card renderer
+const SERVICE_H = 156; // service cards carry a 2-line intent + a stats row, so they're taller
+const BOUNDARY_H = 48; // a "talks to →" stub is a single compact row
+
+/**
+ * Rendered height of a node, in canvas px. Shared by the layout (vertical
+ * stacking) and the renderer (edge-port geometry) so they never disagree. The
+ * resource list lives in the drawer, so service cards are a fixed height; boundary
+ * stubs are a single compact row.
+ */
+export function nodeCardHeight(n: TopologyNode): number {
+  if (n.kind !== "service") return NODE_H;
+  return n.meta?.boundary ? BOUNDARY_H : SERVICE_H;
+}
+
+// Vertical footprint a node reserves when stacked in a column. Service cards are
+// taller than resource cards, so stacking by a flat NODE_H crammed them together.
+const slotHeight = (n: TopologyNode): number => nodeCardHeight(n);
+
+export type Density = "comfortable" | "compact";
+
+export type LayoutOptions = {
+  density?: Density;
+  /** Extra top padding so group label tabs have room. */
+  padTop?: number;
+  padLeft?: number;
+  /**
+   * Swimlane mode: give each group its own horizontal band so group containers
+   * never overlap. Nodes keep their dependency-layer X (left→right flow), but a
+   * node's Y is determined by which lane its group occupies. Falls back to the
+   * plain layered layout when there are no groups.
+   */
+  lanes?: boolean;
+  /**
+   * Wrap the layered layout to this pixel width: when the dependency chain is
+   * wider than `maxWidth`, later layers reflow onto a new row band (like wrapping
+   * text) at FULL node size — no zooming/scaling. Only applies to the plain
+   * (non-swimlane) path. Omit for an un-wrapped single row.
+   */
+  maxWidth?: number;
+};
+
+export type Positioned = {
+  positions: Map<string, { x: number; y: number }>;
+  layers: Map<string, number>;
+  extent: { w: number; h: number };
+};
+
+const GAPS: Record<Density, { h: number; v: number }> = {
+  comfortable: { h: 120, v: 40 },
+  compact: { h: 84, v: 24 },
+};
+
+/** Longest-path layering. layer(source)=0; layer(n)=max(layer(pred))+1. */
+export function assignLayers(t: Topology): Map<string, number> {
+  const layer = new Map<string, number>(t.nodes.map((n) => [n.id, 0]));
+  const ids = new Set(layer.keys());
+  const edges = t.edges.filter((e) => ids.has(e.from) && ids.has(e.to));
+  // Relax up to |nodes| times (Bellman-Ford style). A valid DAG's longest path is
+  // at most |nodes|-1, so clamping each layer there never affects a real DAG but
+  // bounds (and thus terminates) layering when the graph contains a cycle.
+  const cap = Math.max(0, t.nodes.length - 1);
+  for (let pass = 0; pass < t.nodes.length; pass++) {
+    let changed = false;
+    for (const e of edges) {
+      const next = (layer.get(e.from) ?? 0) + 1;
+      if (next <= cap && next > (layer.get(e.to) ?? 0)) {
+        layer.set(e.to, next);
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+  return layer;
+}
+
+/**
+ * Order nodes within each layer to reduce edge crossings, using a few barycenter
+ * sweeps. Deterministic: initial order is by id, ties always broken by id.
+ */
+function orderWithinLayers(t: Topology, layer: Map<string, number>): Map<number, string[]> {
+  const byLayer = new Map<number, string[]>();
+  for (const n of [...t.nodes].sort((a, b) => a.id.localeCompare(b.id))) {
+    const l = layer.get(n.id) ?? 0;
+    (byLayer.get(l) ?? byLayer.set(l, []).get(l)!).push(n.id);
+  }
+
+  const preds = new Map<string, string[]>();
+  const succs = new Map<string, string[]>();
+  for (const e of t.edges) {
+    (succs.get(e.from) ?? succs.set(e.from, []).get(e.from)!).push(e.to);
+    (preds.get(e.to) ?? preds.set(e.to, []).get(e.to)!).push(e.from);
+  }
+
+  const layerKeys = [...byLayer.keys()].sort((a, b) => a - b);
+  const indexInLayer = () => {
+    const idx = new Map<string, number>();
+    for (const l of layerKeys) byLayer.get(l)!.forEach((id, i) => idx.set(id, i));
+    return idx;
+  };
+
+  const sweep = (neighbors: Map<string, string[]>, order: number[]) => {
+    const idx = indexInLayer();
+    for (const l of order) {
+      const row = byLayer.get(l)!;
+      const bary = new Map<string, number>();
+      row.forEach((id, i) => {
+        const ns = neighbors.get(id) ?? [];
+        const positions = ns.map((m) => idx.get(m)).filter((v): v is number => v != null);
+        bary.set(
+          id,
+          positions.length ? positions.reduce((a, b) => a + b, 0) / positions.length : i,
+        );
+      });
+      row.sort((a, b) => {
+        const d = (bary.get(a) ?? 0) - (bary.get(b) ?? 0);
+        return d !== 0 ? d : a.localeCompare(b);
+      });
+    }
+  };
+
+  // A down sweep (order by predecessors) then up sweep (by successors), twice.
+  for (let i = 0; i < 2; i++) {
+    sweep(preds, layerKeys);
+    sweep(succs, [...layerKeys].reverse());
+  }
+  return byLayer;
+}
+
+export function layoutTopology(t: Topology, opts: LayoutOptions = {}): Positioned {
+  if (opts.lanes && t.groups.length > 0) return layoutSwimlanes(t, opts);
+
+  const gap = GAPS[opts.density ?? "comfortable"];
+  const padTop = opts.padTop ?? 64;
+  const padLeft = opts.padLeft ?? 32;
+
+  const layer = assignLayers(t);
+  const byLayer = orderWithinLayers(t, layer);
+  const nodeById = new Map(t.nodes.map((n) => [n.id, n]));
+  const colW = NODE_W + gap.h;
+
+  // How many layer-columns fit per row before we wrap to a new band.
+  const layerKeys = [...byLayer.keys()].sort((a, b) => a - b);
+  const fitCols = opts.maxWidth
+    ? Math.floor((opts.maxWidth - 2 * padLeft + gap.h) / colW)
+    : Number.POSITIVE_INFINITY;
+  const maxCols = Math.max(1, Math.min(layerKeys.length, fitCols));
+
+  // Height of each layer's vertical stack, then the height of each wrap band.
+  const stackH = (ids: string[]) =>
+    ids.reduce((h, id) => h + (slotHeight(nodeById.get(id) ?? FALLBACK) + gap.v), 0) - gap.v;
+  const bandOf = (idx: number) => Math.floor(idx / maxCols);
+  const bandHeight = new Map<number, number>();
+  layerKeys.forEach((l, idx) => {
+    const b = bandOf(idx);
+    bandHeight.set(b, Math.max(bandHeight.get(b) ?? 0, stackH(byLayer.get(l)!)));
+  });
+
+  const BAND_GAP = gap.v * 2 + 28;
+  const bandTop = new Map<number, number>();
+  let cursor = padTop;
+  for (const b of [...bandHeight.keys()].sort((a, b2) => a - b2)) {
+    bandTop.set(b, cursor);
+    cursor += (bandHeight.get(b) ?? 0) + BAND_GAP;
+  }
+
+  const positions = new Map<string, { x: number; y: number }>();
+  layerKeys.forEach((l, idx) => {
+    const col = idx % maxCols;
+    const x = padLeft + col * colW;
+    let y = bandTop.get(bandOf(idx)) ?? padTop;
+    for (const id of byLayer.get(l)!) {
+      positions.set(id, { x, y });
+      y += slotHeight(nodeById.get(id) ?? FALLBACK) + gap.v;
+    }
+  });
+
+  const colsUsed = Math.min(maxCols, layerKeys.length);
+  const extent = {
+    w: padLeft * 2 + Math.max(1, colsUsed) * NODE_W + Math.max(0, colsUsed - 1) * gap.h,
+    h: cursor - BAND_GAP + padTop,
+  };
+  return { positions, layers: layer, extent };
+}
+
+// Stand-in node when a synthetic/unknown id has no record (keeps slotHeight total).
+const FALLBACK = { id: "", kind: "compute", label: "", provider: "infra" } as const;
+
+// Vertical room reserved above each lane for its group label tab + separation.
+const LANE_TOP_PAD = 64;
+const LANE_BOTTOM_PAD = 28;
+
+/**
+ * Swimlane layout: one horizontal band per group, stacked top-to-bottom in the
+ * order `topology.groups` declares (ungrouped nodes get a trailing lane). Within
+ * a lane, a node sits at its global dependency-layer X and is stacked vertically
+ * when several of the lane's nodes share a layer. Group containers drawn around
+ * these bands never overlap, while edges still flow left→right.
+ */
+function layoutSwimlanes(t: Topology, opts: LayoutOptions): Positioned {
+  const gap = GAPS[opts.density ?? "comfortable"];
+  const padLeft = opts.padLeft ?? 32;
+  const layer = assignLayers(t);
+
+  const laneIds = [...t.groups.map((g) => g.id), "__ungrouped__"];
+  const nodesInLane = (laneId: string) =>
+    t.nodes.filter((n) =>
+      laneId === "__ungrouped__"
+        ? !n.group || !t.groups.some((g) => g.id === n.group)
+        : n.group === laneId,
+    );
+
+  const nodeById = new Map(t.nodes.map((n) => [n.id, n]));
+  const positions = new Map<string, { x: number; y: number }>();
+  let cursorY = opts.padTop ?? 24;
+  let maxX = padLeft;
+
+  for (const laneId of laneIds) {
+    const members = nodesInLane(laneId);
+    if (members.length === 0) continue;
+
+    // Bucket the lane's members by layer, deterministic order within a column.
+    const columns = new Map<number, string[]>();
+    for (const n of [...members].sort((a, b) => a.id.localeCompare(b.id))) {
+      const l = layer.get(n.id) ?? 0;
+      (columns.get(l) ?? columns.set(l, []).get(l)!).push(n.id);
+    }
+    const laneTop = cursorY + LANE_TOP_PAD;
+    let laneBottom = laneTop;
+    for (const [l, ids] of columns) {
+      const x = padLeft + l * (NODE_W + gap.h);
+      let y = laneTop;
+      for (const id of ids) {
+        positions.set(id, { x, y });
+        const node = nodeById.get(id);
+        y += (node ? slotHeight(node) : NODE_H) + gap.v;
+      }
+      maxX = Math.max(maxX, x + NODE_W);
+      laneBottom = Math.max(laneBottom, y - gap.v);
+    }
+    cursorY = laneBottom + LANE_BOTTOM_PAD;
+  }
+
+  const extent = { w: maxX + padLeft, h: cursorY + (opts.padTop ?? 24) };
+  return { positions, layers: layer, extent };
+}

--- a/packages/topology/src/providers.test.ts
+++ b/packages/topology/src/providers.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  type AwsInfraSnapshot,
+  type ServiceGraph,
+  awsInfraProvider,
+  mergeTopologies,
+  telemetryProvider,
+} from "./providers.js";
+
+const infra: AwsInfraSnapshot = {
+  resources: [
+    { id: "ecs:api", kind: "compute", label: "api", sublabel: "ECS Fargate", service: "ecs" },
+    { id: "rds:postgres", kind: "database", label: "postgres", service: "rds" },
+    { id: "alb", kind: "edge", label: "app ALB", service: "elb" },
+  ],
+  relationships: [{ from: "alb", to: "ecs:api", kind: "routes", label: ":4100" }],
+};
+
+const graph: ServiceGraph = {
+  services: [{ name: "superlog-api", spans: 16795 }],
+  edges: [{ from: "@superlog/web", to: "superlog-api", calls: 1373 }],
+  externalDeps: [
+    { from: "superlog-api", target: "api.anthropic.com", peerKind: "http", calls: 1864 },
+    { from: "superlog-api", target: "postgresql", peerKind: "db", calls: 13583 },
+  ],
+};
+
+test("awsInfraProvider maps resources to infra nodes and inferred edges", () => {
+  const t = awsInfraProvider(infra);
+  assert.equal(t.nodes.length, 3);
+  assert.ok(t.nodes.every((n) => n.provider === "infra"));
+  assert.equal(t.edges.length, 1);
+  assert.equal(t.edges[0]?.source, "infra");
+  assert.equal(t.edges[0]?.kind, "routes");
+});
+
+test("telemetryProvider emits observed edges + external dependency nodes", () => {
+  const t = telemetryProvider(graph);
+  // web (auto from edge endpoint is NOT created — only declared services), api, anthropic, postgresql
+  const labels = t.nodes.map((n) => n.label).sort();
+  assert.ok(labels.includes("superlog-api"));
+  assert.ok(labels.includes("api.anthropic.com"));
+  assert.ok(labels.includes("postgresql"));
+  // the call edge is telemetry-sourced and labelled
+  const call = t.edges.find((e) => e.kind === "calls" && e.label?.includes("calls"));
+  assert.ok(call, "expected a labelled call edge");
+  assert.equal(call?.source, "telemetry");
+  // a db peer becomes a database node read by the service
+  const dbNode = t.nodes.find((n) => n.label === "postgresql");
+  assert.equal(dbNode?.kind, "database");
+  const readEdge = t.edges.find((e) => e.kind === "reads");
+  assert.equal(readEdge?.source, "telemetry");
+});
+
+test("mergeTopologies reconciles an OTLP service with its AWS resource via aliases", () => {
+  const aws = awsInfraProvider(infra);
+  const tel = telemetryProvider(graph);
+  // telemetry ids are "svc:<name>" / "ext:<name>"; alias superlog-api → the ECS resource,
+  // and the db peer → the same RDS resource infra knows about.
+  const merged = mergeTopologies([aws, tel], {
+    "svc:superlog-api": "ecs:api",
+    "ext:postgresql": "rds:postgres",
+  });
+
+  // superlog-api and ecs:api collapse into ONE node, now provider "merged".
+  const api = merged.nodes.filter((n) => n.id === "ecs:api");
+  assert.equal(api.length, 1, "api node must be deduped");
+  assert.equal(api[0]?.provider, "merged");
+  assert.equal(api[0]?.label, "api"); // infra label wins (higher precedence)
+
+  // postgres telemetry peer folded into the RDS node — no stray ext:postgresql.
+  assert.ok(!merged.nodes.some((n) => n.id === "ext:postgresql"));
+  assert.ok(merged.nodes.some((n) => n.id === "rds:postgres"));
+
+  // the observed web→api call edge now points at the canonical api id.
+  const webCall = merged.edges.find((e) => e.to === "ecs:api" && e.source === "telemetry");
+  assert.ok(webCall, "web→api telemetry edge survives canonicalization");
+
+  // anthropic stays an external node (no alias).
+  assert.ok(merged.nodes.some((n) => n.label === "api.anthropic.com"));
+});
+
+test("merge keeps the higher-precedence edge source for the same pair", () => {
+  const a = { nodes: [n("x"), n("y")], edges: [e("x", "y", "infra", "routes")], groups: [] };
+  const b = { nodes: [n("x"), n("y")], edges: [e("x", "y", "telemetry", "calls")], groups: [] };
+  const merged = mergeTopologies([a, b]);
+  const xy = merged.edges.filter((edge) => edge.from === "x" && edge.to === "y");
+  assert.equal(xy.length, 1, "one edge per pair");
+  assert.equal(xy[0]?.source, "telemetry", "observed beats inferred");
+});
+
+// tiny builders
+function n(id: string) {
+  return { id, kind: "compute" as const, label: id, provider: "infra" as const };
+}
+function e(from: string, to: string, source: "infra" | "telemetry", kind: string) {
+  return { id: `${from}->${to}:${kind}`, from, to, source, kind };
+}

--- a/packages/topology/src/providers.test.ts
+++ b/packages/topology/src/providers.test.ts
@@ -39,9 +39,11 @@ test("telemetryProvider emits observed edges + external dependency nodes", () =>
   const t = telemetryProvider(graph);
   // web (auto from edge endpoint is NOT created — only declared services), api, anthropic, postgresql
   const labels = t.nodes.map((n) => n.label).sort();
-  assert.ok(labels.includes("superlog-api"));
-  assert.ok(labels.includes("api.anthropic.com"));
-  assert.ok(labels.includes("postgresql"));
+  // exact membership (.some(===)) not .includes — the latter trips CodeQL's
+  // URL-substring rule on the host-looking label, a false positive here.
+  assert.ok(labels.some((l) => l === "superlog-api"));
+  assert.ok(labels.some((l) => l === "api.anthropic.com"));
+  assert.ok(labels.some((l) => l === "postgresql"));
   // the call edge is telemetry-sourced and labelled
   const call = t.edges.find((e) => e.kind === "calls" && e.label?.includes("calls"));
   assert.ok(call, "expected a labelled call edge");

--- a/packages/topology/src/providers.ts
+++ b/packages/topology/src/providers.ts
@@ -228,7 +228,9 @@ function mergeSignals(a?: Signal[], b?: Signal[]): Signal[] {
   return [...by.entries()].map(([kind, count]) => ({ kind: kind as Signal["kind"], count }));
 }
 
-const pairKey = (from: string, to: string) => `${from}${to}`;
+// Unit-separator delimiter that can't occur in a node id, so distinct endpoint
+// pairs never collide (e.g. ("ab","c") vs ("a","bc")).
+const pairKey = (from: string, to: string) => `${from}\u001f${to}`;
 
 /**
  * Merge any number of partial topologies into one. `aliases` rewrites node ids

--- a/packages/topology/src/providers.ts
+++ b/packages/topology/src/providers.ts
@@ -1,0 +1,287 @@
+// ---------------------------------------------------------------------------
+// Topology providers
+//
+// A provider translates one domain source into a partial `Topology`. They are
+// pure functions with no React/IO so they can run identically in the storybook
+// (against baked fixtures) and, later, in the worker (against live inventory +
+// ClickHouse). `mergeTopologies` reconciles the partials into one graph.
+//
+//   awsInfraProvider   — AWS resources → resource nodes + inferred infra edges
+//   telemetryProvider  — observed service graph → service nodes + real edges
+//   mergeTopologies    — union + de-dupe, reconciling ids via an alias map
+// ---------------------------------------------------------------------------
+
+import {
+  type EdgeKind,
+  type EdgeSource,
+  type NodeKind,
+  type NodeProvider,
+  type Signal,
+  type Topology,
+  type TopologyEdge,
+  type TopologyNode,
+  edgeId,
+} from "./topology.js";
+
+// --- AWS infra provider ------------------------------------------------------
+
+export type AwsResource = {
+  /** Stable node id, e.g. "ecs:api". Providers own their id namespace. */
+  id: string;
+  kind: NodeKind;
+  label: string;
+  sublabel?: string;
+  arn?: string;
+  /** AWS service short name, e.g. "ecs", "rds", "sqs". */
+  service?: string;
+  tags?: Record<string, string>;
+  signals?: Signal[];
+  /**
+   * Extra provider-specific detail folded into the node's `meta` bag — e.g. a
+   * console deep-link, a headline `badge`, and per-kind `facts`. Kept generic so
+   * the renderer never learns AWS specifics; it just displays what's here.
+   */
+  meta?: Record<string, unknown>;
+};
+
+export type AwsRelationship = {
+  from: string;
+  to: string;
+  kind: EdgeKind;
+  label?: string;
+};
+
+export type AwsInfraSnapshot = {
+  resources: AwsResource[];
+  relationships: AwsRelationship[];
+};
+
+export function awsInfraProvider(snapshot: AwsInfraSnapshot): Topology {
+  const nodes: TopologyNode[] = snapshot.resources.map((r) => ({
+    id: r.id,
+    kind: r.kind,
+    label: r.label,
+    sublabel: r.sublabel,
+    provider: "infra" as NodeProvider,
+    signals: r.signals,
+    meta: { arn: r.arn, service: r.service, tags: r.tags, ...r.meta },
+  }));
+  const edges: TopologyEdge[] = snapshot.relationships.map((rel) => ({
+    id: edgeId(rel.from, rel.to, rel.kind),
+    from: rel.from,
+    to: rel.to,
+    kind: rel.kind,
+    source: "infra" as EdgeSource,
+    label: rel.label,
+  }));
+  return { nodes, edges, groups: [] };
+}
+
+// --- Telemetry provider ------------------------------------------------------
+
+export type ServiceGraph = {
+  /** Distinct emitting services (OTLP service.name). */
+  services: { name: string; spans?: number; status?: TopologyNode["status"] }[];
+  /** Observed cross-service calls (parent.service → child.service). */
+  edges: { from: string; to: string; calls?: number }[];
+  /** Observed outbound client spans to a non-service peer (DB / SaaS / queue). */
+  externalDeps: {
+    from: string;
+    /** Peer host or system, e.g. "api.anthropic.com", "postgresql". */
+    target: string;
+    peerKind?: "db" | "messaging" | "http";
+    calls?: number;
+  }[];
+};
+
+/**
+ * Map an OTLP service.name (or external peer) onto a canonical node id so the
+ * same logical thing seen by infra + telemetry reconciles in merge. Returns the
+ * canonical id, or undefined to keep the telemetry-native id.
+ */
+export type AliasResolver = (name: string) => string | undefined;
+
+const compact = (n?: number): string | undefined => {
+  if (n == null) return undefined;
+  if (n < 1000) return `${n}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+};
+
+export function telemetryProvider(
+  graph: ServiceGraph,
+  alias: AliasResolver = () => undefined,
+): Topology {
+  const resolve = (name: string) => alias(name) ?? `svc:${name}`;
+  const resolveExternal = (target: string) => alias(target) ?? `ext:${target}`;
+
+  // Materialize a service node for every declared service AND every edge
+  // endpoint — an observed call implies both peers exist even if one of them
+  // emitted no spans of its own in the window.
+  const svcNodes = new Map<string, TopologyNode>();
+  const ensureService = (name: string, extra?: Partial<TopologyNode>) => {
+    const id = resolve(name);
+    if (!svcNodes.has(id)) {
+      svcNodes.set(id, {
+        id,
+        kind: "compute",
+        label: name,
+        provider: "telemetry",
+        meta: { serviceName: name },
+        ...extra,
+      });
+    }
+  };
+  for (const s of graph.services)
+    ensureService(s.name, { status: s.status, meta: { spans: s.spans, serviceName: s.name } });
+  for (const e of graph.edges) {
+    ensureService(e.from);
+    ensureService(e.to);
+  }
+  for (const dep of graph.externalDeps) ensureService(dep.from);
+
+  const edges: TopologyEdge[] = graph.edges.map((e) => {
+    const from = resolve(e.from);
+    const to = resolve(e.to);
+    return {
+      id: edgeId(from, to, "calls"),
+      from,
+      to,
+      kind: "calls" as EdgeKind,
+      source: "telemetry" as EdgeSource,
+      label: compact(e.calls) ? `${compact(e.calls)} calls` : undefined,
+    };
+  });
+
+  // External dependencies become nodes (so they show up on the map) plus an edge.
+  const extNodes = new Map<string, TopologyNode>();
+  for (const dep of graph.externalDeps) {
+    const id = resolveExternal(dep.target);
+    if (!extNodes.has(id)) {
+      const kind: NodeKind =
+        dep.peerKind === "db" ? "database" : dep.peerKind === "messaging" ? "queue" : "external";
+      extNodes.set(id, {
+        id,
+        kind,
+        label: dep.target,
+        provider: "telemetry",
+        meta: { peer: dep.target, peerKind: dep.peerKind },
+      });
+    }
+    const from = resolve(dep.from);
+    const to = id;
+    const kind: EdgeKind =
+      dep.peerKind === "db" ? "reads" : dep.peerKind === "messaging" ? "enqueues" : "calls";
+    edges.push({
+      id: edgeId(from, to, kind),
+      from,
+      to,
+      kind,
+      source: "telemetry",
+      label: compact(dep.calls),
+    });
+  }
+
+  return { nodes: [...svcNodes.values(), ...extNodes.values()], edges, groups: [] };
+}
+
+// --- Merge -------------------------------------------------------------------
+
+// Field precedence when two providers describe the same node: manual wins, then
+// infra (canonical resource), then telemetry, then a prior merge result.
+const NODE_PRECEDENCE: Record<NodeProvider, number> = {
+  manual: 4,
+  infra: 3,
+  telemetry: 2,
+  merged: 1,
+};
+// Edge precedence: a manual edge is intentional; telemetry is observed fact;
+// infra is inferred; suggested is an AI guess.
+const EDGE_PRECEDENCE: Record<EdgeSource, number> = {
+  manual: 4,
+  telemetry: 3,
+  infra: 2,
+  suggested: 1,
+};
+
+function mergeNode(a: TopologyNode, b: TopologyNode): TopologyNode {
+  const [hi, lo] = NODE_PRECEDENCE[a.provider] >= NODE_PRECEDENCE[b.provider] ? [a, b] : [b, a];
+  const signals = mergeSignals(a.signals, b.signals);
+  return {
+    ...lo,
+    ...hi,
+    // keep the richer label/sublabel if the winner lacks one
+    label: hi.label || lo.label,
+    sublabel: hi.sublabel ?? lo.sublabel,
+    status: hi.status ?? lo.status,
+    signals: signals.length ? signals : undefined,
+    provider: a.provider === b.provider ? a.provider : "merged",
+    aiProposed: a.aiProposed || b.aiProposed,
+    meta: { ...lo.meta, ...hi.meta },
+  };
+}
+
+function mergeSignals(a?: Signal[], b?: Signal[]): Signal[] {
+  const by = new Map<string, number>();
+  for (const s of [...(a ?? []), ...(b ?? [])])
+    by.set(s.kind, Math.max(by.get(s.kind) ?? 0, s.count));
+  return [...by.entries()].map(([kind, count]) => ({ kind: kind as Signal["kind"], count }));
+}
+
+const pairKey = (from: string, to: string) => `${from}${to}`;
+
+/**
+ * Merge any number of partial topologies into one. `aliases` rewrites node ids
+ * (alias → canonical) on both nodes and edge endpoints *before* de-duping, so a
+ * telemetry node "svc:superlog-api" and an infra node "ecs:api" collapse when
+ * aliases maps "svc:superlog-api" → "ecs:api". Nodes de-dupe by id; edges
+ * de-dupe by (from,to) keeping the highest-precedence source.
+ */
+export function mergeTopologies(
+  partials: Topology[],
+  aliases: Record<string, string> = {},
+): Topology {
+  const canon = (id: string) => aliases[id] ?? id;
+
+  const nodes = new Map<string, TopologyNode>();
+  for (const part of partials) {
+    for (const raw of part.nodes) {
+      const node = { ...raw, id: canon(raw.id) };
+      const existing = nodes.get(node.id);
+      nodes.set(node.id, existing ? mergeNode(existing, node) : node);
+    }
+  }
+
+  const edges = new Map<string, TopologyEdge>();
+  for (const part of partials) {
+    for (const raw of part.edges) {
+      const from = canon(raw.from);
+      const to = canon(raw.to);
+      if (from === to) continue; // canonicalization can collapse a self-loop
+      const key = pairKey(from, to);
+      const edge: TopologyEdge = { ...raw, id: edgeId(from, to, raw.kind), from, to };
+      const existing = edges.get(key);
+      if (!existing) {
+        edges.set(key, edge);
+      } else {
+        const [hi, lo] =
+          EDGE_PRECEDENCE[existing.source] >= EDGE_PRECEDENCE[edge.source]
+            ? [existing, edge]
+            : [edge, existing];
+        edges.set(key, { ...hi, label: hi.label ?? lo.label });
+      }
+    }
+  }
+
+  // Drop dangling edges whose endpoints didn't survive (defensive).
+  const liveEdges = [...edges.values()].filter((e) => nodes.has(e.from) && nodes.has(e.to));
+
+  const groups = dedupeGroups(partials.flatMap((p) => p.groups));
+  return { nodes: [...nodes.values()], edges: liveEdges, groups };
+}
+
+function dedupeGroups(groups: Topology["groups"]): Topology["groups"] {
+  const by = new Map<string, Topology["groups"][number]>();
+  for (const g of groups) if (!by.has(g.id)) by.set(g.id, g);
+  return [...by.values()];
+}

--- a/packages/topology/src/services.test.ts
+++ b/packages/topology/src/services.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { groupPath, isLeafGroup, serviceNodeId, viewTopology } from "./services.js";
+import type { Topology } from "./topology.js";
+
+// backend{api} ; telemetry{collector} > clickhouse{replica1, keeper1}
+const t: Topology = {
+  nodes: [
+    { id: "api", kind: "compute", label: "API", provider: "merged", group: "backend" },
+    { id: "collector", kind: "compute", label: "Collector", provider: "infra", group: "telemetry" },
+    { id: "replica1", kind: "compute", label: "Replica 1", provider: "infra", group: "clickhouse" },
+    { id: "keeper1", kind: "compute", label: "Keeper 1", provider: "infra", group: "clickhouse" },
+  ],
+  edges: [
+    { id: "api->collector", from: "api", to: "collector", source: "telemetry", kind: "calls" },
+    {
+      id: "collector->replica1",
+      from: "collector",
+      to: "replica1",
+      source: "infra",
+      kind: "writes",
+    },
+    { id: "replica1->keeper1", from: "replica1", to: "keeper1", source: "infra", kind: "depends" },
+  ],
+  groups: [
+    { id: "backend", label: "API & backend", tone: "neutral", intent: "Serves the API" },
+    { id: "telemetry", label: "Telemetry pipeline", tone: "warning", intent: "Ingests telemetry" },
+    {
+      id: "clickhouse",
+      label: "ClickHouse cluster",
+      tone: "success",
+      intent: "Analytics store",
+      parentId: "telemetry",
+    },
+  ],
+};
+
+test("root view shows top-level services with whole-subtree member counts", () => {
+  const v = viewTopology(t, null);
+  const ids = v.nodes.map((n) => n.id).sort();
+  assert.deepEqual(ids, [serviceNodeId("backend"), serviceNodeId("telemetry")]);
+  const tel = v.nodes.find((n) => n.id === serviceNodeId("telemetry"))!;
+  assert.equal(tel.meta?.memberCount, 3); // collector + replica1 + keeper1 (whole subtree)
+  assert.equal(tel.meta?.hasChildren, true);
+  // the actual resources inside, so the card can list them (not just a count)
+  const members = tel.meta?.members as { id: string; label: string }[];
+  assert.deepEqual(
+    members.map((m) => m.id).sort(),
+    ["collector", "keeper1", "replica1"],
+  );
+  // backend → telemetry edge (api→collector); clickhouse-internal edges hidden at root
+  assert.equal(v.edges.length, 1);
+  assert.equal(v.edges[0]?.from, serviceNodeId("backend"));
+  assert.equal(v.edges[0]?.to, serviceNodeId("telemetry"));
+});
+
+test("drilling a parent shows nested sub-service + direct resources + boundary stub", () => {
+  const v = viewTopology(t, "telemetry");
+  const ids = v.nodes.map((n) => n.id).sort();
+  assert.ok(ids.includes(serviceNodeId("clickhouse")));
+  assert.ok(ids.includes("collector"));
+  assert.ok(ids.includes("boundary:backend"));
+  const ch = v.nodes.find((n) => n.id === serviceNodeId("clickhouse"))!;
+  assert.equal(ch.meta?.memberCount, 2);
+  // Internal links are kept (collector → clickhouse); so is the inbound boundary
+  // edge. The renderer reroutes the boundary edge to the frame, not the model.
+  assert.ok(v.edges.some((e) => e.from === "collector" && e.to === serviceNodeId("clickhouse")));
+  assert.ok(v.edges.some((e) => e.from === "boundary:backend" && e.to === "collector"));
+});
+
+test("drilling a leaf group shows its resources + a boundary to outside services", () => {
+  const v = viewTopology(t, "clickhouse");
+  const ids = v.nodes.map((n) => n.id).sort();
+  assert.ok(ids.includes("replica1") && ids.includes("keeper1"));
+  assert.ok(ids.includes("boundary:telemetry"));
+  assert.ok(v.edges.some((e) => e.from === "replica1" && e.to === "keeper1"));
+  assert.ok(isLeafGroup(t, "clickhouse"));
+  assert.ok(!isLeafGroup(t, "telemetry"));
+});
+
+test("drilling drops edges between two outside neighbours (no orphan stub)", () => {
+  const g: Topology = {
+    nodes: [
+      { id: "x1", kind: "compute", label: "X1", provider: "infra", group: "X" },
+      { id: "a1", kind: "compute", label: "A1", provider: "infra", group: "A" },
+      { id: "b1", kind: "compute", label: "B1", provider: "infra", group: "B" },
+    ],
+    edges: [
+      { id: "x1->a1", from: "x1", to: "a1", source: "infra", kind: "calls" }, // X → A
+      { id: "a1->b1", from: "a1", to: "b1", source: "infra", kind: "calls" }, // A → B (both outside X)
+    ],
+    groups: [
+      { id: "X", label: "X", tone: "neutral" },
+      { id: "A", label: "A", tone: "neutral" },
+      { id: "B", label: "B", tone: "neutral" },
+    ],
+  };
+  const v = viewTopology(g, "X");
+  const ids = v.nodes.map((n) => n.id);
+  assert.ok(ids.includes("x1") && ids.includes("boundary:A"));
+  assert.ok(!ids.includes("boundary:B")); // B never materialises — only A touches X
+  assert.ok(v.edges.some((e) => e.from === "x1" && e.to === "boundary:A"));
+  assert.ok(!v.edges.some((e) => e.from.startsWith("boundary:") && e.to.startsWith("boundary:")));
+});
+
+test("groupPath builds the breadcrumb chain root→focus", () => {
+  assert.deepEqual(groupPath(t, "clickhouse"), [
+    { id: "telemetry", label: "Telemetry pipeline" },
+    { id: "clickhouse", label: "ClickHouse cluster" },
+  ]);
+  assert.deepEqual(groupPath(t, null), []);
+});

--- a/packages/topology/src/services.ts
+++ b/packages/topology/src/services.ts
@@ -1,0 +1,257 @@
+// ---------------------------------------------------------------------------
+// Hierarchical service view
+//
+// The LLM groups resources into a TREE of logical services (groups with a
+// `parentId`): e.g. "Telemetry pipeline" contains a "ClickHouse cluster" sub-group
+// which contains the keeper/replica resources. `viewTopology(t, focusId)` renders
+// ONE level of that tree:
+//
+//   • focusId = null  → the top-level services.
+//   • focusId = a group → that group's direct children: nested sub-services
+//     (collapsed) + any resources assigned directly to it, with faded "boundary"
+//     stubs to the neighbouring top-level services it talks to (click to hop).
+//
+// Edges are aggregated to whatever each endpoint's representative is AT this level.
+// Always returns a plain `Topology`, so the same canvas renders any level.
+// ---------------------------------------------------------------------------
+
+import type {
+  EdgeSource,
+  Topology,
+  TopologyEdge,
+  TopologyGroup,
+  TopologyNode,
+} from "./topology.js";
+
+const SERVICE_PREFIX = "service:";
+const BOUNDARY_PREFIX = "boundary:";
+
+export const serviceNodeId = (groupId: string) => `${SERVICE_PREFIX}${groupId}`;
+
+// How many member resources a service card lists before "+N more".
+const MEMBER_CAP = 6;
+
+/** A compact descriptor of one resource inside a service, for the card's list. */
+export type ServiceMember = {
+  id: string;
+  label: string;
+  kind: string;
+  /** Headline fact (e.g. "3/3 tasks", "db.t4g.medium"), from the node's meta. */
+  badge?: string;
+  /** AWS console deep-link, from the node's meta. */
+  console?: string;
+};
+
+const memberOf = (n: TopologyNode): ServiceMember => ({
+  id: n.id,
+  label: n.label,
+  kind: n.kind,
+  badge: typeof n.meta?.badge === "string" ? n.meta.badge : undefined,
+  console: typeof n.meta?.console === "string" ? n.meta.console : undefined,
+});
+
+// Datastores and entrypoints are what a human scans a service for; surface them
+// before generic compute, then sort by label so the list is stable run-to-run.
+const MEMBER_KIND_RANK: Record<string, number> = {
+  edge: 0,
+  database: 1,
+  cache: 1,
+  queue: 1,
+  storage: 2,
+  compute: 3,
+};
+const memberOrder = (a: ServiceMember, b: ServiceMember): number => {
+  const ra = MEMBER_KIND_RANK[a.kind] ?? 4;
+  const rb = MEMBER_KIND_RANK[b.kind] ?? 4;
+  return ra !== rb ? ra - rb : a.label.localeCompare(b.label);
+};
+
+const EDGE_RANK: Record<EdgeSource, number> = { manual: 4, telemetry: 3, infra: 2, suggested: 1 };
+
+type Groups = TopologyGroup[];
+const groupById = (groups: Groups) => new Map(groups.map((g) => [g.id, g]));
+const parentOf = (
+  groups: Map<string, TopologyGroup>,
+  id: string | null | undefined,
+): string | null => (id ? (groups.get(id)?.parentId ?? null) : null);
+
+/**
+ * The ancestor of `leaf` that is a DIRECT child of `focus` (or `leaf` itself if it
+ * is). Returns null when `leaf` is not inside `focus`'s subtree. focus=null = root.
+ */
+function childUnder(
+  groups: Map<string, TopologyGroup>,
+  leaf: string | null | undefined,
+  focus: string | null,
+): string | null {
+  let g: string | null = leaf ?? null;
+  const seen = new Set<string>();
+  while (g != null && !seen.has(g)) {
+    seen.add(g);
+    const p = parentOf(groups, g);
+    if (p === focus) return g;
+    g = p;
+  }
+  return null;
+}
+
+/** Breadcrumb path root→focus, as [{id,label}] (excludes the synthetic root). */
+export function groupPath(t: Topology, focusId: string | null): { id: string; label: string }[] {
+  if (!focusId) return [];
+  const groups = groupById(t.groups);
+  const chain: { id: string; label: string }[] = [];
+  let g: string | null = focusId;
+  const seen = new Set<string>();
+  while (g != null && !seen.has(g)) {
+    seen.add(g);
+    const grp = groups.get(g);
+    if (!grp) break;
+    chain.unshift({ id: grp.id, label: grp.label });
+    g = grp.parentId ?? null;
+  }
+  return chain;
+}
+
+/** True if `focusId` is a leaf group (no child groups) — i.e. it holds resources directly. */
+export function isLeafGroup(t: Topology, focusId: string): boolean {
+  return !t.groups.some((g) => g.parentId === focusId);
+}
+
+export function viewTopology(t: Topology, focusId: string | null = null): Topology {
+  const groups = groupById(t.groups);
+  const byId = new Map(t.nodes.map((n) => [n.id, n]));
+  const focus = focusId ?? null;
+
+  // What represents node `id` at this focus level: itself (direct resource), a
+  // child service-group, or a boundary stub to its top-level ancestor.
+  type Rep =
+    | { kind: "direct"; id: string }
+    | { kind: "service"; gid: string }
+    | { kind: "boundary"; gid: string | null };
+  const repOf = (id: string): Rep | null => {
+    const n = byId.get(id);
+    if (!n) return null;
+    if ((n.group ?? null) === focus) return { kind: "direct", id };
+    const child = childUnder(groups, n.group, focus);
+    if (child) return { kind: "service", gid: child };
+    return { kind: "boundary", gid: childUnder(groups, n.group, null) };
+  };
+  const repId = (r: Rep): string =>
+    r.kind === "direct"
+      ? r.id
+      : r.kind === "service"
+        ? serviceNodeId(r.gid)
+        : `${BOUNDARY_PREFIX}${r.gid}`;
+
+  // --- nodes ---------------------------------------------------------------
+  const childCounts = new Map<string, number>();
+  const childKinds = new Map<string, Map<string, number>>();
+  const childMembers = new Map<string, ServiceMember[]>();
+  const directNodes: TopologyNode[] = [];
+  for (const n of t.nodes) {
+    if ((n.group ?? null) === focus) {
+      directNodes.push(n);
+      continue;
+    }
+    const child = childUnder(groups, n.group, focus);
+    if (!child) continue; // not in this subtree
+    childCounts.set(child, (childCounts.get(child) ?? 0) + 1);
+    const km = childKinds.get(child) ?? new Map();
+    km.set(n.kind, (km.get(n.kind) ?? 0) + 1);
+    childKinds.set(child, km);
+    const ms = childMembers.get(child) ?? [];
+    ms.push(memberOf(n));
+    childMembers.set(child, ms);
+  }
+
+  const serviceNodes: TopologyNode[] = [...childCounts.keys()].map((gid) => {
+    const g = groups.get(gid);
+    const members = childMembers.get(gid) ?? [];
+    return {
+      id: serviceNodeId(gid),
+      kind: "service",
+      label: g?.label ?? gid,
+      sublabel: g?.intent,
+      provider: "merged",
+      aiProposed: g?.aiProposed,
+      meta: {
+        serviceId: gid,
+        memberCount: childCounts.get(gid) ?? 0,
+        kinds: Object.fromEntries(childKinds.get(gid) ?? []),
+        // The concrete resources inside, so the card can list them (capped; the
+        // count above is the true total). Datastores/edges first — the things a
+        // human scans for — then by label for stability.
+        members: [...members].sort(memberOrder).slice(0, MEMBER_CAP),
+        tone: g?.tone,
+        hasChildren: t.groups.some((x) => x.parentId === gid),
+      },
+    };
+  });
+
+  // --- edges + boundary stubs ---------------------------------------------
+  const out: TopologyNode[] = [...serviceNodes, ...directNodes];
+  const present = new Set(out.map((n) => n.id));
+  const boundary = new Map<string, TopologyNode>();
+  const agg = new Map<
+    string,
+    { from: string; to: string; count: number; source: EdgeSource; kind?: string }
+  >();
+
+  for (const e of t.edges) {
+    const ra = repOf(e.from);
+    const rb = repOf(e.to);
+    if (!ra || !rb) continue;
+    const fromId = repId(ra);
+    const toId = repId(rb);
+    if (fromId === toId) continue; // intra
+    // An edge between two OUTSIDE neighbours is noise at this focus level — it
+    // neither touches the focused group's contents nor warrants materialising a
+    // neighbour node. Skip it entirely (so no orphan boundary stub is created).
+    if (ra.kind === "boundary" && rb.kind === "boundary") continue;
+    // a boundary endpoint must reference an actual neighbouring service
+    for (const [r, id] of [
+      [ra, fromId],
+      [rb, toId],
+    ] as const) {
+      if (r.kind === "boundary" && r.gid && !boundary.has(id)) {
+        const g = groups.get(r.gid);
+        boundary.set(id, {
+          id,
+          kind: "service",
+          label: g?.label ?? r.gid,
+          provider: "merged",
+          meta: { serviceId: r.gid, boundary: true, tone: g?.tone },
+        });
+      }
+    }
+    // skip edges where a boundary endpoint couldn't resolve
+    if (ra.kind === "boundary" && !ra.gid) continue;
+    if (rb.kind === "boundary" && !rb.gid) continue;
+    const key = `${fromId} ${toId}`;
+    const cur = agg.get(key);
+    if (!cur) agg.set(key, { from: fromId, to: toId, count: 1, source: e.source, kind: e.kind });
+    else {
+      cur.count++;
+      if (EDGE_RANK[e.source] > EDGE_RANK[cur.source]) cur.source = e.source;
+    }
+  }
+
+  const allNodes = [...out, ...boundary.values()];
+  const liveIds = new Set(allNodes.map((n) => n.id));
+  const edges: TopologyEdge[] = [...agg.values()]
+    .filter((a) => liveIds.has(a.from) && liveIds.has(a.to))
+    .map((a) => ({
+      id: `${a.from}->${a.to}`,
+      from: a.from,
+      to: a.to,
+      source: a.source,
+      // services collapse many links → show a count; direct resource→resource keeps its verb.
+      label:
+        present.has(a.from) && a.from.startsWith(SERVICE_PREFIX)
+          ? `${a.count} ${a.count === 1 ? "link" : "links"}`
+          : a.kind,
+      kind: a.kind,
+    }));
+
+  return { nodes: allNodes, edges, groups: [] };
+}

--- a/packages/topology/src/services.ts
+++ b/packages/topology/src/services.ts
@@ -190,7 +190,6 @@ export function viewTopology(t: Topology, focusId: string | null = null): Topolo
 
   // --- edges + boundary stubs ---------------------------------------------
   const out: TopologyNode[] = [...serviceNodes, ...directNodes];
-  const present = new Set(out.map((n) => n.id));
   const boundary = new Map<string, TopologyNode>();
   const agg = new Map<
     string,
@@ -227,7 +226,7 @@ export function viewTopology(t: Topology, focusId: string | null = null): Topolo
     // skip edges where a boundary endpoint couldn't resolve
     if (ra.kind === "boundary" && !ra.gid) continue;
     if (rb.kind === "boundary" && !rb.gid) continue;
-    const key = `${fromId} ${toId}`;
+    const key = `${fromId}\u001f${toId}`; // unit separator — ids can't contain it
     const cur = agg.get(key);
     if (!cur) agg.set(key, { from: fromId, to: toId, count: 1, source: e.source, kind: e.kind });
     else {
@@ -245,9 +244,10 @@ export function viewTopology(t: Topology, focusId: string | null = null): Topolo
       from: a.from,
       to: a.to,
       source: a.source,
-      // services collapse many links → show a count; direct resource→resource keeps its verb.
+      // A collapsed service endpoint (on EITHER side) aggregates many underlying
+      // links → show the count; a direct resource→resource edge keeps its verb.
       label:
-        present.has(a.from) && a.from.startsWith(SERVICE_PREFIX)
+        a.from.startsWith(SERVICE_PREFIX) || a.to.startsWith(SERVICE_PREFIX)
           ? `${a.count} ${a.count === 1 ? "link" : "links"}`
           : a.kind,
       kind: a.kind,

--- a/packages/topology/src/topology.ts
+++ b/packages/topology/src/topology.ts
@@ -1,0 +1,137 @@
+// ---------------------------------------------------------------------------
+// Generic topology model
+//
+// The renderer (TopologyCanvas) knows nothing about AWS, telemetry, or any
+// specific domain — it draws a `Topology`. Domain sources are translated into
+// this model by *providers* (providers.ts), and an optional LLM refinement pass
+// (enrich.ts) layers reviewable suggestions on top. Adding a new kind of map =
+// adding a new provider, never touching the renderer. That's the extensibility
+// seam the feature is built around.
+// ---------------------------------------------------------------------------
+
+// Node kinds are an OPEN union: the listed members get first-class icons/styling,
+// but any string is accepted so new providers can introduce their own kinds
+// without a renderer change (unknown kinds fall back to a generic glyph).
+export type NodeKind =
+  | "service" // a logical service (collapsed group of resources) — the top level
+  | "edge" // internet-facing entrypoint (LB, CDN, gateway)
+  | "compute" // a running service (ECS task, container, function, process)
+  | "queue" // message queue / stream (SQS, Kafka, Kinesis)
+  | "database" // OLTP/OLAP store (RDS, ClickHouse, Dynamo)
+  | "cache" // Redis / Memcached
+  | "storage" // object store (S3, GCS)
+  | "external" // a third-party dependency we call out to (SaaS API)
+  | "group-anchor" // synthetic node used only for layout, never rendered
+  | (string & {});
+
+export type NodeStatus = "healthy" | "degraded" | "down" | "unknown";
+
+// Provenance of a node: which provider asserted it. Drives subtle styling and
+// lets merge() reconcile the same logical thing seen by two providers.
+export type NodeProvider = "infra" | "telemetry" | "manual" | "merged";
+
+// The signal-badge model carried over from the original storyboard. Kept here
+// so nodes can surface cost/security/performance counts uniformly.
+export type SignalKind = "cost" | "security" | "performance";
+export type Signal = { kind: SignalKind; count: number };
+
+export type TopologyNode = {
+  id: string;
+  kind: NodeKind;
+  label: string;
+  /** Secondary line, e.g. "ECS Fargate", "db.m6g.large", "anthropic.com". */
+  sublabel?: string;
+  /** Group id this node belongs to (see TopologyGroup). Optional → ungrouped. */
+  group?: string;
+  provider: NodeProvider;
+  status?: NodeStatus;
+  signals?: Signal[];
+  /** True when an LLM refinement pass renamed/regrouped/added this — review me. */
+  aiProposed?: boolean;
+  /** Free-form provenance / extra attributes; never required by the renderer. */
+  meta?: Record<string, unknown>;
+};
+
+// Edge kinds are also an OPEN union. The relationship verb, used for labels and
+// (optionally) styling.
+export type EdgeKind =
+  | "routes" // load balancer → service
+  | "calls" // service → service (observed request/response)
+  | "enqueues" // producer → queue
+  | "consumes" // queue → consumer
+  | "reads" // service → datastore (read path)
+  | "writes" // service → datastore (write path)
+  | "depends" // generic dependency
+  | (string & {});
+
+// Where an edge came from. This is the most important field for trust: the UI
+// styles telemetry edges as solid (observed fact), infra edges as hairline
+// (inferred from config), and suggested edges as dashed + AI-marked (review).
+export type EdgeSource = "telemetry" | "infra" | "manual" | "suggested";
+
+export type TopologyEdge = {
+  id: string;
+  from: string;
+  to: string;
+  kind?: EdgeKind;
+  source: EdgeSource;
+  /** Short annotation, e.g. "1.3k calls", "219k", "postgres". */
+  label?: string;
+  meta?: Record<string, unknown>;
+};
+
+export type GroupTone = "accent" | "success" | "warning" | "neutral" | "danger";
+
+export type TopologyGroup = {
+  id: string;
+  label: string;
+  tone: GroupTone;
+  /**
+   * What this group/service is *for* — a one-line intent the LLM assigns. Shown
+   * as the service's sublabel in the collapsed (top-level) view.
+   */
+  intent?: string;
+  /**
+   * Parent group id, for a nested service hierarchy (e.g. a "ClickHouse cluster"
+   * group whose parent is "Telemetry pipeline"). Undefined = a top-level service.
+   * A node always belongs to a single LEAF group; the tree is formed by the groups.
+   */
+  parentId?: string;
+  /** True when an LLM refinement pass proposed this grouping — review me. */
+  aiProposed?: boolean;
+};
+
+export type Topology = {
+  nodes: TopologyNode[];
+  edges: TopologyEdge[];
+  groups: TopologyGroup[];
+};
+
+// --- small, dependency-free helpers shared across providers/layout/enrich -----
+
+export const emptyTopology = (): Topology => ({ nodes: [], edges: [], groups: [] });
+
+/** Stable id for an edge, so the same logical edge dedupes across providers. */
+export const edgeId = (from: string, to: string, kind?: EdgeKind): string =>
+  `${from}->${to}${kind ? `:${kind}` : ""}`;
+
+export const nodeById = (t: Topology): Map<string, TopologyNode> =>
+  new Map(t.nodes.map((n) => [n.id, n]));
+
+/** Out-degree / in-degree maps, handy for layout and "is this a source" checks. */
+export function degrees(t: Topology): {
+  out: Map<string, number>;
+  in: Map<string, number>;
+} {
+  const out = new Map<string, number>();
+  const inn = new Map<string, number>();
+  for (const n of t.nodes) {
+    out.set(n.id, 0);
+    inn.set(n.id, 0);
+  }
+  for (const e of t.edges) {
+    if (out.has(e.from)) out.set(e.from, (out.get(e.from) ?? 0) + 1);
+    if (inn.has(e.to)) inn.set(e.to, (inn.get(e.to) ?? 0) + 1);
+  }
+  return { out, in: inn };
+}

--- a/packages/topology/tsconfig.json
+++ b/packages/topology/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,9 @@ importers:
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.10
         version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@superlog/topology':
+        specifier: workspace:*
+        version: link:../../packages/topology
       '@tanstack/react-query':
         specifier: ^5.62.8
         version: 5.100.1(react@19.2.5)
@@ -447,6 +450,9 @@ importers:
       '@superlog/fingerprint':
         specifier: workspace:*
         version: link:../../packages/fingerprint
+      '@superlog/topology':
+        specifier: workspace:*
+        version: link:../../packages/topology
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -517,6 +523,18 @@ importers:
         version: 5.9.3
 
   packages/fingerprint:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
+  packages/topology:
     devDependencies:
       '@types/node':
         specifier: ^22.10.1


### PR DESCRIPTION
## What

Adds a **service map** to the Overview page: a project's infrastructure rendered as a navigable topology, with services grouped by intent and explodable into the resources inside them. Shown only for projects that have a cloud connection.

## How it's built

**`@superlog/topology` (new package)** — framework-agnostic, dependency-free model + builders shared by the worker and the web renderer:
- `Topology { nodes, edges, groups }` with an open node-kind union (`service`/`compute`/`database`/`queue`/`edge`/…).
- **Providers** translate a domain source into a partial topology (`awsInfraProvider` from the resource inventory, `telemetryProvider` from the observed service call-graph) and `mergeTopologies` reconciles them via an alias map.
- **Hierarchical view** (`viewTopology`) collapses a tree of groups into one level at a time — groups → services → resources — with breadcrumb (`groupPath`) and boundary stubs for cross-group links.
- **Enrichment contract** (`applyEnrichment`) layers a reviewable LLM grouping on top of the deterministic graph.
- **Layout** — hand-rolled layered placement with wrap-to-width (no scaling).

**DB** — one `project_topologies` row per project: `graph` (deterministic) + `enrichment` (AI) as jsonb, plus `status`/`generatedAt`/`refreshRequestedAt`. Migration `0072`.

**Worker** — `buildProjectTopology` reads the active resource inventory (Postgres) + the cross-service call-graph (ClickHouse self-join on `otel_traces`), assembles a deterministic topology, then runs an inline Anthropic grouping pass (forced-tool structured output; opts out when no API key). A pg-boss cron (~5 min) builds stale/connected projects. Per-resource detail (`resource-detail.ts`) derives console deep-links + headline facts (ECS task counts, RDS class, …) from each resource's config.

**API** — `GET /api/projects/:id/topology` serves the persisted row; `POST …/topology/generate` requests a rebuild.

**Web** — the map renders on Overview (gated on an existing cloud connection): services grouped by intent, click a group to drill into its services and a service to drill into its resources, a boundary frame depicts cross-group dependencies (neighbours connect to the group boundary, not its members), and a detail drawer with console links. Degrades to an empty state with connect/generate actions.

## Tests

`@superlog/topology` unit tests (providers, services/hierarchy, layout, enrichment) + worker build/enrich/resource-detail tests. New migration applies cleanly on a fresh database.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a service map to the Overview page that shows a project’s AWS infrastructure as a navigable topology with logical service grouping and drill‑down. Built from inventory + telemetry, persisted per project, gated to connected clouds, and resilient when enrichment is unavailable.

- **New Features**
  - Shared `@superlog/topology` library with providers (`awsInfraProvider`, `telemetryProvider`), merge, hierarchical view (`viewTopology`), enrichment contract, and layered layout.
  - Worker job builds and persists project topologies: deterministic graph from inventory + ClickHouse service graph, reviewable enrichment pass, and stored status/timestamps.
  - API: `GET /api/projects/:id/topology` returns the persisted map; `POST /api/projects/:id/topology/generate` requests a rebuild.
  - Web: Overview renders the map with group→service→resource drill‑down, boundary links for cross‑group edges, detail drawer with console deep‑links, polling while generating, and an empty state with actions.
  - DB: new `project_topologies` table for `graph`, `enrichment`, `status`, `error`, and timing fields (migration 0072).

- **Bug Fixes**
  - Only rebuild maps for projects with an active cloud connection; UI shows the map section only when a connection exists.
  - Persist the deterministic graph when the enrichment call fails; enrichment parser breaks parent cycles and tolerates null toggles.
  - More robust IDs: resource IDs include region; slash‑less ARN parsing falls back to the last “:” segment; edge IDs use a distinct delimiter to prevent collisions.
  - Edge labels include call counts; the web view resets stale focus when context changes.
  - CI reliability: fixed test glob expansion and tightened tests to satisfy CodeQL.

<sup>Written for commit 6a5c10ec8a256c3e218edb72c403ad6932a7cb48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

