### PR TITLE
feat(orgs): let users create and delete organizations from settings

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -27,13 +27,12 @@ import type { Context } from "hono";
 import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import { nanoid } from "nanoid";
-import { mountAlerts } from "./alerts.js";
 import { loadIncidentAlertEpisodes } from "./alerts-service.js";
+import { mountAlerts } from "./alerts.js";
 import { auth } from "./auth.js";
 import { shouldRunMigrationsOnBoot } from "./boot-migrations.js";
 import { mountCloudConnectionsAuthed } from "./cloud-connections.js";
 import { mountDashboards } from "./dashboards.js";
-import { mountTopology } from "./topology.js";
 import {
   demoOverlay,
   demoProjectId,
@@ -94,6 +93,7 @@ import {
 } from "./mcp/clickhouse.js";
 import { mountMcpAuthed, mountMcpPublic } from "./mcp/index.js";
 import { resolveActiveOrgContext, resolveMaybeActiveOrgContext } from "./org-context.js";
+import { ORG_NAME_MAX, createOrgWithDefaults, mountOrgCrud } from "./orgs.js";
 import { mountPersonalAccessTokens } from "./personal-access-tokens.js";
 import { mountSettingsAuthed } from "./settings.js";
 import { normalizeSignupIntentKeyHash, normalizeSignupIntentKeyPrefix } from "./signup-intents.js";
@@ -102,6 +102,7 @@ import { sourceMapObjectStoreFromEnv } from "./sourcemaps.js";
 import { userIsStaff } from "./staff.js";
 import { symbolicateIssueSample, symbolicateTelemetrySample } from "./symbolication.js";
 import { buildSystemCapabilities } from "./system-capabilities.js";
+import { mountTopology } from "./topology.js";
 import { mountWebhooks } from "./webhooks.js";
 
 const PORT = Number(process.env.PORT ?? 4100);
@@ -316,6 +317,7 @@ mountOrgKeyManagementAuthed(app);
 mountDashboards(app);
 mountCloudConnectionsAuthed(app);
 mountIngestFilters(app);
+mountOrgCrud(app);
 mountTopology(app);
 mountAlerts(app, { ch });
 mountWebhooks(app);
@@ -465,27 +467,6 @@ app.put("/api/me/favorite", async (c) => {
   return c.json({ favorite: { orgId: org.id, projectId: project.id } });
 });
 
-const ORG_NAME_MAX = 80;
-
-function slugifyOrgName(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 40);
-}
-
-async function uniqueOrgSlug(client: Pick<typeof db, "query">, base: string): Promise<string> {
-  const seed = base || "org";
-  let candidate = seed;
-  for (let attempt = 0; attempt < 20; attempt += 1) {
-    const existing = await client.query.orgs.findFirst({ where: eq(schema.orgs.slug, candidate) });
-    if (!existing) return candidate;
-    candidate = `${seed.slice(0, 32)}-${nanoid(6).toLowerCase()}`;
-  }
-  return `${seed.slice(0, 20)}-${nanoid(12).toLowerCase()}`;
-}
-
 // First-org creation. Called by the onboarding wizard's create-org step for
 // users that signed up but don't have a membership yet. Idempotent on retry:
 // if the user already has an org, returns it instead of creating a duplicate.
@@ -559,25 +540,7 @@ app.post("/api/me/orgs", async (c) => {
         };
       }
 
-      const slug = await uniqueOrgSlug(tx, slugifyOrgName(rawName));
-      const [org] = await tx.insert(schema.orgs).values({ name: rawName, slug }).returning();
-      if (!org) throw new HTTPException(500, { message: "failed to create org" });
-
-      await tx
-        .insert(schema.orgMembers)
-        .values({ orgId: org.id, userId, role: "owner" })
-        .onConflictDoNothing({ target: [schema.orgMembers.orgId, schema.orgMembers.userId] });
-
-      const [project] = await tx
-        .insert(schema.projects)
-        .values({ orgId: org.id, name: "Default", slug: "default" })
-        .returning();
-      if (!project) throw new HTTPException(500, { message: "failed to create default project" });
-
-      await tx
-        .insert(schema.projectAutomationSettings)
-        .values({ projectId: project.id, agentRunProvider: resolveDefaultAgentRunProvider() })
-        .onConflictDoNothing({ target: schema.projectAutomationSettings.projectId });
+      const { org, project } = await createOrgWithDefaults(tx, { userId, name: rawName });
 
       // Promote the new org to active on every session this user has open, so the
       // next /api/me call returns it without requiring a sign-out/sign-in round trip.

