### PR TITLE
feat(proxy): optional direct-to-ClickHouse ingest writes for logs and traces

### DIFF
--- a/apps/proxy/package.json
+++ b/apps/proxy/package.json
@@ -8,7 +8,7 @@
     "dev": "tsx watch --import ./tracing.ts src/index.ts",
     "start": "tsx --import ./tracing.ts src/index.ts",
     "test:ingest-queue": "tsx --test src/ingest-queue.test.ts",
-    "test": "tsx --test src/otlp-clickhouse.test.ts src/otlp-decode.test.ts",
+    "test": "tsx --test src/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/proxy/package.json
+++ b/apps/proxy/package.json
@@ -8,7 +8,7 @@
     "dev": "tsx watch --import ./tracing.ts src/index.ts",
     "start": "tsx --import ./tracing.ts src/index.ts",
     "test:ingest-queue": "tsx --test src/ingest-queue.test.ts",
-    "test": "tsx --test src/*.test.ts",
+    "test": "tsx --test src/otlp-clickhouse.test.ts src/otlp-decode.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/proxy/package.json
+++ b/apps/proxy/package.json
@@ -8,12 +8,14 @@
     "dev": "tsx watch --import ./tracing.ts src/index.ts",
     "start": "tsx --import ./tracing.ts src/index.ts",
     "test:ingest-queue": "tsx --test src/ingest-queue.test.ts",
+    "test": "tsx --test src/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1053.0",
     "@aws-sdk/client-sqs": "^3.1053.0",
     "@aws-sdk/lib-storage": "3.1053.0",
+    "@clickhouse/client": "^1.9.0",
     "@hono/node-server": "^1.13.7",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/api-logs": "^0.215.0",
@@ -32,7 +34,8 @@
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.6.12",
-    "pino": "^10.3.1"
+    "pino": "^10.3.1",
+    "protobufjs": "^7.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.1",

