### PR TITLE
feat(cloudflare): auto-wire the account's Workers to the destinations on connect

### DIFF
--- a/apps/api/src/cloudflare-service.test.ts
+++ b/apps/api/src/cloudflare-service.test.ts
@@ -12,10 +12,12 @@ import {
   listAccounts,
   parseAccountsResponse,
   parseCreateDestinationResponse,
+  parseScriptsResponse,
   parseTokenResponse,
   signState,
   staleDestinationSlugs,
   verifyState,
+  wireObservabilityDestinations,
 } from "./cloudflare-service.js";
 
 const SECRET = "test-state-secret";
@@ -33,9 +35,11 @@ test("cloudflareConfigFromEnv returns null until required vars are set", () => {
   assert.equal(cfg.intakeBaseUrl, "https://intake.example.com");
   assert.equal(cfg.redirectUri, "http://localhost:4100/cloudflare/oauth/callback");
   assert.deepEqual(cfg.scopes, [
-    "account.read",
-    "workers-observability.read",
+    "account-settings.read",
     "workers-observability.write",
+    "workers-observability-telemetry.write",
+    "workers-scripts.read",
+    "workers-scripts.write",
   ]);
 });
 
@@ -192,6 +196,64 @@ test("staleDestinationSlugs only deletes prior slugs for signals that got a repl
 
   // Cloudflare returned the same slug (upsert-by-name) → it's the live one, keep it.
   assert.deepEqual(staleDestinationSlugs({ traces: "same" }, { traces: "same" }), {});
+});
+
+test("parseScriptsResponse pulls script ids and ignores malformed rows", () => {
+  assert.deepEqual(
+    parseScriptsResponse({ result: [{ id: "worker-a" }, { id: "worker-b" }, {}, "x"] }),
+    ["worker-a", "worker-b"],
+  );
+  assert.deepEqual(parseScriptsResponse(null), []);
+});
+
+test("wireObservabilityDestinations is additive + idempotent and skips when already wired", () => {
+  // Fresh Worker (no observability) → enable everything, add both destinations.
+  assert.deepEqual(
+    wireObservabilityDestinations(null, { traces: "superlog-traces", logs: "superlog-logs" }),
+    {
+      enabled: true,
+      logs: { enabled: true, destinations: ["superlog-logs"] },
+      traces: { enabled: true, destinations: ["superlog-traces"] },
+    },
+  );
+
+  // Existing config: keep other destinations + fields, append ours, enable traces.
+  assert.deepEqual(
+    wireObservabilityDestinations(
+      {
+        enabled: true,
+        head_sampling_rate: 1,
+        logs: { enabled: true, persist: true, destinations: ["other-dest"] },
+        traces: { enabled: false, head_sampling_rate: 1 },
+      },
+      { traces: "superlog-traces", logs: "superlog-logs" },
+    ),
+    {
+      enabled: true,
+      head_sampling_rate: 1,
+      logs: { enabled: true, persist: true, destinations: ["other-dest", "superlog-logs"] },
+      traces: { enabled: true, head_sampling_rate: 1, destinations: ["superlog-traces"] },
+    },
+  );
+
+  // Already wired → null (no PATCH needed).
+  assert.equal(
+    wireObservabilityDestinations(
+      {
+        enabled: true,
+        logs: { enabled: true, destinations: ["superlog-logs"] },
+        traces: { enabled: true, destinations: ["superlog-traces"] },
+      },
+      { traces: "superlog-traces", logs: "superlog-logs" },
+    ),
+    null,
+  );
+
+  // Only the signals we pass a slug for are touched.
+  assert.deepEqual(wireObservabilityDestinations(null, { logs: "superlog-logs" }), {
+    enabled: true,
+    logs: { enabled: true, destinations: ["superlog-logs"] },
+  });
 });
 
 test("parseCreateDestinationResponse returns slug on success and message on failure", () => {

--- a/apps/api/src/cloudflare-service.test.ts
+++ b/apps/api/src/cloudflare-service.test.ts
@@ -8,6 +8,7 @@ import {
   createDestination,
   deleteDestination,
   exchangeCodeForToken,
+  getScriptObservability,
   intakeUrlForSignal,
   listAccounts,
   parseAccountsResponse,
@@ -196,6 +197,21 @@ test("staleDestinationSlugs only deletes prior slugs for signals that got a repl
 
   // Cloudflare returned the same slug (upsert-by-name) → it's the live one, keep it.
   assert.deepEqual(staleDestinationSlugs({ traces: "same" }, { traces: "same" }), {});
+});
+
+test("getScriptObservability throws on a failed read but returns null when genuinely unset", async () => {
+  const obs = { enabled: true, logs: { enabled: true, destinations: ["d"] } };
+  const respond = (status: number, body: unknown) =>
+    (async () => new Response(JSON.stringify(body), { status })) as unknown as typeof fetch;
+  const call = (fetchImpl: typeof fetch) =>
+    getScriptObservability({ accountId: "a", script: "w", accessToken: "t", fetchImpl });
+
+  assert.deepEqual(await call(respond(200, { success: true, result: { observability: obs } })), obs);
+  // success + no observability → genuinely fresh Worker.
+  assert.equal(await call(respond(200, { success: true, result: {} })), null);
+  // A failed read must THROW — never resolve to null (which would make the caller
+  // PATCH a minimal config and clobber the Worker's real observability).
+  await assert.rejects(() => call(respond(403, { success: false, errors: [{ message: "nope" }] })));
 });
 
 test("parseScriptsResponse pulls script ids and ignores malformed rows", () => {

--- a/apps/api/src/cloudflare-service.ts
+++ b/apps/api/src/cloudflare-service.ts
@@ -21,18 +21,23 @@ export const CLOUDFLARE_OAUTH_TOKEN_URL = "https://dash.cloudflare.com/oauth2/to
 export const CLOUDFLARE_OAUTH_REVOKE_URL = "https://dash.cloudflare.com/oauth2/revoke";
 export const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4";
 
-// Cloudflare OAuth scope identifiers mirror API-token permission names
-// (dot-delimited). These defaults cover what the connector needs: read the
-// account list (to resolve the account id the destination APIs are scoped to)
-// and manage Workers Observability telemetry destinations. They're best-effort —
-// confirm the exact identifiers via `GET /client/v4/oauth/scopes` when
-// registering the client and override with CLOUDFLARE_OAUTH_SCOPES if they
-// differ. `offline_access` is added/removed automatically by Cloudflare based on
-// the client's grant types, so we don't list it here.
+// Cloudflare OAuth scope identifiers (dot-delimited, mirroring API-token
+// permission names — verified against `GET /client/v4/oauth/scopes`). The
+// connector needs to:
+//   - account-settings.read            list the account (resolve the account id)
+//   - workers-observability(.write)    create the telemetry destinations
+//   - workers-observability-telemetry.write   (destinations live under this perm)
+//   - workers-scripts.read/.write      read each Worker's observability config
+//                                      and wire our destinations into it
+// Override with CLOUDFLARE_OAUTH_SCOPES if a deployment's client differs.
+// `offline_access` is added/removed automatically by Cloudflare based on the
+// client's grant types, so we don't list it here.
 export const DEFAULT_CLOUDFLARE_OAUTH_SCOPES = [
-  "account.read",
-  "workers-observability.read",
+  "account-settings.read",
   "workers-observability.write",
+  "workers-observability-telemetry.write",
+  "workers-scripts.read",
+  "workers-scripts.write",
 ];
 
 export type CloudflareSignal = "traces" | "logs" | "metrics";
@@ -306,6 +311,71 @@ export function staleDestinationSlugs(
 }
 
 // ---------------------------------------------------------------------------
+// Worker observability wiring
+//
+// Creating a destination is not enough: a Worker only exports to a destination
+// when its own `observability` config enables the signal and lists the
+// destination by name. So on connect we read each Worker's settings and merge our
+// destination slugs in.
+// ---------------------------------------------------------------------------
+
+export type WorkerObservabilitySignal = {
+  enabled?: boolean;
+  destinations?: string[];
+  [k: string]: unknown;
+};
+export type WorkerObservability = {
+  enabled?: boolean;
+  logs?: WorkerObservabilitySignal;
+  traces?: WorkerObservabilitySignal;
+  [k: string]: unknown;
+};
+
+/** signal → the Worker `observability` sub-key it maps to (metrics isn't a Worker signal). */
+const WORKER_OBSERVABILITY_SIGNALS = ["logs", "traces"] as const;
+
+/**
+ * Merge our destination slugs into a Worker's existing observability config so it
+ * exports the matching signals to our intake. Additive and idempotent: turns on
+ * observability and each wired signal, and appends our slug to that signal's
+ * `destinations` without dropping the Worker's existing destinations, sampling
+ * rates, or any other fields. Returns the updated config, or `null` when the
+ * Worker is already wired (nothing to change) so the caller can skip the PATCH.
+ *
+ * `slugs` maps our signal name (traces/logs) to the destination slug we created;
+ * metrics is omitted because Workers Observability has no per-Worker metrics
+ * signal.
+ */
+export function wireObservabilityDestinations(
+  current: WorkerObservability | null | undefined,
+  slugs: { traces?: string; logs?: string },
+): WorkerObservability | null {
+  const next: WorkerObservability = current ? { ...current } : {};
+  let changed = false;
+  if (next.enabled !== true) {
+    next.enabled = true;
+    changed = true;
+  }
+  for (const signal of WORKER_OBSERVABILITY_SIGNALS) {
+    const slug = slugs[signal];
+    if (!slug) continue;
+    const sig: WorkerObservabilitySignal = { ...(next[signal] ?? {}) };
+    const destinations = Array.isArray(sig.destinations) ? [...sig.destinations] : [];
+    if (sig.enabled !== true) {
+      sig.enabled = true;
+      changed = true;
+    }
+    if (!destinations.includes(slug)) {
+      destinations.push(slug);
+      changed = true;
+    }
+    sig.destinations = destinations;
+    next[signal] = sig;
+  }
+  return changed ? next : null;
+}
+
+// ---------------------------------------------------------------------------
 // HTTP wrappers (injectable fetch)
 // ---------------------------------------------------------------------------
 
@@ -412,5 +482,91 @@ export async function revokeToken(input: {
     });
   } catch {
     // best-effort
+  }
+}
+
+/** Parse `GET /workers/scripts` → list of script (Worker) ids. */
+export function parseScriptsResponse(json: unknown): string[] {
+  if (!json || typeof json !== "object") return [];
+  const result = (json as Record<string, unknown>).result;
+  if (!Array.isArray(result)) return [];
+  const ids: string[] = [];
+  for (const item of result) {
+    const id = item && typeof item === "object" ? (item as Record<string, unknown>).id : null;
+    if (typeof id === "string" && id) ids.push(id);
+  }
+  return ids;
+}
+
+/** List the Worker script ids in an account. Returns [] on any failure. */
+export async function listScripts(
+  accountId: string,
+  accessToken: string,
+  fetchImpl: FetchImpl = fetch,
+): Promise<string[]> {
+  const res = await fetchImpl(`${CLOUDFLARE_API_BASE}/accounts/${accountId}/workers/scripts`, {
+    headers: { authorization: `Bearer ${accessToken}` },
+  });
+  const json = await res.json().catch(() => null);
+  return parseScriptsResponse(json);
+}
+
+/** Read one Worker's `observability` config (null when unset/unavailable). */
+export async function getScriptObservability(input: {
+  accountId: string;
+  script: string;
+  accessToken: string;
+  fetchImpl?: FetchImpl;
+}): Promise<WorkerObservability | null> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const res = await fetchImpl(
+    `${CLOUDFLARE_API_BASE}/accounts/${input.accountId}/workers/scripts/${encodeURIComponent(
+      input.script,
+    )}/settings`,
+    { headers: { authorization: `Bearer ${input.accessToken}` } },
+  );
+  const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+  const result = json?.result as Record<string, unknown> | undefined;
+  const obs = result?.observability;
+  return obs && typeof obs === "object" ? (obs as WorkerObservability) : null;
+}
+
+/**
+ * PATCH a Worker's settings to set its `observability` config. The settings
+ * endpoint only accepts `multipart/form-data` with a JSON `settings` part (not a
+ * JSON body), so we build a FormData and let fetch set the multipart boundary.
+ */
+export async function updateScriptObservability(input: {
+  accountId: string;
+  script: string;
+  observability: WorkerObservability;
+  accessToken: string;
+  fetchImpl?: FetchImpl;
+}): Promise<{ ok: boolean; error?: string }> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const form = new FormData();
+  form.append(
+    "settings",
+    new Blob([JSON.stringify({ observability: input.observability })], {
+      type: "application/json",
+    }),
+    "settings.json",
+  );
+  try {
+    const res = await fetchImpl(
+      `${CLOUDFLARE_API_BASE}/accounts/${input.accountId}/workers/scripts/${encodeURIComponent(
+        input.script,
+      )}/settings`,
+      {
+        method: "PATCH",
+        headers: { authorization: `Bearer ${input.accessToken}` },
+        body: form,
+      },
+    );
+    const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    if (json?.success === true) return { ok: true };
+    return { ok: false, error: extractCreateError(json ?? {}) };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "request_failed" };
   }
 }

