### PR TITLE
perf(proxy): split ingest admission into buffer/upload lanes

### DIFF
--- a/apps/proxy/package.json
+++ b/apps/proxy/package.json
@@ -29,6 +29,7 @@
     "@opentelemetry/sdk-metrics": "^2.7.0",
     "@opentelemetry/sdk-node": "^0.215.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
+    "@smithy/node-http-handler": "^4.7.4",
     "@superlog/db": "workspace:*",
     "@superlog/fingerprint": "workspace:*",
     "dotenv": "^17.4.2",

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -4,7 +4,7 @@ import { Readable } from "node:stream";
 // tracing.ts, so the OTel flush can't race the ingest drain and exit early.
 import { shutdownTelemetry } from "./telemetry-shutdown.js";
 import { serve } from "@hono/node-server";
-import { type Span, SpanStatusCode, trace } from "@opentelemetry/api";
+import { type Span, SpanStatusCode, metrics, trace } from "@opentelemetry/api";
 import { hashApiKey, schema, syncLoopsContactsForProject } from "@superlog/db";
 import { db } from "@superlog/db";
 import { eq } from "drizzle-orm";
@@ -102,20 +102,59 @@ function otlpSignalForPath(path: string): TelemetrySignal | null {
   return null;
 }
 
-// Bound how many ingest requests buffer/stream their bodies at once. Together
-// with the per-request body cap (INGEST_MAX_BODY_BYTES) and S3 streaming for
-// large bodies, this makes the proxy's memory a provable constant — roughly
-// `permits × max_bytes_held_per_request` — so a burst can never OOM-kill the
-// task (exit 137, the 2026-05-31 incident). Excess requests WAIT for a permit
-// (backpressure) rather than being rejected; the body is only read once a permit
-// is held, so waiters cost ~nothing. Default 64; tune via
-// INGEST_MAX_INFLIGHT_REQUESTS, or set to 0 to disable.
+// Admission control is split into two lanes so a slow request can't head-of-line
+// block a fast one waiting for the same permit. The body is only read once a
+// permit is held, so each lane's memory is a provable constant (permits ×
+// max-bytes-held) — a burst can never OOM-kill the task (exit 137, the
+// 2026-05-31 incident). Excess requests WAIT for a permit (backpressure) rather
+// than being rejected; waiters cost ~nothing (just a socket + pending promise).
+//
+//  - BUFFER lane: small bodies that buffer in memory and ship inline (the common
+//    fast path), plus the direct-mode + Firehose paths that fully buffer. Memory
+//    ≈ permits × max-bytes-held.
+//  - UPLOAD lane: oversize bodies that stream to S3 via a multi-second multipart
+//    upload. These held a permit far longer than their memory cost justified
+//    (one 5 MiB part), so under an oversize burst they used to starve the buffer
+//    lane and stall small, latency-sensitive requests past their client timeout.
+//    A separate pool isolates that slow work. Memory ≈ permits × part.
+//
+// The request edge routes by Content-Length (ingestQueue.laneForContentLength).
+// Default 64 each; tune via INGEST_MAX_INFLIGHT_REQUESTS / INGEST_MAX_INFLIGHT_UPLOADS,
+// or set to 0 to disable a lane's limiter.
 const DEFAULT_MAX_INFLIGHT_REQUESTS = 64;
+const DEFAULT_MAX_INFLIGHT_UPLOADS = 64;
 const MAX_INFLIGHT_REQUESTS = readNonNegativeIntEnv(
   process.env.INGEST_MAX_INFLIGHT_REQUESTS,
   DEFAULT_MAX_INFLIGHT_REQUESTS,
 );
