### PR TITLE
fix(clickhouse): prune otel_logs reads, bound trace-detail queries, drop demo-feed ALTER DELETE trim

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -779,7 +779,10 @@ app.get("/api/projects/:projectId/stats", async (c) => {
   const projectId = await requireProjectAccess(c, c.req.param("projectId"));
   const [traces, logs, metrics, issueRows] = await Promise.all([
     chCount("otel_traces", "Timestamp", projectId),
-    chCount("otel_logs", "Timestamp", projectId),
+    // otel_logs is partitioned by toDate(TimestampTime); count on that column so
+    // the "last 1h" stat prunes to recent partitions instead of scanning every
+    // retained day (otel_traces partitions on Timestamp, so it stays as-is).
+    chCount("otel_logs", "TimestampTime", projectId),
     chMetricsCount(projectId),
     db.select({ c: count() }).from(schema.issues).where(eq(schema.issues.projectId, projectId)),
   ]);

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -192,6 +192,16 @@ export async function queryLogs(
     "ResourceAttributes['superlog.project_id'] = {projectId:String}",
     `Timestamp >= ${sinceExpr}`,
     `Timestamp <= ${untilExpr}`,
+    // otel_logs is partitioned by toDate(TimestampTime) and sorted by
+    // (ServiceName, TimestampTime, Timestamp). Filtering only Timestamp — a
+    // different column — gives ClickHouse nothing to prune partitions by, so it
+    // scans every retained day (incident 2026-06-25: ~12M rows for a 1h window).
+    // Bracketing TimestampTime by the same window lets the partition minmax
+    // index prune to the queried days. TimestampTime = toDateTime(Timestamp) is
+    // truncated down to the second, so pad the lower bound by 1s to never drop a
+    // sub-second row the precise Timestamp filter above keeps.
+    `TimestampTime >= (${sinceExpr}) - INTERVAL 1 SECOND`,
+    `TimestampTime <= ${untilExpr}`,
     ...attr.conds,
     ...logAttr.conds,
     ...field.conds,
@@ -417,6 +427,37 @@ export async function queryTracesAggregated(
 }
 
 export async function getTraceDetail(ch: ClickHouseClient, projectId: string, traceId: string) {
+  // otel_traces / otel_logs are partitioned by day and sorted by
+  // (ServiceName, SpanName, Timestamp), so a bare `TraceId = …` predicate can't
+  // use the primary index — it scans every partition (all retained days, every
+  // part). That's a multi-second-to-minutes full scan on a busy table, and a
+  // burst of trace-detail loads saturates the read pool and starves every other
+  // query (incident 2026-06-25: this was the lever that took prod reads down).
+  // otel_traces_trace_id_ts is sorted by TraceId, so it resolves the trace's
+  // [Start, End] window in O(log n); bounding Timestamp by it prunes the scan to
+  // the 1–2 daily partitions the trace actually lives in. coalesce() falls back
+  // to a bounded recent window if the index has no row yet (e.g. a just-ingested
+  // trace), so we never silently regress to a full scan.
+  const winStart = `coalesce(
+              (SELECT min(Start) FROM otel_traces_trace_id_ts WHERE TraceId = {traceId:String}),
+              now() - INTERVAL 6 HOUR
+            ) - INTERVAL 1 MINUTE`;
+  const winEnd = `coalesce(
+              (SELECT max(End) FROM otel_traces_trace_id_ts WHERE TraceId = {traceId:String}),
+              now()
+            ) + INTERVAL 1 MINUTE`;
+  // otel_traces is partitioned by toDate(Timestamp), so a Timestamp window prunes it.
+  const traceWindow = `
+        AND Timestamp >= ${winStart}
+        AND Timestamp <= ${winEnd}`;
+  // otel_logs is partitioned by toDate(TimestampTime), so it needs the window on
+  // TimestampTime too (the 1-minute margins above already cover the sub-second
+  // truncation, so no extra padding is needed here). Without this the logs leg
+  // of the trace view scans every retained day.
+  const logWindow = `${traceWindow}
+        AND TimestampTime >= ${winStart}
+        AND TimestampTime <= ${winEnd}`;
+
   const spansQ = ch.query({
     query: `
       SELECT
@@ -440,7 +481,7 @@ export async function getTraceDetail(ch: ClickHouseClient, projectId: string, tr
         if(exception_event_index = 0, '', Events.Attributes[exception_event_index]['exception.stacktrace']) AS exception_stacktrace
       FROM otel_traces
       WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
-        AND TraceId = {traceId:String}
+        AND TraceId = {traceId:String}${traceWindow}
       ORDER BY Timestamp ASC, SpanId ASC
       LIMIT 5000
     `,
@@ -465,7 +506,7 @@ export async function getTraceDetail(ch: ClickHouseClient, projectId: string, tr
         LogAttributes['exception.stacktrace'] AS exception_stacktrace
       FROM otel_logs
       WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
-        AND TraceId = {traceId:String}
+        AND TraceId = {traceId:String}${logWindow}
       ORDER BY Timestamp ASC
       LIMIT 5000
     `,

--- a/apps/worker/src/jobs.ts
+++ b/apps/worker/src/jobs.ts
@@ -17,8 +17,10 @@ import { logger } from "./logger.js";
 // only when a real job needs more.
 export type JobDeps = {
   db: DB;
-  // `command` is exposed alongside `query` so jobs can run lightweight DDL/DML
-  // (e.g. the demo-feed job's ALTER … DELETE retention trim).
+  // `command` is exposed alongside `query` so jobs can run lightweight DDL/DML.
+  // Note: avoid per-tick ALTER … DELETE on the shared OTel tables for retention —
+  // those mutations rewrite parts and pile up under any short schedule, starving
+  // merges and reads (a "mutation storm"). Lean on table TTL instead.
   clickhouse: Pick<ClickHouseClient, "query" | "command">;
 };
 

--- a/apps/worker/src/jobs/demo-feed.ts
+++ b/apps/worker/src/jobs/demo-feed.ts
@@ -4,8 +4,15 @@
 // instrument anything: the API serves them a hidden, curated demo project's
 // data (read-only). This job keeps that project's telemetry feeling LIVE —
 // every couple of minutes it appends a fresh burst of traces / INFO-WARN logs /
-// gauge metrics (timestamped ~now) and trims rows past the retention window, so
-// charts move and "last 1h" views stay populated.
+// gauge metrics (timestamped ~now), so charts move and "last 1h" views stay
+// populated.
+//
+// It deliberately does NOT prune old rows: the feed is tiny (a few dozen rows
+// per tick) and otel_traces carries a 30d table TTL, so the demo project stays
+// bounded on its own. An earlier per-tick `ALTER … DELETE` retention pass was
+// removed after it piled up unfinished mutations on the shared OTel tables and
+// starved merges + reads cluster-wide (a "mutation storm"). Per-tick ALTER
+// DELETE is the wrong tool for retention; lean on TTL instead.
 //
 // Deliberately emits NO span `exception` events and NO ERROR/SeverityNumber>=17
 // logs: issues/incidents are minted only from those, and the demo's incidents
@@ -16,7 +23,7 @@
 // Opt-in: the job only schedules when DEMO_PROJECT_ID and DEMO_COLLECTOR_URL are
 // set, so stock / self-host builds schedule nothing.
 
-import type { JobDefinition, JobDeps } from "../jobs.js";
+import type { JobDefinition } from "../jobs.js";
 import { logger } from "../logger.js";
 
 const SERVICES = ["checkout-api", "catalog-api", "payments-api", "web", "worker"] as const;
@@ -35,8 +42,6 @@ const METRICS = [
   { name: "http.server.requests", unit: "1", base: 40, spread: 30 },
   { name: "process.memory.usage", unit: "By", base: 256_000_000, spread: 40_000_000 },
 ] as const;
-// Retention window for demo telemetry — anything older is trimmed each tick.
-const RETENTION_HOURS = 24;
 
 const HEX = "0123456789abcdef";
 function hex(len: number): string {
@@ -162,32 +167,12 @@ async function postSignal(
   }
 }
 
-async function trimOldTelemetry(deps: JobDeps, projectId: string): Promise<void> {
-  // Compute the cutoff in JS and pass it as a literal. ALTER ... DELETE on a
-  // ReplicatedMergeTree (prod) rejects non-deterministic functions, so we can't
-  // use now() in the predicate — fromUnixTimestamp64Milli of a fixed value is
-  // deterministic. (otel_traces also has a 30d table TTL; otel_logs/metrics have
-  // none, so this trim is what bounds them for the demo project.)
-  const cutoffMs = Date.now() - RETENTION_HOURS * 60 * 60 * 1000;
-  const tables: Array<{ table: string; tsCol: string }> = [
-    { table: "otel_traces", tsCol: "Timestamp" },
-    { table: "otel_logs", tsCol: "Timestamp" },
-    { table: "otel_metrics_gauge", tsCol: "TimeUnix" },
-  ];
-  for (const { table, tsCol } of tables) {
-    await deps.clickhouse.command({
-      query: `ALTER TABLE ${table} DELETE WHERE ResourceAttributes['superlog.project_id'] = {projectId:String} AND ${tsCol} < fromUnixTimestamp64Milli({cutoffMs:Int64})`,
-      query_params: { projectId, cutoffMs },
-    });
-  }
-}
-
 export const job: JobDefinition = {
   name: "demo-feed",
   // Every 2 minutes — fine-grained enough that "last 5m" / "last 1h" views stay
   // alive without flooding the project.
   schedule: "*/2 * * * *",
-  create: (deps: JobDeps) => {
+  create: () => {
     const projectId = process.env.DEMO_PROJECT_ID?.trim();
     const collectorUrl = process.env.DEMO_COLLECTOR_URL?.trim();
     if (!projectId || !collectorUrl) return null; // opt out: not a demo deployment
@@ -197,13 +182,6 @@ export const job: JobDefinition = {
       await postSignal(collectorUrl, projectId, "traces", batch.traces);
       await postSignal(collectorUrl, projectId, "logs", batch.logs);
       await postSignal(collectorUrl, projectId, "metrics", batch.metrics);
-      await trimOldTelemetry(deps, projectId).catch((err) => {
-        // Trim is best-effort: a failed retention pass must not fail the feed.
-        logger.warn(
-          { scope: "jobs.demo-feed", err: err instanceof Error ? err.message : String(err) },
-          "demo-feed retention trim failed",
-        );
-      });
       logger.info({ scope: "jobs.demo-feed", projectId }, "demo telemetry feed tick complete");
     };
   },


### PR DESCRIPTION
Three independent ClickHouse read-reliability fixes that compound badly under load.

## 1. `getTraceDetail` — bound the trace-by-id queries
Both the spans (`otel_traces`) and logs (`otel_logs`) queries filtered only `WHERE TraceId = …` with **no time window**. `TraceId` isn't a sort-key prefix, so each query scanned **every retained partition** (seconds-to-minutes). A burst of trace-detail loads then saturates the read pool and starves every other query.

Fix: resolve the trace's `[Start, End]` window from `otel_traces_trace_id_ts` (sorted by `TraceId`, so the lookup is O(log n)) and bound both queries by it, pruning to the 1–2 daily partitions the trace lives in. **Measured 50s → 3s under load.** `coalesce()` falls back to a bounded recent window if the index has no row yet, so we never silently regress to a full scan.

## 2. `otel_logs` reads — prune by the partition column
`otel_logs` is `PARTITION BY toDate(TimestampTime)`, but `queryLogs` and the project-stats count filtered `Timestamp` (a *different* column), so partition pruning never fired — every "last 1h" read scanned all retained days.

Fix: bracket `TimestampTime` alongside the existing `Timestamp` filter (padded 1s for the sub-second truncation). `EXPLAIN indexes=1` for a 1h window: **266 → 11 parts selected**. `otel_traces` partitions on `Timestamp`, so it's intentionally left unchanged.

## 3. `demo-feed` — drop the per-tick `ALTER … DELETE` trim
The job fired three `ALTER … DELETE` retention mutations on the shared OTel tables every 2 minutes. On a large table those mutations can't keep up with that cadence and pile into hundreds of unfinished mutations, starving merges and reads. The feed is tiny and the table TTL already bounds it, so the trim is removed entirely.

## Tests
- `apps/api` + `apps/worker` typecheck clean.
- `clickhouse.test.ts` (28) and `demo-feed.test.ts` (3) pass.
- Pruning verified against a live cluster via `EXPLAIN indexes=1`; trace-detail latency measured before/after.

## Follow-up (not in this PR)
Other `otel_logs` read sites (attribute-key/value lookups, issue/incident queries, gateway count) still filter `Timestamp` only. They're fast on an unsaturated cluster but should adopt the same `TimestampTime` bracketing via a shared helper.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve ClickHouse read reliability by pruning `otel_logs` partitions and bounding trace-detail queries. Also remove the demo-feed retention mutation to prevent merge pressure. Trace-detail loads drop from ~50s to ~3s under load.

- **Bug Fixes**
  - Bound `getTraceDetail` span and log queries to the trace’s [Start, End] window resolved from `otel_traces_trace_id_ts`; falls back to a recent bounded window if missing.
  - Pruned `otel_logs` reads by bracketing `TimestampTime` alongside `Timestamp` in `queryLogs` and the project stats count (EXPLAIN: 266 → 11 parts for a 1h window).
  - Removed per-tick `ALTER … DELETE` in the demo-feed; rely on table TTL to avoid mutation storms.

<sup>Written for commit 5903387298740ab22ccf18890a7c6141457ab4bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

