### PR TITLE
fix(settings): agent custom instructions render empty on load

### DIFF
--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -87,6 +87,7 @@ import {
   useWebhooks,
 } from "./api";
 import { Dropdown, type DropdownOption } from "./design/Dropdown.tsx";
+import { syncInstructionsDraft } from "./instructions-field-state.ts";
 import { Btn, Chip, FieldLabel, Input, Label, Tile } from "./design/ui";
 import { AgentMemoriesCard } from "./settings/AgentMemoriesCard.tsx";
 import { BillingCard } from "./settings/BillingCard.tsx";
@@ -1973,7 +1974,9 @@ function AgentFlowchart({ projectId }: { projectId: string | undefined }) {
               Linear tickets, no PRs.
             </p>
             <InstructionsField
+              key={projectId}
               value={data.customInstructions}
+              settingsLoaded={settings.isSuccess}
               disabled={!investigateOn || save.isPending}
               onSave={(v) => patch({ customInstructions: v })}
             />
@@ -2982,10 +2985,12 @@ function PolicyControls<T extends string>({
 
 function InstructionsField({
   value,
+  settingsLoaded,
   disabled,
   onSave,
 }: {
   value: string;
+  settingsLoaded: boolean;
   disabled: boolean;
   onSave: (v: string) => void;
 }) {
@@ -2993,13 +2998,17 @@ function InstructionsField({
   const [loaded, setLoaded] = useState(false);
   const [expanded, setExpanded] = useState(value.length > 0);
 
+  // Seed the draft from the server value exactly once, and only after the
+  // settings query has resolved — seeding from the placeholder "" emitted while
+  // the query is pending would leave the field stuck empty on a cold load and
+  // let an empty Save overwrite the saved instructions.
   useEffect(() => {
-    if (!loaded) {
-      setDraft(value);
-      setLoaded(true);
-      if (value.length > 0) setExpanded(true);
-    }
-  }, [value, loaded]);
+    const next = syncInstructionsDraft({ loaded, settingsLoaded, serverValue: value, expanded });
+    if (!next) return;
+    setDraft(next.draft);
+    setLoaded(next.loaded);
+    setExpanded(next.expanded);
+  }, [value, loaded, settingsLoaded, expanded]);
 
   const dirty = loaded && draft !== value;
 

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -2995,22 +2995,30 @@ function InstructionsField({
   onSave: (v: string) => void;
 }) {
   const [draft, setDraft] = useState(value);
-  const [loaded, setLoaded] = useState(false);
+  const [syncedValue, setSyncedValue] = useState<string | null>(null);
   const [expanded, setExpanded] = useState(value.length > 0);
 
-  // Seed the draft from the server value exactly once, and only after the
-  // settings query has resolved — seeding from the placeholder "" emitted while
-  // the query is pending would leave the field stuck empty on a cold load and
-  // let an empty Save overwrite the saved instructions.
+  // Reconcile the local draft with the server value. The draft follows the
+  // server while the editor is clean (so a cold load, a background refetch, or
+  // an edit made elsewhere is picked up) but never clobbers in-progress edits.
+  // Crucially it ignores the placeholder "" emitted while the query is pending,
+  // which previously left the field stuck empty on a cold load and let an empty
+  // Save overwrite the saved instructions.
   useEffect(() => {
-    const next = syncInstructionsDraft({ loaded, settingsLoaded, serverValue: value, expanded });
+    const next = syncInstructionsDraft({
+      settingsLoaded,
+      serverValue: value,
+      draft,
+      syncedValue,
+      expanded,
+    });
     if (!next) return;
     setDraft(next.draft);
-    setLoaded(next.loaded);
+    setSyncedValue(next.syncedValue);
     setExpanded(next.expanded);
-  }, [value, loaded, settingsLoaded, expanded]);
+  }, [value, settingsLoaded, draft, syncedValue, expanded]);
 
-  const dirty = loaded && draft !== value;
+  const dirty = syncedValue !== null && draft !== value;
 
   if (!expanded) {
     return (

--- a/apps/web/src/instructions-field-state.test.ts
+++ b/apps/web/src/instructions-field-state.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { syncInstructionsDraft } from "./instructions-field-state.ts";
+
+// Regression: the field used to seed its draft from `value` on first render,
+// before the settings query resolved. On a cold page load `value` is "" while
+// the query is pending, so the field locked in an empty draft and never picked
+// up the real instructions when they arrived — showing an empty box (and, once
+// expanded, an enabled Save button that would overwrite the saved text with "").
+
+test("does not seed the draft before settings have loaded", () => {
+  assert.equal(
+    syncInstructionsDraft({
+      loaded: false,
+      settingsLoaded: false,
+      serverValue: "",
+      expanded: false,
+    }),
+    null,
+  );
+});
+
+test("seeds the draft once settings load with existing instructions", () => {
+  assert.deepEqual(
+    syncInstructionsDraft({
+      loaded: false,
+      settingsLoaded: true,
+      serverValue: "do not open PRs on local",
+      expanded: false,
+    }),
+    { draft: "do not open PRs on local", loaded: true, expanded: true },
+  );
+});
+
+test("seeds an empty draft without auto-expanding when there are no instructions", () => {
+  assert.deepEqual(
+    syncInstructionsDraft({
+      loaded: false,
+      settingsLoaded: true,
+      serverValue: "",
+      expanded: false,
+    }),
+    { draft: "", loaded: true, expanded: false },
+  );
+});
+
+test("keeps the field expanded if the user already opened it", () => {
+  assert.deepEqual(
+    syncInstructionsDraft({
+      loaded: false,
+      settingsLoaded: true,
+      serverValue: "",
+      expanded: true,
+    }),
+    { draft: "", loaded: true, expanded: true },
+  );
+});
+
+test("does not re-seed (clobber edits) once already loaded", () => {
+  assert.equal(
+    syncInstructionsDraft({
+      loaded: true,
+      settingsLoaded: true,
+      serverValue: "fresh server value",
+      expanded: true,
+    }),
+    null,
+  );
+});

--- a/apps/web/src/instructions-field-state.test.ts
+++ b/apps/web/src/instructions-field-state.test.ts
@@ -11,9 +11,10 @@ import { syncInstructionsDraft } from "./instructions-field-state.ts";
 test("does not seed the draft before settings have loaded", () => {
   assert.equal(
     syncInstructionsDraft({
-      loaded: false,
       settingsLoaded: false,
       serverValue: "",
+      draft: "",
+      syncedValue: null,
       expanded: false,
     }),
     null,
@@ -23,47 +24,93 @@ test("does not seed the draft before settings have loaded", () => {
 test("seeds the draft once settings load with existing instructions", () => {
   assert.deepEqual(
     syncInstructionsDraft({
-      loaded: false,
       settingsLoaded: true,
       serverValue: "do not open PRs on local",
+      draft: "",
+      syncedValue: null,
       expanded: false,
     }),
-    { draft: "do not open PRs on local", loaded: true, expanded: true },
+    { draft: "do not open PRs on local", syncedValue: "do not open PRs on local", expanded: true },
   );
 });
 
 test("seeds an empty draft without auto-expanding when there are no instructions", () => {
   assert.deepEqual(
     syncInstructionsDraft({
-      loaded: false,
       settingsLoaded: true,
       serverValue: "",
+      draft: "",
+      syncedValue: null,
       expanded: false,
     }),
-    { draft: "", loaded: true, expanded: false },
+    { draft: "", syncedValue: "", expanded: false },
   );
 });
 
 test("keeps the field expanded if the user already opened it", () => {
   assert.deepEqual(
     syncInstructionsDraft({
-      loaded: false,
       settingsLoaded: true,
       serverValue: "",
+      draft: "",
+      syncedValue: null,
       expanded: true,
     }),
-    { draft: "", loaded: true, expanded: true },
+    { draft: "", syncedValue: "", expanded: true },
   );
 });
 
-test("does not re-seed (clobber edits) once already loaded", () => {
+test("does nothing when already reconciled to the current server value", () => {
   assert.equal(
     syncInstructionsDraft({
-      loaded: true,
       settingsLoaded: true,
-      serverValue: "fresh server value",
+      serverValue: "rules",
+      draft: "rules",
+      syncedValue: "rules",
       expanded: true,
     }),
     null,
+  );
+});
+
+test("a clean editor follows a newer server value (background refetch / edit elsewhere)", () => {
+  assert.deepEqual(
+    syncInstructionsDraft({
+      settingsLoaded: true,
+      serverValue: "updated rules",
+      draft: "old rules",
+      syncedValue: "old rules",
+      expanded: true,
+    }),
+    { draft: "updated rules", syncedValue: "updated rules", expanded: true },
+  );
+});
+
+test("does not clobber unsaved local edits when the server changes underneath", () => {
+  assert.equal(
+    syncInstructionsDraft({
+      settingsLoaded: true,
+      serverValue: "updated rules",
+      draft: "my work-in-progress edit",
+      syncedValue: "old rules",
+      expanded: true,
+    }),
+    null,
+  );
+});
+
+test("reconciles bookkeeping (without touching the draft) once the server catches up to the draft", () => {
+  // After the user's own save lands, the refetched server value equals the
+  // draft. We advance syncedValue so the editor is clean again, but leave the
+  // draft alone.
+  assert.deepEqual(
+    syncInstructionsDraft({
+      settingsLoaded: true,
+      serverValue: "my saved rules",
+      draft: "my saved rules",
+      syncedValue: "old rules",
+      expanded: true,
+    }),
+    { draft: "my saved rules", syncedValue: "my saved rules", expanded: true },
   );
 });

--- a/apps/web/src/instructions-field-state.ts
+++ b/apps/web/src/instructions-field-state.ts
@@ -1,35 +1,67 @@
 export type InstructionsSyncInput = {
-  /** Whether the field has already seeded its draft from the server. */
-  loaded: boolean;
   /** Whether the underlying settings query has actually resolved. */
   settingsLoaded: boolean;
-  /** The instructions value coming from the server. */
+  /** The latest instructions value coming from the server. */
   serverValue: string;
+  /** The current local draft in the editor. */
+  draft: string;
+  /**
+   * The server value the draft was last reconciled to, or `null` if the editor
+   * has never seeded from a resolved query yet. The editor is "clean" when
+   * `draft === syncedValue`.
+   */
+  syncedValue: string | null;
   /** Whether the editor is currently expanded. */
   expanded: boolean;
 };
 
 export type InstructionsSyncResult = {
   draft: string;
-  loaded: true;
+  syncedValue: string;
   expanded: boolean;
 };
 
 /**
- * Decide how an instructions editor should seed its local draft from the
+ * Decide how an instructions editor should reconcile its local draft with the
  * server value.
  *
- * The draft is seeded exactly once, and only after the settings query has
- * actually resolved — never from the placeholder empty value emitted while the
- * query is still pending. Returns `null` when no state change is needed (either
- * because the draft is already seeded, or because the server data hasn't loaded
- * yet), so the field doesn't clobber the user's in-progress edits on refetch.
+ * Rules (returns `null` when no state change is needed):
+ *  - Do nothing until the settings query has actually resolved — seeding from
+ *    the placeholder "" emitted while the query is pending would leave the
+ *    field stuck empty on a cold load.
+ *  - On the first resolved value, seed the draft (and expand when there are
+ *    saved instructions).
+ *  - When the server value changes and the editor is clean (no local edits),
+ *    follow it — so a background refetch or an edit made elsewhere is picked up
+ *    instead of being permanently ignored.
+ *  - When the user has unsaved edits, never clobber them. The one exception is
+ *    when the server catches up to exactly the draft (e.g. right after the
+ *    user's own save lands): reconcile the bookkeeping without touching the
+ *    draft, so the editor becomes clean again and resumes following the server.
  */
 export function syncInstructionsDraft(input: InstructionsSyncInput): InstructionsSyncResult | null {
-  if (input.loaded || !input.settingsLoaded) return null;
-  return {
-    draft: input.serverValue,
-    loaded: true,
-    expanded: input.expanded || input.serverValue.length > 0,
-  };
+  const { settingsLoaded, serverValue, draft, syncedValue, expanded } = input;
+  if (!settingsLoaded) return null;
+
+  const seed = (value: string): InstructionsSyncResult => ({
+    draft: value,
+    syncedValue: value,
+    expanded: expanded || value.length > 0,
+  });
+
+  // First resolved value — seed the draft from the server.
+  if (syncedValue === null) return seed(serverValue);
+
+  // Already reconciled to this exact server value: nothing to do.
+  if (serverValue === syncedValue) return null;
+
+  // Clean editor (no local edits) — follow the new server value.
+  if (draft === syncedValue) return seed(serverValue);
+
+  // The server caught up to the draft (e.g. our own save landed) — reconcile
+  // the bookkeeping without disturbing the draft.
+  if (draft === serverValue) return { draft, syncedValue: serverValue, expanded };
+
+  // Genuine conflict: keep the user's in-progress edits.
+  return null;
 }

--- a/apps/web/src/instructions-field-state.ts
+++ b/apps/web/src/instructions-field-state.ts
@@ -1,0 +1,35 @@
+export type InstructionsSyncInput = {
+  /** Whether the field has already seeded its draft from the server. */
+  loaded: boolean;
+  /** Whether the underlying settings query has actually resolved. */
+  settingsLoaded: boolean;
+  /** The instructions value coming from the server. */
+  serverValue: string;
+  /** Whether the editor is currently expanded. */
+  expanded: boolean;
+};
+
+export type InstructionsSyncResult = {
+  draft: string;
+  loaded: true;
+  expanded: boolean;
+};
+
+/**
+ * Decide how an instructions editor should seed its local draft from the
+ * server value.
+ *
+ * The draft is seeded exactly once, and only after the settings query has
+ * actually resolved — never from the placeholder empty value emitted while the
+ * query is still pending. Returns `null` when no state change is needed (either
+ * because the draft is already seeded, or because the server data hasn't loaded
+ * yet), so the field doesn't clobber the user's in-progress edits on refetch.
+ */
+export function syncInstructionsDraft(input: InstructionsSyncInput): InstructionsSyncResult | null {
+  if (input.loaded || !input.settingsLoaded) return null;
+  return {
+    draft: input.serverValue,
+    loaded: true,
+    expanded: input.expanded || input.serverValue.length > 0,
+  };
+}


### PR DESCRIPTION
## Summary

- Fixes the Project → Agent → Custom instructions editor showing an empty box on load and intermittently appearing/disappearing.
- The field seeded its local draft from the settings value on the **first** render and then locked itself with a `loaded` flag, so it never re-synced once the query resolved. On a cold load the query is still pending and the value is an empty placeholder, so the field stuck on an empty draft (blank after save/refresh, correct only later once the query cache was warm).
- This also created a data-loss path: the empty draft made the field "dirty" vs. the saved value, so **Save was enabled with empty content** and could overwrite the saved instructions with `""` — after which the agent stops honoring them.

## Fix

- Extracted the seeding decision into a pure, unit-tested helper `syncInstructionsDraft` (`apps/web/src/instructions-field-state.ts`): seed only after the query has actually resolved, exactly once, and never clobber in-progress edits on refetch.
- Wired it into `InstructionsField`, passing the query's loaded state and adding `key={projectId}` so switching projects re-seeds from the correct value.

Resolves #67.

## Test plan

- [x] `node --test apps/web/src/instructions-field-state.test.ts` (cold-load, empty, user-expanded, no-clobber-on-refetch cases)
- [x] `pnpm --filter @superlog/web typecheck`
- [x] Biome clean on new files
- [ ] Manual: open Agent settings with saved instructions on a cold load → instructions render; empty Save no longer enabled

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Agent → Custom instructions editor rendering empty on cold load and staying stale after refetch. The draft now seeds only after settings load, follows server updates while the editor is clean, and never overwrites saved text with empty content.

- **Bug Fixes**
  - Seed after the settings query resolves and track the last-synced value via `syncInstructionsDraft` (unit-tested) so a clean editor follows server updates (cold load, refetch, edits elsewhere).
  - Protect in-progress edits: do not clobber local changes; reconcile cleanly once the server matches the draft (after save).
  - Re-key the editor per project with `key={projectId}` to re-seed when switching projects.

<sup>Written for commit 1b5bcfc18cf54200bf48d70359b8d837020db068. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

