### PR TITLE
fix(worker): 3-way apply agent patches across base-branch drift

### DIFF
--- a/apps/worker/src/github-app.test.ts
+++ b/apps/worker/src/github-app.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 import {
+  applyAgentPatch,
   formatRetryBranchName,
   isGitPushBranchCollision,
   isMissingRemoteBranchFailure,
@@ -32,9 +37,7 @@ test("redactGitSecrets scrubs gho/ghp/ghu tokens and fine-grained PATs", () => {
 
 test("redactGitSecrets scrubs x-access-token and basic auth headers", () => {
   const token = ["ghs", "AbCdEf0123456789AbCdEf0123456789"].join("_");
-  const out = redactGitSecrets(
-    `https://x-access-token:${token}@github.com/o/r.git`,
-  );
+  const out = redactGitSecrets(`https://x-access-token:${token}@github.com/o/r.git`);
   assert.ok(!out.includes(token));
   assert.match(redactGitSecrets("AUTHORIZATION: Basic eC1hY2Nlc3M6c2VjcmV0"), /Basic \*\*\*/);
 });
@@ -100,4 +103,117 @@ test("isMissingRemoteBranchFailure detects clone failures for deleted base branc
     true,
   );
   assert.equal(isMissingRemoteBranchFailure("fatal: repository not found"), false);
+});
+
+// --- applyAgentPatch: real-git drift tolerance (Tier 0) ----------------------
+//
+// The agent diffs its patch against the base commit it cloned. By the time the
+// worker applies it, the base branch may have moved — including edits to the
+// very context lines the patch's hunk relies on. Plain `git apply` has zero
+// tolerance for that and fails with "patch does not apply". `applyAgentPatch`
+// uses `--3way`, which reconstructs the agent's original file from the
+// pre-image blob recorded in the diff and 3-way merges the change in, so a
+// non-overlapping drift still lands.
+
+function git(cwd: string, args: string[], input?: string): string {
+  const res = spawnSync("git", args, { cwd, input, encoding: "utf8" });
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${res.stderr || res.stdout}`);
+  }
+  return res.stdout;
+}
+
+// Builds a repo where the agent's patch edits line 10, then the base drifts by
+// editing line 8 — a *context* line inside the patch hunk. Returns the repo dir
+// and the path to the agent patch (written outside the repo, as in production).
+async function buildDriftedRepo(): Promise<{
+  workdir: string;
+  repoDir: string;
+  patchPath: string;
+}> {
+  const workdir = await mkdtemp(path.join(os.tmpdir(), "superlog-apply-test-"));
+  const repoDir = path.join(workdir, "repo");
+  await mkdtemp(repoDir).catch(() => {});
+  git(workdir, ["init", "-q", "repo"]);
+  git(repoDir, ["config", "user.email", "test@example.com"]);
+  git(repoDir, ["config", "user.name", "Test"]);
+  git(repoDir, ["config", "commit.gpgsign", "false"]);
+
+  const lines = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`);
+  await writeFile(path.join(repoDir, "file.txt"), `${lines.join("\n")}\n`, "utf8");
+  git(repoDir, ["add", "file.txt"]);
+  git(repoDir, ["commit", "-q", "-m", "base"]);
+
+  // Agent edit: change line 10, capture the diff (with index lines), then revert.
+  const edited = [...lines];
+  edited[9] = "line 10 — AGENT CHANGE";
+  await writeFile(path.join(repoDir, "file.txt"), `${edited.join("\n")}\n`, "utf8");
+  const patchBody = git(repoDir, ["diff"]);
+  git(repoDir, ["checkout", "--", "file.txt"]);
+
+  // Upstream drift: change line 8 (a context line of the agent hunk) and commit.
+  const drifted = [...lines];
+  drifted[7] = "line 8 — UPSTREAM DRIFT";
+  await writeFile(path.join(repoDir, "file.txt"), `${drifted.join("\n")}\n`, "utf8");
+  git(repoDir, ["commit", "-q", "-am", "drift"]);
+
+  const patchPath = path.join(workdir, "superlog.patch");
+  await writeFile(patchPath, patchBody, "utf8");
+  return { workdir, repoDir, patchPath };
+}
+
+test("applyAgentPatch 3-way-merges a patch whose context line drifted upstream", async () => {
+  const { workdir, repoDir, patchPath } = await buildDriftedRepo();
+  try {
+    // Control: plain `git apply` (today's flags) cannot apply across the drift.
+    const plain = spawnSync("git", ["apply", "--index", "--whitespace=nowarn", patchPath], {
+      cwd: repoDir,
+      encoding: "utf8",
+    });
+    assert.notEqual(plain.status, 0, "plain git apply should fail on context drift");
+
+    // applyAgentPatch (--3way) merges the non-overlapping change in.
+    await applyAgentPatch({ repoDir, patchPath });
+
+    const result = await readFile(path.join(repoDir, "file.txt"), "utf8");
+    assert.match(result, /line 10 — AGENT CHANGE/, "agent change must land");
+    assert.match(result, /line 8 — UPSTREAM DRIFT/, "upstream drift must be preserved");
+    assert.doesNotMatch(result, /<<<<<<<|>>>>>>>/, "no conflict markers");
+
+    // The change is staged (--index), so the downstream commit step sees it.
+    const staged = git(repoDir, ["diff", "--cached", "--name-only"]).trim();
+    assert.equal(staged, "file.txt");
+  } finally {
+    await rm(workdir, { recursive: true, force: true });
+  }
+});
+
+test("applyAgentPatch throws on a genuinely conflicting patch", async () => {
+  const workdir = await mkdtemp(path.join(os.tmpdir(), "superlog-apply-test-"));
+  const repoDir = path.join(workdir, "repo");
+  try {
+    git(workdir, ["init", "-q", "repo"]);
+    git(repoDir, ["config", "user.email", "test@example.com"]);
+    git(repoDir, ["config", "user.name", "Test"]);
+    git(repoDir, ["config", "commit.gpgsign", "false"]);
+    await writeFile(path.join(repoDir, "file.txt"), "alpha\nbeta\ngamma\n", "utf8");
+    git(repoDir, ["add", "file.txt"]);
+    git(repoDir, ["commit", "-q", "-m", "base"]);
+
+    // Agent rewrites line 2 → "beta-agent"; capture diff; revert.
+    await writeFile(path.join(repoDir, "file.txt"), "alpha\nbeta-agent\ngamma\n", "utf8");
+    const patchBody = git(repoDir, ["diff"]);
+    git(repoDir, ["checkout", "--", "file.txt"]);
+
+    // Upstream rewrites the SAME line 2 → "beta-upstream": a true conflict.
+    await writeFile(path.join(repoDir, "file.txt"), "alpha\nbeta-upstream\ngamma\n", "utf8");
+    git(repoDir, ["commit", "-q", "-am", "conflicting drift"]);
+
+    const patchPath = path.join(workdir, "superlog.patch");
+    await writeFile(patchPath, patchBody, "utf8");
+
+    await assert.rejects(() => applyAgentPatch({ repoDir, patchPath }));
+  } finally {
+    await rm(workdir, { recursive: true, force: true });
+  }
 });