--- a/apps/api/src/org-crud.test.ts
+++ b/apps/api/src/org-crud.test.ts
@@ -1,0 +1,170 @@
+import "dotenv/config";
+import { strict as assert } from "node:assert";
+import { after, before, test } from "node:test";
+import { closeDb, db, runMigrations, schema } from "@superlog/db";
+import { and, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { mountOrgCrud } from "./orgs.js";
+
+type Vars = { userId: string; orgId: string | null };
+
+const orgIds: string[] = [];
+const userIds: string[] = [];
+
+before(async () => {
+  await runMigrations();
+});
+after(async () => {
+  try {
+    // Orgs first (cascades members/projects), then the users we seeded.
+    for (const orgId of orgIds.reverse()) {
+      await db.delete(schema.orgs).where(eq(schema.orgs.id, orgId));
+    }
+    for (const userId of userIds.reverse()) {
+      await db.delete(schema.users).where(eq(schema.users.id, userId));
+    }
+  } finally {
+    await closeDb();
+  }
+});
+
+function uniq(prefix: string) {
+  return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+}
+
+async function seedUser() {
+  const tag = uniq("ocrud-user");
+  const [user] = await db
+    .insert(schema.users)
+    .values({ email: `${tag}@example.com` })
+    .returning();
+  if (!user) throw new Error("seed user failed");
+  userIds.push(user.id);
+  return user;
+}
+
+async function seedOrgWithMember(userId: string, role: "owner" | "admin" | "member" = "owner") {
+  const tag = uniq("ocrud-org");
+  const [org] = await db.insert(schema.orgs).values({ name: tag, slug: tag }).returning();
+  if (!org) throw new Error("seed org failed");
+  orgIds.push(org.id);
+  await db.insert(schema.orgMembers).values({ orgId: org.id, userId, role });
+  return org;
+}
+
+function appFor(userId: string, orgId: string | null) {
+  const app = new Hono<{ Variables: Vars }>();
+  app.use("*", (c, next) => {
+    c.set("userId", userId);
+    c.set("orgId", orgId);
+    return next();
+  });
+  mountOrgCrud(app);
+  return app;
+}
+
+test("POST /api/orgs creates a new owner org with a Default project", async () => {
+  const user = await seedUser();
+  const app = appFor(user.id, null);
+
+  const res = await app.request("/api/orgs", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "Acme Two" }),
+  });
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as {
+    org: { id: string; name: string; slug: string };
+    project: { id: string; name: string; slug: string };
+  };
+  orgIds.push(body.org.id); // ensure teardown removes the endpoint-created org
+
+  assert.equal(body.org.name, "Acme Two");
+  assert.ok(body.org.slug.length > 0);
+
+  const member = await db.query.orgMembers.findFirst({
+    where: and(eq(schema.orgMembers.orgId, body.org.id), eq(schema.orgMembers.userId, user.id)),
+  });
+  assert.equal(member?.role, "owner");
+
+  const project = await db.query.projects.findFirst({
+    where: eq(schema.projects.id, body.project.id),
+  });
+  assert.equal(project?.orgId, body.org.id);
+  assert.equal(project?.slug, "default");
+
+  const settings = await db.query.projectAutomationSettings.findFirst({
+    where: eq(schema.projectAutomationSettings.projectId, body.project.id),
+  });
+  assert.ok(settings, "default project should have automation settings");
+});
+
+test("POST /api/orgs rejects an empty name", async () => {
+  const user = await seedUser();
+  const app = appFor(user.id, null);
+  const res = await app.request("/api/orgs", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "   " }),
+  });
+  assert.equal(res.status, 400);
+});
+
+test("DELETE /api/orgs/:id as owner removes the org and cascades its projects", async () => {
+  const user = await seedUser();
+  const keepOrg = await seedOrgWithMember(user.id, "owner");
+  const delOrg = await seedOrgWithMember(user.id, "owner");
+  const [proj] = await db
+    .insert(schema.projects)
+    .values({ orgId: delOrg.id, name: "Doomed", slug: uniq("doomed") })
+    .returning();
+  assert.ok(proj);
+
+  const app = appFor(user.id, delOrg.id);
+  const res = await app.request(`/api/orgs/${delOrg.id}`, { method: "DELETE" });
+  assert.equal(res.status, 200);
+
+  assert.equal(await db.query.orgs.findFirst({ where: eq(schema.orgs.id, delOrg.id) }), undefined);
+  assert.equal(
+    await db.query.projects.findFirst({ where: eq(schema.projects.id, proj.id) }),
+    undefined,
+    "project should be cascade-deleted with the org",
+  );
+  assert.ok(
+    await db.query.orgs.findFirst({ where: eq(schema.orgs.id, keepOrg.id) }),
+    "the caller's other org must be untouched",
+  );
+});
+
+test("DELETE /api/orgs/:id as a non-owner member is forbidden (403)", async () => {
+  const user = await seedUser();
+  await seedOrgWithMember(user.id, "owner"); // a second org so the last-org guard doesn't mask the 403
+  const org = await seedOrgWithMember(user.id, "member");
+
+  const app = appFor(user.id, org.id);
+  const res = await app.request(`/api/orgs/${org.id}`, { method: "DELETE" });
+  assert.equal(res.status, 403);
+  assert.ok(await db.query.orgs.findFirst({ where: eq(schema.orgs.id, org.id) }));
+});
+
+test("DELETE /api/orgs/:id of an org the caller doesn't belong to is 404", async () => {
+  const owner = await seedUser();
+  const org = await seedOrgWithMember(owner.id, "owner");
+  const stranger = await seedUser();
+  await seedOrgWithMember(stranger.id, "owner");
+
+  const app = appFor(stranger.id, null);
+  const res = await app.request(`/api/orgs/${org.id}`, { method: "DELETE" });
+  assert.equal(res.status, 404);
+  assert.ok(await db.query.orgs.findFirst({ where: eq(schema.orgs.id, org.id) }));
+});
+
+test("DELETE /api/orgs/:id of the caller's only org is blocked (409)", async () => {
+  const user = await seedUser();
+  const org = await seedOrgWithMember(user.id, "owner");
+
+  const app = appFor(user.id, org.id);
+  const res = await app.request(`/api/orgs/${org.id}`, { method: "DELETE" });
+  assert.equal(res.status, 409);
+  assert.ok(await db.query.orgs.findFirst({ where: eq(schema.orgs.id, org.id) }));
+});

--- a/apps/api/src/org-crud.test.ts
+++ b/apps/api/src/org-crud.test.ts
@@ -99,6 +99,27 @@ test("POST /api/orgs creates a new owner org with a Default project", async () =
   assert.ok(settings, "default project should have automation settings");
 });
 
