### PR TITLE
feat(onboarding): "Connect your data" chooser with no-code AWS connect

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,6 +4,10 @@ CLICKHOUSE_DB=superlog
 BETTER_AUTH_SECRET=replace_me_32_byte_random_string
 BETTER_AUTH_URL=http://localhost:4100
 STATE_SIGNING_SECRET=replace_me_32_byte_random_string
+# Encrypts integration secrets at rest (AWS connect external IDs, Slack/Linear
+# tokens). Required for any integration that stores a secret — without it those
+# routes 500. Must base64-decode to exactly 32 bytes: openssl rand -base64 32
+AGENT_SECRETS_KEY=
 # OAuth provider credentials for Better Auth (set per-environment).
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
@@ -47,3 +51,20 @@ SLACK_OAUTH_REDIRECT_URL=http://localhost:4100/slack/oauth/callback
 LINEAR_CLIENT_ID=
 LINEAR_CLIENT_SECRET=
 LINEAR_OAUTH_REDIRECT_URL=http://localhost:4100/linear/oauth/callback
+# AWS connect (CloudFormation-based "connect your data" onboarding). When unset,
+# the "Connect AWS" flow returns 500 "AWS connect is not configured". The first
+# two are the minimum to enable connect; the combined-stack + Firehose intake
+# trio below enables the one-step (scrape role + metric + log streaming) launch.
+# SUPERLOG_AWS_ACCOUNT_ID is passed as a stack *parameter* (never baked into the
+# public template), so prod topology stays out of the open-core repo.
+SUPERLOG_AWS_ACCOUNT_ID=
+AWS_CONNECT_TEMPLATE_URL=
+# Optional: SNS topic ARN for zero-paste connect (role ARN reported back via SNS).
+AWS_CONNECT_SERVICE_TOKEN=
+# One-step combined connect (all three required together):
+AWS_CONNECT_STACK_TEMPLATE_URL=
+AWS_FIREHOSE_METRICS_INTAKE_URL=
+AWS_FIREHOSE_LOGS_INTAKE_URL=
+# Legacy per-signal stream templates (only if not using the combined stack):
+AWS_METRICS_TEMPLATE_URL=
+AWS_LOGS_TEMPLATE_URL=

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -86,6 +86,7 @@ import {
   useWebhookDeliveries,
   useWebhooks,
 } from "./api";
+import { AWS_REGIONS } from "./awsRegions.ts";
 import { Dropdown, type DropdownOption } from "./design/Dropdown.tsx";
 import { Btn, Chip, FieldLabel, Input, Label, Tile } from "./design/ui";
 import { AgentMemoriesCard } from "./settings/AgentMemoriesCard.tsx";
