### PR TITLE
perf(autorecovery): rollup service-traffic counts + reap stranded agent runs

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -26,6 +26,7 @@
     "test:alerts-evaluate": "tsx --test src/alerts/evaluate.test.ts",
     "test:autorecovery-domain": "tsx --test src/autorecovery/domain.test.ts",
     "test:autorecovery-agent": "tsx --test src/autorecovery/agent.test.ts",
+    "test:autorecovery-metrics": "tsx --test src/autorecovery/metrics-repository.test.ts",
     "test:autorecovery-tick": "tsx --test src/autorecovery/tick.test.ts",
     "test:grouping-domain": "tsx --test src/grouping/domain.test.ts",
     "test:grouping-candidate-search": "tsx --test src/grouping/candidate-search.test.ts",

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -477,6 +477,30 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
     }
   } catch (err) {
     if (isTransientError(err)) {
+      // A run whose provider session has gone permanently unreachable (e.g. a
+      // session abandoned across a deploy, or one Anthropic has since reaped)
+      // throws a transient-shaped error — timeout / connection reset / 5xx —
+      // on EVERY collect(). Left alone it retries forever and sits in
+      // `running` indefinitely (weeks, in prod), holding a slot in the active
+      // set that the tick rotates through on every pass. The wall-clock
+      // backstop above can't catch these: it lives past the collect() call
+      // that's throwing. So apply the same budget here — once a run has blown
+      // its wall-clock budget, stop retrying transient failures and reap it.
+      if (
+        exceededWallClockBudget({
+          startedAt: ctx.agentRun.startedAt,
+          now: new Date(),
+          maxRuntimeMinutes: ctx.automation.maxRuntimeMinutes,
+        })
+      ) {
+        await failAgentRun(
+          ctx,
+          "wall_clock_timeout",
+          "Investigation exceeded its wall-clock budget while its managed session stayed unreachable.",
+          { err },
+        );
+        return;
+      }
       logger.error(
         {
           err,

--- a/apps/worker/src/agent-runs/tick.ts
+++ b/apps/worker/src/agent-runs/tick.ts
@@ -2,13 +2,17 @@ import { SpanStatusCode, trace } from "@opentelemetry/api";
 import { db, schema } from "@superlog/db";
 import { asc, eq, inArray } from "drizzle-orm";
 import { loadAgentRunContext } from "../agent-run-context.js";
-import { ACTIVE_STATES as AGENT_RUN_ACTIVE_STATES } from "../agent-run.js";
+import {
+  ACTIVE_STATES as AGENT_RUN_ACTIVE_STATES,
+  createAgentRunLifecycle,
+} from "../agent-run.js";
 import { retryQueuedPullRequestDelivery } from "./pr-delivery.js";
 import { resumeAgentRunFromHumanInput } from "./resume.js";
 import { startQueuedAgentRun } from "./start-run.js";
 import { syncRunningAgentRun } from "./sync.js";
 
 const tracer = trace.getTracer("@superlog/worker");
+const lifecycle = createAgentRunLifecycle(db);
 const AGENT_RUN_BATCH_SIZE = parsePositiveInt(
   process.env.AGENT_RUN_BATCH_SIZE ?? process.env.INVESTIGATION_BATCH_SIZE,
   20,
@@ -50,7 +54,23 @@ export async function tickAgentRuns(): Promise<number> {
           .set({ updatedAt: new Date() })
           .where(eq(schema.agentRuns.id, agentRun.id));
         const ctx = await loadAgentRunContext(agentRun);
-        if (!ctx) continue;
+        if (!ctx) {
+          // loadAgentRunContext returns null only when the run's incident or
+          // project row is gone (deleted) — a permanent condition; transient
+          // DB errors throw and are handled by the surrounding span. Such a
+          // run can never make progress, so failing here is the only way it
+          // leaves an active state. Skipping it (the old behaviour) left it
+          // rotating through the asc(updatedAt) batch forever as dead weight
+          // that crowds out runnable work.
+          await lifecycle.fail({
+            id: agentRun.id,
+            currentState: agentRun.state,
+            reason: "context_unavailable",
+            summary: "Investigation's incident or project no longer exists.",
+            category: "infra",
+          });
+          continue;
+        }
         processed += 1;
         if (ctx.agentRun.state === "queued" || ctx.agentRun.state === "repo_discovery") {
           await startQueuedAgentRun(ctx);

--- a/apps/worker/src/autorecovery/metrics-repository.test.ts
+++ b/apps/worker/src/autorecovery/metrics-repository.test.ts
@@ -7,7 +7,10 @@ import { createAutorecoveryMetricsRepository } from "./metrics-repository.js";
 
 type CapturedQuery = { query: string; params: Record<string, unknown> };
 
-function makeFakeCh(rows: Array<Record<string, unknown>>): {
+function makeFakeCh(
+  rows: Array<Record<string, unknown>>,
+  opts: { rollupExists?: boolean } = {},
+): {
   client: ClickHouseClient;
   captured: CapturedQuery[];
 } {
@@ -15,14 +18,25 @@ function makeFakeCh(rows: Array<Record<string, unknown>>): {
   const client = {
     async query(input: { query: string; query_params: Record<string, unknown> }) {
       captured.push({ query: input.query, params: input.query_params });
+      const isProbe = /EXISTS TABLE/i.test(input.query);
       return {
         async json() {
+          // The rollup fast path probes `EXISTS TABLE events_per_minute` once;
+          // answer it so the data query under test is exercised, defaulting to
+          // "rollup present" unless a test opts out.
+          if (isProbe) return [{ result: opts.rollupExists === false ? 0 : 1 }];
           return rows;
         },
       };
     },
   } as unknown as ClickHouseClient;
   return { client, captured };
+}
+
+// The data query is whatever the repository runs that isn't the availability
+// probe.
+function dataQuery(captured: CapturedQuery[]): CapturedQuery | undefined {
+  return captured.find((q) => !/EXISTS TABLE/i.test(q.query));
 }
 
 function makeCandidate(overrides: Partial<CandidateIncident> = {}): CandidateIncident {
@@ -105,18 +119,55 @@ test("queryIncidentActivity short-circuits with zero events when there are no si
   assert.deepEqual(result, { totalEvents: 0, perHour: [], lookbackHours: 24 });
 });
 
-test("queryServiceTraffic ignores issue signatures and counts all spans on the service", async () => {
+test("queryServiceTraffic reads the events_per_minute rollup, summing trace counts", async () => {
   const { client, captured } = makeFakeCh([{ hour: "2026-05-23 00:00:00", count: "1500" }]);
   const repo = createAutorecoveryMetricsRepository(async () => client);
 
   const result = await repo.queryServiceTraffic(makeCandidate(), 6);
 
-  assert.equal(captured.length, 1);
-  const q = captured[0];
-  assert.ok(q);
+  const q = dataQuery(captured);
+  assert.ok(q, "expected a data query");
+  // The raw otel_traces scan reads every span in the window — 100M+ rows for a
+  // high-volume service over a multi-day lookback, which saturated the CH read
+  // pool and stalled the rest of the worker tick. The rollup answers the same
+  // per-service span count from pre-aggregated minute cells.
+  assert.match(q.query, /FROM events_per_minute/);
+  assert.doesNotMatch(q.query, /FROM otel_traces/);
+  assert.match(q.query, /signal = 'traces'/);
+  assert.match(q.query, /sum\(c\)/);
   // Service traffic is the "is the operation still being exercised" signal —
   // it must NOT be narrowed by exception type, otherwise a recovered error
   // path would look like a traffic dropout.
   assert.doesNotMatch(q.query, /exception_types/);
+  assert.equal(q.params.service, "@superlog/api");
+  assert.equal(q.params.hours, 6);
   assert.equal(result.totalSpans, 1500);
+});
+
+test("queryServiceTraffic falls back to the raw otel_traces scan when the rollup is absent", async () => {
+  // Self-hosted deployments that never ran the events_per_minute migration
+  // (it isn't part of the collector's auto-created schema) must still answer.
+  const { client, captured } = makeFakeCh([{ hour: "2026-05-23 00:00:00", count: "1500" }], {
+    rollupExists: false,
+  });
+  const repo = createAutorecoveryMetricsRepository(async () => client);
+
+  const result = await repo.queryServiceTraffic(makeCandidate(), 6);
+
+  const q = dataQuery(captured);
+  assert.ok(q, "expected a data query");
+  assert.match(q.query, /FROM otel_traces/);
+  assert.match(q.query, /ServiceName = \{service:String\}/);
+  assert.equal(result.totalSpans, 1500);
+});
+
+test("queryServiceTraffic short-circuits without querying when the incident has no service", async () => {
+  const { client, captured } = makeFakeCh([{ hour: "x", count: "999" }]);
+  const repo = createAutorecoveryMetricsRepository(async () => client);
+
+  const result = await repo.queryServiceTraffic(makeCandidate({ service: null }), 6);
+
+  // No service means no traffic question to ask — don't probe or scan.
+  assert.equal(captured.length, 0);
+  assert.deepEqual(result, { totalSpans: 0, perHour: [], lookbackHours: 6, service: null });
 });

--- a/apps/worker/src/autorecovery/metrics-repository.test.ts
+++ b/apps/worker/src/autorecovery/metrics-repository.test.ts
@@ -135,6 +135,10 @@ test("queryServiceTraffic reads the events_per_minute rollup, summing trace coun
   assert.doesNotMatch(q.query, /FROM otel_traces/);
   assert.match(q.query, /signal = 'traces'/);
   assert.match(q.query, /sum\(c\)/);
+  // Lower bound rounds to the rollup's minute granularity, not the hour —
+  // rounding to the hour would over-count the earliest bucket by up to ~59min
+  // and skew the traffic signal vs the raw path's exact bound.
+  assert.match(q.query, /minute >= toStartOfMinute\(/);
   // Service traffic is the "is the operation still being exercised" signal —
   // it must NOT be narrowed by exception type, otherwise a recovered error
   // path would look like a traffic dropout.

--- a/apps/worker/src/autorecovery/metrics-repository.ts
+++ b/apps/worker/src/autorecovery/metrics-repository.ts
@@ -109,7 +109,13 @@ export function createAutorecoveryMetricsRepository(getCh: () => Promise<ClickHo
             WHERE project_id = {project_id:String}
               AND signal = 'traces'
               AND service = {service:String}
-              AND minute >= toStartOfHour(now() - INTERVAL {hours:UInt32} HOUR)
+              -- Round the lower bound down to the rollup's minute granularity
+              -- (the finest it stores) to mirror the raw path's exact
+              -- now() - INTERVAL hours HOUR bound. Rounding to the hour instead
+              -- would pull up to ~59 extra minutes into the earliest bucket and
+              -- inflate the traffic signal. Matches the API read path
+              -- (countSeriesFromRollup in apps/api/src/mcp/clickhouse.ts).
+              AND minute >= toStartOfMinute(now() - INTERVAL {hours:UInt32} HOUR)
             GROUP BY hour
             ORDER BY hour ASC
           `,

--- a/apps/worker/src/autorecovery/metrics-repository.ts
+++ b/apps/worker/src/autorecovery/metrics-repository.ts
@@ -87,6 +87,43 @@ export function createAutorecoveryMetricsRepository(getCh: () => Promise<ClickHo
         return { totalSpans: 0, perHour: [], lookbackHours: hours, service: null };
       }
       const ch = await getCh();
+      // Prefer the events_per_minute rollup. A service's total span count by
+      // hour is exactly sum(c) over the (project, signal='traces', service)
+      // cells. The raw otel_traces scan instead reads every span in the window:
+      // for a high-volume service over a multi-day lookback that is 100M+ rows
+      // (~100s per query), and the autorecovery agent fires this tool for many
+      // candidates per tick. Those scans saturated the ClickHouse read pool,
+      // which timed out the rest of the worker's sequential tick — including
+      // the agent-run queue, leaving investigations stuck in 'queued'. The
+      // rollup answers the same count from ~10k pre-aggregated rows in
+      // milliseconds. Fall back to the raw scan only where the rollup isn't
+      // deployed (it is not part of the collector's auto-created schema — see
+      // infra/clickhouse/migrations/003_events_per_minute.sql).
+      if (await rollupAvailable(ch)) {
+        const result = await ch.query({
+          query: `
+            SELECT
+              toString(toStartOfHour(minute)) AS hour,
+              toUInt64(sum(c)) AS count
+            FROM events_per_minute
+            WHERE project_id = {project_id:String}
+              AND signal = 'traces'
+              AND service = {service:String}
+              AND minute >= toStartOfHour(now() - INTERVAL {hours:UInt32} HOUR)
+            GROUP BY hour
+            ORDER BY hour ASC
+          `,
+          query_params: {
+            project_id: incident.projectId,
+            service: incident.service,
+            hours,
+          },
+          format: "JSONEachRow",
+        });
+        const rows = (await result.json()) as ActivityBucket[];
+        const totalSpans = rows.reduce((acc, r) => acc + Number(r.count), 0);
+        return { totalSpans, perHour: rows, lookbackHours: hours, service: incident.service };
+      }
       const result = await ch.query({
         query: `
           SELECT
@@ -111,6 +148,34 @@ export function createAutorecoveryMetricsRepository(getCh: () => Promise<ClickHo
       return { totalSpans, perHour: rows, lookbackHours: hours, service: incident.service };
     },
   };
+}
+
+// Probe whether the events_per_minute rollup exists, memoized per client so the
+// common (rollup-present) path costs one EXISTS check per process. Mirrors the
+// API read path (apps/api/src/mcp/clickhouse.ts). A failed probe drops the memo
+// and reports absent, so a transient ClickHouse blip falls back to the raw scan
+// for that call without pinning the slow path until restart.
+const rollupAvailability = new WeakMap<ClickHouseClient, Promise<boolean>>();
+
+function rollupAvailable(ch: ClickHouseClient): Promise<boolean> {
+  let probe = rollupAvailability.get(ch);
+  if (!probe) {
+    probe = (async () => {
+      try {
+        const r = await ch.query({
+          query: "EXISTS TABLE events_per_minute",
+          format: "JSONEachRow",
+        });
+        const rows = (await r.json()) as { result: number | string }[];
+        return Number(rows[0]?.result) === 1;
+      } catch {
+        rollupAvailability.delete(ch);
+        return false;
+      }
+    })();
+    rollupAvailability.set(ch, probe);
+  }
+  return probe;
 }
 
 let cachedClient: ClickHouseClient | null = null;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -59,7 +59,11 @@ export type AgentRunFailureReason =
   | "missing_session_for_resume"
   | "github_repo_discovery_failed"
   | "github_repo_token_failed"
-  | "unsupported_provider";
+  | "unsupported_provider"
+  // The run's incident or project no longer exists, so its context can never
+  // load and it can never make progress — reaped from the tick rather than
+  // left to rotate through the active set forever.
+  | "context_unavailable";
 
 export type AgentRunFailureCategory = "agent" | "deliverable" | "infra";
 


### PR DESCRIPTION
## Problem

Investigations were sitting in `queued` for ~30 min before starting. Root cause was **not** the runner — it was the worker's single sequential tick stalling on ClickHouse.

The autorecovery agent's `query_service_traffic` tool counts a service's spans by scanning **raw `otel_traces`** over the lookback window (clamp max 168h). For a high-volume service that's **100M+ rows / ~100s per query**, and the agent fires it for many candidates per tick. Those scans saturate the ClickHouse read pool, so the other CH calls in the worker's sequential tick (`spans → logs → agent_runs → … → autorecovery → usage_metering`) time out at 30s and each cycle balloons to minutes. `agent_runs` only gets one turn per cycle, so the queue drains far slower than it fills.

## Changes

**1. Route `query_service_traffic` to the `events_per_minute` rollup.**
A service's per-hour span count is exactly `sum(c)` over the `(project, signal='traces', service)` cells, which the rollup answers from a few thousand pre-aggregated rows in milliseconds instead of scanning every span. Memoized `EXISTS TABLE` probe + raw-`otel_traces` fallback for deployments that never created the rollup (it isn't part of the collector's auto-created schema) — mirrors the API read path in `apps/api/src/mcp/clickhouse.ts`. `queryIncidentActivity` had already moved off raw traces (onto `otel_exceptions`); this was the leftover scanner. Validated for parity against a real high-volume project: rollup sum vs raw count agree within ~0.16% (edge-minute rounding), reading ~13,000× fewer rows.

**2. Reap runs that can never make progress** (they otherwise sit in `running` forever and crowd the active-state batch the tick rotates through):
- `sync`: a run whose provider session is permanently unreachable throws a *transient-shaped* error (timeout / connection reset / 5xx) on every `collect()`, so it retries forever — the wall-clock backstop can't catch it because it lives past the throwing `collect()` call. Now reaps once the wall-clock budget is blown.
- `tick`: a run whose incident/project was deleted (`loadAgentRunContext` → `null`) was skipped silently and never left an active state. Now failed with a new `context_unavailable` reason.

**3.** Wired the existing `metrics-repository.test.ts` into `package.json` (it had no script).

## Tests

TDD red→green on the rollup routing (`test:autorecovery-metrics`, 6/6): asserts the rollup path, the raw fallback when the rollup is absent, and the no-service short-circuit. The reaper changes reuse the already-tested `exceededWallClockBudget` / `isTransientError` predicates. `@superlog/worker` + `@superlog/db` typecheck clean.

> Note: a pre-existing failure in `agent-run.test.ts` ("ACTIVE_STATES + DORMANT_STATES + TERMINAL_STATES partition…") is unrelated to this change and already fails on `main` — the worker package has no aggregate `test` script, so `pnpm -r --if-present test` skips it in CI. Worth a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up autorecovery and unblock the agent-run queue by reading service span counts from the `events_per_minute` rollup instead of scanning `otel_traces`, and by reaping runs that can never progress. This removes ClickHouse read-pool stalls that left investigations stuck in `queued`.

- **Performance**
  - Route `query_service_traffic` to `events_per_minute` (sum of `c` per hour) and avoid raw `otel_traces` scans.
  - Use a memoized `EXISTS TABLE events_per_minute` probe with a raw-scan fallback for deployments without the rollup.
  - Round the rollup’s lower bound to the minute (`toStartOfMinute`) to match the raw path and avoid over-counting the earliest bucket.

- **Bug Fixes**
  - In `sync`, stop retrying transient-shaped `collect()` errors once the wall-clock budget is exceeded and fail with `wall_clock_timeout`.
  - In `tick`, fail runs whose incident or project is missing with a new `context_unavailable` reason so they leave active states.

<sup>Written for commit a37148bfca7e04bcd07830686ab27d41084c1021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