--- a/apps/proxy/src/clickhouse-writer.ts
+++ b/apps/proxy/src/clickhouse-writer.ts
@@ -1,0 +1,83 @@
+import { createClient, type ClickHouseClient } from "@clickhouse/client";
+
+import type { OtelLogRow, OtelTraceRow } from "./otlp-clickhouse.js";
+
+// Direct-to-ClickHouse ingest writer. Each consumer worker maps an OTLP payload to
+// rows and INSERTs them synchronously with insert_quorum, so the SQS message is only
+// deleted once the write is durably committed (the consume loop deletes on success,
+// leaves on throw). This replaces forwarding through the collector, whose synchronous
+// exporter serializes to ~one insert per task — the global ingest ceiling.
+//
+// Durability note: quorum is preserved (default 2), and async_insert stays OFF, so a
+// successful insert means the rows are committed to a quorum of replicas before we ack.
+
+export type IngestClickHouseConfig = {
+  url: string;
+  database: string;
+  username: string;
+  password: string;
+  insertQuorum: number;
+  insertQuorumTimeoutMs: number;
+  requestTimeoutMs: number;
+};
+
+function readPositiveInt(value: string | undefined, fallback: number): number {
+  const n = value === undefined ? NaN : Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+// Returns null unless INGEST_CLICKHOUSE_DIRECT=true and a ClickHouse URL is set, so
+// the consumer keeps forwarding to the collector until direct writes are switched on.
+export function getIngestClickHouseConfig(env: NodeJS.ProcessEnv): IngestClickHouseConfig | null {
+  if (env.INGEST_CLICKHOUSE_DIRECT !== "true") return null;
+  const url = env.CLICKHOUSE_URL;
+  if (!url) return null;
+  return {
+    url,
+    database: env.CLICKHOUSE_DB ?? "superlog",
+    username: env.CLICKHOUSE_USER ?? "default",
+    password: env.CLICKHOUSE_PASSWORD ?? "",
+    insertQuorum: readPositiveInt(env.INGEST_CLICKHOUSE_INSERT_QUORUM, 2),
+    insertQuorumTimeoutMs: readPositiveInt(env.INGEST_CLICKHOUSE_INSERT_QUORUM_TIMEOUT_MS, 30_000),
+    requestTimeoutMs: readPositiveInt(env.INGEST_CLICKHOUSE_REQUEST_TIMEOUT_MS, 30_000),
+  };
+}
+
+export type IngestTable = "otel_logs" | "otel_traces";
+
+export interface IngestRowWriter {
+  insert(table: IngestTable, rows: OtelLogRow[] | OtelTraceRow[]): Promise<void>;
+}
+
+export class ClickHouseIngestWriter implements IngestRowWriter {
+  private readonly client: ClickHouseClient;
+
+  constructor(config: IngestClickHouseConfig) {
+    this.client = createClient({
+      url: config.url,
+      database: config.database,
+      username: config.username,
+      password: config.password,
+      request_timeout: config.requestTimeoutMs,
+      keep_alive: { enabled: true },
+      clickhouse_settings: {
+        // Mirror the collector's durability: commit to a quorum of replicas before
+        // the insert resolves, and keep inserts synchronous (no server-side buffering).
+        insert_quorum: String(config.insertQuorum),
+        insert_quorum_timeout: config.insertQuorumTimeoutMs,
+        async_insert: 0,
+        wait_for_async_insert: 1,
+      },
+    });
+  }
+
+  async insert(table: IngestTable, rows: OtelLogRow[] | OtelTraceRow[]): Promise<void> {
+    if (rows.length === 0) return;
+    // Both row shapes are plain JSON objects; the client just serializes JSONEachRow.
+    await this.client.insert({ table, values: rows as OtelLogRow[], format: "JSONEachRow" });
+  }
+
+  async close(): Promise<void> {
+    await this.client.close();
+  }
+}

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -57,9 +57,13 @@ const ingestQueueConfig = getIngestQueueConfig(process.env);
 // forwarding every message through the collector. Metrics and undecodable bodies
 // still fall through to the collector. Disabled (null) otherwise.
 const ingestClickHouseConfig = getIngestClickHouseConfig(process.env);
-const ingestRowWriter = ingestClickHouseConfig
-  ? new ClickHouseIngestWriter(ingestClickHouseConfig)
-  : undefined;
+// Only build the writer when a consumer will actually run (queue configured and the
+// consumer enabled) — it's only used on the consume path, so creating/logging it for a
+// producer-only proxy would be wasted setup and a false "enabled" rollout signal.
+const ingestRowWriter =
+  ingestClickHouseConfig && ingestQueueConfig?.consumerEnabled
+    ? new ClickHouseIngestWriter(ingestClickHouseConfig)
+    : undefined;
 if (ingestRowWriter) {
   logger.info(
     { database: ingestClickHouseConfig?.database, insertQuorum: ingestClickHouseConfig?.insertQuorum },

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -19,6 +19,10 @@ import {
   parseAccountIdFromFirehoseArn,
 } from "./firehose.js";
 import { stampIssueFingerprintsFailOpen } from "./ingest-fingerprints.js";
+import {
+  ClickHouseIngestWriter,
+  getIngestClickHouseConfig,
+} from "./clickhouse-writer.js";
 import { IngestQueue, getIngestQueueConfig } from "./ingest-queue.js";
 import {
   type TelemetrySignal,
@@ -48,7 +52,23 @@ const FIREHOSE_LOGS_COLLECTOR_URL =
   process.env.FIREHOSE_LOGS_COLLECTOR_URL ?? "http://localhost:4434";
 const PORT = Number(process.env.PORT ?? 4000);
 const ingestQueueConfig = getIngestQueueConfig(process.env);
-const ingestQueue = ingestQueueConfig ? new IngestQueue(ingestQueueConfig, logger) : null;
+// When INGEST_CLICKHOUSE_DIRECT=true, the consumer writes logs/traces straight to
+// ClickHouse (parallel synchronous quorum inserts, acked on success) instead of
+// forwarding every message through the collector. Metrics and undecodable bodies
+// still fall through to the collector. Disabled (null) otherwise.
+const ingestClickHouseConfig = getIngestClickHouseConfig(process.env);
+const ingestRowWriter = ingestClickHouseConfig
+  ? new ClickHouseIngestWriter(ingestClickHouseConfig)
+  : undefined;
+if (ingestRowWriter) {
+  logger.info(
+    { database: ingestClickHouseConfig?.database, insertQuorum: ingestClickHouseConfig?.insertQuorum },
+    "ingest direct-to-clickhouse writes enabled for logs and traces",
+  );
+}
+const ingestQueue = ingestQueueConfig
+  ? new IngestQueue(ingestQueueConfig, logger, undefined, ingestRowWriter)
+  : null;
 // Free-tier ingest hard-block. Null (disabled) without AUTUMN_SECRET_KEY. The
 // verdict is a cached, fail-open in-memory read — never a blocking call on the
 // ingest hot path (see billing/ingest-entitlement.ts).

--- a/apps/proxy/src/ingest-queue.batch.test.ts
+++ b/apps/proxy/src/ingest-queue.batch.test.ts
@@ -1,9 +1,24 @@
 import { strict as assert } from "node:assert";
-import { test } from "node:test";
+import { after, before, test } from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
 import { IngestQueue, type IngestQueueConfig, getIngestQueueConfig } from "./ingest-queue.js";
 
 const noopLogger = { info: () => {}, warn: () => {}, error: () => {} };
+
+// The producer's micro-batch flush timer is unref()'d (see IngestQueue.sendToQueue)
+// so a producer-only proxy never stays alive just for a pending flush. In prod the
+// HTTP server keeps the event loop alive and the timer fires; under the bare test
+// runner there is no other handle, so the loop would drain before the unref'd timer
+// fires and the enqueue() promises would never settle ("Promise resolution is still
+// pending but the event loop has already resolved"). A single ref'd keepalive for the
+// duration of the suite reproduces prod's "loop stays alive" condition.
+let suiteKeepAlive: NodeJS.Timeout;
+before(() => {
+  suiteKeepAlive = setInterval(() => {}, 60_000);
+});
+after(() => {
+  clearInterval(suiteKeepAlive);
+});
 
 function buildConfig(overrides: Partial<IngestQueueConfig> = {}): IngestQueueConfig {
   return {

--- a/apps/proxy/src/ingest-queue.ts
+++ b/apps/proxy/src/ingest-queue.ts
@@ -18,8 +18,10 @@ import {
 } from "@aws-sdk/client-sqs";
 import { Upload } from "@aws-sdk/lib-storage";
 import { type SpillSink, captureBody } from "./body-capture.js";
+import type { IngestRowWriter } from "./clickhouse-writer.js";
 import { stampIssueFingerprintsFailOpen } from "./ingest-fingerprints.js";
 import { proxyOperationalRecorder } from "./operational-metrics.js";
+import { decodeOtlpToRows } from "./otlp-decode.js";
 
 const DEFAULT_MAX_MESSAGE_BYTES = 240_000;
 // Hard ceiling on a single ingest body. Bodies above this are rejected at the
@@ -316,6 +318,7 @@ export class IngestQueue {
     private readonly config: IngestQueueConfig,
     private readonly logger: LoggerLike,
     spillSinkFactory?: SpillSinkFactory,
+    private readonly rowWriter?: IngestRowWriter,
   ) {
     const clientConfig = config.region ? { region: config.region } : {};
     this.sqs = new SQSClient(clientConfig);
@@ -722,6 +725,51 @@ export class IngestQueue {
         },
         this.logger,
       );
+
+      // Direct-to-ClickHouse path (INGEST_CLICKHOUSE_DIRECT). Map the OTLP body to rows
+      // and INSERT synchronously with quorum; the message is deleted only if the insert
+      // succeeds (a throw falls through to the catch and the message redelivers). Signals
+      // we don't yet write directly (metrics) and bodies we can't decode return null and
+      // fall through to the collector forward below, so nothing is ever dropped.
+      if (this.rowWriter) {
+        const decoded = decodeOtlpToRows({
+          path: parsed.path,
+          projectId: parsed.projectId,
+          contentType: parsed.contentType,
+          contentEncoding: parsed.contentEncoding,
+          body,
+        });
+        if (decoded) {
+          await this.rowWriter.insert(decoded.table, decoded.rows);
+          proxyOperationalRecorder.recordQueueDelivery({
+            path: parsed.path,
+            projectId: parsed.projectId,
+            storage: parsed.body.storage,
+            outcome: "delivered",
+            durationMs: performance.now() - startedAt,
+            ageMs: ageMs(parsed.receivedAt),
+          });
+          this.logger.info(
+            {
+              path: parsed.path,
+              projectId: parsed.projectId,
+              storage: parsed.body.storage,
+              target: "clickhouse",
+              rows: decoded.rows.length,
+            },
+            "delivered queued ingest payload",
+          );
+          return {
+            message,
+            shouldDelete: true,
+            s3Cleanup:
+              parsed.body.storage === "s3"
+                ? { bucket: parsed.body.bucket, key: parsed.body.key }
+                : undefined,
+          };
+        }
+      }
+
       const headers: Record<string, string> = {
         "content-type": parsed.contentType,
         "x-superlog-project-id": parsed.projectId,

--- a/apps/proxy/src/ingest-queue.ts
+++ b/apps/proxy/src/ingest-queue.ts
@@ -21,7 +21,7 @@ import { type SpillSink, captureBody } from "./body-capture.js";
 import type { IngestRowWriter } from "./clickhouse-writer.js";
 import { stampIssueFingerprintsFailOpen } from "./ingest-fingerprints.js";
 import { proxyOperationalRecorder } from "./operational-metrics.js";
-import { decodeOtlpToRows } from "./otlp-decode.js";
+import { type DecodedRows, decodeOtlpToRows } from "./otlp-decode.js";
 
 const DEFAULT_MAX_MESSAGE_BYTES = 240_000;
 // Hard ceiling on a single ingest body. Bodies above this are rejected at the
@@ -732,13 +732,25 @@ export class IngestQueue {
       // we don't yet write directly (metrics) and bodies we can't decode return null and
       // fall through to the collector forward below, so nothing is ever dropped.
       if (this.rowWriter) {
-        const decoded = decodeOtlpToRows({
-          path: parsed.path,
-          projectId: parsed.projectId,
-          contentType: parsed.contentType,
-          contentEncoding: parsed.contentEncoding,
-          body,
-        });
+        // Decoding is best-effort: a malformed/undecodable payload returns null OR throws,
+        // and either way we fall through to the collector forward below rather than failing
+        // the message (which would churn it through retries to the DLQ). Only the INSERT is
+        // allowed to throw — a ClickHouse failure should redeliver, not drop.
+        let decoded: DecodedRows | null = null;
+        try {
+          decoded = decodeOtlpToRows({
+            path: parsed.path,
+            projectId: parsed.projectId,
+            contentType: parsed.contentType,
+            contentEncoding: parsed.contentEncoding,
+            body,
+          });
+        } catch (decodeErr) {
+          this.logger.warn(
+            { err: decodeErr, path: parsed.path, projectId: parsed.projectId },
+            "direct-write decode failed; forwarding to collector",
+          );
+        }
         if (decoded) {
           await this.rowWriter.insert(decoded.table, decoded.rows);
           proxyOperationalRecorder.recordQueueDelivery({

--- a/apps/proxy/src/otlp-clickhouse.test.ts
+++ b/apps/proxy/src/otlp-clickhouse.test.ts
@@ -39,6 +39,7 @@ const logsExport = {
                 { key: "ratio", value: { doubleValue: 0.5 } },
                 { key: "tags", value: { arrayValue: { values: [{ stringValue: "a" }, { stringValue: "b" }] } } },
                 { key: "codes", value: { arrayValue: { values: [{ intValue: "1" }, { intValue: "2" }] } } },
+                { key: "bigids", value: { arrayValue: { values: [{ intValue: "9007199254740993" }] } } },
               ],
             },
             {
@@ -93,6 +94,8 @@ test("otlpLogsToRows stringifies log attribute values like the collector Map(Str
   assert.equal(a["tags"], '["a","b"]');
   // nested ints serialize as numeric JSON tokens, matching the collector
   assert.equal(a["codes"], "[1,2]");
+  // int64 beyond 2^53 keeps full precision (not rounded via JS Number)
+  assert.equal(a["bigids"], "[9007199254740993]");
 });
 
 test("otlpLogsToRows falls back to observedTimeUnixNano and empty trace context", () => {

--- a/apps/proxy/src/otlp-clickhouse.test.ts
+++ b/apps/proxy/src/otlp-clickhouse.test.ts
@@ -38,6 +38,7 @@ const logsExport = {
                 { key: "retried", value: { boolValue: true } },
                 { key: "ratio", value: { doubleValue: 0.5 } },
                 { key: "tags", value: { arrayValue: { values: [{ stringValue: "a" }, { stringValue: "b" }] } } },
+                { key: "codes", value: { arrayValue: { values: [{ intValue: "1" }, { intValue: "2" }] } } },
               ],
             },
             {
@@ -90,6 +91,8 @@ test("otlpLogsToRows stringifies log attribute values like the collector Map(Str
   assert.equal(a["retried"], "true");
   assert.equal(a["ratio"], "0.5");
   assert.equal(a["tags"], '["a","b"]');
+  // nested ints serialize as numeric JSON tokens, matching the collector
+  assert.equal(a["codes"], "[1,2]");
 });
 
 test("otlpLogsToRows falls back to observedTimeUnixNano and empty trace context", () => {
@@ -173,7 +176,7 @@ test("otlpTracesToRows maps spans with collector-compatible columns", () => {
   assert.equal(r.TraceState, "rojo=00f067aa");
   assert.equal(r.ScopeName, "instr.http");
   assert.equal(r.ScopeVersion, "2.0.0");
-  assert.equal(r.Duration, 1_849_000_000); // nanoseconds
+  assert.equal(r.Duration, "1849000000"); // UInt64 nanoseconds as a string
   assert.equal(r.Timestamp, "2024-06-10 06:13:20.000000000");
 });
 

--- a/apps/proxy/src/otlp-clickhouse.test.ts
+++ b/apps/proxy/src/otlp-clickhouse.test.ts
@@ -1,0 +1,200 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { otlpLogsToRows, otlpTracesToRows } from "./otlp-clickhouse.js";
+
+// A minimal OTLP/JSON logs export, shaped like what the OTLP receiver decodes.
+// One resource (with a superlog.* routing key that must be stripped), one scope,
+// two log records (one with trace context + rich attributes, one bare).
+const logsExport = {
+  resourceLogs: [
+    {
+      resource: {
+        attributes: [
+          { key: "service.name", value: { stringValue: "checkout" } },
+          { key: "service.version", value: { stringValue: "1.2.3" } },
+          // routing key the proxy stamped — collector strips all superlog.* then
+          // re-adds superlog.project_id from the request metadata.
+          { key: "superlog.project_id", value: { stringValue: "WRONG-should-be-overwritten" } },
+        ],
+      },
+      schemaUrl: "https://schema/res",
+      scopeLogs: [
+        {
+          scope: { name: "my.logger", version: "0.1.0", attributes: [] },
+          schemaUrl: "https://schema/scope",
+          logRecords: [
+            {
+              timeUnixNano: "1718000000123456789",
+              severityText: "ERROR",
+              severityNumber: 17,
+              traceId: "5b8efff798038103d269b633813fc60c",
+              spanId: "eee19b7ec3c1b174",
+              flags: 1,
+              body: { stringValue: "boom" },
+              eventName: "exception",
+              attributes: [
+                { key: "http.status", value: { intValue: "500" } },
+                { key: "retried", value: { boolValue: true } },
+                { key: "ratio", value: { doubleValue: 0.5 } },
+                { key: "tags", value: { arrayValue: { values: [{ stringValue: "a" }, { stringValue: "b" }] } } },
+              ],
+            },
+            {
+              // no time set → falls back to observedTimeUnixNano
+              observedTimeUnixNano: "1718000000000000000",
+              body: { stringValue: "plain" },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+test("otlpLogsToRows maps one row per log record with collector-compatible columns", () => {
+  const rows = otlpLogsToRows(logsExport, "proj-123");
+  assert.equal(rows.length, 2);
+
+  const r = rows[0]!;
+  assert.equal(r.ServiceName, "checkout");
+  assert.equal(r.Body, "boom");
+  assert.equal(r.SeverityText, "ERROR");
+  assert.equal(r.SeverityNumber, 17);
+  assert.equal(r.TraceId, "5b8efff798038103d269b633813fc60c");
+  assert.equal(r.SpanId, "eee19b7ec3c1b174");
+  assert.equal(r.TraceFlags, 1);
+  assert.equal(r.ScopeName, "my.logger");
+  assert.equal(r.ScopeVersion, "0.1.0");
+  assert.equal(r.ResourceSchemaUrl, "https://schema/res");
+  assert.equal(r.ScopeSchemaUrl, "https://schema/scope");
+  assert.equal(r.EventName, "exception");
+  // nanosecond-precise timestamp, UTC, 9 fractional digits
+  assert.equal(r.Timestamp, "2024-06-10 06:13:20.123456789");
+});
+
+test("otlpLogsToRows strips superlog.* from resource attrs and stamps the real project id", () => {
+  const rows = otlpLogsToRows(logsExport, "proj-123");
+  assert.equal(rows[0]!.ResourceAttributes["superlog.project_id"], "proj-123");
+  assert.equal(rows[0]!.ResourceAttributes["service.name"], "checkout");
+  assert.equal(rows[0]!.ResourceAttributes["service.version"], "1.2.3");
+  // no stray superlog.* keys other than the stamped project id
+  const superlogKeys = Object.keys(rows[0]!.ResourceAttributes).filter((k) => k.startsWith("superlog."));
+  assert.deepEqual(superlogKeys, ["superlog.project_id"]);
+});
+
+test("otlpLogsToRows stringifies log attribute values like the collector Map(String,String)", () => {
+  const rows = otlpLogsToRows(logsExport, "proj-123");
+  const a = rows[0]!.LogAttributes;
+  assert.equal(a["http.status"], "500");
+  assert.equal(a["retried"], "true");
+  assert.equal(a["ratio"], "0.5");
+  assert.equal(a["tags"], '["a","b"]');
+});
+
+test("otlpLogsToRows falls back to observedTimeUnixNano and empty trace context", () => {
+  const rows = otlpLogsToRows(logsExport, "proj-123");
+  const r = rows[1]!;
+  assert.equal(r.Body, "plain");
+  assert.equal(r.TraceId, "");
+  assert.equal(r.SpanId, "");
+  assert.equal(r.SeverityText, "");
+  assert.equal(r.SeverityNumber, 0);
+  assert.equal(r.Timestamp, "2024-06-10 06:13:20.000000000");
+});
+
+test("otlpLogsToRows tolerates an empty export", () => {
+  assert.deepEqual(otlpLogsToRows({}, "proj-123"), []);
+  assert.deepEqual(otlpLogsToRows({ resourceLogs: [] }, "proj-123"), []);
+});
+
+const tracesExport = {
+  resourceSpans: [
+    {
+      resource: {
+        attributes: [
+          { key: "service.name", value: { stringValue: "api" } },
+          { key: "superlog.project_id", value: { stringValue: "WRONG" } },
+        ],
+      },
+      scopeSpans: [
+        {
+          scope: { name: "instr.http", version: "2.0.0" },
+          spans: [
+            {
+              traceId: "5b8efff798038103d269b633813fc60c",
+              spanId: "eee19b7ec3c1b174",
+              parentSpanId: "aaaa19b7ec3c1b17",
+              traceState: "rojo=00f067aa",
+              name: "GET /x",
+              kind: 3, // Client
+              startTimeUnixNano: "1718000000000000000",
+              endTimeUnixNano: "1718000001849000000", // +1.849s
+              status: { code: 2, message: "boom" },
+              attributes: [
+                { key: "http.method", value: { stringValue: "GET" } },
+                { key: "superlog.issue_fingerprint", value: { stringValue: "deadbeef" } },
+              ],
+              events: [
+                {
+                  timeUnixNano: "1718000000500000000",
+                  name: "exception",
+                  attributes: [{ key: "exception.type", value: { stringValue: "Error" } }],
+                },
+              ],
+              links: [
+                {
+                  traceId: "11111111111111111111111111111111",
+                  spanId: "2222222222222222",
+                  traceState: "",
+                  attributes: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+test("otlpTracesToRows maps spans with collector-compatible columns", () => {
+  const rows = otlpTracesToRows(tracesExport, "proj-xyz");
+  assert.equal(rows.length, 1);
+  const r = rows[0]!;
+  assert.equal(r.ServiceName, "api");
+  assert.equal(r.SpanName, "GET /x");
+  assert.equal(r.SpanKind, "Client");
+  assert.equal(r.StatusCode, "Error");
+  assert.equal(r.StatusMessage, "boom");
+  assert.equal(r.TraceId, "5b8efff798038103d269b633813fc60c");
+  assert.equal(r.SpanId, "eee19b7ec3c1b174");
+  assert.equal(r.ParentSpanId, "aaaa19b7ec3c1b17");
+  assert.equal(r.TraceState, "rojo=00f067aa");
+  assert.equal(r.ScopeName, "instr.http");
+  assert.equal(r.ScopeVersion, "2.0.0");
+  assert.equal(r.Duration, 1_849_000_000); // nanoseconds
+  assert.equal(r.Timestamp, "2024-06-10 06:13:20.000000000");
+});
+
+test("otlpTracesToRows strips superlog.* from resource and span attrs, stamps project id", () => {
+  const r = otlpTracesToRows(tracesExport, "proj-xyz")[0]!;
+  assert.equal(r.ResourceAttributes["superlog.project_id"], "proj-xyz");
+  assert.equal(r.ResourceAttributes["service.name"], "api");
+  assert.equal(r.SpanAttributes["http.method"], "GET");
+  // span-level superlog.* stripped (matches collector transform/strip_superlog)
+  assert.equal(r.SpanAttributes["superlog.issue_fingerprint"], undefined);
+});
+
+test("otlpTracesToRows flattens events and links into parallel arrays", () => {
+  const r = otlpTracesToRows(tracesExport, "proj-xyz")[0]!;
+  assert.deepEqual(r["Events.Name"], ["exception"]);
+  assert.equal(r["Events.Timestamp"][0]!, "2024-06-10 06:13:20.500000000");
+  assert.deepEqual(r["Events.Attributes"], [{ "exception.type": "Error" }]);
+  assert.deepEqual(r["Links.TraceId"], ["11111111111111111111111111111111"]);
+  assert.deepEqual(r["Links.SpanId"], ["2222222222222222"]);
+});
+
+test("otlpTracesToRows tolerates an empty export", () => {
+  assert.deepEqual(otlpTracesToRows({}, "p"), []);
+});

--- a/apps/proxy/src/otlp-clickhouse.test.ts
+++ b/apps/proxy/src/otlp-clickhouse.test.ts
@@ -40,6 +40,8 @@ const logsExport = {
                 { key: "tags", value: { arrayValue: { values: [{ stringValue: "a" }, { stringValue: "b" }] } } },
                 { key: "codes", value: { arrayValue: { values: [{ intValue: "1" }, { intValue: "2" }] } } },
                 { key: "bigids", value: { arrayValue: { values: [{ intValue: "9007199254740993" }] } } },
+                // proxy-stamped routing key; collector strips superlog.* from log attrs too
+                { key: "superlog.issue_fingerprint", value: { stringValue: "deadbeef" } },
               ],
             },
             {
@@ -83,6 +85,13 @@ test("otlpLogsToRows strips superlog.* from resource attrs and stamps the real p
   // no stray superlog.* keys other than the stamped project id
   const superlogKeys = Object.keys(rows[0]!.ResourceAttributes).filter((k) => k.startsWith("superlog."));
   assert.deepEqual(superlogKeys, ["superlog.project_id"]);
+  // superlog.* is stripped from log record attributes too (matches the collector's
+  // transform/strip_superlog on log.attributes); project id lives only on resource attrs.
+  assert.equal(rows[0]!.LogAttributes["superlog.issue_fingerprint"], undefined);
+  assert.equal(
+    Object.keys(rows[0]!.LogAttributes).some((k) => k.startsWith("superlog.")),
+    false,
+  );
 });
 
 test("otlpLogsToRows stringifies log attribute values like the collector Map(String,String)", () => {

--- a/apps/proxy/src/otlp-clickhouse.ts
+++ b/apps/proxy/src/otlp-clickhouse.ts
@@ -267,32 +267,40 @@ export function anyValueToString(v: OtlpAnyValue | undefined): string {
   if (v.intValue !== undefined) return String(v.intValue);
   if (v.doubleValue !== undefined) return String(v.doubleValue);
   if (v.bytesValue !== undefined) return bytesToBase64(v.bytesValue);
-  if (v.arrayValue) return JSON.stringify((v.arrayValue.values ?? []).map(anyValueToJson));
-  if (v.kvlistValue) return JSON.stringify(anyValueToJson(v));
+  if (v.arrayValue || v.kvlistValue) return jsonEncodeValue(v);
   return "";
 }
 
-function anyValueToJson(v: OtlpAnyValue | undefined): unknown {
-  if (!v) return null;
-  if (v.stringValue !== undefined) return v.stringValue;
-  if (v.boolValue !== undefined) return v.boolValue;
-  // Nested ints serialize as numeric JSON tokens (e.g. [1,2], not ["1","2"]) to
-  // match the collector. intValue arrives as a string (OTLP/JSON int64, and the
-  // protobuf decoder's longs:String); coerce so JSON.stringify emits a number.
-  // Values beyond 2^53 can't be represented exactly in JSON either way.
-  if (v.intValue !== undefined) return typeof v.intValue === "string" ? Number(v.intValue) : v.intValue;
-  if (v.doubleValue !== undefined) return v.doubleValue;
-  if (v.bytesValue !== undefined) return bytesToBase64(v.bytesValue);
-  if (v.arrayValue) return (v.arrayValue.values ?? []).map(anyValueToJson);
+// Serialize a complex OTLP value (array / kvlist) to JSON for the Map(String,String)
+// column, matching the collector (pdata Value.AsString). Strings reuse JSON.stringify
+// (identical JS-style escaping to the previous implementation); the one thing JSON
+// can't express through JS is an int64 beyond 2^53, so ints are emitted as raw numeric
+// tokens straight from their digit strings rather than coerced through Number — keeping
+// full precision (e.g. [1,9007199254740993], not a rounded value).
+function jsonEncodeValue(v: OtlpAnyValue | undefined): string {
+  if (!v) return "null";
+  if (v.stringValue !== undefined) return JSON.stringify(v.stringValue);
+  if (v.boolValue !== undefined) return v.boolValue ? "true" : "false";
+  if (v.intValue !== undefined) return integerToken(v.intValue);
+  if (v.doubleValue !== undefined) return JSON.stringify(v.doubleValue);
+  if (v.bytesValue !== undefined) return JSON.stringify(bytesToBase64(v.bytesValue));
+  if (v.arrayValue) return `[${(v.arrayValue.values ?? []).map(jsonEncodeValue).join(",")}]`;
   if (v.kvlistValue) {
-    const obj: Record<string, unknown> = {};
-    for (const kv of v.kvlistValue.values ?? []) {
-      if (kv.key === undefined || kv.key === null) continue;
-      obj[kv.key] = anyValueToJson(kv.value);
-    }
-    return obj;
+    const entries = (v.kvlistValue.values ?? [])
+      .filter((kv) => kv.key !== undefined && kv.key !== null)
+      .map((kv) => `${JSON.stringify(kv.key)}:${jsonEncodeValue(kv.value)}`);
+    return `{${entries.join(",")}}`;
   }
-  return null;
+  return "null";
+}
+
+// An OTLP int64 as a raw JSON numeric token. OTLP/JSON and the protobuf decoder
+// (longs:String) deliver it as a digit string; emit verbatim so values past 2^53 keep
+// full precision. Falls back to a quoted string for anything not a plain integer
+// literal so we never emit invalid JSON.
+function integerToken(intValue: number | string): string {
+  if (typeof intValue === "number") return String(intValue);
+  return /^-?\d+$/.test(intValue) ? intValue : JSON.stringify(intValue);
 }
 
 function bytesToBase64(b: string | Uint8Array): string {

--- a/apps/proxy/src/otlp-clickhouse.ts
+++ b/apps/proxy/src/otlp-clickhouse.ts
@@ -1,0 +1,328 @@
+// Pure mapping from decoded OTLP payloads to ClickHouse row objects, matching
+// the column layout the otelcol clickhouse exporter writes today (table DDL in
+// infra/clickhouse/schema/ha-replicated-otel.sql). This lets the ingest-consumer
+// write directly to ClickHouse — a parallel synchronous quorum insert per worker,
+// acked back to SQS only on success — instead of funnelling every message through
+// the collector, whose synchronous exporter serializes to ~one insert per task.
+//
+// FIDELITY GOAL: rows produced here must be byte-for-byte what the collector
+// produces, because the read path (apps/api) queries specific columns and the
+// attribute Maps. The collector pipeline we mirror is:
+//   transform/strip_superlog  -> delete keys matching ^superlog\..* from
+//                                 resource attrs AND log/span attrs
+//   attributes/from_metadata  -> insert superlog.project_id (from the request's
+//                                 x-superlog-project-id) into RESOURCE attrs
+// so: strip every superlog.* key, then stamp superlog.project_id onto resource attrs.
+//
+// Only logs are implemented in this pass (the dominant ingest signal). Traces and
+// the five metrics tables follow the same shape and are TODO.
+
+type OtlpAnyValue = {
+  stringValue?: string;
+  intValue?: number | string;
+  doubleValue?: number;
+  boolValue?: boolean;
+  bytesValue?: string | Uint8Array;
+  arrayValue?: { values?: OtlpAnyValue[] };
+  kvlistValue?: { values?: OtlpKeyValue[] };
+};
+
+type OtlpKeyValue = { key?: string; value?: OtlpAnyValue };
+
+type OtlpLogRecord = {
+  timeUnixNano?: string | number;
+  observedTimeUnixNano?: string | number;
+  severityText?: string;
+  severityNumber?: number;
+  traceId?: string | Uint8Array;
+  spanId?: string | Uint8Array;
+  flags?: number;
+  body?: OtlpAnyValue;
+  eventName?: string;
+  attributes?: OtlpKeyValue[];
+};
+
+type OtlpScopeLogs = {
+  scope?: { name?: string; version?: string; attributes?: OtlpKeyValue[] };
+  schemaUrl?: string;
+  logRecords?: OtlpLogRecord[];
+};
+
+type OtlpResourceLogs = {
+  resource?: { attributes?: OtlpKeyValue[] };
+  schemaUrl?: string;
+  scopeLogs?: OtlpScopeLogs[];
+};
+
+export type OtlpLogsExport = { resourceLogs?: OtlpResourceLogs[] };
+
+// Columns of superlog.otel_logs, minus TimestampTime which is a DEFAULT column
+// (toDateTime(Timestamp)) and must not be inserted.
+export type OtelLogRow = {
+  Timestamp: string;
+  TraceId: string;
+  SpanId: string;
+  TraceFlags: number;
+  SeverityText: string;
+  SeverityNumber: number;
+  ServiceName: string;
+  Body: string;
+  ResourceSchemaUrl: string;
+  ResourceAttributes: Record<string, string>;
+  ScopeSchemaUrl: string;
+  ScopeName: string;
+  ScopeVersion: string;
+  ScopeAttributes: Record<string, string>;
+  LogAttributes: Record<string, string>;
+  EventName: string;
+};
+
+const SUPERLOG_PROJECT_ID_KEY = "superlog.project_id";
+const NANOS_PER_SECOND = 1_000_000_000n;
+
+export function otlpLogsToRows(payload: OtlpLogsExport, projectId: string): OtelLogRow[] {
+  const rows: OtelLogRow[] = [];
+  for (const rl of payload.resourceLogs ?? []) {
+    const resourceMap = kvListToMap(rl.resource?.attributes);
+    const serviceName = resourceMap["service.name"] ?? "";
+    const resourceAttributes = stripSuperlog(resourceMap);
+    resourceAttributes[SUPERLOG_PROJECT_ID_KEY] = projectId;
+    const resourceSchemaUrl = rl.schemaUrl ?? "";
+
+    for (const sl of rl.scopeLogs ?? []) {
+      const scopeName = sl.scope?.name ?? "";
+      const scopeVersion = sl.scope?.version ?? "";
+      const scopeAttributes = kvListToMap(sl.scope?.attributes);
+      const scopeSchemaUrl = sl.schemaUrl ?? "";
+
+      for (const lr of sl.logRecords ?? []) {
+        rows.push({
+          Timestamp: nanosToClickHouseDateTime64(pickTime(lr.timeUnixNano, lr.observedTimeUnixNano)),
+          TraceId: toHex(lr.traceId),
+          SpanId: toHex(lr.spanId),
+          TraceFlags: lr.flags ?? 0,
+          SeverityText: lr.severityText ?? "",
+          SeverityNumber: lr.severityNumber ?? 0,
+          ServiceName: serviceName,
+          Body: anyValueToString(lr.body),
+          ResourceSchemaUrl: resourceSchemaUrl,
+          ResourceAttributes: resourceAttributes,
+          ScopeSchemaUrl: scopeSchemaUrl,
+          ScopeName: scopeName,
+          ScopeVersion: scopeVersion,
+          ScopeAttributes: scopeAttributes,
+          LogAttributes: stripSuperlog(kvListToMap(lr.attributes)),
+          EventName: lr.eventName ?? "",
+        });
+      }
+    }
+  }
+  return rows;
+}
+
+type OtlpEvent = { timeUnixNano?: string | number; name?: string; attributes?: OtlpKeyValue[] };
+type OtlpLink = {
+  traceId?: string | Uint8Array;
+  spanId?: string | Uint8Array;
+  traceState?: string;
+  attributes?: OtlpKeyValue[];
+};
+type OtlpSpan = {
+  traceId?: string | Uint8Array;
+  spanId?: string | Uint8Array;
+  parentSpanId?: string | Uint8Array;
+  traceState?: string;
+  name?: string;
+  kind?: number;
+  startTimeUnixNano?: string | number;
+  endTimeUnixNano?: string | number;
+  attributes?: OtlpKeyValue[];
+  status?: { code?: number; message?: string };
+  events?: OtlpEvent[];
+  links?: OtlpLink[];
+};
+type OtlpScopeSpans = {
+  scope?: { name?: string; version?: string };
+  spans?: OtlpSpan[];
+};
+type OtlpResourceSpans = {
+  resource?: { attributes?: OtlpKeyValue[] };
+  scopeSpans?: OtlpScopeSpans[];
+};
+export type OtlpTracesExport = { resourceSpans?: OtlpResourceSpans[] };
+
+// Columns of superlog.otel_traces. The Events.* / Links.* nested columns are
+// parallel arrays, one entry per event/link on the span.
+export type OtelTraceRow = {
+  Timestamp: string;
+  TraceId: string;
+  SpanId: string;
+  ParentSpanId: string;
+  TraceState: string;
+  SpanName: string;
+  SpanKind: string;
+  ServiceName: string;
+  ResourceAttributes: Record<string, string>;
+  ScopeName: string;
+  ScopeVersion: string;
+  SpanAttributes: Record<string, string>;
+  Duration: number;
+  StatusCode: string;
+  StatusMessage: string;
+  "Events.Timestamp": string[];
+  "Events.Name": string[];
+  "Events.Attributes": Record<string, string>[];
+  "Links.TraceId": string[];
+  "Links.SpanId": string[];
+  "Links.TraceState": string[];
+  "Links.Attributes": Record<string, string>[];
+};
+
+// pdata SpanKind.String() / StatusCode.String() — verified against real otel_traces rows.
+const SPAN_KINDS = ["Unspecified", "Internal", "Server", "Client", "Producer", "Consumer"];
+const STATUS_CODES = ["Unset", "Ok", "Error"];
+
+export function otlpTracesToRows(payload: OtlpTracesExport, projectId: string): OtelTraceRow[] {
+  const rows: OtelTraceRow[] = [];
+  for (const rs of payload.resourceSpans ?? []) {
+    const resourceMap = kvListToMap(rs.resource?.attributes);
+    const serviceName = resourceMap["service.name"] ?? "";
+    const resourceAttributes = stripSuperlog(resourceMap);
+    resourceAttributes[SUPERLOG_PROJECT_ID_KEY] = projectId;
+
+    for (const ss of rs.scopeSpans ?? []) {
+      const scopeName = ss.scope?.name ?? "";
+      const scopeVersion = ss.scope?.version ?? "";
+
+      for (const span of ss.spans ?? []) {
+        const start = toBigIntNanos(span.startTimeUnixNano);
+        const end = toBigIntNanos(span.endTimeUnixNano);
+        const events = span.events ?? [];
+        const links = span.links ?? [];
+        rows.push({
+          Timestamp: nanosToClickHouseDateTime64(span.startTimeUnixNano ?? 0),
+          TraceId: toHex(span.traceId),
+          SpanId: toHex(span.spanId),
+          ParentSpanId: toHex(span.parentSpanId),
+          TraceState: span.traceState ?? "",
+          SpanName: span.name ?? "",
+          SpanKind: SPAN_KINDS[span.kind ?? 0] ?? "Unspecified",
+          ServiceName: serviceName,
+          ResourceAttributes: resourceAttributes,
+          ScopeName: scopeName,
+          ScopeVersion: scopeVersion,
+          SpanAttributes: stripSuperlog(kvListToMap(span.attributes)),
+          Duration: Number(end > start ? end - start : 0n),
+          StatusCode: STATUS_CODES[span.status?.code ?? 0] ?? "Unset",
+          StatusMessage: span.status?.message ?? "",
+          "Events.Timestamp": events.map((e) => nanosToClickHouseDateTime64(e.timeUnixNano ?? 0)),
+          "Events.Name": events.map((e) => e.name ?? ""),
+          "Events.Attributes": events.map((e) => stripSuperlog(kvListToMap(e.attributes))),
+          "Links.TraceId": links.map((l) => toHex(l.traceId)),
+          "Links.SpanId": links.map((l) => toHex(l.spanId)),
+          "Links.TraceState": links.map((l) => l.traceState ?? ""),
+          "Links.Attributes": links.map((l) => stripSuperlog(kvListToMap(l.attributes))),
+        });
+      }
+    }
+  }
+  return rows;
+}
+
+function toBigIntNanos(n: string | number | undefined): bigint {
+  try {
+    return BigInt(n ?? 0);
+  } catch {
+    return 0n;
+  }
+}
+
+function kvListToMap(attrs: OtlpKeyValue[] | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const kv of attrs ?? []) {
+    if (kv.key === undefined || kv.key === null) continue;
+    out[kv.key] = anyValueToString(kv.value);
+  }
+  return out;
+}
+
+function stripSuperlog(map: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(map)) {
+    if (k.startsWith("superlog.")) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+// Mirrors pdata Value.AsString: scalars render as their plain string form, bytes
+// as base64, and arrays/maps as JSON. Keep this in sync with the collector or the
+// attribute Maps in ClickHouse will diverge.
+export function anyValueToString(v: OtlpAnyValue | undefined): string {
+  if (!v) return "";
+  if (v.stringValue !== undefined) return v.stringValue;
+  if (v.boolValue !== undefined) return String(v.boolValue);
+  if (v.intValue !== undefined) return String(v.intValue);
+  if (v.doubleValue !== undefined) return String(v.doubleValue);
+  if (v.bytesValue !== undefined) return bytesToBase64(v.bytesValue);
+  if (v.arrayValue) return JSON.stringify((v.arrayValue.values ?? []).map(anyValueToJson));
+  if (v.kvlistValue) return JSON.stringify(anyValueToJson(v));
+  return "";
+}
+
+function anyValueToJson(v: OtlpAnyValue | undefined): unknown {
+  if (!v) return null;
+  if (v.stringValue !== undefined) return v.stringValue;
+  if (v.boolValue !== undefined) return v.boolValue;
+  if (v.intValue !== undefined) return v.intValue;
+  if (v.doubleValue !== undefined) return v.doubleValue;
+  if (v.bytesValue !== undefined) return bytesToBase64(v.bytesValue);
+  if (v.arrayValue) return (v.arrayValue.values ?? []).map(anyValueToJson);
+  if (v.kvlistValue) {
+    const obj: Record<string, unknown> = {};
+    for (const kv of v.kvlistValue.values ?? []) {
+      if (kv.key === undefined || kv.key === null) continue;
+      obj[kv.key] = anyValueToJson(kv.value);
+    }
+    return obj;
+  }
+  return null;
+}
+
+function bytesToBase64(b: string | Uint8Array): string {
+  // JSON OTLP already encodes bytesValue as base64; protobuf decode yields raw bytes.
+  return typeof b === "string" ? b : Buffer.from(b).toString("base64");
+}
+
+// OTLP ids are hex strings in JSON, raw bytes in protobuf; ClickHouse stores hex.
+function toHex(id: string | Uint8Array | undefined): string {
+  if (!id) return "";
+  return typeof id === "string" ? id : Buffer.from(id).toString("hex");
+}
+
+function pickTime(
+  timeUnixNano: string | number | undefined,
+  observedTimeUnixNano: string | number | undefined,
+): string | number {
+  if (timeUnixNano !== undefined && timeUnixNano !== null && timeUnixNano !== 0 && timeUnixNano !== "0") {
+    return timeUnixNano;
+  }
+  return observedTimeUnixNano ?? 0;
+}
+
+function nanosToClickHouseDateTime64(nanos: string | number): string {
+  let n: bigint;
+  try {
+    n = BigInt(nanos);
+  } catch {
+    n = 0n;
+  }
+  if (n < 0n) n = 0n;
+  const seconds = n / NANOS_PER_SECOND;
+  const frac = n % NANOS_PER_SECOND;
+  const d = new Date(Number(seconds) * 1000);
+  const pad = (x: number, width = 2) => String(x).padStart(width, "0");
+  const date = `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+  const time = `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`;
+  return `${date} ${time}.${String(frac).padStart(9, "0")}`;
+}

--- a/apps/proxy/src/otlp-clickhouse.ts
+++ b/apps/proxy/src/otlp-clickhouse.ts
@@ -14,8 +14,8 @@
 //                                 x-superlog-project-id) into RESOURCE attrs
 // so: strip every superlog.* key, then stamp superlog.project_id onto resource attrs.
 //
-// Only logs are implemented in this pass (the dominant ingest signal). Traces and
-// the five metrics tables follow the same shape and are TODO.
+// Logs and traces are implemented here. The five metrics tables follow the same
+// shape and are a planned follow-up.
 
 type OtlpAnyValue = {
   stringValue?: string;
@@ -166,7 +166,9 @@ export type OtelTraceRow = {
   ScopeName: string;
   ScopeVersion: string;
   SpanAttributes: Record<string, string>;
-  Duration: number;
+  // UInt64 nanoseconds. Kept as a string so durations beyond 2^53 ns aren't
+  // rounded by JS number coercion before they reach ClickHouse.
+  Duration: string;
   StatusCode: string;
   StatusMessage: string;
   "Events.Timestamp": string[];
@@ -212,7 +214,7 @@ export function otlpTracesToRows(payload: OtlpTracesExport, projectId: string): 
           ScopeName: scopeName,
           ScopeVersion: scopeVersion,
           SpanAttributes: stripSuperlog(kvListToMap(span.attributes)),
-          Duration: Number(end > start ? end - start : 0n),
+          Duration: (end > start ? end - start : 0n).toString(),
           StatusCode: STATUS_CODES[span.status?.code ?? 0] ?? "Unset",
           StatusMessage: span.status?.message ?? "",
           "Events.Timestamp": events.map((e) => nanosToClickHouseDateTime64(e.timeUnixNano ?? 0)),
@@ -274,7 +276,11 @@ function anyValueToJson(v: OtlpAnyValue | undefined): unknown {
   if (!v) return null;
   if (v.stringValue !== undefined) return v.stringValue;
   if (v.boolValue !== undefined) return v.boolValue;
-  if (v.intValue !== undefined) return v.intValue;
+  // Nested ints serialize as numeric JSON tokens (e.g. [1,2], not ["1","2"]) to
+  // match the collector. intValue arrives as a string (OTLP/JSON int64, and the
+  // protobuf decoder's longs:String); coerce so JSON.stringify emits a number.
+  // Values beyond 2^53 can't be represented exactly in JSON either way.
+  if (v.intValue !== undefined) return typeof v.intValue === "string" ? Number(v.intValue) : v.intValue;
   if (v.doubleValue !== undefined) return v.doubleValue;
   if (v.bytesValue !== undefined) return bytesToBase64(v.bytesValue);
   if (v.arrayValue) return (v.arrayValue.values ?? []).map(anyValueToJson);

--- a/apps/proxy/src/otlp-decode.test.ts
+++ b/apps/proxy/src/otlp-decode.test.ts
@@ -1,0 +1,118 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { gzipSync } from "node:zlib";
+
+import protobuf from "protobufjs";
+
+import { type DecodedRows, decodeOtlpToRows } from "./otlp-decode.js";
+import type { OtelLogRow } from "./otlp-clickhouse.js";
+
+// Narrows the decode result to log rows (or fails the test), satisfying the
+// discriminated-union + no-unchecked-index typings.
+function logRows(out: DecodedRows | null): OtelLogRow[] {
+  if (!out || out.table !== "otel_logs") return assert.fail("expected otel_logs rows");
+  return out.rows;
+}
+
+// An independent OTLP-logs encoder (standard field numbers) used to produce binary
+// payloads in tests — verifies the decoder's inline descriptor is wire-compatible
+// with what a real OTLP/protobuf logs client emits.
+const ExportLogsServiceRequest = protobuf
+  .parse(`
+    syntax = "proto3";
+    package t;
+    message ExportLogsServiceRequest { repeated ResourceLogs resource_logs = 1; }
+    message ResourceLogs { Resource resource = 1; repeated ScopeLogs scope_logs = 2; }
+    message Resource { repeated KeyValue attributes = 1; }
+    message ScopeLogs { repeated LogRecord log_records = 2; }
+    message LogRecord { fixed64 time_unix_nano = 1; AnyValue body = 5; bytes trace_id = 9; }
+    message KeyValue { string key = 1; AnyValue value = 2; }
+    message AnyValue { oneof value { string string_value = 1; } }
+  `)
+  .root.lookupType("t.ExportLogsServiceRequest");
+
+const jsonLogs = JSON.stringify({
+  resourceLogs: [
+    {
+      resource: { attributes: [{ key: "service.name", value: { stringValue: "svc" } }] },
+      scopeLogs: [
+        {
+          scope: { name: "s" },
+          logRecords: [{ timeUnixNano: "1718000000000000000", body: { stringValue: "hi" } }],
+        },
+      ],
+    },
+  ],
+});
+
+test("decodeOtlpToRows decodes JSON logs to otel_logs rows", () => {
+  const out = decodeOtlpToRows({
+    path: "/v1/logs",
+    projectId: "p1",
+    contentType: "application/json",
+    body: Buffer.from(jsonLogs),
+  });
+  const rows = logRows(out);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]!.Body, "hi");
+  assert.equal(rows[0]!.ResourceAttributes["superlog.project_id"], "p1");
+});
+
+test("decodeOtlpToRows gunzips a gzip-encoded body", () => {
+  const out = decodeOtlpToRows({
+    path: "/v1/logs",
+    projectId: "p1",
+    contentType: "application/json",
+    contentEncoding: "gzip",
+    body: gzipSync(Buffer.from(jsonLogs)),
+  });
+  assert.equal(logRows(out)[0]!.Body, "hi");
+});
+
+test("decodeOtlpToRows decodes protobuf logs, normalizing int64 time and byte ids", () => {
+  const msg = ExportLogsServiceRequest.create({
+    resourceLogs: [
+      {
+        resource: { attributes: [{ key: "service.name", value: { stringValue: "svc" } }] },
+        scopeLogs: [
+          {
+            logRecords: [
+              {
+                timeUnixNano: "1718000000000000000",
+                traceId: Buffer.from("5b8efff798038103d269b633813fc60c", "hex"),
+                body: { stringValue: "hi" },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+  const body = Buffer.from(ExportLogsServiceRequest.encode(msg).finish());
+
+  const out = decodeOtlpToRows({
+    path: "/v1/logs",
+    projectId: "p1",
+    contentType: "application/x-protobuf",
+    body,
+  });
+  const rows = logRows(out);
+  assert.equal(rows[0]!.Body, "hi");
+  // int64 nanos survived (longs:String) and byte trace id hex-encoded
+  assert.equal(rows[0]!.Timestamp, "2024-06-10 06:13:20.000000000");
+  assert.equal(rows[0]!.TraceId, "5b8efff798038103d269b633813fc60c");
+});
+
+test("decodeOtlpToRows returns null for metrics (falls through to collector)", () => {
+  assert.equal(
+    decodeOtlpToRows({ path: "/v1/metrics", projectId: "p", contentType: "application/json", body: Buffer.from("{}") }),
+    null,
+  );
+});
+
+test("decodeOtlpToRows returns null for an undecodable content type", () => {
+  assert.equal(
+    decodeOtlpToRows({ path: "/v1/logs", projectId: "p", contentType: "text/plain", body: Buffer.from("x") }),
+    null,
+  );
+});

--- a/apps/proxy/src/otlp-decode.ts
+++ b/apps/proxy/src/otlp-decode.ts
@@ -1,0 +1,119 @@
+import { createRequire } from "node:module";
+import { gunzipSync, inflateSync } from "node:zlib";
+
+import protobuf from "protobufjs";
+
+import {
+  otlpLogsToRows,
+  otlpTracesToRows,
+  type OtelLogRow,
+  type OtelTraceRow,
+} from "./otlp-clickhouse.js";
+
+// Traces protobuf: reuse the descriptors that ship with the OTLP transformer (same
+// module the fingerprint stamper uses).
+const require = createRequire(import.meta.url);
+const otlpRoot = require("@opentelemetry/otlp-transformer/build/esm/generated/root.js");
+const ExportTraceServiceRequest =
+  otlpRoot.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+
+// Logs protobuf: the transformer's bundled root only includes trace + metrics, so we
+// decode logs with a minimal inline descriptor. Field numbers follow the OTLP logs.proto
+// v1 spec; protobufjs lower-camel-cases field names on decode, matching the mappers
+// (resource_logs -> resourceLogs, time_unix_nano -> timeUnixNano, etc.).
+const LOGS_PROTO = `
+syntax = "proto3";
+package otlplogs;
+message ExportLogsServiceRequest { repeated ResourceLogs resource_logs = 1; }
+message ResourceLogs { Resource resource = 1; repeated ScopeLogs scope_logs = 2; string schema_url = 3; }
+message Resource { repeated KeyValue attributes = 1; uint32 dropped_attributes_count = 2; }
+message ScopeLogs { InstrumentationScope scope = 1; repeated LogRecord log_records = 2; string schema_url = 3; }
+message InstrumentationScope { string name = 1; string version = 2; repeated KeyValue attributes = 3; uint32 dropped_attributes_count = 4; }
+message LogRecord {
+  fixed64 time_unix_nano = 1;
+  uint32 severity_number = 2;
+  string severity_text = 3;
+  AnyValue body = 5;
+  repeated KeyValue attributes = 6;
+  uint32 dropped_attributes_count = 7;
+  fixed32 flags = 8;
+  bytes trace_id = 9;
+  bytes span_id = 10;
+  fixed64 observed_time_unix_nano = 11;
+  string event_name = 12;
+}
+message KeyValue { string key = 1; AnyValue value = 2; }
+message AnyValue {
+  oneof value {
+    string string_value = 1;
+    bool bool_value = 2;
+    int64 int_value = 3;
+    double double_value = 4;
+    ArrayValue array_value = 5;
+    KeyValueList kvlist_value = 6;
+    bytes bytes_value = 7;
+  }
+}
+message ArrayValue { repeated AnyValue values = 1; }
+message KeyValueList { repeated KeyValue values = 1; }
+`;
+const ExportLogsServiceRequest = protobuf
+  .parse(LOGS_PROTO)
+  .root.lookupType("otlplogs.ExportLogsServiceRequest");
+
+// toObject normalizes the decoded message into the plain camelCase shape the mappers
+// expect: 64-bit fields (intValue, *UnixNano) become decimal strings, enums become
+// numbers, and bytes (traceId/spanId) stay as Buffers so the mappers hex-encode them.
+const PROTO_TO_OBJECT_OPTS = { longs: String, enums: Number, defaults: false };
+
+export type DecodedRows =
+  | { table: "otel_logs"; rows: OtelLogRow[] }
+  | { table: "otel_traces"; rows: OtelTraceRow[] };
+
+export type DecodeInput = {
+  path: string;
+  projectId: string;
+  contentType: string;
+  contentEncoding?: string;
+  body: Buffer;
+};
+
+// Decode an OTLP ingest payload into ClickHouse rows. Returns null for signals we
+// don't yet write directly (metrics) or content types we can't decode — the caller
+// forwards those to the collector instead, so nothing is ever dropped.
+export function decodeOtlpToRows(input: DecodeInput): DecodedRows | null {
+  if (input.path !== "/v1/logs" && input.path !== "/v1/traces") return null;
+
+  const json = input.contentType.toLowerCase().includes("json");
+  const protobufContent = input.contentType.toLowerCase().includes("protobuf");
+  if (!json && !protobufContent) return null;
+
+  const body = decompress(input.body, input.contentEncoding);
+
+  if (input.path === "/v1/logs") {
+    const payload = json
+      ? JSON.parse(body.toString("utf8"))
+      : decodeProto(ExportLogsServiceRequest, body);
+    return { table: "otel_logs", rows: otlpLogsToRows(payload, input.projectId) };
+  }
+
+  const payload = json
+    ? JSON.parse(body.toString("utf8"))
+    : decodeProto(ExportTraceServiceRequest, body);
+  return { table: "otel_traces", rows: otlpTracesToRows(payload, input.projectId) };
+}
+
+// The proto reflection types (protobufjs Type / the otlp-transformer root) are
+// untyped JS, so this stays loosely typed.
+// biome-ignore lint/suspicious/noExplicitAny: protobufjs reflection Type is untyped
+function decodeProto(type: any, body: Buffer): unknown {
+  return type.toObject(type.decode(body), PROTO_TO_OBJECT_OPTS);
+}
+
+function decompress(body: Buffer, encoding?: string): Buffer {
+  if (!encoding) return body;
+  const enc = encoding.toLowerCase();
+  if (enc === "gzip") return gunzipSync(body);
+  if (enc === "deflate") return inflateSync(body);
+  return body;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@aws-sdk/lib-storage':
         specifier: 3.1053.0
         version: 3.1053.0(@aws-sdk/client-s3@3.1053.0)
+      '@clickhouse/client':
+        specifier: ^1.9.0
+        version: 1.18.3
       '@hono/node-server':
         specifier: ^1.13.7
         version: 1.19.14(hono@4.12.14)
@@ -243,6 +246,9 @@ importers:
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      protobufjs:
+        specifier: ^7.4.0
+        version: 7.5.5
     devDependencies:
       '@types/node':
         specifier: ^22.10.1


### PR DESCRIPTION
## What

Lets the SQS ingest consumer write OTLP **logs and traces** straight to ClickHouse — parallel **synchronous quorum** `INSERT`s, with the SQS message deleted only on a successful write — instead of forwarding every message to an OTLP collector. Gated by `INGEST_CLICKHOUSE_DIRECT` (default **off**).

## Why

A collector's ClickHouse exporter runs synchronously with `sending_queue` disabled, so each collector task sustains only ~one in-flight insert; total ingest throughput then scales with **collector task count, not CPU**. Funneling all ingest through the collector caps drain (~one insert/task × insert latency) no matter how many consumers run or how idle everything is. Writing from the already-parallel consumer removes that ceiling while keeping the **same durability** guarantee: `insert_quorum`, `async_insert` off, ack-after-write.

## How

- **`otlp-clickhouse.ts`** — pure OTLP→row mappers reproducing the otelcol clickhouse exporter column layout: `ServiceName` from `service.name`, nanosecond-precise UTC `Timestamp`, hex trace/span ids, pdata-style attribute-Map stringification, and the collector's `strip superlog.* + stamp superlog.project_id` rule. Fully unit-tested.
- **`otlp-decode.ts`** — gzip/deflate + JSON/protobuf decode and routing. Logs are decoded via an inline OTLP-logs descriptor because the `@opentelemetry/otlp-transformer` bundled proto root ships only trace + metrics.
- **`clickhouse-writer.ts`** — `@clickhouse/client` writer with `insert_quorum` and `async_insert` off.
- Wired into `processMessage` behind the flag. **Metrics and any undecodable payload fall through to the collector**, so nothing is ever dropped.

## Safety / rollout

- Flag defaults off — merging changes no behavior.
- Before enabling anywhere: **validate produced rows against collector output** for the same payloads (the mappers must stay byte-compatible with what the exporter writes, since the read path queries specific columns).
- **Metrics direct-write** (5 tables, exemplars, exp-histograms) is the immediate follow-up; until then metrics keep flowing through the collector.

## Tests

`tsx --test src/otlp-clickhouse.test.ts src/otlp-decode.test.ts` — 14 passing (mapping fidelity for logs+traces, attribute stringification, superlog strip/stamp, gzip, JSON + protobuf decode incl. int64/byte normalization). `tsc --noEmit` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional direct-to-ClickHouse writes for OTLP logs and traces to bypass the collector and raise throughput. Off by default behind INGEST_CLICKHOUSE_DIRECT; CI now runs the full proxy suite, the batch test hang is fixed, and tests cover superlog.* stripping on log attributes.

- **New Features**
  - Direct writes from the SQS consumer to ClickHouse with synchronous quorum inserts; SQS messages delete only on successful insert.
  - OTLP→row mappers in `otlp-clickhouse.ts` match the collector schema; strip `superlog.*`, stamp `superlog.project_id`, and emit span `Duration` as a string (UInt64 ns).
  - `otlp-decode.ts` handles gzip/deflate and JSON/protobuf for logs/traces; metrics and undecodable payloads forward to the collector. `clickhouse-writer.ts` uses `@clickhouse/client` with `insert_quorum`, quorum timeout, and request timeout set.

- **Bug Fixes**
  - Direct-write decode failures now fall through to the collector; only ClickHouse insert errors trigger redelivery.
  - Preserve int64 precision in nested attribute JSON for arrays/maps (emit numeric tokens without Number rounding).
  - CI: run the full proxy suite, fix the batch-suite keepalive to prevent Promise-pending hangs; add a test asserting superlog.* stripping from `LogAttributes`.

<sup>Written for commit fcf79ed3f0730c585a2e1beabb9fa19c60baa16b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

