### PR TITLE
fix(worker): sanitize lone UTF-16 surrogates for Postgres

### DIFF
--- a/apps/worker/src/telemetry/ingest.ts
+++ b/apps/worker/src/telemetry/ingest.ts
@@ -5,7 +5,7 @@ import {
   type Fingerprint,
   fingerprint,
   fingerprintLog,
-  stripNullBytes,
+  sanitizeForPg,
 } from "@superlog/fingerprint";
 import { inArray, sql } from "drizzle-orm";
 import { logger } from "../logger.js";
@@ -203,14 +203,15 @@ async function existingProjectIds(database: DB, projectIds: string[]): Promise<S
   return new Set(rows.map((row) => row.id));
 }
 
-// Strip NUL bytes from attribute keys/values before they are JSON-encoded into
-// the `last_sample` jsonb column — Postgres jsonb rejects 0x00 just like text.
+// Sanitize attribute keys/values (NUL bytes, lone surrogates) before they are
+// JSON-encoded into the `last_sample` jsonb column — Postgres jsonb rejects
+// both just like text.
 function sanitizeAttrs(
   attrs: Record<string, string> | null | undefined,
 ): Record<string, string> | null {
   if (!attrs) return null;
   const out: Record<string, string> = {};
-  for (const [k, v] of Object.entries(attrs)) out[stripNullBytes(k)] = stripNullBytes(v);
+  for (const [k, v] of Object.entries(attrs)) out[sanitizeForPg(k)] = sanitizeForPg(v);
   return out;
 }
 
