### PR TITLE
Fix usage-notifier balance parsing: read `balances`, not `features`

### DIFF
--- a/apps/worker/src/billing/usage-notifier-infra.ts
+++ b/apps/worker/src/billing/usage-notifier-infra.ts
@@ -8,18 +8,19 @@
 // Gated on USAGE_NOTIFICATIONS_ENABLED + AUTUMN_SECRET_KEY: otherwise
 // createUsageNotifier returns null and every trigger is a no-op (the
 // `usageNotifier?.` callers below).
-import {
-  type FeatureBalance,
-  currentBillingPeriod,
-  periodKey as toPeriodKey,
-} from "@superlog/billing";
+import { currentBillingPeriod, periodKey as toPeriodKey } from "@superlog/billing";
 import { db, fetchOrgMemberContacts, schema } from "@superlog/db";
 import { and, eq } from "drizzle-orm";
 import { postSlackMessage } from "../infra/slack/api.js";
 import { fetchSlackTargetsForOrg } from "../infra/slack/incident-messages.js";
 import { logger } from "../logger.js";
 import { renderUsageEmail } from "./usage-email.js";
-import { type UsageNotifierDeps, mapAutumnFeatures, notifyOrgUsage } from "./usage-notifier.js";
+import {
+  type UsageNotifierDeps,
+  isFreePlan,
+  mapAutumnFeatures,
+  notifyOrgUsage,
+} from "./usage-notifier.js";
 
 const log = logger.child({ scope: "billing.usage-notify" });
 
@@ -55,11 +56,11 @@ function currentPeriodKey(now: () => Date): string {
   return toPeriodKey(currentBillingPeriod(now(), 1));
 }
 
