### PR TITLE
web: emit a PostHog signup event with source attribution

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -48,6 +48,10 @@ function SignupSourceCapture() {
     }
     // Stash the full first-touch attribution (source + UTM + referrer) so the
     // PostHog signup event can report it once the user creates their first org.
+    // landingPath is passed unconditionally on purpose: persistFirstTouchAttribution
+    // only writes when there's real attribution signal (source/UTM/referrer) and
+    // treats landingPath as ride-along context, so this can't lock in a
+    // landingPath-only record on a plain pageview and shut out a later landing.
     persistFirstTouchAttribution(window.localStorage, {
       ...attr,
       landingPath: window.location.pathname,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -27,6 +27,7 @@ import { DashboardsList } from "./dashboards/DashboardsList.tsx";
 import { AppShell, ThemeToggle, Wordmark } from "./design/ui.tsx";
 import { McpInstallPill } from "./onboarding/McpInstallPill.tsx";
 import { OnboardingGate } from "./onboarding/OnboardingGate.tsx";
+import { parseAttribution, persistFirstTouchAttribution } from "./signupAttribution.ts";
 import { startSkillOnboarding } from "./skillOnboarding.ts";
 
 const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:4100";
@@ -34,17 +35,23 @@ const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:4100";
 function SignupSourceCapture() {
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const params = new URLSearchParams(window.location.search);
-    const raw = params.get("source");
-    if (!raw) return;
-    const source = raw.trim().toLowerCase();
-    if (!/^[a-z0-9_-]{1,32}$/.test(source)) return;
-    try {
-      const existing = window.localStorage.getItem("superlog.signup_source");
-      if (!existing) window.localStorage.setItem("superlog.signup_source", source);
-    } catch {
-      /* ignore */
+    const attr = parseAttribution(window.location.search, document.referrer);
+    // The `?source=` tag is also forwarded to /api/me as a header and persisted
+    // on orgs.signup_source, so keep its dedicated key untouched (see api.ts).
+    if (attr.source) {
+      try {
+        const existing = window.localStorage.getItem("superlog.signup_source");
+        if (!existing) window.localStorage.setItem("superlog.signup_source", attr.source);
+      } catch {
+        /* ignore */
+      }
     }
+    // Stash the full first-touch attribution (source + UTM + referrer) so the
+    // PostHog signup event can report it once the user creates their first org.
+    persistFirstTouchAttribution(window.localStorage, {
+      ...attr,
+      landingPath: window.location.pathname,
+    });
   }, []);
   return null;
 }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,6 +1,36 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { usePostHog } from "posthog-js/react";
+import { buildSignupEventProperties, readFirstTouchAttribution } from "./signupAttribution.ts";
 
 const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:4100";
+
+// PostHog instance shape we actually use — `usePostHog()` returns the (possibly
+// uninitialized) global when no token is configured, so callers must null-guard.
+type PostHogLike = {
+  capture(event: string, properties?: Record<string, unknown>): void;
+} | null;
+
+// Fire the "new account" signup event once the user creates their first org —
+// the one moment that's common to both email and social signups. Attribution
+// (source + UTM + referrer) was stashed at landing in localStorage. Best-effort:
+// analytics must never block or break account creation.
+function captureSignupEvent(posthog: PostHogLike) {
+  if (!posthog || typeof window === "undefined") return;
+  try {
+    const attr = readFirstTouchAttribution(window.localStorage) ?? {};
+    const authMethod =
+      window.localStorage.getItem("superlog.auth.last_provider")?.trim() || undefined;
+    const props = buildSignupEventProperties(attr, { authMethod });
+    posthog.capture("user_signed_up", {
+      ...props,
+      // Persist first-touch attribution onto the PostHog person so signups can be
+      // segmented by source/UTM indefinitely, without clobbering a later touch.
+      $set_once: props,
+    });
+  } catch {
+    /* analytics is best-effort */
+  }
+}
 
 export type Me = {
   user: { id: string; email: string; name: string; isStaff: boolean; impersonating: boolean };
@@ -118,13 +148,17 @@ export function useSystemCapabilities() {
 export function useCreateMyFirstOrg() {
   const fetcher = useFetcher();
   const qc = useQueryClient();
+  const posthog = usePostHog();
   return useMutation({
     mutationFn: (name: string) =>
       fetcher<{
         org: { id: string; name: string; slug: string };
         project: { id: string; name: string; slug: string };
       }>("/api/me/orgs", { method: "POST", body: JSON.stringify({ name }) }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["me"] }),
+    onSuccess: () => {
+      captureSignupEvent(posthog);
+      return qc.invalidateQueries({ queryKey: ["me"] });
+    },
   });
 }
 

--- a/apps/web/src/signupAttribution.test.ts
+++ b/apps/web/src/signupAttribution.test.ts
@@ -73,12 +73,45 @@ test("persistFirstTouchAttribution does not write an all-empty attribution", () 
   assert.equal(store.getItem(FIRST_TOUCH_STORAGE_KEY), null);
 });
 
+test("persistFirstTouchAttribution ignores a landingPath-only touch (no signal)", () => {
+  // landingPath is always present (pathname is at least "/"), so it must not be
+  // treated as signal — otherwise the first plain pageview would lock in and shut
+  // out a later attributed landing.
+  const store = fakeStorage();
+  persistFirstTouchAttribution(store, { landingPath: "/explore" });
+  assert.equal(store.getItem(FIRST_TOUCH_STORAGE_KEY), null);
+});
+
+test("persistFirstTouchAttribution stores landingPath alongside real signal", () => {
+  const store = fakeStorage();
+  // First, an unattributed pageview — not persisted.
+  persistFirstTouchAttribution(store, { landingPath: "/" });
+  // Then a real attributed landing — persisted, carrying its landingPath.
+  persistFirstTouchAttribution(store, { source: "skill", landingPath: "/explore" });
+  const got = readFirstTouchAttribution(store);
+  assert.equal(got?.source, "skill");
+  assert.equal(got?.landingPath, "/explore");
+});
+
 test("readFirstTouchAttribution returns null on missing / corrupt JSON", () => {
   assert.equal(readFirstTouchAttribution(fakeStorage()), null);
   assert.equal(
     readFirstTouchAttribution(fakeStorage({ [FIRST_TOUCH_STORAGE_KEY]: "{not json" })),
     null,
   );
+});
+
+test("readFirstTouchAttribution drops non-string and unknown values from tampered storage", () => {
+  const store = fakeStorage({
+    [FIRST_TOUCH_STORAGE_KEY]: JSON.stringify({
+      source: "skill",
+      utmSource: 123, // wrong type
+      referrer: { nested: true }, // wrong type
+      injected: "evil", // unknown key
+    }),
+  });
+  const got = readFirstTouchAttribution(store);
+  assert.deepEqual(got, { source: "skill" });
 });
 
 test("buildSignupEventProperties emits snake_case keys and omits undefined", () => {

--- a/apps/web/src/signupAttribution.test.ts
+++ b/apps/web/src/signupAttribution.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  FIRST_TOUCH_STORAGE_KEY,
+  buildSignupEventProperties,
+  parseAttribution,
+  persistFirstTouchAttribution,
+  readFirstTouchAttribution,
+} from "./signupAttribution.ts";
+
+// A tiny in-memory localStorage stand-in so the storage helpers can be tested
+// without a DOM. Mirrors the subset of the Web Storage API we use.
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+    setItem: (k: string, v: string) => void map.set(k, String(v)),
+    removeItem: (k: string) => void map.delete(k),
+    get size() {
+      return map.size;
+    },
+  };
+}
+
+test("parseAttribution extracts a valid source param", () => {
+  const attr = parseAttribution("?source=Skill", "");
+  assert.equal(attr.source, "skill"); // normalized to lower-case
+});
+
+test("parseAttribution rejects an out-of-range / malformed source", () => {
+  assert.equal(parseAttribution("?source=not a source!", "").source, undefined);
+  assert.equal(parseAttribution(`?source=${"x".repeat(40)}`, "").source, undefined);
+  assert.equal(parseAttribution("", "").source, undefined);
+});
+
+test("parseAttribution pulls all UTM fields", () => {
+  const attr = parseAttribution(
+    "?utm_source=twitter&utm_medium=social&utm_campaign=launch&utm_term=obs&utm_content=hero",
+    "",
+  );
+  assert.equal(attr.utmSource, "twitter");
+  assert.equal(attr.utmMedium, "social");
+  assert.equal(attr.utmCampaign, "launch");
+  assert.equal(attr.utmTerm, "obs");
+  assert.equal(attr.utmContent, "hero");
+});
+
+test("parseAttribution derives referrer and referring domain", () => {
+  const attr = parseAttribution("", "https://news.ycombinator.com/item?id=1");
+  assert.equal(attr.referrer, "https://news.ycombinator.com/item?id=1");
+  assert.equal(attr.referringDomain, "news.ycombinator.com");
+});
+
+test("parseAttribution ignores a same-origin / empty referrer for the domain", () => {
+  const attr = parseAttribution("", "");
+  assert.equal(attr.referrer, undefined);
+  assert.equal(attr.referringDomain, undefined);
+});
+
+test("persistFirstTouchAttribution is write-once (first touch wins)", () => {
+  const store = fakeStorage();
+  persistFirstTouchAttribution(store, { source: "skill", utmSource: "twitter" });
+  // A later visit with different params must NOT overwrite the first touch.
+  persistFirstTouchAttribution(store, { source: "web", utmSource: "google" });
+  const got = readFirstTouchAttribution(store);
+  assert.equal(got?.source, "skill");
+  assert.equal(got?.utmSource, "twitter");
+});
+
+test("persistFirstTouchAttribution does not write an all-empty attribution", () => {
+  const store = fakeStorage();
+  persistFirstTouchAttribution(store, {});
+  assert.equal(store.getItem(FIRST_TOUCH_STORAGE_KEY), null);
+});
+
+test("readFirstTouchAttribution returns null on missing / corrupt JSON", () => {
+  assert.equal(readFirstTouchAttribution(fakeStorage()), null);
+  assert.equal(
+    readFirstTouchAttribution(fakeStorage({ [FIRST_TOUCH_STORAGE_KEY]: "{not json" })),
+    null,
+  );
+});
+
+test("buildSignupEventProperties emits snake_case keys and omits undefined", () => {
+  const props = buildSignupEventProperties(
+    { source: "skill", utmSource: "twitter", referringDomain: "t.co" },
+    { authMethod: "email" },
+  );
+  assert.deepEqual(props, {
+    signup_source: "skill",
+    utm_source: "twitter",
+    referring_domain: "t.co",
+    auth_method: "email",
+  });
+});
+
+test("buildSignupEventProperties yields an empty object for empty inputs", () => {
+  assert.deepEqual(buildSignupEventProperties({}, {}), {});
+});