+test("POST /api/orgs with a duplicate name succeeds with a distinct slug", async () => {
+  const user = await seedUser();
+  const app = appFor(user.id, null);
+  const name = "Dup Name Co";
+  const create = async () => {
+    const res = await app.request("/api/orgs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name }),
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { org: { id: string; slug: string } };
+    orgIds.push(body.org.id);
+    return body.org;
+  };
+  const first = await create();
+  const second = await create();
+  assert.notEqual(first.id, second.id);
+  assert.notEqual(first.slug, second.slug, "second org must get a unique slug, not a 500");
+});
+
 test("POST /api/orgs rejects an empty name", async () => {
   const user = await seedUser();
   const app = appFor(user.id, null);

--- a/apps/api/src/orgs.ts
+++ b/apps/api/src/orgs.ts
@@ -133,17 +133,24 @@ export function mountOrgCrud(app: Hono<{ Variables: Vars }>) {
     const orgId = c.req.param("orgId");
 
     const result = await db.transaction(async (tx) => {
-      // Lock *every* membership this user has, up front, and decide from the
-      // locked set. This serializes concurrent deletes by the same user, so two
-      // requests deleting two different orgs can't both pass the last-org guard
-      // and leave the user with zero orgs. Locking only the target org row
-      // wouldn't help — deletes of different orgs take non-conflicting locks.
-      // The unique (org_id, user_id) index means one row per org the caller is in.
+      // Serialize this user's concurrent org mutations on their `users` row —
+      // the same lock the create path takes. The last-org guard only concerns
+      // the acting user, so one consistent per-user lock both enforces it (two
+      // tabs deleting two different orgs can't both pass and leave zero orgs)
+      // and avoids deadlocks: locking many org_members rows instead would let
+      // two owners each deleting an org the other also belongs to lock each
+      // other's membership rows in opposite order during the cascade.
+      await tx
+        .select({ id: schema.users.id })
+        .from(schema.users)
+        .where(eq(schema.users.id, userId))
+        .for("update");
+
+      // One row per org the caller belongs to (unique (org_id, user_id) index).
       const memberships = await tx
         .select({ orgId: schema.orgMembers.orgId, role: schema.orgMembers.role })
         .from(schema.orgMembers)
-        .where(eq(schema.orgMembers.userId, userId))
-        .for("update");
+        .where(eq(schema.orgMembers.userId, userId));
 
       const membership = memberships.find((m) => m.orgId === orgId);
       // Don't leak the existence of orgs the caller can't see.

--- a/apps/api/src/orgs.ts
+++ b/apps/api/src/orgs.ts
@@ -1,5 +1,5 @@
 import { db, resolveDefaultAgentRunProvider, schema } from "@superlog/db";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import type { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { nanoid } from "nanoid";
@@ -8,6 +8,15 @@ type Vars = { userId: string; orgId: string | null };
 
 // The transaction handle drizzle passes to `db.transaction(async (tx) => …)`.
 type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+// Postgres unique-constraint violation. drizzle/postgres-js surfaces the raw
+// SQLSTATE either directly on the error or on its `cause`.
+function isUniqueViolation(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const direct = (err as { code?: unknown }).code;
+  const nested = (err as { cause?: { code?: unknown } }).cause?.code;
+  return direct === "23505" || nested === "23505";
+}
 
 export const ORG_NAME_MAX = 80;
 
@@ -44,8 +53,29 @@ export async function createOrgWithDefaults(
   org: typeof schema.orgs.$inferSelect;
   project: typeof schema.projects.$inferSelect;
 }> {
-  const slug = await uniqueOrgSlug(tx, slugifyOrgName(input.name));
-  const [org] = await tx.insert(schema.orgs).values({ name: input.name, slug }).returning();
+  // uniqueOrgSlug pre-checks for a free slug, but two concurrent creates can
+  // still pick the same slug between the check and the insert. Retry on the
+  // resulting unique-violation with a fresh suffixed slug, each attempt inside
+  // a SAVEPOINT (nested tx) so a failed insert rolls back just that attempt
+  // instead of poisoning the whole org-creation transaction.
+  const base = slugifyOrgName(input.name) || "org";
+  let org: typeof schema.orgs.$inferSelect | undefined;
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const slug =
+      attempt === 0
+        ? await uniqueOrgSlug(tx, base)
+        : `${base.slice(0, 32)}-${nanoid(6).toLowerCase()}`;
+    try {
+      org = await tx.transaction(async (sp) => {
+        const [row] = await sp.insert(schema.orgs).values({ name: input.name, slug }).returning();
+        return row;
+      });
+      break;
+    } catch (err) {
+      if (isUniqueViolation(err) && attempt < 4) continue;
+      throw err;
+    }
+  }
   if (!org) throw new HTTPException(500, { message: "failed to create org" });
 
   await tx
@@ -103,17 +133,19 @@ export function mountOrgCrud(app: Hono<{ Variables: Vars }>) {
     const orgId = c.req.param("orgId");
 
     const result = await db.transaction(async (tx) => {
-      // Lock the org row so a concurrent delete/rename serializes behind us.
-      const [org] = await tx
-        .select({ id: schema.orgs.id })
-        .from(schema.orgs)
-        .where(eq(schema.orgs.id, orgId))
+      // Lock *every* membership this user has, up front, and decide from the
+      // locked set. This serializes concurrent deletes by the same user, so two
+      // requests deleting two different orgs can't both pass the last-org guard
+      // and leave the user with zero orgs. Locking only the target org row
+      // wouldn't help — deletes of different orgs take non-conflicting locks.
+      // The unique (org_id, user_id) index means one row per org the caller is in.
+      const memberships = await tx
+        .select({ orgId: schema.orgMembers.orgId, role: schema.orgMembers.role })
+        .from(schema.orgMembers)
+        .where(eq(schema.orgMembers.userId, userId))
         .for("update");
-      if (!org) return { status: 404 as const, body: { error: "organization not found" } };
 
-      const membership = await tx.query.orgMembers.findFirst({
-        where: and(eq(schema.orgMembers.orgId, orgId), eq(schema.orgMembers.userId, userId)),
-      });
+      const membership = memberships.find((m) => m.orgId === orgId);
       // Don't leak the existence of orgs the caller can't see.
       if (!membership) return { status: 404 as const, body: { error: "organization not found" } };
       if (membership.role !== "owner") {
@@ -122,14 +154,8 @@ export function mountOrgCrud(app: Hono<{ Variables: Vars }>) {
           body: { error: "only an owner can delete an organization" },
         };
       }
-
       // Every user keeps at least one org — mirror the "cannot delete the last
-      // project in an org" guard. The unique (org_id, user_id) index means the
-      // row count equals the number of distinct orgs the caller belongs to.
-      const memberships = await tx
-        .select({ orgId: schema.orgMembers.orgId })
-        .from(schema.orgMembers)
-        .where(eq(schema.orgMembers.userId, userId));
+      // project in an org" guard.
       if (memberships.length <= 1) {
         return {
           status: 409 as const,

--- a/apps/api/src/orgs.ts
+++ b/apps/api/src/orgs.ts
@@ -1,0 +1,154 @@
+import { db, resolveDefaultAgentRunProvider, schema } from "@superlog/db";
+import { and, eq } from "drizzle-orm";
+import type { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { nanoid } from "nanoid";
+
+type Vars = { userId: string; orgId: string | null };
+
+// The transaction handle drizzle passes to `db.transaction(async (tx) => …)`.
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+export const ORG_NAME_MAX = 80;
+
+export function slugifyOrgName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+}
+
+export async function uniqueOrgSlug(
+  client: Pick<typeof db, "query">,
+  base: string,
+): Promise<string> {
+  const seed = base || "org";
+  let candidate = seed;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const existing = await client.query.orgs.findFirst({ where: eq(schema.orgs.slug, candidate) });
+    if (!existing) return candidate;
+    candidate = `${seed.slice(0, 32)}-${nanoid(6).toLowerCase()}`;
+  }
+  return `${seed.slice(0, 20)}-${nanoid(12).toLowerCase()}`;
+}
+
+// Creates an org with the caller as owner plus a "Default" project and its
+// automation settings — the shared core behind both first-org onboarding
+// (POST /api/me/orgs) and creating additional orgs (POST /api/orgs). Must run
+// inside a transaction so a failure rolls the whole thing back.
+export async function createOrgWithDefaults(
+  tx: Tx,
+  input: { userId: string; name: string },
+): Promise<{
+  org: typeof schema.orgs.$inferSelect;
+  project: typeof schema.projects.$inferSelect;
+}> {
+  const slug = await uniqueOrgSlug(tx, slugifyOrgName(input.name));
+  const [org] = await tx.insert(schema.orgs).values({ name: input.name, slug }).returning();
+  if (!org) throw new HTTPException(500, { message: "failed to create org" });
+
+  await tx
+    .insert(schema.orgMembers)
+    .values({ orgId: org.id, userId: input.userId, role: "owner" })
+    .onConflictDoNothing({ target: [schema.orgMembers.orgId, schema.orgMembers.userId] });
+
+  const [project] = await tx
+    .insert(schema.projects)
+    .values({ orgId: org.id, name: "Default", slug: "default" })
+    .returning();
+  if (!project) throw new HTTPException(500, { message: "failed to create default project" });
+
+  await tx
+    .insert(schema.projectAutomationSettings)
+    .values({ projectId: project.id, agentRunProvider: resolveDefaultAgentRunProvider() })
+    .onConflictDoNothing({ target: schema.projectAutomationSettings.projectId });
+
+  return { org, project };
+}
+
+export function mountOrgCrud(app: Hono<{ Variables: Vars }>) {
+  // Create an additional organization. Unlike POST /api/me/orgs (idempotent
+  // first-org onboarding), this always creates a fresh org. The web client
+  // calls authClient.organization.setActive() afterwards to switch into it, so
+  // we don't touch sessions or fire the onboarding-only Loops welcome flow.
+  app.post("/api/orgs", async (c) => {
+    const body = (await c.req.json().catch(() => ({}))) as { name?: unknown };
+    const rawName = typeof body.name === "string" ? body.name.trim() : "";
+    if (!rawName) throw new HTTPException(400, { message: "name required" });
+    if (rawName.length > ORG_NAME_MAX) {
+      throw new HTTPException(400, { message: `name must be ${ORG_NAME_MAX} chars or fewer` });
+    }
+
+    const userId = c.var.userId;
+    const { org, project } = await db.transaction(async (tx) => {
+      const [user] = await tx
+        .select({ id: schema.users.id })
+        .from(schema.users)
+        .where(eq(schema.users.id, userId))
+        .for("update");
+      if (!user) throw new HTTPException(404, { message: "user not found" });
+      return createOrgWithDefaults(tx, { userId, name: rawName });
+    });
+
+    return c.json({
+      org: { id: org.id, name: org.name, slug: org.slug },
+      project: { id: project.id, name: project.name, slug: project.slug },
+    });
+  });
+
+  // Delete an organization. Owner-only, and never the caller's last org.
+  app.delete("/api/orgs/:orgId", async (c) => {
+    const userId = c.var.userId;
+    const orgId = c.req.param("orgId");
+
+    const result = await db.transaction(async (tx) => {
+      // Lock the org row so a concurrent delete/rename serializes behind us.
+      const [org] = await tx
+        .select({ id: schema.orgs.id })
+        .from(schema.orgs)
+        .where(eq(schema.orgs.id, orgId))
+        .for("update");
+      if (!org) return { status: 404 as const, body: { error: "organization not found" } };
+
+      const membership = await tx.query.orgMembers.findFirst({
+        where: and(eq(schema.orgMembers.orgId, orgId), eq(schema.orgMembers.userId, userId)),
+      });
+      // Don't leak the existence of orgs the caller can't see.
+      if (!membership) return { status: 404 as const, body: { error: "organization not found" } };
+      if (membership.role !== "owner") {
+        return {
+          status: 403 as const,
+          body: { error: "only an owner can delete an organization" },
+        };
+      }
+
+      // Every user keeps at least one org — mirror the "cannot delete the last
+      // project in an org" guard. The unique (org_id, user_id) index means the
+      // row count equals the number of distinct orgs the caller belongs to.
+      const memberships = await tx
+        .select({ orgId: schema.orgMembers.orgId })
+        .from(schema.orgMembers)
+        .where(eq(schema.orgMembers.userId, userId));
+      if (memberships.length <= 1) {
+        return {
+          status: 409 as const,
+          body: { error: "cannot delete your only organization" },
+        };
+      }
+
+      // Cascades clean up members, projects (+ all their children), invitations,
+      // org API keys, integrations, GitHub installs, and agent memories/settings.
+      // users.activeOrgId/favoriteOrgId and sessions.activeOrganizationId are
+      // SET NULL, so the caller's next /api/me re-resolves an active org via the
+      // favorite > last-used > first precedence.
+      // NOTE: the org's Autumn billing customer (when billing is configured) is
+      // intentionally NOT torn down here — orphaned-customer cleanup is a tracked
+      // follow-up, out of scope for self-serve delete.
+      await tx.delete(schema.orgs).where(eq(schema.orgs.id, orgId));
+      return { status: 200 as const, body: { ok: true } };
+    });
+
+    return c.json(result.body, result.status);
+  });
+}

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -90,6 +90,8 @@ import { Dropdown, type DropdownOption } from "./design/Dropdown.tsx";
 import { Btn, Chip, FieldLabel, Input, Label, Tile } from "./design/ui";
 import { AgentMemoriesCard } from "./settings/AgentMemoriesCard.tsx";
 import { BillingCard } from "./settings/BillingCard.tsx";
+import { CreateOrgCard } from "./settings/CreateOrgCard.tsx";
+import { OrgDangerCard } from "./settings/OrgDangerCard.tsx";
 import { OrgGeneralCard } from "./settings/OrgGeneralCard.tsx";
 import { OrgMembersCard } from "./settings/OrgMembersCard.tsx";
 import {
@@ -517,6 +519,15 @@ function OrgSectionView({ section }: { section: OrgSectionId }) {
             subtitle="A short Slack recap of the top 3 pending bug-fix PRs, ranked by an LLM."
           >
             <WeeklyDigestCard />
+          </Section>
+          <Section
+            title="Create organization"
+            subtitle="Spin up another organization — useful for separating teams, clients, or environments."
+          >
+            <CreateOrgCard />
+          </Section>
+          <Section title="Danger zone" subtitle="Irreversible actions for this organization.">
+            <OrgDangerCard />
           </Section>
         </div>
       );

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -128,36 +128,29 @@ export function useCreateMyFirstOrg() {
   });
 }
 
-// Create an additional organization (the caller already has one). The settings
-// UI switches the active org to the new one after this resolves.
+// Create an additional organization (the caller already has one). Callers
+// switch the active org to the new one and then invalidate ["me"] /
+// ["org-projects"] — so invalidation lives at the call site (after setActive),
+// not here, to avoid a premature refetch against the old active org.
 export function useCreateOrg() {
   const fetcher = useFetcher();
-  const qc = useQueryClient();
   return useMutation({
     mutationFn: (name: string) =>
       fetcher<{
         org: { id: string; name: string; slug: string };
         project: { id: string; name: string; slug: string };
       }>("/api/orgs", { method: "POST", body: JSON.stringify({ name }) }),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["me"] });
-      qc.invalidateQueries({ queryKey: ["org-projects"] });
-    },
   });
 }
 
 // Delete an organization (owner-only, and never the caller's last org — both
-// enforced server-side). The caller should setActive() to a remaining org first.
+// enforced server-side). Callers setActive() to a remaining org first and then
+// invalidate the org-scoped queries, so invalidation lives at the call site.
 export function useDeleteOrg() {
   const fetcher = useFetcher();
-  const qc = useQueryClient();
   return useMutation({
     mutationFn: (orgId: string) =>
       fetcher<{ ok: true }>(`/api/orgs/${orgId}`, { method: "DELETE" }),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["me"] });
-      qc.invalidateQueries({ queryKey: ["org-projects"] });
-    },
   });
 }
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -128,6 +128,39 @@ export function useCreateMyFirstOrg() {
   });
 }
 
+// Create an additional organization (the caller already has one). The settings
+// UI switches the active org to the new one after this resolves.
+export function useCreateOrg() {
+  const fetcher = useFetcher();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (name: string) =>
+      fetcher<{
+        org: { id: string; name: string; slug: string };
+        project: { id: string; name: string; slug: string };
+      }>("/api/orgs", { method: "POST", body: JSON.stringify({ name }) }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["me"] });
+      qc.invalidateQueries({ queryKey: ["org-projects"] });
+    },
+  });
+}
+
+// Delete an organization (owner-only, and never the caller's last org — both
+// enforced server-side). The caller should setActive() to a remaining org first.
+export function useDeleteOrg() {
+  const fetcher = useFetcher();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (orgId: string) =>
+      fetcher<{ ok: true }>(`/api/orgs/${orgId}`, { method: "DELETE" }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["me"] });
+      qc.invalidateQueries({ queryKey: ["org-projects"] });
+    },
+  });
+}
+
 export type SignupIntentClaim = {
   id: string | null;
   keyPrefix: string;

--- a/apps/web/src/settings/CreateOrgCard.tsx
+++ b/apps/web/src/settings/CreateOrgCard.tsx
@@ -1,0 +1,79 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useCreateOrg } from "../api.ts";
+import { authClient } from "../auth-client.ts";
+import { Btn, Input } from "../design/ui.tsx";
+import { SettingsCard, SettingsCardFooter, SettingsRow } from "./rows.tsx";
+
+const ORG_NAME_MAX = 80;
+
+function errorMessage(err: unknown): string {
+  // useFetcher throws `Error("<status>: <body>")`; the body is JSON {error}.
+  const raw = err instanceof Error ? err.message : String(err);
+  const match = raw.match(/^\d+:\s*(.*)$/s);
+  const payload = match?.[1] ?? raw;
+  try {
+    const parsed = JSON.parse(payload) as { error?: string };
+    if (parsed.error) return parsed.error;
+  } catch {}
+  return payload || "Failed to create organization";
+}
+
+export function CreateOrgCard() {
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const qc = useQueryClient();
+  const navigate = useNavigate();
+  const create = useCreateOrg();
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Name is required");
+      return;
+    }
+    create.mutate(trimmed, {
+      onSuccess: async (data) => {
+        // Switch into the new org so the user lands in it, then refresh the
+        // surfaces that read org context and go to the dashboard.
+        await authClient.organization.setActive({ organizationId: data.org.id }).catch(() => {});
+        await Promise.all([
+          qc.invalidateQueries({ queryKey: ["me"] }),
+          qc.invalidateQueries({ queryKey: ["org-projects"] }),
+        ]);
+        setName("");
+        navigate("/");
+      },
+      onError: (err) => setError(errorMessage(err)),
+    });
+  };
+
+  return (
+    <form onSubmit={submit}>
+      <SettingsCard>
+        <SettingsRow
+          title="New organization"
+          description="Create a separate org with its own projects, members, and billing. You'll be switched to it."
+          control={
+            <div className="w-60">
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value.slice(0, ORG_NAME_MAX))}
+                placeholder="Acme Inc"
+              />
+            </div>
+          }
+        />
+        <SettingsCardFooter>
+          {error && <span className="mr-auto text-[12px] text-danger">{error}</span>}
+          <Btn type="submit" size="sm" loading={create.isPending} disabled={!name.trim()}>
+            Create organization
+          </Btn>
+        </SettingsCardFooter>
+      </SettingsCard>
+    </form>
+  );
+}

