### PR TITLE
Per-widget value units + aggregation-aware legend, settings-styled editor

### DIFF
--- a/apps/api/src/dashboards-service.ts
+++ b/apps/api/src/dashboards-service.ts
@@ -26,6 +26,7 @@ export const dashboardWidgetConfigSchema = z.object({
   aggregation: z.enum(["sum", "avg", "min", "max", "p95", "p99"]).optional(),
   limit: z.number().int().positive().max(500).optional(),
   chartType: z.enum(["line", "bar"]).optional(),
+  unit: z.enum(["none", "duration_ms", "duration_s", "bytes", "percent"]).optional(),
   showXAxis: z.boolean().optional(),
   showYAxis: z.boolean().optional(),
   showLegend: z.boolean().optional(),

--- a/apps/web/src/dashboards/WidgetForm.tsx
+++ b/apps/web/src/dashboards/WidgetForm.tsx
@@ -360,20 +360,32 @@ export function WidgetForm({
                 <SettingsRow
                   title="X-axis markers"
                   control={
-                    <Toggle checked={form.showXAxis} onChange={(v) => update({ showXAxis: v })} />
+                    <Toggle
+                      label="X-axis markers"
+                      checked={form.showXAxis}
+                      onChange={(v) => update({ showXAxis: v })}
+                    />
                   }
                 />
                 <SettingsRow
                   title="Y-axis markers"
                   control={
-                    <Toggle checked={form.showYAxis} onChange={(v) => update({ showYAxis: v })} />
+                    <Toggle
+                      label="Y-axis markers"
+                      checked={form.showYAxis}
+                      onChange={(v) => update({ showYAxis: v })}
+                    />
                   }
                 />
                 <SettingsRow
                   title="Legend"
                   description="Show a key of series names and values"
                   control={
-                    <Toggle checked={form.showLegend} onChange={(v) => update({ showLegend: v })} />
+                    <Toggle
+                      label="Legend"
+                      checked={form.showLegend}
+                      onChange={(v) => update({ showLegend: v })}
+                    />
                   }
                 />
                 {form.showLegend && (
@@ -449,12 +461,16 @@ export function WidgetForm({
   );
 }
 
-// Switch toggle matching the settings rows (see Settings.tsx Toggle).
+// Switch toggle matching the settings rows (see Settings.tsx Toggle). The row
+// title is only a visual sibling, so `label` is required to give the switch an
+// accessible name (role="switch" otherwise reads as an unnamed control).
 function Toggle({
+  label,
   checked,
   disabled = false,
   onChange,
 }: {
+  label: string;
   checked: boolean;
   disabled?: boolean;
   onChange: (v: boolean) => void;
@@ -463,6 +479,7 @@ function Toggle({
     <button
       type="button"
       role="switch"
+      aria-label={label}
       aria-checked={checked}
       disabled={disabled}
       onClick={() => onChange(!checked)}

--- a/apps/web/src/dashboards/WidgetForm.tsx
+++ b/apps/web/src/dashboards/WidgetForm.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
+import { AddFilter, GroupBySelect, MetricNamePicker } from "../Explore.tsx";
+import { type ExploreRange, METRIC_AGGREGATIONS } from "../api.ts";
+import { Btn, Chip, Input, Label, PillToggle, Tile } from "../design/ui.tsx";
+import { SettingsCard, SettingsRow } from "../settings/rows.tsx";
 import {
-  AddFilter,
-  GroupBySelect,
-  MetricNamePicker,
-  SegmentedToggle,
-} from "../Explore.tsx";
-import { METRIC_AGGREGATIONS, type ExploreRange } from "../api.ts";
-import { Btn, Chip, FieldLabel, Input, Label, Tile } from "../design/ui.tsx";
-import { type Widget, type WidgetConfig, type WidgetType, defaultChartType, defaultLayoutFor } from "./types.ts";
+  type Widget,
+  type WidgetConfig,
+  type WidgetType,
+  defaultChartType,
+  defaultLayoutFor,
+} from "./types.ts";
 import {
   type WidgetFormState,
   buildWidgetConfig,
@@ -16,6 +18,7 @@ import {
   widgetTypeFor,
 } from "./widget-config.ts";
 import { WidgetBody } from "./widgets/WidgetBody.tsx";
+import { WIDGET_UNITS, WIDGET_UNIT_LABELS } from "./widgets/widget-format.ts";
 
 export function WidgetForm({
   projectId,
@@ -157,215 +160,261 @@ export function WidgetForm({
             </button>
           </div>
 
-          <div className="flex flex-col gap-4">
-            <div>
-              <FieldLabel>kind</FieldLabel>
-              <SegmentedToggle
-                value={kind}
-                options={[
-                  { value: "chart", label: "chart" },
-                  { value: "table", label: "table" },
-                  { value: "note", label: "note" },
-                ]}
-                onChange={(v) => update({ kind: v as WidgetFormState["kind"] })}
-              />
-            </div>
+          {/* Widget kind as pill tabs, mirroring the settings tab bar. */}
+          <div className="mb-5">
+            <PillToggle
+              value={kind}
+              options={[
+                { value: "chart", label: "Chart" },
+                { value: "table", label: "Table" },
+                { value: "note", label: "Note" },
+              ]}
+              onChange={(v) => update({ kind: v as WidgetFormState["kind"] })}
+            />
+          </div>
 
+          <div className="space-y-4">
             {!isNote && (
-              <div>
-                <FieldLabel>source</FieldLabel>
-                <SegmentedToggle
-                  value={source}
-                  options={sourceOptions}
-                  onChange={(v) => update({ source: v as WidgetFormState["source"] })}
-                />
-              </div>
-            )}
-
-            {isChart && (
-              <div>
-                <FieldLabel>chart type</FieldLabel>
-                <SegmentedToggle
-                  value={form.chartType ?? defaultChartType(type)}
-                  options={[
-                    { value: "line", label: "line" },
-                    { value: "bar", label: "bar" },
-                  ]}
-                  onChange={(v) => update({ chartType: v as WidgetFormState["chartType"] })}
-                />
-              </div>
-            )}
-
-            {isMetric && (
-              <div>
-                <FieldLabel>metric</FieldLabel>
-                <MetricNamePicker
-                  projectId={projectId}
-                  range={range}
-                  value={form.metricName}
-                  onChange={(v) => update({ metricName: v })}
-                />
-              </div>
-            )}
-
-            {isMetric && (
-              <div>
-                <FieldLabel>aggregation</FieldLabel>
-                <SegmentedToggle
-                  value={form.aggregation}
-                  options={["auto", ...METRIC_AGGREGATIONS].map((a) => ({ value: a, label: a }))}
-                  onChange={(v) => update({ aggregation: v as WidgetFormState["aggregation"] })}
-                />
-              </div>
-            )}
-
-            {isChart && (
-              <div>
-                <FieldLabel>group by</FieldLabel>
-                <GroupBySelect
-                  projectId={projectId}
-                  range={range}
-                  source={source === "metric" ? undefined : source}
-                  value={form.groupBy}
-                  onChange={(g) => update({ groupBy: g })}
-                  shortcut={false}
-                  triggerLabel=""
-                />
-              </div>
-            )}
-
-            {isChart && form.groupBy && (
-              <div>
-                <FieldLabel>top series</FieldLabel>
-                <Input
-                  type="number"
-                  min={1}
-                  max={50}
-                  step={1}
-                  value={form.seriesLimit}
-                  onChange={(e) =>
-                    update({
-                      seriesLimit: Math.max(1, Math.min(50, Number(e.target.value) || 10)),
-                    })
+              <SettingsCard>
+                <SettingsRow
+                  title="Source"
+                  description="Where this widget pulls its data from"
+                  control={
+                    <PillToggle
+                      value={source}
+                      options={sourceOptions}
+                      onChange={(v) => update({ source: v as WidgetFormState["source"] })}
+                    />
                   }
                 />
-                <div className="mt-1 font-mono text-[10px] text-subtle">
-                  remaining groups roll into “Other”
-                </div>
-              </div>
-            )}
 
-            {isTable && (
-              <div>
-                <FieldLabel>row limit</FieldLabel>
-                <Input
-                  type="number"
-                  min={10}
-                  max={500}
-                  step={10}
-                  value={form.rowLimit}
-                  onChange={(e) =>
-                    update({ rowLimit: Math.max(10, Math.min(500, Number(e.target.value) || 50)) })
-                  }
-                />
-              </div>
+                {isMetric && (
+                  <SettingsRow title="Metric" description="The metric series to chart">
+                    <MetricNamePicker
+                      projectId={projectId}
+                      range={range}
+                      value={form.metricName}
+                      onChange={(v) => update({ metricName: v })}
+                    />
+                  </SettingsRow>
+                )}
+
+                {isMetric && (
+                  <SettingsRow
+                    title="Aggregation"
+                    description="How points combine within each bucket"
+                    control={
+                      <PillToggle
+                        size="sm"
+                        value={form.aggregation}
+                        options={["auto", ...METRIC_AGGREGATIONS].map((a) => ({
+                          value: a,
+                          label: a,
+                        }))}
+                        onChange={(v) =>
+                          update({ aggregation: v as WidgetFormState["aggregation"] })
+                        }
+                      />
+                    }
+                  />
+                )}
+
+                {isChart && (
+                  <SettingsRow
+                    title="Group by"
+                    description="Split into one series per attribute value"
+                    control={
+                      <div className="w-52">
+                        <GroupBySelect
+                          projectId={projectId}
+                          range={range}
+                          source={source === "metric" ? undefined : source}
+                          value={form.groupBy}
+                          onChange={(g) => update({ groupBy: g })}
+                          shortcut={false}
+                          triggerLabel=""
+                        />
+                      </div>
+                    }
+                  />
+                )}
+
+                {isChart && form.groupBy && (
+                  <SettingsRow
+                    title="Top series"
+                    description="Remaining groups roll into “Other”"
+                    control={
+                      <div className="w-24">
+                        <Input
+                          type="number"
+                          min={1}
+                          max={50}
+                          step={1}
+                          value={form.seriesLimit}
+                          onChange={(e) =>
+                            update({
+                              seriesLimit: Math.max(1, Math.min(50, Number(e.target.value) || 10)),
+                            })
+                          }
+                        />
+                      </div>
+                    }
+                  />
+                )}
+
+                {isTable && (
+                  <SettingsRow
+                    title="Row limit"
+                    description="Maximum rows shown in the table"
+                    control={
+                      <div className="w-24">
+                        <Input
+                          type="number"
+                          min={10}
+                          max={500}
+                          step={10}
+                          value={form.rowLimit}
+                          onChange={(e) =>
+                            update({
+                              rowLimit: Math.max(10, Math.min(500, Number(e.target.value) || 50)),
+                            })
+                          }
+                        />
+                      </div>
+                    }
+                  />
+                )}
+
+                <SettingsRow title="Filters" description="Limit to matching resource attributes">
+                  <div className="flex flex-wrap items-center gap-2">
+                    {form.attrs.map((a, i) => (
+                      <button
+                        type="button"
+                        key={`${a.key}=${a.value}-${i}`}
+                        onClick={() => update({ attrs: form.attrs.filter((_, j) => j !== i) })}
+                        title="remove"
+                      >
+                        <Chip tone="accent">
+                          <span className="opacity-70">{a.key}</span>
+                          <span>=</span>
+                          <span>{a.value}</span>
+                          <span className="ml-1 opacity-60">×</span>
+                        </Chip>
+                      </button>
+                    ))}
+                    <div className="relative">
+                      <Btn variant="secondary" size="sm" onClick={() => setFilterOpen((v) => !v)}>
+                        + add filter
+                      </Btn>
+                      {filterOpen && (
+                        <AddFilter
+                          projectId={projectId}
+                          range={range}
+                          source={source === "metric" ? undefined : source}
+                          existing={form.attrs}
+                          onClose={() => setFilterOpen(false)}
+                          onPick={(f) => {
+                            if (f.kind === "attr") {
+                              update({ attrs: [...form.attrs, { key: f.key, value: f.value }] });
+                            }
+                            setFilterOpen(false);
+                          }}
+                        />
+                      )}
+                    </div>
+                  </div>
+                </SettingsRow>
+              </SettingsCard>
             )}
 
             {isChart && (
-              <div>
-                <FieldLabel>display</FieldLabel>
-                <div className="flex flex-col gap-2">
-                  <Toggle
-                    label="x-axis markers"
-                    checked={form.showXAxis}
-                    onChange={(v) => update({ showXAxis: v })}
-                  />
-                  <Toggle
-                    label="y-axis markers"
-                    checked={form.showYAxis}
-                    onChange={(v) => update({ showYAxis: v })}
-                  />
-                  <Toggle
-                    label="legend"
-                    checked={form.showLegend}
-                    onChange={(v) => update({ showLegend: v })}
-                  />
-                  {form.showLegend && (
-                    <div className="pt-1">
-                      <SegmentedToggle
+              <SettingsCard>
+                <SettingsRow
+                  title="Chart type"
+                  control={
+                    <PillToggle
+                      value={form.chartType ?? defaultChartType(type)}
+                      options={[
+                        { value: "line", label: "Line" },
+                        { value: "bar", label: "Bar" },
+                      ]}
+                      onChange={(v) => update({ chartType: v as WidgetFormState["chartType"] })}
+                    />
+                  }
+                />
+                <SettingsRow
+                  title="Value unit"
+                  description="Scales axis, tooltip & legend (e.g. 15000 ms → 15s)"
+                  control={
+                    <PillToggle
+                      size="sm"
+                      value={form.unit}
+                      options={WIDGET_UNITS.map((u) => ({
+                        value: u,
+                        label: WIDGET_UNIT_LABELS[u],
+                      }))}
+                      onChange={(v) => update({ unit: v as WidgetFormState["unit"] })}
+                    />
+                  }
+                />
+                <SettingsRow
+                  title="X-axis markers"
+                  control={
+                    <Toggle checked={form.showXAxis} onChange={(v) => update({ showXAxis: v })} />
+                  }
+                />
+                <SettingsRow
+                  title="Y-axis markers"
+                  control={
+                    <Toggle checked={form.showYAxis} onChange={(v) => update({ showYAxis: v })} />
+                  }
+                />
+                <SettingsRow
+                  title="Legend"
+                  description="Show a key of series names and values"
+                  control={
+                    <Toggle checked={form.showLegend} onChange={(v) => update({ showLegend: v })} />
+                  }
+                />
+                {form.showLegend && (
+                  <SettingsRow
+                    title="Legend position"
+                    control={
+                      <PillToggle
                         value={form.legendPosition}
                         options={[
-                          { value: "side", label: "side" },
-                          { value: "bottom", label: "bottom" },
+                          { value: "side", label: "Side" },
+                          { value: "bottom", label: "Bottom" },
                         ]}
                         onChange={(v) =>
                           update({ legendPosition: v as WidgetFormState["legendPosition"] })
                         }
                       />
-                    </div>
-                  )}
-                </div>
-              </div>
+                    }
+                  />
+                )}
+              </SettingsCard>
             )}
 
             {isNote && (
-              <div>
-                <FieldLabel>markdown</FieldLabel>
-                <textarea
-                  value={form.markdown}
-                  onChange={(e) => update({ markdown: e.target.value })}
-                  className="min-h-40 w-full resize-y rounded-sm border border-border bg-surface-2 px-3 py-2 font-mono text-[12px] leading-relaxed text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none"
-                />
-              </div>
-            )}
-
-            {!isNote && (
-              <div>
-                <FieldLabel>filters</FieldLabel>
-                <div className="flex flex-wrap items-center gap-2">
-                  {form.attrs.map((a, i) => (
-                    <button
-                      type="button"
-                      key={`${a.key}=${a.value}-${i}`}
-                      onClick={() => update({ attrs: form.attrs.filter((_, j) => j !== i) })}
-                      title="remove"
-                    >
-                      <Chip tone="accent">
-                        <span className="opacity-70">{a.key}</span>
-                        <span>=</span>
-                        <span>{a.value}</span>
-                        <span className="ml-1 opacity-60">×</span>
-                      </Chip>
-                    </button>
-                  ))}
-                  <div className="relative">
-                    <Btn variant="secondary" size="sm" onClick={() => setFilterOpen((v) => !v)}>
-                      + add filter
-                    </Btn>
-                    {filterOpen && (
-                      <AddFilter
-                        projectId={projectId}
-                        range={range}
-                        source={source === "metric" ? undefined : source}
-                        existing={form.attrs}
-                        onClose={() => setFilterOpen(false)}
-                        onPick={(f) => {
-                          if (f.kind === "attr") {
-                            update({ attrs: [...form.attrs, { key: f.key, value: f.value }] });
-                          }
-                          setFilterOpen(false);
-                        }}
-                      />
-                    )}
-                  </div>
-                </div>
-              </div>
+              <SettingsCard>
+                <SettingsRow
+                  title="Markdown"
+                  description="Rendered with headings, bullets, and inline code"
+                >
+                  <textarea
+                    value={form.markdown}
+                    onChange={(e) => update({ markdown: e.target.value })}
+                    className="min-h-40 w-full resize-y rounded-lg border border-border bg-surface-2 px-3 py-2 font-mono text-[12px] leading-relaxed text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none"
+                  />
+                </SettingsRow>
+              </SettingsCard>
             )}
           </div>
 
-          <div className="mt-6 border-t border-border pt-5">
+          <div className="mt-6">
             <Label>preview</Label>
-            <div className="mt-3 h-[260px] border border-border bg-surface-1 p-4">
+            <div className="mt-3 h-[260px] rounded-lg border border-border bg-surface-1 p-4">
               {isMetric && !form.metricName ? (
                 <div className="flex h-full items-center justify-center font-mono text-[11px] text-subtle">
                   pick a metric to preview
@@ -380,16 +429,16 @@ export function WidgetForm({
             </div>
           </div>
 
-          <div className="mt-6 flex items-center justify-end gap-3 border-t border-border pt-4">
-            {error && (
-              <span className="mr-auto font-mono text-[11px] text-danger" role="alert">
-                {error}
-              </span>
-            )}
-            <Btn variant="ghost" onClick={onClose}>
+          {error && (
+            <div className="mt-4 text-[12px] text-danger" role="alert">
+              {error}
+            </div>
+          )}
+          <div className="mt-4 flex items-center justify-end gap-2">
+            <Btn variant="ghost" size="sm" onClick={onClose}>
               cancel
             </Btn>
-            <Btn onClick={submit} loading={submitting} disabled={disabled}>
+            <Btn size="sm" onClick={submit} loading={submitting} disabled={disabled}>
               {mode === "edit" ? "save changes" : "add widget"}
             </Btn>
           </div>
@@ -400,24 +449,32 @@ export function WidgetForm({
   );
 }
 
+// Switch toggle matching the settings rows (see Settings.tsx Toggle).
 function Toggle({
-  label,
   checked,
+  disabled = false,
   onChange,
 }: {
-  label: string;
   checked: boolean;
+  disabled?: boolean;
   onChange: (v: boolean) => void;
 }) {
   return (
-    <label className="flex cursor-pointer items-center justify-between font-mono text-[11px] text-muted hover:text-fg">
-      <span>{label}</span>
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-        className="h-3.5 w-3.5 cursor-pointer accent-accent"
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors ${
+        checked ? "border-accent bg-accent" : "border-border bg-surface-3"
+      } ${disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
+    >
+      <span
+        className={`inline-block h-3.5 w-3.5 transform rounded-full bg-accent-ink transition-transform ${
+          checked ? "translate-x-[18px]" : "translate-x-[2px]"
+        }`}
       />
-    </label>
+    </button>
   );
 }

--- a/apps/web/src/dashboards/types.ts
+++ b/apps/web/src/dashboards/types.ts
@@ -1,5 +1,6 @@
 import type { ExploreFilter, ResourceAttr } from "../api.ts";
 import type { MetricAggregation } from "../api.ts";
+import type { WidgetUnit } from "./widgets/widget-format.ts";
 
 export type WidgetType =
   | "timeseries_count"
@@ -18,6 +19,8 @@ export type WidgetConfig = {
   aggregation?: MetricAggregation;
   limit?: number;
   chartType?: ChartType;
+  /** How values are formatted on the axis, tooltip, and legend. Defaults to "none". */
+  unit?: WidgetUnit;
   showXAxis?: boolean;
   showYAxis?: boolean;
   showLegend?: boolean;

--- a/apps/web/src/dashboards/widget-config.test.ts
+++ b/apps/web/src/dashboards/widget-config.test.ts
@@ -83,6 +83,34 @@ test("round-trips a fully specified metric widget config", () => {
   assert.deepEqual(buildWidgetConfig(formFromWidget(w)), w.config);
 });
 
+test("round-trips a metric widget with a unit", () => {
+  const w = widget({
+    type: "timeseries_metric",
+    config: {
+      filter: {},
+      metricName: "ingest.latency",
+      aggregation: "avg",
+      unit: "duration_ms",
+      chartType: "line",
+      showXAxis: true,
+      showYAxis: true,
+      showLegend: true,
+      legendPosition: "side",
+    },
+  });
+  assert.deepEqual(buildWidgetConfig(formFromWidget(w)), w.config);
+});
+
+test("unit 'none' is omitted from config", () => {
+  const form = {
+    ...emptyWidgetForm(),
+    kind: "chart" as const,
+    source: "logs" as const,
+    unit: "none" as const,
+  };
+  assert.equal(buildWidgetConfig(form).unit, undefined);
+});
+
 test("round-trips a markdown note", () => {
   const w = widget({ type: "markdown", config: { filter: {}, markdown: "# Hi" } });
   assert.deepEqual(buildWidgetConfig(formFromWidget(w)), w.config);

--- a/apps/web/src/dashboards/widget-config.ts
+++ b/apps/web/src/dashboards/widget-config.ts
@@ -1,6 +1,7 @@
 import type { MetricAggregation, ResourceAttr } from "../api.ts";
 import { type ChartType, type LegendPosition, type Widget, type WidgetConfig, type WidgetType } from "./types.ts";
 import { DEFAULT_TOP_N } from "./widgets/series-topn.ts";
+import type { WidgetUnit } from "./widgets/widget-format.ts";
 
 export type WidgetKind = "chart" | "table" | "note";
 export type WidgetDataSource = "metric" | "traces" | "logs";
@@ -22,6 +23,7 @@ export type WidgetFormState = {
   attrs: ResourceAttr[];
   chartType?: ChartType;
   aggregation: MetricAggregation | "auto";
+  unit: WidgetUnit;
   showXAxis: boolean;
   showYAxis: boolean;
   showLegend: boolean;
@@ -40,6 +42,7 @@ export function emptyWidgetForm(): WidgetFormState {
     attrs: [],
     chartType: undefined,
     aggregation: "auto",
+    unit: "none",
     showXAxis: true,
     showYAxis: true,
     showLegend: false,
@@ -123,6 +126,7 @@ export function formFromWidget(widget: Widget): WidgetFormState {
     attrs: c.filter?.resourceAttrs ?? [],
     chartType: c.chartType,
     aggregation: c.aggregation ?? "auto",
+    unit: c.unit ?? "none",
     showXAxis: c.showXAxis ?? base.showXAxis,
     showYAxis: c.showYAxis ?? base.showYAxis,
     showLegend: c.showLegend ?? base.showLegend,
@@ -151,6 +155,7 @@ export function buildWidgetConfig(form: WidgetFormState): WidgetConfig {
   set("aggregation", isMetric && form.aggregation !== "auto" ? form.aggregation : undefined);
   set("limit", isTable ? form.rowLimit : grouped ? form.seriesLimit : undefined);
   set("chartType", isChart ? form.chartType : undefined);
+  set("unit", isChart && form.unit !== "none" ? form.unit : undefined);
   set("showXAxis", isChart ? form.showXAxis : undefined);
   set("showYAxis", isChart ? form.showYAxis : undefined);
   set("showLegend", isChart ? form.showLegend : undefined);

--- a/apps/web/src/dashboards/widgets/CountChart.tsx
+++ b/apps/web/src/dashboards/widgets/CountChart.tsx
@@ -13,6 +13,7 @@ import {
   buildTopNSeries,
   parseStepMs,
 } from "./series-topn.ts";
+import { type SummaryAgg, type WidgetUnit, formatValue, summarizeSeries } from "./widget-format.ts";
 
 type SeriesChartProps<T extends GroupedRow> = {
   rows: T[];
@@ -32,6 +33,14 @@ type SeriesChartProps<T extends GroupedRow> = {
   showYAxis?: boolean;
   showLegend: boolean;
   legendPosition: LegendPosition;
+  /** How to render values on the axis, in the tooltip, and in the legend. */
+  unit?: WidgetUnit;
+  /**
+   * Aggregation the legend headline mirrors: "sum" for count widgets, the
+   * widget's own aggregation for metric widgets (the window total of per-bucket
+   * sums is meaningless for a gauge metric, so the headline matches the chart).
+   */
+  legendAgg?: SummaryAgg;
   /** Optional horizontal reference line (e.g. an alert threshold). */
   threshold?: number;
   thresholdLabel?: string;
@@ -65,10 +74,6 @@ const AXIS_LABEL_COLOR = "rgba(138, 138, 143, 0.5)";
 const GRID_LINE_COLOR = "rgba(255, 255, 255, 0.07)";
 const THRESHOLD_COLOR = "#E8649D";
 
-const defaultNumberFormat = new Intl.NumberFormat(undefined, {
-  maximumFractionDigits: 3,
-});
-
 const timestampFormat = new Intl.DateTimeFormat(undefined, {
   month: "short",
   day: "numeric",
@@ -89,6 +94,8 @@ export function CountChart<T extends GroupedRow>({
   showYAxis = false,
   showLegend,
   legendPosition,
+  unit = "none",
+  legendAgg = "sum",
   threshold,
   thresholdLabel,
 }: SeriesChartProps<T>) {
@@ -152,6 +159,7 @@ export function CountChart<T extends GroupedRow>({
       xMax={window?.untilMs}
       showXAxis={showXAxis}
       showYAxis={showYAxis}
+      unit={unit}
       threshold={threshold}
       thresholdLabel={thresholdLabel}
       optionUpdateBehavior={{ notMerge: true, lazyUpdate: true }}
@@ -171,19 +179,23 @@ export function CountChart<T extends GroupedRow>({
           hiddenSeries={hiddenSeries}
           onToggleSeries={toggleSeries}
           position="bottom"
+          unit={unit}
+          legendAgg={legendAgg}
         />
       </div>
     );
   }
 
   return (
-    <div className="grid h-full min-h-0 grid-cols-[minmax(0,1fr)_150px]">
+    <div className="grid h-full min-h-0 grid-cols-[minmax(0,1fr)_180px]">
       <div className="min-h-0 min-w-0">{chart}</div>
       <SeriesLegend
         series={allSeries}
         hiddenSeries={hiddenSeries}
         onToggleSeries={toggleSeries}
         position="side"
+        unit={unit}
+        legendAgg={legendAgg}
       />
     </div>
   );
@@ -197,6 +209,7 @@ function KumoLikeTimeseriesChart({
   xMax,
   showXAxis,
   showYAxis,
+  unit,
   threshold,
   thresholdLabel,
   optionUpdateBehavior,
@@ -208,6 +221,7 @@ function KumoLikeTimeseriesChart({
   xMax?: number;
   showXAxis: boolean;
   showYAxis: boolean;
+  unit: WidgetUnit;
   threshold?: number;
   thresholdLabel?: string;
   optionUpdateBehavior?: SetOptionOpts;
@@ -247,7 +261,7 @@ function KumoLikeTimeseriesChart({
         label: {
           show: true,
           position: "insideEndTop" as const,
-          formatter: thresholdLabel ?? `threshold ${formatDefaultValue(threshold)}`,
+          formatter: thresholdLabel ?? `threshold ${formatValue(threshold, unit)}`,
           color: THRESHOLD_COLOR,
           fontSize: 10,
         },
@@ -291,7 +305,7 @@ function KumoLikeTimeseriesChart({
           color: AXIS_LABEL_COLOR,
           fontSize: 11,
           margin: 10,
-          formatter: (value: number) => formatDefaultValue(value),
+          formatter: (value: number) => formatValue(value, unit),
         },
         splitLine: {
           show: true,
@@ -307,7 +321,7 @@ function KumoLikeTimeseriesChart({
       },
       series: transformSeries,
     } satisfies EChartsOption;
-  }, [data, type, xMin, xMax, showXAxis, showYAxis, threshold, thresholdLabel]);
+  }, [data, type, xMin, xMax, showXAxis, showYAxis, unit, threshold, thresholdLabel]);
 
   const events = useMemo<Partial<ChartEvents>>(
     () => ({
@@ -367,7 +381,7 @@ function KumoLikeTimeseriesChart({
             collisionPadding={8}
           >
             <TooltipPrimitive.Popup className="rounded-lg border border-border-strong bg-surface px-2 py-2 text-fg shadow-2xl shadow-black/30">
-              <TooltipContent state={tooltipState} />
+              <TooltipContent state={tooltipState} unit={unit} />
             </TooltipPrimitive.Popup>
           </TooltipPrimitive.Positioner>
         </TooltipPrimitive.Portal>
@@ -480,7 +494,13 @@ const Chart = forwardRef<
 
 Chart.displayName = "Chart";
 
-const TooltipContent = memo(function TooltipContent({ state }: { state: TooltipState }) {
+const TooltipContent = memo(function TooltipContent({
+  state,
+  unit,
+}: {
+  state: TooltipState;
+  unit: WidgetUnit;
+}) {
   const { ts, rows, hiddenCount } = state;
   return (
     <>
@@ -497,7 +517,7 @@ const TooltipContent = memo(function TooltipContent({ state }: { state: TooltipS
             </span>
           </div>
           <span className="shrink-0 text-xs font-semibold text-fg">
-            {formatDefaultValue(row.value)}
+            {formatValue(row.value, unit)}
           </span>
         </div>
       ))}
@@ -511,11 +531,15 @@ function SeriesLegend({
   hiddenSeries,
   onToggleSeries,
   position,
+  unit,
+  legendAgg,
 }: {
   series: TimeseriesData[];
   hiddenSeries: Set<string>;
   onToggleSeries: (name: string) => void;
   position: LegendPosition;
+  unit: WidgetUnit;
+  legendAgg: SummaryAgg;
 }) {
   const isBottom = position === "bottom";
   return (
@@ -561,7 +585,7 @@ function SeriesLegend({
                   inactive && "text-subtle line-through opacity-60",
                 )}
               >
-                {formatDefaultValue(item.total)}
+                {formatValue(summarizeSeries(item.values, legendAgg), unit)}
               </span>
             </button>
           );
@@ -608,11 +632,6 @@ function getAxisPointerTimestamp(params: unknown): number | undefined {
   const axesInfo = (params as { axesInfo?: Array<{ value?: unknown }> }).axesInfo;
   const value = axesInfo?.[0]?.value;
   return typeof value === "number" ? value : undefined;
-}
-
-function formatDefaultValue(value: number): string {
-  if (Number.isInteger(value)) return String(value);
-  return defaultNumberFormat.format(value);
 }
 
 function formatTimestamp(value: number): string {

--- a/apps/web/src/dashboards/widgets/TimeseriesCountWidget.tsx
+++ b/apps/web/src/dashboards/widgets/TimeseriesCountWidget.tsx
@@ -36,6 +36,8 @@ export function TimeseriesCountWidget({
         showYAxis={widget.config.showYAxis ?? true}
         showLegend={widget.config.showLegend ?? false}
         legendPosition={widget.config.legendPosition ?? "side"}
+        unit={widget.config.unit ?? "none"}
+        legendAgg="sum"
       />
     </div>
   );

--- a/apps/web/src/dashboards/widgets/TimeseriesMetricWidget.tsx
+++ b/apps/web/src/dashboards/widgets/TimeseriesMetricWidget.tsx
@@ -48,6 +48,11 @@ export function TimeseriesMetricWidget({
         showYAxis={widget.config.showYAxis ?? true}
         showLegend={widget.config.showLegend ?? false}
         legendPosition={widget.config.legendPosition ?? "side"}
+        unit={widget.config.unit ?? "none"}
+        // The window total of per-bucket aggregates is meaningless for a gauge
+        // metric, so the legend headline mirrors the widget's own aggregation
+        // (defaulting to avg, which is the server default for gauge metrics).
+        legendAgg={widget.config.aggregation ?? "avg"}
       />
     </div>
   );

--- a/apps/web/src/dashboards/widgets/series-topn.test.ts
+++ b/apps/web/src/dashboards/widgets/series-topn.test.ts
@@ -29,6 +29,33 @@ test("orders series by total descending", () => {
   );
 });
 
+test("values holds present buckets only, excluding cross-series zero-fill", () => {
+  // Two groups share a bucket axis: "a" has data in both buckets, "b" only in
+  // the first. "b"'s `data` is zero-filled to align the axis, but `values` must
+  // contain only the bucket it actually had — so a legend avg/min isn't dragged
+  // to zero.
+  const rows = [
+    { bucket: "2026-06-01 00:00:00", group: "a", count: 10 },
+    { bucket: "2026-06-01 00:01:00", group: "a", count: 20 },
+    { bucket: "2026-06-01 00:00:00", group: "b", count: 7 },
+  ];
+  const series = buildTopNSeries(rows, count, 10);
+  const a = series.find((s) => s.name === "a");
+  const b = series.find((s) => s.name === "b");
+  assert.ok(a && b);
+  assert.deepEqual(a.values, [10, 20]);
+  assert.deepEqual(
+    a.data.map((d) => d[1]),
+    [10, 20],
+  );
+  // b is zero-filled in the second bucket for the chart, but values has just 7.
+  assert.deepEqual(b.values, [7]);
+  assert.deepEqual(
+    b.data.map((d) => d[1]),
+    [7, 0],
+  );
+});
+
 test("rolls groups beyond the limit into a single Other series, placed last", () => {
   // 5 groups, limit 3 → top 3 + Other (sum of remaining 2).
   const rows = rowsFor(

--- a/apps/web/src/dashboards/widgets/series-topn.ts
+++ b/apps/web/src/dashboards/widgets/series-topn.ts
@@ -58,10 +58,16 @@ function gridBucketsMs(grid: BucketGrid): number[] | null {
 export type ChartSeries = {
   /** Group value, or "Other" for the rolled-up remainder, "(none)" when empty. */
   name: string;
-  /** Sum of every point in this series — drives ordering and the legend value. */
+  /** Sum of every point in this series — drives top-N ordering. */
   total: number;
   /** `[timestamp_ms, value]` tuples, one per bucket, ascending by time. */
   data: [number, number][];
+  /**
+   * Per-bucket values for buckets this series actually has data in — the
+   * cross-series zero-fill in `data` is excluded. Drives the legend headline so
+   * summaries like avg/min reflect the real distribution, not padded zeros.
+   */
+  values: number[];
   /** True only for the synthetic rolled-up remainder series. */
   isOther: boolean;
 };
@@ -116,36 +122,54 @@ export function buildTopNSeries<T extends GroupedRow>(
   // Accumulate per-bucket values, zero-filled, so lines/bars don't gap. The
   // rollup remainder lives in its own accumulator (not the points map) so a
   // real group literally named "Other" can't collide with the synthetic series.
+  // `seen` tracks which buckets each series actually has a row in, so the chart
+  // can zero-fill `data` for alignment while the legend summary (`values`) skips
+  // those padded buckets.
   const points = new Map<string, number[]>();
-  for (const g of topGroups) points.set(g, new Array(buckets.length).fill(0));
+  const seen = new Map<string, boolean[]>();
+  for (const g of topGroups) {
+    points.set(g, new Array(buckets.length).fill(0));
+    seen.set(g, new Array(buckets.length).fill(false));
+  }
   const otherArr = hasOther ? new Array<number>(buckets.length).fill(0) : null;
+  const otherSeen = hasOther ? new Array<boolean>(buckets.length).fill(false) : null;
 
   for (const r of rows) {
     const g = r.group || NONE_LABEL;
-    const arr = topGroups.has(g) ? points.get(g) : otherArr;
+    const inTop = topGroups.has(g);
+    const arr = inTop ? points.get(g) : otherArr;
+    const seenArr = inTop ? seen.get(g) : otherSeen;
     const i = bucketIndex.get(bucketToMs(r.bucket));
-    if (!arr || i === undefined) continue;
+    if (!arr || !seenArr || i === undefined) continue;
     arr[i] = (arr[i] ?? 0) + valFn(r);
+    seenArr[i] = true;
   }
 
-  const toSeries = (name: string, arr: number[], isOther: boolean): ChartSeries => {
+  const toSeries = (
+    name: string,
+    arr: number[],
+    seenArr: boolean[],
+    isOther: boolean,
+  ): ChartSeries => {
     let total = 0;
+    const values: number[] = [];
     const data: [number, number][] = buckets.map((b, i) => {
       const v = arr[i] ?? 0;
       total += v;
+      if (seenArr[i]) values.push(v);
       return [b, v];
     });
-    return { name, total, data, isOther };
+    return { name, total, data, values, isOther };
   };
 
   // Real series in rank order, "Other" always last.
   const series = ranked
     .filter((g) => topGroups.has(g))
-    .map((g) => toSeries(g, points.get(g) ?? [], false));
-  if (otherArr) {
+    .map((g) => toSeries(g, points.get(g) ?? [], seen.get(g) ?? [], false));
+  if (otherArr && otherSeen) {
     // The rollup name must be unique among the real series — visibility,
     // legend, and tooltip dedup are all keyed by name (see CountChart).
-    series.push(toSeries(uniqueOtherName(topGroups), otherArr, true));
+    series.push(toSeries(uniqueOtherName(topGroups), otherArr, otherSeen, true));
   }
   return series;
 }

--- a/apps/web/src/dashboards/widgets/widget-format.test.ts
+++ b/apps/web/src/dashboards/widgets/widget-format.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatValue, summarizeSeries } from "./widget-format.ts";
+
+test("summarizeSeries: sum/avg/min/max", () => {
+  const v = [2, 4, 6];
+  assert.equal(summarizeSeries(v, "sum"), 12);
+  assert.equal(summarizeSeries(v, "avg"), 4);
+  assert.equal(summarizeSeries(v, "min"), 2);
+  assert.equal(summarizeSeries(v, "max"), 6);
+});
+
+test("summarizeSeries: empty series is 0", () => {
+  assert.equal(summarizeSeries([], "avg"), 0);
+  assert.equal(summarizeSeries([], "sum"), 0);
+});
+
+test("summarizeSeries: percentiles use nearest-rank", () => {
+  const v = Array.from({ length: 100 }, (_, i) => i + 1); // 1..100
+  assert.equal(summarizeSeries(v, "p95"), 95);
+  assert.equal(summarizeSeries(v, "p99"), 99);
+});
+
+test("summarizeSeries: avg ignores absent buckets (no zero pollution)", () => {
+  // The caller passes only present buckets, so a sparse series averages to its
+  // real mean rather than being dragged toward zero.
+  assert.equal(summarizeSeries([15000, 15000], "avg"), 15000);
+  assert.equal(summarizeSeries([15000, 15000], "min"), 15000);
+});
+
+test("formatValue none: integers exact, decimals up to 3 places", () => {
+  assert.equal(formatValue(42, "none"), "42");
+  assert.equal(formatValue(1.23456, "none"), "1.235");
+});
+
+test("formatValue none: compact notation for huge magnitudes", () => {
+  // The legend SUM that motivated this: 1,922,160 -> short, not a wall of digits.
+  assert.equal(formatValue(1_922_160, "none"), "1.9M");
+  assert.equal(formatValue(1_852_782.5, "none"), "1.9M");
+  // Y-axis ticks like 60000 stay exact (below the compact threshold).
+  assert.equal(formatValue(60000, "none"), "60,000");
+});
+
+test("formatValue duration_ms auto-scales ms to a human unit", () => {
+  assert.equal(formatValue(250, "duration_ms"), "250ms");
+  assert.equal(formatValue(15000, "duration_ms"), "15s");
+  assert.equal(formatValue(1900, "duration_ms"), "1.9s");
+  assert.equal(formatValue(90000, "duration_ms"), "1.5min");
+  assert.equal(formatValue(7_200_000, "duration_ms"), "2h");
+});
+
+test("formatValue duration_s treats the value as seconds", () => {
+  assert.equal(formatValue(15, "duration_s"), "15s");
+  assert.equal(formatValue(0.25, "duration_s"), "250ms");
+});
+
+test("formatValue bytes uses base-1024 units", () => {
+  assert.equal(formatValue(512, "bytes"), "512B");
+  assert.equal(formatValue(1024, "bytes"), "1KB");
+  assert.equal(formatValue(1_572_864, "bytes"), "1.5MB");
+});
+
+test("formatValue percent appends a percent sign", () => {
+  assert.equal(formatValue(42.5, "percent"), "42.5%");
+  assert.equal(formatValue(100, "percent"), "100%");
+});
+
+test("formatValue is safe for non-finite input", () => {
+  assert.equal(formatValue(Number.NaN, "none"), "—");
+  assert.equal(formatValue(Number.POSITIVE_INFINITY, "duration_ms"), "—");
+});

--- a/apps/web/src/dashboards/widgets/widget-format.ts
+++ b/apps/web/src/dashboards/widgets/widget-format.ts
@@ -1,0 +1,127 @@
+// Pure value-formatting + per-series summarization for dashboard chart widgets.
+// Kept dependency-free (no react/api imports) so it runs under `tsx --test`,
+// same as series-topn.ts.
+
+/**
+ * How a widget's numeric values should be rendered on the axis, in the tooltip,
+ * and in the legend. `none` is a plain number; the rest carry a dimension so we
+ * can auto-scale (15000 ms -> "15s") instead of showing raw magnitudes.
+ */
+export type WidgetUnit = "none" | "duration_ms" | "duration_s" | "bytes" | "percent";
+
+export const WIDGET_UNITS: readonly WidgetUnit[] = [
+  "none",
+  "duration_ms",
+  "duration_s",
+  "bytes",
+  "percent",
+] as const;
+
+/** Human labels for the widget editor's unit picker. */
+export const WIDGET_UNIT_LABELS: Record<WidgetUnit, string> = {
+  none: "number",
+  duration_ms: "ms",
+  duration_s: "seconds",
+  bytes: "bytes",
+  percent: "percent",
+};
+
+// The aggregations the legend headline can mirror — the same set as the API's
+// MetricAggregation, plus the implicit "sum" used by count widgets. Declared
+// locally so this module imports nothing.
+export type SummaryAgg = "sum" | "avg" | "min" | "max" | "p95" | "p99";
+
+/**
+ * Collapse a series' per-bucket values into the single headline shown in the
+ * legend, mirroring how the chart itself aggregates. Callers pass only the
+ * buckets the series actually has data in (no zero-fill), so `avg`/`min` reflect
+ * the real distribution rather than being dragged toward zero by empty buckets.
+ */
+export function summarizeSeries(values: number[], agg: SummaryAgg): number {
+  if (values.length === 0) return 0;
+  switch (agg) {
+    case "sum":
+      return values.reduce((a, b) => a + b, 0);
+    case "avg":
+      return values.reduce((a, b) => a + b, 0) / values.length;
+    case "min":
+      return values.reduce((a, b) => (b < a ? b : a));
+    case "max":
+      return values.reduce((a, b) => (b > a ? b : a));
+    case "p95":
+      return percentile(values, 0.95);
+    case "p99":
+      return percentile(values, 0.99);
+  }
+}
+
+// Nearest-rank percentile. Per-bucket p95s aren't true global p95, but as a
+// legend headline this matches the chart's own approximation.
+function percentile(values: number[], q: number): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = Math.max(1, Math.ceil(q * sorted.length));
+  return sorted[rank - 1] ?? sorted[sorted.length - 1] ?? 0;
+}
+
+// Exact below the threshold (so axis ticks like 60000 read normally); compact
+// above it so the legend doesn't become a wall of digits.
+const COMPACT_THRESHOLD = 100_000;
+const plainFormat = new Intl.NumberFormat(undefined, { maximumFractionDigits: 3 });
+const compactFormat = new Intl.NumberFormat(undefined, {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+/** Format a single value for display according to the widget's unit. */
+export function formatValue(value: number, unit: WidgetUnit = "none"): string {
+  if (!Number.isFinite(value)) return "—";
+  switch (unit) {
+    case "duration_ms":
+      return formatDuration(value);
+    case "duration_s":
+      return formatDuration(value * 1000);
+    case "bytes":
+      return formatBytes(value);
+    case "percent":
+      return `${formatNumber(value)}%`;
+    default:
+      return formatNumber(value);
+  }
+}
+
+function formatNumber(value: number): string {
+  return Math.abs(value) >= COMPACT_THRESHOLD
+    ? compactFormat.format(value)
+    : plainFormat.format(value);
+}
+
+// Trim trailing zeros from a fixed-precision number so "15.0" -> "15".
+function trim(value: number, digits: number): string {
+  return String(Number(value.toFixed(digits)));
+}
+
+function formatDuration(ms: number): string {
+  const sign = ms < 0 ? "-" : "";
+  const x = Math.abs(ms);
+  if (x < 1000) return `${sign}${trim(x, x < 10 ? 1 : 0)}ms`;
+  const s = x / 1000;
+  if (s < 60) return `${sign}${trim(s, s < 10 ? 2 : 1)}s`;
+  const m = s / 60;
+  if (m < 60) return `${sign}${trim(m, 1)}min`;
+  const h = m / 60;
+  if (h < 24) return `${sign}${trim(h, 1)}h`;
+  return `${sign}${trim(h / 24, 1)}d`;
+}
+
+const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB", "PB"];
+
+function formatBytes(bytes: number): string {
+  const sign = bytes < 0 ? "-" : "";
+  let x = Math.abs(bytes);
+  let i = 0;
+  while (x >= 1024 && i < BYTE_UNITS.length - 1) {
+    x /= 1024;
+    i++;
+  }
+  return `${sign}${trim(x, i === 0 ? 0 : 1)}${BYTE_UNITS[i]}`;
+}


### PR DESCRIPTION
## Why

The chart-widget legend rendered the **window sum** of every per-bucket value. For a count widget that's a reasonable total, but for a gauge/metric (e.g. latency in ms) it produced a meaningless figure like `1,922,160` — and the long value squeezed the series name down to `tra…`.

## What

**1. Legend value matches the widget's aggregation (not always a sum)**
- Count widgets → sum; metric widgets → their own aggregation (`avg`/`min`/`max`/`p95`/`p99`), defaulting to `avg`.
- `series-topn` now exposes the *present-only* per-bucket values, so `avg`/`min` aren't dragged toward zero by the cross-series zero-fill used to align the chart. `total` (sum) still drives top-N ranking.

**2. Per-widget value unit**
- New config field: `number` / `duration_ms` / `duration_s` / `bytes` / `percent`, chosen in the widget editor and applied consistently to the y-axis, tooltip, and legend.
- Durations auto-scale (`15000 ms → 15s`), bytes use base-1024 (`MB`/`GB`), and large plain numbers use compact notation (`1.9M`). The side-legend column is widened so names stop collapsing.

**3. Editor restyled to match the settings pages**
- Pill tabs for the widget kind, `SettingsCard`/`SettingsRow` label-left / control-right layout, `PillToggle` for segmented choices, and switch toggles for display flags.

## Implementation notes
- New pure, dependency-free module `widget-format.ts` (`summarizeSeries` + `formatValue`) — runs under `tsx --test` like `series-topn.ts`.
- Config schema gains an optional `unit` enum (back-compat: omitted ⇒ `number`).

## Tests
- New `widget-format.test.ts`; extended `series-topn.test.ts` (present-only values) and `widget-config.test.ts` (unit round-trip). 39 unit tests pass; web + api typecheck clean.
- Verified in a running stack: metric widgets with bytes / percent / duration units render correct, aggregation-based legend values; the latency-in-ms case now reads `15.9s` instead of `1,922,160`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make chart legends aggregation-aware and add per-widget value units, fixing meaningless sums for metric widgets (e.g., latency) and improving readability across axis, tooltip, and legend. The widget editor is restyled to match the settings UI.

- New Features
  - Legend headline mirrors the widget’s aggregation: counts use sum; metrics use avg/min/max/p95/p99 (default avg). Uses present-only per-bucket values so averages/mins aren’t skewed by zero-fill.
  - Per-widget value unit: "none" / "duration_ms" / "duration_s" / "bytes" / "percent". Applied to y-axis, tooltip, and legend. Durations auto-scale, bytes use base-1024, large numbers use compact notation. Side legend widened to reduce name truncation.
  - New `widget-format.ts` with `summarizeSeries` and `formatValue`, plus unit tests.

- Bug Fixes
  - Switch toggles now have accessible names (aria-label) so screen readers announce them correctly.

<sup>Written for commit 47b771f6acd9ed09c14ad69d84f5769bccb2d084. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