--- a/apps/api/src/cloudflare-service.ts
+++ b/apps/api/src/cloudflare-service.ts
@@ -511,7 +511,13 @@ export async function listScripts(
   return parseScriptsResponse(json);
 }
 
-/** Read one Worker's `observability` config (null when unset/unavailable). */
+/**
+ * Read one Worker's `observability` config. Returns `null` only on a *successful*
+ * read where observability is unset (a genuinely fresh Worker). A failed read
+ * (non-OK HTTP or `success !== true`) THROWS — the caller must not treat that as
+ * "fresh" and PATCH a minimal config, which would clobber an existing
+ * observability block we simply couldn't read.
+ */
 export async function getScriptObservability(input: {
   accountId: string;
   script: string;
@@ -526,7 +532,10 @@ export async function getScriptObservability(input: {
     { headers: { authorization: `Bearer ${input.accessToken}` } },
   );
   const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
-  const result = json?.result as Record<string, unknown> | undefined;
+  if (!res.ok || !json || json.success !== true) {
+    throw new Error(`cloudflare: read worker settings failed (status ${res.status})`);
+  }
+  const result = json.result as Record<string, unknown> | undefined;
   const obs = result?.observability;
   return obs && typeof obs === "object" ? (obs as WorkerObservability) : null;
 }

--- a/apps/api/src/cloudflare.ts
+++ b/apps/api/src/cloudflare.ts
@@ -35,11 +35,15 @@ import {
   createDestination,
   deleteDestination,
   exchangeCodeForToken,
+  getScriptObservability,
   listAccounts,
+  listScripts,
   revokeToken,
   signState,
   staleDestinationSlugs,
+  updateScriptObservability,
   verifyState,
+  wireObservabilityDestinations,
 } from "./cloudflare-service.js";
 import { logger } from "./logger.js";
 import { resolveActiveOrgContext } from "./org-context.js";
@@ -199,6 +203,54 @@ async function teardownInstallation(
     .update(schema.cloudflareInstallations)
     .set({ revokedAt: new Date(), updatedAt: new Date() })
     .where(eq(schema.cloudflareInstallations.id, row.id));
+}
+
+/**
+ * Wire the account's Workers to our destinations. Creating a destination only
+ * makes telemetry flow once each Worker's own `observability` config enables the
+ * signal and lists the destination, so we read every Worker's settings and merge
+ * our slugs in (additive + idempotent). Best-effort and per-Worker isolated: a
+ * Worker we can't update is logged and skipped, never failing the connect. Only
+ * traces/logs are wired — Workers Observability has no per-Worker metrics signal.
+ */
+async function wireAccountWorkers(input: {
+  accountId: string;
+  accessToken: string;
+  destinations: Record<string, string>;
+  fetchImpl: typeof fetch;
+}): Promise<void> {
+  const slugs = { traces: input.destinations.traces, logs: input.destinations.logs };
+  if (!slugs.traces && !slugs.logs) return;
+  const scripts = await listScripts(input.accountId, input.accessToken, input.fetchImpl);
+  let wired = 0;
+  for (const script of scripts) {
+    try {
+      const current = await getScriptObservability({
+        accountId: input.accountId,
+        script,
+        accessToken: input.accessToken,
+        fetchImpl: input.fetchImpl,
+      });
+      const next = wireObservabilityDestinations(current, slugs);
+      if (!next) continue; // already wired
+      const res = await updateScriptObservability({
+        accountId: input.accountId,
+        script,
+        observability: next,
+        accessToken: input.accessToken,
+        fetchImpl: input.fetchImpl,
+      });
+      if (res.ok) wired += 1;
+      else
+        log.warn({ script, error: res.error }, "cloudflare: failed to wire worker observability");
+    } catch (e) {
+      log.warn({ err: e, script }, "cloudflare: failed to wire worker observability");
+    }
+  }
+  log.info(
+    { account_id: input.accountId, scripts: scripts.length, wired },
+    "cloudflare: wired worker observability to destinations",
+  );
 }
 
 export function mountCloudflarePublic(
@@ -488,6 +540,16 @@ async function provisionInstallation(input: {
     for (const row of superseded) {
       await teardownInstallation(row, { config: input.config, fetchImpl: input.fetchImpl });
     }
+
+    // Wire the account's Workers to the destinations we just created — without
+    // this the destinations exist but no Worker exports to them, so no telemetry
+    // ever flows (the connect looks done but the project stays empty).
+    await wireAccountWorkers({
+      accountId: input.account.id,
+      accessToken: input.token.accessToken,
+      destinations,
+      fetchImpl: input.fetchImpl,
+    });
   } catch (e) {
     log.warn(
       { err: e, project_id: input.projectId },

--- a/apps/api/src/cloudflare.ts
+++ b/apps/api/src/cloudflare.ts
@@ -437,11 +437,17 @@ async function provisionInstallation(input: {
     throw new Error("cloudflare connect: no telemetry destinations were created");
   }
 
+  // On a same-account reconnect, merge the prior slugs under the new ones so a
+  // signal whose recreate *failed* keeps its existing destination. This is the
+  // set we both persist and wire Workers to, so Workers point at retained slugs
+  // (not just the ones created this run).
+  const persistedDestinations = sameAccount?.destinations
+    ? { ...sameAccount.destinations, ...destinations }
+    : destinations;
+
   // Encrypt + persist as one unit. Encryption is inside the boundary too: if it
   // throws (e.g. a misconfigured secrets key) the destinations/key/grant created
-  // above are still rolled back. On a same-account reconnect we merge the prior
-  // slugs under the new ones so a signal whose recreate *failed* keeps its
-  // existing destination in the row instead of being dropped.
+  // above are still rolled back.
   try {
     const accessCipher = encryptIntegrationSecret(input.token.accessToken);
     const refreshCipher = input.token.refreshToken
@@ -451,9 +457,6 @@ async function provisionInstallation(input: {
     const tokenExpiresAt =
       input.token.expiresIn != null ? new Date(Date.now() + input.token.expiresIn * 1000) : null;
     const now = new Date();
-    const persistedDestinations = sameAccount?.destinations
-      ? { ...sameAccount.destinations, ...destinations }
-      : destinations;
 
     await db
       .insert(schema.cloudflareInstallations)
@@ -541,13 +544,15 @@ async function provisionInstallation(input: {
       await teardownInstallation(row, { config: input.config, fetchImpl: input.fetchImpl });
     }
 
-    // Wire the account's Workers to the destinations we just created — without
-    // this the destinations exist but no Worker exports to them, so no telemetry
-    // ever flows (the connect looks done but the project stays empty).
+    // Wire the account's Workers to the destinations — without this the
+    // destinations exist but no Worker exports to them, so no telemetry ever
+    // flows (the connect looks done but the project stays empty). Use the merged
+    // set so Workers are wired to slugs we retained from a prior connect too, not
+    // just the ones created this run.
     await wireAccountWorkers({
       accountId: input.account.id,
       accessToken: input.token.accessToken,
-      destinations,
+      destinations: persistedDestinations,
       fetchImpl: input.fetchImpl,
     });
   } catch (e) {


### PR DESCRIPTION
## Why
Creating a Workers Observability destination is necessary but **not sufficient** for telemetry to flow. A Worker only exports to a destination when its *own* `observability` config enables the signal and lists that destination by name (destinations are account-wide, opt-in per Worker). So today a connect succeeds — destinations created, key minted — but the project stays empty because no Worker feeds the destination. Confirmed live: a freshly-connected account had the destination created and its ingest key never used until each Worker's `observability` was wired.

## What
After the destinations are created and the install row is committed, list the account's Workers and merge our destination slugs into each Worker's observability config.

- **`wireObservabilityDestinations(current, {traces, logs})`** — pure, additive, idempotent: turns on observability + each wired signal and appends our slug to that signal's `destinations` without dropping the Worker's existing destinations, sampling rates, or other fields. Returns `null` when already wired so the caller skips the PATCH. Metrics is omitted (no per-Worker metrics signal).
- **`listScripts` / `getScriptObservability` / `updateScriptObservability`** — the script-settings endpoint only accepts `multipart/form-data` with a JSON `settings` part (a JSON body returns `415 Content-Type must be one of: multipart/form-data`), so the update builds a `FormData`.
- Wiring runs in the **best-effort post-commit block** and is **per-Worker isolated** — a Worker we can't read/patch is logged and skipped, never failing the connect.
- **Scopes** corrected + widened: `account-settings.read` (the old default `account.read` doesn't exist), `workers-observability.write`, `workers-observability-telemetry.write`, and now `workers-scripts.read` / `workers-scripts.write` to read+patch Worker settings.

## Test
- `pnpm --filter @superlog/api exec tsx --test src/cloudflare-service.test.ts` — 17 pass (added wiring-helper cases: fresh / existing-merge / idempotent-null / partial, plus the scripts parser).
- typecheck + biome clean.
- Verified live: PATCHing a real Worker's observability to add the destinations made traces land in the project within ~90s.

Deployments using a registered OAuth client must add the `workers-scripts` read/write permissions to the client for this step to work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Connect now PATCHes every Worker’s observability settings (with safeguards against clobbering on read failure), and broader OAuth scopes are required for wiring to succeed.
> 
> **Overview**
> **Connect now wires every account Worker** so traces/logs actually reach Superlog: destinations alone were not enough because Workers only export when their per-script `observability` enables the signal and lists the destination slug.
> 
> After the install row commits, **`wireAccountWorkers`** lists scripts, reads settings via **`getScriptObservability`** (failed reads throw so a bad read cannot clobber config), merges slugs with **`wireObservabilityDestinations`**, and PATCHes only when needed via **`updateScriptObservability`** (multipart `settings` JSON). Wiring is **best-effort per Worker** and uses the **merged `persistedDestinations`** on reconnect so retained slugs from a failed recreate are wired too.
> 
> **Default OAuth scopes** change to `account-settings.read`, `workers-observability.write`, `workers-observability-telemetry.write`, and **`workers-scripts.read` / `workers-scripts.write`** — deployments must update their OAuth client accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c32b5eb5f32bd133525ef4da0f00bcf2765ae47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically wires Cloudflare account Workers to Observability destinations during connect so traces/logs start flowing immediately, including retained slugs on reconnect. The wiring is additive, idempotent, and best-effort per Worker, and never overwrites settings on failed reads.

- New Features
  - On connect, list Workers, read each `observability`, and merge our destination slugs for traces/logs (preserves existing settings; skips PATCH when already wired).
  - Uses merged retained slugs from prior connects when a recreate failed, so Workers keep exporting to live destinations.
  - Added helpers: `listScripts`, `getScriptObservability` (throws on failed reads; null only when genuinely unset), `updateScriptObservability` (multipart `settings`), and `wireObservabilityDestinations`.

- Migration
  - Update the OAuth client to include `workers-scripts.read` and `workers-scripts.write`, and replace `account.read` with `account-settings.read`.

<sup>Written for commit 3c32b5eb5f32bd133525ef4da0f00bcf2765ae47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

