### PR TITLE
feat(mcp): default dashboard widget layout to the standard size per type

### DIFF
--- a/apps/api/src/dashboards-service.ts
+++ b/apps/api/src/dashboards-service.ts
@@ -40,6 +40,18 @@ export const dashboardWidgetLayoutSchema = z.object({
   h: z.number().int().min(1).max(100),
 });
 
+export type DashboardWidgetType = z.infer<typeof dashboardWidgetTypeSchema>;
+export type DashboardWidgetLayout = z.infer<typeof dashboardWidgetLayoutSchema>;
+
+// The standard widget size per type, against the 12-column grid the UI renders.
+// Kept in sync with the web's `defaultLayoutFor` (apps/web/src/dashboards/types.ts).
+// y=9999 means "append at the bottom": the grid compacts vertically on load.
+export function defaultWidgetLayout(type: DashboardWidgetType): DashboardWidgetLayout {
+  if (type === "markdown") return { x: 0, y: 9999, w: 4, h: 5 };
+  if (type === "trace_table" || type === "log_table") return { x: 0, y: 9999, w: 12, h: 6 };
+  return { x: 0, y: 9999, w: 6, h: 4 };
+}
+
 export const dashboardCreateSchema = z.object({ name: z.string().min(1).max(120) });
 export const dashboardUpdateSchema = z.object({ name: z.string().min(1).max(120) });
 
@@ -47,7 +59,9 @@ export const dashboardWidgetCreateSchema = z.object({
   type: dashboardWidgetTypeSchema,
   title: z.string().min(1).max(200),
   config: dashboardWidgetConfigSchema,
-  layout: dashboardWidgetLayoutSchema,
+  // Optional: when omitted, `addDashboardWidget` applies the standard size for
+  // the widget type via `defaultWidgetLayout`.
+  layout: dashboardWidgetLayoutSchema.optional(),
 });
 
 export const dashboardWidgetUpdateSchema = z.object({
@@ -163,7 +177,7 @@ export async function addDashboardWidget(
       type: input.type,
       title: input.title,
       config: input.config,
-      layout: input.layout,
+      layout: input.layout ?? defaultWidgetLayout(input.type),
       position: nextPosition,
     })
     .returning();

--- a/apps/api/src/dashboards-service.ts
+++ b/apps/api/src/dashboards-service.ts
@@ -33,10 +33,14 @@ export const dashboardWidgetConfigSchema = z.object({
   markdown: z.string().max(20_000).optional(),
 });
 
+// Layouts are placed on the 12-column grid the UI renders (DashboardView.tsx
+// uses cols=12), so a column index is 0..11 and a span is 1..12. Bounding the
+// schema to the grid keeps it the single source of truth — an agent that sends
+// w:48 is rejected here rather than producing a widget wider than the grid.
 export const dashboardWidgetLayoutSchema = z.object({
-  x: z.number().int().min(0).max(48),
+  x: z.number().int().min(0).max(11),
   y: z.number().int().min(0).max(100000),
-  w: z.number().int().min(1).max(48),
+  w: z.number().int().min(1).max(12),
   h: z.number().int().min(1).max(100),
 });
 
@@ -47,9 +51,22 @@ export type DashboardWidgetLayout = z.infer<typeof dashboardWidgetLayoutSchema>;
 // Kept in sync with the web's `defaultLayoutFor` (apps/web/src/dashboards/types.ts).
 // y=9999 means "append at the bottom": the grid compacts vertically on load.
 export function defaultWidgetLayout(type: DashboardWidgetType): DashboardWidgetLayout {
-  if (type === "markdown") return { x: 0, y: 9999, w: 4, h: 5 };
-  if (type === "trace_table" || type === "log_table") return { x: 0, y: 9999, w: 12, h: 6 };
-  return { x: 0, y: 9999, w: 6, h: 4 };
+  switch (type) {
+    case "markdown":
+      return { x: 0, y: 9999, w: 4, h: 5 };
+    case "trace_table":
+    case "log_table":
+      return { x: 0, y: 9999, w: 12, h: 6 };
+    case "timeseries_count":
+    case "timeseries_metric":
+      return { x: 0, y: 9999, w: 6, h: 4 };
+    default: {
+      // Exhaustiveness guard: adding a widget type to the enum without a case
+      // here is a compile error rather than a silent fall-through.
+      const _exhaustive: never = type;
+      throw new Error(`unhandled widget type: ${String(_exhaustive)}`);
+    }
+  }
 }
 
 export const dashboardCreateSchema = z.object({ name: z.string().min(1).max(120) });

--- a/apps/api/src/dashboards-widget-defaults.test.ts
+++ b/apps/api/src/dashboards-widget-defaults.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  dashboardWidgetCreateSchema,
+  defaultWidgetLayout,
+} from "./dashboards-service.js";
+
+test("defaultWidgetLayout returns the standard size per widget type", () => {
+  // Chart widgets default to half-width on the 12-column grid.
+  assert.deepEqual(defaultWidgetLayout("timeseries_count"), { x: 0, y: 9999, w: 6, h: 4 });
+  assert.deepEqual(defaultWidgetLayout("timeseries_metric"), { x: 0, y: 9999, w: 6, h: 4 });
+  // Tables default to full-width.
+  assert.deepEqual(defaultWidgetLayout("trace_table"), { x: 0, y: 9999, w: 12, h: 6 });
+  assert.deepEqual(defaultWidgetLayout("log_table"), { x: 0, y: 9999, w: 12, h: 6 });
+  // Markdown defaults to a small third-width note.
+  assert.deepEqual(defaultWidgetLayout("markdown"), { x: 0, y: 9999, w: 4, h: 5 });
+});
+
+test("every default layout satisfies the widget layout schema", () => {
+  for (const type of [
+    "timeseries_count",
+    "timeseries_metric",
+    "trace_table",
+    "log_table",
+    "markdown",
+  ] as const) {
+    const parsed = dashboardWidgetCreateSchema.parse({
+      type,
+      title: "t",
+      config: { filter: {} },
+    });
+    // layout is now optional — callers may omit it and get the standard size.
+    assert.equal(parsed.layout, undefined);
+  }
+});
+
+test("dashboardWidgetCreateSchema still accepts an explicit layout", () => {
+  const parsed = dashboardWidgetCreateSchema.parse({
+    type: "timeseries_count",
+    title: "t",
+    config: { filter: {} },
+    layout: { x: 2, y: 0, w: 3, h: 3 },
+  });
+  assert.deepEqual(parsed.layout, { x: 2, y: 0, w: 3, h: 3 });
+});