-const requestSemaphore = new Semaphore(MAX_INFLIGHT_REQUESTS);
+const MAX_INFLIGHT_UPLOADS = readNonNegativeIntEnv(
+  process.env.INGEST_MAX_INFLIGHT_UPLOADS,
+  DEFAULT_MAX_INFLIGHT_UPLOADS,
+);
+const bufferSemaphore = new Semaphore(MAX_INFLIGHT_REQUESTS);
+const uploadSemaphore = new Semaphore(MAX_INFLIGHT_UPLOADS);
+const ingestLaneSemaphores = { buffer: bufferSemaphore, upload: uploadSemaphore } as const;
+
+// Per-lane admission gauges, so an oversize burst that drains the upload lane and
+// backs up its waiter queue is visible instead of inferred. available_permits
+// hitting 0 with a rising queue_depth on a lane = that lane is the bottleneck.
+const ingestMeter = metrics.getMeter("@superlog/proxy");
+ingestMeter
+  .createObservableGauge("superlog.proxy.ingest.admission.available_permits", {
+    description: "Free admission permits per ingest lane (0 = lane saturated).",
+  })
+  .addCallback((observer) => {
+    observer.observe(bufferSemaphore.availablePermits, { "ingest.lane": "buffer" });
+    observer.observe(uploadSemaphore.availablePermits, { "ingest.lane": "upload" });
+  });
+ingestMeter
+  .createObservableGauge("superlog.proxy.ingest.admission.queue_depth", {
+    description: "Requests waiting for an admission permit per ingest lane (backpressure depth).",
+  })
+  .addCallback((observer) => {
+    observer.observe(bufferSemaphore.queueLength, { "ingest.lane": "buffer" });
+    observer.observe(uploadSemaphore.queueLength, { "ingest.lane": "upload" });
+  });
 
 // Hard per-request body ceiling for the no-queue (direct) path. The queue path
 // enforces its own copy via IngestQueueConfig.maxBodyBytes; both read the same
@@ -307,17 +346,30 @@ async function forward(c: Context<{ Variables: Variables }>, path: string, rootK
     let requestBytes = 0;
     let storage: "direct" | "inline" | "s3" = "direct";
 
+    // Route into the matching admission lane by declared body size, so a slow
+    // oversize S3 upload can't head-of-line block a tiny request. Unknown size
+    // (no Content-Length) defaults to the buffer lane; if such a body actually
+    // spills, captureBody still handles it correctly — only the lane differs.
+    // Direct mode (no queue, no S3) always uses the buffer lane.
+    const declaredContentLength = Number.parseInt(c.req.header("content-length") ?? "", 10);
+    const lane = ingestQueue
+      ? ingestQueue.laneForContentLength(
+          Number.isNaN(declaredContentLength) ? undefined : declaredContentLength,
+        )
+      : "buffer";
+    span.setAttribute("ingest.lane", lane);
+
     span.setAttribute("otlp.path", path);
     span.setAttribute("otlp.root_key", rootKey);
     span.setAttribute("tenant.project_id", projectId);
     span.setAttribute("http.request.content_type", contentType);
     if (contentEncoding) span.setAttribute("http.request.content_encoding", contentEncoding);
 
-    // Wait for a concurrency permit before touching the body. Excess requests
-    // queue here cheaply (just a pending promise + their socket) instead of being
-    // rejected — backpressure, not shedding. The body is only read once a permit
-    // is held, so memory stays bounded by `permits × max-bytes-per-request`.
-    await requestSemaphore.acquire();
+    // Wait for a permit in this request's lane before touching the body. Excess
+    // requests queue here cheaply (just a pending promise + their socket) instead
+    // of being rejected — backpressure, not shedding. The body is only read once a
+    // permit is held, so memory stays bounded by `permits × max-bytes-per-request`.
+    await ingestLaneSemaphores[lane].acquire();
 
     try {
       // Per-project source filter FIRST: if the project turned off its OTLP
@@ -483,10 +535,10 @@ async function forward(c: Context<{ Variables: Variables }>, path: string, rootK
       span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
       throw err;
     } finally {
-      // Release the permit once the body is fully read and forwarded. Released on
-      // every path (success, 4xx, throw) so a failing request can't leak permits
-      // and wedge the proxy into permanent backpressure.
-      requestSemaphore.release();
+      // Release the lane's permit once the body is fully read and forwarded.
+      // Released on every path (success, 4xx, throw) so a failing request can't
+      // leak permits and wedge the proxy into permanent backpressure.
+      ingestLaneSemaphores[lane].release();
 
       const durationMs = performance.now() - startedAt;
       const emitOperationalMetric = (org?: { orgId: string; orgName: string } | null) => {
@@ -499,6 +551,7 @@ async function forward(c: Context<{ Variables: Variables }>, path: string, rootK
           durationMs,
           requestBytes,
           storage,
+          lane,
         });
       };
       void lookupOrgForProject(projectId)
@@ -619,7 +672,9 @@ async function forwardFirehose(
       });
       if (!upstreamHeaders) return fail(400, "missing X-Amz-Firehose-Request-Id header");
 
-      await requestSemaphore.acquire();
+      // Firehose batches fully buffer (no S3 spill), so they belong in the
+      // buffer lane alongside the other memory-bounded buffered paths.
+      await bufferSemaphore.acquire();
       try {
         const bodyStream = requestBodyStream(c);
         if (!bodyStream) return fail(400, "empty Firehose request body");
@@ -675,7 +730,7 @@ async function forwardFirehose(
         resHeaders.set("content-type", res.headers.get("content-type") ?? "application/json");
         return new Response(res.body, { status: res.status, headers: resHeaders });
       } finally {
-        requestSemaphore.release();
+        bufferSemaphore.release();
       }
     } catch (err) {
       span.recordException(err as Error);

--- a/apps/proxy/src/ingest-queue.batch.test.ts
+++ b/apps/proxy/src/ingest-queue.batch.test.ts
@@ -33,6 +33,8 @@ function buildConfig(overrides: Partial<IngestQueueConfig> = {}): IngestQueueCon
     batchSize: 10,
     consumerConcurrency: 1,
     sendLingerMs: 5,
+    s3MaxSockets: 128,
+    sqsMaxSockets: 64,
     ...overrides,
   };
 }