--- a/apps/worker/src/github-app.ts
+++ b/apps/worker/src/github-app.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import crypto from "node:crypto";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -455,6 +455,34 @@ function gitApplyError(args: string[], result: GitResult, patch: string): Error 
   return new Error(`${formatGitCommand(args)} failed: ${detail}`);
 }
 
+// Applies an agent-authored patch into a checked-out repo.
+//
+// Uses `git apply --3way`: the agent diffs its patch against the base commit it
+// cloned, but by delivery time the base branch may have moved — including edits
+// to the very context lines the hunk relies on. Plain `git apply` has zero
+// tolerance for that and fails with "patch does not apply". `--3way`
+// reconstructs the agent's original file from the pre-image blob recorded in
+// the diff's `index <sha>..<sha>` line and 3-way merges the change in, so a
+// non-overlapping drift still lands. A genuine, overlapping content conflict
+// still exits non-zero (leaving conflict markers in the throwaway workdir) — we
+// surface it as a failure rather than push conflict-marked files.
+//
+// `env` must carry the GitHub auth header: with a blobless partial clone the
+// pre-image blob is not present locally, so `--3way` lazily fetches it from the
+// `origin` promisor remote during apply — an unauthenticated fetch would 404.
+export async function applyAgentPatch(opts: {
+  repoDir: string;
+  patchPath: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<void> {
+  const applyArgs = ["apply", "--3way", "--index", "--whitespace=nowarn", opts.patchPath];
+  const result = await runGit(applyArgs, { cwd: opts.repoDir, env: opts.env });
+  if (result.code !== 0) {
+    const patchBody = await readFile(opts.patchPath, "utf8").catch(() => "");
+    throw gitApplyError(applyArgs, result, patchBody);
+  }
+}
+
 async function cloneRepositoryAtBaseBranch(opts: {
   repoFullName: string;
   repoDir: string;
@@ -466,8 +494,12 @@ async function cloneRepositoryAtBaseBranch(opts: {
     ensureGitOk(
       [
         "clone",
-        "--depth",
-        "1",
+        // Blobless partial clone: skip downloading file contents up front and
+        // fetch only the blobs we actually touch on demand. This keeps `git
+        // apply --3way` able to reconstruct the agent's pre-image blob (so it
+        // can merge across base-branch drift) without paying a full-history
+        // download per delivery. `--depth 1` would omit those blobs entirely.
+        "--filter=blob:none",
         "--branch",
         branch,
         `https://github.com/${opts.repoFullName}.git`,
@@ -583,11 +615,7 @@ export async function applyPatchAndOpenPr(opts: {
     const patchPath = path.join(workdir, "superlog.patch");
     const patchBody = normalizeAgentPatch(opts.patch);
     await writeFile(patchPath, patchBody, "utf8");
-    const applyArgs = ["apply", "--index", "--whitespace=nowarn", patchPath];
-    const applyResult = await runGit(applyArgs, { cwd: repoDir });
-    if (applyResult.code !== 0) {
-      throw gitApplyError(applyArgs, applyResult, patchBody);
-    }
+    await applyAgentPatch({ repoDir, patchPath, env: gitAuthEnv });
 
     // The agent validates its own patch inside its session sandbox (running
     // the project's build/tests/repro as it sees fit) and reports the outcome
@@ -698,8 +726,10 @@ export async function pushPatchToExistingAgentPr(opts: {
     await ensureGitOk(
       [
         "clone",
-        "--depth",
-        "1",
+        // Blobless partial clone — see cloneRepositoryAtBaseBranch: lets the
+        // `--3way` apply below fetch the agent's pre-image blobs on demand so a
+        // follow-up patch still lands if the PR branch moved.
+        "--filter=blob:none",
         "--branch",
         opts.branchName,
         `https://github.com/${opts.repoFullName}.git`,
@@ -717,11 +747,7 @@ export async function pushPatchToExistingAgentPr(opts: {
     const patchPath = path.join(workdir, "superlog.patch");
     const patchBody = normalizeAgentPatch(opts.patch);
     await writeFile(patchPath, patchBody, "utf8");
-    const applyArgs = ["apply", "--index", "--whitespace=nowarn", patchPath];
-    const applyResult = await runGit(applyArgs, { cwd: repoDir });
-    if (applyResult.code !== 0) {
-      throw gitApplyError(applyArgs, applyResult, patchBody);
-    }
+    await applyAgentPatch({ repoDir, patchPath, env: gitAuthEnv });
     const status = await ensureGitOk(["status", "--porcelain"], { cwd: repoDir });
     if (!status.stdout.trim()) {
       throw new Error("patch produced no working tree changes");


### PR DESCRIPTION
## Problem

Agent-authored fix PRs were frequently failing at delivery with:

```
Failed to open the PR: git apply --index --whitespace=nowarn ... failed:
  error: patch failed: <file>:<line>
```

The agent generates its patch against the base (or existing PR) branch as it saw it during the investigation. The worker then clones that branch's **tip at delivery time** and applies the patch with plain `git apply --index`. If any commit landed on the branch in between — even an edit to a *context* line the hunk relies on — `git apply` (which has zero fuzz/context tolerance) rejects the whole patch and the delivery fails, despite the change itself being perfectly mergeable.

This hit both delivery paths (opening a new PR, and pushing a follow-up commit to an existing PR branch), and was the dominant cause of failed deliveries.

## Fix

Apply with **`git apply --3way`** instead. A `git diff` patch records the pre-image blob OIDs in its `index <sha>..<sha>` lines, so when a straight apply fails git can reconstruct the agent's original version of the file and perform a real 3-way merge — landing the change across non-overlapping drift. A genuinely overlapping conflict still exits non-zero, so we never commit/push conflict-marked files.

For `--3way` to have the pre-image blob available without downloading the entire repo history on every delivery, both delivery clones switch from `--depth 1` to a **blobless partial clone** (`--filter=blob:none`): the working tree is still checked out at the branch tip, and `--3way` lazily fetches only the specific blobs it needs on demand. The apply now runs with the git auth env so that on-demand fetch is authenticated.

The two apply sites are consolidated into a single `applyAgentPatch()` helper.

## Tests

`github-app.test.ts` gains real-git coverage:
- a patch whose **context line drifted** upstream — fails under plain `git apply` (asserted) and succeeds via `applyAgentPatch` (`--3way`), preserving both the upstream drift and the agent's change with no conflict markers;
- a **genuinely conflicting** patch — still throws.

## Deploy note

No schema or config change. The on-demand blob fetch relies on the remote supporting partial clone (standard on GitHub).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix frequent patch-apply failures by using a 3-way merge when applying agent patches. Patches now land even if the base branch changed in non-overlapping lines.

- **Bug Fixes**
  - Apply with `git apply --3way` so changes merge across context drift; true conflicts still fail.
  - Switch delivery clones to `--filter=blob:none` and run apply with GitHub auth so needed pre-image blobs fetch on demand.
  - Added real-git tests: drifted context applies cleanly; genuine conflicts throw.

- **Refactors**
  - Extracted `applyAgentPatch()` used by both initial PRs and follow-up commits.

<sup>Written for commit 522bfa65bd8845053649a9abfe633f82fd530c4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