--- a/apps/web/src/signupAttribution.ts
+++ b/apps/web/src/signupAttribution.ts
@@ -1,0 +1,141 @@
+// First-touch signup attribution.
+//
+// We want PostHog to be able to answer "how many signups, and where did they
+// come from?". Two kinds of "where from" are captured here:
+//   - `source`: our own first-party tag (?source=skill|web|mcp|github|cli),
+//     the same value the API persists on `orgs.signup_source`.
+//   - UTM params + referrer: standard marketing attribution.
+//
+// The values are read at landing time and stashed in localStorage so they
+// survive the OAuth redirect round-trip and the multi-step onboarding wizard.
+// The actual PostHog event is fired once the user creates their first org (the
+// canonical "new account" moment — see useCreateMyFirstOrg), which covers email
+// and social signups uniformly.
+
+export type SignupAttribution = {
+  source?: string;
+  utmSource?: string;
+  utmMedium?: string;
+  utmCampaign?: string;
+  utmTerm?: string;
+  utmContent?: string;
+  referrer?: string;
+  referringDomain?: string;
+  landingPath?: string;
+};
+
+// Kept in sync with the API's ALLOWED_SIGNUP_SOURCES validation shape: a short
+// slug of lower-case letters/digits/_/-. We normalize case but otherwise pass
+// the raw value through (the API enforces the allow-list server-side).
+const SOURCE_RE = /^[a-z0-9_-]{1,32}$/;
+
+// A minimal slice of the Web Storage API so callers can pass `window.localStorage`
+// and tests can pass an in-memory stand-in.
+export type StorageLike = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+};
+
+export const FIRST_TOUCH_STORAGE_KEY = "superlog.signup_attribution";
+
+function cleanParam(value: string | null): string | undefined {
+  if (value == null) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 && trimmed.length <= 256 ? trimmed : undefined;
+}
+
+/** Parse attribution from a URL query string and the document referrer. Pure. */
+export function parseAttribution(search: string, referrer: string): SignupAttribution {
+  const params = new URLSearchParams(search);
+
+  const rawSource = params.get("source")?.trim().toLowerCase();
+  const source = rawSource && SOURCE_RE.test(rawSource) ? rawSource : undefined;
+
+  let referringDomain: string | undefined;
+  const ref = cleanParam(referrer);
+  if (ref) {
+    try {
+      referringDomain = new URL(ref).hostname || undefined;
+    } catch {
+      /* malformed referrer — leave the domain undefined */
+    }
+  }
+
+  return omitEmpty({
+    source,
+    utmSource: cleanParam(params.get("utm_source")),
+    utmMedium: cleanParam(params.get("utm_medium")),
+    utmCampaign: cleanParam(params.get("utm_campaign")),
+    utmTerm: cleanParam(params.get("utm_term")),
+    utmContent: cleanParam(params.get("utm_content")),
+    referrer: ref,
+    referringDomain,
+  });
+}
+
+function omitEmpty(attr: SignupAttribution): SignupAttribution {
+  const out: SignupAttribution = {};
+  for (const [k, v] of Object.entries(attr)) {
+    if (v !== undefined && v !== null && v !== "") out[k as keyof SignupAttribution] = v;
+  }
+  return out;
+}
+
+function isEmpty(attr: SignupAttribution): boolean {
+  return Object.keys(omitEmpty(attr)).length === 0;
+}
+
+/**
+ * Persist attribution write-once: the first non-empty touch wins and is never
+ * overwritten, so a user who lands via `?source=skill` and later navigates to a
+ * plain URL keeps the original attribution.
+ */
+export function persistFirstTouchAttribution(storage: StorageLike, attr: SignupAttribution): void {
+  const cleaned = omitEmpty(attr);
+  if (isEmpty(cleaned)) return;
+  try {
+    if (storage.getItem(FIRST_TOUCH_STORAGE_KEY)) return;
+    storage.setItem(FIRST_TOUCH_STORAGE_KEY, JSON.stringify(cleaned));
+  } catch {
+    /* storage unavailable (private mode, quota) — attribution is best-effort */
+  }
+}
+
+export function readFirstTouchAttribution(storage: StorageLike): SignupAttribution | null {
+  try {
+    const raw = storage.getItem(FIRST_TOUCH_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as SignupAttribution) : null;
+  } catch {
+    return null;
+  }
+}
+
+export type SignupEventContext = {
+  authMethod?: string;
+};
+
+/** Flatten attribution into snake_case PostHog event properties, omitting blanks. */
+export function buildSignupEventProperties(
+  attr: SignupAttribution,
+  ctx: SignupEventContext,
+): Record<string, string> {
+  const props: Record<string, string | undefined> = {
+    signup_source: attr.source,
+    utm_source: attr.utmSource,
+    utm_medium: attr.utmMedium,
+    utm_campaign: attr.utmCampaign,
+    utm_term: attr.utmTerm,
+    utm_content: attr.utmContent,
+    referrer: attr.referrer,
+    referring_domain: attr.referringDomain,
+    landing_path: attr.landingPath,
+    auth_method: ctx.authMethod,
+  };
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(props)) {
+    if (v !== undefined && v !== null && v !== "") out[k] = v;
+  }
+  return out;
+}

