### PR TITLE
Export per-org PR lifecycle counters (created / merged / closed)

### DIFF
--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -7,7 +7,7 @@ import {
   schema,
   syncLoopsContactsForOrg,
 } from "@superlog/db";
-import { and, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, ne, sql } from "drizzle-orm";
 import type { Hono } from "hono";
 import type { Context } from "hono";
 import {
@@ -629,9 +629,10 @@ async function handleAgentPrWebhook(
     };
     if (pr.head?.sha) updates.headSha = pr.head.sha;
     if (typeof pr.title === "string") updates.title = pr.title;
-    // Decide whether this delivery is a brand-new terminal transition before we
-    // apply the update — gating on the prior state keeps webhook re-deliveries
-    // and reopen→close cycles from double-counting superlog.prs.{merged,closed}.
+    // Decide whether this delivery looks like a brand-new terminal transition
+    // from the row we read. This is only a first cut — the read is stale under
+    // concurrent deliveries, so the actual once-only guarantee comes from the
+    // conditional UPDATE below, not from this check.
     const countTransition = prTerminalTransition({
       action,
       merged: Boolean(pr.merged),
@@ -656,12 +657,29 @@ async function handleAgentPrWebhook(
       updates.state = "open";
       updates.closedAt = null;
     }
-    await db
+    // For a terminal transition, fold the prior-state predicate into the WHERE
+    // so only one of N concurrent deliveries actually flips the row. `.returning`
+    // tells us which one won; the counter is incremented exactly once off that,
+    // not off the stale read above. Non-terminal updates (reopened, push-only
+    // field writes) stay unconditional.
+    const updated = await db
       .update(schema.agentPullRequests)
       .set(updates)
-      .where(eq(schema.agentPullRequests.id, agentPrRow.id));
-    if (countTransition === "merged") await recordPrMergedMetric(agentPrRow.incidentId);
-    else if (countTransition === "closed") await recordPrClosedMetric(agentPrRow.incidentId);
+      .where(
+        countTransition
+          ? and(
+              eq(schema.agentPullRequests.id, agentPrRow.id),
+              ne(schema.agentPullRequests.state, countTransition),
+            )
+          : eq(schema.agentPullRequests.id, agentPrRow.id),
+      )
+      .returning({ id: schema.agentPullRequests.id });
+    const wonTransition = updated.length > 0;
+    if (countTransition === "merged" && wonTransition) {
+      await recordPrMergedMetric(agentPrRow.incidentId);
+    } else if (countTransition === "closed" && wonTransition) {
+      await recordPrClosedMetric(agentPrRow.incidentId);
+    }
     if (mergedResolution) {
       await resolveIncidentForMergedAgentPr({
         agentPr: agentPrRow,

--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -20,6 +20,8 @@ import { type RepoBranch, type RepoBranchInfo, mergeRepoBranches } from "./githu
 import { runResolvedIncidentSideEffectsForIncident } from "./incidents/resolution-side-effects.js";
 import { logger } from "./logger.js";
 import { resolveActiveOrgContext } from "./org-context.js";
+import { prTerminalTransition } from "./pr-metrics-transition.js";
+import { recordPrClosedMetric, recordPrMergedMetric } from "./pr-metrics.js";
 
 const log = logger.child({ scope: "github" });
 type Vars = { userId: string; orgId: string | null };
@@ -627,6 +629,14 @@ async function handleAgentPrWebhook(
     };
     if (pr.head?.sha) updates.headSha = pr.head.sha;
     if (typeof pr.title === "string") updates.title = pr.title;
+    // Decide whether this delivery is a brand-new terminal transition before we
+    // apply the update — gating on the prior state keeps webhook re-deliveries
+    // and reopen→close cycles from double-counting superlog.prs.{merged,closed}.
+    const countTransition = prTerminalTransition({
+      action,
+      merged: Boolean(pr.merged),
+      prevState: agentPrRow.state,
+    });
     if (action === "closed") {
       if (pr.merged) {
         updates.state = "merged";
@@ -650,6 +660,8 @@ async function handleAgentPrWebhook(
       .update(schema.agentPullRequests)
       .set(updates)
       .where(eq(schema.agentPullRequests.id, agentPrRow.id));
+    if (countTransition === "merged") await recordPrMergedMetric(agentPrRow.incidentId);
+    else if (countTransition === "closed") await recordPrClosedMetric(agentPrRow.incidentId);
     if (mergedResolution) {
       await resolveIncidentForMergedAgentPr({
         agentPr: agentPrRow,

--- a/apps/api/src/pr-metrics-transition.test.ts
+++ b/apps/api/src/pr-metrics-transition.test.ts
@@ -1,0 +1,53 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { prTerminalTransition } from "./pr-metrics-transition.js";
+
+test("counts a merge when an open PR is closed-as-merged", () => {
+  assert.equal(
+    prTerminalTransition({ action: "closed", merged: true, prevState: "open" }),
+    "merged",
+  );
+});
+
+test("counts a close-without-merge when an open PR is closed unmerged", () => {
+  assert.equal(
+    prTerminalTransition({ action: "closed", merged: false, prevState: "open" }),
+    "closed",
+  );
+});
+
+test("does not count non-terminal actions", () => {
+  for (const action of ["opened", "reopened", "edited", "synchronize", "ready_for_review"]) {
+    assert.equal(prTerminalTransition({ action, merged: false, prevState: "open" }), null);
+    assert.equal(prTerminalTransition({ action, merged: true, prevState: "open" }), null);
+  }
+});
+
+test("does not re-count a merge already recorded (webhook re-delivery)", () => {
+  assert.equal(prTerminalTransition({ action: "closed", merged: true, prevState: "merged" }), null);
+});
+
+test("does not re-count a close already recorded (webhook re-delivery)", () => {
+  assert.equal(
+    prTerminalTransition({ action: "closed", merged: false, prevState: "closed" }),
+    null,
+  );
+});
+
+test("counts a merge after a prior close (closed → reopened → merged lands once)", () => {
+  // The PR was closed unmerged, reopened, then merged. The merge is a fresh
+  // terminal transition relative to the 'closed' prior state, so it counts.
+  assert.equal(
+    prTerminalTransition({ action: "closed", merged: true, prevState: "closed" }),
+    "merged",
+  );
+});
+
+test("counts a close after a prior merge state only as a fresh transition", () => {
+  // Defensive: if a PR somehow goes merged → reopened → closed-unmerged, the
+  // close is a fresh transition relative to 'merged'.
+  assert.equal(
+    prTerminalTransition({ action: "closed", merged: false, prevState: "merged" }),
+    "closed",
+  );
+});

--- a/apps/api/src/pr-metrics-transition.ts
+++ b/apps/api/src/pr-metrics-transition.ts
@@ -1,0 +1,21 @@
+export type PrTerminalOutcome = "merged" | "closed";
+
+/**
+ * Decide which terminal PR counter (if any) a GitHub `pull_request` webhook
+ * delivery should increment, given the PR's state *before* this delivery is
+ * applied. Returns null unless the delivery represents a brand-new terminal
+ * transition, so webhook re-deliveries and reopen→close→reopen cycles don't
+ * double-count. "closed" here means closed-without-merge (a merged PR is
+ * counted as "merged" only).
+ *
+ * Kept free of any db import so it can be unit-tested without a connection.
+ */
+export function prTerminalTransition(args: {
+  action: string;
+  merged: boolean;
+  prevState: string;
+}): PrTerminalOutcome | null {
+  if (args.action !== "closed") return null;
+  if (args.merged) return args.prevState === "merged" ? null : "merged";
+  return args.prevState === "closed" ? null : "closed";
+}

--- a/apps/api/src/pr-metrics.ts
+++ b/apps/api/src/pr-metrics.ts
@@ -1,0 +1,73 @@
+import { metrics } from "@opentelemetry/api";
+import { db, schema } from "@superlog/db";
+import { eq } from "drizzle-orm";
+import { logger } from "./logger.js";
+
+// Per-org PR lifecycle counters, API half. PR "merged"/"closed" transitions
+// arrive over the GitHub webhook (apps/api/src/github.ts), so they're counted
+// here; the "created" counter is emitted by the worker when it opens the PR
+// (apps/worker/src/pr-metrics.ts). Same `tenant.org.*` attributes as the gauges
+// in the worker's tenant-metrics.ts so a dashboard can group all PR metrics by
+// org uniformly.
+//
+// Monotonic cumulative counters (OTel default); the read path reconstructs the
+// per-bucket increase — see cumulativeMonotonicSumQuery in src/mcp/clickhouse.ts.
+const log = logger.child({ scope: "pr-metrics" });
+const meter = metrics.getMeter("@superlog/api/prs");
+
+const prMergedCounter = meter.createCounter("superlog.prs.merged", {
+  description: "Agent pull requests merged, counted per org at merge time.",
+  unit: "1",
+});
+
+const prClosedCounter = meter.createCounter("superlog.prs.closed", {
+  description: "Agent pull requests closed without merging, counted per org.",
+  unit: "1",
+});
+
+// incident → project → org, the same path the worker's tenant-metrics.ts uses.
+async function resolveIncidentOrg(
+  incidentId: string,
+): Promise<{ id: string; name: string } | null> {
+  const rows = await db
+    .select({ id: schema.orgs.id, name: schema.orgs.name })
+    .from(schema.incidents)
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.incidents.projectId))
+    .innerJoin(schema.orgs, eq(schema.orgs.id, schema.projects.orgId))
+    .where(eq(schema.incidents.id, incidentId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+async function recordPrTerminalMetric(
+  incidentId: string,
+  outcome: "merged" | "closed",
+): Promise<void> {
+  try {
+    const org = await resolveIncidentOrg(incidentId);
+    if (!org) return;
+    const attrs = { "tenant.org.id": org.id, "tenant.org.name": org.name };
+    (outcome === "merged" ? prMergedCounter : prClosedCounter).add(1, attrs);
+  } catch (err) {
+    log.warn({ err, incidentId, outcome }, "pr terminal metric emit failed");
+  }
+}
+
+/**
+ * Increment `superlog.prs.merged` for the org owning `incidentId`. Best-effort:
+ * a telemetry failure must never 500 the webhook. Gate the call on an actual
+ * state transition (prior state != "merged") so webhook re-deliveries and
+ * reopen→close cycles don't double-count.
+ */
+export function recordPrMergedMetric(incidentId: string): Promise<void> {
+  return recordPrTerminalMetric(incidentId, "merged");
+}
+
+/**
+ * Increment `superlog.prs.closed` (closed without merge) for the org owning
+ * `incidentId`. Same best-effort / transition-gating contract as
+ * {@link recordPrMergedMetric}.
+ */
+export function recordPrClosedMetric(incidentId: string): Promise<void> {
+  return recordPrTerminalMetric(incidentId, "closed");
+}

--- a/apps/api/src/pr-metrics.ts
+++ b/apps/api/src/pr-metrics.ts
@@ -1,6 +1,5 @@
 import { metrics } from "@opentelemetry/api";
-import { db, schema } from "@superlog/db";
-import { eq } from "drizzle-orm";
+import { resolveIncidentOrg } from "@superlog/db";
 import { logger } from "./logger.js";
 
 // Per-org PR lifecycle counters, API half. PR "merged"/"closed" transitions
@@ -24,20 +23,6 @@ const prClosedCounter = meter.createCounter("superlog.prs.closed", {
   description: "Agent pull requests closed without merging, counted per org.",
   unit: "1",
 });
-
-// incident → project → org, the same path the worker's tenant-metrics.ts uses.
-async function resolveIncidentOrg(
-  incidentId: string,
-): Promise<{ id: string; name: string } | null> {
-  const rows = await db
-    .select({ id: schema.orgs.id, name: schema.orgs.name })
-    .from(schema.incidents)
-    .innerJoin(schema.projects, eq(schema.projects.id, schema.incidents.projectId))
-    .innerJoin(schema.orgs, eq(schema.orgs.id, schema.projects.orgId))
-    .where(eq(schema.incidents.id, incidentId))
-    .limit(1);
-  return rows[0] ?? null;
-}
 
 async function recordPrTerminalMetric(
   incidentId: string,

--- a/apps/worker/src/agent-runs/deliverable-records.ts
+++ b/apps/worker/src/agent-runs/deliverable-records.ts
@@ -1,5 +1,6 @@
 import { db, schema } from "@superlog/db";
 import type { AgentRunContext } from "../agent-run-context.js";
+import { recordPrCreatedMetric } from "../pr-metrics.js";
 
 export async function recordFiledLinearTicket(
   ctx: AgentRunContext,
@@ -97,4 +98,7 @@ export async function recordOpenedAgentPullRequest(opts: {
       occurredAt: now,
     })
     .onConflictDoNothing();
+  // Only reached when the PR row was newly inserted (see `if (!row) return`
+  // above), so retries / re-deliveries don't double-count.
+  await recordPrCreatedMetric(opts.incidentId);
 }

--- a/apps/worker/src/pr-metrics.ts
+++ b/apps/worker/src/pr-metrics.ts
@@ -1,0 +1,52 @@
+import { metrics } from "@opentelemetry/api";
+import { db, schema } from "@superlog/db";
+import { eq } from "drizzle-orm";
+import { logger } from "./logger.js";
+
+// Per-org PR lifecycle counters. The "created" half lives in the worker because
+// that's where we open the PR; the "merged"/"closed" halves live in the API
+// (apps/api/src/pr-metrics.ts) because those transitions arrive over the GitHub
+// webhook. All three carry the same `tenant.org.*` attributes as the gauges in
+// tenant-metrics.ts so a dashboard can group every PR metric by org uniformly.
+//
+// These are monotonic cumulative counters (OTel default). To chart per-period
+// activity ("PRs opened this week") the read path reconstructs the per-bucket
+// increase — see cumulativeMonotonicSumQuery in apps/api/src/mcp/clickhouse.ts.
+const meter = metrics.getMeter("@superlog/worker/prs");
+
+const prCreatedCounter = meter.createCounter("superlog.prs.created", {
+  description: "Agent pull requests opened, counted per org at open time.",
+  unit: "1",
+});
+
+// incident → project → org, the same path tenant-metrics.ts uses. Returns null
+// when the incident (or its project/org) can't be resolved so callers can skip
+// emitting rather than fabricate an attribute set.
+async function resolveIncidentOrg(
+  incidentId: string,
+): Promise<{ id: string; name: string } | null> {
+  const rows = await db
+    .select({ id: schema.orgs.id, name: schema.orgs.name })
+    .from(schema.incidents)
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.incidents.projectId))
+    .innerJoin(schema.orgs, eq(schema.orgs.id, schema.projects.orgId))
+    .where(eq(schema.incidents.id, incidentId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * Increment `superlog.prs.created` for the org owning `incidentId`. Best-effort:
+ * a telemetry failure must never break PR delivery, so all errors are swallowed
+ * after a warn. Call this only when a PR row was newly inserted (not on the
+ * idempotent no-op path) so retries don't double-count.
+ */
+export async function recordPrCreatedMetric(incidentId: string): Promise<void> {
+  try {
+    const org = await resolveIncidentOrg(incidentId);
+    if (!org) return;
+    prCreatedCounter.add(1, { "tenant.org.id": org.id, "tenant.org.name": org.name });
+  } catch (err) {
+    logger.warn({ err, scope: "pr-metrics", incidentId }, "pr.created metric emit failed");
+  }
+}

--- a/apps/worker/src/pr-metrics.ts
+++ b/apps/worker/src/pr-metrics.ts
@@ -1,6 +1,5 @@
 import { metrics } from "@opentelemetry/api";
-import { db, schema } from "@superlog/db";
-import { eq } from "drizzle-orm";
+import { resolveIncidentOrg } from "@superlog/db";
 import { logger } from "./logger.js";
 
 // Per-org PR lifecycle counters. The "created" half lives in the worker because
@@ -18,22 +17,6 @@ const prCreatedCounter = meter.createCounter("superlog.prs.created", {
   description: "Agent pull requests opened, counted per org at open time.",
   unit: "1",
 });
-
-// incident → project → org, the same path tenant-metrics.ts uses. Returns null
-// when the incident (or its project/org) can't be resolved so callers can skip
-// emitting rather than fabricate an attribute set.
-async function resolveIncidentOrg(
-  incidentId: string,
-): Promise<{ id: string; name: string } | null> {
-  const rows = await db
-    .select({ id: schema.orgs.id, name: schema.orgs.name })
-    .from(schema.incidents)
-    .innerJoin(schema.projects, eq(schema.projects.id, schema.incidents.projectId))
-    .innerJoin(schema.orgs, eq(schema.orgs.id, schema.projects.orgId))
-    .where(eq(schema.incidents.id, incidentId))
-    .limit(1);
-  return rows[0] ?? null;
-}
 
 /**
  * Increment `superlog.prs.created` for the org owning `incidentId`. Best-effort:

--- a/packages/db/src/incident-org.ts
+++ b/packages/db/src/incident-org.ts
@@ -1,0 +1,24 @@
+import { eq } from "drizzle-orm";
+import { type DB, db } from "./client.js";
+import * as schema from "./schema.js";
+
+/**
+ * Resolve the org that owns an incident, via incident → project → org — the
+ * same join the worker's tenant-metrics.ts uses. Returns null when the incident
+ * (or its project/org) can't be resolved, so callers can skip rather than
+ * fabricate data. Shared by the worker and API PR-metric emitters so the join
+ * lives in one place.
+ */
+export async function resolveIncidentOrg(
+  incidentId: string,
+  database: DB = db,
+): Promise<{ id: string; name: string } | null> {
+  const rows = await database
+    .select({ id: schema.orgs.id, name: schema.orgs.name })
+    .from(schema.incidents)
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.incidents.projectId))
+    .innerJoin(schema.orgs, eq(schema.orgs.id, schema.projects.orgId))
+    .where(eq(schema.incidents.id, incidentId))
+    .limit(1);
+  return rows[0] ?? null;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -169,6 +169,7 @@ export {
   type CloseIncidentPullRequest,
   type IncidentOpenPullRequestToClose,
 } from "./incident-pr-resolution.js";
+export { resolveIncidentOrg } from "./incident-org.js";
 export {
   encryptIntegrationSecret,
   decryptIntegrationSecret,


### PR DESCRIPTION
## What

Adds three monotonic OTel counters that record PR throughput per org, so it can be charted on a dashboard:

| Metric | Emitted by | Fires when |
|---|---|---|
| `superlog.prs.created` | worker | a PR is opened (`recordOpenedAgentPullRequest`) |
| `superlog.prs.merged`  | api    | the `pull_request` webhook reports a merge |
| `superlog.prs.closed`  | api    | the `pull_request` webhook reports a close **without** merge |

Each carries `tenant.org.id` / `tenant.org.name` (resolved incident → project → org), matching the existing `superlog.tenant.prs.*` gauges, so dashboards can group all PR metrics by org the same way.

## Why counters (not gauges)

These are standard cumulative monotonic counters. The metric read path already reconstructs per-bucket increase for `AggregationTemporality = 2 AND IsMonotonic` sums (`cumulativeMonotonicSumQuery` in `apps/api/src/mcp/clickhouse.ts`), so a `sum`-aggregated `timeseries_metric` widget renders "PRs created/merged/closed in this period", summed correctly across service instances and process restarts.

## Correctness / safety

- **No double-counting.** `created` only fires on the newly-inserted PR row (the idempotent no-op path is skipped). `merged`/`closed` are gated on an actual state transition — the pure `prTerminalTransition` helper returns a count only when the prior state differs — so webhook re-deliveries and reopen→close cycles count each PR once.
- **Best-effort.** Emission is wrapped so a telemetry failure never breaks PR delivery or 500s the webhook.
- `closed` = closed-without-merge (`state='closed'`); a merged PR counts only as `merged`. So `created ≈ merged + closed + still-open`.

## Tests

`apps/api/src/pr-metrics-transition.test.ts` covers the transition gating (fresh merge/close, non-terminal actions, re-delivery dedup, reopen cycles). `tsc` + `biome` clean on worker and api.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-org PR lifecycle counters to chart PR throughput by org. Exposes `superlog.prs.created`, `superlog.prs.merged`, and `superlog.prs.closed` as monotonic counters with race-safe dedup across retries, concurrent deliveries, and webhook re-deliveries.

- **New Features**
  - Worker emits `superlog.prs.created` only on newly inserted PR rows.
  - API emits `superlog.prs.merged` and `superlog.prs.closed` from the `pull_request` webhook (`closed` means closed without merge).
  - All counters include `tenant.org.id` and `tenant.org.name` (resolved incident → project → org) to match existing gauges.
  - Race-safe dedup: conditional UPDATE with a prior-state predicate; increment only if the row actually flips. Best-effort emission; never breaks delivery.
  - Unit tests cover merge/close transitions, deduping, and reopen cycles.

- **Refactors**
  - Extracted incident→project→org resolver to `@superlog/db` as `resolveIncidentOrg`; used by both API and worker.

<sup>Written for commit d876d791d60b75570a029337bf290111f450f45d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

