### PR TITLE
perf(worker): batch issue upserts by fingerprint

### DIFF
--- a/apps/worker/src/telemetry/ingest.test.ts
+++ b/apps/worker/src/telemetry/ingest.test.ts
@@ -299,11 +299,17 @@ test("log ingestion isolates a failing row and still advances past it", async ()
       if (call === 1) throw new Error('invalid byte sequence for encoding "UTF8": 0x00');
     },
   });
+  // Distinct exc_type => distinct fingerprints => two separate upsert groups.
   const rows = [
-    { ...logRow({ traceId: "t1", spanId: "s1", body: "poison" }), project_id: VALID_PROJECT_ID },
+    {
+      ...logRow({ traceId: "t1", spanId: "s1", body: "poison" }),
+      project_id: VALID_PROJECT_ID,
+      exc_type: "PoisonError",
+    },
     {
       ...logRow({ traceId: "t2", spanId: "s2", body: "healthy" }),
       project_id: VALID_PROJECT_ID,
+      exc_type: "HealthyError",
       ts: "2026-05-23 10:00:01.000000",
     },
   ];
@@ -328,10 +334,50 @@ test("log ingestion isolates a failing row and still advances past it", async ()
 
   const processed = await ingestor.tickLogs();
   assert.equal(processed, 2);
-  // Both rows attempted (poison row did not abort the loop).
+  // Both groups attempted (the poison group did not abort the flush).
   assert.equal(executeCalls(), 2);
   // Cursor advanced past the poison row to the healthy row's timestamp.
   assert.equal(state.get("fingerprint-logs")?.cursor.toISOString(), "2026-05-23T10:00:01.000Z");
+});
+
+test("log ingestion collapses same-fingerprint rows into a single upsert", async () => {
+  // An exception storm: many rows, one fingerprint. Must be ONE upsert, not N.
+  const { database, state, executeCalls } = fakeDbWithProject({});
+  const rows = [
+    { ...logRow({ traceId: "t1", spanId: "s1", body: "boom" }), project_id: VALID_PROJECT_ID },
+    {
+      ...logRow({ traceId: "t2", spanId: "s2", body: "boom" }),
+      project_id: VALID_PROJECT_ID,
+      ts: "2026-05-23 10:00:01.000000",
+    },
+    {
+      ...logRow({ traceId: "t3", spanId: "s3", body: "boom" }),
+      project_id: VALID_PROJECT_ID,
+      ts: "2026-05-23 10:00:02.000000",
+    },
+  ];
+  let callCount = 0;
+  const clickhouse = {
+    async query() {
+      const out = callCount === 0 ? rows : [];
+      callCount += 1;
+      return {
+        async json() {
+          return out;
+        },
+      };
+    },
+  };
+  const ingestor = createTelemetryIngestor({
+    clickhouse,
+    database,
+    batchSize: 10,
+    async handleIssueTransition() {},
+  });
+
+  assert.equal(await ingestor.tickLogs(), 3);
+  // Three rows, one fingerprint => exactly one upsert round-trip.
+  assert.equal(executeCalls(), 1);
 });
 
 function spanRow(opts: { traceId: string; spanId: string; message: string }) {

--- a/apps/worker/src/telemetry/ingest.ts
+++ b/apps/worker/src/telemetry/ingest.ts
@@ -291,28 +291,99 @@ async function loadIssueFiltersForProjects(
   return out;
 }
 
-async function upsertIssue(row: {
-  database: DB;
+type PendingIssue = {
   projectId: string;
   kind: "span" | "log";
   service: string | null;
   fp: Fingerprint;
   message: string | null;
-  seenAt: Date;
+  firstSeen: Date;
+  lastSeen: Date;
   lastSample: IssueSample;
-}): Promise<{ transition: Transition; issue: schema.Issue }> {
-  return tracer.startActiveSpan("issue.fingerprint", async (span) => {
-    span.setAttribute("issue.kind", row.kind);
-    span.setAttribute("issue.fingerprint", row.fp.hash);
-    span.setAttribute("issue.exception_type", row.fp.exceptionType);
-    if (row.service) span.setAttribute("issue.service", row.service);
-    span.setAttribute("issue.project_id", row.projectId);
+  eventCount: number;
+};
+
+// Collapse rows that share a (project, fingerprint) into one pending upsert.
+// A single exception storm emits thousands of rows that all map to one issue,
+// so instead of one Postgres round-trip per row we accumulate the count in
+// memory and issue one upsert per distinct fingerprint per batch. We keep the
+// newest row's sample (and its message/service) and the min/max seen times.
+function accumulateIssue(groups: Map<string, PendingIssue>, candidate: PendingIssue): void {
+  const key = `${candidate.projectId}::${candidate.fp.hash}`;
+  const existing = groups.get(key);
+  if (!existing) {
+    groups.set(key, candidate);
+    return;
+  }
+  existing.eventCount += candidate.eventCount;
+  if (candidate.firstSeen < existing.firstSeen) existing.firstSeen = candidate.firstSeen;
+  if (candidate.lastSeen >= existing.lastSeen) {
+    existing.lastSeen = candidate.lastSeen;
+    existing.lastSample = candidate.lastSample;
+    existing.message = candidate.message ?? existing.message;
+    existing.service = candidate.service ?? existing.service;
+  }
+}
+
+// Upsert every accumulated group, isolating each one so a single failing group
+// (e.g. a value Postgres rejects) is logged + counted and skipped rather than
+// wedging the cursor for the whole batch.
+async function flushIssueGroups(
+  database: DB,
+  groups: Map<string, PendingIssue>,
+  handleIssueTransition: IssueTransitionHandler,
+): Promise<void> {
+  for (const group of groups.values()) {
     try {
-      const title = buildIssueTitle(row.fp, row.message);
-      const seenAtIso = row.seenAt.toISOString();
-      const normalizedFrames = JSON.stringify(row.fp.normalizedFrames);
-      const lastSample = JSON.stringify(row.lastSample);
-      const result = await row.database.execute<{
+      const up = await upsertIssue(database, group);
+      if (up.transition !== "seen" && up.issue) {
+        logger.info(
+          {
+            kind: group.kind,
+            transition: up.transition,
+            projectId: group.projectId,
+            fingerprint: group.fp.hash,
+            exceptionType: group.fp.exceptionType,
+            events: group.eventCount,
+          },
+          "issue transition",
+        );
+        await handleIssueTransition(up.issue, up.transition);
+      }
+    } catch (err) {
+      rowFailures.add(group.eventCount, { "telemetry.kind": group.kind });
+      logger.error(
+        {
+          err,
+          kind: group.kind,
+          projectId: group.projectId,
+          fingerprint: group.fp.hash,
+          events: group.eventCount,
+        },
+        "issue upsert failed; skipping rows",
+      );
+    }
+  }
+}
+
+async function upsertIssue(
+  database: DB,
+  group: PendingIssue,
+): Promise<{ transition: Transition; issue: schema.Issue | null }> {
+  return tracer.startActiveSpan("issue.fingerprint", async (span) => {
+    span.setAttribute("issue.kind", group.kind);
+    span.setAttribute("issue.fingerprint", group.fp.hash);
+    span.setAttribute("issue.exception_type", group.fp.exceptionType);
+    if (group.service) span.setAttribute("issue.service", group.service);
+    span.setAttribute("issue.project_id", group.projectId);
+    span.setAttribute("issue.event_count", group.eventCount);
+    try {
+      const title = buildIssueTitle(group.fp, group.message);
+      const firstSeenIso = group.firstSeen.toISOString();
+      const lastSeenIso = group.lastSeen.toISOString();
+      const normalizedFrames = JSON.stringify(group.fp.normalizedFrames);
+      const lastSample = JSON.stringify(group.lastSample);
+      const result = await database.execute<{
         id: string;
         xmax: string;
         prev_issue_id: string | null;
@@ -323,8 +394,8 @@ async function upsertIssue(row: {
       FROM issues i
       LEFT JOIN incident_issues ii ON ii.issue_id = i.id
       LEFT JOIN incidents inc ON inc.id = ii.incident_id
-      WHERE i.project_id = ${row.projectId}
-        AND i.fingerprint = ${row.fp.hash}
+      WHERE i.project_id = ${group.projectId}
+        AND i.fingerprint = ${group.fp.hash}
         AND i.silenced_at IS NULL
     ),
     up AS (
@@ -333,14 +404,14 @@ async function upsertIssue(row: {
         title, message, top_frame, normalized_frames, last_sample,
         first_seen, last_seen, event_count
       ) VALUES (
-        ${row.projectId}, ${row.fp.hash}, ${row.kind}, ${row.service}, ${row.fp.exceptionType},
-        ${title}, ${row.message}, ${row.fp.topFrame}, ${normalizedFrames}::jsonb, ${lastSample}::jsonb,
-        ${seenAtIso}::timestamptz, ${seenAtIso}::timestamptz, 1
+        ${group.projectId}, ${group.fp.hash}, ${group.kind}, ${group.service}, ${group.fp.exceptionType},
+        ${title}, ${group.message}, ${group.fp.topFrame}, ${normalizedFrames}::jsonb, ${lastSample}::jsonb,
+        ${firstSeenIso}::timestamptz, ${lastSeenIso}::timestamptz, ${group.eventCount}
       )
       ON CONFLICT (project_id, fingerprint) WHERE silenced_at IS NULL DO UPDATE SET
         last_seen = GREATEST(issues.last_seen, EXCLUDED.last_seen),
         first_seen = LEAST(issues.first_seen, EXCLUDED.first_seen),
-        event_count = issues.event_count + 1,
+        event_count = issues.event_count + ${group.eventCount},
         message = COALESCE(EXCLUDED.message, issues.message),
         service = COALESCE(EXCLUDED.service, issues.service),
         top_frame = COALESCE(EXCLUDED.top_frame, issues.top_frame),
@@ -362,15 +433,21 @@ async function upsertIssue(row: {
           prev_incident_status: string | null;
         }>
       )[0];
-      const issue = await row.database.query.issues.findFirst({
-        where: (issues, { eq }) => eq(issues.id, raw?.id ?? ""),
-      });
-      if (!issue) throw new Error("failed to load issue after upsert");
       const transition = computeTransition(
         raw?.prev_issue_id ?? null,
         raw?.prev_incident_status ?? null,
       );
       span.setAttribute("issue.transition", transition);
+      // Only reload the full row when a downstream handler needs it (new or
+      // regressed). The common "seen" path skips a second query per group.
+      let issue: schema.Issue | null = null;
+      if (transition !== "seen") {
+        issue =
+          (await database.query.issues.findFirst({
+            where: (issues, { eq }) => eq(issues.id, raw?.id ?? ""),
+          })) ?? null;
+        if (!issue) throw new Error("failed to load issue after upsert");
+      }
       return { transition, issue };
     } catch (err) {
       span.recordException(err as Error);
@@ -553,18 +630,20 @@ async function tickSpans(opts: {
         opts.database,
         rows.map((row) => row.project_id),
       );
+      const groups = new Map<string, PendingIssue>();
       let skippedUnknownProjects = 0;
       let skippedByFilter = 0;
       for (const row of rows) {
+        // Advance past every selected row up front (even skipped/failed ones) so
+        // the batch can never wedge the cursor; the upserts happen afterward.
+        nextCursor = row.ts;
         if (!validProjectIds.has(row.project_id)) {
           skippedUnknownProjects += 1;
-          nextCursor = row.ts;
           continue;
         }
         const filter = issueFilters.get(row.project_id) ?? schema.EMPTY_ISSUE_FILTER_CONFIG;
         if (!eventPassesIssueFilter("span", filter, [row.resource_attrs, row.span_attrs])) {
           skippedByFilter += 1;
-          nextCursor = row.ts;
           continue;
         }
         const excMessage = stripNullBytes(row.exc_message) || null;
@@ -593,42 +672,19 @@ async function tickSpans(opts: {
           spanAttrs: sanitizeAttrs(row.span_attrs),
           resourceAttrs: sanitizeAttrs(row.resource_attrs),
         };
-        try {
-          const up = await upsertIssue({
-            database: opts.database,
-            projectId: row.project_id,
-            kind: "span",
-            service,
-            fp,
-            message: excMessage,
-            seenAt,
-            lastSample,
-          });
-          if (up.transition !== "seen") {
-            logger.info(
-              {
-                kind: "span",
-                transition: up.transition,
-                projectId: row.project_id,
-                fingerprint: fp.hash,
-                exceptionType: fp.exceptionType,
-              },
-              "issue transition",
-            );
-            await opts.handleIssueTransition(up.issue, up.transition);
-          }
-        } catch (rowErr) {
-          // Never let a single bad row wedge the cursor — a poison row (e.g. a
-          // value Postgres rejects) would otherwise re-fail every tick and stall
-          // issue ingestion for all projects. Log, count, and advance past it.
-          rowFailures.add(1, { "telemetry.kind": "span" });
-          logger.error(
-            { err: rowErr, kind: "span", projectId: row.project_id, fingerprint: fp.hash },
-            "issue upsert failed; skipping row",
-          );
-        }
-        nextCursor = row.ts;
+        accumulateIssue(groups, {
+          projectId: row.project_id,
+          kind: "span",
+          service,
+          fp,
+          message: excMessage,
+          firstSeen: seenAt,
+          lastSeen: seenAt,
+          lastSample,
+          eventCount: 1,
+        });
       }
+      await flushIssueGroups(opts.database, groups, opts.handleIssueTransition);
       logSkippedEvents("span", skippedUnknownProjects, skippedByFilter);
       if (selectedTimestampCount < opts.batchSize) nextCursor = cursorWindow.untilTs;
       await setCursor(opts.database, SPAN_CURSOR, nextCursor);
@@ -722,18 +778,20 @@ async function tickLogs(opts: {
         opts.database,
         rows.map((row) => row.project_id),
       );
+      const groups = new Map<string, PendingIssue>();
       let skippedUnknownProjects = 0;
       let skippedByFilter = 0;
       for (const row of rows) {
+        // Advance past every selected row up front (even skipped/failed ones) so
+        // the batch can never wedge the cursor; the upserts happen afterward.
+        nextCursor = row.ts;
         if (!validProjectIds.has(row.project_id)) {
           skippedUnknownProjects += 1;
-          nextCursor = row.ts;
           continue;
         }
         const filter = issueFilters.get(row.project_id) ?? schema.EMPTY_ISSUE_FILTER_CONFIG;
         if (!eventPassesIssueFilter("log", filter, [row.resource_attrs, row.log_attrs])) {
           skippedByFilter += 1;
-          nextCursor = row.ts;
           continue;
         }
         const body = stripNullBytes(row.body) || null;
@@ -764,42 +822,19 @@ async function tickLogs(opts: {
           logAttrs: sanitizeAttrs(row.log_attrs),
           resourceAttrs: sanitizeAttrs(row.resource_attrs),
         };
-        try {
-          const up = await upsertIssue({
-            database: opts.database,
-            projectId: row.project_id,
-            kind: "log",
-            service,
-            fp,
-            message: body,
-            seenAt,
-            lastSample,
-          });
-          if (up.transition !== "seen") {
-            logger.info(
-              {
-                kind: "log",
-                transition: up.transition,
-                projectId: row.project_id,
-                fingerprint: fp.hash,
-                exceptionType: fp.exceptionType,
-              },
-              "issue transition",
-            );
-            await opts.handleIssueTransition(up.issue, up.transition);
-          }
-        } catch (rowErr) {
-          // Never let a single bad row wedge the cursor — a poison row (e.g. a
-          // value Postgres rejects) would otherwise re-fail every tick and stall
-          // issue ingestion for all projects. Log, count, and advance past it.
-          rowFailures.add(1, { "telemetry.kind": "log" });
-          logger.error(
-            { err: rowErr, kind: "log", projectId: row.project_id, fingerprint: fp.hash },
-            "issue upsert failed; skipping row",
-          );
-        }
-        nextCursor = row.ts;
+        accumulateIssue(groups, {
+          projectId: row.project_id,
+          kind: "log",
+          service,
+          fp,
+          message: body,
+          firstSeen: seenAt,
+          lastSeen: seenAt,
+          lastSample,
+          eventCount: 1,
+        });
       }
+      await flushIssueGroups(opts.database, groups, opts.handleIssueTransition);
       logSkippedEvents("log", skippedUnknownProjects, skippedByFilter);
       if (selectedTimestampCount < opts.batchSize) nextCursor = cursorWindow.untilTs;
       await setCursor(opts.database, LOG_CURSOR, nextCursor);


### PR DESCRIPTION
## Problem

The telemetry-ingest tick (`apps/worker/src/telemetry/ingest.ts`) upserts issues **one Postgres round-trip per row**, and `upsertIssue` then does a **second `findFirst` reload per row**. An exception storm emits thousands of rows that all map to a *single* fingerprint/issue, so the tick turns into thousands of sequential round-trips — throttling the durable cursor to a crawl even when the absolute row count is small (e.g. ~15k rows of one recurring `PostgrestError` from a single project = ~15k upserts + ~15k reloads for what is really one issue).

This is what makes a backlog drain slowly after any ingest stall: dense windows pay per-row cost while sparse windows fly.

## Change

1. **Collapse by fingerprint within a batch.** Rows sharing `(project_id, fingerprint)` are accumulated in memory (sum `event_count`, keep the newest sample + min/max seen timestamps) and flushed as **one upsert per distinct fingerprint per batch** — typically a 10–100× reduction in round-trips for error-heavy projects. `event_count` increments by the group size; `first_seen`/`last_seen` use the group min/max.
2. **Skip the redundant reload.** The post-upsert `findFirst` only runs when the transition is `new`/`regressed` (the only case the downstream handler needs the row). The common `seen` path is now a single query.
3. **Preserve poison-row isolation.** Each group's upsert is wrapped in try/catch: a failing group is logged + counted (`row_failures += group size`) and skipped while the cursor still advances — same guarantee as before, now per-group.

No schema change. Behaviour is otherwise identical: same fingerprints, same transitions (a fingerprint still transitions once per batch), same sample retention.

## Tests

- Same-fingerprint rows collapse to exactly **one** upsert.
- A failing group no longer aborts the rest of the batch; the cursor still advances past it.
- Existing ingest tests (cursor bounds, empty-window advance, projection source) unchanged and green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch issue upserts by `(project_id, fingerprint)` in the telemetry worker to cut Postgres round-trips and speed up backlog drain during exception storms. Skips redundant reloads on `seen` transitions while preserving poison-row isolation.

- **Refactors**
  - Collapse same-fingerprint rows per batch; accumulate `event_count`, keep newest sample and min/max seen; one upsert per fingerprint (often 10–100× fewer queries).
  - Reload issue only for `new` or `regressed` transitions; the common `seen` path is a single query.
  - Isolate failures per group; log and count (`row_failures += group size`) and keep the cursor moving.
  - No schema changes; transitions and sample retention unchanged.

<sup>Written for commit c2b8434812e2f1a0ead2bdaa3a196187611e1ee8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