--- a/apps/proxy/src/ingest-queue.shutdown.test.ts
+++ b/apps/proxy/src/ingest-queue.shutdown.test.ts
@@ -17,6 +17,8 @@ const config: IngestQueueConfig = {
   batchSize: 1,
   consumerConcurrency: 1,
   sendLingerMs: 0,
+  s3MaxSockets: 128,
+  sqsMaxSockets: 64,
 };
 
 const inlineBody = encodeIngestMessage(

--- a/apps/proxy/src/ingest-queue.stream.test.ts
+++ b/apps/proxy/src/ingest-queue.stream.test.ts
@@ -1,7 +1,21 @@
 import { strict as assert } from "node:assert";
-import { test } from "node:test";
+import { after, before, test } from "node:test";
 import { PayloadTooLargeError, type SpillSink } from "./body-capture.js";
 import { IngestQueue, type IngestQueueConfig, type SpillSinkFactory } from "./ingest-queue.js";
+
+// The producer's micro-batch flush timer is unref()'d (see IngestQueue.sendToQueue),
+// so under the bare test runner the event loop can drain before the timer fires and
+// an enqueue() promise would never settle ("Promise resolution is still pending but
+// the event loop has already resolved"). Whether it drains in time depends on
+// incidental module-load timing, so pin prod's "the HTTP server keeps the loop alive"
+// condition with a single ref'd keepalive for the suite. Mirrors ingest-queue.batch.test.ts.
+let suiteKeepAlive: NodeJS.Timeout;
+before(() => {
+  suiteKeepAlive = setInterval(() => {}, 60_000);
+});
+after(() => {
+  clearInterval(suiteKeepAlive);
+});
 
 class FakeSqs {
   sent: string[] = [];
@@ -54,6 +68,8 @@ function buildQueue(overrides: Partial<IngestQueueConfig> = {}): {
     batchSize: 10,
     consumerConcurrency: 4,
     sendLingerMs: 0,
+    s3MaxSockets: 128,
+    sqsMaxSockets: 64,
     ...overrides,
   };
   const sinks: RecordingSink[] = [];

--- a/apps/proxy/src/ingest-queue.test.ts
+++ b/apps/proxy/src/ingest-queue.test.ts
@@ -5,6 +5,7 @@ import {
   describeCollectorFailure,
   encodeIngestMessage,
   getIngestQueueConfig,
+  ingestLaneForContentLength,
   isPermanentCollectorFailure,
   isPoisonMessageError,
   parseIngestMessage,
@@ -177,4 +178,47 @@ test("queueDeliveryMetricFromParsedMessage ignores malformed parsed payloads", (
     ),
     null,
   );
+});
+
+// Lane routing: small requests buffer-and-inline (the fast lane); only bodies
+// over the inline threshold stream to S3 (the slow, multi-second upload lane).
+// Routing on Content-Length keeps a slow oversize upload from head-of-line
+// blocking a tiny request behind the same admission permit.
+test("ingestLaneForContentLength routes by the inline threshold", () => {
+  const threshold = 175_000;
+  // A body at or under the threshold buffers inline → fast lane.
+  assert.equal(ingestLaneForContentLength(0, threshold), "buffer");
+  assert.equal(ingestLaneForContentLength(1, threshold), "buffer");
+  assert.equal(ingestLaneForContentLength(threshold, threshold), "buffer");
+  // Strictly over the threshold spills to S3 → upload lane.
+  assert.equal(ingestLaneForContentLength(threshold + 1, threshold), "upload");
+  assert.equal(ingestLaneForContentLength(40 * 1024 * 1024, threshold), "upload");
+});
+
+test("ingestLaneForContentLength defaults to the buffer lane when size is unknown or invalid", () => {
+  const threshold = 175_000;
+  // No Content-Length header (chunked) → buffer lane; captureBody promotes to a
+  // spill if it actually crosses the threshold while streaming.
+  assert.equal(ingestLaneForContentLength(undefined, threshold), "buffer");
+  assert.equal(ingestLaneForContentLength(Number.NaN, threshold), "buffer");
+  assert.equal(ingestLaneForContentLength(-1, threshold), "buffer");
+});
+
+test("getIngestQueueConfig reads bounded S3/SQS socket pools", () => {
+  const base = { INGEST_QUEUE_URL: "https://sqs.us-west-2.amazonaws.com/123/superlog-test-ingest" };
+
+  // Defaults: the S3 pool is generous enough that oversize uploads don't queue
+  // at the socket layer below the upload-lane permit cap.
+  const defaults = getIngestQueueConfig(base);
+  assert.equal(defaults?.s3MaxSockets, 128);
+  assert.equal(defaults?.sqsMaxSockets, 64);
+
+  // Overridable via env.
+  const tuned = getIngestQueueConfig({
+    ...base,
+    INGEST_S3_MAX_SOCKETS: "256",
+    INGEST_SQS_MAX_SOCKETS: "96",
+  });
+  assert.equal(tuned?.s3MaxSockets, 256);
+  assert.equal(tuned?.sqsMaxSockets, 96);
 });

--- a/apps/proxy/src/ingest-queue.ts
+++ b/apps/proxy/src/ingest-queue.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { Agent as HttpsAgent } from "node:https";
 import { PassThrough } from "node:stream";
 import { setTimeout as sleep } from "node:timers/promises";
 import {
@@ -17,6 +18,7 @@ import {
   SendMessageBatchCommand,
 } from "@aws-sdk/client-sqs";
 import { Upload } from "@aws-sdk/lib-storage";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
 import { type SpillSink, captureBody } from "./body-capture.js";
 import type { IngestRowWriter } from "./clickhouse-writer.js";
 import { stampIssueFingerprintsFailOpen } from "./ingest-fingerprints.js";
@@ -34,6 +36,15 @@ const INLINE_ENVELOPE_SLACK_BYTES = 1_024;
 // One S3 multipart part held in memory at a time per spilling upload, so a
 // large body costs ~PART_SIZE of RSS regardless of its total size.
 const SPILL_PART_SIZE_BYTES = 5 * 1024 * 1024;
+// Per-origin socket caps for the AWS SDK HTTP clients. @smithy/node-http-handler
+// defaults to 50 sockets per origin; under an oversize-payload burst that pool
+// can become a hidden bottleneck *tighter* than the upload-lane permit cap, so
+// uploads serialize at the socket layer and hold their admission permit longer.
+// We size the S3 pool generously (above the upload-lane permit count) so the
+// explicit semaphore — not an invisible socket queue — is the single point of
+// backpressure. SQS sends are coalesced into batches, so a smaller pool suffices.
+const DEFAULT_S3_MAX_SOCKETS = 128;
+const DEFAULT_SQS_MAX_SOCKETS = 64;
 const DEFAULT_WAIT_TIME_SECONDS = 20;
 const DEFAULT_VISIBILITY_TIMEOUT_SECONDS = 120;
 const DEFAULT_BATCH_SIZE = 10;
@@ -68,7 +79,33 @@ export type IngestQueueConfig = {
   batchSize: number;
   consumerConcurrency: number;
   sendLingerMs: number;
+  s3MaxSockets: number;
+  sqsMaxSockets: number;
 };
+
+/**
+ * Which admission lane a request belongs in, decided from its declared
+ * `Content-Length`. A body at or under the inline threshold buffers in memory
+ * and ships inline — cheap and fast (the "buffer" lane). A larger body streams
+ * to S3 via a multi-second multipart upload (the "upload" lane). Keeping the two
+ * in separate permit pools stops a slow oversize upload from head-of-line
+ * blocking a tiny request waiting for the same admission permit.
+ *
+ * Unknown or invalid sizes (no Content-Length / chunked transfer) default to the
+ * buffer lane; `captureBody` still promotes such a body to an S3 spill if it
+ * actually crosses the threshold while streaming, so correctness never depends
+ * on the header being present — only the lane assignment does.
+ */
+export function ingestLaneForContentLength(
+  declaredContentLengthBytes: number | undefined,
+  inlineThresholdBytes: number,
+): "buffer" | "upload" {
+  if (declaredContentLengthBytes === undefined) return "buffer";
+  if (!Number.isFinite(declaredContentLengthBytes) || declaredContentLengthBytes < 0) {
+    return "buffer";
+  }
+  return declaredContentLengthBytes > inlineThresholdBytes ? "upload" : "buffer";
+}
 
 export type IngestQueueInput = {
   path: string;
@@ -151,6 +188,8 @@ export function getIngestQueueConfig(env: NodeJS.ProcessEnv): IngestQueueConfig 
       32,
     ),
     sendLingerMs: readNonNegativeInt(env.INGEST_QUEUE_SEND_LINGER_MS, DEFAULT_SEND_LINGER_MS),
+    s3MaxSockets: readPositiveInt(env.INGEST_S3_MAX_SOCKETS, DEFAULT_S3_MAX_SOCKETS),
+    sqsMaxSockets: readPositiveInt(env.INGEST_SQS_MAX_SOCKETS, DEFAULT_SQS_MAX_SOCKETS),
   };
 }
 
