### PR TITLE
fix(proxy): deliver SIGTERM to node so the ingest consumer drains on deploy

### DIFF
--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -20,4 +20,12 @@ COPY packages/fingerprint packages/fingerprint
 ENV PORT=4000
 EXPOSE 4000
 
-CMD ["pnpm", "--filter", "@superlog/proxy", "start"]
+# Run node directly with the tsx loader rather than via `pnpm --filter … start`.
+# `pnpm run` does NOT forward SIGTERM to the node child, so the graceful-shutdown
+# handler in src/index.ts never fired on an ECS rolling deploy — the task was
+# killed mid-batch and its in-flight SQS messages stayed invisible for the full
+# visibility timeout before redelivering (the ingest-lag sawtooth that paged on
+# every deploy). Running node as the container's main process delivers SIGTERM
+# straight to the handler. Mirrors the package.json "start" script.
+WORKDIR /app/apps/proxy
+CMD ["node", "--import", "tsx", "--import", "./tracing.ts", "src/index.ts"]

--- a/apps/proxy/package.json
+++ b/apps/proxy/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch --import ./tracing.ts src/index.ts",
-    "start": "tsx --import ./tracing.ts src/index.ts",
+    "start": "node --import tsx --import ./tracing.ts src/index.ts",
     "test:ingest-queue": "tsx --test src/ingest-queue.test.ts",
     "test": "tsx --test src/*.test.ts",
     "typecheck": "tsc --noEmit"

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -1,5 +1,8 @@
 import "./env.js";
 import { Readable } from "node:stream";
+// Telemetry flush is owned by shutdown() below (the single SIGTERM owner), not by
+// tracing.ts, so the OTel flush can't race the ingest drain and exit early.
+import { shutdownTelemetry } from "./telemetry-shutdown.js";
 import { serve } from "@hono/node-server";
 import { type Span, SpanStatusCode, trace } from "@opentelemetry/api";
 import { hashApiKey, schema, syncLoopsContactsForProject } from "@superlog/db";
@@ -744,6 +747,10 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
     if (ingestQueue) {
       await ingestQueue.stop();
     }
+    // Flush telemetry LAST, after the ingest drain. tracing.ts no longer
+    // registers its own SIGTERM handler — it used to race this one and
+    // process.exit(0) mid-drain, orphaning in-flight SQS messages.
+    await shutdownTelemetry();
   } catch (err) {
     // Exit non-zero so a failed drain is visible rather than masquerading as a
     // clean stop.

--- a/apps/proxy/src/telemetry-shutdown.ts
+++ b/apps/proxy/src/telemetry-shutdown.ts
@@ -1,0 +1,19 @@
+// Decouples the OTel flush (set up in apps/proxy/tracing.ts, which loads before
+// the app via `node --import ./tracing.ts`) from the process shutdown sequence in
+// index.ts. tracing.ts registers the flush here; index.ts invokes it AFTER it
+// drains in-flight ingest work, so the flush can't race the drain and exit the
+// process early — the bug that orphaned in-flight SQS messages on every deploy.
+// Living in src/ keeps it inside the package tsconfig's rootDir, so index.ts can
+// import it without a cross-dir violation (tracing.ts itself is outside src/).
+
+let flush: () => Promise<void> = async () => {};
+
+/** Called once by tracing.ts when the OTel SDK starts. */
+export function setTelemetryShutdown(fn: () => Promise<void>): void {
+  flush = fn;
+}
+
+/** Flush and shut down telemetry. No-op unless the SDK registered a flush. */
+export function shutdownTelemetry(): Promise<void> {
+  return flush();
+}

--- a/apps/proxy/tracing.ts
+++ b/apps/proxy/tracing.ts
@@ -48,6 +48,7 @@ import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import { setTelemetryShutdown } from "./src/telemetry-shutdown.js";
 
 if (process.env.OTEL_DIAG_DEBUG === "1") {
   diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
@@ -134,10 +135,10 @@ if (telemetryEnabled) {
     }
   };
 
-  process.once("SIGTERM", () => {
-    void shutdown().finally(() => process.exit(0));
-  });
-  process.once("SIGINT", () => {
-    void shutdown().finally(() => process.exit(0));
-  });
+  // Do NOT register a SIGTERM/SIGINT handler here. The app's shutdown sequence
+  // (apps/proxy/src/index.ts) owns the signals and invokes this flush AFTER it
+  // drains in-flight ingest work. A second handler here used to process.exit(0)
+  // as soon as the OTel flush finished, killing the process before the slower
+  // SQS drain completed — orphaning in-flight messages on every deploy.
+  setTelemetryShutdown(shutdown);
 }