@@ -646,9 +647,9 @@ async function tickSpans(opts: {
           skippedByFilter += 1;
           continue;
         }
-        const excMessage = stripNullBytes(row.exc_message) || null;
-        const excStack = stripNullBytes(row.exc_stack) || null;
-        const service = stripNullBytes(row.service) || null;
+        const excMessage = sanitizeForPg(row.exc_message) || null;
+        const excStack = sanitizeForPg(row.exc_stack) || null;
+        const service = sanitizeForPg(row.service) || null;
         const fp = fingerprint({
           type: row.exc_type,
           stacktrace: excStack,
@@ -668,7 +669,7 @@ async function tickSpans(opts: {
           seenAt: seenAt.toISOString(),
           traceId: row.trace_id || null,
           spanId: row.span_id || null,
-          spanName: stripNullBytes(row.span_name) || null,
+          spanName: sanitizeForPg(row.span_name) || null,
           spanAttrs: sanitizeAttrs(row.span_attrs),
           resourceAttrs: sanitizeAttrs(row.resource_attrs),
         };
@@ -794,9 +795,9 @@ async function tickLogs(opts: {
           skippedByFilter += 1;
           continue;
         }
-        const body = stripNullBytes(row.body) || null;
-        const excStack = stripNullBytes(row.exc_stack) || null;
-        const service = stripNullBytes(row.service) || null;
+        const body = sanitizeForPg(row.body) || null;
+        const excStack = sanitizeForPg(row.exc_stack) || null;
+        const service = sanitizeForPg(row.service) || null;
         const fp = fingerprintLog({
           service: row.service,
           severity: row.severity,
@@ -808,7 +809,7 @@ async function tickLogs(opts: {
         const lastSample: IssueSample = {
           kind: "log",
           service,
-          severity: stripNullBytes(row.severity) || null,
+          severity: sanitizeForPg(row.severity) || null,
           message: body,
           body,
           exceptionType: fp.exceptionType,

--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { fingerprint, fingerprintLog, messageBucketFor, stripNullBytes } from "./index.js";
+import { fingerprint, fingerprintLog, messageBucketFor, sanitizeForPg } from "./index.js";
 
 // A single route-scanner error class (e.g. Phoenix NoRouteError) emits one
 // exception per probed path. The stacktrace is identical across all of them —
@@ -48,40 +48,55 @@ test("messageBucketFor still separates genuinely different messages", () => {
   );
 });
 
-// Postgres text and jsonb columns reject the NUL byte (0x00) — it raises
-// `22021 invalid byte sequence for encoding "UTF8": 0x00`. Telemetry can carry
-// a raw NUL in a message or stack frame; the fingerprint outputs feed straight
-// into the issues upsert, so they must be NUL-free.
+// Postgres text/jsonb columns reject two things telemetry can carry: the NUL
+// byte (0x00 -> `22021 invalid byte sequence`) and lone UTF-16 surrogates
+// (-> `22P05 untranslatable_character`). The fingerprint outputs feed straight
+// into the issues upsert, so they must be free of both.
 const NUL = String.fromCharCode(0);
+const LONE_HIGH = String.fromCharCode(0xd800); // unpaired high surrogate
+const LONE_LOW = String.fromCharCode(0xdc00); // unpaired low surrogate
+const EMOJI = "\u{1f4a5}"; // a valid surrogate pair — must survive intact
+const REPLACEMENT = "�";
 
-test("stripNullBytes removes NUL bytes and leaves other text intact", () => {
-  assert.equal(stripNullBytes(`ab${NUL}cd`), "abcd");
-  assert.equal(stripNullBytes(`${NUL}boom${NUL}`), "boom");
-  assert.equal(stripNullBytes("clean string"), "clean string");
-  assert.equal(stripNullBytes(null), null);
-  assert.equal(stripNullBytes(undefined), undefined);
+test("sanitizeForPg removes NUL bytes and leaves other text intact", () => {
+  assert.equal(sanitizeForPg(`ab${NUL}cd`), "abcd");
+  assert.equal(sanitizeForPg(`${NUL}boom${NUL}`), "boom");
+  assert.equal(sanitizeForPg("clean string"), "clean string");
+  assert.equal(sanitizeForPg(null), null);
+  assert.equal(sanitizeForPg(undefined), undefined);
 });
 
-test("fingerprint strips NUL bytes from exception type and frames", () => {
+test("sanitizeForPg replaces lone surrogates but keeps valid pairs", () => {
+  assert.equal(sanitizeForPg(`a${LONE_HIGH}b`), `a${REPLACEMENT}b`);
+  assert.equal(sanitizeForPg(`a${LONE_LOW}b`), `a${REPLACEMENT}b`);
+  // A truncated pair (high without its low) is still a lone surrogate.
+  assert.equal(sanitizeForPg(`x${LONE_HIGH}`), `x${REPLACEMENT}`);
+  // A valid emoji (proper high+low pair) must pass through unchanged.
+  assert.equal(sanitizeForPg(`hi ${EMOJI}`), `hi ${EMOJI}`);
+});
+
+test("fingerprint sanitizes exception type and frames for Postgres", () => {
   const fp = fingerprint({
-    type: `Boom${NUL}Error`,
+    type: `Boom${NUL}${LONE_HIGH}Error`,
     stacktrace: `    at do${NUL}Thing (apps/worker/src/x.ts:1:1)`,
     message: "broke here",
   });
-  assert.equal(fp.exceptionType.includes(NUL), false);
-  assert.ok(!fp.topFrame?.includes(NUL));
+  const bad = (s: string) => s.includes(NUL) || s.includes(LONE_HIGH) || s.includes(LONE_LOW);
+  assert.equal(bad(fp.exceptionType), false);
+  assert.ok(!(fp.topFrame && bad(fp.topFrame)));
   for (const frame of fp.normalizedFrames) {
-    assert.equal(frame.includes(NUL), false);
+    assert.equal(bad(frame), false);
   }
 });
 
-test("fingerprintLog strips NUL bytes from exception type", () => {
+test("fingerprintLog sanitizes exception type for Postgres", () => {
   const fp = fingerprintLog({
     service: "superlog-worker",
     severity: "ERROR",
     body: `tick step failed${NUL}`,
-    exceptionType: `Cause${NUL}Error`,
+    exceptionType: `Cause${LONE_LOW}Error`,
     stacktrace: null,
   });
   assert.equal(fp.exceptionType.includes(NUL), false);
+  assert.equal(fp.exceptionType.includes(LONE_LOW), false);
 });

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -29,14 +29,21 @@ const IGNORE_PATH = [
 ];
 
 const NUL_BYTE = String.fromCharCode(0);
+// Lone (unpaired) UTF-16 surrogates: a high surrogate not followed by a low one,
+// or a low surrogate not preceded by a high one. Valid surrogate pairs (real
+// astral-plane characters like emoji) are left untouched.
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+const REPLACEMENT_CHAR = "�";
 
-// Postgres `text` and `jsonb` columns reject the NUL byte (0x00) with
-// `22021 invalid byte sequence for encoding "UTF8": 0x00`. Telemetry can carry
-// a raw NUL inside an exception message, body, or stack frame, and these
-// fingerprint outputs flow straight into the issues upsert — so strip NUL
-// before it can poison a parameter. Passes null/undefined through unchanged.
-export function stripNullBytes<T extends string | null | undefined>(value: T): T {
-  return (typeof value === "string" ? value.split(NUL_BYTE).join("") : value) as T;
+// Make a string safe to persist in Postgres `text`/`jsonb`. Postgres rejects
+// two things telemetry can carry inside an exception message, body, or stack
+// frame: the NUL byte (0x00 → `22021 invalid byte sequence for encoding
+// "UTF8"`) and lone UTF-16 surrogates (→ `22P05 untranslatable_character`).
+// These values flow straight into the issues upsert, so strip NUL and replace
+// lone surrogates with U+FFFD. Passes null/undefined through unchanged.
+export function sanitizeForPg<T extends string | null | undefined>(value: T): T {
+  if (typeof value !== "string") return value;
+  return value.split(NUL_BYTE).join("").replace(LONE_SURROGATE, REPLACEMENT_CHAR) as T;
 }
 
 export function fingerprint(input: {
@@ -55,11 +62,11 @@ export function fingerprint(input: {
   const hash = createHash("sha256").update(canonical).digest("hex").slice(0, HASH_LEN);
 
   // The hash is hex (always safe); the human-readable fields below are persisted
-  // to Postgres, so they must be NUL-free.
-  const safeFrames = normalized.map((frame) => stripNullBytes(frame));
+  // to Postgres, so they must be free of NUL bytes and lone surrogates.
+  const safeFrames = normalized.map((frame) => sanitizeForPg(frame));
   return {
     hash,
-    exceptionType: stripNullBytes(type),
+    exceptionType: sanitizeForPg(type),
     topFrame: safeFrames[0] ?? null,
     normalizedFrames: safeFrames,
   };
@@ -81,7 +88,7 @@ export function fingerprintLog(input: LogFingerprintInput): Fingerprint {
 
   return {
     hash,
-    exceptionType: stripNullBytes(type),
+    exceptionType: sanitizeForPg(type),
     topFrame: null,
     normalizedFrames: [],
   };


### PR DESCRIPTION
## What

Extends the issue-ingest sanitizer beyond the NUL byte to also handle **lone (unpaired) UTF-16 surrogates**.

Postgres rejects lone surrogates in `text`/`jsonb` with `22P05 untranslatable_character` — a distinct failure from the NUL byte's `22021`. We saw both during the recent ingest wedge. Telemetry picks up a lone surrogate when a logged string is sliced mid-emoji, truncated, or carries binary data treated as text (JS strings are UTF-16 and can hold an unpaired surrogate). These values flow straight into the issues upsert.

## Change

- Rename `stripNullBytes` → `sanitizeForPg`. It still strips NUL (`0x00` → 22021) and now also replaces lone surrogates (`U+D800`–`U+DFFF` not part of a valid pair) with `U+FFFD`. **Valid surrogate pairs (real emoji / astral-plane chars) pass through untouched.**
- Applied in the same places `stripNullBytes` already ran: fingerprint outputs (`@superlog/fingerprint`) and the ClickHouse-derived strings + attribute maps in `apps/worker/src/telemetry/ingest.ts`.

## Why it's safe / low-risk

The per-row/per-group isolation from the batching change already prevents a 22P05 row from wedging the tick — it gets caught, counted (`row_failures`), and skipped. The only downside today is that such an issue is **dropped**. With this, the row upserts cleanly and the issue is **kept**. No schema change.

## Tests

- `sanitizeForPg` replaces lone high/low/truncated surrogates with `U+FFFD` and leaves a valid emoji pair intact (plus the existing NUL cases).
- `fingerprint` / `fingerprintLog` outputs are free of NUL and lone surrogates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes telemetry strings for Postgres by stripping NUL bytes and replacing lone UTF-16 surrogates. This prevents `22P05`/`22021` ingest failures so rows upsert cleanly instead of being dropped.

- **Bug Fixes**
  - Renamed `stripNullBytes` to `sanitizeForPg`; now also replaces lone surrogates (`U+D800–U+DFFF`) with `U+FFFD` while keeping valid pairs (emoji) intact.
  - Applied `sanitizeForPg` across issue ingest (exception fields, span/log fields, attribute maps) and `@superlog/fingerprint` outputs.
  - Added tests for NUL removal, lone surrogate replacement, and fingerprint/fingerprintLog sanitization.

<sup>Written for commit 18407c7ee043a89f8e2870da6216ec365983d7f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