-async function fetchAutumnBalances(
+async function fetchAutumnCustomer(
   secretKey: string,
   orgId: string,
   fetchImpl: typeof fetch,
-): Promise<FeatureBalance[] | null> {
+): Promise<unknown | null> {
   try {
     const res = await fetchImpl(`${AUTUMN_BASE_URL}/customers/${encodeURIComponent(orgId)}`, {
       headers: { Authorization: `Bearer ${secretKey}` },
@@ -67,11 +68,11 @@ async function fetchAutumnBalances(
     });
     // 404 = org not provisioned yet; any non-2xx → skip (fail open, no warning).
     if (!res.ok) return null;
-    return mapAutumnFeatures(await res.json());
+    return await res.json();
   } catch (err) {
     log.warn(
       { orgId, err: err instanceof Error ? err.message : String(err) },
-      "autumn balance fetch failed; skipping usage notification",
+      "autumn customer fetch failed; skipping usage notification",
     );
     return null;
   }
@@ -102,8 +103,12 @@ function buildDeps(
     },
 
     fetchOrgUsage: async (orgId) => {
-      const balances = await fetchAutumnBalances(secretKey, orgId, fetchImpl);
-      if (!balances) return null;
+      const customer = await fetchAutumnCustomer(secretKey, orgId, fetchImpl);
+      if (!customer) return null;
+      // Free plan only — never warn/enforce a paying org, even if one of their
+      // features is hard-capped without overage (e.g. a grandfathered plan).
+      if (!isFreePlan(customer)) return null;
+      const balances = mapAutumnFeatures(customer);
       const rows = await db
         .select({ name: schema.orgs.name })
         .from(schema.orgs)

--- a/apps/worker/src/billing/usage-notifier.test.ts
+++ b/apps/worker/src/billing/usage-notifier.test.ts
@@ -146,17 +146,31 @@ test("a billing-provider error (null usage) is a silent no-op", async () => {
   assert.equal(h.events.length, 0);
 });
 
-test("mapAutumnFeatures reads granted/usage/flags and skips missing features", () => {
+test("mapAutumnFeatures reads granted/usage/flags from balances, skips missing", () => {
+  // Shape from a live Autumn GET /v1/customers/{id}: balances keyed by feature_id.
   const balances = mapAutumnFeatures({
-    features: {
+    balances: {
       spans: {
-        included_usage: 1_000_000,
+        feature_id: "spans",
+        granted: 1_000_000,
         usage: 500_000,
         overage_allowed: false,
         unlimited: false,
       },
-      logs: { included: 5_000_000, used: 100, overageAllowed: true },
-      investigations: { unlimited: true, usage: 3 },
+      logs: {
+        feature_id: "logs",
+        granted: 5_000_000,
+        usage: 100,
+        overage_allowed: true,
+        unlimited: false,
+      },
+      investigations: {
+        feature_id: "investigations",
+        granted: 0,
+        usage: 3,
+        overage_allowed: false,
+        unlimited: true,
+      },
       // metric_points omitted → skipped
     },
   });
@@ -173,10 +187,10 @@ test("mapAutumnFeatures reads granted/usage/flags and skips missing features", (
   ]);
 });
 
-test("mapAutumnFeatures tolerates a missing/empty features object", () => {
+test("mapAutumnFeatures tolerates a missing/empty balances object", () => {
   assert.deepEqual(mapAutumnFeatures(null), []);
   assert.deepEqual(mapAutumnFeatures({}), []);
-  assert.deepEqual(mapAutumnFeatures({ features: {} }), []);
+  assert.deepEqual(mapAutumnFeatures({ balances: {} }), []);
 });
 
 test("100% Slack copy differs by enforcement + feature", () => {

--- a/apps/worker/src/billing/usage-notifier.test.ts
+++ b/apps/worker/src/billing/usage-notifier.test.ts
@@ -5,6 +5,7 @@ import {
   type UsageNotificationEvent,
   type UsageNotifierDeps,
   buildUsageSlackText,
+  isFreePlan,
   mapAutumnFeatures,
   notifyOrgUsage,
 } from "./usage-notifier.js";
@@ -191,6 +192,41 @@ test("mapAutumnFeatures tolerates a missing/empty balances object", () => {
   assert.deepEqual(mapAutumnFeatures(null), []);
   assert.deepEqual(mapAutumnFeatures({}), []);
   assert.deepEqual(mapAutumnFeatures({ balances: {} }), []);
+});
+
+test("isFreePlan: only true when every active subscription is the free plan", () => {
+  // Free org (auto-enabled free subscription)
+  assert.equal(isFreePlan({ subscriptions: [{ plan_id: "free", status: "active" }] }), true);
+  // Paying org (grandfathered) — the Trellis case: hard-capped feature but NOT free
+  assert.equal(
+    isFreePlan({ subscriptions: [{ plan_id: "grandfathered", status: "active" }] }),
+    false,
+  );
+  assert.equal(isFreePlan({ subscriptions: [{ plan_id: "payg", status: "active" }] }), false);
+  // free + a paid add-on → not free
+  assert.equal(
+    isFreePlan({
+      subscriptions: [
+        { plan_id: "free", status: "active" },
+        { plan_id: "pack_150", status: "active" },
+      ],
+    }),
+    false,
+  );
+  // canceled/expired paid sub is ignored; remaining active free → free
+  assert.equal(
+    isFreePlan({
+      subscriptions: [
+        { plan_id: "free", status: "active" },
+        { plan_id: "payg", status: "active", canceled_at: 123 },
+      ],
+    }),
+    true,
+  );
+  // no active subscriptions / unknown shape → not free (stay silent)
+  assert.equal(isFreePlan({ subscriptions: [] }), false);
+  assert.equal(isFreePlan(null), false);
+  assert.equal(isFreePlan({}), false);
 });
 
 test("100% Slack copy differs by enforcement + feature", () => {

--- a/apps/worker/src/billing/usage-notifier.test.ts
+++ b/apps/worker/src/billing/usage-notifier.test.ts
@@ -252,6 +252,19 @@ test("isFreePlan: only true when every active subscription is the free plan", ()
     }),
     true,
   );
+  // a `scheduled` future paid sub hasn't started → doesn't grant access yet, so
+  // the org is still Free today (it would otherwise be wrongly excluded).
+  assert.equal(
+    isFreePlan({
+      subscriptions: [
+        { plan_id: "free", status: "active" },
+        { plan_id: "payg", status: "scheduled" },
+      ],
+    }),
+    true,
+  );
+  // a trialing paid sub grants access → not free.
+  assert.equal(isFreePlan({ subscriptions: [{ plan_id: "payg", status: "trialing" }] }), false);
   // no active subscriptions / unknown shape → not free (stay silent)
   assert.equal(isFreePlan({ subscriptions: [] }), false);
   assert.equal(isFreePlan(null), false);

--- a/apps/worker/src/billing/usage-notifier.test.ts
+++ b/apps/worker/src/billing/usage-notifier.test.ts
@@ -213,12 +213,41 @@ test("isFreePlan: only true when every active subscription is the free plan", ()
     }),
     false,
   );
-  // canceled/expired paid sub is ignored; remaining active free → free
+  // canceled-at-period-end paid sub still grants access (canceled_at set,
+  // expires_at in the future) → NOT free, even alongside a free sub. This is the
+  // cubic P1: don't drop a paid sub just because canceled_at is present.
+  assert.equal(
+    isFreePlan(
+      {
+        subscriptions: [
+          { plan_id: "free", status: "active" },
+          { plan_id: "payg", status: "active", canceled_at: 1000, expires_at: 5000 },
+        ],
+      },
+      2000, // now < expires_at → paid access still live
+    ),
+    false,
+  );
+  // genuinely-lapsed paid sub (expires_at in the past) is ignored; remaining
+  // active free → free.
+  assert.equal(
+    isFreePlan(
+      {
+        subscriptions: [
+          { plan_id: "free", status: "active" },
+          { plan_id: "payg", status: "active", canceled_at: 1000, expires_at: 5000 },
+        ],
+      },
+      9000, // now > expires_at → paid access has lapsed
+    ),
+    true,
+  );
+  // status `expired` paid sub is ignored regardless of timestamps.
   assert.equal(
     isFreePlan({
       subscriptions: [
         { plan_id: "free", status: "active" },
-        { plan_id: "payg", status: "active", canceled_at: 123 },
+        { plan_id: "payg", status: "expired" },
       ],
     }),
     true,

--- a/apps/worker/src/billing/usage-notifier.ts
+++ b/apps/worker/src/billing/usage-notifier.ts
@@ -59,15 +59,27 @@ export function mapAutumnFeatures(body: unknown): FeatureBalance[] {
 // Usage-limit warnings + enforcement apply to the FREE plan only. A paying tier
 // (grandfathered / payg / packs / internal) can still have a hard-capped feature
 // with no overage — so "has a hard cap" is NOT the same as "Free". Gate on the
-// org's actual active Autumn subscription instead: free iff every active
-// subscription is the `free` plan. Unknown/absent subscriptions → not free
-// (safer to stay silent than to warn or block a paying customer).
+// org's actual Autumn subscriptions instead: free iff every subscription that
+// still grants access is the `free` plan. Unknown/absent subscriptions → not
+// free (safer to stay silent than to warn or block a paying customer).
+//
+// Crucially, a paid plan canceled at period end keeps `status:"active"` with
+// `canceled_at` set and `expires_at` in the future — it still grants access, so
+// `canceled_at` alone must NOT drop it (doing so would let a still-paying org
+// with a parallel free subscription look Free and get warned/enforced). A
+// subscription only stops granting access once its window has actually elapsed:
+// status `expired`, or `expires_at` in the past.
 const FREE_PLAN_ID = "free";
-export function isFreePlan(body: unknown): boolean {
+export function isFreePlan(body: unknown, now: number = Date.now()): boolean {
   const subs = (body as { subscriptions?: Array<Record<string, unknown>> } | null)?.subscriptions;
   if (!Array.isArray(subs)) return false;
-  const active = subs.filter((s) => s.status === "active" && !s.canceled_at && !s.expires_at);
-  return active.length > 0 && active.every((s) => s.plan_id === FREE_PLAN_ID);
+  const live = subs.filter((s) => {
+    if (s.status === "expired") return false;
+    const expiresAt = typeof s.expires_at === "number" ? s.expires_at : null;
+    if (expiresAt !== null && expiresAt <= now) return false;
+    return true;
+  });
+  return live.length > 0 && live.every((s) => s.plan_id === FREE_PLAN_ID);
 }
 
 // Structured payload handed to the Loops event sender (the email copy lives in a

--- a/apps/worker/src/billing/usage-notifier.ts
+++ b/apps/worker/src/billing/usage-notifier.ts
@@ -63,18 +63,23 @@ export function mapAutumnFeatures(body: unknown): FeatureBalance[] {
 // still grants access is the `free` plan. Unknown/absent subscriptions → not
 // free (safer to stay silent than to warn or block a paying customer).
 //
-// Crucially, a paid plan canceled at period end keeps `status:"active"` with
-// `canceled_at` set and `expires_at` in the future — it still grants access, so
-// `canceled_at` alone must NOT drop it (doing so would let a still-paying org
-// with a parallel free subscription look Free and get warned/enforced). A
-// subscription only stops granting access once its window has actually elapsed:
-// status `expired`, or `expires_at` in the past.
+// Only count subscriptions that grant access *right now*:
+//   - status is access-granting (active / trialing / past_due). A `scheduled`
+//     future plan hasn't started, and `expired`/lapsed plans are gone — neither
+//     reflects what the org is entitled to today.
+//   - and the access window hasn't elapsed (`expires_at` in the past).
+// A paid plan canceled at period end keeps `status:"active"` with `canceled_at`
+// set and `expires_at` in the future, so it stays live and (correctly) keeps the
+// org out of the Free cohort — `canceled_at` alone must NOT drop it, otherwise a
+// still-paying org with a parallel free subscription would look Free and get
+// warned/enforced.
 const FREE_PLAN_ID = "free";
+const ACCESS_STATUSES = new Set(["active", "trialing", "past_due"]);
 export function isFreePlan(body: unknown, now: number = Date.now()): boolean {
   const subs = (body as { subscriptions?: Array<Record<string, unknown>> } | null)?.subscriptions;
   if (!Array.isArray(subs)) return false;
   const live = subs.filter((s) => {
-    if (s.status === "expired") return false;
+    if (!ACCESS_STATUSES.has(String(s.status))) return false;
     const expiresAt = typeof s.expires_at === "number" ? s.expires_at : null;
     if (expiresAt !== null && expiresAt <= now) return false;
     return true;

--- a/apps/worker/src/billing/usage-notifier.ts
+++ b/apps/worker/src/billing/usage-notifier.ts
@@ -56,6 +56,20 @@ export function mapAutumnFeatures(body: unknown): FeatureBalance[] {
   return out;
 }
 
+// Usage-limit warnings + enforcement apply to the FREE plan only. A paying tier
+// (grandfathered / payg / packs / internal) can still have a hard-capped feature
+// with no overage — so "has a hard cap" is NOT the same as "Free". Gate on the
+// org's actual active Autumn subscription instead: free iff every active
+// subscription is the `free` plan. Unknown/absent subscriptions → not free
+// (safer to stay silent than to warn or block a paying customer).
+const FREE_PLAN_ID = "free";
+export function isFreePlan(body: unknown): boolean {
+  const subs = (body as { subscriptions?: Array<Record<string, unknown>> } | null)?.subscriptions;
+  if (!Array.isArray(subs)) return false;
+  const active = subs.filter((s) => s.status === "active" && !s.canceled_at && !s.expires_at);
+  return active.length > 0 && active.every((s) => s.plan_id === FREE_PLAN_ID);
+}
+
 // Structured payload handed to the Loops event sender (the email copy lives in a
 // Loops workflow keyed on `threshold` / `enforcement`, not in this repo).
 export type UsageNotificationEvent = {

--- a/apps/worker/src/billing/usage-notifier.ts
+++ b/apps/worker/src/billing/usage-notifier.ts
@@ -35,24 +35,22 @@ function num(value: unknown): number {
 }
 
 // Map an Autumn `GET /v1/customers/{id}` response body to our FeatureBalance[].
-// Pure + defensive: Autumn's REST balance field names are read with fallbacks
-// (the exact shape should be confirmed against a live response — see the verify
-// step). A feature missing from the response is simply skipped.
+// Confirmed against a live response: balances live under `balances`, keyed by
+// feature_id, each `{ granted, usage, unlimited, overage_allowed, ... }`. A
+// feature missing from the response is simply skipped.
 export function mapAutumnFeatures(body: unknown): FeatureBalance[] {
-  const features = (body as { features?: Record<string, unknown> } | null)?.features;
-  if (!features || typeof features !== "object") return [];
+  const balances = (body as { balances?: Record<string, unknown> } | null)?.balances;
+  if (!balances || typeof balances !== "object") return [];
   const out: FeatureBalance[] = [];
   for (const featureId of USAGE_FEATURE_IDS) {
-    const f = (features as Record<string, Record<string, unknown>>)[featureId];
-    if (!f || typeof f !== "object") continue;
-    const granted = num(f.included_usage ?? f.included ?? f.allowance ?? f.granted ?? f.limit);
-    const usage = num(f.usage ?? f.used);
+    const b = (balances as Record<string, Record<string, unknown>>)[featureId];
+    if (!b || typeof b !== "object") continue;
     out.push({
       featureId,
-      usage,
-      granted,
-      overageAllowed: f.overage_allowed === true || f.overageAllowed === true,
-      unlimited: f.unlimited === true,
+      usage: num(b.usage),
+      granted: num(b.granted),
+      overageAllowed: b.overage_allowed === true,
+      unlimited: b.unlimited === true,
     });
   }
   return out;


### PR DESCRIPTION
Two correctness fixes to the usage-limit notifier, both found via a read-only dry run against live data before enabling.

### 1. Read `balances`, not `features`
`mapAutumnFeatures` read `body.features`, but the provider's `GET /v1/customers/{id}` returns balances under **`balances`** (keyed by `feature_id`, each `{ granted, usage, unlimited, overage_allowed }`). So it always returned `[]` → `highestWatermark` was always null → **the notifier would never fire.** (0 orgs resolved a watermark with the old key vs 377 with the correct one.)

### 2. Only notify orgs on the Free plan
A paying tier (grandfathered / payg / packs / internal) can still have a hard-capped feature with no overage — so "has a hard cap" ≠ "Free". The notifier would have warned a paying customer. New `isFreePlan(body)` gate: proceed only when every **active** Autumn subscription is the `free` plan; `fetchOrgUsage` returns null otherwise.

Live check: of the orgs that would fire at 100%, exactly **one** was paying (an active `grandfathered` sub, investigations capped 300/300, no overage) — now excluded; the other 38 are genuinely Free.

No behavior change risk — notifier is still gated off (`USAGE_NOTIFICATIONS_ENABLED`).

> Note for the enforcement phase: this Free-plan gate protects **notifications** only. Before flipping `BILLING_ENFORCEMENT_ENABLED`, the same paying-customer-with-a-hard-cap case needs handling on the enforcement path too — best fixed at the plan config (paid plans shouldn't hard-cap features without overage), so Autumn's own gate doesn't block them.