### PR TITLE
Service map empty state: 'Generate map' for connected projects

### DIFF
--- a/apps/web/src/service-map/EmptyState.tsx
+++ b/apps/web/src/service-map/EmptyState.tsx
@@ -12,11 +12,16 @@ import { Btn } from "../design/ui.tsx";
 
 export function TopologyEmptyState({
   onConnectAws,
-  onBuildFromTelemetry,
+  onBuild,
+  building = false,
   height = 680,
 }: {
+  /** Only passed when the project has NO cloud connection — otherwise omitted. */
   onConnectAws?: () => void;
-  onBuildFromTelemetry?: () => void;
+  /** Request a build/rebuild of the map from the connected inventory + telemetry. */
+  onBuild?: () => void;
+  /** A build is in flight (worker is generating) — show progress, not the CTA. */
+  building?: boolean;
   height?: number | string;
 }) {
   return (
@@ -60,20 +65,25 @@ export function TopologyEmptyState({
           </div>
           <h2 className="text-[20px] font-semibold tracking-tight text-fg">Map your system</h2>
           <p className="mx-auto mt-2 max-w-sm text-[13.5px] leading-relaxed text-muted">
-            Build a live map of your services and infrastructure — drawn from the telemetry you
-            already send, then enriched with the resources behind it. An assistant proposes the
-            groupings and links; you adjust anything.
+            {onConnectAws
+              ? "Connect your AWS account to map the infrastructure behind your services. An assistant proposes the groupings and links; you adjust anything."
+              : "Build a live map from your connected cloud inventory and the telemetry you send. An assistant proposes the groupings and links; you adjust anything."}
           </p>
           <div className="mt-5 flex items-center justify-center gap-2.5">
-            <Btn size="md" variant="primary" onClick={onBuildFromTelemetry}>
-              Build from telemetry
-            </Btn>
-            <Btn size="md" variant="secondary" onClick={onConnectAws}>
-              Connect AWS
-            </Btn>
+            {onConnectAws ? (
+              <Btn size="md" variant="primary" onClick={onConnectAws}>
+                Connect AWS
+              </Btn>
+            ) : (
+              <Btn size="md" variant="primary" onClick={onBuild} disabled={building}>
+                {building ? "Building…" : "Generate map"}
+              </Btn>
+            )}
           </div>
           <p className="mt-3 text-[12px] text-subtle">
-            Takes a few seconds · you can edit or regenerate any time
+            {building
+              ? "Building from your infrastructure & telemetry…"
+              : "Takes a few seconds · you can edit or regenerate any time"}
           </p>
         </div>
       </div>

--- a/apps/web/src/service-map/ServiceMap.tsx
+++ b/apps/web/src/service-map/ServiceMap.tsx
@@ -6,7 +6,6 @@ import {
   viewTopology,
 } from "@superlog/topology";
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { type TopologyDoc, useGenerateTopology, useTopology } from "../api.ts";
 import { TopologyEmptyState } from "./EmptyState.tsx";
 import { EdgeLegend, TopologyCanvas } from "./TopologyCanvas.tsx";
@@ -17,7 +16,6 @@ import { EdgeLegend, TopologyCanvas } from "./TopologyCanvas.tsx";
 export function ServiceMap({ projectId }: { projectId: string }) {
   const { data, isLoading } = useTopology(projectId);
   const generate = useGenerateTopology(projectId);
-  const navigate = useNavigate();
   const [focused, setFocused] = useState<string | null>(null);
 
   const graph = data?.graph ?? null;
@@ -60,8 +58,8 @@ export function ServiceMap({ projectId }: { projectId: string }) {
       ) : empty ? (
         <TopologyEmptyState
           height={420}
-          onBuildFromTelemetry={() => generate.mutate()}
-          onConnectAws={() => navigate("/settings?scope=project&section=integrations")}
+          onBuild={() => generate.mutate()}
+          building={generate.isPending || data?.status === "generating"}
         />
       ) : (
         <>


### PR DESCRIPTION
Follow-up to #89. The service map only renders for projects that already have a cloud connection, so the empty state shouldn't offer "Connect AWS" or frame the build as telemetry-only.

- Drops the redundant "Connect AWS" button (only shown now if a disconnected caller passes `onConnectAws`).
- Primary action is **"Generate map"** (builds from the connected inventory + telemetry), with an in-flight **"Building…"** state.
- Reworded copy: "Build a live map from your connected cloud inventory and the telemetry you send."

Note: the map needs a synced resource inventory to produce nodes — the build reads `cloud_resources`, which is populated by the connection's "Sync now" action. (A one-click "generate also syncs" / periodic auto-sync is a possible follow-up.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the service map empty state for AWS-connected projects by replacing “Connect AWS”/“Build from telemetry” with a single “Generate map” action that builds from connected inventory + telemetry and shows a “Building…” state. The “Connect AWS” button only appears when a disconnected caller provides `onConnectAws`.

- **Refactors**
  - `TopologyEmptyState` now accepts `onBuild` and `building` (replaces `onBuildFromTelemetry`); updated copy to “Build a live map from your connected cloud inventory and the telemetry you send.”
  - `ServiceMap` wires `onBuild` to `useGenerateTopology` and passes `building`; removed settings navigation.

<sup>Written for commit 1c54af8f6dcbf4c4020999cb91b0620a9ab493c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