@@ -311,7 +350,9 @@ export class IngestQueue {
   // Raw-byte threshold below which a body's base64 inline envelope still fits
   // within maxMessageBytes. Bodies at or under this are buffered in memory and
   // sent inline; larger ones stream to S3. Derived from the SQS message budget.
-  private readonly inlineRawThreshold: number;
+  // Public so the request edge can route by Content-Length into the matching
+  // admission lane (see {@link laneForContentLength}).
+  readonly inlineRawThreshold: number;
   private readonly spillSinkFactory: SpillSinkFactory;
 
   constructor(
@@ -321,8 +362,22 @@ export class IngestQueue {
     private readonly rowWriter?: IngestRowWriter,
   ) {
     const clientConfig = config.region ? { region: config.region } : {};
-    this.sqs = new SQSClient(clientConfig);
-    this.s3 = new S3Client(clientConfig);
+    // Explicit, generously-sized socket pools so oversize S3 uploads don't queue
+    // at the default 50-socket-per-origin layer (which would hold their admission
+    // permit longer and starve the buffer lane). The semaphores are the intended
+    // backpressure point, not the SDK's hidden socket cap.
+    this.sqs = new SQSClient({
+      ...clientConfig,
+      requestHandler: new NodeHttpHandler({
+        httpsAgent: new HttpsAgent({ keepAlive: true, maxSockets: config.sqsMaxSockets }),
+      }),
+    });
+    this.s3 = new S3Client({
+      ...clientConfig,
+      requestHandler: new NodeHttpHandler({
+        httpsAgent: new HttpsAgent({ keepAlive: true, maxSockets: config.s3MaxSockets }),
+      }),
+    });
     this.inlineRawThreshold = Math.max(
       0,
       Math.floor(((config.maxMessageBytes - INLINE_ENVELOPE_SLACK_BYTES) * 3) / 4),
@@ -337,6 +392,13 @@ export class IngestQueue {
         }
         return this.createS3SpillSink(bucket, key, contentType);
       });
+  }
+
+  /** The admission lane a request with this declared `Content-Length` belongs in,
+   *  using this queue's configured inline threshold. See
+   *  {@link ingestLaneForContentLength}. */
+  laneForContentLength(declaredContentLengthBytes: number | undefined): "buffer" | "upload" {
+    return ingestLaneForContentLength(declaredContentLengthBytes, this.inlineRawThreshold);
   }
 
   async enqueue(input: IngestQueueInput): Promise<"inline" | "s3"> {

--- a/apps/proxy/src/operational-metrics.test.ts
+++ b/apps/proxy/src/operational-metrics.test.ts
@@ -22,6 +22,7 @@ test("createProxyOperationalRecorder records ingest requests by org, project, si
     durationMs: 18,
     requestBytes: 2048,
     storage: "s3",
+    lane: "upload",
   });
 
   assert.deepEqual(requests, [
@@ -35,6 +36,7 @@ test("createProxyOperationalRecorder records ingest requests by org, project, si
         "http.response.status_code": 200,
         "http.response.status_class": "2xx",
         "ingest.queue.storage": "s3",
+        "ingest.lane": "upload",
       },
     },
   ]);