### PR DESCRIPTION
## Symptom
Every ECS rolling deploy of `proxy` / `ingest-consumer` produced a ~120s **ingest-lag sawtooth**: `ApproximateAgeOfOldestMessage` on `superlog-prod-app-ingest` climbed to the SQS visibility timeout (120s) then snapped back to 0 — enough to trip the ingest-lag page. (Surfaced today when the dialtone monitor flapped during a deploy.)

## Diagnosis (from prod logs/metrics)
The graceful-drain code in `apps/proxy/src/index.ts` (`shutdown()` → `ingestQueue.stop()`) is correct but **never executed**. Two stacked process-lifecycle bugs:

1. **`pnpm` ate the signal.** Container CMD was `pnpm --filter @superlog/proxy start`. `pnpm run` doesn't forward SIGTERM to the node child — on deploy the task logged `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL` + `Command failed with signal "SIGTERM"` and died with **no** `"received shutdown signal; draining"` line. In-flight SQS messages were received-but-undeleted → invisible for the full 120s visibility timeout → redelivered (the sawtooth).
2. **Telemetry handler won the exit race.** `tracing.ts` registered its *own* `SIGTERM`/`SIGINT` handler doing `sdk.shutdown().finally(() => process.exit(0))`. Even after fixing #1, that fast OTel flush would `process.exit(0)` before the slower ingest drain finished — still orphaning messages.

## Fix
- **`Dockerfile`**: run node as the container's main process with the tsx loader (`node --import tsx --import ./tracing.ts src/index.ts`) instead of via `pnpm run`, so SIGTERM reaches node's handler. `package.json` `start` updated to match.
- **`tracing.ts`**: no longer registers signal handlers. It registers its flush via the new `src/telemetry-shutdown.ts`.
- **`src/index.ts`**: `shutdown()` calls `shutdownTelemetry()` **last** — drain ingest → flush telemetry → exit. Single shutdown owner.
- **`src/telemetry-shutdown.ts`** (new): tiny in-`src/` indirection so `index.ts` imports the flush without a cross-`rootDir` violation (`tracing.ts` lives outside `src/`).

## Verification
- `tsc --noEmit` clean; **76/76** proxy tests pass.
- Smoke-tested `node --import tsx` runs the TS entry and the SIGTERM handler fires (node 20/22).
- Confirmed the `--import`'d `tracing.ts` and the in-`src` module share one instance, and the flush is a safe no-op when telemetry is disabled (non-prod).
- Post-merge validation plan: force one rolling `ingest-consumer` deploy and confirm `ApproximateAgeOfOldestMessage` stays flat (no 120s sawtooth) and the `draining`/`drained` log lines now appear.

## Deploy note
`superlog-cloud` pins this repo as a submodule — needs a submodule bump there to ship.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure SIGTERM reaches the Node process and make shutdown single-owned so the ingest consumer drains before exit, removing the ~120s ingest-lag sawtooth on ECS deploys. Telemetry now flushes after draining to avoid orphaned SQS messages.

- **Bug Fixes**
  - Run Node as the container entrypoint with the tsx loader (`node --import tsx --import ./tracing.ts src/index.ts`); update `start` to match. This avoids `pnpm run` swallowing SIGTERM.
  - Remove signal handlers from `tracing.ts`. Add `src/telemetry-shutdown.ts` and have `src/index.ts` own SIGTERM/SIGINT and call `shutdownTelemetry()` after `ingestQueue.stop()`.

- **Migration**
  - Bump the submodule in `superlog-cloud` to ship this change.

<sup>Written for commit c5d2defc5257d013e68fb2289907fce8c4b8e7cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