--- a/apps/web/src/settings/CreateOrgCard.tsx
+++ b/apps/web/src/settings/CreateOrgCard.tsx
@@ -4,21 +4,10 @@ import { useNavigate } from "react-router-dom";
 import { useCreateOrg } from "../api.ts";
 import { authClient } from "../auth-client.ts";
 import { Btn, Input } from "../design/ui.tsx";
+import { fetchErrorMessage } from "./orgErrors.ts";
 import { SettingsCard, SettingsCardFooter, SettingsRow } from "./rows.tsx";
 
 const ORG_NAME_MAX = 80;
-
-function errorMessage(err: unknown): string {
-  // useFetcher throws `Error("<status>: <body>")`; the body is JSON {error}.
-  const raw = err instanceof Error ? err.message : String(err);
-  const match = raw.match(/^\d+:\s*(.*)$/s);
-  const payload = match?.[1] ?? raw;
-  try {
-    const parsed = JSON.parse(payload) as { error?: string };
-    if (parsed.error) return parsed.error;
-  } catch {}
-  return payload || "Failed to create organization";
-}
 
 export function CreateOrgCard() {
   const [name, setName] = useState("");
@@ -47,7 +36,7 @@ export function CreateOrgCard() {
         setName("");
         navigate("/");
       },
-      onError: (err) => setError(errorMessage(err)),
+      onError: (err) => setError(fetchErrorMessage(err, "Failed to create organization")),
     });
   };
 

