### PR TITLE
fix(proxy): reject declared-empty OTLP bodies before auth

### DIFF
--- a/apps/proxy/src/empty-body-guard.test.ts
+++ b/apps/proxy/src/empty-body-guard.test.ts
@@ -1,0 +1,35 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { isDeclaredEmptyBody } from "./empty-body-guard.js";
+
+test("treats a Content-Length of exactly zero as a declared-empty body", () => {
+  assert.equal(isDeclaredEmptyBody("0"), true);
+});
+
+test("passes through a non-zero Content-Length", () => {
+  assert.equal(isDeclaredEmptyBody("1"), false);
+  assert.equal(isDeclaredEmptyBody("42"), false);
+  assert.equal(isDeclaredEmptyBody("1024"), false);
+});
+
+test("passes through when Content-Length is absent (chunked body)", () => {
+  // No header → size is unknown, so we can't cheaply prove it's empty here. A
+  // truly-empty chunked body still gets a 400 later via the body-capture path.
+  assert.equal(isDeclaredEmptyBody(undefined), false);
+  assert.equal(isDeclaredEmptyBody(null), false);
+  assert.equal(isDeclaredEmptyBody(""), false);
+});
+
+test("ignores surrounding whitespace and leading zeros", () => {
+  assert.equal(isDeclaredEmptyBody(" 0 "), true);
+  assert.equal(isDeclaredEmptyBody("00"), true);
+});
+
+test("passes through a malformed Content-Length rather than rejecting it", () => {
+  // Not our job to validate the header; only fast-reject a provably-empty body.
+  // Anything non-numeric falls through to the normal path.
+  assert.equal(isDeclaredEmptyBody("abc"), false);
+  assert.equal(isDeclaredEmptyBody("0x0"), false);
+  assert.equal(isDeclaredEmptyBody("0.5"), false);
+  assert.equal(isDeclaredEmptyBody("-0"), false);
+});