--- a/apps/api/src/dashboards-widget-defaults.test.ts
+++ b/apps/api/src/dashboards-widget-defaults.test.ts
@@ -2,8 +2,12 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   dashboardWidgetCreateSchema,
+  dashboardWidgetLayoutSchema,
+  dashboardWidgetTypeSchema,
   defaultWidgetLayout,
 } from "./dashboards-service.js";
+
+const ALL_TYPES = dashboardWidgetTypeSchema.options;
 
 test("defaultWidgetLayout returns the standard size per widget type", () => {
   // Chart widgets default to half-width on the 12-column grid.
@@ -16,25 +20,23 @@ test("defaultWidgetLayout returns the standard size per widget type", () => {
   assert.deepEqual(defaultWidgetLayout("markdown"), { x: 0, y: 9999, w: 4, h: 5 });
 });
 
-test("every default layout satisfies the widget layout schema", () => {
-  for (const type of [
-    "timeseries_count",
-    "timeseries_metric",
-    "trace_table",
-    "log_table",
-    "markdown",
-  ] as const) {
-    const parsed = dashboardWidgetCreateSchema.parse({
-      type,
-      title: "t",
-      config: { filter: {} },
-    });
-    // layout is now optional — callers may omit it and get the standard size.
+test("every default layout is valid against the widget layout schema", () => {
+  for (const type of ALL_TYPES) {
+    // The schema is the single source of truth for the 12-column grid; every
+    // default we hand back must pass it.
+    assert.doesNotThrow(() => dashboardWidgetLayoutSchema.parse(defaultWidgetLayout(type)));
+  }
+});
+
+test("dashboardWidgetCreateSchema makes layout optional", () => {
+  for (const type of ALL_TYPES) {
+    const parsed = dashboardWidgetCreateSchema.parse({ type, title: "t", config: { filter: {} } });
+    // Omitted layout — the service applies the standard size at insert time.
     assert.equal(parsed.layout, undefined);
   }
 });
 
-test("dashboardWidgetCreateSchema still accepts an explicit layout", () => {
+test("dashboardWidgetCreateSchema still accepts an explicit in-grid layout", () => {
   const parsed = dashboardWidgetCreateSchema.parse({
     type: "timeseries_count",
     title: "t",
@@ -42,4 +44,9 @@ test("dashboardWidgetCreateSchema still accepts an explicit layout", () => {
     layout: { x: 2, y: 0, w: 3, h: 3 },
   });
   assert.deepEqual(parsed.layout, { x: 2, y: 0, w: 3, h: 3 });
+});
+
+test("the layout schema rejects spans wider than the 12-column grid", () => {
+  assert.throws(() => dashboardWidgetLayoutSchema.parse({ x: 0, y: 0, w: 48, h: 4 }));
+  assert.throws(() => dashboardWidgetLayoutSchema.parse({ x: 12, y: 0, w: 1, h: 4 }));
 });

--- a/apps/api/src/mcp/dashboards.ts
+++ b/apps/api/src/mcp/dashboards.ts
@@ -116,9 +116,9 @@ export function registerDashboardTools(
       title: "Add dashboard widget",
       description:
         "Append a widget to a dashboard. Widget types: timeseries_count, timeseries_metric, trace_table, log_table, markdown. " +
-        "Omit `layout` to use the standard size for the type — recommended. The grid is 12 columns wide; the standard sizes are " +
-        "w:6 h:4 for timeseries charts (half-width), w:12 h:6 for trace_table/log_table (full-width), and w:4 h:5 for markdown. " +
-        "Only pass `layout` when you deliberately want a non-standard size or position.",
+        "Omit `layout` to use the standard size for the type — recommended. The grid is 12 columns wide, so x is 0-11 and w is 1-12; " +
+        "the standard sizes are w:6 h:4 for timeseries charts (half-width), w:12 h:6 for trace_table/log_table (full-width), and " +
+        "w:4 h:5 for markdown. Only pass `layout` when you deliberately want a non-standard size or position.",
       inputSchema: {
         project_id: projectIdSchema,
         dashboard_id: z.string().uuid(),
@@ -128,7 +128,7 @@ export function registerDashboardTools(
         layout: dashboardWidgetLayoutSchema
           .optional()
           .describe(
-            "Grid placement {x,y,w,h} on a 12-column grid. Omit to use the standard size for the widget type.",
+            "Grid placement {x,y,w,h} on a 12-column grid (x 0-11, w 1-12). Omit to use the standard size for the widget type.",
           ),
       },
     },

--- a/apps/api/src/mcp/dashboards.ts
+++ b/apps/api/src/mcp/dashboards.ts
@@ -115,14 +115,21 @@ export function registerDashboardTools(
     {
       title: "Add dashboard widget",
       description:
-        "Append a widget to a dashboard. Widget types: timeseries_count, timeseries_metric, trace_table, log_table, markdown.",
+        "Append a widget to a dashboard. Widget types: timeseries_count, timeseries_metric, trace_table, log_table, markdown. " +
+        "Omit `layout` to use the standard size for the type — recommended. The grid is 12 columns wide; the standard sizes are " +
+        "w:6 h:4 for timeseries charts (half-width), w:12 h:6 for trace_table/log_table (full-width), and w:4 h:5 for markdown. " +
+        "Only pass `layout` when you deliberately want a non-standard size or position.",
       inputSchema: {
         project_id: projectIdSchema,
         dashboard_id: z.string().uuid(),
         type: dashboardWidgetTypeSchema,
         title: z.string().min(1).max(200),
         config: dashboardWidgetConfigSchema,
-        layout: dashboardWidgetLayoutSchema,
+        layout: dashboardWidgetLayoutSchema
+          .optional()
+          .describe(
+            "Grid placement {x,y,w,h} on a 12-column grid. Omit to use the standard size for the widget type.",
+          ),
       },
     },
     async (input) => {


### PR DESCRIPTION
## Problem

The `add_dashboard_widget` MCP tool forced callers to pass an explicit `layout`, with no indication that the dashboard grid is 12 columns wide. AI agents using the MCP would guess sizes — often against the loose `w<=48` schema bound — and produce mis-sized widgets that don't match the sizes the UI uses when you add a widget by hand.

## Change

- **`layout` is now optional.** When omitted, `addDashboardWidget` falls back to a standard size per widget type via the new `defaultWidgetLayout(type)`, mirroring the web's `defaultLayoutFor`:
  - timeseries charts → `w:6 h:4` (half-width)
  - `trace_table` / `log_table` → `w:12 h:6` (full-width)
  - `markdown` → `w:4 h:5`
- **Tool description now documents the convention** — that the grid is 12 columns wide, what the standard sizes are, and that `layout` should only be set when a non-standard size/position is deliberately wanted.

Together these mean an agent gets correctly-sized widgets by default just by omitting `layout`, and has clear guidance if it does choose to set one.

## Compatibility

Backwards-compatible: the REST route and the web UI already always send a `layout`, so only callers that omit it (MCP agents) get the new default.

## Tests

`apps/api/src/dashboards-widget-defaults.test.ts` covers the per-type defaults, schema validity of each default, optionality of `layout`, and that an explicit layout is still accepted. `@superlog/api` typechecks clean.

## Note

`defaultWidgetLayout` (api) and `defaultLayoutFor` (web) are now parallel definitions in two packages; cross-referencing comments keep them in sync since they can't easily share a module.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default dashboard widget layout per type in MCP. `add_dashboard_widget` now makes `layout` optional and uses standard sizes on a 12-column grid, and the layout schema now enforces that grid to prevent invalid widths.

- **New Features**
  - `defaultWidgetLayout(type)` applies defaults: timeseries charts → w:6 h:4; `trace_table`/`log_table` → w:12 h:6; `markdown` → w:4 h:5.
  - Input `layout` is optional; explicit layouts are still accepted.
  - MCP tool description now explains the 12-column grid, the defaults, and when to override.

- **Bug Fixes**
  - Tightened `dashboardWidgetLayoutSchema` to the 12-column grid (`x` 0–11, `w` 1–12) to reject out-of-grid spans and match the docs.
  - Made `defaultWidgetLayout` exhaustive to catch missing widget types at compile time.

<sup>Written for commit ff5f9989e6a51eb961bd46d8386d25900bdbf937. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