--- a/apps/web/src/settings/OrgDangerCard.tsx
+++ b/apps/web/src/settings/OrgDangerCard.tsx
@@ -5,19 +5,8 @@ import { useDeleteOrg, useMe } from "../api.ts";
 import { authClient, useListOrganizations } from "../auth-client.ts";
 import { Btn, Input } from "../design/ui.tsx";
 import { nextOrgIdAfterDelete } from "./nav.ts";
+import { fetchErrorMessage } from "./orgErrors.ts";
 import { SettingsCard, SettingsCardFooter, SettingsRow } from "./rows.tsx";
-
-function errorMessage(err: unknown): string {
-  // useFetcher throws `Error("<status>: <body>")`; the body is JSON {error}.
-  const raw = err instanceof Error ? err.message : String(err);
-  const match = raw.match(/^\d+:\s*(.*)$/s);
-  const payload = match?.[1] ?? raw;
-  try {
-    const parsed = JSON.parse(payload) as { error?: string };
-    if (parsed.error) return parsed.error;
-  } catch {}
-  return payload || "Failed to delete organization";
-}
 
 export function OrgDangerCard() {
   const me = useMe();
@@ -71,7 +60,7 @@ export function OrgDangerCard() {
         ]);
         navigate("/");
       },
-      onError: (err) => setError(errorMessage(err)),
+      onError: (err) => setError(fetchErrorMessage(err, "Failed to delete organization")),
     });
   };
 

