### PR TITLE
Add MCP tools for issue filter, project context, and agent memories

### DIFF
--- a/apps/api/src/agent-memories-service.test.ts
+++ b/apps/api/src/agent-memories-service.test.ts
@@ -1,0 +1,88 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
+const {
+  parseMemoryKind,
+  parseMemoryText,
+  parseMemoryStatus,
+  serializeAgentMemory,
+  createAgentMemory,
+  AGENT_MEMORY_TITLE_MAX_LEN,
+  AGENT_MEMORY_BODY_MAX_LEN,
+} = await import("./agent-memories-service.js");
+
+test("parseMemoryKind accepts the four valid kinds and rejects others", () => {
+  for (const kind of ["feedback", "terminology", "infra", "project"]) {
+    assert.equal(parseMemoryKind(kind), kind);
+  }
+  assert.equal(parseMemoryKind("bogus"), null);
+  assert.equal(parseMemoryKind(42), null);
+  assert.equal(parseMemoryKind(undefined), null);
+});
+
+test("parseMemoryText trims, rejects empty, and clamps to maxLen", () => {
+  assert.equal(parseMemoryText("  hello  ", 100), "hello");
+  assert.equal(parseMemoryText("   ", 100), null);
+  assert.equal(parseMemoryText(123, 100), null);
+  assert.equal(parseMemoryText("x".repeat(50), 10)?.length, 10);
+});
+
+test("title/body max lengths are exported for the MCP schema", () => {
+  assert.equal(AGENT_MEMORY_TITLE_MAX_LEN, 200);
+  assert.equal(AGENT_MEMORY_BODY_MAX_LEN, 4000);
+});
+
+test("parseMemoryStatus only accepts active/archived", () => {
+  assert.equal(parseMemoryStatus("active"), "active");
+  assert.equal(parseMemoryStatus("archived"), "archived");
+  assert.equal(parseMemoryStatus("deleted"), null);
+  assert.equal(parseMemoryStatus(undefined), null);
+});
+
+test("createAgentMemory rejects an unattributed or doubly-attributed create", async () => {
+  const base = { orgId: "o1", projectId: "p1", kind: "project" as const, title: "t", body: "b" };
+  // The guard throws before any DB access, so these never open a connection.
+  await assert.rejects(
+    () => createAgentMemory(base),
+    /exactly one of sourceUserId or sourceAgentRunId/,
+  );
+  await assert.rejects(
+    () => createAgentMemory({ ...base, sourceUserId: "u1", sourceAgentRunId: "r1" }),
+    /exactly one of sourceUserId or sourceAgentRunId/,
+  );
+});
+
+test("serializeAgentMemory derives source from which provenance column is set", () => {
+  const base = {
+    id: "m1",
+    orgId: "o1",
+    projectId: "p1",
+    kind: "infra" as const,
+    title: "Checkout runs on ECS",
+    body: "...",
+    status: "active" as const,
+    sourceAgentRunId: null,
+    sourceUserId: null,
+    lastUsedAt: null,
+    createdAt: new Date("2026-06-27T00:00:00.000Z"),
+    updatedAt: new Date("2026-06-27T00:00:00.000Z"),
+  };
+
+  assert.equal(serializeAgentMemory({ ...base, sourceAgentRunId: "run1" }).source, "agent");
+  assert.equal(serializeAgentMemory({ ...base, sourceUserId: "user1" }).source, "user");
+  assert.equal(serializeAgentMemory(base).source, null);
+
+  const out = serializeAgentMemory(base);
+  assert.deepEqual(out, {
+    id: "m1",
+    kind: "infra",
+    projectId: "p1",
+    title: "Checkout runs on ECS",
+    body: "...",
+    status: "active",
+    source: null,
+    createdAt: "2026-06-27T00:00:00.000Z",
+    updatedAt: "2026-06-27T00:00:00.000Z",
+  });
+});

