### PR TITLE
fix(worker): stop a NUL byte from wedging issue ingestion

### DIFF
--- a/apps/web/src/dashboards/widgets/CountChart.tsx
+++ b/apps/web/src/dashboards/widgets/CountChart.tsx
@@ -285,7 +285,13 @@ function KumoLikeTimeseriesChart({
         // empty space instead of stretching to fill the chart.
         min: xMin,
         max: xMax,
-        splitLine: { show: false },
+        // Vertical gridlines at the time ticks, matching the horizontal ones, so
+        // a window with no (or sparse) data still reads as a grid all the way to
+        // the tile edge rather than a bare panel.
+        splitLine: {
+          show: true,
+          lineStyle: { type: "dashed", width: 1, color: GRID_LINE_COLOR },
+        },
         axisLine: { show: false },
         axisTick: { show: showXAxis },
         axisLabel: {

--- a/apps/worker/src/telemetry/ingest.test.ts
+++ b/apps/worker/src/telemetry/ingest.test.ts
@@ -1,7 +1,7 @@
 import "../agent-run.test-env.js";
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import type { DB } from "@superlog/db";
+import type { DB, schema } from "@superlog/db";
 import { createTelemetryIngestor } from "./ingest.js";
 
 type QueryCall = {
@@ -216,6 +216,122 @@ test("span ingestion rounds sub-millisecond discovery windows up to one millisec
   assert.equal(await ingestor.tickSpans(), 0);
   assert.equal(calls[0]?.query_params?.untilTs, "2026-05-23 10:00:00.001");
   assert.equal(state.get("fingerprint")?.cursor.toISOString(), "2026-05-23T10:00:00.001Z");
+});
+
+const VALID_PROJECT_ID = "11111111-1111-4111-8111-111111111111";
+
+// A fake DB whose project resolves (valid UUID) so rows reach `upsertIssue`.
+// `execute` runs `onExecute(call#)` so a test can make a specific row's upsert
+// throw — simulating the Postgres `22021` NUL-byte rejection that used to wedge
+// the whole batch.
+function fakeDbWithProject(opts: { onExecute?: (call: number) => void }): {
+  database: DB;
+  state: Map<string, { cursor: Date }>;
+  executeCalls: () => number;
+} {
+  const state = new Map<string, { cursor: Date }>();
+  state.set("fingerprint", { cursor: new Date("2026-05-23T10:00:00.000Z") });
+  state.set("fingerprint-logs", { cursor: new Date("2026-05-23T10:00:00.000Z") });
+  let calls = 0;
+  const database = {
+    query: {
+      workerState: {
+        async findFirst(args?: { where?: unknown }) {
+          const where = args?.where;
+          if (typeof where !== "function") return undefined;
+          const filter = where(
+            { name: "name" },
+            { eq: (_c: unknown, value: string) => ({ value }) },
+          ) as { value?: string };
+          return filter.value ? state.get(filter.value) : undefined;
+        },
+      },
+      projectAutomationSettings: {
+        async findMany() {
+          return [];
+        },
+      },
+      issues: {
+        async findFirst() {
+          return { id: "issue-1", projectId: VALID_PROJECT_ID } as unknown as schema.Issue;
+        },
+      },
+    },
+    select() {
+      return {
+        from() {
+          return {
+            async where() {
+              return [{ id: VALID_PROJECT_ID }];
+            },
+          };
+        },
+      };
+    },
+    async execute() {
+      calls += 1;
+      opts.onExecute?.(calls);
+      return [
+        { id: "issue-1", xmax: "0", prev_issue_id: null, prev_incident_status: null },
+      ] as unknown as never;
+    },
+    insert() {
+      return {
+        values(values: { name: string; cursor: Date }) {
+          return {
+            async onConflictDoUpdate() {
+              state.set(values.name, { cursor: values.cursor });
+            },
+          };
+        },
+      };
+    },
+  } as unknown as DB;
+  return { database, state, executeCalls: () => calls };
+}
+
+test("log ingestion isolates a failing row and still advances past it", async () => {
+  // First row's upsert throws (mimics PG 22021 NUL-byte rejection). The tick
+  // must NOT throw, must still process the second row, and must advance the
+  // cursor past the poison row so ingestion is never wedged.
+  const { database, state, executeCalls } = fakeDbWithProject({
+    onExecute: (call) => {
+      if (call === 1) throw new Error('invalid byte sequence for encoding "UTF8": 0x00');
+    },
+  });
+  const rows = [
+    { ...logRow({ traceId: "t1", spanId: "s1", body: "poison" }), project_id: VALID_PROJECT_ID },
+    {
+      ...logRow({ traceId: "t2", spanId: "s2", body: "healthy" }),
+      project_id: VALID_PROJECT_ID,
+      ts: "2026-05-23 10:00:01.000000",
+    },
+  ];
+  let callCount = 0;
+  const clickhouse = {
+    async query() {
+      const out = callCount === 0 ? rows : [];
+      callCount += 1;
+      return {
+        async json() {
+          return out;
+        },
+      };
+    },
+  };
+  const ingestor = createTelemetryIngestor({
+    clickhouse,
+    database,
+    batchSize: 2,
+    async handleIssueTransition() {},
+  });
+
+  const processed = await ingestor.tickLogs();
+  assert.equal(processed, 2);
+  // Both rows attempted (poison row did not abort the loop).
+  assert.equal(executeCalls(), 2);
+  // Cursor advanced past the poison row to the healthy row's timestamp.
+  assert.equal(state.get("fingerprint-logs")?.cursor.toISOString(), "2026-05-23T10:00:01.000Z");
 });
 
 function spanRow(opts: { traceId: string; spanId: string; message: string }) {

--- a/apps/worker/src/telemetry/ingest.ts
+++ b/apps/worker/src/telemetry/ingest.ts
@@ -1,7 +1,12 @@
 import { performance } from "node:perf_hooks";
 import { SpanStatusCode, metrics, trace } from "@opentelemetry/api";
 import { type DB, type IssueSample, db as defaultDb, schema } from "@superlog/db";
-import { type Fingerprint, fingerprint, fingerprintLog } from "@superlog/fingerprint";
+import {
+  type Fingerprint,
+  fingerprint,
+  fingerprintLog,
+  stripNullBytes,
+} from "@superlog/fingerprint";
 import { inArray, sql } from "drizzle-orm";
 import { logger } from "../logger.js";
 
@@ -26,6 +31,10 @@ const batchFull = meter.createCounter("superlog.worker.telemetry.batch_full", {
 const batchDurationMs = meter.createHistogram("superlog.worker.telemetry.batch_duration_ms", {
   description: "Wall-clock duration of a telemetry ingest batch.",
   unit: "ms",
+});
+const rowFailures = meter.createCounter("superlog.worker.telemetry.row_failures", {
+  description:
+    "Telemetry rows whose issue upsert threw and were skipped so the batch could make progress.",
 });
 const pendingRowsGauge = meter.createObservableGauge("superlog.worker.telemetry.pending_rows", {
   description: "Rows currently matching telemetry ingest filters after the durable cursor.",
@@ -192,6 +201,17 @@ async function existingProjectIds(database: DB, projectIds: string[]): Promise<S
     .from(schema.projects)
     .where(inArray(schema.projects.id, unique));
   return new Set(rows.map((row) => row.id));
+}
+
+// Strip NUL bytes from attribute keys/values before they are JSON-encoded into
+// the `last_sample` jsonb column — Postgres jsonb rejects 0x00 just like text.
+function sanitizeAttrs(
+  attrs: Record<string, string> | null | undefined,
+): Record<string, string> | null {
+  if (!attrs) return null;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(attrs)) out[stripNullBytes(k)] = stripNullBytes(v);
+  return out;
 }
 
 function buildIssueTitle(fp: Fingerprint, message: string | null): string {
@@ -547,51 +567,65 @@ async function tickSpans(opts: {
           nextCursor = row.ts;
           continue;
         }
+        const excMessage = stripNullBytes(row.exc_message) || null;
+        const excStack = stripNullBytes(row.exc_stack) || null;
+        const service = stripNullBytes(row.service) || null;
         const fp = fingerprint({
           type: row.exc_type,
-          stacktrace: row.exc_stack,
-          message: row.exc_message,
+          stacktrace: excStack,
+          message: excMessage,
         });
         const seenAt = chStringToDate(row.ts);
         const lastSample: IssueSample = {
           kind: "span",
-          service: row.service || null,
+          service,
           severity: null,
-          message: row.exc_message || null,
+          message: excMessage,
           body: null,
           exceptionType: fp.exceptionType,
           topFrame: fp.topFrame,
           normalizedFrames: fp.normalizedFrames,
-          stacktrace: row.exc_stack || null,
+          stacktrace: excStack,
           seenAt: seenAt.toISOString(),
           traceId: row.trace_id || null,
           spanId: row.span_id || null,
-          spanName: row.span_name || null,
-          spanAttrs: row.span_attrs ?? null,
-          resourceAttrs: row.resource_attrs ?? null,
+          spanName: stripNullBytes(row.span_name) || null,
+          spanAttrs: sanitizeAttrs(row.span_attrs),
+          resourceAttrs: sanitizeAttrs(row.resource_attrs),
         };
-        const up = await upsertIssue({
-          database: opts.database,
-          projectId: row.project_id,
-          kind: "span",
-          service: row.service || null,
-          fp,
-          message: row.exc_message || null,
-          seenAt,
-          lastSample,
-        });
-        if (up.transition !== "seen") {
-          logger.info(
-            {
-              kind: "span",
-              transition: up.transition,
-              projectId: row.project_id,
-              fingerprint: fp.hash,
-              exceptionType: fp.exceptionType,
-            },
-            "issue transition",
+        try {
+          const up = await upsertIssue({
+            database: opts.database,
+            projectId: row.project_id,
+            kind: "span",
+            service,
+            fp,
+            message: excMessage,
+            seenAt,
+            lastSample,
+          });
+          if (up.transition !== "seen") {
+            logger.info(
+              {
+                kind: "span",
+                transition: up.transition,
+                projectId: row.project_id,
+                fingerprint: fp.hash,
+                exceptionType: fp.exceptionType,
+              },
+              "issue transition",
+            );
+            await opts.handleIssueTransition(up.issue, up.transition);
+          }
+        } catch (rowErr) {
+          // Never let a single bad row wedge the cursor — a poison row (e.g. a
+          // value Postgres rejects) would otherwise re-fail every tick and stall
+          // issue ingestion for all projects. Log, count, and advance past it.
+          rowFailures.add(1, { "telemetry.kind": "span" });
+          logger.error(
+            { err: rowErr, kind: "span", projectId: row.project_id, fingerprint: fp.hash },
+            "issue upsert failed; skipping row",
           );
-          await opts.handleIssueTransition(up.issue, up.transition);
         }
         nextCursor = row.ts;
       }
@@ -702,53 +736,67 @@ async function tickLogs(opts: {
           nextCursor = row.ts;
           continue;
         }
+        const body = stripNullBytes(row.body) || null;
+        const excStack = stripNullBytes(row.exc_stack) || null;
+        const service = stripNullBytes(row.service) || null;
         const fp = fingerprintLog({
           service: row.service,
           severity: row.severity,
           body: row.body,
           exceptionType: row.exc_type || null,
-          stacktrace: row.exc_stack || null,
+          stacktrace: excStack,
         });
         const seenAt = chStringToDate(row.ts);
         const lastSample: IssueSample = {
           kind: "log",
-          service: row.service || null,
-          severity: row.severity || null,
-          message: row.body || null,
-          body: row.body || null,
+          service,
+          severity: stripNullBytes(row.severity) || null,
+          message: body,
+          body,
           exceptionType: fp.exceptionType,
           topFrame: fp.topFrame,
           normalizedFrames: fp.normalizedFrames,
-          stacktrace: row.exc_stack || null,
+          stacktrace: excStack,
           seenAt: seenAt.toISOString(),
           traceId: row.trace_id || null,
           spanId: row.span_id || null,
           severityNumber: row.severity_number ?? null,
-          logAttrs: row.log_attrs ?? null,
-          resourceAttrs: row.resource_attrs ?? null,
+          logAttrs: sanitizeAttrs(row.log_attrs),
+          resourceAttrs: sanitizeAttrs(row.resource_attrs),
         };
-        const up = await upsertIssue({
-          database: opts.database,
-          projectId: row.project_id,
-          kind: "log",
-          service: row.service || null,
-          fp,
-          message: row.body || null,
-          seenAt,
-          lastSample,
-        });
-        if (up.transition !== "seen") {
-          logger.info(
-            {
-              kind: "log",
-              transition: up.transition,
-              projectId: row.project_id,
-              fingerprint: fp.hash,
-              exceptionType: fp.exceptionType,
-            },
-            "issue transition",
+        try {
+          const up = await upsertIssue({
+            database: opts.database,
+            projectId: row.project_id,
+            kind: "log",
+            service,
+            fp,
+            message: body,
+            seenAt,
+            lastSample,
+          });
+          if (up.transition !== "seen") {
+            logger.info(
+              {
+                kind: "log",
+                transition: up.transition,
+                projectId: row.project_id,
+                fingerprint: fp.hash,
+                exceptionType: fp.exceptionType,
+              },
+              "issue transition",
+            );
+            await opts.handleIssueTransition(up.issue, up.transition);
+          }
+        } catch (rowErr) {
+          // Never let a single bad row wedge the cursor — a poison row (e.g. a
+          // value Postgres rejects) would otherwise re-fail every tick and stall
+          // issue ingestion for all projects. Log, count, and advance past it.
+          rowFailures.add(1, { "telemetry.kind": "log" });
+          logger.error(
+            { err: rowErr, kind: "log", projectId: row.project_id, fingerprint: fp.hash },
+            "issue upsert failed; skipping row",
           );
-          await opts.handleIssueTransition(up.issue, up.transition);
         }
         nextCursor = row.ts;
       }

--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { fingerprint, messageBucketFor } from "./index.js";
+import { fingerprint, fingerprintLog, messageBucketFor, stripNullBytes } from "./index.js";
 
 // A single route-scanner error class (e.g. Phoenix NoRouteError) emits one
 // exception per probed path. The stacktrace is identical across all of them —
@@ -35,7 +35,10 @@ test("fingerprint groups same-stack route-scanner errors that differ only by pat
 test("messageBucketFor keeps a bare path token distinct from a real path", () => {
   // A leading-slash path collapses; an in-word slash (and/or) must not.
   assert.equal(messageBucketFor("request to /api/v2/users failed"), "request to <path> failed");
-  assert.equal(messageBucketFor("read timeout and/or connection reset"), "read timeout and/or connection reset");
+  assert.equal(
+    messageBucketFor("read timeout and/or connection reset"),
+    "read timeout and/or connection reset",
+  );
 });
 
 test("messageBucketFor still separates genuinely different messages", () => {
@@ -43,4 +46,42 @@ test("messageBucketFor still separates genuinely different messages", () => {
     messageBucketFor("model is not supported"),
     messageBucketFor("extra inputs are not permitted"),
   );
+});
+
+// Postgres text and jsonb columns reject the NUL byte (0x00) — it raises
+// `22021 invalid byte sequence for encoding "UTF8": 0x00`. Telemetry can carry
+// a raw NUL in a message or stack frame; the fingerprint outputs feed straight
+// into the issues upsert, so they must be NUL-free.
+const NUL = String.fromCharCode(0);
+
+test("stripNullBytes removes NUL bytes and leaves other text intact", () => {
+  assert.equal(stripNullBytes(`ab${NUL}cd`), "abcd");
+  assert.equal(stripNullBytes(`${NUL}boom${NUL}`), "boom");
+  assert.equal(stripNullBytes("clean string"), "clean string");
+  assert.equal(stripNullBytes(null), null);
+  assert.equal(stripNullBytes(undefined), undefined);
+});
+
+test("fingerprint strips NUL bytes from exception type and frames", () => {
+  const fp = fingerprint({
+    type: `Boom${NUL}Error`,
+    stacktrace: `    at do${NUL}Thing (apps/worker/src/x.ts:1:1)`,
+    message: "broke here",
+  });
+  assert.equal(fp.exceptionType.includes(NUL), false);
+  assert.ok(!fp.topFrame?.includes(NUL));
+  for (const frame of fp.normalizedFrames) {
+    assert.equal(frame.includes(NUL), false);
+  }
+});
+
+test("fingerprintLog strips NUL bytes from exception type", () => {
+  const fp = fingerprintLog({
+    service: "superlog-worker",
+    severity: "ERROR",
+    body: `tick step failed${NUL}`,
+    exceptionType: `Cause${NUL}Error`,
+    stacktrace: null,
+  });
+  assert.equal(fp.exceptionType.includes(NUL), false);
 });

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -28,6 +28,17 @@ const IGNORE_PATH = [
   /^webpack:\/\/\//,
 ];
 
+const NUL_BYTE = String.fromCharCode(0);
+
+// Postgres `text` and `jsonb` columns reject the NUL byte (0x00) with
+// `22021 invalid byte sequence for encoding "UTF8": 0x00`. Telemetry can carry
+// a raw NUL inside an exception message, body, or stack frame, and these
+// fingerprint outputs flow straight into the issues upsert — so strip NUL
+// before it can poison a parameter. Passes null/undefined through unchanged.
+export function stripNullBytes<T extends string | null | undefined>(value: T): T {
+  return (typeof value === "string" ? value.split(NUL_BYTE).join("") : value) as T;
+}
+
 export function fingerprint(input: {
   type: string;
   stacktrace: string | null | undefined;
@@ -43,11 +54,14 @@ export function fingerprint(input: {
   const canonical = `${type}::${messageBucket}::${normalized.join("|")}`;
   const hash = createHash("sha256").update(canonical).digest("hex").slice(0, HASH_LEN);
 
+  // The hash is hex (always safe); the human-readable fields below are persisted
+  // to Postgres, so they must be NUL-free.
+  const safeFrames = normalized.map((frame) => stripNullBytes(frame));
   return {
     hash,
-    exceptionType: type,
-    topFrame: normalized[0] ?? null,
-    normalizedFrames: normalized,
+    exceptionType: stripNullBytes(type),
+    topFrame: safeFrames[0] ?? null,
+    normalizedFrames: safeFrames,
   };
 }
 
@@ -67,7 +81,7 @@ export function fingerprintLog(input: LogFingerprintInput): Fingerprint {
 
   return {
     hash,
-    exceptionType: type,
+    exceptionType: stripNullBytes(type),
     topFrame: null,
     normalizedFrames: [],
   };


### PR DESCRIPTION
## Problem

A single telemetry event carrying a raw **NUL byte (`0x00`)** in event-derived text (log body, exception message, or a stack frame) wedges the worker's issue-ingestion tick.

Postgres rejects `0x00` in both `text` and `jsonb` columns with:

```
22021 invalid byte sequence for encoding "UTF8": 0x00
```

In `apps/worker/src/telemetry/ingest.ts` the issues upsert runs inside a per-row `for` loop. When `upsertIssue` throws on the bad row, the error escapes the loop to the outer `catch`, so `setCursor` is never reached and the durable cursor doesn't advance. Every subsequent tick re-reads the same discovery window, re-hits the same row, and fails again — **issue/incident creation stalls for all projects** until the poison row ages out of the window. It surfaces as a steady stream of `tick step failed` ERROR logs (both the `spans` and `logs` steps) with `causeCode: "22021"`, and the telemetry-ingest backlog gauges (`oldest_pending_age_ms`) climb 1:1 with wall-clock while `pending_rows` stays pinned.

## Fix

1. **Strip NUL at the source.** New `stripNullBytes()` in `@superlog/fingerprint`, applied to the fingerprint outputs that get persisted (`exceptionType`, `topFrame`, `normalizedFrames`), and to the ClickHouse-derived strings (`body` / `exc_message` / `exc_stack` / `service` / `severity` / `span_name`) and attribute maps before they reach the `text` / `jsonb` columns in the ingest path. The hash itself is hex and was never affected. Poisoned rows now upsert cleanly and we keep the issue.
2. **Isolate per-row failures.** Each row's upsert + transition handling is wrapped in a `try/catch`. A failing row is logged, counted on a new `superlog.worker.telemetry.row_failures` counter, and skipped while the cursor advances past it. No single bad row — NUL or any future surprise — can wedge global ingestion again.

## Tests

- `@superlog/fingerprint`: `stripNullBytes` behavior + NUL stripped from `fingerprint` / `fingerprintLog` outputs.
- `apps/worker` telemetry ingest: a row whose upsert throws no longer aborts the batch — the next row is still processed and the cursor advances past the failing one.

Red before the change, green after. `typecheck` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops telemetry rows with NUL bytes from stalling issue ingestion by sanitizing inputs and isolating per‑row failures. Also enables vertical gridlines on timeseries charts for empty or sparse windows.

- **Bug Fixes**
  - Added `stripNullBytes()` in `@superlog/fingerprint`; applied to fingerprint outputs and ClickHouse-derived strings/attrs before Postgres `text`/`jsonb`.
  - Wrapped each row’s upsert in `try/catch`; log and skip failing rows while advancing the cursor.
  - Added counter `superlog.worker.telemetry.row_failures` to track skipped rows.
  - Timeseries charts: show dashed vertical gridlines on the x-axis so empty regions still read as a grid.

- **Tests**
  - Unit tests for `stripNullBytes`, `fingerprint`, and `fingerprintLog`.
  - Ingest test ensures a throwing row doesn’t abort the batch and the cursor advances past it.

<sup>Written for commit 47777790967c3f2214202022dc08afeb1068ec00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