--- a/apps/web/src/signupAttribution.ts
+++ b/apps/web/src/signupAttribution.ts
@@ -61,7 +61,7 @@ export function parseAttribution(search: string, referrer: string): SignupAttrib
     }
   }
 
-  return omitEmpty({
+  return sanitize({
     source,
     utmSource: cleanParam(params.get("utm_source")),
     utmMedium: cleanParam(params.get("utm_medium")),
@@ -73,26 +73,48 @@ export function parseAttribution(search: string, referrer: string): SignupAttrib
   });
 }
 
-function omitEmpty(attr: SignupAttribution): SignupAttribution {
+const ATTRIBUTION_KEYS = [
+  "source",
+  "utmSource",
+  "utmMedium",
+  "utmCampaign",
+  "utmTerm",
+  "utmContent",
+  "referrer",
+  "referringDomain",
+  "landingPath",
+] as const;
+
+// `landingPath` is context that rides along with a real touch, not a touch in
+// its own right — it's always present (pathname is at least "/"), so counting it
+// as signal would lock in first-touch on the very first pageview and shut out a
+// later ?source=/UTM landing. Gate persistence on everything else.
+const SIGNAL_KEYS = ATTRIBUTION_KEYS.filter((k) => k !== "landingPath");
+
+/** Keep only known keys whose value is a non-empty string. */
+function sanitize(attr: SignupAttribution): SignupAttribution {
   const out: SignupAttribution = {};
-  for (const [k, v] of Object.entries(attr)) {
-    if (v !== undefined && v !== null && v !== "") out[k as keyof SignupAttribution] = v;
+  for (const key of ATTRIBUTION_KEYS) {
+    const v = attr[key];
+    if (typeof v === "string" && v !== "") out[key] = v;
   }
   return out;
 }
 
-function isEmpty(attr: SignupAttribution): boolean {
-  return Object.keys(omitEmpty(attr)).length === 0;
+function hasAttributionSignal(attr: SignupAttribution): boolean {
+  return SIGNAL_KEYS.some((k) => typeof attr[k] === "string" && attr[k] !== "");
 }
 
 /**
- * Persist attribution write-once: the first non-empty touch wins and is never
- * overwritten, so a user who lands via `?source=skill` and later navigates to a
- * plain URL keeps the original attribution.
+ * Persist attribution write-once: the first touch carrying real signal (source,
+ * UTM, or referrer) wins and is never overwritten, so a user who lands via
+ * `?source=skill` and later navigates to a plain URL keeps the original
+ * attribution. A pageview with no signal is not persisted, so it can't lock in
+ * a `landingPath`-only record and shut out a later attributed landing.
  */
 export function persistFirstTouchAttribution(storage: StorageLike, attr: SignupAttribution): void {
-  const cleaned = omitEmpty(attr);
-  if (isEmpty(cleaned)) return;
+  const cleaned = sanitize(attr);
+  if (!hasAttributionSignal(cleaned)) return;
   try {
     if (storage.getItem(FIRST_TOUCH_STORAGE_KEY)) return;
     storage.setItem(FIRST_TOUCH_STORAGE_KEY, JSON.stringify(cleaned));
@@ -106,7 +128,10 @@ export function readFirstTouchAttribution(storage: StorageLike): SignupAttributi
     const raw = storage.getItem(FIRST_TOUCH_STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === "object" ? (parsed as SignupAttribution) : null;
+    // Storage is user-writable; sanitize so non-string values can't leak past
+    // the Record<string, string> typing into event properties downstream.
+    if (!parsed || typeof parsed !== "object") return null;
+    return sanitize(parsed as SignupAttribution);
   } catch {
     return null;
   }


### PR DESCRIPTION
PostHog currently only `identify()`s logged-in users and captures exceptions — it fires **no custom events**, so we cannot count signups or see where they came from.

## What this does

- **`signupAttribution.ts`** (new, pure + unit-tested) — parses first-touch attribution from the URL + referrer: our own `?source=` tag (`skill|web|mcp|github|cli`), `utm_*` params, and the referrer/referring domain. Persists it write-once to `localStorage` so it survives the OAuth redirect round-trip and the multi-step onboarding wizard.
- **Landing capture** (`App.tsx`) — the existing `SignupSourceCapture` effect now also stashes the full attribution blob (it still writes the dedicated `signup_source` key the API reads).
- **The event** (`api.ts`) — fires `user_signed_up` on first-org creation (`useCreateMyFirstOrg`). That step is common to **both** email and social signups, so the count covers all new accounts uniformly. Event properties carry `signup_source`, `utm_*`, `referrer`, `referring_domain`, `landing_path`, and `auth_method`; the same values are written to the PostHog person via `$set_once` for durable segmentation.

In PostHog this gives you a `user_signed_up` event to count, breakdown-able by source / UTM / referrer.

Analytics is best-effort and guarded — it never blocks or breaks account creation, and is a no-op when no PostHog token is configured.

## Testing

- `signupAttribution.test.ts`: 10 cases covering source validation/normalization, UTM extraction, referrer→domain derivation, write-once first-touch persistence, corrupt-JSON handling, and snake_case property building. All green.
- `tsc --noEmit` and `biome check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit a `user_signed_up` PostHog event with first-touch attribution (source, UTM, referrer) to count signups and see where they came from. Capture on landing; fire on first org creation; analytics is best-effort and never blocks signup.

- New Features
  - New `signupAttribution.ts`: parse first touch (source, UTM, referrer) and persist to `localStorage`, including `landing_path`.
  - Landing (`App.tsx`): stash attribution; keep `superlog.signup_source` for API forwarding; pass `landingPath` unconditionally while persistence remains signal-gated.
  - On first org creation: send `user_signed_up` via `posthog-js/react` with snake_case props and `$set_once` on the person.

- Bug Fixes
  - Persist first touch only when there’s real signal (source/UTM/referrer); `landing_path` alone no longer locks in.
  - Sanitize stored attribution on read; drop unknown keys and non-string values.

<sup>Written for commit ddfd788e9297c3508c841d95a5aeb5c0292358a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