--- a/apps/proxy/src/empty-body-guard.ts
+++ b/apps/proxy/src/empty-body-guard.ts
@@ -1,0 +1,33 @@
+/**
+ * Fast, pre-auth rejection of declared-empty OTLP ingest requests.
+ *
+ * An OTLP HTTP export with a zero-length body carries no records, so it can
+ * never succeed — it's a permanent 400. The auth middleware, by contrast, hashes
+ * the API key, reads the `api_keys` row, and writes `last_used_at` on every
+ * request: a DB read *and* write per call. A misbehaving client looping empty
+ * exports would otherwise pay that full per-request cost, and enough of them
+ * saturate the shared proxy fleet's CPU until health checks fail and the load
+ * balancer serves 5xx to every tenant.
+ *
+ * Recognising the empty body from the `Content-Length` header lets us reject it
+ * before any of that work. Only the `Content-Length: 0` case is fast-rejected
+ * here — a chunked request with no declared length that turns out to be empty
+ * still falls through to the body-capture `EmptyBodyError` → 400 path; it just
+ * isn't cheap. That gap is acceptable: real OTLP exporters set `Content-Length`.
+ */
+
+/** The 400 body sent for an empty ingest request, whether caught here or later. */
+export const EMPTY_BODY_ERROR_MESSAGE = "empty OTLP request body; no records to ingest";
+
+/**
+ * True iff the `Content-Length` header is present and provably zero. Absent,
+ * empty, or non-numeric values return false so the request takes the normal
+ * path — this only fast-rejects a body we can cheaply prove carries no records.
+ */
+export function isDeclaredEmptyBody(contentLength: string | null | undefined): boolean {
+  if (contentLength === null || contentLength === undefined) return false;
+  // A run of zero digits (with optional surrounding whitespace) is the only
+  // shape that means "empty". parseInt would coerce "0.5" / "0x0" to 0 and
+  // wrongly reject them, so match the digits explicitly instead.
+  return /^\s*0+\s*$/.test(contentLength);
+}

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -190,11 +190,20 @@ app.use(
 // the key hash, the api_keys read, and the last_used_at write the auth
 // middleware does per request, so a client looping empty exports can't burn CPU
 // on the ingest fleet and drive it unhealthy. Registered after cors() so the
-// 400 still carries CORS headers for browser SDKs. cors()
-// answers OPTIONS preflights itself and never calls next(), so this only sees
-// real requests; the POST check keeps it scoped to ingest regardless.
+// 400 still carries CORS headers for browser SDKs. cors() answers OPTIONS
+// preflights itself and never calls next(), so this only sees real requests;
+// the POST check keeps it scoped to ingest regardless.
+//
+// Test keys are exempt: the auth middleware answers their empty smoke-test
+// probes with a 200 short-circuit (no DB), and recognising one is a cheap
+// header/prefix check — so let them through and keep that behavior identical
+// whether or not the probe declares a Content-Length.
 app.use("/v1/*", async (c, next) => {
-  if (c.req.method === "POST" && isDeclaredEmptyBody(c.req.header("content-length"))) {
+  if (
+    c.req.method === "POST" &&
+    isDeclaredEmptyBody(c.req.header("content-length")) &&
+    !isTestKey(extractApiKey(c))
+  ) {
     emptyBodyRejections.add(1, {
       "otlp.signal": otlpSignalForPath(new URL(c.req.url).pathname) ?? "unknown",
     });
@@ -213,7 +222,7 @@ app.use("/v1/*", async (c, next) => {
         return c.json({ error: "missing api key" }, 401);
       }
 
-      if (key === "SUPERLOG_TEST" || key.startsWith("superlog_test_")) {
+      if (isTestKey(key)) {
         span.setAttribute("auth.result", "test_key");
         const path = new URL(c.req.url).pathname;
         if (path === "/v1/traces" || path === "/v1/logs" || path === "/v1/metrics") {
@@ -367,6 +376,13 @@ function extractApiKey(c: Context): string | null {
   return null;
 }
 
+/** The smoke-test credentials the auth middleware answers with a 200 short-circuit
+ *  (no DB). Kept in one place so the pre-auth empty-body guard and the auth check
+ *  can't drift on what counts as a test key. */
+function isTestKey(key: string | null): boolean {
+  return key === "SUPERLOG_TEST" || (key?.startsWith("superlog_test_") ?? false);
+}
+
 async function forward(c: Context<{ Variables: Variables }>, path: string, rootKey: string) {
   return tracer.startActiveSpan("ingest.forward", async (span) => {
     const startedAt = performance.now();
@@ -455,7 +471,7 @@ async function forward(c: Context<{ Variables: Variables }>, path: string, rootK
         responseStatus = 400;
         span.setAttribute("ingest.empty_body", true);
         logger.warn({ path, projectId }, "dropping OTLP request with no body");
-        return c.json({ error: "empty OTLP request body; no records to ingest" }, 400);
+        return c.json({ error: EMPTY_BODY_ERROR_MESSAGE }, 400);
       }
 
       // Issue-fingerprint stamping deserializes the whole payload, so in queue mode it runs

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -13,6 +13,7 @@ import type { Context } from "hono";
 import { cors } from "hono/cors";
 import { createIngestEntitlementGate, signalForPath } from "./billing/ingest-entitlement.js";
 import { EmptyBodyError, PayloadTooLargeError } from "./body-capture.js";
+import { EMPTY_BODY_ERROR_MESSAGE, isDeclaredEmptyBody } from "./empty-body-guard.js";
 import {
   FIREHOSE_ACCESS_KEY_HEADER,
   FIREHOSE_REQUEST_ID_HEADER,
@@ -156,6 +157,18 @@ ingestMeter
     observer.observe(uploadSemaphore.queueLength, { "ingest.lane": "upload" });
   });
 
+// Count declared-empty ingest requests fast-rejected before auth (see the
+// /v1/* guard below). A rising rate on one signal = a client looping empty
+// OTLP exports. No tenant attribute: we reject before resolving the key, which
+// is the whole point.
+const emptyBodyRejections = ingestMeter.createCounter(
+  "superlog.proxy.ingest.empty_body_rejected",
+  {
+    description:
+      "OTLP ingest requests fast-rejected pre-auth for a declared-empty (Content-Length: 0) body.",
+  },
+);
+
 // Hard per-request body ceiling for the no-queue (direct) path. The queue path
 // enforces its own copy via IngestQueueConfig.maxBodyBytes; both read the same
 // env so they stay in lockstep. Bodies above this get a 413 (a permanent 4xx —
@@ -171,6 +184,24 @@ app.use(
     allowMethods: ["POST", "OPTIONS"],
   }),
 );
+
+// Fast-reject declared-empty bodies BEFORE auth. A Content-Length: 0 OTLP
+// export carries no records, so it's a permanent 400 — rejecting it here skips
+// the key hash, the api_keys read, and the last_used_at write the auth
+// middleware does per request, so a client looping empty exports can't burn CPU
+// on the ingest fleet and drive it unhealthy. Registered after cors() so the
+// 400 still carries CORS headers for browser SDKs. cors()
+// answers OPTIONS preflights itself and never calls next(), so this only sees
+// real requests; the POST check keeps it scoped to ingest regardless.
+app.use("/v1/*", async (c, next) => {
+  if (c.req.method === "POST" && isDeclaredEmptyBody(c.req.header("content-length"))) {
+    emptyBodyRejections.add(1, {
+      "otlp.signal": otlpSignalForPath(new URL(c.req.url).pathname) ?? "unknown",
+    });
+    return c.json({ error: EMPTY_BODY_ERROR_MESSAGE }, 400);
+  }
+  return next();
+});
 
 app.use("/v1/*", async (c, next) => {
   return tracer.startActiveSpan("auth.validate", async (span) => {
@@ -322,7 +353,7 @@ function handleIngestBodyError(
     logger.warn({ path, projectId }, "dropping empty OTLP request body");
     return {
       status: 400,
-      response: c.json({ error: "empty OTLP request body; no records to ingest" }, 400),
+      response: c.json({ error: EMPTY_BODY_ERROR_MESSAGE }, 400),
     };
   }
   return null;


### PR DESCRIPTION
An OTLP HTTP export with a zero-length body carries no records. The proxy
already returns a permanent `400` for it — but only *after* the auth middleware
hashes the API key, reads the `api_keys` row, and writes `last_used_at`. That is
a DB read **and** write on every request, before the body is even inspected.

A client looping empty exports therefore drives real per-request work at high
volume. Enough of it saturates the shared ingest fleet's CPU until health
checks start failing; with no healthy targets the load balancer returns `5xx`
to **every** tenant, not just the misbehaving one. We saw exactly this shape:
one project sent millions of empty-body requests in a tight loop and tipped the
whole ingest path over.

## Change

- New `empty-body-guard.ts`: `isDeclaredEmptyBody(contentLength)` — true only
  when `Content-Length` is present and provably zero. Absent / non-numeric
  values fall through to the normal path (we only fast-reject a body we can
  cheaply prove is empty).
- A `/v1/*` middleware registered **before** auth returns the same `400`
  (shared `EMPTY_BODY_ERROR_MESSAGE`) for a declared-empty `POST`, before any
  key hashing or DB access. Registered after `cors()` so the `400` keeps its
  CORS headers, and `cors()` still answers `OPTIONS` preflights itself.
- New `superlog.proxy.ingest.empty_body_rejected` counter (by signal) so the
  rejected rate is visible.

Only `Content-Length: 0` is fast-rejected. A chunked request with no declared
length that turns out empty still gets a `400` via the existing body-capture
`EmptyBodyError` path — just not cheaply. Real OTLP exporters set
`Content-Length`, so that gap does not matter in practice.

## Test

TDD: `empty-body-guard.test.ts` covers zero / non-zero / absent / whitespace /
malformed. Full proxy suite green (84 tests), typecheck clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared ingest hot path and middleware order on `/v1/*`; behavior change is narrow (only declared-empty POSTs) but incorrect header parsing could wrongly pass or reject requests.
> 
> **Overview**
> Adds a **pre-auth fast path** on `/v1/*` so `POST` requests with a provably zero `Content-Length` get the same permanent **400** as before, but **without** API key hashing, `api_keys` lookup, or `last_used_at` updates—reducing CPU/DB load when clients loop empty OTLP exports.
> 
> New `empty-body-guard.ts` exposes `isDeclaredEmptyBody()` (regex `^\s*0+\s*$` so values like `0.5`/`0x0` are not misclassified) and shared `EMPTY_BODY_ERROR_MESSAGE`; the later `EmptyBodyError` handler now uses that constant. Chunked or unknown-length empty bodies still hit the existing body-capture path.
> 
> Instrumentation: `superlog.proxy.ingest.empty_body_rejected` counter by OTLP signal (no tenant—rejection happens before key resolution). Middleware runs after CORS so 400s keep CORS headers. Unit tests cover zero, non-zero, absent, whitespace, and malformed `Content-Length`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd1b305b9dfeaef36853283566563c015cd3800c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject OTLP requests that declare an empty body (`Content-Length: 0`) before auth to avoid DB work and protect ingest CPU from empty-export loops. Keeps the same 400 and now skips test keys so smoke probes still return 200.

- **Bug Fixes**
  - Pre-auth middleware on `/v1/*` 400s POSTs with `Content-Length: 0`, runs after `cors`, skipping key hash and DB; chunked or unknown-length bodies still error later.
  - Exempt test keys (`SUPERLOG_TEST`/`superlog_test_*`) via shared `isTestKey()` so smoke probes still 200; auth uses the same helper.
  - Shared `EMPTY_BODY_ERROR_MESSAGE` across all empty-body paths and new `isDeclaredEmptyBody()`; added `superlog.proxy.ingest.empty_body_rejected` counter and tests for header parsing.

<sup>Written for commit 4beb69cbaba80975a4eb647ebf55dd28ba1fb7e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