--- a/apps/web/src/settings/OrgDangerCard.tsx
+++ b/apps/web/src/settings/OrgDangerCard.tsx
@@ -1,0 +1,115 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useDeleteOrg, useMe } from "../api.ts";
+import { authClient, useListOrganizations } from "../auth-client.ts";
+import { Btn, Input } from "../design/ui.tsx";
+import { nextOrgIdAfterDelete } from "./nav.ts";
+import { SettingsCard, SettingsCardFooter, SettingsRow } from "./rows.tsx";
+
+function errorMessage(err: unknown): string {
+  // useFetcher throws `Error("<status>: <body>")`; the body is JSON {error}.
+  const raw = err instanceof Error ? err.message : String(err);
+  const match = raw.match(/^\d+:\s*(.*)$/s);
+  const payload = match?.[1] ?? raw;
+  try {
+    const parsed = JSON.parse(payload) as { error?: string };
+    if (parsed.error) return parsed.error;
+  } catch {}
+  return payload || "Failed to delete organization";
+}
+
+export function OrgDangerCard() {
+  const me = useMe();
+  const orgId = me.data?.org?.id;
+  const orgName = me.data?.org?.name ?? "";
+  const myUserId = me.data?.user.id;
+
+  const orgsQ = useListOrganizations();
+  const membersQ = useQuery({
+    queryKey: orgId ? ["org-members", orgId] : ["org-members", "none"],
+    enabled: !!orgId,
+    queryFn: async () => {
+      const res = await authClient.organization.listMembers({ query: { organizationId: orgId } });
+      if (res.error) throw new Error(res.error.message ?? "Failed to load members");
+      return (res.data?.members ?? []) as Array<{ userId: string; role: string }>;
+    },
+  });
+
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const qc = useQueryClient();
+  const navigate = useNavigate();
+  const del = useDeleteOrg();
+
+  if (!orgId) return null;
+
+  const myRole = membersQ.data?.find((m) => m.userId === myUserId)?.role ?? "member";
+  const isOwner = myRole === "owner";
+  const orgCount = orgsQ.data?.length ?? 1;
+  const isLastOrg = orgCount <= 1;
+  const blockedReason = !isOwner
+    ? "Only an owner can delete this organization."
+    : isLastOrg
+      ? "You can't delete your only organization — create another one first."
+      : null;
+  const confirmed = confirm.trim() === orgName;
+
+  const onDelete = () => {
+    setError(null);
+    del.mutate(orgId, {
+      onSuccess: async () => {
+        // Switch into a remaining org before the deleted one disappears from
+        // under the active session, then refresh and go to the dashboard.
+        const nextId = nextOrgIdAfterDelete(orgsQ.data ?? [], orgId);
+        if (nextId) {
+          await authClient.organization.setActive({ organizationId: nextId }).catch(() => {});
+        }
+        await Promise.all([
+          qc.invalidateQueries({ queryKey: ["me"] }),
+          qc.invalidateQueries({ queryKey: ["org-projects"] }),
+        ]);
+        navigate("/");
+      },
+      onError: (err) => setError(errorMessage(err)),
+    });
+  };
+
+  return (
+    <SettingsCard className="border-danger/40">
+      <SettingsRow
+        title="Delete this organization"
+        description={
+          blockedReason ??
+          `Permanently deletes ${orgName} and all its projects, members, and data. This can't be undone.`
+        }
+        control={
+          blockedReason ? null : (
+            <div className="w-60">
+              <Input
+                value={confirm}
+                onChange={(e) => setConfirm(e.target.value)}
+                placeholder={`Type "${orgName}" to confirm`}
+              />
+            </div>
+          )
+        }
+      />
+      {!blockedReason && (
+        <SettingsCardFooter>
+          {error && <span className="mr-auto text-[12px] text-danger">{error}</span>}
+          <Btn
+            type="button"
+            size="sm"
+            variant="danger"
+            loading={del.isPending}
+            disabled={!confirmed}
+            onClick={onDelete}
+          >
+            Delete organization
+          </Btn>
+        </SettingsCardFooter>
+      )}
+    </SettingsCard>
+  );
+}

