### PR TITLE
fix(db): prevent infinite loop in findRepoRoot on Windows

### DIFF
--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -13,10 +13,16 @@ import { defineConfig } from "drizzle-kit";
 // itself, so historically only manual reruns hit this.
 function findRepoRoot(start: string): string {
   let dir = start;
-  while (dir !== "/") {
+
+  while (true) {
     if (existsSync(join(dir, "pnpm-workspace.yaml"))) return dir;
-    dir = dirname(dir);
+
+    const parent = dirname(dir);
+    if (parent === dir) break;
+
+    dir = parent;
   }
+
   return start;
 }
 


### PR DESCRIPTION
What & Why

The current implementation of "findRepoRoot()" stops traversal only when "dir === "/"".

This works on Unix-like systems but can result in an infinite loop on Windows because "dirname("C:\\") === "C:\\"", so the loop never reaches "/".

This PR replaces the platform-specific termination condition with a platform-independent check that stops when the parent directory equals the current directory, ensuring correct behavior across Windows, macOS, and Linux.

Addresses audit finding #1 reported in #68.

How to Test

- [ ] Verify repository root detection still works when "pnpm-workspace.yaml" exists.
- [ ] Verify traversal terminates correctly at the filesystem root on Windows.
- [ ] Verify behavior remains unchanged on Unix-like systems.

AI Assistance

- [x] Used AI for identifying the platform-specific edge case and discussing a cross-platform fix.

Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / cleanup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed an infinite loop on Windows when finding the repository root by stopping traversal when the parent directory equals the current directory. This replaces the "/" check and makes repo root detection work consistently on Windows, macOS, and Linux.

<sup>Written for commit bcd84b3650633c189b466a594a5dc4bb13ff110b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

