### PR TITLE
perf(clickhouse): add otel_exceptions projection to stop ARRAY JOIN Events scans

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2240,6 +2240,17 @@ const INCIDENT_USERS_CAP = 200;
 
 // Bulk fetch distinct user IDs per (kind, service, exception_type) across a project.
 // Caller maps the returned tuples back to incidents and Set-unions per-incident.
+// WHERE fragment selecting otel_exceptions rows for the given incident
+// (service, exception_type) pairs, per signal kind. Empty input arrays make the
+// arrayZip empty, so that kind's clause matches nothing — callers don't need to
+// special-case empty inputs. Used by the incident-list aggregates below;
+// reads the exception-only projection (migrations/004_otel_exceptions.sql)
+// instead of full ARRAY JOIN Events scans of otel_traces.
+const INCIDENT_EXCEPTION_PAIR_WHERE = `(
+        (kind = 'span' AND (service, exception_type) IN arrayZip({spanServices:Array(String)}, {spanExcTypes:Array(String)}))
+        OR (kind = 'log' AND (service, exception_type) IN arrayZip({logServices:Array(String)}, {logExcTypes:Array(String)}))
+      )`;
+
 async function fetchIncidentUserIdsByPair(args: {
   projectId: string;
   spanServices: string[];
@@ -2251,44 +2262,16 @@ async function fetchIncidentUserIdsByPair(args: {
   const { projectId, spanServices, spanExcTypes, logServices, logExcTypes, windowDays } = args;
   if (spanServices.length === 0 && logServices.length === 0) return [];
 
-  const spanWhere =
-    spanServices.length === 0
-      ? "0"
-      : `(coalesce(ServiceName, ''), coalesce(event_attrs['exception.type'], '')) IN arrayZip({spanServices:Array(String)}, {spanExcTypes:Array(String)})`;
-  const logWhere =
-    logServices.length === 0
-      ? "0"
-      : `(coalesce(ServiceName, ''), coalesce(LogAttributes['exception.type'], '')) IN arrayZip({logServices:Array(String)}, {logExcTypes:Array(String)})`;
-
   const query = `
-    SELECT 'span' AS kind,
-      coalesce(ServiceName, '') AS svc,
-      coalesce(event_attrs['exception.type'], '') AS et,
-      groupUniqArray(${INCIDENT_USERS_CAP})(nullIf(coalesce(SpanAttributes['user.id'], ResourceAttributes['user.id']), '')) AS users
-    FROM (
-      SELECT Timestamp, ServiceName, SpanAttributes, ResourceAttributes, Events.Name, Events.Attributes
-      FROM otel_traces
-      WHERE Timestamp > now() - INTERVAL {days:UInt32} DAY
-        AND ResourceAttributes['superlog.project_id'] = {projectId:String}
-        AND has({spanServices:Array(String)}, coalesce(ServiceName, ''))
-        AND has(Events.Name, 'exception')
-    )
-    ARRAY JOIN Events.Name AS event_name, Events.Attributes AS event_attrs
-    WHERE event_name = 'exception'
-      AND ${spanWhere}
-    GROUP BY svc, et
-    UNION ALL
-    SELECT 'log' AS kind,
-      coalesce(ServiceName, '') AS svc,
-      coalesce(LogAttributes['exception.type'], '') AS et,
-      groupUniqArray(${INCIDENT_USERS_CAP})(nullIf(coalesce(LogAttributes['user.id'], ResourceAttributes['user.id']), '')) AS users
-    FROM otel_logs
-    WHERE Timestamp > now() - INTERVAL {days:UInt32} DAY
-      AND ResourceAttributes['superlog.project_id'] = {projectId:String}
-      AND SeverityNumber >= 17
-      AND has({logServices:Array(String)}, coalesce(ServiceName, ''))
-      AND ${logWhere}
-    GROUP BY svc, et
+    SELECT kind,
+      service AS svc,
+      exception_type AS et,
+      groupUniqArray(${INCIDENT_USERS_CAP})(nullIf(user_id, '')) AS users
+    FROM otel_exceptions
+    WHERE project_id = {projectId:String}
+      AND Timestamp > now() - INTERVAL {days:UInt32} DAY
+      AND ${INCIDENT_EXCEPTION_PAIR_WHERE}
+    GROUP BY kind, svc, et
   `;
 
   const res = await ch.query({
@@ -2328,46 +2311,17 @@ async function fetchIncidentTimeseriesPairs(args: {
   const { projectId, spanServices, spanExcTypes, logServices, logExcTypes, windowDays } = args;
   if (spanServices.length === 0 && logServices.length === 0) return [];
 
-  const spanWhere =
-    spanServices.length === 0
-      ? "0"
-      : `(coalesce(ServiceName, ''), coalesce(event_attrs['exception.type'], '')) IN arrayZip({spanServices:Array(String)}, {spanExcTypes:Array(String)})`;
-  const logWhere =
-    logServices.length === 0
-      ? "0"
-      : `(coalesce(ServiceName, ''), coalesce(LogAttributes['exception.type'], '')) IN arrayZip({logServices:Array(String)}, {logExcTypes:Array(String)})`;
-
   const query = `
-    SELECT 'span' AS kind,
-      coalesce(ServiceName, '') AS svc,
-      coalesce(event_attrs['exception.type'], '') AS et,
+    SELECT kind,
+      service AS svc,
+      exception_type AS et,
       toString(toDate(Timestamp)) AS day,
       count() AS c
-    FROM (
-      SELECT Timestamp, ServiceName, Events.Name, Events.Attributes
-      FROM otel_traces
-      WHERE Timestamp > now() - INTERVAL {days:UInt32} DAY
-        AND ResourceAttributes['superlog.project_id'] = {projectId:String}
-        AND has({spanServices:Array(String)}, coalesce(ServiceName, ''))
-        AND has(Events.Name, 'exception')
-    )
-    ARRAY JOIN Events.Name AS event_name, Events.Attributes AS event_attrs
-    WHERE event_name = 'exception'
-      AND ${spanWhere}
-    GROUP BY svc, et, day
-    UNION ALL
-    SELECT 'log' AS kind,
-      coalesce(ServiceName, '') AS svc,
-      coalesce(LogAttributes['exception.type'], '') AS et,
-      toString(toDate(Timestamp)) AS day,
-      count() AS c
-    FROM otel_logs
-    WHERE Timestamp > now() - INTERVAL {days:UInt32} DAY
-      AND ResourceAttributes['superlog.project_id'] = {projectId:String}
-      AND SeverityNumber >= 17
-      AND has({logServices:Array(String)}, coalesce(ServiceName, ''))
-      AND ${logWhere}
-    GROUP BY svc, et, day
+    FROM otel_exceptions
+    WHERE project_id = {projectId:String}
+      AND Timestamp > now() - INTERVAL {days:UInt32} DAY
+      AND ${INCIDENT_EXCEPTION_PAIR_WHERE}
+    GROUP BY kind, svc, et, day
   `;
 
   const res = await ch.query({

--- a/apps/worker/scripts/backfill-otel-exceptions.ts
+++ b/apps/worker/scripts/backfill-otel-exceptions.ts
@@ -1,0 +1,244 @@
+import "../src/env.js";
+import { createClient } from "@clickhouse/client";
+
+// Backfill historical rows into superlog.otel_exceptions (see
+// infra/clickhouse/migrations/004_otel_exceptions.sql). The materialized views
+// only capture rows ingested AFTER they are created, so existing exception
+// spans / error logs need this one-time pass.
+//
+// The SELECTs below are identical to the two MVs, with an added [from, to)
+// Timestamp window — so a backfilled row is byte-for-byte what the MV would
+// have produced.
+//
+// DUPLICATES: otel_exceptions is a plain ReplicatedMergeTree (no dedup). Rows
+// inserted here AND by the live MV for the same event are double-counted by the
+// readers. Run the backfill only up to the moment the MVs went live:
+//   --to <migration-apply time>   (and --from <retention start>)
+// so the backfill covers [retention_start, mv_cutover) and the MV owns
+// [mv_cutover, now). Re-running the same window also duplicates — don't.
+//
+// Dry run by default; pass --apply to write. Example:
+//   pnpm --filter @superlog/worker exec tsx scripts/backfill-otel-exceptions.ts \
+//     --from 2026-05-27 --to 2026-06-26T09:00:00Z --chunk-hours 6 --apply
+
+type Args = {
+  from: Date;
+  to: Date;
+  chunkHours: number;
+  projectId?: string;
+  source: "all" | "traces" | "logs";
+  apply: boolean;
+};
+
+const args = parseArgs(process.argv.slice(2));
+const clickhouse = createClient({
+  url: process.env.CLICKHOUSE_URL ?? "http://localhost:8123",
+  username: process.env.CLICKHOUSE_USER ?? "default",
+  password: process.env.CLICKHOUSE_PASSWORD ?? "",
+  database: process.env.CLICKHOUSE_DB ?? "superlog",
+});
+
+// Column projections shared by the dry-run count and the INSERT, kept identical
+// to otel_exceptions_from_{traces,logs}_mv so backfilled rows match live rows.
+function tracesSelectBody(projectFilter: string): string {
+  return `
+    FROM otel_traces
+    ARRAY JOIN Events.Name AS event_name, Events.Attributes AS event_attrs
+    WHERE event_name = 'exception'
+      AND ResourceAttributes['superlog.project_id'] != ''
+      AND Timestamp >= parseDateTime64BestEffort({from:String}, 9)
+      AND Timestamp < parseDateTime64BestEffort({to:String}, 9)
+      ${projectFilter}
+  `;
+}
+
+function logsSelectBody(projectFilter: string): string {
+  return `
+    FROM otel_logs
+    WHERE SeverityNumber >= 17
+      AND ResourceAttributes['superlog.project_id'] != ''
+      AND Timestamp >= parseDateTime64BestEffort({from:String}, 9)
+      AND Timestamp < parseDateTime64BestEffort({to:String}, 9)
+      ${projectFilter}
+  `;
+}
+
+function tracesInsert(projectFilter: string): string {
+  return `
+    INSERT INTO otel_exceptions
+    SELECT
+      ResourceAttributes['superlog.project_id'] AS project_id,
+      Timestamp,
+      'span' AS kind,
+      ServiceName AS service,
+      SpanName AS span_name,
+      TraceId AS trace_id,
+      SpanId AS span_id,
+      event_attrs['exception.type'] AS exception_type,
+      event_attrs['exception.message'] AS exception_message,
+      event_attrs['exception.stacktrace'] AS exception_stacktrace,
+      event_attrs['superlog.issue_fingerprint'] AS fingerprint,
+      if(SpanAttributes['user.id'] != '', SpanAttributes['user.id'], ResourceAttributes['user.id']) AS user_id,
+      ResourceAttributes AS resource_attrs,
+      SpanAttributes AS attrs,
+      '' AS body,
+      '' AS severity,
+      toUInt8(0) AS severity_number
+    ${tracesSelectBody(projectFilter)}
+  `;
+}
+
+function logsInsert(projectFilter: string): string {
+  return `
+    INSERT INTO otel_exceptions
+    SELECT
+      ResourceAttributes['superlog.project_id'] AS project_id,
+      Timestamp,
+      'log' AS kind,
+      ServiceName AS service,
+      '' AS span_name,
+      TraceId AS trace_id,
+      SpanId AS span_id,
+      LogAttributes['exception.type'] AS exception_type,
+      LogAttributes['exception.message'] AS exception_message,
+      LogAttributes['exception.stacktrace'] AS exception_stacktrace,
+      LogAttributes['superlog.issue_fingerprint'] AS fingerprint,
+      if(LogAttributes['user.id'] != '', LogAttributes['user.id'], ResourceAttributes['user.id']) AS user_id,
+      ResourceAttributes AS resource_attrs,
+      LogAttributes AS attrs,
+      Body AS body,
+      SeverityText AS severity,
+      toUInt8(SeverityNumber) AS severity_number
+    ${logsSelectBody(projectFilter)}
+  `;
+}
+
+async function countRows(selectBody: string, params: Record<string, unknown>): Promise<number> {
+  const res = await clickhouse.query({
+    query: `SELECT count() AS c ${selectBody}`,
+    query_params: params,
+    format: "JSONEachRow",
+  });
+  const rows = (await res.json()) as { c: string | number }[];
+  return Number(rows[0]?.c ?? 0);
+}
+
+let insertedSpanRows = 0;
+let insertedLogRows = 0;
+
+try {
+  console.log(
+    JSON.stringify({
+      apply: args.apply,
+      source: args.source,
+      from: args.from.toISOString(),
+      to: args.to.toISOString(),
+      chunkHours: args.chunkHours,
+      projectId: args.projectId ?? null,
+      note: args.apply
+        ? "INSERTs are additive and not deduplicated; do not overlap the live MV window or rerun a range."
+        : "dry run only; pass --apply to insert rows into otel_exceptions",
+    }),
+  );
+
+  const projectFilter = args.projectId
+    ? "AND ResourceAttributes['superlog.project_id'] = {projectId:String}"
+    : "";
+
+  for (const [from, to] of chunkWindows(args.from, args.to, args.chunkHours)) {
+    const params: Record<string, unknown> = {
+      from: from.toISOString(),
+      to: to.toISOString(),
+      ...(args.projectId ? { projectId: args.projectId } : {}),
+    };
+
+    let spanRows = 0;
+    let logRows = 0;
+
+    if (args.source === "all" || args.source === "traces") {
+      spanRows = await countRows(tracesSelectBody(projectFilter), params);
+      if (args.apply && spanRows > 0) {
+        await clickhouse.command({ query: tracesInsert(projectFilter), query_params: params });
+        insertedSpanRows += spanRows;
+      }
+    }
+    if (args.source === "all" || args.source === "logs") {
+      logRows = await countRows(logsSelectBody(projectFilter), params);
+      if (args.apply && logRows > 0) {
+        await clickhouse.command({ query: logsInsert(projectFilter), query_params: params });
+        insertedLogRows += logRows;
+      }
+    }
+
+    console.log(
+      JSON.stringify({ from: from.toISOString(), to: to.toISOString(), spanRows, logRows }),
+    );
+  }
+
+  console.log(JSON.stringify({ insertedSpanRows, insertedLogRows, applied: args.apply }));
+} finally {
+  await clickhouse.close();
+}
+
+function* chunkWindows(from: Date, to: Date, chunkHours: number): Generator<[Date, Date]> {
+  const chunkMs = chunkHours * 60 * 60 * 1000;
+  for (let cursor = from.getTime(); cursor < to.getTime(); cursor += chunkMs) {
+    yield [new Date(cursor), new Date(Math.min(cursor + chunkMs, to.getTime()))];
+  }
+}
+
+function parseArgs(argv: string[]): Args {
+  const values = new Map<string, string | true>();
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--") continue;
+    if (!arg.startsWith("--")) throw new Error(`unexpected argument: ${arg}`);
+    const key = arg.slice(2);
+    if (key === "apply") {
+      values.set(key, true);
+      continue;
+    }
+    const value = argv[i + 1];
+    if (!value || value.startsWith("--")) throw new Error(`missing value for --${key}`);
+    values.set(key, value);
+    i += 1;
+  }
+
+  const to = parseDate(values.get("to")) ?? startOfUtcTomorrow(new Date());
+  const from = parseDate(values.get("from")) ?? new Date(to.getTime() - 14 * 24 * 60 * 60 * 1000);
+  const chunkHours = Number(values.get("chunk-hours") ?? 6);
+  const source = values.get("source") ?? "all";
+  if (source !== "all" && source !== "traces" && source !== "logs") {
+    throw new Error("--source must be all, traces, or logs");
+  }
+  if (!Number.isFinite(chunkHours) || chunkHours <= 0)
+    throw new Error("--chunk-hours must be positive");
+  if (from >= to) throw new Error("--from must be before --to");
+
+  return {
+    from,
+    to,
+    chunkHours,
+    source,
+    apply: values.get("apply") === true,
+    projectId:
+      typeof values.get("project-id") === "string"
+        ? (values.get("project-id") as string)
+        : undefined,
+  };
+}
+
+function parseDate(value: string | true | undefined): Date | null {
+  if (typeof value !== "string") return null;
+  const withTime = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00.000Z` : value;
+  const date = new Date(withTime);
+  if (!Number.isFinite(date.getTime())) throw new Error(`invalid date: ${value}`);
+  return date;
+}
+
+function startOfUtcTomorrow(now: Date): Date {
+  const out = new Date(now);
+  out.setUTCHours(0, 0, 0, 0);
+  out.setUTCDate(out.getUTCDate() + 1);
+  return out;
+}

--- a/apps/worker/src/autorecovery/metrics-repository.test.ts
+++ b/apps/worker/src/autorecovery/metrics-repository.test.ts
@@ -55,9 +55,13 @@ test("queryIncidentActivity filters by the candidate's issue exception types", a
   // The query must scope by the actual issue signatures, not just project+service.
   // Without this filter, a project-wide spike in unrelated exceptions (e.g.
   // ECONNREFUSED storm) would be attributed to this incident.
-  assert.match(q.query, /exception\.type/i);
   assert.match(q.query, /\{exception_types:Array\(String\)\}/);
   assert.deepEqual(q.params.exception_types, ["APIError"]);
+  // Reads the exception-only projection, not a full ARRAY JOIN Events scan of
+  // otel_traces; kind='span' preserves the old otel_traces-only scope.
+  assert.match(q.query, /FROM otel_exceptions/);
+  assert.match(q.query, /kind = 'span'/);
+  assert.doesNotMatch(q.query, /ARRAY JOIN/);
 });
 
 test("queryIncidentActivity collapses duplicate exception types and filters by service", async () => {

--- a/apps/worker/src/autorecovery/metrics-repository.ts
+++ b/apps/worker/src/autorecovery/metrics-repository.ts
@@ -48,18 +48,21 @@ export function createAutorecoveryMetricsRepository(getCh: () => Promise<ClickHo
         return { totalEvents: 0, perHour: [], lookbackHours: hours };
       }
       const ch = await getCh();
+      // Reads the exception-only projection (otel_exceptions) instead of
+      // ARRAY JOIN Events over otel_traces — same trace-exception counts, but a
+      // small indexed table rather than a full multi-day scan of every span's
+      // events. kind = 'span' preserves the original otel_traces-only scope.
       const result = await ch.query({
         query: `
           SELECT
             toString(toStartOfHour(Timestamp)) AS hour,
             toUInt64(count()) AS count
-          FROM otel_traces
-          ARRAY JOIN Events AS event
-          WHERE ResourceAttributes['superlog.project_id'] = {project_id:String}
-            AND event.Name = 'exception'
-            AND event.Attributes['exception.type'] IN {exception_types:Array(String)}
+          FROM otel_exceptions
+          WHERE project_id = {project_id:String}
+            AND kind = 'span'
+            AND exception_type IN {exception_types:Array(String)}
             AND Timestamp >= now() - INTERVAL {hours:UInt32} HOUR
-            ${incident.service ? "AND ServiceName = {service:String}" : ""}
+            ${incident.service ? "AND service = {service:String}" : ""}
           GROUP BY hour
           ORDER BY hour ASC
         `,

--- a/apps/worker/src/telemetry/ingest.test.ts
+++ b/apps/worker/src/telemetry/ingest.test.ts
@@ -81,6 +81,10 @@ test("span ingestion processes every row for a selected timestamp", async () => 
 
   assert.equal(await ingestor.tickSpans(), 2);
   assert.match(calls[0]?.query ?? "", /GROUP BY Timestamp/);
+  // Reads the exception-only projection, not ARRAY JOIN Events over otel_traces.
+  assert.match(calls[0]?.query ?? "", /FROM otel_exceptions/);
+  assert.match(calls[0]?.query ?? "", /kind = 'span'/);
+  assert.doesNotMatch(calls[0]?.query ?? "", /ARRAY JOIN/);
   assert.equal("cursorKey0" in (calls[0]?.query_params ?? {}), false);
   assert.equal(calls[0]?.query_params?.cursorTs, "2026-05-23 10:00:00.000");
   assert.equal(state.get("fingerprint")?.cursor.toISOString(), "2026-05-23T10:00:00.000Z");
@@ -115,6 +119,9 @@ test("log ingestion processes every row for a selected timestamp", async () => {
 
   assert.equal(await ingestor.tickLogs(), 2);
   assert.match(calls[0]?.query ?? "", /GROUP BY Timestamp/);
+  // Reads the exception-only projection (kind='log'), not a full otel_logs scan.
+  assert.match(calls[0]?.query ?? "", /FROM otel_exceptions/);
+  assert.match(calls[0]?.query ?? "", /kind = 'log'/);
   assert.equal("cursorKey0" in (calls[0]?.query_params ?? {}), false);
   assert.equal(calls[0]?.query_params?.cursorTs, "2026-05-23 10:00:00.000");
   assert.equal(state.get("fingerprint-logs")?.cursor.toISOString(), "2026-05-23T10:00:00.000Z");

--- a/apps/worker/src/telemetry/ingest.ts
+++ b/apps/worker/src/telemetry/ingest.ts
@@ -431,18 +431,22 @@ async function loadBacklogStats(opts: {
   };
 }
 
+// Backlog stats + the tick fetches below read otel_exceptions (the
+// exception-only projection, see migrations/004_otel_exceptions.sql) instead of
+// ARRAY JOIN-scanning otel_traces / full-scanning otel_logs. Membership in
+// otel_exceptions already mirrors the old predicates (span `exception` events;
+// logs SeverityNumber>=17), so the `kind` filter is the only scope needed.
 function spanBacklogStatsQuery(): string {
   return `
     SELECT
       count() AS pending_rows,
       toString(min(Timestamp)) AS oldest_pending_ts,
       toString(max(Timestamp)) AS latest_pending_ts
-    FROM otel_traces
-    ARRAY JOIN Events.Name AS event_name
-    WHERE Timestamp > parseDateTime64BestEffort({cursorTs:String}, 6)
+    FROM otel_exceptions
+    WHERE kind = 'span'
+      AND Timestamp > parseDateTime64BestEffort({cursorTs:String}, 6)
       AND Timestamp <= parseDateTime64BestEffort({untilTs:String}, 6)
-      AND event_name = 'exception'
-      AND ResourceAttributes['superlog.project_id'] != ''
+      AND project_id != ''
   `;
 }
 
@@ -452,11 +456,11 @@ function logBacklogStatsQuery(): string {
       count() AS pending_rows,
       toString(min(Timestamp)) AS oldest_pending_ts,
       toString(max(Timestamp)) AS latest_pending_ts
-    FROM otel_logs
-    WHERE Timestamp > parseDateTime64BestEffort({cursorTs:String}, 6)
+    FROM otel_exceptions
+    WHERE kind = 'log'
+      AND Timestamp > parseDateTime64BestEffort({cursorTs:String}, 6)
       AND Timestamp <= parseDateTime64BestEffort({untilTs:String}, 6)
-      AND SeverityNumber >= 17
-      AND ResourceAttributes['superlog.project_id'] != ''
+      AND project_id != ''
   `;
 }
 
@@ -480,12 +484,11 @@ async function tickSpans(opts: {
         query: `
       WITH selected_timestamps AS (
         SELECT Timestamp
-        FROM otel_traces
-        ARRAY JOIN Events.Name AS event_name
-        WHERE Timestamp > parseDateTime64BestEffort({cursorTs:String}, 6)
+        FROM otel_exceptions
+        WHERE kind = 'span'
+          AND Timestamp > parseDateTime64BestEffort({cursorTs:String}, 6)
           AND Timestamp <= parseDateTime64BestEffort({untilTs:String}, 6)
-          AND event_name = 'exception'
-          AND ResourceAttributes['superlog.project_id'] != ''
+          AND project_id != ''
         GROUP BY Timestamp
         ORDER BY Timestamp ASC
         LIMIT {limit:UInt32}
@@ -497,30 +500,15 @@ async function tickSpans(opts: {
         span_name,
         trace_id,
         span_id,
-        span_attrs,
+        attrs AS span_attrs,
         resource_attrs,
-        exc_type,
-        exc_message,
-        exc_stack
-      FROM (
-        SELECT
-          Timestamp,
-          ResourceAttributes['superlog.project_id'] AS project_id,
-          ServiceName AS service,
-          SpanName AS span_name,
-          TraceId AS trace_id,
-          SpanId AS span_id,
-          SpanAttributes AS span_attrs,
-          ResourceAttributes AS resource_attrs,
-          event_attrs['exception.type'] AS exc_type,
-          event_attrs['exception.message'] AS exc_message,
-          event_attrs['exception.stacktrace'] AS exc_stack
-        FROM otel_traces
-        ARRAY JOIN Events.Name AS event_name, Events.Attributes AS event_attrs
-        WHERE event_name = 'exception'
-          AND ResourceAttributes['superlog.project_id'] != ''
-          AND Timestamp IN (SELECT Timestamp FROM selected_timestamps)
-      )
+        exception_type AS exc_type,
+        exception_message AS exc_message,
+        exception_stacktrace AS exc_stack
+      FROM otel_exceptions
+      WHERE kind = 'span'
+        AND project_id != ''
+        AND Timestamp IN (SELECT Timestamp FROM selected_timestamps)
       ORDER BY Timestamp ASC, project_id ASC, service ASC, trace_id ASC, span_id ASC, exc_type ASC, exc_message ASC, exc_stack ASC
     `,
         query_params: { ...cursorWindow, limit: opts.batchSize },
@@ -650,11 +638,11 @@ async function tickLogs(opts: {
         query: `
       WITH selected_timestamps AS (
         SELECT Timestamp
-        FROM otel_logs
-        WHERE Timestamp > parseDateTime64BestEffort({cursorTs:String}, 6)
+        FROM otel_exceptions
+        WHERE kind = 'log'
+          AND Timestamp > parseDateTime64BestEffort({cursorTs:String}, 6)
           AND Timestamp <= parseDateTime64BestEffort({untilTs:String}, 6)
-          AND SeverityNumber >= 17
-          AND ResourceAttributes['superlog.project_id'] != ''
+          AND project_id != ''
         GROUP BY Timestamp
         ORDER BY Timestamp ASC
         LIMIT {limit:UInt32}
@@ -668,31 +656,15 @@ async function tickLogs(opts: {
         body,
         trace_id,
         span_id,
-        log_attrs,
+        attrs AS log_attrs,
         resource_attrs,
-        exc_type,
-        exc_stack
-      FROM (
-        SELECT
-          Timestamp,
-          ResourceAttributes['superlog.project_id'] AS project_id,
-          ServiceName AS service,
-          SeverityText AS severity,
-          toUInt8(SeverityNumber) AS severity_number,
-          leftPad(toString(toUInt8(SeverityNumber)), 3, '0') AS severity_number_key,
-          Body AS body,
-          TraceId AS trace_id,
-          SpanId AS span_id,
-          LogAttributes AS log_attrs,
-          ResourceAttributes AS resource_attrs,
-          LogAttributes['exception.type'] AS exc_type,
-          LogAttributes['exception.stacktrace'] AS exc_stack
-        FROM otel_logs
-        WHERE SeverityNumber >= 17
-          AND ResourceAttributes['superlog.project_id'] != ''
-          AND Timestamp IN (SELECT Timestamp FROM selected_timestamps)
-      )
-      ORDER BY Timestamp ASC, project_id ASC, service ASC, trace_id ASC, span_id ASC, severity_number_key ASC, severity ASC, body ASC, exc_type ASC, exc_stack ASC
+        exception_type AS exc_type,
+        exception_stacktrace AS exc_stack
+      FROM otel_exceptions
+      WHERE kind = 'log'
+        AND project_id != ''
+        AND Timestamp IN (SELECT Timestamp FROM selected_timestamps)
+      ORDER BY Timestamp ASC, project_id ASC, service ASC, trace_id ASC, span_id ASC, leftPad(toString(severity_number), 3, '0') ASC, severity ASC, body ASC, exc_type ASC, exc_stack ASC
     `,
         query_params: { ...cursorWindow, limit: opts.batchSize },
         format: "JSONEachRow",

--- a/infra/clickhouse/migrations/004_otel_exceptions.sql
+++ b/infra/clickhouse/migrations/004_otel_exceptions.sql
@@ -1,0 +1,111 @@
+-- A narrow, exception-only projection of otel_traces + otel_logs.
+--
+-- The Issues/Incidents feature (incident sparklines, affected-users counts,
+-- occurrences-over-time) and the worker's exception-ingest loop all find
+-- exceptions by scanning the full otel_traces table with
+-- `ARRAY JOIN Events ... WHERE event_name = 'exception'`. `Events` is a nested
+-- column with no usable skip index, so every one of those reads expands and
+-- scans *every* span's events over a multi-day window — 130M+ rows / ~90s on a
+-- busy project, which periodically saturates the shared read pool (and is what
+-- the end-to-end uptime monitor trips on first).
+--
+-- `otel_exceptions` holds one row per exception event (a tiny fraction of all
+-- spans/logs), keyed so those queries become small indexed reads instead of
+-- full-table ARRAY JOIN scans. New rows are fed by the two materialized views
+-- below; historical rows need the companion backfill script
+-- `apps/worker/scripts/backfill-otel-exceptions.ts`.
+--
+-- Membership mirrors the app's existing notion of an "exception" exactly, so
+-- the query rewrites are behaviour-preserving:
+--   * traces: an `exception` span event
+--   * logs:   SeverityNumber >= 17 (ERROR+)
+-- `exception_type` / `fingerprint` / `user_id` are stored verbatim (empty when
+-- absent) — callers filter on them, they don't define membership.
+--
+-- No TTL clause: otel_traces / otel_logs themselves carry none, so bounding
+-- this derived table at N days would under-report long-window queries relative
+-- to the source. (A TTL can be added later alongside source-table retention.)
+
+CREATE TABLE IF NOT EXISTS superlog.otel_exceptions ON CLUSTER superlog_ha
+(
+    `project_id` String CODEC(ZSTD(1)),
+    `Timestamp` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    `kind` LowCardinality(String) CODEC(ZSTD(1)),
+    `service` LowCardinality(String) CODEC(ZSTD(1)),
+    `span_name` LowCardinality(String) CODEC(ZSTD(1)),
+    `trace_id` String CODEC(ZSTD(1)),
+    `span_id` String CODEC(ZSTD(1)),
+    `exception_type` LowCardinality(String) CODEC(ZSTD(1)),
+    `exception_message` String CODEC(ZSTD(1)),
+    `exception_stacktrace` String CODEC(ZSTD(1)),
+    `fingerprint` String CODEC(ZSTD(1)),
+    `user_id` String CODEC(ZSTD(1)),
+    -- Full attribute maps so the worker's exception-ingest loop (issue
+    -- fingerprinting + issue-filtering + lastSample) can read this table rather
+    -- than ARRAY JOIN-scanning otel_traces. `attrs` = SpanAttributes for spans /
+    -- LogAttributes for logs; `resource_attrs` = the resource map for both.
+    `resource_attrs` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `attrs` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    -- Log-only fields the worker needs for fingerprintLog + lastSample (the log
+    -- "message" is its Body, not exception.message). Empty/0 for span rows.
+    `body` String CODEC(ZSTD(1)),
+    `severity` LowCardinality(String) CODEC(ZSTD(1)),
+    `severity_number` UInt8 CODEC(ZSTD(1)),
+    INDEX idx_exc_project_id project_id TYPE set(0) GRANULARITY 4
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
+PARTITION BY toDate(Timestamp)
+ORDER BY (project_id, service, exception_type, Timestamp)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.otel_exceptions_from_traces_mv ON CLUSTER superlog_ha
+TO superlog.otel_exceptions
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    Timestamp,
+    'span' AS kind,
+    ServiceName AS service,
+    SpanName AS span_name,
+    TraceId AS trace_id,
+    SpanId AS span_id,
+    event_attrs['exception.type'] AS exception_type,
+    event_attrs['exception.message'] AS exception_message,
+    event_attrs['exception.stacktrace'] AS exception_stacktrace,
+    event_attrs['superlog.issue_fingerprint'] AS fingerprint,
+    if(SpanAttributes['user.id'] != '', SpanAttributes['user.id'], ResourceAttributes['user.id']) AS user_id,
+    ResourceAttributes AS resource_attrs,
+    SpanAttributes AS attrs,
+    '' AS body,
+    '' AS severity,
+    toUInt8(0) AS severity_number
+FROM superlog.otel_traces
+ARRAY JOIN Events.Name AS event_name, Events.Attributes AS event_attrs
+WHERE event_name = 'exception'
+  AND ResourceAttributes['superlog.project_id'] != ''
+;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.otel_exceptions_from_logs_mv ON CLUSTER superlog_ha
+TO superlog.otel_exceptions
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    Timestamp,
+    'log' AS kind,
+    ServiceName AS service,
+    '' AS span_name,
+    TraceId AS trace_id,
+    SpanId AS span_id,
+    LogAttributes['exception.type'] AS exception_type,
+    LogAttributes['exception.message'] AS exception_message,
+    LogAttributes['exception.stacktrace'] AS exception_stacktrace,
+    LogAttributes['superlog.issue_fingerprint'] AS fingerprint,
+    if(LogAttributes['user.id'] != '', LogAttributes['user.id'], ResourceAttributes['user.id']) AS user_id,
+    ResourceAttributes AS resource_attrs,
+    LogAttributes AS attrs,
+    Body AS body,
+    SeverityText AS severity,
+    toUInt8(SeverityNumber) AS severity_number
+FROM superlog.otel_logs
+WHERE SeverityNumber >= 17
+  AND ResourceAttributes['superlog.project_id'] != ''
+;

--- a/infra/clickhouse/schema/ha-replicated-otel.sql
+++ b/infra/clickhouse/schema/ha-replicated-otel.sql
@@ -382,3 +382,81 @@ FROM superlog.otel_logs
 WHERE ResourceAttributes['superlog.project_id'] != ''
 GROUP BY project_id, signal, service, severity, status_code, minute
 ;
+-- otel_exceptions (exception-only projection; see migrations/004_otel_exceptions.sql
+-- for rationale + backfill notes). One row per exception event so the Issues
+-- feature + worker exception-ingest stop full ARRAY JOIN Events scans of otel_traces.
+CREATE TABLE IF NOT EXISTS superlog.otel_exceptions ON CLUSTER superlog_ha
+(
+    `project_id` String CODEC(ZSTD(1)),
+    `Timestamp` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    `kind` LowCardinality(String) CODEC(ZSTD(1)),
+    `service` LowCardinality(String) CODEC(ZSTD(1)),
+    `span_name` LowCardinality(String) CODEC(ZSTD(1)),
+    `trace_id` String CODEC(ZSTD(1)),
+    `span_id` String CODEC(ZSTD(1)),
+    `exception_type` LowCardinality(String) CODEC(ZSTD(1)),
+    `exception_message` String CODEC(ZSTD(1)),
+    `exception_stacktrace` String CODEC(ZSTD(1)),
+    `fingerprint` String CODEC(ZSTD(1)),
+    `user_id` String CODEC(ZSTD(1)),
+    `resource_attrs` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `attrs` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `body` String CODEC(ZSTD(1)),
+    `severity` LowCardinality(String) CODEC(ZSTD(1)),
+    `severity_number` UInt8 CODEC(ZSTD(1)),
+    INDEX idx_exc_project_id project_id TYPE set(0) GRANULARITY 4
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
+PARTITION BY toDate(Timestamp)
+ORDER BY (project_id, service, exception_type, Timestamp)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+;
+-- otel_exceptions_from_traces_mv
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.otel_exceptions_from_traces_mv ON CLUSTER superlog_ha TO superlog.otel_exceptions
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    Timestamp,
+    'span' AS kind,
+    ServiceName AS service,
+    SpanName AS span_name,
+    TraceId AS trace_id,
+    SpanId AS span_id,
+    event_attrs['exception.type'] AS exception_type,
+    event_attrs['exception.message'] AS exception_message,
+    event_attrs['exception.stacktrace'] AS exception_stacktrace,
+    event_attrs['superlog.issue_fingerprint'] AS fingerprint,
+    if(SpanAttributes['user.id'] != '', SpanAttributes['user.id'], ResourceAttributes['user.id']) AS user_id,
+    ResourceAttributes AS resource_attrs,
+    SpanAttributes AS attrs,
+    '' AS body,
+    '' AS severity,
+    toUInt8(0) AS severity_number
+FROM superlog.otel_traces
+ARRAY JOIN Events.Name AS event_name, Events.Attributes AS event_attrs
+WHERE event_name = 'exception'
+  AND ResourceAttributes['superlog.project_id'] != ''
+;
+-- otel_exceptions_from_logs_mv
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.otel_exceptions_from_logs_mv ON CLUSTER superlog_ha TO superlog.otel_exceptions
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    Timestamp,
+    'log' AS kind,
+    ServiceName AS service,
+    '' AS span_name,
+    TraceId AS trace_id,
+    SpanId AS span_id,
+    LogAttributes['exception.type'] AS exception_type,
+    LogAttributes['exception.message'] AS exception_message,
+    LogAttributes['exception.stacktrace'] AS exception_stacktrace,
+    LogAttributes['superlog.issue_fingerprint'] AS fingerprint,
+    if(LogAttributes['user.id'] != '', LogAttributes['user.id'], ResourceAttributes['user.id']) AS user_id,
+    ResourceAttributes AS resource_attrs,
+    LogAttributes AS attrs,
+    Body AS body,
+    SeverityText AS severity,
+    toUInt8(SeverityNumber) AS severity_number
+FROM superlog.otel_logs
+WHERE SeverityNumber >= 17
+  AND ResourceAttributes['superlog.project_id'] != ''
+;


### PR DESCRIPTION
## Problem

Every exception read path locates exceptions by scanning `otel_traces` with `ARRAY JOIN Events ... WHERE event_name = 'exception'` (plus full `SeverityNumber>=17` scans of `otel_logs`):

- autorecovery incident-activity query (`metrics-repository.queryIncidentActivity`)
- the worker exception-ingest loop (`telemetry/ingest.ts` backlog stats + `tickSpans`/`tickLogs`)
- incident-list sparkline + affected-users aggregates (`fetchIncidentTimeseriesPairs` / `fetchIncidentUserIdsByPair`)

`Events` is a nested column with no usable skip index, so each of these expands and scans **every span's events** over a multi-day window — 130M+ rows / up to a few minutes on a busy project. Bursts of them periodically saturate the shared ClickHouse read pool, which slows every other reader (and trips end-to-end read latency).

## Change

Add `superlog.otel_exceptions` — **one row per exception event**, projected from `otel_traces` + `otel_logs` by two materialized views. Membership mirrors the existing definitions exactly (span `exception` events; logs `SeverityNumber>=17`), and the table carries the attribute maps + log `body`/`severity` the worker needs, so the read rewrites are **behaviour-preserving**. The hot reads become small indexed lookups (`ORDER BY (project_id, service, exception_type, Timestamp)`, day-partitioned) instead of full `ARRAY JOIN` scans.

- `infra/clickhouse/migrations/004_otel_exceptions.sql` + the HA schema: table + 2 MVs
- `apps/worker/scripts/backfill-otel-exceptions.ts`: backfill historical rows (MVs only capture rows ingested after creation) — server-side `INSERT...SELECT`, chunked, dry-run by default, dup-avoidance window documented
- autorecovery `queryIncidentActivity`, worker backlog stats + `tickSpans`/`tickLogs`, and the incident-list aggregates now read `otel_exceptions`
- tests assert the rewritten queries target `otel_exceptions`, not `ARRAY JOIN`

The rare incident-detail fallback (raw `bucketsQuery`/`usersQuery`, used only when the `issue_activity_daily` rollup query errors) is intentionally left on `otel_traces` for now.

## Rollout (order matters — reads can't move until the table is populated)

1. Apply migration `004` (MVs start capturing; note the apply time `T`).
2. Backfill `--from <retention start> --to T --apply` (covers history up to the MV cutover; no overlap ⇒ no duplicate rows).
3. Deploy this code (reads switch to `otel_exceptions`).

## Validation

- Schema + both MVs (17-column positional inserts) + every rewritten read shape validated against ClickHouse 26.5.
- `@superlog/worker` + `@superlog/api` typecheck clean; worker + incident tests green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `superlog.otel_exceptions`, an exception-only ClickHouse projection, and switch hot reads to it to replace costly `ARRAY JOIN` scans. This makes incident queries and the worker’s exception ingest faster and more stable.

- **New Features**
  - New `otel_exceptions` table with two MVs from `otel_traces` (span `exception` events) and `otel_logs` (`SeverityNumber>=17`), keyed for indexed reads and carrying attrs and log body/severity.
  - Rewrote reads to use `otel_exceptions`: incident activity, worker backlog stats and `tickSpans`/`tickLogs`, and incident-list users/timeseries. Tests assert no `ARRAY JOIN`.
  - Added `apps/worker/scripts/backfill-otel-exceptions.ts` for historical rows (chunked, server-side `INSERT...SELECT`, dry-run by default). Rare incident-detail fallback remains on `otel_traces`.

- **Migration**
  - Apply migration `004` to create the table + MVs (note the apply time T).
  - Run the backfill: `--from <retention start> --to T --apply` (avoid overlap to prevent duplicates).
  - Deploy to switch reads to `otel_exceptions`.

<sup>Written for commit dc4f4747cb30ccb9f4ef1f0e9992249b9e8a1523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

