### PR TITLE
fix(onboarding): resume Cloudflare flow after redirect + honest 'first events' signal

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -134,6 +134,12 @@ export function useMe() {
       clearPendingSignupSource();
       return me;
     },
+    // Poll while the active project hasn't ingested yet, then stop. This is what
+    // makes the onboarding gate teleport off the install wizard / demo data the
+    // instant real telemetry lands (hasIngested is derived from the ingest key's
+    // last_used_at), and the onboarding flows key their "first events" state off
+    // the same field. Post-ingest (the common case) there's no polling.
+    refetchInterval: (query) => (query.state.data?.project?.hasIngested ? false : 10_000),
   });
 }
 

--- a/apps/web/src/onboarding/CloudflareConnectFlow.tsx
+++ b/apps/web/src/onboarding/CloudflareConnectFlow.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import {
-  type Stats,
-  useCloudflareInstallation,
-  useStartCloudflareInstall,
-  useStats,
-} from "../api.ts";
+import { useCloudflareInstallation, useStartCloudflareInstall } from "../api.ts";
 import { Btn } from "../design/ui.tsx";
 import {
   type CloudflarePhase,
@@ -37,18 +32,18 @@ function openConsent(url: string) {
   }
 }
 
-function hasEvents(stats: Stats | undefined): boolean {
-  if (!stats) return false;
-  return stats.traces + stats.logs + stats.metrics > 0;
-}
-
 export function CloudflareConnectFlow({
   projectId,
+  eventsArrived,
   onBack,
   onDone,
   onExploreDemo,
 }: {
   projectId: string;
+  // Whether the real project has ingested telemetry yet (from the parent's
+  // `me.project.hasIngested`). NOT derived from the stats endpoint, which is
+  // demo-overlaid for un-ingested projects and would falsely report events.
+  eventsArrived: boolean;
   onBack: () => void;
   onDone: () => void;
   onExploreDemo?: () => void;
@@ -62,7 +57,6 @@ export function CloudflareConnectFlow({
 
   const install = useCloudflareInstallation(projectId);
   const start = useStartCloudflareInstall(projectId);
-  const stats = useStats(projectId, { poll: true });
 
   // The callback redirects back to the app with `?cloudflare=...`. When the
   // consent was opened in the same tab (popup blocked), a denial/error lands
@@ -83,7 +77,6 @@ export function CloudflareConnectFlow({
 
   const installed = install.data?.installed === true;
   const phase = cloudflarePhase({ installed, launched });
-  const eventsArrived = hasEvents(stats.data);
 
   const connect = () => {
     if (start.isPending) return;

--- a/apps/web/src/onboarding/OnboardingGate.tsx
+++ b/apps/web/src/onboarding/OnboardingGate.tsx
@@ -88,6 +88,7 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
       <OnboardingWizard
         mode={skillMode ? "agent" : "web"}
         projectId={null}
+        hasIngested={hasIngested}
         userName={me.data.user.name}
         userEmail={me.data.user.email}
         onComplete={() => {
@@ -103,6 +104,7 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
       <OnboardingWizard
         mode="agent"
         projectId={me.data.project.id}
+        hasIngested={hasIngested}
         userName={me.data.user.name}
         userEmail={me.data.user.email}
         onComplete={() => {
@@ -131,6 +133,7 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
   return (
     <OnboardingWizard
       projectId={me.data.project.id}
+      hasIngested={hasIngested}
       userName={me.data.user.name}
       userEmail={me.data.user.email}
       onComplete={() => {

--- a/apps/web/src/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/onboarding/OnboardingWizard.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from "react";
 import { OrgProjectSwitcher } from "../OrgProjectSwitcher.tsx";
 import {
   type GithubInstallation,
-  type Stats,
   useClaimSignupIntent,
   useCreateKey,
   useCreateMyFirstOrg,
@@ -10,7 +9,6 @@ import {
   useSlackInstallation,
   useStartGithubInstall,
   useStartSlackInstall,
-  useStats,
 } from "../api.ts";
 import { authClient, useSession } from "../auth-client.ts";
 import { Btn, Wordmark } from "../design/ui.tsx";
@@ -47,14 +45,19 @@ type Mode = "web" | "agent";
 // or the coding-agent install/deploy flow.
 type WebView = "chooser" | "aws" | "cloudflare" | "code";
 
-function hasEvents(stats: Stats | undefined): boolean {
-  if (!stats) return false;
-  return stats.traces + stats.logs + stats.metrics > 0;
+// The Cloudflare OAuth callback redirects back to the app with `?cloudflare=...`.
+// When that lands we want to drop straight into the Cloudflare flow (which reads
+// the outcome + install status), not the chooser — otherwise the user is bounced
+// back to "Connect your data" and has to click Cloudflare again to see progress.
+function initialWebView(): WebView {
+  if (typeof window === "undefined") return "chooser";
+  return new URLSearchParams(window.location.search).has("cloudflare") ? "cloudflare" : "chooser";
 }
 
 export function OnboardingWizard({
   mode = "web",
   projectId,
+  hasIngested,
   userName,
   userEmail,
   onComplete,
@@ -64,6 +67,11 @@ export function OnboardingWizard({
   // Null until the user has created their first org. While null, the wizard
   // only renders the create-org step regardless of `mode`.
   projectId: string | null;
+  // Whether the *real* project has ingested telemetry (from the ingest key's
+  // last_used_at). This is the honest "events arrived" signal — unlike the stats
+  // endpoint, which is demo-overlaid for un-ingested projects and would otherwise
+  // make the wizard claim "first events received" while showing demo data.
+  hasIngested: boolean;
   userName: string;
   userEmail: string;
   onComplete: () => void;
@@ -72,7 +80,7 @@ export function OnboardingWizard({
   onExploreDemo?: () => void;
 }) {
   const [step, setStep] = useState<Step>("install");
-  const [webView, setWebView] = useState<WebView>("chooser");
+  const [webView, setWebView] = useState<WebView>(initialWebView);
 
   const createKey = useCreateKey(projectId ?? "");
   const github = useGithubInstallation();
@@ -107,8 +115,7 @@ export function OnboardingWizard({
     createKey.mutate("Setup install");
   }, [mode, webView, projectId, createKey.mutate]);
 
-  const stats = useStats(projectId ?? undefined, { poll: true });
-  const eventsArrived = hasEvents(stats.data);
+  const eventsArrived = hasIngested;
 
   return (
     <div className="min-h-screen bg-bg font-sans text-fg">
@@ -154,6 +161,7 @@ export function OnboardingWizard({
           ) : webView === "cloudflare" ? (
             <CloudflareConnectFlow
               projectId={projectId}
+              eventsArrived={eventsArrived}
               onBack={() => setWebView("chooser")}
               onDone={onComplete}
               onExploreDemo={onExploreDemo}


### PR DESCRIPTION
Two onboarding bugs in the "Connect your data" flow.

## 1. Bounced back to the chooser after connecting
The Cloudflare OAuth callback redirects to `/?cloudflare=installed`, which reloads the app. `OnboardingWizard` initialized its view to `chooser`, so the user landed back on "Connect your data" and had to click Cloudflare **again** to see install progress. The wizard now initializes to the Cloudflare view when a `?cloudflare=` param is present, so the redirect lands directly on the progress screen.

## 2. "First events received" shown immediately, then demo data on Continue
The flows derived "events arrived" from `useStats`, which is **demo-overlaid** for un-ingested projects (the server returns the *demo* project's stats). So the progress screen claimed "first events received" while the real project was empty, and Continue dropped the user onto demo data. Switched to the real signal the gate already uses — `me.project.hasIngested` (from the ingest key's `last_used_at`) — threaded from `OnboardingGate` → `OnboardingWizard` → both the deploy step and `CloudflareConnectFlow`.

Also: `useMe` now polls every 10s **while the active project hasn't ingested**, then stops. This makes the honest "events arrived" state update live and lets the gate auto-teleport off the wizard/demo data the instant real telemetry lands (previously it only flipped on a manual refresh / focus).

## Test
- `pnpm --filter @superlog/web typecheck` — clean.
- `cloudflareConnectModel` + `connectChoices` tests pass (14).
- biome clean.

Verified by typecheck + unit tests (no worktree booted in this session); behavior confirmed against the live symptoms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 48d11bb37898fcd25ed18c3631ef199e3595adcf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two onboarding issues in the Cloudflare connect flow: the app now resumes the Cloudflare step after OAuth redirect, and the "first events received" status uses the real ingest signal instead of demo stats. This makes the return from consent smooth and prevents landing on demo data after Continue.

- **Bug Fixes**
  - Resume Cloudflare flow after redirect by initializing `OnboardingWizard` to the Cloudflare view when `?cloudflare=` is present.
  - Use `me.project.hasIngested` as the source of truth for “first events,” threaded from `OnboardingGate` → `OnboardingWizard` → `CloudflareConnectFlow` and the deploy step; remove stats-based check to avoid demo overlay.
  - Poll `useMe` every 10s until ingest, then stop, so the wizard/gate update live and auto-exit once real telemetry arrives.

<sup>Written for commit 48d11bb37898fcd25ed18c3631ef199e3595adcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

