### PR TITLE
fix(dashboards): render gridlines across empty chart windows

### DIFF
--- a/apps/web/src/dashboards/widgets/CountChart.tsx
+++ b/apps/web/src/dashboards/widgets/CountChart.tsx
@@ -285,7 +285,13 @@ function KumoLikeTimeseriesChart({
         // empty space instead of stretching to fill the chart.
         min: xMin,
         max: xMax,
-        splitLine: { show: false },
+        // Vertical gridlines at the time ticks, matching the horizontal ones, so
+        // a window with no (or sparse) data still reads as a grid all the way to
+        // the tile edge rather than a bare panel.
+        splitLine: {
+          show: true,
+          lineStyle: { type: "dashed", width: 1, color: GRID_LINE_COLOR },
+        },
         axisLine: { show: false },
         axisTick: { show: showXAxis },
         axisLabel: {


### PR DESCRIPTION
Timeseries widgets (`timeseries_count` and `timeseries_metric`) pin the x-axis to the selected query window, so sparse data sits in honest empty space instead of stretching to fill the chart. But the x-axis `splitLine` was disabled — so a window with little or no data rendered a bare panel on the right: the horizontal gridlines and time ticks were drawn, but the empty region had no vertical grid structure connecting it to the time axis.

This enables vertical gridlines (same dashed style and color as the horizontal ones) so the grid and time markers read all the way to the tile edge regardless of how much data lands in the window. Applies to both bar and line chart widgets.

### Before / after
Over a wide range where data only covers the recent hours, the empty portion of the panel now shows the full grid + time ticks rather than a blank area.

### Testing
- `pnpm --filter @superlog/web typecheck` passes.
- Verified in-browser on a dashboard widget over a `Last 24h` range with data only in the most recent hours: vertical + horizontal gridlines and time markers span the full panel; data still renders in its honest position on the right.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable vertical gridlines on the x-axis for timeseries widgets so empty parts of the selected window still show a full grid and time ticks. Improves readability without changing how data is pinned to the time range.

- **Bug Fixes**
  - Enabled x-axis `splitLine` in `CountChart` with dashed 1px `GRID_LINE_COLOR` to match horizontal lines; applies to both bar and line charts (`timeseries_count` and `timeseries_metric`).

<sup>Written for commit 98ef7abd8ba2f718e1d2de743b1b1531299f1746. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