--- a/apps/api/src/agent-memories-service.ts
+++ b/apps/api/src/agent-memories-service.ts
@@ -1,0 +1,137 @@
+import { db, schema } from "@superlog/db";
+import { and, asc, eq } from "drizzle-orm";
+
+export const AGENT_MEMORY_TITLE_MAX_LEN = 200;
+export const AGENT_MEMORY_BODY_MAX_LEN = 4000;
+
+export const AGENT_MEMORY_KINDS: schema.AgentMemoryKind[] = [
+  "feedback",
+  "terminology",
+  "infra",
+  "project",
+];
+
+export type AgentMemoryStatus = "active" | "archived";
+
+export function parseMemoryKind(value: unknown): schema.AgentMemoryKind | null {
+  return typeof value === "string" && (AGENT_MEMORY_KINDS as string[]).includes(value)
+    ? (value as schema.AgentMemoryKind)
+    : null;
+}
+
+export function parseMemoryText(value: unknown, maxLen: number): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  return trimmed.slice(0, maxLen);
+}
+
+export function parseMemoryStatus(value: unknown): AgentMemoryStatus | null {
+  return value === "active" || value === "archived" ? value : null;
+}
+
+export function serializeAgentMemory(row: schema.AgentMemory) {
+  return {
+    id: row.id,
+    kind: row.kind,
+    projectId: row.projectId,
+    title: row.title,
+    body: row.body,
+    status: row.status,
+    source: row.sourceAgentRunId ? "agent" : row.sourceUserId ? "user" : null,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export function listAgentMemories(orgId: string, projectId: string) {
+  return db.query.agentMemories.findMany({
+    where: and(
+      eq(schema.agentMemories.orgId, orgId),
+      eq(schema.agentMemories.projectId, projectId),
+    ),
+    orderBy: [asc(schema.agentMemories.createdAt)],
+  });
+}
+
+export type CreateAgentMemoryInput = {
+  orgId: string;
+  projectId: string;
+  kind: schema.AgentMemoryKind;
+  title: string;
+  body: string;
+  /**
+   * Provenance: pass exactly one. user-authored memories set sourceUserId,
+   * agent-authored ones set sourceAgentRunId. (The schema also permits both
+   * null for system backfills, but those don't go through this helper — it's
+   * for attributed creates, so we reject an unattributed call here.)
+   */
+  sourceUserId?: string;
+  sourceAgentRunId?: string;
+};
+
+export async function createAgentMemory(
+  input: CreateAgentMemoryInput,
+): Promise<schema.AgentMemory | null> {
+  if (!!input.sourceUserId === !!input.sourceAgentRunId) {
+    throw new Error("createAgentMemory requires exactly one of sourceUserId or sourceAgentRunId");
+  }
+  const [row] = await db
+    .insert(schema.agentMemories)
+    .values({
+      orgId: input.orgId,
+      projectId: input.projectId,
+      kind: input.kind,
+      title: input.title,
+      body: input.body,
+      sourceUserId: input.sourceUserId,
+      sourceAgentRunId: input.sourceAgentRunId,
+    })
+    .returning();
+  return row ?? null;
+}
+
+export type AgentMemoryPatch = {
+  kind?: schema.AgentMemoryKind;
+  title?: string;
+  body?: string;
+  status?: AgentMemoryStatus;
+};
+
+export async function updateAgentMemory(
+  orgId: string,
+  projectId: string,
+  id: string,
+  patch: AgentMemoryPatch,
+): Promise<schema.AgentMemory | null> {
+  const [row] = await db
+    .update(schema.agentMemories)
+    .set({ ...patch, updatedAt: new Date() })
+    .where(
+      and(
+        eq(schema.agentMemories.id, id),
+        eq(schema.agentMemories.orgId, orgId),
+        eq(schema.agentMemories.projectId, projectId),
+      ),
+    )
+    .returning();
+  return row ?? null;
+}
+
+export async function deleteAgentMemory(
+  orgId: string,
+  projectId: string,
+  id: string,
+): Promise<boolean> {
+  const [row] = await db
+    .delete(schema.agentMemories)
+    .where(
+      and(
+        eq(schema.agentMemories.id, id),
+        eq(schema.agentMemories.orgId, orgId),
+        eq(schema.agentMemories.projectId, projectId),
+      ),
+    )
+    .returning({ id: schema.agentMemories.id });
+  return !!row;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -67,6 +67,7 @@ import {
   spanSampleKey,
 } from "./incidents/stats.js";
 import { mountIngestFilters } from "./ingest-filters.js";
+import { sanitizeIssueFilterConfig } from "./issue-filter-service.js";
 import { mountLinearAuthed, mountLinearPublic } from "./linear.js";
 import { logger } from "./logger.js";
 import { mountManagementApi, mountOrgKeyManagementAuthed } from "./management.js";
@@ -1181,44 +1182,6 @@ async function getProjectAutomation(projectId: string): Promise<{
     autoMergeFixPrs: row?.autoMergeFixPrs ?? "never",
     autoMergeMethod: row?.autoMergeMethod ?? "squash",
     issueFilterConfig: row?.issueFilterConfig ?? schema.EMPTY_ISSUE_FILTER_CONFIG,
-  };
-}
-
-function sanitizeClauseList(input: unknown): schema.IssueFilterClause[] {
-  if (!Array.isArray(input)) return [];
-  const out: schema.IssueFilterClause[] = [];
-  const seen = new Set<string>();
-  for (const item of input) {
-    if (!item || typeof item !== "object") continue;
-    const key =
-      typeof (item as { key?: unknown }).key === "string"
-        ? (item as { key: string }).key.trim()
-        : "";
-    const value =
-      typeof (item as { value?: unknown }).value === "string"
-        ? (item as { value: string }).value.trim()
-        : "";
-    if (!key || !value) continue;
-    const dedupe = `${key.toLowerCase()}=${value}`;
-    if (seen.has(dedupe)) continue;
-    seen.add(dedupe);
-    out.push({ key: key.slice(0, 200), value: value.slice(0, 400) });
-    if (out.length >= 20) break;
-  }
-  return out;
-}
-
-function sanitizeIssueFilterConfig(
-  input: unknown,
-  fallback: schema.IssueFilterConfig,
-): schema.IssueFilterConfig {
-  if (!input || typeof input !== "object") return fallback;
-  const o = input as Partial<Record<keyof schema.IssueFilterConfig, unknown>>;
-  return {
-    includeLogs: sanitizeClauseList(o.includeLogs),
-    includeSpans: sanitizeClauseList(o.includeSpans),
-    excludeLogs: sanitizeClauseList(o.excludeLogs),
-    excludeSpans: sanitizeClauseList(o.excludeSpans),
   };
 }
 

--- a/apps/api/src/issue-filter-service.test.ts
+++ b/apps/api/src/issue-filter-service.test.ts
@@ -1,0 +1,104 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+// Pure-function tests; the service transitively imports the db client which
+// connects lazily, so a dummy URL keeps import-time side effects happy without
+// opening a socket. Same pattern as alerts-service.test.ts.
+process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
+const { sanitizeClauseList, sanitizeIssueFilterConfig, mergeIssueFilterConfig } = await import(
+  "./issue-filter-service.js"
+);
+
+const EMPTY = {
+  includeLogs: [],
+  includeSpans: [],
+  excludeLogs: [],
+  excludeSpans: [],
+};
+
+test("sanitizeClauseList trims, drops empties, and ignores non-objects", () => {
+  assert.deepEqual(
+    sanitizeClauseList([
+      { key: "  service.name ", value: " checkout " },
+      { key: "", value: "x" },
+      { key: "x", value: "" },
+      "nonsense",
+      null,
+      42,
+    ]),
+    [{ key: "service.name", value: "checkout" }],
+  );
+});
+
+test("sanitizeClauseList dedupes case-insensitively by key", () => {
+  assert.deepEqual(
+    sanitizeClauseList([
+      { key: "Service.Name", value: "checkout" },
+      { key: "service.name", value: "checkout" },
+      { key: "service.name", value: "billing" },
+    ]),
+    [
+      { key: "Service.Name", value: "checkout" },
+      { key: "service.name", value: "billing" },
+    ],
+  );
+});
+
+test("sanitizeClauseList caps at 20 clauses", () => {
+  const many = Array.from({ length: 30 }, (_, i) => ({ key: `k${i}`, value: "v" }));
+  assert.equal(sanitizeClauseList(many).length, 20);
+});
+
+test("sanitizeClauseList caps key/value length", () => {
+  const [clause] = sanitizeClauseList([{ key: "k".repeat(500), value: "v".repeat(900) }]);
+  assert.equal(clause?.key.length, 200);
+  assert.equal(clause?.value.length, 400);
+});
+
+test("sanitizeClauseList returns [] for non-arrays", () => {
+  assert.deepEqual(sanitizeClauseList(undefined), []);
+  assert.deepEqual(sanitizeClauseList({ key: "x", value: "y" }), []);
+});
+
+test("sanitizeIssueFilterConfig falls back when input is not an object", () => {
+  const fallback = { ...EMPTY, includeLogs: [{ key: "a", value: "b" }] };
+  assert.equal(sanitizeIssueFilterConfig(null, fallback), fallback);
+  assert.equal(sanitizeIssueFilterConfig("nope", fallback), fallback);
+});
+
+test("sanitizeIssueFilterConfig sanitizes each bucket, missing buckets become []", () => {
+  const result = sanitizeIssueFilterConfig(
+    { includeSpans: [{ key: "http.route", value: "/pay" }] },
+    { ...EMPTY, excludeLogs: [{ key: "stale", value: "1" }] },
+  );
+  assert.deepEqual(result, {
+    includeLogs: [],
+    includeSpans: [{ key: "http.route", value: "/pay" }],
+    excludeLogs: [],
+    excludeSpans: [],
+  });
+});
+
+test("mergeIssueFilterConfig only replaces buckets present in the patch", () => {
+  const current = {
+    includeLogs: [{ key: "keep", value: "1" }],
+    includeSpans: [],
+    excludeLogs: [{ key: "drop-me", value: "1" }],
+    excludeSpans: [],
+  };
+  const merged = mergeIssueFilterConfig(current, {
+    excludeLogs: [{ key: "noise", value: "x" }],
+  });
+  assert.deepEqual(merged, {
+    includeLogs: [{ key: "keep", value: "1" }],
+    includeSpans: [],
+    excludeLogs: [{ key: "noise", value: "x" }],
+    excludeSpans: [],
+  });
+});
+
+test("mergeIssueFilterConfig can clear a bucket with an empty array", () => {
+  const current = { ...EMPTY, excludeLogs: [{ key: "noise", value: "x" }] };
+  const merged = mergeIssueFilterConfig(current, { excludeLogs: [] });
+  assert.deepEqual(merged.excludeLogs, []);
+});

--- a/apps/api/src/issue-filter-service.ts
+++ b/apps/api/src/issue-filter-service.ts
@@ -1,0 +1,108 @@
+import { db, schema } from "@superlog/db";
+import { eq } from "drizzle-orm";
+
+const MAX_CLAUSES_PER_BUCKET = 20;
+const CLAUSE_KEY_MAX_LEN = 200;
+const CLAUSE_VALUE_MAX_LEN = 400;
+
+export const ISSUE_FILTER_BUCKETS = [
+  "includeLogs",
+  "includeSpans",
+  "excludeLogs",
+  "excludeSpans",
+] as const satisfies readonly (keyof schema.IssueFilterConfig)[];
+
+/**
+ * Normalize an arbitrary value into a clean clause list: drop non-objects and
+ * clauses missing key/value, trim, cap key/value length, dedupe
+ * case-insensitively by key (value compared verbatim), and cap the list size.
+ * Shared by the REST automation handler and the MCP issue-filter tools so both
+ * surfaces apply identical rules.
+ */
+export function sanitizeClauseList(input: unknown): schema.IssueFilterClause[] {
+  if (!Array.isArray(input)) return [];
+  const out: schema.IssueFilterClause[] = [];
+  const seen = new Set<string>();
+  for (const item of input) {
+    if (!item || typeof item !== "object") continue;
+    const key =
+      typeof (item as { key?: unknown }).key === "string"
+        ? (item as { key: string }).key.trim()
+        : "";
+    const value =
+      typeof (item as { value?: unknown }).value === "string"
+        ? (item as { value: string }).value.trim()
+        : "";
+    if (!key || !value) continue;
+    const dedupe = `${key.toLowerCase()}=${value}`;
+    if (seen.has(dedupe)) continue;
+    seen.add(dedupe);
+    out.push({
+      key: key.slice(0, CLAUSE_KEY_MAX_LEN),
+      value: value.slice(0, CLAUSE_VALUE_MAX_LEN),
+    });
+    if (out.length >= MAX_CLAUSES_PER_BUCKET) break;
+  }
+  return out;
+}
+
+/**
+ * Sanitize a whole config. Any bucket that isn't a usable array falls back to
+ * the corresponding bucket in `fallback` (so a malformed partial doesn't wipe
+ * existing rules).
+ */
+export function sanitizeIssueFilterConfig(
+  input: unknown,
+  fallback: schema.IssueFilterConfig,
+): schema.IssueFilterConfig {
+  if (!input || typeof input !== "object") return fallback;
+  const o = input as Partial<Record<keyof schema.IssueFilterConfig, unknown>>;
+  return {
+    includeLogs: sanitizeClauseList(o.includeLogs),
+    includeSpans: sanitizeClauseList(o.includeSpans),
+    excludeLogs: sanitizeClauseList(o.excludeLogs),
+    excludeSpans: sanitizeClauseList(o.excludeSpans),
+  };
+}
+
+/**
+ * Per-bucket patch: only buckets present in `patch` are replaced (after
+ * sanitizing); buckets the caller omits keep their current value. Lets the MCP
+ * `update_issue_filter` tool tweak one bucket without resending the rest.
+ */
+export function mergeIssueFilterConfig(
+  current: schema.IssueFilterConfig,
+  patch: Partial<Record<keyof schema.IssueFilterConfig, unknown>>,
+): schema.IssueFilterConfig {
+  const next: schema.IssueFilterConfig = { ...current };
+  for (const bucket of ISSUE_FILTER_BUCKETS) {
+    if (patch[bucket] !== undefined) next[bucket] = sanitizeClauseList(patch[bucket]);
+  }
+  return next;
+}
+
+export async function getIssueFilterConfig(projectId: string): Promise<schema.IssueFilterConfig> {
+  const row = await db.query.projectAutomationSettings.findFirst({
+    where: eq(schema.projectAutomationSettings.projectId, projectId),
+    columns: { issueFilterConfig: true },
+  });
+  return row?.issueFilterConfig ?? schema.EMPTY_ISSUE_FILTER_CONFIG;
+}
+
+/**
+ * Persist a fully-formed config, upserting the automation row if absent. The
+ * caller is responsible for sanitizing/merging first.
+ */
+export async function setIssueFilterConfig(
+  projectId: string,
+  config: schema.IssueFilterConfig,
+): Promise<schema.IssueFilterConfig> {
+  await db
+    .insert(schema.projectAutomationSettings)
+    .values({ projectId, issueFilterConfig: config })
+    .onConflictDoUpdate({
+      target: schema.projectAutomationSettings.projectId,
+      set: { issueFilterConfig: config, updatedAt: new Date() },
+    });
+  return config;
+}

--- a/apps/api/src/mcp/agent-config.ts
+++ b/apps/api/src/mcp/agent-config.ts
@@ -1,0 +1,333 @@
+import type { ClickHouseClient } from "@clickhouse/client";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { db, schema } from "@superlog/db";
+import { and, eq } from "drizzle-orm";
+import { HTTPException } from "hono/http-exception";
+import { z } from "zod";
+import {
+  AGENT_MEMORY_BODY_MAX_LEN,
+  AGENT_MEMORY_TITLE_MAX_LEN,
+  createAgentMemory,
+  deleteAgentMemory,
+  listAgentMemories,
+  parseMemoryText,
+  serializeAgentMemory,
+  updateAgentMemory,
+} from "../agent-memories-service.js";
+import {
+  getIssueFilterConfig,
+  mergeIssueFilterConfig,
+  sanitizeIssueFilterConfig,
+  setIssueFilterConfig,
+} from "../issue-filter-service.js";
+import { getProjectContext, setProjectContext } from "../project-context-service.js";
+import { previewIssueFilterMatches } from "./clickhouse.js";
+
+const projectIdSchema = z
+  .string()
+  .uuid()
+  .optional()
+  .describe(
+    "Project to operate on. Defaults to the session's active project. Use list_projects to discover ids.",
+  );
+
+const clauseSchema = z.object({
+  key: z.string().min(1).max(200).describe("Attribute key, e.g. 'service.name' or 'http.route'"),
+  value: z.string().min(1).max(400).describe("Exact value the attribute must equal"),
+});
+const clauseListSchema = z.array(clauseSchema).max(20);
+
+// Picker/preview population matches the REST editor: ERROR events in the last
+// 24h, the window the worker filter actually applies to.
+const ISSUE_FILTER_RANGE = "now() - INTERVAL 24 HOUR";
+
+const memoryKindSchema = z
+  .enum(["feedback", "terminology", "infra", "project"])
+  .describe(
+    "feedback = a correction/preference for how the agent should work; terminology = a domain term/acronym; infra = how the system is deployed/runs; project = general project facts.",
+  );
+
+const text = (v: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(v) }] });
+
+type Session = {
+  userId: string;
+  activeProjectId: string;
+  allowedOrgId?: string;
+};
+
+export function registerAgentConfigTools(
+  server: McpServer,
+  session: Session,
+  ch: ClickHouseClient,
+): void {
+  // Resolve a project id, enforcing both the token's org scope (if any) and the
+  // user's org membership, and return the owning org so memory rows are stamped
+  // correctly.
+  const resolve = async (
+    explicit: string | undefined,
+  ): Promise<{ projectId: string; orgId: string }> => {
+    const projectId = explicit ?? session.activeProjectId;
+    const project = await db.query.projects.findFirst({
+      where: eq(schema.projects.id, projectId),
+      columns: { id: true, orgId: true },
+    });
+    if (!project) throw new HTTPException(404, { message: "project not found" });
+    if (session.allowedOrgId && project.orgId !== session.allowedOrgId) {
+      throw new HTTPException(403, { message: "project is outside this MCP token's org scope" });
+    }
+    const membership = await db.query.orgMembers.findFirst({
+      where: and(
+        eq(schema.orgMembers.userId, session.userId),
+        eq(schema.orgMembers.orgId, project.orgId),
+      ),
+    });
+    if (!membership) throw new HTTPException(403, { message: "no access to project" });
+    return { projectId: project.id, orgId: project.orgId };
+  };
+
+  // ---- Issue filter ----------------------------------------------------
+
+  server.registerTool(
+    "get_issue_filter",
+    {
+      title: "Get issue filter",
+      description:
+        "Read the project's issue filter: per-kind include/exclude attribute clauses that decide which ERROR events become issues/incidents. Excludes win; a non-empty include list means an event must match at least one clause.",
+      inputSchema: { project_id: projectIdSchema },
+    },
+    async (input) => {
+      const { projectId } = await resolve(input.project_id);
+      return text(await getIssueFilterConfig(projectId));
+    },
+  );
+
+  server.registerTool(
+    "update_issue_filter",
+    {
+      title: "Update issue filter",
+      description:
+        "Update the issue filter. Each bucket you provide REPLACES that bucket; omit a bucket to leave it unchanged; pass [] to clear it. Use this to quiet recurring noise (add an exclude clause) or to scope investigations to specific services/routes (add an include clause). Call get_issue_filter first if you want to add to the existing rules rather than overwrite them.",
+      inputSchema: {
+        project_id: projectIdSchema,
+        includeLogs: clauseListSchema
+          .optional()
+          .describe("Logs must match ≥1 of these (if non-empty) to become an issue."),
+        includeSpans: clauseListSchema
+          .optional()
+          .describe("Spans must match ≥1 of these (if non-empty) to become an issue."),
+        excludeLogs: clauseListSchema
+          .optional()
+          .describe("Logs matching ANY of these are dropped (never become issues)."),
+        excludeSpans: clauseListSchema
+          .optional()
+          .describe("Spans matching ANY of these are dropped (never become issues)."),
+      },
+    },
+    async (input) => {
+      const { projectId } = await resolve(input.project_id);
+      const current = await getIssueFilterConfig(projectId);
+      const next = mergeIssueFilterConfig(current, {
+        includeLogs: input.includeLogs,
+        includeSpans: input.includeSpans,
+        excludeLogs: input.excludeLogs,
+        excludeSpans: input.excludeSpans,
+      });
+      return text(await setIssueFilterConfig(projectId, next));
+    },
+  );
+
+  server.registerTool(
+    "preview_issue_filter",
+    {
+      title: "Preview issue filter",
+      description:
+        "Preview which recent ERROR events (last 24h) would still become issues under a candidate filter, WITHOUT saving. Buckets you pass are merged over the project's current filter (same semantics as update_issue_filter); omit all buckets to preview the current saved filter. Returns sample matching events.",
+      inputSchema: {
+        project_id: projectIdSchema,
+        includeLogs: clauseListSchema.optional(),
+        includeSpans: clauseListSchema.optional(),
+        excludeLogs: clauseListSchema.optional(),
+        excludeSpans: clauseListSchema.optional(),
+      },
+    },
+    async (input) => {
+      const { projectId } = await resolve(input.project_id);
+      const current = await getIssueFilterConfig(projectId);
+      const config = sanitizeIssueFilterConfig(
+        mergeIssueFilterConfig(current, {
+          includeLogs: input.includeLogs,
+          includeSpans: input.includeSpans,
+          excludeLogs: input.excludeLogs,
+          excludeSpans: input.excludeSpans,
+        }),
+        current,
+      );
+      const events = await previewIssueFilterMatches(
+        ch,
+        projectId,
+        config,
+        { since: ISSUE_FILTER_RANGE },
+        10,
+      );
+      return text({ config, events });
+    },
+  );
+
+  // ---- Project context -------------------------------------------------
+
+  server.registerTool(
+    "get_project_context",
+    {
+      title: "Get project context",
+      description:
+        "Read the project's freeform context — the human-written description of the system (architecture, conventions, key services) that the investigation agent reads on every run.",
+      inputSchema: { project_id: projectIdSchema },
+    },
+    async (input) => {
+      const { projectId } = await resolve(input.project_id);
+      return text({ projectContext: await getProjectContext(projectId) });
+    },
+  );
+
+  server.registerTool(
+    "set_project_context",
+    {
+      title: "Set project context",
+      description:
+        "Overwrite the project's freeform context (max 8000 chars; longer input is truncated). This REPLACES the whole field — call get_project_context first and edit the returned text if you want to preserve existing content. Use for durable, system-level facts that apply to every investigation; for narrower learnings prefer create_agent_memory.",
+      inputSchema: {
+        project_id: projectIdSchema,
+        context: z
+          .string()
+          .max(20000)
+          .describe("The full context text. Replaces the existing value."),
+      },
+    },
+    async (input) => {
+      const { projectId } = await resolve(input.project_id);
+      return text({ projectContext: await setProjectContext(projectId, input.context) });
+    },
+  );
+
+  // ---- Agent memories --------------------------------------------------
+
+  server.registerTool(
+    "list_agent_memories",
+    {
+      title: "List agent memories",
+      description:
+        "List the investigation agent's stored memories for the project — durable learnings (feedback, terminology, infra, project facts) that are injected into future investigations.",
+      inputSchema: { project_id: projectIdSchema },
+    },
+    async (input) => {
+      const { projectId, orgId } = await resolve(input.project_id);
+      const rows = await listAgentMemories(orgId, projectId);
+      return text({ memories: rows.map(serializeAgentMemory) });
+    },
+  );
+
+  server.registerTool(
+    "create_agent_memory",
+    {
+      title: "Create agent memory",
+      description:
+        "Record a durable, reusable learning so future investigations inherit it. Record a memory whenever you discover something worth remembering across investigations — a root-cause pattern, a piece of infra/architecture, a domain term, or a user correction about how to investigate. Keep the title a short handle and the body the specific, reusable fact (not a one-off incident narrative).",
+      inputSchema: {
+        project_id: projectIdSchema,
+        kind: memoryKindSchema,
+        title: z
+          .string()
+          .min(1)
+          .max(AGENT_MEMORY_TITLE_MAX_LEN)
+          .describe("Short handle for the memory."),
+        body: z
+          .string()
+          .min(1)
+          .max(AGENT_MEMORY_BODY_MAX_LEN)
+          .describe("The specific, reusable fact or instruction."),
+      },
+    },
+    async (input) => {
+      const { projectId, orgId } = await resolve(input.project_id);
+      const title = parseMemoryText(input.title, AGENT_MEMORY_TITLE_MAX_LEN);
+      const body = parseMemoryText(input.body, AGENT_MEMORY_BODY_MAX_LEN);
+      if (!title) throw new HTTPException(400, { message: "title is required" });
+      if (!body) throw new HTTPException(400, { message: "body is required" });
+      const row = await createAgentMemory({
+        orgId,
+        projectId,
+        kind: input.kind,
+        title,
+        body,
+        sourceUserId: session.userId,
+      });
+      if (!row) throw new HTTPException(500, { message: "failed to create memory" });
+      return text({ memory: serializeAgentMemory(row) });
+    },
+  );
+
+  server.registerTool(
+    "update_agent_memory",
+    {
+      title: "Update agent memory",
+      description:
+        "Patch a stored memory. Provide only the fields you want to change. Set status='archived' to retire a memory without deleting it (archived memories stop being injected into investigations).",
+      inputSchema: {
+        project_id: projectIdSchema,
+        id: z.string().uuid().describe("Memory id from list_agent_memories"),
+        kind: memoryKindSchema.optional(),
+        title: z.string().min(1).max(AGENT_MEMORY_TITLE_MAX_LEN).optional(),
+        body: z.string().min(1).max(AGENT_MEMORY_BODY_MAX_LEN).optional(),
+        status: z.enum(["active", "archived"]).optional(),
+      },
+    },
+    async (input) => {
+      const { projectId, orgId } = await resolve(input.project_id);
+      const patch: {
+        kind?: typeof input.kind;
+        title?: string;
+        body?: string;
+        status?: "active" | "archived";
+      } = {};
+      if (input.kind !== undefined) patch.kind = input.kind;
+      if (input.title !== undefined) {
+        const title = parseMemoryText(input.title, AGENT_MEMORY_TITLE_MAX_LEN);
+        if (!title) throw new HTTPException(400, { message: "title must be a non-empty string" });
+        patch.title = title;
+      }
+      if (input.body !== undefined) {
+        const body = parseMemoryText(input.body, AGENT_MEMORY_BODY_MAX_LEN);
+        if (!body) throw new HTTPException(400, { message: "body must be a non-empty string" });
+        patch.body = body;
+      }
+      if (input.status !== undefined) patch.status = input.status;
+      if (Object.keys(patch).length === 0) {
+        throw new HTTPException(400, {
+          message: "provide at least one of kind, title, body, status",
+        });
+      }
+      const row = await updateAgentMemory(orgId, projectId, input.id, patch);
+      if (!row) throw new HTTPException(404, { message: "memory not found" });
+      return text({ memory: serializeAgentMemory(row) });
+    },
+  );
+
+  server.registerTool(
+    "delete_agent_memory",
+    {
+      title: "Delete agent memory",
+      description:
+        "Permanently delete a stored memory by id. To retire one reversibly, prefer update_agent_memory with status='archived'.",
+      inputSchema: {
+        project_id: projectIdSchema,
+        id: z.string().uuid().describe("Memory id from list_agent_memories"),
+      },
+    },
+    async (input) => {
+      const { projectId, orgId } = await resolve(input.project_id);
+      const ok = await deleteAgentMemory(orgId, projectId, input.id);
+      if (!ok) throw new HTTPException(404, { message: "memory not found" });
+      return text({ ok: true });
+    },
+  );
+}

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -3,6 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { db, schema } from "@superlog/db";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
+import { registerAgentConfigTools } from "./agent-config.js";
 import { registerAlertTools } from "./alerts.js";
 import { listServices, queryLogs, queryMetrics, queryTraces } from "./clickhouse.js";
 import { registerDashboardTools } from "./dashboards.js";
