### PR TITLE
fix(cloudflare): valid destination name + skip preflight + surface validation errors

### DIFF
--- a/apps/api/src/cloudflare-service.test.ts
+++ b/apps/api/src/cloudflare-service.test.ts
@@ -93,7 +93,11 @@ test("buildDestinationPayload builds a Logpush OTLP destination with the ingest 
     ingestKey: "sl_public_abc123",
   });
   assert.equal(payload.enabled, true);
-  assert.equal(payload.name, "Superlog logs");
+  // Cloudflare requires the name to match ^[a-z0-9-]+$ — a display string like
+  // "Superlog logs" is rejected with a ZodError.
+  assert.equal(payload.name, "superlog-logs");
+  assert.match(payload.name, /^[a-z0-9-]+$/);
+  assert.equal(payload.skipPreflightCheck, true);
   assert.equal(payload.configuration.type, "logpush");
   assert.equal(payload.configuration.logpushDataset, "opentelemetry-logs");
   assert.equal(payload.configuration.url, "https://intake.example.com/v1/logs");
@@ -202,6 +206,18 @@ test("parseCreateDestinationResponse returns slug on success and message on fail
   assert.deepEqual(
     parseCreateDestinationResponse({ success: false, errors: [{ message: "nope" }] }),
     { ok: false, error: "nope" },
+  );
+  // Request-body validation failures come back as a ZodError, not the standard
+  // envelope — surface the issue message instead of a generic "request_failed".
+  assert.deepEqual(
+    parseCreateDestinationResponse({
+      success: false,
+      error: {
+        name: "ZodError",
+        issues: [{ message: "The destination name must contain only lowercase letters…" }],
+      },
+    }),
+    { ok: false, error: "The destination name must contain only lowercase letters…" },
   );
   // A malformed/partial response that omits `success` must NOT be accepted as a
   // provisioned destination — it's a failure, not a slug-less success.

--- a/apps/api/src/cloudflare-service.ts
+++ b/apps/api/src/cloudflare-service.ts
@@ -106,6 +106,11 @@ export function intakeUrlForSignal(base: string, signal: CloudflareSignal): stri
 export type DestinationPayload = {
   name: string;
   enabled: boolean;
+  // Skip Cloudflare's create-time reachability probe. The probe is a Logpush-style
+  // test request against the destination URL; our intake speaks OTLP and rejects
+  // it, which fails the create even though the real OTLP export path works. We own
+  // the intake and mint the key here, so the probe adds nothing but a failure mode.
+  skipPreflightCheck: boolean;
   configuration: {
     type: "logpush";
     logpushDataset: string;
@@ -118,6 +123,9 @@ export type DestinationPayload = {
  * Build the Workers Observability destination payload for one signal: a Logpush
  * destination with the matching `opentelemetry-*` dataset, pointed at our intake
  * and authenticated with the project's ingest key via `x-api-key`.
+ *
+ * The destination `name` must match Cloudflare's `^[a-z0-9-]+$` rule (lowercase
+ * letters, numbers, hyphens), so it's `superlog-<signal>` — not a display string.
  */
 export function buildDestinationPayload(input: {
   signal: CloudflareSignal;
@@ -126,8 +134,9 @@ export function buildDestinationPayload(input: {
 }): DestinationPayload {
   const sig = CLOUDFLARE_OTLP_SIGNALS[input.signal];
   return {
-    name: `Superlog ${input.signal}`,
+    name: `superlog-${input.signal}`,
     enabled: true,
+    skipPreflightCheck: true,
     configuration: {
       type: "logpush",
       logpushDataset: sig.dataset,
@@ -228,6 +237,30 @@ export type CreateDestinationResult =
   | { ok: true; slug: string | null }
   | { ok: false; error: string };
 
+/**
+ * Pull a human-readable error out of a failed create-destination response.
+ * Cloudflare uses two shapes here: the standard envelope `{errors:[{message}]}`,
+ * and — for request-body validation — a Zod error `{error:{name, issues:[{message,
+ * path}]}}` (mirrored as `_error`). We surface both so a validation failure (e.g.
+ * an invalid destination name) isn't flattened to a generic "request_failed".
+ */
+function extractCreateError(o: Record<string, unknown>): string {
+  const errors = Array.isArray(o.errors) ? o.errors : [];
+  const first = errors[0] as Record<string, unknown> | undefined;
+  if (first && typeof first.message === "string") return first.message;
+
+  const zod = (o.error ?? o._error) as Record<string, unknown> | undefined;
+  if (zod && typeof zod === "object") {
+    const issues = Array.isArray(zod.issues) ? zod.issues : [];
+    const msgs = issues
+      .map((i) => (i as Record<string, unknown>)?.message)
+      .filter((m): m is string => typeof m === "string");
+    if (msgs.length > 0) return msgs.join("; ");
+    if (typeof zod.name === "string") return zod.name;
+  }
+  return "request_failed";
+}
+
 /** Parse the create-destination response → `{ success, result: { slug } }`. */
 export function parseCreateDestinationResponse(json: unknown): CreateDestinationResult {
   if (!json || typeof json !== "object") return { ok: false, error: "invalid_response" };
@@ -237,10 +270,7 @@ export function parseCreateDestinationResponse(json: unknown): CreateDestination
   // that omits it) as a failure — otherwise an error body could be recorded as a
   // provisioned destination with an empty slug.
   if (o.success !== true) {
-    const errors = Array.isArray(o.errors) ? o.errors : [];
-    const first = errors[0] as Record<string, unknown> | undefined;
-    const msg = first && typeof first.message === "string" ? first.message : "request_failed";
-    return { ok: false, error: msg };
+    return { ok: false, error: extractCreateError(o) };
   }
   const result = o.result;
   const slug =


### PR DESCRIPTION
Connecting Cloudflare failed at destination creation — every signal returned a generic `request_failed` and the connect aborted with "no telemetry destinations were created". Root cause, confirmed against the live API:

1. **Invalid destination `name`.** The create endpoint requires `name` to match `^[a-z0-9-]+$` (lowercase letters, numbers, hyphens). We sent a display string `"Superlog <signal>"` (capital + space), so Cloudflare rejected it:
   ```json
   {"success":false,"error":{"name":"ZodError","issues":[{"message":"The destination name must contain only lowercase letters, numbers, and hyphens and dashes.","path":["name"]}]}}
   ```
2. **The real error was masked.** That validation failure is a `ZodError` shape (`{error:{issues:[{message}]}}`), not the standard `{errors:[{message}]}` envelope, so `parseCreateDestinationResponse` flattened it to `request_failed` — which made it look like a transport/permission problem.
3. **Preflight probe.** The create runs a preflight reachability probe (a Logpush-style request) against the destination URL; an OTLP intake rejects that probe, so the create fails even when the real OTLP export path is fine.

## Fix
- `name` → `superlog-<signal>` (matches `^[a-z0-9-]+$`).
- Set `skipPreflightCheck: true` — we own the intake and mint the key, so the probe only adds a failure mode.
- `parseCreateDestinationResponse` now also surfaces `ZodError` issue messages, so a request-body validation failure shows the real reason instead of `request_failed`.

## Test
- `pnpm --filter @superlog/api exec tsx --test src/cloudflare-service.test.ts` — 15 pass (added name-regex + skipPreflightCheck + ZodError-parsing assertions).
- typecheck + biome clean.
- Verified end-to-end against the live API with a real OAuth token: the old payload returns the ZodError; `name: "superlog-traces"` returns `success: true` with a slug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Cloudflare connect provisioning path and destination naming; misconfiguration could affect telemetry export for connected projects, but scope is limited to the connector module with unit test coverage.
> 
> **Overview**
> Fixes **Cloudflare Workers Observability destination creation** so Connect can provision OTLP destinations instead of failing with a generic `request_failed`.
> 
> **Destination payload:** `buildDestinationPayload` now uses `superlog-<signal>` names (matching Cloudflare’s `^[a-z0-9-]+$` rule) instead of display strings like `Superlog logs`, and sets **`skipPreflightCheck: true`** so create-time Logpush-style probes don’t fail against an OTLP-only intake.
> 
> **Error handling:** Failed creates now surface **Zod validation messages** from Cloudflare’s `{ error: { issues: [...] } }` body via `extractCreateError`, not only the standard `{ errors: [{ message }] }` envelope—so invalid names and similar body errors show the real reason in the UI/logs.
> 
> Tests cover the new name/skip-preflight behavior and Zod-shaped error parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e48a62f6857b0f9f676a08b208b6fea33350ba18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Cloudflare destination creation failures: names now meet API rules, preflight is skipped for OTLP, and we surface validation messages instead of a generic error. This unblocks connecting all signals and shows clear error messages when input is invalid.

- **Bug Fixes**
  - Destination name now conforms to `^[a-z0-9-]+$`: `superlog-<signal>`.
  - Set `skipPreflightCheck: true` to avoid the Logpush probe that OTLP intake rejects.
  - Updated `parseCreateDestinationResponse` to extract messages from `{error:{issues[]}}` (and `_error`) so validation errors are shown.

<sup>Written for commit e48a62f6857b0f9f676a08b208b6fea33350ba18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