@@ -1486,42 +1487,6 @@ function awsStatusChip(c?: CloudConnection) {
 
 // Commercial AWS regions. Metric streams / Firehose are regional, so the
 // connection targets one region (multi-region = multiple connections later).
-const AWS_REGIONS: ReadonlyArray<{ code: string; name: string }> = [
-  { code: "us-east-1", name: "US East (N. Virginia)" },
-  { code: "us-east-2", name: "US East (Ohio)" },
-  { code: "us-west-1", name: "US West (N. California)" },
-  { code: "us-west-2", name: "US West (Oregon)" },
-  { code: "ca-central-1", name: "Canada (Central)" },
-  { code: "ca-west-1", name: "Canada West (Calgary)" },
-  { code: "eu-west-1", name: "Europe (Ireland)" },
-  { code: "eu-west-2", name: "Europe (London)" },
-  { code: "eu-west-3", name: "Europe (Paris)" },
-  { code: "eu-central-1", name: "Europe (Frankfurt)" },
-  { code: "eu-central-2", name: "Europe (Zurich)" },
-  { code: "eu-north-1", name: "Europe (Stockholm)" },
-  { code: "eu-south-1", name: "Europe (Milan)" },
-  { code: "eu-south-2", name: "Europe (Spain)" },
-  { code: "ap-south-1", name: "Asia Pacific (Mumbai)" },
-  { code: "ap-south-2", name: "Asia Pacific (Hyderabad)" },
-  { code: "ap-southeast-1", name: "Asia Pacific (Singapore)" },
-  { code: "ap-southeast-2", name: "Asia Pacific (Sydney)" },
-  { code: "ap-southeast-3", name: "Asia Pacific (Jakarta)" },
-  { code: "ap-southeast-4", name: "Asia Pacific (Melbourne)" },
-  { code: "ap-southeast-5", name: "Asia Pacific (Malaysia)" },
-  { code: "ap-southeast-7", name: "Asia Pacific (Thailand)" },
-  { code: "ap-northeast-1", name: "Asia Pacific (Tokyo)" },
-  { code: "ap-northeast-2", name: "Asia Pacific (Seoul)" },
-  { code: "ap-northeast-3", name: "Asia Pacific (Osaka)" },
-  { code: "ap-east-1", name: "Asia Pacific (Hong Kong)" },
-  { code: "ap-east-2", name: "Asia Pacific (Taipei)" },
-  { code: "sa-east-1", name: "South America (São Paulo)" },
-  { code: "mx-central-1", name: "Mexico (Central)" },
-  { code: "me-south-1", name: "Middle East (Bahrain)" },
-  { code: "me-central-1", name: "Middle East (UAE)" },
-  { code: "il-central-1", name: "Israel (Tel Aviv)" },
-  { code: "af-south-1", name: "Africa (Cape Town)" },
-];
-
 const AWS_REGION_OPTIONS = AWS_REGIONS.map((r) => ({
   value: r.code,
   label: (

--- a/apps/web/src/awsRegions.ts
+++ b/apps/web/src/awsRegions.ts
@@ -1,0 +1,43 @@
+// Canonical commercial AWS region list, shared by the settings stream-config
+// picker and the onboarding "Connect AWS" picker so the two never drift. Keep
+// this aligned with the API's region guard (`/^[a-z0-9-]{1,32}$/` in
+// cloud-connections.ts) — every code here must satisfy it.
+export const AWS_REGIONS: ReadonlyArray<{ code: string; name: string }> = [
+  { code: "us-east-1", name: "US East (N. Virginia)" },
+  { code: "us-east-2", name: "US East (Ohio)" },
+  { code: "us-west-1", name: "US West (N. California)" },
+  { code: "us-west-2", name: "US West (Oregon)" },
+  { code: "ca-central-1", name: "Canada (Central)" },
+  { code: "ca-west-1", name: "Canada West (Calgary)" },
+  { code: "eu-west-1", name: "Europe (Ireland)" },
+  { code: "eu-west-2", name: "Europe (London)" },
+  { code: "eu-west-3", name: "Europe (Paris)" },
+  { code: "eu-central-1", name: "Europe (Frankfurt)" },
+  { code: "eu-central-2", name: "Europe (Zurich)" },
+  { code: "eu-north-1", name: "Europe (Stockholm)" },
+  { code: "eu-south-1", name: "Europe (Milan)" },
+  { code: "eu-south-2", name: "Europe (Spain)" },
+  { code: "ap-south-1", name: "Asia Pacific (Mumbai)" },
+  { code: "ap-south-2", name: "Asia Pacific (Hyderabad)" },
+  { code: "ap-southeast-1", name: "Asia Pacific (Singapore)" },
+  { code: "ap-southeast-2", name: "Asia Pacific (Sydney)" },
+  { code: "ap-southeast-3", name: "Asia Pacific (Jakarta)" },
+  { code: "ap-southeast-4", name: "Asia Pacific (Melbourne)" },
+  { code: "ap-southeast-5", name: "Asia Pacific (Malaysia)" },
+  { code: "ap-southeast-7", name: "Asia Pacific (Thailand)" },
+  { code: "ap-northeast-1", name: "Asia Pacific (Tokyo)" },
+  { code: "ap-northeast-2", name: "Asia Pacific (Seoul)" },
+  { code: "ap-northeast-3", name: "Asia Pacific (Osaka)" },
+  { code: "ap-east-1", name: "Asia Pacific (Hong Kong)" },
+  { code: "ap-east-2", name: "Asia Pacific (Taipei)" },
+  { code: "sa-east-1", name: "South America (São Paulo)" },
+  { code: "mx-central-1", name: "Mexico (Central)" },
+  { code: "me-south-1", name: "Middle East (Bahrain)" },
+  { code: "me-central-1", name: "Middle East (UAE)" },
+  { code: "il-central-1", name: "Israel (Tel Aviv)" },
+  { code: "af-south-1", name: "Africa (Cape Town)" },
+];
+
+export const AWS_REGION_CODES: readonly string[] = AWS_REGIONS.map((r) => r.code);
+
+export const DEFAULT_AWS_REGION = "us-east-1";

--- a/apps/web/src/onboarding/AwsConnectFlow.tsx
+++ b/apps/web/src/onboarding/AwsConnectFlow.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   type StackComponent,
   useCloudConnections,
@@ -103,8 +103,18 @@ export function AwsConnectFlow({
     connection?.id,
     connection?.status === "connected",
   );
+  // Latch on first delivery. `awsStreamFlowing` reads stack-health "working",
+  // which is a rolling recency window (a stream goes quiet → back to non-working
+  // after ~15 min). The onboarding milestone is whether the first AWS events
+  // *ever* arrived, so once we've seen the stream flow we keep the flow unlocked
+  // instead of regressing to "Waiting for data…".
+  const [everFlowed, setEverFlowed] = useState(false);
   const streamFlowing = awsStreamFlowing(stackHealth.data?.components);
-  const phase = awsPhase({ connection, streamFlowing });
+  useEffect(() => {
+    if (streamFlowing) setEverFlowed(true);
+  }, [streamFlowing]);
+  const flowing = streamFlowing || everFlowed;
+  const phase = awsPhase({ connection, streamFlowing: flowing });
 
   const connect = () => {
     if (!isValidRegion(region) || create.isPending) return;
@@ -158,7 +168,7 @@ export function AwsConnectFlow({
       {(phase === "connected" || phase === "flowing") && connection && (
         <ConnectedPanel
           components={stackHealth.data?.components ?? []}
-          streamFlowing={streamFlowing}
+          streamFlowing={flowing}
           region={connection.region}
           accountId={connection.accountId}
           resourceCount={resources.data?.length ?? 0}

--- a/apps/web/src/onboarding/AwsConnectFlow.tsx
+++ b/apps/web/src/onboarding/AwsConnectFlow.tsx
@@ -1,0 +1,441 @@
+import { useState } from "react";
+import {
+  type StackComponent,
+  type Stats,
+  useCloudConnections,
+  useCloudResources,
+  useCloudStackHealth,
+  useCreateCloudConnection,
+  useStats,
+  useSyncCloudConnection,
+  useVerifyCloudConnection,
+} from "../api.ts";
+import { Btn } from "../design/ui.tsx";
+import {
+  AWS_REGIONS,
+  DEFAULT_AWS_REGION,
+  activeConnection,
+  awsPhase,
+  canContinueAws,
+  connectionStatusText,
+  isValidRegion,
+  stackComponentTone,
+} from "./awsConnectModel.ts";
+import { CheckIcon, ExternalLinkIcon, SpinnerIcon } from "./icons.tsx";
+import {
+  ExploreDemoLink,
+  SOFT_LINE,
+  STRONG_LINE,
+  StepFooter,
+  StepHeader,
+} from "./wizardChrome.tsx";
+
+function hasEvents(stats: Stats | undefined): boolean {
+  if (!stats) return false;
+  return stats.traces + stats.logs + stats.metrics > 0;
+}
+
+// Open the CloudFormation console in a new tab, falling back to a same-tab
+// navigation if the popup was blocked.
+function openLaunch(url: string) {
+  const win = window.open(url, "_blank", "noopener,noreferrer");
+  if (!win) window.location.assign(url);
+}
+
+const TONE_DOT: Record<ReturnType<typeof stackComponentTone>, string> = {
+  success: "bg-success",
+  warning: "bg-warning",
+  danger: "bg-danger",
+  muted: "bg-subtle",
+};
+
+function HealthRow({ component }: { component: StackComponent }) {
+  const tone = stackComponentTone(component.state);
+  return (
+    <div className="flex items-center gap-3 px-[18px] py-[13px]">
+      <span className={`h-2 w-2 shrink-0 rounded-full ${TONE_DOT[tone]}`} />
+      <span className="min-w-0 flex-1">
+        <span className="block text-[13px] font-medium text-fg">{component.label}</span>
+        <span className="block text-[12px] text-muted">{component.detail}</span>
+      </span>
+      {component.state === "working" && (
+        <span className="text-success">
+          <CheckIcon size={14} />
+        </span>
+      )}
+      {component.state === "pending" && (
+        <span className="text-warning">
+          <SpinnerIcon size={13} />
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function AwsConnectFlow({
+  projectId,
+  onBack,
+  onDone,
+  onExploreDemo,
+}: {
+  projectId: string;
+  onBack: () => void;
+  onDone: () => void;
+  onExploreDemo?: () => void;
+}) {
+  const [region, setRegion] = useState<string>(DEFAULT_AWS_REGION);
+  const [launchUrl, setLaunchUrl] = useState<string | null>(null);
+  const [showPaste, setShowPaste] = useState(false);
+  const [roleArn, setRoleArn] = useState("");
+
+  const connections = useCloudConnections(projectId);
+  const create = useCreateCloudConnection(projectId);
+  const verify = useVerifyCloudConnection(projectId);
+  const sync = useSyncCloudConnection(projectId);
+  const resources = useCloudResources(projectId);
+  const stats = useStats(projectId, { poll: true });
+
+  const connection = activeConnection(connections.data);
+  const eventsArrived = hasEvents(stats.data);
+  const phase = awsPhase({ connection, eventsArrived });
+
+  const stackHealth = useCloudStackHealth(
+    projectId,
+    connection?.id,
+    phase === "connected" || phase === "flowing",
+  );
+
+  const connect = () => {
+    if (!isValidRegion(region) || create.isPending) return;
+    create.mutate(
+      { region },
+      {
+        onSuccess: (data) => {
+          setLaunchUrl(data.launchUrl);
+          openLaunch(data.launchUrl);
+        },
+      },
+    );
+  };
+
+  const submitVerify = () => {
+    if (!connection || !roleArn.trim() || verify.isPending) return;
+    verify.mutate({ id: connection.id, scrapeRoleArn: roleArn.trim() });
+  };
+
+  const header = headerForPhase(phase);
+
+  return (
+    <>
+      <StepHeader title={header.title} sub={header.sub} />
+
+      {phase === "start" && (
+        <StartPanel
+          region={region}
+          onRegion={setRegion}
+          onConnect={connect}
+          pending={create.isPending}
+          error={create.error ? String(create.error) : null}
+        />
+      )}
+
+      {phase === "launching" && connection && (
+        <LaunchingPanel
+          statusText={connectionStatusText(connection.status, connection.lastError)}
+          failed={connection.status === "failed" || connection.status === "account_mismatch"}
+          launchUrl={launchUrl}
+          showPaste={showPaste}
+          onTogglePaste={() => setShowPaste((v) => !v)}
+          roleArn={roleArn}
+          onRoleArn={setRoleArn}
+          onVerify={submitVerify}
+          verifying={verify.isPending}
+          verifyError={verify.error ? String(verify.error) : null}
+        />
+      )}
+
+      {(phase === "connected" || phase === "flowing") && connection && (
+        <ConnectedPanel
+          components={stackHealth.data?.components ?? []}
+          eventsArrived={eventsArrived}
+          region={connection.region}
+          accountId={connection.accountId}
+          resourceCount={resources.data?.length ?? 0}
+          onRescan={() => sync.mutate(connection.id)}
+          rescanning={sync.isPending}
+        />
+      )}
+
+      <StepFooter
+        onBack={onBack}
+        onNext={onDone}
+        nextLabel={canContinueAws(phase) ? "Continue" : "Waiting for data…"}
+        nextDisabled={!canContinueAws(phase)}
+      />
+      {!canContinueAws(phase) && <ExploreDemoLink onExploreDemo={onExploreDemo} />}
+    </>
+  );
+}
+
+function headerForPhase(phase: ReturnType<typeof awsPhase>): {
+  title: string;
+  sub: string;
+} {
+  switch (phase) {
+    case "start":
+      return {
+        title: "Connect Amazon Web Services",
+        sub: "Launch one CloudFormation stack. It creates a read-only role and streams CloudWatch logs and metrics into Superlog — no agent, no code changes.",
+      };
+    case "launching":
+      return {
+        title: "Finish in CloudFormation",
+        sub: "Deploy the stack we opened in AWS. Once it reports back we'll verify the role automatically — keep this tab open.",
+      };
+    case "connected":
+      return {
+        title: "Almost there",
+        sub: "Your account is connected. We're waiting for the first logs and metrics to stream in from CloudWatch.",
+      };
+    default:
+      return {
+        title: "You're flowing",
+        sub: "Telemetry from AWS is arriving. You can head to your dashboard now — discovery keeps running in the background.",
+      };
+  }
+}
+
+function StartPanel({
+  region,
+  onRegion,
+  onConnect,
+  pending,
+  error,
+}: {
+  region: string;
+  onRegion: (r: string) => void;
+  onConnect: () => void;
+  pending: boolean;
+  error: string | null;
+}) {
+  return (
+    <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+      <div className={`border-b px-[22px] py-[18px] ${SOFT_LINE}`}>
+        <label htmlFor="aws-region" className="block text-[12.5px] font-medium text-muted">
+          Region
+        </label>
+        <div className="relative mt-2 max-w-[260px]">
+          <select
+            id="aws-region"
+            value={region}
+            onChange={(e) => onRegion(e.target.value)}
+            disabled={pending}
+            className="h-9 w-full appearance-none rounded-[10px] border border-[rgba(255,255,255,0.12)] bg-[#0f1014] pl-3 pr-8 font-mono text-[13px] text-fg outline-none transition-colors focus:border-[#8C98F0] disabled:opacity-60"
+          >
+            {AWS_REGIONS.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+          <svg
+            className="pointer-events-none absolute right-2.5 top-1/2 h-3 w-3 -translate-y-1/2 text-subtle"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path d="m6 9 6 6 6-6" />
+          </svg>
+        </div>
+        <p className="mt-2.5 text-[11.5px] leading-[1.5] text-subtle">
+          We never store long-lived AWS credentials — the stack grants a role Superlog assumes with
+          an external ID, scoped to read-only telemetry.
+        </p>
+      </div>
+      <div className="flex items-center justify-between gap-3 px-[22px] py-[16px]">
+        <span className="text-[12.5px] text-muted">
+          Opens the AWS console in a new tab to review and deploy.
+        </span>
+        <Btn
+          variant="primary"
+          size="md"
+          onClick={onConnect}
+          loading={pending}
+          className="!h-[36px] !rounded-[8px] !px-[14px] !text-[13px]"
+        >
+          {pending ? "Preparing…" : "Connect AWS account"}
+          {!pending && <ExternalLinkIcon size={13} />}
+        </Btn>
+      </div>
+      {error && (
+        <div className={`border-t px-[22px] py-[12px] ${SOFT_LINE}`}>
+          <p className="m-0 text-[12.5px] text-danger">{error}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LaunchingPanel({
+  statusText,
+  failed,
+  launchUrl,
+  showPaste,
+  onTogglePaste,
+  roleArn,
+  onRoleArn,
+  onVerify,
+  verifying,
+  verifyError,
+}: {
+  statusText: string;
+  failed: boolean;
+  launchUrl: string | null;
+  showPaste: boolean;
+  onTogglePaste: () => void;
+  roleArn: string;
+  onRoleArn: (v: string) => void;
+  onVerify: () => void;
+  verifying: boolean;
+  verifyError: string | null;
+}) {
+  return (
+    <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+      <div
+        className={`flex items-center gap-2.5 border-b px-[18px] py-[12px] ${SOFT_LINE} text-[12px]`}
+      >
+        <span className={failed ? "text-danger" : "text-[#8C98F0]"}>
+          {failed ? "!" : <SpinnerIcon size={13} />}
+        </span>
+        <span className={failed ? "text-danger" : "text-muted"}>{statusText}</span>
+      </div>
+      <div className="px-[22px] py-[18px]">
+        <ol className="m-0 list-decimal space-y-1.5 pl-4 text-[13px] leading-[1.5] text-muted">
+          <li>Review the stack in the AWS console and click Create.</li>
+          <li>Wait for it to reach CREATE_COMPLETE (about a minute).</li>
+          <li>We verify the role automatically — this panel updates on its own.</li>
+        </ol>
+        {launchUrl && (
+          <button
+            type="button"
+            onClick={() => openLaunch(launchUrl)}
+            className="mt-3 inline-flex items-center gap-1.5 text-[12.5px] font-medium text-[#8C98F0] transition-colors hover:text-fg"
+          >
+            <ExternalLinkIcon size={13} /> Reopen CloudFormation
+          </button>
+        )}
+      </div>
+      <div className={`border-t px-[22px] py-[14px] ${SOFT_LINE}`}>
+        <button
+          type="button"
+          onClick={onTogglePaste}
+          className="text-[12px] font-medium text-subtle transition-colors hover:text-muted"
+        >
+          {showPaste ? "Hide manual step" : "Stack won't report back? Paste the role ARN instead"}
+        </button>
+        {showPaste && (
+          <div className="mt-3 flex items-center gap-2">
+            <input
+              type="text"
+              value={roleArn}
+              onChange={(e) => onRoleArn(e.target.value)}
+              placeholder="arn:aws:iam::123456789012:role/superlog-connect"
+              className="h-9 min-w-0 flex-1 rounded-[10px] border border-[rgba(255,255,255,0.12)] bg-[#0f1014] px-3 font-mono text-[12px] text-fg outline-none transition-colors focus:border-[#8C98F0]"
+            />
+            <Btn
+              variant="secondary"
+              size="md"
+              onClick={onVerify}
+              loading={verifying}
+              disabled={!roleArn.trim()}
+              className="!h-9 !rounded-[8px]"
+            >
+              Verify
+            </Btn>
+          </div>
+        )}
+        {verifyError && <p className="m-0 mt-2 text-[12px] text-danger">{verifyError}</p>}
+      </div>
+    </div>
+  );
+}
+
+function ConnectedPanel({
+  components,
+  eventsArrived,
+  region,
+  accountId,
+  resourceCount,
+  onRescan,
+  rescanning,
+}: {
+  components: StackComponent[];
+  eventsArrived: boolean;
+  region: string;
+  accountId: string | null;
+  resourceCount: number;
+  onRescan: () => void;
+  rescanning: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className={`overflow-hidden rounded-[14px] border bg-[#0a0a0c] ${SOFT_LINE}`}>
+        <div
+          className={`flex items-center justify-between gap-2 border-b px-[18px] py-[10px] ${SOFT_LINE}`}
+        >
+          <span className="text-[11px] uppercase tracking-[0.08em] text-subtle">
+            {accountId ? `account ${accountId}` : "aws"} · {region}
+          </span>
+          <button
+            type="button"
+            onClick={onRescan}
+            disabled={rescanning}
+            className="inline-flex items-center gap-1.5 text-[11.5px] font-medium text-muted transition-colors hover:text-fg disabled:opacity-50"
+          >
+            {rescanning ? <SpinnerIcon size={12} /> : null}
+            {rescanning ? "Scanning…" : "Rescan resources"}
+          </button>
+        </div>
+        <div className="divide-y divide-[rgba(255,255,255,0.07)]">
+          {components.length === 0 ? (
+            <div className="px-[18px] py-[14px] text-[12.5px] text-muted">
+              Reading stack health…
+            </div>
+          ) : (
+            components.map((c) => <HealthRow key={c.key} component={c} />)
+          )}
+        </div>
+        {resourceCount > 0 && (
+          <div className={`border-t px-[18px] py-[11px] text-[12px] text-muted ${SOFT_LINE}`}>
+            Discovered <span className="font-medium text-fg">{resourceCount}</span> AWS resource
+            {resourceCount === 1 ? "" : "s"} so far.
+          </div>
+        )}
+      </div>
+
+      {eventsArrived ? (
+        <div className="flex items-center gap-2.5 rounded-[10px] border border-[rgba(65,209,149,0.35)] bg-[rgba(65,209,149,0.06)] px-4 py-3">
+          <span className="text-success">
+            <CheckIcon size={14} />
+          </span>
+          <div className="flex-1 text-[12.5px] text-fg">
+            First events received. <span className="text-muted">You're flowing.</span>
+          </div>
+        </div>
+      ) : (
+        <div
+          className={`flex items-center gap-2.5 rounded-[10px] border border-dashed px-4 py-3 ${STRONG_LINE}`}
+        >
+          <span className="text-[#8C98F0]">
+            <SpinnerIcon size={14} />
+          </span>
+          <div className="flex-1 text-[12.5px] text-muted">
+            Waiting for your first events from AWS…
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/onboarding/AwsConnectFlow.tsx
+++ b/apps/web/src/onboarding/AwsConnectFlow.tsx
@@ -1,21 +1,19 @@
 import { useState } from "react";
 import {
   type StackComponent,
-  type Stats,
   useCloudConnections,
   useCloudResources,
   useCloudStackHealth,
   useCreateCloudConnection,
-  useStats,
   useSyncCloudConnection,
   useVerifyCloudConnection,
 } from "../api.ts";
+import { AWS_REGIONS, DEFAULT_AWS_REGION } from "../awsRegions.ts";
 import { Btn } from "../design/ui.tsx";
 import {
-  AWS_REGIONS,
-  DEFAULT_AWS_REGION,
   activeConnection,
   awsPhase,
+  awsStreamFlowing,
   canContinueAws,
   connectionStatusText,
   isValidRegion,
@@ -30,16 +28,18 @@ import {
   StepHeader,
 } from "./wizardChrome.tsx";
 
-function hasEvents(stats: Stats | undefined): boolean {
-  if (!stats) return false;
-  return stats.traces + stats.logs + stats.metrics > 0;
-}
-
 // Open the CloudFormation console in a new tab, falling back to a same-tab
-// navigation if the popup was blocked.
+// navigation if the popup was blocked. We can't pass "noopener" to window.open
+// because that forces it to return null, which would make every launch also
+// navigate the current tab via the fallback. Instead open normally, then sever
+// the opener reference ourselves for the same security guarantee.
 function openLaunch(url: string) {
-  const win = window.open(url, "_blank", "noopener,noreferrer");
-  if (!win) window.location.assign(url);
+  const win = window.open(url, "_blank");
+  if (win) {
+    win.opener = null;
+  } else {
+    window.location.assign(url);
+  }
 }
 
 const TONE_DOT: Record<ReturnType<typeof stackComponentTone>, string> = {
@@ -93,17 +93,18 @@ export function AwsConnectFlow({
   const verify = useVerifyCloudConnection(projectId);
   const sync = useSyncCloudConnection(projectId);
   const resources = useCloudResources(projectId);
-  const stats = useStats(projectId, { poll: true });
 
   const connection = activeConnection(connections.data);
-  const eventsArrived = hasEvents(stats.data);
-  const phase = awsPhase({ connection, eventsArrived });
-
+  // Poll stack health once the role is verified so we can tell when *this*
+  // connection's CloudWatch streams actually deliver — distinct from any
+  // pre-existing project telemetry.
   const stackHealth = useCloudStackHealth(
     projectId,
     connection?.id,
-    phase === "connected" || phase === "flowing",
+    connection?.status === "connected",
   );
+  const streamFlowing = awsStreamFlowing(stackHealth.data?.components);
+  const phase = awsPhase({ connection, streamFlowing });
 
   const connect = () => {
     if (!isValidRegion(region) || create.isPending) return;
@@ -157,7 +158,7 @@ export function AwsConnectFlow({
       {(phase === "connected" || phase === "flowing") && connection && (
         <ConnectedPanel
           components={stackHealth.data?.components ?? []}
-          eventsArrived={eventsArrived}
+          streamFlowing={streamFlowing}
           region={connection.region}
           accountId={connection.accountId}
           resourceCount={resources.data?.length ?? 0}
@@ -233,8 +234,8 @@ function StartPanel({
             className="h-9 w-full appearance-none rounded-[10px] border border-[rgba(255,255,255,0.12)] bg-[#0f1014] pl-3 pr-8 font-mono text-[13px] text-fg outline-none transition-colors focus:border-[#8C98F0] disabled:opacity-60"
           >
             {AWS_REGIONS.map((r) => (
-              <option key={r} value={r}>
-                {r}
+              <option key={r.code} value={r.code}>
+                {r.code} · {r.name}
               </option>
             ))}
           </select>
@@ -364,7 +365,7 @@ function LaunchingPanel({
 
 function ConnectedPanel({
   components,
-  eventsArrived,
+  streamFlowing,
   region,
   accountId,
   resourceCount,
@@ -372,7 +373,7 @@ function ConnectedPanel({
   rescanning,
 }: {
   components: StackComponent[];
-  eventsArrived: boolean;
+  streamFlowing: boolean;
   region: string;
   accountId: string | null;
   resourceCount: number;
@@ -381,12 +382,12 @@ function ConnectedPanel({
 }) {
   return (
     <div className="flex flex-col gap-4">
-      <div className={`overflow-hidden rounded-[14px] border bg-[#0a0a0c] ${SOFT_LINE}`}>
+      <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
         <div
           className={`flex items-center justify-between gap-2 border-b px-[18px] py-[10px] ${SOFT_LINE}`}
         >
-          <span className="text-[11px] uppercase tracking-[0.08em] text-subtle">
-            {accountId ? `account ${accountId}` : "aws"} · {region}
+          <span className="font-mono text-[12px] text-muted">
+            {accountId ? `Account ${accountId}` : "AWS"} · {region}
           </span>
           <button
             type="button"
@@ -415,7 +416,7 @@ function ConnectedPanel({
         )}
       </div>
 
-      {eventsArrived ? (
+      {streamFlowing ? (
         <div className="flex items-center gap-2.5 rounded-[10px] border border-[rgba(65,209,149,0.35)] bg-[rgba(65,209,149,0.06)] px-4 py-3">
           <span className="text-success">
             <CheckIcon size={14} />

--- a/apps/web/src/onboarding/ConnectDataChooser.tsx
+++ b/apps/web/src/onboarding/ConnectDataChooser.tsx
@@ -1,0 +1,154 @@
+import {
+  CONNECT_SECTIONS,
+  type ConnectAction,
+  type ConnectIcon,
+  type ConnectOption,
+  type ConnectSection,
+} from "./connectChoices.ts";
+import {
+  AgentSparkIcon,
+  AwsIcon,
+  ChevronRightIcon,
+  CloudflareIcon,
+  GithubActionsIcon,
+  KubernetesIcon,
+  OtelIcon,
+  VercelIcon,
+} from "./icons.tsx";
+import { ExploreDemoLink, SOFT_LINE } from "./wizardChrome.tsx";
+
+// The path chooser: a flat, low-color list (modeled on a Plugins page) that
+// forks new users between no-code integrations (AWS first — integration-first)
+// and the coding-agent skill. See design.md.
+
+function ConnectGlyph({ icon }: { icon: ConnectIcon }) {
+  const map: Record<ConnectIcon, typeof AwsIcon> = {
+    aws: AwsIcon,
+    otel: OtelIcon,
+    agent: AgentSparkIcon,
+    vercel: VercelIcon,
+    kubernetes: KubernetesIcon,
+    cloudflare: CloudflareIcon,
+    githubActions: GithubActionsIcon,
+  };
+  const Glyph = map[icon];
+  return <Glyph size={18} />;
+}
+
+function IconTile({ icon }: { icon: ConnectIcon }) {
+  return (
+    <span className="grid h-9 w-9 shrink-0 place-items-center rounded-[9px] border border-border bg-surface-2 text-muted">
+      <ConnectGlyph icon={icon} />
+    </span>
+  );
+}
+
+function ListRow({
+  option,
+  onPick,
+}: {
+  option: ConnectOption;
+  onPick: (action: ConnectAction) => void;
+}) {
+  const disabled = option.action === null;
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => option.action && onPick(option.action)}
+      className={`group flex w-full items-center gap-3.5 px-[18px] py-[14px] text-left transition-colors ${
+        disabled ? "cursor-default opacity-55" : "hover:bg-surface-2"
+      }`}
+    >
+      <IconTile icon={option.icon} />
+      <span className="min-w-0 flex-1">
+        <span className="block text-[14px] font-medium text-fg">{option.title}</span>
+        <span className="mt-0.5 block text-[12.5px] leading-[1.45] text-muted">
+          {option.description}
+        </span>
+      </span>
+      {!disabled && (
+        <span className="text-subtle transition-colors group-hover:text-muted">
+          <ChevronRightIcon size={16} />
+        </span>
+      )}
+    </button>
+  );
+}
+
+function GridTile({ option }: { option: ConnectOption }) {
+  return (
+    <div
+      className={`flex items-center gap-3 rounded-[12px] border bg-surface px-3.5 py-3 ${SOFT_LINE}`}
+    >
+      <IconTile icon={option.icon} />
+      <span className="min-w-0">
+        <span className="block text-[13px] font-medium text-fg">{option.title}</span>
+        <span className="block text-[11.5px] text-subtle">{option.description}</span>
+      </span>
+    </div>
+  );
+}
+
+function SectionLabel({ children }: { children: string }) {
+  return <div className="mb-2.5 text-[13px] font-medium text-muted">{children}</div>;
+}
+
+function Section({
+  section,
+  onPick,
+}: {
+  section: ConnectSection;
+  onPick: (action: ConnectAction) => void;
+}) {
+  return (
+    <div>
+      <SectionLabel>{section.label}</SectionLabel>
+      {section.variant === "grid" ? (
+        <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
+          {section.options.map((option) => (
+            <GridTile key={option.id} option={option} />
+          ))}
+        </div>
+      ) : (
+        <div
+          className={`divide-y divide-[rgba(255,255,255,0.07)] overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}
+        >
+          {section.options.map((option) => (
+            <ListRow key={option.id} option={option} onPick={onPick} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ConnectDataChooser({
+  onPick,
+  onExploreDemo,
+}: {
+  onPick: (action: ConnectAction) => void;
+  onExploreDemo?: () => void;
+}) {
+  return (
+    <>
+      <div className="mb-7">
+        <h1 className="m-0 text-[28px] font-semibold leading-[1.1] tracking-[-0.025em] text-fg">
+          Connect your data
+        </h1>
+        <p className="m-0 mt-2.5 max-w-[540px] text-[14px] text-muted">
+          Pick how Superlog should start seeing your telemetry. A no-code integration is the fastest
+          way in — you can always add more sources later from settings.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-7">
+        {CONNECT_SECTIONS.map((section) => (
+          <Section key={section.id} section={section} onPick={onPick} />
+        ))}
+      </div>
+
+      <ExploreDemoLink onExploreDemo={onExploreDemo} />
+    </>
+  );
+}

--- a/apps/web/src/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/onboarding/OnboardingWizard.tsx
@@ -16,16 +16,12 @@ import { authClient, useSession } from "../auth-client.ts";
 import { Btn, Wordmark } from "../design/ui.tsx";
 import { INSTALL_PROMPT, buildInstallPrompt } from "../installPrompt.ts";
 import { getSkillOnboardingIntent } from "../skillOnboarding.ts";
+import { AwsConnectFlow } from "./AwsConnectFlow.tsx";
+import { ConnectDataChooser } from "./ConnectDataChooser.tsx";
 import { TruncatedKey } from "./TruncatedKey.tsx";
-import {
-  ArrowIcon,
-  ArrowLeftIcon,
-  CheckIcon,
-  CopyIcon,
-  GithubIcon,
-  SlackIcon,
-  SpinnerIcon,
-} from "./icons.tsx";
+import type { ConnectAction } from "./connectChoices.ts";
+import { CheckIcon, CopyIcon, GithubIcon, SlackIcon, SpinnerIcon } from "./icons.tsx";
+import { SOFT_LINE, STRONG_LINE, StepFooter, StepHeader } from "./wizardChrome.tsx";
 
 // Standalone fullscreen wizard shown to new users before they reach the
 // dashboard. Mirrors the playground's Onboarding (dots variant):
@@ -40,12 +36,9 @@ import {
 
 type Step = "install" | "deploy";
 type Mode = "web" | "agent";
-
-// Hairlines matching the playground's --sl-line / --sl-line-2 tokens. Host's
-// `border-border` (#24272e) reads as a boxed line on top of the dark canvas;
-// the playground uses translucent whites for the soft elevation effect.
-const SOFT_LINE = "border-[rgba(255,255,255,0.07)]";
-const STRONG_LINE = "border-[rgba(255,255,255,0.12)]";
+// Web-mode landing fork: choose a source, then either the AWS integration flow
+// or the coding-agent install/deploy flow.
+type WebView = "chooser" | "aws" | "code";
 
 function hasEvents(stats: Stats | undefined): boolean {
   if (!stats) return false;
@@ -72,10 +65,23 @@ export function OnboardingWizard({
   onExploreDemo?: () => void;
 }) {
   const [step, setStep] = useState<Step>("install");
+  const [webView, setWebView] = useState<WebView>("chooser");
 
   const createKey = useCreateKey(projectId ?? "");
   const github = useGithubInstallation();
   const slack = useSlackInstallation();
+
+  // Route a chooser selection to the matching flow. OpenTelemetry/SDK shares the
+  // coding-agent install flow (both hand back an SDK + ingest key); AWS gets its
+  // own no-code integration flow.
+  const handlePick = (action: ConnectAction) => {
+    if (action === "aws") {
+      setWebView("aws");
+    } else {
+      setStep("install");
+      setWebView("code");
+    }
+  };
 
   // Mint exactly once per mount, and only after we have a project to mint
   // into. The ref guard makes the mint a strict per-mount one-shot,
@@ -124,11 +130,20 @@ export function OnboardingWizard({
               slackLoading={slack.isLoading}
               onDone={onComplete}
             />
+          ) : webView === "chooser" ? (
+            <ConnectDataChooser onPick={handlePick} />
+          ) : webView === "aws" ? (
+            <AwsConnectFlow
+              projectId={projectId}
+              onBack={() => setWebView("chooser")}
+              onDone={onComplete}
+            />
           ) : step === "install" ? (
             <InstallStep
               apiKey={createKey.data?.plaintext ?? null}
               minting={createKey.isPending && !createKey.data}
               error={createKey.error ? String(createKey.error) : null}
+              onBack={() => setWebView("chooser")}
               onNext={() => setStep("deploy")}
               onExploreDemo={onExploreDemo}
             />
@@ -545,81 +560,18 @@ function SkippedPill({ icon, label }: { icon: React.ReactNode; label: string }) 
   );
 }
 
-function StepHeader({ title, sub }: { title: string; sub: React.ReactNode }) {
-  return (
-    <div className="mb-7">
-      <h1 className="m-0 text-[32px] font-semibold leading-[1.1] tracking-[-0.025em] text-fg">
-        {title}
-      </h1>
-      <div className="mt-2.5 max-w-[540px] text-[14px] text-muted">{sub}</div>
-    </div>
-  );
-}
-
-function StepFooter({
-  onBack,
-  onNext,
-  nextLabel,
-  nextDisabled,
-  onSkip,
-  skipLabel,
-}: {
-  onBack?: () => void;
-  onNext: () => void;
-  nextLabel: string;
-  nextDisabled?: boolean;
-  onSkip?: () => void;
-  skipLabel?: string;
-}) {
-  return (
-    <div className={`mt-9 flex items-center justify-between gap-2 border-t pt-5 ${SOFT_LINE}`}>
-      <div>
-        {onBack && (
-          <button
-            type="button"
-            onClick={onBack}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-muted transition-colors hover:text-fg"
-          >
-            <ArrowLeftIcon />
-            Back
-          </button>
-        )}
-      </div>
-      <div className="flex items-center gap-2">
-        {onSkip && (
-          <button
-            type="button"
-            onClick={onSkip}
-            className="inline-flex items-center px-3 py-1.5 text-[13px] font-medium text-muted transition-colors hover:text-fg"
-          >
-            {skipLabel ?? "Skip"}
-          </button>
-        )}
-        <Btn
-          variant="primary"
-          size="md"
-          onClick={onNext}
-          disabled={nextDisabled}
-          className="!h-[36px] !rounded-[8px] !px-[14px] !text-[13px]"
-        >
-          {nextLabel}
-          <ArrowIcon />
-        </Btn>
-      </div>
-    </div>
-  );
-}
-
 function InstallStep({
   apiKey,
   minting,
   error,
+  onBack,
   onNext,
   onExploreDemo,
 }: {
   apiKey: string | null;
   minting: boolean;
   error: string | null;
+  onBack?: () => void;
   onNext: () => void;
   onExploreDemo?: () => void;
 }) {
@@ -691,7 +643,7 @@ function InstallStep({
         </div>
       </div>
 
-      <StepFooter onNext={onNext} nextLabel="The agent is done" />
+      <StepFooter onBack={onBack} onNext={onNext} nextLabel="The agent is done" />
       <ExploreDemoLink onExploreDemo={onExploreDemo} />
     </>
   );

--- a/apps/web/src/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/onboarding/OnboardingWizard.tsx
@@ -21,7 +21,13 @@ import { ConnectDataChooser } from "./ConnectDataChooser.tsx";
 import { TruncatedKey } from "./TruncatedKey.tsx";
 import type { ConnectAction } from "./connectChoices.ts";
 import { CheckIcon, CopyIcon, GithubIcon, SlackIcon, SpinnerIcon } from "./icons.tsx";
-import { SOFT_LINE, STRONG_LINE, StepFooter, StepHeader } from "./wizardChrome.tsx";
+import {
+  ExploreDemoLink,
+  SOFT_LINE,
+  STRONG_LINE,
+  StepFooter,
+  StepHeader,
+} from "./wizardChrome.tsx";
 
 // Standalone fullscreen wizard shown to new users before they reach the
 // dashboard. Mirrors the playground's Onboarding (dots variant):
@@ -83,17 +89,20 @@ export function OnboardingWizard({
     }
   };
 
-  // Mint exactly once per mount, and only after we have a project to mint
-  // into. The ref guard makes the mint a strict per-mount one-shot,
-  // independent of mutation state identity or polling re-renders.
+  // Mint exactly once per mount, and only after we have a project to mint into
+  // *and* the user has chosen the code/SDK path — the no-code AWS integration
+  // never uses an ingest key, so minting on chooser entry would leave an unused
+  // key on the project. The ref guard makes the mint a strict per-mount
+  // one-shot, independent of mutation state identity or polling re-renders.
   const minted = useRef(false);
   useEffect(() => {
     if (mode !== "web") return;
+    if (webView !== "code") return;
     if (!projectId) return;
     if (minted.current) return;
     minted.current = true;
     createKey.mutate("Setup install");
-  }, [mode, projectId, createKey.mutate]);
+  }, [mode, webView, projectId, createKey.mutate]);
 
   const stats = useStats(projectId ?? undefined, { poll: true });
   const eventsArrived = hasEvents(stats.data);
@@ -131,12 +140,13 @@ export function OnboardingWizard({
               onDone={onComplete}
             />
           ) : webView === "chooser" ? (
-            <ConnectDataChooser onPick={handlePick} />
+            <ConnectDataChooser onPick={handlePick} onExploreDemo={onExploreDemo} />
           ) : webView === "aws" ? (
             <AwsConnectFlow
               projectId={projectId}
               onBack={() => setWebView("chooser")}
               onDone={onComplete}
+              onExploreDemo={onExploreDemo}
             />
           ) : step === "install" ? (
             <InstallStep
@@ -646,24 +656,6 @@ function InstallStep({
       <StepFooter onBack={onBack} onNext={onNext} nextLabel="The agent is done" />
       <ExploreDemoLink onExploreDemo={onExploreDemo} />
     </>
-  );
-}
-
-// Subtle escape hatch shown only when a shared demo project is configured: lets
-// a new user explore sample data before instrumenting. The install wizard stays
-// the primary path; this is a secondary, lower-emphasis action.
-function ExploreDemoLink({ onExploreDemo }: { onExploreDemo?: () => void }) {
-  if (!onExploreDemo) return null;
-  return (
-    <div className="mt-3 text-right">
-      <button
-        type="button"
-        onClick={onExploreDemo}
-        className="pr-1 text-[12.5px] font-medium text-muted underline-offset-4 transition-colors hover:text-fg hover:underline"
-      >
-        Not ready yet? Explore with sample data first →
-      </button>
-    </div>
   );
 }
 

--- a/apps/web/src/onboarding/awsConnectModel.test.ts
+++ b/apps/web/src/onboarding/awsConnectModel.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  AWS_REGIONS,
+  DEFAULT_AWS_REGION,
+  activeConnection,
+  awsPhase,
+  canContinueAws,
+  connectionStatusText,
+  isValidRegion,
+  stackComponentTone,
+} from "./awsConnectModel.ts";
+
+test("default region is one of the offered regions", () => {
+  assert.ok(AWS_REGIONS.includes(DEFAULT_AWS_REGION));
+});
+
+test("isValidRegion mirrors the API guard", () => {
+  for (const r of AWS_REGIONS) assert.equal(isValidRegion(r), true);
+  assert.equal(isValidRegion(""), false);
+  assert.equal(isValidRegion("US-EAST-1"), false); // uppercase rejected
+  assert.equal(isValidRegion("us east 1"), false); // spaces rejected
+  assert.equal(isValidRegion("a".repeat(33)), false); // too long
+});
+
+test("awsPhase walks start -> launching -> connected -> flowing", () => {
+  assert.equal(awsPhase({ connection: null, eventsArrived: false }), "start");
+  assert.equal(awsPhase({ connection: { status: "pending" }, eventsArrived: false }), "launching");
+  assert.equal(awsPhase({ connection: { status: "failed" }, eventsArrived: false }), "launching");
+  assert.equal(
+    awsPhase({ connection: { status: "account_mismatch" }, eventsArrived: false }),
+    "launching",
+  );
+  assert.equal(
+    awsPhase({ connection: { status: "connected" }, eventsArrived: false }),
+    "connected",
+  );
+  assert.equal(awsPhase({ connection: { status: "connected" }, eventsArrived: true }), "flowing");
+});
+
+test("events flowing before verify still requires the connection to be verified", () => {
+  // Defensive: a stray event shouldn't unlock the flow while pending.
+  assert.equal(awsPhase({ connection: { status: "pending" }, eventsArrived: true }), "launching");
+});
+
+test("canContinueAws only unlocks once telemetry is flowing", () => {
+  assert.equal(canContinueAws("start"), false);
+  assert.equal(canContinueAws("launching"), false);
+  assert.equal(canContinueAws("connected"), false);
+  assert.equal(canContinueAws("flowing"), true);
+});
+
+test("stackComponentTone maps API states to chip tones", () => {
+  assert.equal(stackComponentTone("working"), "success");
+  assert.equal(stackComponentTone("pending"), "warning");
+  assert.equal(stackComponentTone("broken"), "danger");
+  assert.equal(stackComponentTone("missing"), "muted");
+});
+
+test("connectionStatusText surfaces the failure reason", () => {
+  assert.equal(connectionStatusText("connected", null), "Connected");
+  assert.equal(connectionStatusText("pending", null), "Waiting for the stack…");
+  assert.match(connectionStatusText("failed", "AccessDenied"), /AccessDenied/);
+  assert.match(connectionStatusText("account_mismatch", null), /account/i);
+});
+
+test("activeConnection picks the most recently created row", () => {
+  assert.equal(activeConnection(undefined), null);
+  assert.equal(activeConnection([]), null);
+  const rows = [
+    { id: "old", createdAt: "2026-01-01T00:00:00.000Z" },
+    { id: "new", createdAt: "2026-06-01T00:00:00.000Z" },
+    { id: "mid", createdAt: "2026-03-01T00:00:00.000Z" },
+  ];
+  assert.equal(activeConnection(rows)?.id, "new");
+});

--- a/apps/web/src/onboarding/awsConnectModel.test.ts
+++ b/apps/web/src/onboarding/awsConnectModel.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { AWS_REGION_CODES, DEFAULT_AWS_REGION } from "../awsRegions.ts";
 import {
-  AWS_REGIONS,
-  DEFAULT_AWS_REGION,
   activeConnection,
   awsPhase,
+  awsStreamFlowing,
   canContinueAws,
   connectionStatusText,
   isValidRegion,
@@ -12,11 +12,11 @@ import {
 } from "./awsConnectModel.ts";
 
 test("default region is one of the offered regions", () => {
-  assert.ok(AWS_REGIONS.includes(DEFAULT_AWS_REGION));
+  assert.ok(AWS_REGION_CODES.includes(DEFAULT_AWS_REGION));
 });
 
 test("isValidRegion mirrors the API guard", () => {
-  for (const r of AWS_REGIONS) assert.equal(isValidRegion(r), true);
+  for (const r of AWS_REGION_CODES) assert.equal(isValidRegion(r), true);
   assert.equal(isValidRegion(""), false);
   assert.equal(isValidRegion("US-EAST-1"), false); // uppercase rejected
   assert.equal(isValidRegion("us east 1"), false); // spaces rejected
@@ -24,23 +24,35 @@ test("isValidRegion mirrors the API guard", () => {
 });
 
 test("awsPhase walks start -> launching -> connected -> flowing", () => {
-  assert.equal(awsPhase({ connection: null, eventsArrived: false }), "start");
-  assert.equal(awsPhase({ connection: { status: "pending" }, eventsArrived: false }), "launching");
-  assert.equal(awsPhase({ connection: { status: "failed" }, eventsArrived: false }), "launching");
+  assert.equal(awsPhase({ connection: null, streamFlowing: false }), "start");
+  assert.equal(awsPhase({ connection: { status: "pending" }, streamFlowing: false }), "launching");
+  assert.equal(awsPhase({ connection: { status: "failed" }, streamFlowing: false }), "launching");
   assert.equal(
-    awsPhase({ connection: { status: "account_mismatch" }, eventsArrived: false }),
+    awsPhase({ connection: { status: "account_mismatch" }, streamFlowing: false }),
     "launching",
   );
   assert.equal(
-    awsPhase({ connection: { status: "connected" }, eventsArrived: false }),
+    awsPhase({ connection: { status: "connected" }, streamFlowing: false }),
     "connected",
   );
-  assert.equal(awsPhase({ connection: { status: "connected" }, eventsArrived: true }), "flowing");
+  assert.equal(awsPhase({ connection: { status: "connected" }, streamFlowing: true }), "flowing");
 });
 
-test("events flowing before verify still requires the connection to be verified", () => {
-  // Defensive: a stray event shouldn't unlock the flow while pending.
-  assert.equal(awsPhase({ connection: { status: "pending" }, eventsArrived: true }), "launching");
+test("a flowing stream before verify still requires the connection to be verified", () => {
+  // Defensive: a stray signal shouldn't unlock the flow while pending.
+  assert.equal(awsPhase({ connection: { status: "pending" }, streamFlowing: true }), "launching");
+});
+
+test("awsStreamFlowing only counts this connection's metric/log delivery", () => {
+  assert.equal(awsStreamFlowing(undefined), false);
+  assert.equal(awsStreamFlowing([]), false);
+  // The connection row being "working" is not telemetry delivery.
+  assert.equal(awsStreamFlowing([{ key: "connection", state: "working" }]), false);
+  // A pending/missing stream hasn't delivered yet.
+  assert.equal(awsStreamFlowing([{ key: "metrics", state: "pending" }]), false);
+  // A working metric or log stream means real Firehose delivery.
+  assert.equal(awsStreamFlowing([{ key: "metrics", state: "working" }]), true);
+  assert.equal(awsStreamFlowing([{ key: "logs", state: "working" }]), true);
 });
 
 test("canContinueAws only unlocks once telemetry is flowing", () => {

--- a/apps/web/src/onboarding/awsConnectModel.ts
+++ b/apps/web/src/onboarding/awsConnectModel.ts
@@ -1,0 +1,102 @@
+// Pure logic for the AWS connect onboarding flow, split out from the component
+// so the phase/state mapping is unit-testable. Types are imported `type`-only so
+// nothing from api.ts (React Query, browser globals) is pulled in at runtime.
+import type { CloudConnection, CloudConnectionStatus, StackComponentState } from "../api.ts";
+
+// Regions offered in the picker. The launch URL interpolates the region into the
+// CloudFormation console hostname, so it must satisfy the API's validation
+// (see `createSchema` in cloud-connections.ts).
+export const AWS_REGIONS = [
+  "us-east-1",
+  "us-east-2",
+  "us-west-1",
+  "us-west-2",
+  "eu-west-1",
+  "eu-west-2",
+  "eu-central-1",
+  "ap-south-1",
+  "ap-southeast-1",
+  "ap-southeast-2",
+  "ap-northeast-1",
+  "sa-east-1",
+] as const;
+
+export type AwsRegion = (typeof AWS_REGIONS)[number];
+export const DEFAULT_AWS_REGION: AwsRegion = "us-east-1";
+
+// Mirror of the API's region guard (`/^[a-z0-9-]{1,32}$/`). Validated client-side
+// so a malformed custom region never produces a redirecting launch URL.
+const REGION_RE = /^[a-z0-9-]{1,32}$/;
+export function isValidRegion(region: string): boolean {
+  return REGION_RE.test(region);
+}
+
+// The step the AWS flow is on, derived from the connection + whether telemetry
+// has started flowing. Drives which panel renders and whether "Continue" unlocks.
+//   start      — no connection yet; show region picker + Connect button.
+//   launching  — connection exists but isn't verified; the CloudFormation stack
+//                is deploying (or the user still needs to paste the role ARN).
+//   connected  — role verified; waiting for the first events to stream in.
+//   flowing    — events have arrived; onboarding can complete.
+export type AwsPhase = "start" | "launching" | "connected" | "flowing";
+
+export function awsPhase(input: {
+  connection: Pick<CloudConnection, "status"> | null;
+  eventsArrived: boolean;
+}): AwsPhase {
+  const { connection, eventsArrived } = input;
+  if (!connection) return "start";
+  if (connection.status !== "connected") return "launching";
+  return eventsArrived ? "flowing" : "connected";
+}
+
+// "Continue" only unlocks once real telemetry is flowing — same poll-to-unblock
+// contract as the coding-agent deploy step and OnboardingGate's `hasIngested`.
+export function canContinueAws(phase: AwsPhase): boolean {
+  return phase === "flowing";
+}
+
+// Tone for a stack-health component pill. Maps the API's StackComponentState to
+// the design system's chip tones (see design/ui.tsx `ChipTone`).
+export type ComponentTone = "muted" | "warning" | "success" | "danger";
+export function stackComponentTone(state: StackComponentState): ComponentTone {
+  switch (state) {
+    case "working":
+      return "success";
+    case "pending":
+      return "warning";
+    case "broken":
+      return "danger";
+    default:
+      return "muted"; // "missing"
+  }
+}
+
+// Short human label for a connection's status, including the failure reason.
+export function connectionStatusText(
+  status: CloudConnectionStatus,
+  lastError: string | null,
+): string {
+  switch (status) {
+    case "connected":
+      return "Connected";
+    case "pending":
+      return "Waiting for the stack…";
+    case "account_mismatch":
+      return "Account mismatch — re-launch the stack in the right account";
+    case "failed":
+      return lastError ? `Couldn't verify: ${lastError}` : "Verification failed";
+    default:
+      return status;
+  }
+}
+
+// Pick the connection the onboarding flow should track: the most recently
+// created non-revoked row. (The list endpoint already filters revoked rows, but
+// a project can briefly hold more than one while a prior pending attempt lingers.)
+export function activeConnection<T extends { createdAt: string }>(
+  connections: T[] | undefined,
+): T | null {
+  if (!connections || connections.length === 0) return null;
+  return [...connections].sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0] ?? null;
+}

--- a/apps/web/src/onboarding/awsConnectModel.ts
+++ b/apps/web/src/onboarding/awsConnectModel.ts
@@ -1,31 +1,16 @@
 // Pure logic for the AWS connect onboarding flow, split out from the component
 // so the phase/state mapping is unit-testable. Types are imported `type`-only so
 // nothing from api.ts (React Query, browser globals) is pulled in at runtime.
-import type { CloudConnection, CloudConnectionStatus, StackComponentState } from "../api.ts";
-
-// Regions offered in the picker. The launch URL interpolates the region into the
-// CloudFormation console hostname, so it must satisfy the API's validation
-// (see `createSchema` in cloud-connections.ts).
-export const AWS_REGIONS = [
-  "us-east-1",
-  "us-east-2",
-  "us-west-1",
-  "us-west-2",
-  "eu-west-1",
-  "eu-west-2",
-  "eu-central-1",
-  "ap-south-1",
-  "ap-southeast-1",
-  "ap-southeast-2",
-  "ap-northeast-1",
-  "sa-east-1",
-] as const;
-
-export type AwsRegion = (typeof AWS_REGIONS)[number];
-export const DEFAULT_AWS_REGION: AwsRegion = "us-east-1";
+import type {
+  CloudConnection,
+  CloudConnectionStatus,
+  StackComponent,
+  StackComponentState,
+} from "../api.ts";
 
 // Mirror of the API's region guard (`/^[a-z0-9-]{1,32}$/`). Validated client-side
-// so a malformed custom region never produces a redirecting launch URL.
+// so a malformed custom region never produces a redirecting launch URL. The
+// offered region list lives in ../awsRegions.ts (shared with settings).
 const REGION_RE = /^[a-z0-9-]{1,32}$/;
 export function isValidRegion(region: string): boolean {
   return REGION_RE.test(region);
@@ -37,17 +22,31 @@ export function isValidRegion(region: string): boolean {
 //   launching  — connection exists but isn't verified; the CloudFormation stack
 //                is deploying (or the user still needs to paste the role ARN).
 //   connected  — role verified; waiting for the first events to stream in.
-//   flowing    — events have arrived; onboarding can complete.
+//   flowing    — this connection's CloudWatch stream has delivered; complete.
 export type AwsPhase = "start" | "launching" | "connected" | "flowing";
 
 export function awsPhase(input: {
   connection: Pick<CloudConnection, "status"> | null;
-  eventsArrived: boolean;
+  streamFlowing: boolean;
 }): AwsPhase {
-  const { connection, eventsArrived } = input;
+  const { connection, streamFlowing } = input;
   if (!connection) return "start";
   if (connection.status !== "connected") return "launching";
-  return eventsArrived ? "flowing" : "connected";
+  return streamFlowing ? "flowing" : "connected";
+}
+
+// Whether *this AWS connection* has actually delivered telemetry, derived from
+// its own stack-health stream components — not project-wide stats. Using project
+// stats would let pre-existing agent/SDK data unlock the flow before the AWS
+// CloudWatch stream has sent anything. A metric or log stream in `working` state
+// means its dedicated ingest key was used recently (real Firehose delivery).
+export function awsStreamFlowing(
+  components: Pick<StackComponent, "key" | "state">[] | undefined,
+): boolean {
+  return (
+    components?.some((c) => (c.key === "metrics" || c.key === "logs") && c.state === "working") ??
+    false
+  );
 }
 
 // "Continue" only unlocks once real telemetry is flowing — same poll-to-unblock

--- a/apps/web/src/onboarding/connectChoices.test.ts
+++ b/apps/web/src/onboarding/connectChoices.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CONNECT_SECTIONS,
+  connectActionFor,
+  isComingSoon,
+  primaryConnectOption,
+} from "./connectChoices.ts";
+
+test("integration-first: the primary option is a no-code integration (AWS), not the coding agent", () => {
+  const primary = primaryConnectOption();
+  assert.equal(primary.id, "aws");
+  assert.equal(primary.action, "aws");
+});
+
+test("the recommended section is listed before the coding-agent section", () => {
+  const recommendedIdx = CONNECT_SECTIONS.findIndex((s) => s.id === "recommended");
+  const codeIdx = CONNECT_SECTIONS.findIndex((s) => s.id === "code");
+  assert.ok(recommendedIdx >= 0 && codeIdx >= 0);
+  assert.ok(recommendedIdx < codeIdx, "recommended integrations come first");
+});
+
+test("recommended + code options are all actionable; 'more' are coming soon", () => {
+  for (const section of CONNECT_SECTIONS) {
+    for (const option of section.options) {
+      if (section.id === "more") {
+        assert.equal(option.action, null, `${option.id} should be coming soon`);
+        assert.equal(isComingSoon(option), true);
+      } else {
+        assert.notEqual(option.action, null, `${option.id} should be actionable`);
+        assert.equal(isComingSoon(option), false);
+      }
+    }
+  }
+});
+
+test("connectActionFor resolves known ids and returns null for coming-soon / unknown", () => {
+  assert.equal(connectActionFor("aws"), "aws");
+  assert.equal(connectActionFor("otel"), "otel");
+  assert.equal(connectActionFor("agent"), "code");
+  assert.equal(connectActionFor("vercel"), null);
+  assert.equal(connectActionFor("does-not-exist"), null);
+});
+
+test("every option id is unique", () => {
+  const ids = CONNECT_SECTIONS.flatMap((s) => s.options.map((o) => o.id));
+  assert.equal(new Set(ids).size, ids.length);
+});

--- a/apps/web/src/onboarding/connectChoices.ts
+++ b/apps/web/src/onboarding/connectChoices.ts
@@ -1,0 +1,138 @@
+// Catalog + routing for the "Connect your data" onboarding fork, split out from
+// the component so the ordering rules are unit-testable (the `.tsx` can't be
+// imported by the node:test runner).
+//
+// Design principle (see design.md): integration-first. A connected, no-code
+// integration beats hand-written instrumentation for time-to-value, so the
+// recommended no-code sources come first and the coding-agent path is the
+// secondary option.
+
+// What activating a row does. `null` => not yet available (coming soon), so the
+// row renders disabled and is not actionable.
+export type ConnectAction = "aws" | "otel" | "code";
+
+// Glyph key resolved to a neutral monochrome icon by the component. Kept as a
+// string union (not a component) so this module stays free of JSX/React.
+export type ConnectIcon =
+  | "aws"
+  | "otel"
+  | "agent"
+  | "vercel"
+  | "kubernetes"
+  | "cloudflare"
+  | "githubActions";
+
+export type ConnectOption = {
+  id: string;
+  title: string;
+  description: string;
+  icon: ConnectIcon;
+  action: ConnectAction | null;
+  badge?: string;
+};
+
+export type ConnectSection = {
+  id: string;
+  label: string;
+  // "list" => grouped rows with chevrons; "grid" => lighter 2-up tiles.
+  variant: "list" | "grid";
+  options: ConnectOption[];
+};
+
+export const CONNECT_SECTIONS: ConnectSection[] = [
+  {
+    id: "recommended",
+    label: "Recommended · no code",
+    variant: "list",
+    options: [
+      {
+        id: "aws",
+        title: "Amazon Web Services",
+        description:
+          "Stream CloudWatch logs and metrics and auto-discover resources from one CloudFormation stack. No agent, no code.",
+        icon: "aws",
+        action: "aws",
+      },
+      {
+        id: "otel",
+        title: "OpenTelemetry / SDK",
+        description: "Point any OTLP exporter at Superlog with a write-only ingest key.",
+        icon: "otel",
+        action: "otel",
+      },
+    ],
+  },
+  {
+    id: "code",
+    label: "Or instrument with code",
+    variant: "list",
+    options: [
+      {
+        id: "agent",
+        title: "Use your coding agent",
+        description:
+          "Paste a prompt into Cursor, Claude Code, or Codex — it installs the SDK, instruments your app, and opens a PR.",
+        icon: "agent",
+        action: "code",
+      },
+    ],
+  },
+  {
+    id: "more",
+    label: "More integrations",
+    variant: "grid",
+    options: [
+      {
+        id: "vercel",
+        title: "Vercel",
+        description: "Coming soon",
+        icon: "vercel",
+        action: null,
+      },
+      {
+        id: "kubernetes",
+        title: "Kubernetes",
+        description: "Coming soon",
+        icon: "kubernetes",
+        action: null,
+      },
+      {
+        id: "cloudflare",
+        title: "Cloudflare",
+        description: "Coming soon",
+        icon: "cloudflare",
+        action: null,
+      },
+      {
+        id: "github-actions",
+        title: "GitHub Actions",
+        description: "Coming soon",
+        icon: "githubActions",
+        action: null,
+      },
+    ],
+  },
+];
+
+export function isComingSoon(option: ConnectOption): boolean {
+  return option.action === null;
+}
+
+// Flattened lookup of an option's action by id (used by the click handler).
+export function connectActionFor(id: string): ConnectAction | null {
+  for (const section of CONNECT_SECTIONS) {
+    const found = section.options.find((o) => o.id === id);
+    if (found) return found.action;
+  }
+  return null;
+}
+
+// First actionable option across all sections, in display order — this is the
+// row we expect to be the primary, integration-first recommendation.
+export function primaryConnectOption(): ConnectOption {
+  for (const section of CONNECT_SECTIONS) {
+    const actionable = section.options.find((o) => o.action !== null);
+    if (actionable) return actionable;
+  }
+  throw new Error("no actionable connect option configured");
+}

--- a/apps/web/src/onboarding/icons.tsx
+++ b/apps/web/src/onboarding/icons.tsx
@@ -176,3 +176,189 @@ export function CheckIcon({ size = 14, className }: IconProps) {
     </svg>
   );
 }
+
+export function ChevronRightIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="m6 4 4 4-4 4" />
+    </svg>
+  );
+}
+
+export function ExternalLinkIcon({ size = 13, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M8 2h4v4M12 2 6.5 7.5M11 8.5V11a1.5 1.5 0 0 1-1.5 1.5h-6A1.5 1.5 0 0 1 2 11V5a1.5 1.5 0 0 1 1.5-1.5H6" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Connect-source glyphs. Neutral monochrome line icons (currentColor) so no
+// per-integration brand color competes for attention on the chooser.
+// ---------------------------------------------------------------------------
+
+// AWS — a stack of server racks. Deliberately distinct from a cloud so it
+// doesn't read the same as the Cloudflare glyph (design open decision).
+export function AwsIcon({ size = 18, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <rect x="2.5" y="2.5" width="13" height="4.5" rx="1.2" />
+      <rect x="2.5" y="11" width="13" height="4.5" rx="1.2" />
+      <path d="M5 4.75h.01M5 13.25h.01M12.5 4.75h.5M12.5 13.25h.5" />
+    </svg>
+  );
+}
+
+// OpenTelemetry / SDK — a hexagon mark.
+export function OtelIcon({ size = 18, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M9 1.8 15.2 5.4v7.2L9 16.2 2.8 12.6V5.4Z" />
+      <circle cx="9" cy="9" r="2.4" />
+    </svg>
+  );
+}
+
+// Coding agent — a sparkle.
+export function AgentSparkIcon({ size = 18, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M9 2.2c.4 2.9 1.9 4.4 4.8 4.8-2.9.4-4.4 1.9-4.8 4.8-.4-2.9-1.9-4.4-4.8-4.8C7.1 6.6 8.6 5.1 9 2.2Z" />
+      <path d="M13.7 11.4c.2 1.3.9 2 2.1 2.2-1.2.2-1.9.9-2.1 2.2-.2-1.3-.9-2-2.1-2.2 1.2-.2 1.9-.9 2.1-2.2Z" />
+    </svg>
+  );
+}
+
+export function VercelIcon({ size = 18, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M9 3.5 15.5 14.5h-13Z" />
+    </svg>
+  );
+}
+
+export function KubernetesIcon({ size = 18, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M9 1.9 15 4.8l-1.5 6.5L9 16.1 4.5 11.3 3 4.8Z" />
+      <circle cx="9" cy="8.6" r="2.1" />
+    </svg>
+  );
+}
+
+// Cloudflare — a cloud outline (intentionally cloud-shaped, unlike the AWS rack).
+export function CloudflareIcon({ size = 18, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M5.2 13h7.3a2.6 2.6 0 0 0 .3-5.18A3.8 3.8 0 0 0 5.5 7.2 3 3 0 0 0 5.2 13Z" />
+    </svg>
+  );
+}
+
+export function GithubActionsIcon({ size = 18, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="9" cy="9" r="6.3" />
+      <path d="m7.2 6.6 3.4 2.4-3.4 2.4Z" />
+    </svg>
+  );
+}

--- a/apps/web/src/onboarding/wizardChrome.tsx
+++ b/apps/web/src/onboarding/wizardChrome.tsx
@@ -1,0 +1,96 @@
+import type { ReactNode } from "react";
+import { Btn } from "../design/ui.tsx";
+import { ArrowIcon, ArrowLeftIcon } from "./icons.tsx";
+
+// Shared chrome for the onboarding wizard steps, extracted so the install /
+// deploy flow and the new "Connect your data" views render identical headers,
+// footers, and hairlines.
+//
+// Hairlines matching the playground's --sl-line / --sl-line-2 tokens. Host's
+// `border-border` reads as a boxed line on the dark canvas; the playground uses
+// translucent whites for the soft elevation effect.
+export const SOFT_LINE = "border-[rgba(255,255,255,0.07)]";
+export const STRONG_LINE = "border-[rgba(255,255,255,0.12)]";
+
+export function StepHeader({ title, sub }: { title: string; sub: ReactNode }) {
+  return (
+    <div className="mb-7">
+      <h1 className="m-0 text-[32px] font-semibold leading-[1.1] tracking-[-0.025em] text-fg">
+        {title}
+      </h1>
+      <div className="mt-2.5 max-w-[540px] text-[14px] text-muted">{sub}</div>
+    </div>
+  );
+}
+
+export function StepFooter({
+  onBack,
+  onNext,
+  nextLabel,
+  nextDisabled,
+  onSkip,
+  skipLabel,
+}: {
+  onBack?: () => void;
+  onNext: () => void;
+  nextLabel: string;
+  nextDisabled?: boolean;
+  onSkip?: () => void;
+  skipLabel?: string;
+}) {
+  return (
+    <div className={`mt-9 flex items-center justify-between gap-2 border-t pt-5 ${SOFT_LINE}`}>
+      <div>
+        {onBack && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-muted transition-colors hover:text-fg"
+          >
+            <ArrowLeftIcon />
+            Back
+          </button>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        {onSkip && (
+          <button
+            type="button"
+            onClick={onSkip}
+            className="inline-flex items-center px-3 py-1.5 text-[13px] font-medium text-muted transition-colors hover:text-fg"
+          >
+            {skipLabel ?? "Skip"}
+          </button>
+        )}
+        <Btn
+          variant="primary"
+          size="md"
+          onClick={onNext}
+          disabled={nextDisabled}
+          className="!h-[36px] !rounded-[8px] !px-[14px] !text-[13px]"
+        >
+          {nextLabel}
+          <ArrowIcon />
+        </Btn>
+      </div>
+    </div>
+  );
+}
+
+// Subtle escape hatch shown only when a shared demo project is configured: lets
+// a new user explore sample data before instrumenting. The connect flow stays
+// the primary path; this is a secondary, lower-emphasis action.
+export function ExploreDemoLink({ onExploreDemo }: { onExploreDemo?: () => void }) {
+  if (!onExploreDemo) return null;
+  return (
+    <div className="mt-3 text-right">
+      <button
+        type="button"
+        onClick={onExploreDemo}
+        className="pr-1 text-[12.5px] font-medium text-muted underline-offset-4 transition-colors hover:text-fg hover:underline"
+      >
+        Not ready yet? Explore with sample data first →
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a top-level onboarding fork so a new user can either connect a no-code integration (recommended) or instrument with their coding agent. Previously the wizard funnelled everyone straight into the agent install prompt.

- **`ConnectDataChooser`** — integration-first, low-color flat list: *Recommended · no code* (Amazon Web Services, OpenTelemetry / SDK), *Or instrument with code* (the existing agent flow), and a *More integrations* grid of future sources. Cards sit just above the ground surface (not darker), labels are sentence case, and the "Recommended" cue lives only in the section label — no duplicate per-row badge.
- **`AwsConnectFlow`** — region select + one-step CloudFormation launch wired to the existing `cloud-connections` endpoints, with live stack-health polling for the "waiting for first data" state.
- **`wizardChrome`** — extracts the shared `StepHeader` / `StepFooter` / chrome out of `OnboardingWizard` so the new views reuse it.
- **Pure models + `node:test` coverage** — `connectChoices` (integration-first ordering, actionable options, unique ids) and `awsConnectModel` (region validation, phase transitions, status text).
- **`apps/api/.env.example`** — documents the AWS-connect config (`SUPERLOG_AWS_ACCOUNT_ID`, template URLs, Firehose intake URLs) and `AGENT_SECRETS_KEY`, which the connect routes require (they 500 when unset).

The agent install path is unchanged and still reachable via *Or instrument with code*; the "explore sample data" escape hatch is preserved.

## Test plan

- [x] `pnpm --filter @superlog/web typecheck`
- [x] `pnpm --filter @superlog/web exec tsx --test src/onboarding/connectChoices.test.ts src/onboarding/awsConnectModel.test.ts` (13 passing)
- [x] Manual browser run: sign up → chooser renders → AWS connect builds a CloudFormation launch URL (no 500) once `SUPERLOG_AWS_ACCOUNT_ID` / template / `AGENT_SECRETS_KEY` are configured

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Connect your data” onboarding fork with a no‑code AWS connect flow via CloudFormation, making integrations the default path while keeping the coding‑agent route. Region selection is shared, launch behavior is fixed, and Continue unlocks after this connection’s first telemetry arrives (latched so it won’t relock).

- New Features
  - `ConnectDataChooser`: integration‑first list (Recommended · no code: AWS, OpenTelemetry/SDK), plus “Or instrument with code” and a “More integrations” grid.
  - `AwsConnectFlow`: region select using shared `awsRegions.ts` and one‑step CloudFormation launch wired to `cloud-connections`; stack‑health polling scoped to this connection; latch on first stream delivery so “Continue” stays unlocked even if streams go quiet; manual role‑ARN verify fallback; launch opens in a new tab; sample‑data link while waiting.
  - `wizardChrome`: shared `StepHeader` / `StepFooter` and demo escape link for consistent UI across onboarding.
  - Pure models with `node:test` coverage: `connectChoices` (ordering, actions, ids) and `awsConnectModel` (region validation, phase transitions, status text, stream gating). The agent path is unchanged; ingest keys mint only on the code/SDK path.

- Migration
  - Set `AGENT_SECRETS_KEY` (base64‑decoded to 32 bytes) in `apps/api/.env`; connect routes 500 if unset.
  - To enable AWS connect: set `SUPERLOG_AWS_ACCOUNT_ID` and `AWS_CONNECT_TEMPLATE_URL`. For one‑step launch also set `AWS_CONNECT_SERVICE_TOKEN`, `AWS_CONNECT_STACK_TEMPLATE_URL`, `AWS_FIREHOSE_METRICS_INTAKE_URL`, `AWS_FIREHOSE_LOGS_INTAKE_URL` (optional legacy: `AWS_METRICS_TEMPLATE_URL`, `AWS_LOGS_TEMPLATE_URL`).

<sup>Written for commit 450f3249777fa2b0932f272d206cb0cd9106887d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