@@ -75,8 +76,28 @@ export type McpSession = {
   telemetryOnly?: boolean;
 };
 
+// Advisory guidance surfaced to compatible MCP clients in the initialize
+// response. It's a nudge, not a guarantee — the connecting agent decides
+// whether to act on it — but most first-party clients inject it into context,
+// so it's where we steer the agent toward recording durable learnings.
+const SERVER_INSTRUCTIONS = [
+  "Superlog is an observability + investigation platform. Beyond querying telemetry (logs/traces/metrics) and incidents, you can tune how this project investigates issues.",
+  "",
+  "Record memories as you learn. When you uncover something that would help future investigations — a root-cause pattern, an infra/architecture fact, a domain term, or a correction about how to investigate — call create_agent_memory so it's injected into later runs. Prefer a short title + a specific, reusable body over a one-off incident narrative. Check list_agent_memories first to avoid duplicates, and update_agent_memory (status='archived') to retire stale ones.",
+  "",
+  "Capture system-level facts in the project context. For durable facts that apply to every investigation (architecture, conventions, key services), read get_project_context and append via set_project_context (it replaces the whole field, so edit the returned text).",
+  "",
+  "Tune the issue filter to control noise. When the user describes recurring noise or wants investigations scoped to certain services/routes, use get_issue_filter / preview_issue_filter / update_issue_filter — excludes drop matching events, non-empty includes restrict to matching events. Always preview before saving.",
+].join("\n");
+
 export function createMcpServerForSession(session: McpSession): McpServer {
-  const server = new McpServer({ name: "superlog", version: "0.1.0" });
+  // Telemetry-only sessions don't get the agent-config / alert / dashboard /
+  // incident tools, so the guidance below (which is all about them) would
+  // advertise tools that aren't registered. Omit instructions in that case.
+  const server = new McpServer(
+    { name: "superlog", version: "0.1.0" },
+    session.telemetryOnly ? undefined : { instructions: SERVER_INSTRUCTIONS },
+  );
 
   const assertTokenScope = async (projectId: string): Promise<void> => {
     if (!session.allowedOrgId) return;
@@ -284,6 +305,7 @@ export function createMcpServerForSession(session: McpSession): McpServer {
     registerAlertTools(server, session, session.ch);
     registerDashboardTools(server, session);
     registerIncidentTools(server, session);
+    registerAgentConfigTools(server, session, session.ch);
   }
 
   return server;

--- a/apps/api/src/project-context-service.test.ts
+++ b/apps/api/src/project-context-service.test.ts
@@ -1,0 +1,16 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
+const { clampProjectContext, PROJECT_CONTEXT_MAX_LEN } = await import(
+  "./project-context-service.js"
+);
+
+test("clampProjectContext clamps to the max length", () => {
+  assert.equal(clampProjectContext("x".repeat(PROJECT_CONTEXT_MAX_LEN + 100)).length, 8000);
+});
+
+test("clampProjectContext leaves short strings untouched", () => {
+  assert.equal(clampProjectContext("Checkout is a Next.js app on ECS."), "Checkout is a Next.js app on ECS.");
+  assert.equal(clampProjectContext(""), "");
+});

--- a/apps/api/src/project-context-service.ts
+++ b/apps/api/src/project-context-service.ts
@@ -1,0 +1,23 @@
+import { db, schema } from "@superlog/db";
+import { eq } from "drizzle-orm";
+
+export const PROJECT_CONTEXT_MAX_LEN = 8000;
+
+export function clampProjectContext(value: string): string {
+  return value.slice(0, PROJECT_CONTEXT_MAX_LEN);
+}
+
+export async function getProjectContext(projectId: string): Promise<string> {
+  const row = await db.query.projects.findFirst({
+    where: eq(schema.projects.id, projectId),
+    columns: { projectContext: true },
+  });
+  return row?.projectContext ?? "";
+}
+
+/** Overwrites the freeform context (clamped). Returns the stored value. */
+export async function setProjectContext(projectId: string, value: string): Promise<string> {
+  const projectContext = clampProjectContext(value);
+  await db.update(schema.projects).set({ projectContext }).where(eq(schema.projects.id, projectId));
+  return projectContext;
+}

--- a/apps/api/src/settings.ts
+++ b/apps/api/src/settings.ts
@@ -1,55 +1,26 @@
-import {
-  db,
-  encryptIntegrationSecret,
-  resolveDefaultAgentRunProvider,
-  schema,
-} from "@superlog/db";
+import { db, encryptIntegrationSecret, resolveDefaultAgentRunProvider, schema } from "@superlog/db";
 import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import type { Hono } from "hono";
 import type { Context } from "hono";
+import {
+  AGENT_MEMORY_BODY_MAX_LEN,
+  AGENT_MEMORY_TITLE_MAX_LEN,
+  createAgentMemory,
+  deleteAgentMemory,
+  listAgentMemories,
+  parseMemoryKind,
+  parseMemoryStatus,
+  parseMemoryText,
+  serializeAgentMemory,
+  updateAgentMemory,
+} from "./agent-memories-service.js";
 import { INTEGRATION_MANIFESTS } from "./integrations-manifest.js";
 import { resolveActiveOrgContext } from "./org-context.js";
+import { clampProjectContext } from "./project-context-service.js";
 
 type Vars = { userId: string; orgId: string | null };
 
 const ORG_INSTRUCTIONS_MAX_LEN = 8000;
-const PROJECT_CONTEXT_MAX_LEN = 8000;
-
-const AGENT_MEMORY_TITLE_MAX_LEN = 200;
-const AGENT_MEMORY_BODY_MAX_LEN = 4000;
-const AGENT_MEMORY_KINDS: schema.AgentMemoryKind[] = [
-  "feedback",
-  "terminology",
-  "infra",
-  "project",
-];
-
-function parseMemoryKind(value: unknown): schema.AgentMemoryKind | null {
-  return typeof value === "string" && (AGENT_MEMORY_KINDS as string[]).includes(value)
-    ? (value as schema.AgentMemoryKind)
-    : null;
-}
-
-function parseMemoryText(value: unknown, maxLen: number): string | null {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  if (trimmed.length === 0) return null;
-  return trimmed.slice(0, maxLen);
-}
-
-function serializeAgentMemory(row: schema.AgentMemory) {
-  return {
-    id: row.id,
-    kind: row.kind,
-    projectId: row.projectId,
-    title: row.title,
-    body: row.body,
-    status: row.status,
-    source: row.sourceAgentRunId ? "agent" : row.sourceUserId ? "user" : null,
-    createdAt: row.createdAt.toISOString(),
-    updatedAt: row.updatedAt.toISOString(),
-  };
-}
 
 const PROJECT_SLUG_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
 const PROJECT_NAME_MAX_LEN = 80;
@@ -100,13 +71,7 @@ export function mountSettingsAuthed(app: Hono<any>): void {
   app.get("/api/org/projects/:projectId/agent-memories", async (c) => {
     const scope = await resolveProjectScope(c);
     if (!scope) return c.json({ error: "project not found" }, 404);
-    const rows = await db.query.agentMemories.findMany({
-      where: and(
-        eq(schema.agentMemories.orgId, scope.orgId),
-        eq(schema.agentMemories.projectId, scope.projectId),
-      ),
-      orderBy: [asc(schema.agentMemories.createdAt)],
-    });
+    const rows = await listAgentMemories(scope.orgId, scope.projectId);
     return c.json({ memories: rows.map(serializeAgentMemory) });
   });
 
@@ -121,17 +86,14 @@ export function mountSettingsAuthed(app: Hono<any>): void {
     if (!title) return c.json({ error: "title is required" }, 400);
     const memoryBody = parseMemoryText(body.body, AGENT_MEMORY_BODY_MAX_LEN);
     if (!memoryBody) return c.json({ error: "body is required" }, 400);
-    const [row] = await db
-      .insert(schema.agentMemories)
-      .values({
-        orgId: scope.orgId,
-        projectId: scope.projectId,
-        kind,
-        title,
-        body: memoryBody,
-        sourceUserId: scope.userId,
-      })
-      .returning();
+    const row = await createAgentMemory({
+      orgId: scope.orgId,
+      projectId: scope.projectId,
+      kind,
+      title,
+      body: memoryBody,
+      sourceUserId: scope.userId,
+    });
     if (!row) return c.json({ error: "failed to create memory" }, 500);
     return c.json({ memory: serializeAgentMemory(row) });
   });
@@ -140,7 +102,12 @@ export function mountSettingsAuthed(app: Hono<any>): void {
     const scope = await resolveProjectScope(c);
     if (!scope) return c.json({ error: "project not found" }, 404);
     const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
-    const patch: Partial<typeof schema.agentMemories.$inferInsert> = {};
+    const patch: {
+      kind?: schema.AgentMemoryKind;
+      title?: string;
+      body?: string;
+      status?: "active" | "archived";
+    } = {};
     if (body.kind !== undefined) {
       const kind = parseMemoryKind(body.kind);
       if (!kind) return c.json({ error: "invalid kind" }, 400);
@@ -157,25 +124,14 @@ export function mountSettingsAuthed(app: Hono<any>): void {
       patch.body = memoryBody;
     }
     if (body.status !== undefined) {
-      if (body.status !== "active" && body.status !== "archived") {
-        return c.json({ error: "status must be active or archived" }, 400);
-      }
-      patch.status = body.status;
+      const status = parseMemoryStatus(body.status);
+      if (!status) return c.json({ error: "status must be active or archived" }, 400);
+      patch.status = status;
     }
     if (Object.keys(patch).length === 0) {
       return c.json({ error: "provide at least one of kind, title, body, status" }, 400);
     }
-    const [row] = await db
-      .update(schema.agentMemories)
-      .set({ ...patch, updatedAt: new Date() })
-      .where(
-        and(
-          eq(schema.agentMemories.id, c.req.param("id")),
-          eq(schema.agentMemories.orgId, scope.orgId),
-          eq(schema.agentMemories.projectId, scope.projectId),
-        ),
-      )
-      .returning();
+    const row = await updateAgentMemory(scope.orgId, scope.projectId, c.req.param("id"), patch);
     if (!row) return c.json({ error: "memory not found" }, 404);
     return c.json({ memory: serializeAgentMemory(row) });
   });
@@ -183,17 +139,8 @@ export function mountSettingsAuthed(app: Hono<any>): void {
   app.delete("/api/org/projects/:projectId/agent-memories/:id", async (c) => {
     const scope = await resolveProjectScope(c);
     if (!scope) return c.json({ error: "project not found" }, 404);
-    const [row] = await db
-      .delete(schema.agentMemories)
-      .where(
-        and(
-          eq(schema.agentMemories.id, c.req.param("id")),
-          eq(schema.agentMemories.orgId, scope.orgId),
-          eq(schema.agentMemories.projectId, scope.projectId),
-        ),
-      )
-      .returning({ id: schema.agentMemories.id });
-    if (!row) return c.json({ error: "memory not found" }, 404);
+    const ok = await deleteAgentMemory(scope.orgId, scope.projectId, c.req.param("id"));
+    if (!ok) return c.json({ error: "memory not found" }, 404);
     return c.json({ ok: true });
   });
 
@@ -362,9 +309,7 @@ export function mountSettingsAuthed(app: Hono<any>): void {
         name,
         slug: slugInput,
         projectContext:
-          typeof body.projectContext === "string"
-            ? body.projectContext.slice(0, PROJECT_CONTEXT_MAX_LEN)
-            : "",
+          typeof body.projectContext === "string" ? clampProjectContext(body.projectContext) : "",
       })
       .returning();
     if (!project) return c.json({ error: "failed to create project" }, 500);
@@ -419,7 +364,7 @@ export function mountSettingsAuthed(app: Hono<any>): void {
       }
     }
     if (typeof body.projectContext === "string") {
-      patch.projectContext = body.projectContext.slice(0, PROJECT_CONTEXT_MAX_LEN);
+      patch.projectContext = clampProjectContext(body.projectContext);
     }
     if (Object.keys(patch).length === 0) {
       return c.json({


### PR DESCRIPTION
## What

Exposes a project's investigation-tuning settings over the MCP server, so a connected agent can read and edit them — not just query telemetry. Three groups of tools, registered under the same non-telemetry scope gate as the alert/dashboard/incident tools:

- **Issue filter** — `get_issue_filter`, `update_issue_filter`, `preview_issue_filter`
  - `update_issue_filter` is a per-bucket merge: a bucket you provide replaces that bucket, an omitted bucket is left unchanged, and `[]` clears it.
  - `preview_issue_filter` dry-runs a candidate filter against the last 24h of ERROR events without saving (same population the worker filter applies to).
- **Project context** — `get_project_context`, `set_project_context` (clamped to 8000 chars; replaces the whole field).
- **Agent memories** — `list_agent_memories`, `create_agent_memory`, `update_agent_memory`, `delete_agent_memory`.

## How

The validation/persistence logic moves into three services — `issue-filter-service`, `agent-memories-service`, `project-context-service` — that **both** the existing REST settings handlers and the new MCP tools call, so the two surfaces stay in lockstep (same pattern as `alerts-service`). The REST handlers in `settings.ts` / `index.ts` are refactored to delegate to these services; no behavior change on the REST side.

## Server instructions

Sets the MCP server `instructions` field (previously unset). It's advisory guidance that compatible clients inject into context — it nudges the connected agent to record durable learnings via `create_agent_memory`, keep system-level facts in the project context, and tune the issue filter to control noise. A nudge, not a guarantee.

## Scope / safety

The new write tools resolve the target project enforcing **both** the token's org scope and the user's org membership (slightly stricter than the existing alert/dashboard tools, which only check membership).

## Testing

- New unit tests for the sanitizers, per-bucket merge, memory parsers/serializer, and context clamp.
- `tsc --noEmit` clean; full API suite green (254/254) against a live Postgres + ClickHouse.
- End-to-end: minted a PAT and drove the tools through a real MCP client — `tools/list` shows all 9, `create_agent_memory` → `list_agent_memories` round-trips, `update_issue_filter` / `set_project_context` persist, `delete_agent_memory` works, and the `instructions` string is delivered to the client.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP tools for agents to read and edit a project's issue filter, project context, and agent memories. Shared services keep MCP and REST in sync, and the MCP server now sends guidance via instructions for non-telemetry sessions.

- New Features
  - Issue filter tools: get, update (per-bucket merge; [] clears), and preview (dry-run against last 24h of ERROR events).
  - Project context tools: get and set (clamped to 8000 chars; replaces the whole field).
  - Agent memories tools: list, create, update (including status active/archived), delete.
  - MCP server sets `instructions` to nudge agents to record memories, maintain context, and tune filters (omitted for telemetry-only sessions).
  - Access control: tools are behind the non-telemetry scope gate; all operations enforce both the token’s org scope and the user’s org membership.

- Refactors
  - Added `issue-filter-service`, `agent-memories-service`, and `project-context-service`; REST handlers now delegate with no behavior changes.
  - Moved issue-filter sanitizers out of `index.ts`/`settings.ts` into services for consistent validation across surfaces.

<sup>Written for commit c6e8399b7470b83dc810a747dcc7976a0e6a067e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

