### PR TITLE
web(landing): link to the docs site from nav and footer

### DIFF
--- a/apps/web/src/Landing.test.ts
+++ b/apps/web/src/Landing.test.ts
@@ -1,10 +1,20 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
+import { LANDING_DOCS_URL, LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
 
 test("landing navbar uses the public Superlog GitHub repository URL", () => {
   assert.equal(LANDING_GITHUB_REPO_URL, "https://github.com/superloglabs/superlog");
+});
+
+test("landing docs link points at the Mintlify docs site", () => {
+  assert.equal(LANDING_DOCS_URL, "https://docs.superlog.sh");
+});
+
+test("landing top nav renders a Docs link wired to the docs URL", async () => {
+  const source = await readFile(new URL("./Landing.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /href=\{LANDING_DOCS_URL\}[\s\S]*?Docs\s*<\/a>/);
 });
 
 test("landing top nav renders a GitHub link wired to the repository URL", async () => {

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { AuthForm } from "./AuthForm.tsx";
 import { Btn, Chip, Label, Tile, Wordmark } from "./design/ui.tsx";
 import { INSTALL_PROMPT } from "./installPrompt.ts";
-import { LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
+import { LANDING_DOCS_URL, LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
 
 // ---------------------------------------------------------------------------
 // Landing — /
@@ -118,6 +118,14 @@ function TopNav({
             >
               <GitHubIcon />
               GitHub
+            </a>
+            <a
+              href={LANDING_DOCS_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg sm:inline"
+            >
+              Docs
             </a>
             <a
               href="/pricing"
@@ -793,6 +801,14 @@ function Footer() {
           <h3 className="text-[13px] font-semibold text-subtle">Product</h3>
           <div className="mt-5">
             <div className="flex flex-col items-center gap-3 md:items-start">
+              <a
+                href={LANDING_DOCS_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="text-[14px] font-medium text-muted transition-colors hover:text-fg"
+              >
+                Docs
+              </a>
               <a
                 href="/pricing"
                 className="text-[14px] font-medium text-muted transition-colors hover:text-fg"

--- a/apps/web/src/landingLinks.ts
+++ b/apps/web/src/landingLinks.ts
@@ -1,1 +1,3 @@
 export const LANDING_GITHUB_REPO_URL = "https://github.com/superloglabs/superlog";
+
+export const LANDING_DOCS_URL = "https://docs.superlog.sh";


### PR DESCRIPTION
Add a Docs link (https://docs.superlog.sh) to the landing top nav and the footer Product group so visitors can reach the Mintlify documentation.

## What & why

<!-- 1–3 sentences: what changed and why. Link any related issues. -->

Fixes #

## How to test

<!-- Bullet list of concrete steps. Include commands a reviewer can copy-paste. -->

- [ ]
- [ ]

## AI assistance

<!-- If you used generative AI (Claude, Cursor, Copilot, etc.) to draft code, tests, or copy in this PR, disclose it briefly. See CONTRIBUTING.md → "Generative AI policy" for what counts. Skip this section if no AI was used. -->

- [ ] None
- [ ] Used AI for: <one-line description>

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / cleanup

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm format` has been run on changed files
- [ ] Added or updated tests where it makes sense
- [ ] Branch is up to date with `main`
- [ ] PR title follows the area-prefix style for the area being changed (e.g. `worker: …`, `fix(slack): …`)
- [ ] Read [CONTRIBUTING.md](https://github.com/superloglabs/superlog/blob/main/CONTRIBUTING.md) (skim counts)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static outbound links and a URL constant on the landing page only; no auth, API, or data-path changes.
> 
> **Overview**
> Adds **Docs** entry points on the marketing landing page so visitors can open the Mintlify site at `https://docs.superlog.sh`.
> 
> A shared `LANDING_DOCS_URL` constant is introduced in `landingLinks.ts` (same pattern as the GitHub URL). **Top nav** gets a new external Docs link between GitHub and Pricing; the **footer Product** column lists Docs above Pricing. Both use `target="_blank"` and `rel="noreferrer"`.
> 
> Tests assert the constant value and that `Landing.tsx` wires the top-nav Docs anchor to `LANDING_DOCS_URL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 195c3da0830206a717e7ed4f41114c203027a2a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Docs link to the landing page top nav and footer Product section that points to https://docs.superlog.sh and opens in a new tab. Introduces `LANDING_DOCS_URL` and tests to verify the URL and link rendering.

<sup>Written for commit 195c3da0830206a717e7ed4f41114c203027a2a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

