### PR TITLE
fix(clickhouse): full-range fallback for trace-detail when trace_id_ts row is missing

### DIFF
--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -435,12 +435,19 @@ export async function getTraceDetail(ch: ClickHouseClient, projectId: string, tr
   // query (incident 2026-06-25: this was the lever that took prod reads down).
   // otel_traces_trace_id_ts is sorted by TraceId, so it resolves the trace's
   // [Start, End] window in O(log n); bounding Timestamp by it prunes the scan to
-  // the 1–2 daily partitions the trace actually lives in. coalesce() falls back
-  // to a bounded recent window if the index has no row yet (e.g. a just-ingested
-  // trace), so we never silently regress to a full scan.
+  // the 1–2 daily partitions the trace actually lives in.
+  //
+  // Fallback when the index has no row for this trace: scan the FULL retained
+  // range (epoch → now), i.e. the old slow-but-correct full scan. A missing row
+  // is not necessarily a just-ingested trace — it can be an older trace whose
+  // index entry was never written (MV gap, or a span pre-dating the view) — so a
+  // "recent" fallback window would silently return an empty trace for real data.
+  // Correctness wins here; the table TTL already caps how far back the scan can
+  // go, and the common case (row present — the MV writes it on insert) stays
+  // tightly bounded and fast.
   const winStart = `coalesce(
               (SELECT min(Start) FROM otel_traces_trace_id_ts WHERE TraceId = {traceId:String}),
-              now() - INTERVAL 6 HOUR
+              toDateTime(0)
             ) - INTERVAL 1 MINUTE`;
   const winEnd = `coalesce(
               (SELECT max(End) FROM otel_traces_trace_id_ts WHERE TraceId = {traceId:String}),


### PR DESCRIPTION
Follow-up to #94, addressing a Cubic review finding on that PR.

## Issue
`getTraceDetail` resolves a trace's time window from `otel_traces_trace_id_ts` and bounds the spans/logs scans to it. The fallback when the index has **no row** for the trace was `now() - INTERVAL 6 HOUR`.

A missing index row is **not** necessarily a just-ingested (recent) trace — it can be an *older* trace whose index entry was never written (MV gap, or a span that pre-dates the materialized view). For those, the 6h fallback bounds the scan to the last 6 hours and returns an **empty** trace, even though the spans exist. That's a correctness regression: the pre-#94 behavior was a slow full scan that *found* the trace.

## Fix
Fall back to the **full retained range** (`toDateTime(0)` → `now()`) when the index row is missing — i.e. preserve the old slow-but-correct full scan. The table TTL caps how far back the scan can reach, so it never scans beyond retention. The common case (index row present — the MV writes it on insert) is unchanged: tightly bounded and fast.

## Validation
- `apps/api` typecheck clean.
- Fallback query for a non-existent trace returns 0 without error against a live cluster.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix trace detail fallback in `ClickHouse`: when `otel_traces_trace_id_ts` has no row, scan the full retained range (epoch → now) instead of the last 6 hours to avoid empty results for older traces while keeping the common case fast.

- **Bug Fixes**
  - `getTraceDetail`: use `toDateTime(0)` → `now()` as the fallback window; when the index row exists, the query remains tightly bounded.

<sup>Written for commit 601fd0c685897c84cb3d05392413aa53e78ee773. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