--- a/apps/web/src/settings/nav.test.ts
+++ b/apps/web/src/settings/nav.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   ORG_NAV_GROUPS,
   PROJECT_NAV_GROUPS,
+  nextOrgIdAfterDelete,
   nextProjectIdAfterDelete,
   projectPickerOptions,
   resolveOrgSection,
@@ -92,4 +93,13 @@ test("project deletion selects a neighboring project for the URL", () => {
   assert.equal(nextProjectIdAfterDelete(projects, "p3"), "p2");
   assert.equal(nextProjectIdAfterDelete(projects, "p1"), "p2");
   assert.equal(nextProjectIdAfterDelete([{ id: "p1", name: "One" }], "p1"), undefined);
+});
+
+test("nextOrgIdAfterDelete picks the neighbour at the same position", () => {
+  const orgs = [{ id: "o1" }, { id: "o2" }, { id: "o3" }];
+  assert.equal(nextOrgIdAfterDelete(orgs, "o2"), "o3");
+  assert.equal(nextOrgIdAfterDelete(orgs, "o3"), "o2");
+  assert.equal(nextOrgIdAfterDelete(orgs, "o1"), "o2");
+  assert.equal(nextOrgIdAfterDelete([{ id: "o1" }], "o1"), undefined);
+  assert.equal(nextOrgIdAfterDelete(orgs, "missing"), "o1");
 });