@@ -93,6 +95,7 @@ test("recordIngestRequest can emit without org enrichment", () => {
     durationMs: 5,
     requestBytes: 0,
     storage: "direct",
+    lane: "buffer",
   });
 
   assert.deepEqual(requests, [
@@ -104,6 +107,7 @@ test("recordIngestRequest can emit without org enrichment", () => {
         "http.response.status_code": 500,
         "http.response.status_class": "5xx",
         "ingest.queue.storage": "direct",
+        "ingest.lane": "buffer",
       },
     },
   ]);

--- a/apps/proxy/src/operational-metrics.ts
+++ b/apps/proxy/src/operational-metrics.ts
@@ -28,6 +28,7 @@ export type IngestRequestMetricInput = {
   durationMs: number;
   requestBytes: number;
   storage: "direct" | "inline" | "s3";
+  lane: "buffer" | "upload";
 };
 
 export type QueueDeliveryMetricInput = {
@@ -71,6 +72,7 @@ export function createProxyOperationalRecorder(instruments: ProxyOperationalInst
         "http.response.status_code": input.statusCode,
         "http.response.status_class": statusClass(input.statusCode),
         "ingest.queue.storage": input.storage,
+        "ingest.lane": input.lane,
       };
       instruments.ingestRequests?.add(1, attrs);
       instruments.ingestDurationMs?.record(input.durationMs, attrs);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.40.0
         version: 1.40.0
+      '@smithy/node-http-handler':
+        specifier: ^4.7.4
+        version: 4.7.7
       '@superlog/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -6111,7 +6114,7 @@ snapshots:
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
       '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/node-http-handler': 4.7.4
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -6178,7 +6181,7 @@ snapshots:
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
       '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/node-http-handler': 4.7.4
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -6399,7 +6402,7 @@ snapshots:
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
       '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/node-http-handler': 4.7.4
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 


### PR DESCRIPTION
## Problem

Ingest requests share a single concurrency-permit pool, and the request body is only read *after* a permit is held. A burst of **oversize payloads** — which stream to S3 via a multi-second multipart upload — therefore hold permits far longer than their one-part (5 MiB) memory cost justifies, **head-of-line blocking tiny requests** waiting for the same permit. Small, latency-sensitive senders then wait seconds for an ack and can hit their client timeout, even when steady-state ingest is perfectly healthy.

The AWS SDK's default **50-socket-per-origin** pool compounds it: a hidden bottleneck *tighter* than the permit cap, so oversize uploads also serialize at the socket layer and hold their admission permit even longer.

Observed in prod as a per-minute `TargetResponseTime` **max climbing to 5–10s while p50/p99 stayed flat** (~0.12s/0.5s) during oversize-payload bursts — the classic signature of a small number of requests stuck behind slow ones, not a uniform slowdown. CPU/memory were idle the whole time, so it isn't a resource ceiling; it's contention on shared admission resources.

## Fix

Split admission into two lanes, routed by `Content-Length`:

- **buffer lane** (`INGEST_MAX_INFLIGHT_REQUESTS`, default 64): small inline bodies plus the direct-mode and Firehose fully-buffered paths.
- **upload lane** (`INGEST_MAX_INFLIGHT_UPLOADS`, default 64): oversize bodies that stream to S3.

A tiny request can no longer queue behind a slow oversize upload. Per-lane memory stays a provable constant (`permits × max-bytes-held`). **Durability is unchanged** — messages are still acked only after the SQS batch confirms. Unknown size (no `Content-Length`) defaults to the buffer lane; `captureBody` still promotes such a body to an S3 spill if it actually crosses the threshold, so correctness never depends on the header — only lane assignment does.

Also in this PR:

- **Explicit, generously-sized socket pools** for the S3/SQS clients (`INGEST_S3_MAX_SOCKETS=128`, `INGEST_SQS_MAX_SOCKETS=64`) so oversize uploads don't serialize at the SDK's hidden 50-socket cap — the explicit semaphores are the intended single point of backpressure.
- **Per-lane admission observability**: gauges `superlog.proxy.ingest.admission.available_permits` and `…queue_depth` (attributed by `ingest.lane`), plus an `ingest.lane` attribute on the ingest-request metric. `available_permits` hitting 0 with a rising `queue_depth` on a lane pinpoints the bottleneck instead of leaving it to be inferred.

## Tests

- New unit tests for `ingestLaneForContentLength` (threshold boundary, unknown/invalid size → buffer lane) and the socket-pool config parsing.
- Existing config/metric fixtures updated for the new required fields.
- Added the suite-keepalive guard to `ingest-queue.stream.test.ts` (mirrors `ingest-queue.batch.test.ts`) so the spill tests no longer depend on incidental event-loop liveness around the unref'd flush timer.
- Full proxy suite green (79/79), typecheck clean.

## Deploy note

New env knobs (`INGEST_MAX_INFLIGHT_UPLOADS`, `INGEST_S3_MAX_SOCKETS`, `INGEST_SQS_MAX_SOCKETS`) all have safe defaults; no config change is required to deploy. Watch the new admission gauges after rollout to confirm the upload lane absorbs oversize bursts without the buffer lane's `queue_depth` rising.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the ingest hot path (concurrency, lane routing, AWS client wiring); behavior is intentional for a prod latency incident but mis-tuned limits or wrong lane assignment could change backpressure under burst load.
> 
> **Overview**
> **Ingest admission is split into separate buffer and upload permit pools** so slow multipart S3 uploads no longer head-of-line block small OTLP requests that share one semaphore. The OTLP path picks a lane from `Content-Length` against the queue inline threshold (`ingestLaneForContentLength` / `laneForContentLength`); Firehose and direct/no-queue paths stay on the buffer lane. New tuning knob `INGEST_MAX_INFLIGHT_UPLOADS` (default 64) sits beside `INGEST_MAX_INFLIGHT_REQUESTS`.
> 
> **S3 and SQS clients** get explicit keep-alive HTTP handlers with raised socket caps (`INGEST_S3_MAX_SOCKETS`, `INGEST_SQS_MAX_SOCKETS`) so the SDK’s default ~50-socket limit doesn’t serialize uploads under the upload-lane permits.
> 
> **Observability:** per-lane gauges for free permits and waiter queue depth, plus `ingest.lane` on ingest spans and operational ingest metrics. Tests cover lane routing, socket config, and stream-suite event-loop keepalive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f62c1f26850270e38373c337633c2049e852930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split ingest admission into two lanes (buffer and upload) so large uploads can’t block small requests. Adds per-lane metrics and larger S3/SQS socket pools to remove hidden bottlenecks and make backpressure visible.

- **New Features**
  - Two admission lanes by Content-Length: buffer (`INGEST_MAX_INFLIGHT_REQUESTS`, default 64) and upload (`INGEST_MAX_INFLIGHT_UPLOADS`, default 64). Unknown sizes default to buffer. Firehose and direct-mode use buffer. Durability unchanged.
  - Per-lane gauges: `superlog.proxy.ingest.admission.available_permits` and `superlog.proxy.ingest.admission.queue_depth`. Added `ingest.lane` attribute on the ingest request metric.
  - Explicit socket pools to avoid the SDK’s 50-socket cap: `INGEST_S3_MAX_SOCKETS` (default 128) and `INGEST_SQS_MAX_SOCKETS` (default 64).
  - Safe defaults. No config change needed. Monitor the new gauges after rollout.

- **Dependencies**
  - Added `@smithy/node-http-handler` to configure keep-alive HTTP agents with tuned `maxSockets` for S3/SQS.

<sup>Written for commit 4f62c1f26850270e38373c337633c2049e852930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

