### PR TITLE
fix(cloudflare): project-scope destination names + stop requesting unsupported metrics

### DIFF
--- a/apps/api/src/cloudflare-service.test.ts
+++ b/apps/api/src/cloudflare-service.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import {
   CLOUDFLARE_OAUTH_AUTHORIZE_URL,
+  CLOUDFLARE_SIGNALS,
   buildAuthorizeUrl,
   buildDestinationPayload,
   cloudflareConfigFromEnv,
@@ -15,6 +16,7 @@ import {
   parseCreateDestinationResponse,
   parseScriptsResponse,
   parseTokenResponse,
+  projectDestinationToken,
   signState,
   staleDestinationSlugs,
   verifyState,
@@ -91,22 +93,38 @@ test("intakeUrlForSignal maps each signal to the OTLP path", () => {
   );
 });
 
-test("buildDestinationPayload builds a Logpush OTLP destination with the ingest key header", () => {
+test("buildDestinationPayload builds a project-scoped Logpush OTLP destination", () => {
   const payload = buildDestinationPayload({
     signal: "logs",
     intakeBaseUrl: "https://intake.example.com",
     ingestKey: "sl_public_abc123",
+    projectId: "aa49a851-b727-4014-bbff-571dc282613c",
   });
   assert.equal(payload.enabled, true);
-  // Cloudflare requires the name to match ^[a-z0-9-]+$ — a display string like
-  // "Superlog logs" is rejected with a ZodError.
-  assert.equal(payload.name, "superlog-logs");
+  // Name is project-scoped so two projects on one Cloudflare account don't collide
+  // (upsert-by-name would otherwise hijack each other's destination). Must also
+  // match Cloudflare's ^[a-z0-9-]+$ rule.
+  assert.equal(payload.name, "superlog-aa49a851b727-logs");
   assert.match(payload.name, /^[a-z0-9-]+$/);
   assert.equal(payload.skipPreflightCheck, true);
   assert.equal(payload.configuration.type, "logpush");
   assert.equal(payload.configuration.logpushDataset, "opentelemetry-logs");
   assert.equal(payload.configuration.url, "https://intake.example.com/v1/logs");
   assert.equal(payload.configuration.headers["x-api-key"], "sl_public_abc123");
+});
+
+test("projectDestinationToken is a short regex-safe per-project token", () => {
+  assert.equal(projectDestinationToken("aa49a851-b727-4014-bbff-571dc282613c"), "aa49a851b727");
+  assert.match(projectDestinationToken("aa49a851-b727-4014-bbff-571dc282613c"), /^[a-z0-9]+$/);
+  // Distinct projects → distinct tokens (so distinct destination names).
+  assert.notEqual(
+    projectDestinationToken("aa49a851-b727-4014-bbff-571dc282613c"),
+    projectDestinationToken("1b480fe1-c652-4c2c-b4d2-593d278124f9"),
+  );
+});
+
+test("CLOUDFLARE_SIGNALS excludes metrics (Workers Observability exports only traces + logs)", () => {
+  assert.deepEqual(CLOUDFLARE_SIGNALS, ["traces", "logs"]);
 });
 
 test("signState/verifyState round-trips and rejects tampering + expiry", () => {
@@ -206,7 +224,10 @@ test("getScriptObservability throws on a failed read but returns null when genui
   const call = (fetchImpl: typeof fetch) =>
     getScriptObservability({ accountId: "a", script: "w", accessToken: "t", fetchImpl });
 
-  assert.deepEqual(await call(respond(200, { success: true, result: { observability: obs } })), obs);
+  assert.deepEqual(
+    await call(respond(200, { success: true, result: { observability: obs } })),
+    obs,
+  );
   // success + no observability → genuinely fresh Worker.
   assert.equal(await call(respond(200, { success: true, result: {} })), null);
   // A failed read must THROW — never resolve to null (which would make the caller
@@ -376,6 +397,7 @@ test("createDestination hits the account-scoped destinations endpoint", async ()
       signal: "traces",
       intakeBaseUrl: "https://intake.example.com",
       ingestKey: "sl_public_x",
+      projectId: "aa49a851-b727-4014-bbff-571dc282613c",
     }),
     fetchImpl: fakeFetch,
   });

--- a/apps/api/src/cloudflare-service.ts
+++ b/apps/api/src/cloudflare-service.ts
@@ -2,7 +2,7 @@
 // integration. Cloudflare shipped self-managed OAuth for all developers in
 // 2026-06, so we can offer a Slack-style "Connect Cloudflare" button: the user
 // consents, and we use the granted token to create Workers Observability
-// "telemetry destinations" that export OTLP traces/logs/metrics straight to our
+// "telemetry destinations" that export OTLP traces/logs straight to our
 // intake — no copy-paste API tokens.
 //
 // OAuth endpoints (from Cloudflare's "Integrate your OAuth client" docs):
@@ -52,7 +52,13 @@ export const CLOUDFLARE_OTLP_SIGNALS: Record<CloudflareSignal, { dataset: string
     metrics: { dataset: "opentelemetry-metrics", path: "/v1/metrics" },
   };
 
-export const CLOUDFLARE_SIGNALS: CloudflareSignal[] = ["traces", "logs", "metrics"];
+// Signals we actually provision a destination for. Metrics is intentionally
+// excluded: Workers Observability exports only traces and logs over OTLP —
+// metrics export "is not yet supported" (no `observability.metrics` config key,
+// and the create API rejects an `opentelemetry-metrics` destination with a
+// Bad Request). The `metrics` mapping above is kept so this is a one-line
+// re-enable once Cloudflare ships metrics export.
+export const CLOUDFLARE_SIGNALS: CloudflareSignal[] = ["traces", "logs"];
 
 export type CloudflareConnectConfig = {
   clientId: string;
@@ -125,21 +131,41 @@ export type DestinationPayload = {
 };
 
 /**
+ * A destination name is per Cloudflare *account*, so it must also identify the
+ * Superlog project — otherwise a second project connecting the same account
+ * upserts-by-name over the first project's destination (hijacking its ingest
+ * key) and the two projects become mutually exclusive. We derive a short,
+ * regex-safe token from the project id so each project gets its own destination
+ * (`superlog-<token>-<signal>`) and a Worker can fan out to several projects.
+ */
+export function projectDestinationToken(projectId: string): string {
+  return projectId
+    .replace(/[^a-z0-9]/gi, "")
+    .slice(0, 12)
+    .toLowerCase();
+}
+
+export function destinationName(projectId: string, signal: CloudflareSignal): string {
+  return `superlog-${projectDestinationToken(projectId)}-${signal}`;
+}
+
+/**
  * Build the Workers Observability destination payload for one signal: a Logpush
  * destination with the matching `opentelemetry-*` dataset, pointed at our intake
  * and authenticated with the project's ingest key via `x-api-key`.
  *
- * The destination `name` must match Cloudflare's `^[a-z0-9-]+$` rule (lowercase
- * letters, numbers, hyphens), so it's `superlog-<signal>` — not a display string.
+ * The destination `name` is `superlog-<projectToken>-<signal>` — project-scoped
+ * (see destinationName) and matching Cloudflare's `^[a-z0-9-]+$` rule.
  */
 export function buildDestinationPayload(input: {
   signal: CloudflareSignal;
   intakeBaseUrl: string;
   ingestKey: string;
+  projectId: string;
 }): DestinationPayload {
   const sig = CLOUDFLARE_OTLP_SIGNALS[input.signal];
   return {
-    name: `superlog-${input.signal}`,
+    name: destinationName(input.projectId, input.signal),
     enabled: true,
     skipPreflightCheck: true,
     configuration: {

--- a/apps/api/src/cloudflare.ts
+++ b/apps/api/src/cloudflare.ts
@@ -407,6 +407,7 @@ async function provisionInstallation(input: {
         signal,
         intakeBaseUrl: input.config.intakeBaseUrl,
         ingestKey,
+        projectId: input.projectId,
       }),
       fetchImpl: input.fetchImpl,
     });


### PR DESCRIPTION
Two destination-provisioning correctness fixes found while connecting a second project to one Cloudflare account.

## 1. Project-scope the destination names (multi-project fix)
Workers Observability destination names are per **account**, not per project. We named them `superlog-traces` / `superlog-logs`, so a second Superlog project connecting the *same* Cloudflare account did an **upsert-by-name over the first project's destination** — overwriting its ingest key. The two projects became mutually exclusive (whichever connected last owns the shared destination; the other silently stops receiving).

Fix: names are now `superlog-<projectToken>-<signal>` where `projectToken` is the first 12 hex chars of the project id (regex-safe, matches Cloudflare's `^[a-z0-9-]+$`). Each project gets its own destination; since Worker wiring is additive, a Worker feeding several projects ends up referencing all of their destinations and each project receives telemetry **independently**.

Verified live: with the shared names, connecting project B repointed the account's `superlog-traces` destination from project A's key to B's — confirming the collision.

## 2. Stop requesting a metrics destination
Cloudflare Workers Observability exports only **traces and logs** over OTLP — metrics export "is not yet supported" (docs; no `observability.metrics` config key, and the create API rejects an `opentelemetry-metrics` destination with `Bad Request`). `CLOUDFLARE_SIGNALS` is now `["traces", "logs"]`; the metrics dataset mapping stays so it's a one-line re-enable when Cloudflare ships metrics.

## Test
`pnpm --filter @superlog/api exec tsx --test src/cloudflare-service.test.ts` — 20 pass (project-scoped name, token uniqueness, signals-excludes-metrics). typecheck + biome clean.

Note: existing installs created before this have unscoped destination names; reconnecting each project provisions the scoped ones. Leftover shared destinations may need one-time cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live Cloudflare destination provisioning and ingest-key routing for multi-project accounts; wrong naming would misroute telemetry, but behavior is covered by unit tests and matches documented Cloudflare limits.
> 
> **Overview**
> Fixes **multi-project** Cloudflare connects on one account and stops provisioning a **metrics** destination Cloudflare rejects.
> 
> **Project-scoped destination names:** Workers Observability names are account-wide; `superlog-<signal>` caused upsert-by-name so a second Superlog project overwrote the first project’s ingest key. Names are now `superlog-<projectToken>-<signal>` via `projectDestinationToken` / `destinationName`, and `buildDestinationPayload` / `provisionInstallation` pass `projectId`.
> 
> **Signals:** `CLOUDFLARE_SIGNALS` is `["traces", "logs"]` only (metrics OTLP export not supported); the metrics dataset mapping stays for a future one-line re-enable.
> 
> Tests cover scoped names, token uniqueness, and signals excluding metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9bf176acd4e764685543e2ff1faa56b0a203bba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope Cloudflare Workers Observability destination names by project and stop creating metrics destinations. This prevents cross-project collisions on the same Cloudflare account and avoids failing requests for unsupported metrics.

- **Bug Fixes**
  - Name destinations `superlog-<projectToken>-<signal>` using `projectDestinationToken` to ensure per-project uniqueness on an account.
  - Only provision traces and logs by setting `CLOUDFLARE_SIGNALS` to `["traces", "logs"]` (metrics not supported by Cloudflare yet).

- **Migration**
  - Reconnect each existing project to create the new scoped destinations.
  - Optionally delete old shared `superlog-traces` and `superlog-logs` destinations in Cloudflare.

<sup>Written for commit e9bf176acd4e764685543e2ff1faa56b0a203bba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