--- a/apps/web/src/settings/nav.ts
+++ b/apps/web/src/settings/nav.ts
@@ -120,3 +120,17 @@ export function nextProjectIdAfterDelete(
   if (deletedIndex < 0) return remaining[0]?.id;
   return remaining[Math.min(deletedIndex, remaining.length - 1)]?.id;
 }
+
+// Which org to switch to after deleting one — pick the neighbour at the same
+// position, mirroring nextProjectIdAfterDelete. Returns undefined only if no
+// orgs remain (which the delete endpoint forbids, but keep the UI defensive).
+export function nextOrgIdAfterDelete(
+  orgs: ReadonlyArray<{ id: string }>,
+  deletedOrgId: string,
+): string | undefined {
+  const deletedIndex = orgs.findIndex((o) => o.id === deletedOrgId);
+  const remaining = orgs.filter((o) => o.id !== deletedOrgId);
+  if (remaining.length === 0) return undefined;
+  if (deletedIndex < 0) return remaining[0]?.id;
+  return remaining[Math.min(deletedIndex, remaining.length - 1)]?.id;
+}

--- a/apps/web/src/settings/orgErrors.ts
+++ b/apps/web/src/settings/orgErrors.ts
@@ -1,0 +1,14 @@
+// Pull a human-readable message out of an error thrown by `useFetcher`, which
+// throws `Error("<status>: <body>")` where <body> is JSON like `{"error": "…"}`.
+// Used by the org create/delete settings cards so their error handling stays
+// consistent.
+export function fetchErrorMessage(err: unknown, fallback: string): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const match = raw.match(/^\d+:\s*(.*)$/s);
+  const payload = match?.[1] ?? raw;
+  try {
+    const parsed = JSON.parse(payload) as { error?: string };
+    if (parsed.error) return parsed.error;
+  } catch {}
+  return payload || fallback;
+}


### PR DESCRIPTION
## Summary

Lets users create additional organizations and delete ones they own, from **Settings → Organization → General**.

Previously a user could only get an org once, during onboarding: `POST /api/me/orgs` is idempotent and returns the existing org if the caller already has a membership. There was no way to create a second org and no way to delete one.

## Backend — new `apps/api/src/orgs.ts` (mounted in `index.ts`)

- **`createOrgWithDefaults()`** — shared helper that creates the org, the owner membership, a `Default` project, and its automation settings. The existing onboarding handler (`POST /api/me/orgs`) now reuses it so the two creation paths can't drift.
- **`POST /api/orgs`** — always creates a new org (unlike the idempotent onboarding endpoint). The client switches the active org to it afterwards.
- **`DELETE /api/orgs/:orgId`** — **owner-only** (403 for non-owner members; 404 when the caller isn't a member at all, to avoid leaking org existence), and **refuses to delete the caller's last org** (409), mirroring the existing "cannot delete the last project" rule. A single `DELETE FROM orgs` relies on the existing `org_id` FK cascades / `SET NULL`s, so **no migration is needed**.

## Frontend — `apps/web/src`

- `useCreateOrg` / `useDeleteOrg` hooks and a pure `nextOrgIdAfterDelete` nav helper.
- `CreateOrgCard` and a type-to-confirm Danger-zone `OrgDangerCard` rendered in the org General settings section. Delete is hidden for non-owners and shows a blocked message when it's the caller's only org. The server remains the source of truth for both rules.

## Tests

- `apps/api/src/org-crud.test.ts` — create (new owner org + Default project), delete-as-owner (cascade), non-owner → 403, non-member → 404, last-org → 409.
- `apps/web/src/settings/nav.test.ts` — `nextOrgIdAfterDelete`.

## Verification

- API + web typecheck clean; new files lint-clean.
- New API tests + nav test green.
- End-to-end against a running stack: create → 200, delete with ≥2 orgs → 200 (org + projects cascade-deleted, confirmed in Postgres), last org → 409.
- Browser walkthrough: both cards render; single-org Danger zone shows the blocked state with no delete button; creating an org switches into it; with ≥2 orgs the type-to-confirm delete is enabled.

## Follow-up (out of scope)

When billing is configured each org maps to an Autumn billing customer; deleting the org doesn't tear that customer down. Flagged in a code comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users create additional organizations and delete ones they own from Settings → Organization → General. Adds API + UI, switches into the new org on create, and enforces owner-only delete with a last-org safeguard.

- **New Features**
  - API: `POST /api/orgs` always creates a new org plus a `Default` project; onboarding `POST /api/me/orgs` now reuses `createOrgWithDefaults()`. No DB migration.
  - API: `DELETE /api/orgs/:orgId` is owner-only; non-members get 404; returns 409 if deleting the caller’s only org.
  - Web: `CreateOrgCard` and `OrgDangerCard`; hooks `useCreateOrg` and `useDeleteOrg`. On create, switch active org; on delete, switch to a neighbor via `nextOrgIdAfterDelete`.

- **Bug Fixes**
  - Concurrency and slugging: last-org guard now serializes on the caller’s `users` row to avoid deadlocks while preventing concurrent deletes from leaving zero orgs; slug creation retries on unique-violation (SAVEPOINT). Added a duplicate-name test, extracted `fetchErrorMessage`, and removed redundant hook-level query invalidation.

<sup>Written for commit 8b391dbcf9035b7b7f2828dadee219812d401a58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

