### PR TITLE
fix(web): don't let a not-yet-hydrated billing customer crash the app

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,6 +22,7 @@ import { AlertEdit } from "./alerts/AlertEdit.tsx";
 import { AlertsList } from "./alerts/AlertsList.tsx";
 import { useMe } from "./api.ts";
 import { authClient, useSession } from "./auth-client.ts";
+import { signalAtHardCap } from "./billing.ts";
 import { DashboardView } from "./dashboards/DashboardView.tsx";
 import { DashboardsList } from "./dashboards/DashboardsList.tsx";
 import { AppShell, ThemeToggle, Wordmark } from "./design/ui.tsx";
@@ -170,10 +171,9 @@ function AuthenticatedApp() {
     me.data?.billingEnforcement === true &&
     // Only the telemetry signals gate ingest. Investigation credits running out
     // doesn't pause ingest, so it must not trigger the "Ingest paused" bar.
-    ["spans", "logs", "metric_points"].some((f) => {
-      const b = check({ featureId: f }).balance;
-      return !!b && !b.unlimited && b.granted > 0 && !b.overageAllowed && b.usage >= b.granted;
-    });
+    // signalAtHardCap swallows autumn-js check() throwing on a not-yet-hydrated
+    // customer (e.g. a brand-new org) so billing state can't black-screen the app.
+    ["spans", "logs", "metric_points"].some((f) => signalAtHardCap(check, f));
   const showTopBar = impersonating || billingPaused;
   // The banner is fixed-positioned so it doesn't shove the page below it (the
   // fixed nav can't be pushed by document flow anyway). Instead, every piece

--- a/apps/web/src/billing.test.ts
+++ b/apps/web/src/billing.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { type EntitlementBalance, signalAtHardCap } from "./billing.ts";
+
+// A `check` stand-in that returns a fixed balance.
+const checkReturning = (balance: EntitlementBalance) => () => ({ balance });
+
+const hardCapBalance = {
+  unlimited: false,
+  granted: 1_000_000,
+  overageAllowed: false,
+  usage: 1_000_000,
+};
+
+test("signalAtHardCap is true only when a bounded, non-overage signal has caught up to its allowance", () => {
+  assert.equal(signalAtHardCap(checkReturning(hardCapBalance), "spans"), true);
+  assert.equal(
+    signalAtHardCap(checkReturning({ ...hardCapBalance, usage: 1_500_000 }), "spans"),
+    true,
+  );
+});
+
+test("signalAtHardCap is false when the signal is under its cap", () => {
+  assert.equal(
+    signalAtHardCap(checkReturning({ ...hardCapBalance, usage: 999_999 }), "spans"),
+    false,
+  );
+});
+
+test("signalAtHardCap is false for unlimited, unbounded, or overage-allowed signals", () => {
+  assert.equal(
+    signalAtHardCap(checkReturning({ ...hardCapBalance, unlimited: true }), "spans"),
+    false,
+  );
+  assert.equal(signalAtHardCap(checkReturning({ ...hardCapBalance, granted: 0 }), "spans"), false);
+  assert.equal(
+    signalAtHardCap(checkReturning({ ...hardCapBalance, overageAllowed: true }), "spans"),
+    false,
+  );
+});
+
+test("signalAtHardCap is false when there's no balance", () => {
+  assert.equal(signalAtHardCap(checkReturning(null), "spans"), false);
+  assert.equal(signalAtHardCap(checkReturning(undefined), "spans"), false);
+});
+
+// The regression this guard exists for: autumn-js's check() reads
+// `customer.flags[featureId]` with no guard, so a brand-new org whose Autumn
+// customer is truthy but has no `flags` yet makes check() throw
+// "Cannot read properties of undefined (reading 'spans')". That threw during
+// AuthenticatedApp's render and black-screened the app right after a fresh user
+// created their first org. signalAtHardCap must swallow it and report "not
+// capped" (fail-open) so a half-loaded customer never crashes the app.
+test("signalAtHardCap returns false (never throws) when check() throws", () => {
+  const throwingCheck = () => {
+    throw new TypeError("Cannot read properties of undefined (reading 'spans')");
+  };
+  assert.doesNotThrow(() => signalAtHardCap(throwingCheck, "spans"));
+  assert.equal(signalAtHardCap(throwingCheck, "spans"), false);
+});

--- a/apps/web/src/billing.ts
+++ b/apps/web/src/billing.ts
@@ -1,0 +1,45 @@
+// Billing entitlement helpers shared by the app-wide "ingest paused" banner
+// (App.tsx) and the billing settings card (BillingCard.tsx).
+//
+// The balance shape here is the subset of autumn-js's check() result we read.
+// We keep it structural rather than importing autumn-js's types so this stays
+// unit-testable without the billing SDK and doesn't break on SDK type churn.
+export type EntitlementBalance =
+  | {
+      unlimited: boolean;
+      granted: number;
+      overageAllowed: boolean;
+      usage: number;
+    }
+  | null
+  | undefined;
+
+export type EntitlementCheck = (args: { featureId: string }) => { balance: EntitlementBalance };
+
+// True when a signal is at a *hard* cap: a bounded (granted > 0), non-overage
+// feature whose usage has reached its allowance — the Free-tier state where
+// ingest is paused. Metered/overage/unlimited signals never count.
+//
+// Crucially this NEVER throws. autumn-js's check() reads
+// `customer.flags[featureId]` unguarded, so a brand-new org whose Autumn
+// customer is truthy but not yet hydrated with `flags` makes check() throw
+// "Cannot read properties of undefined (reading 'spans')". That used to bubble
+// out of AuthenticatedApp's render and black-screen the whole app right after a
+// user created their first org. We fail open here — an unreadable balance means
+// "not capped", so a half-loaded customer shows the app instead of crashing it
+// (real ingest/investigation enforcement lives server-side, not in this banner).
+export function signalAtHardCap(check: EntitlementCheck, featureId: string): boolean {
+  let balance: EntitlementBalance;
+  try {
+    balance = check({ featureId }).balance;
+  } catch {
+    return false;
+  }
+  return (
+    !!balance &&
+    !balance.unlimited &&
+    balance.granted > 0 &&
+    !balance.overageAllowed &&
+    balance.usage >= balance.granted
+  );
+}

--- a/apps/web/src/settings/BillingCard.tsx
+++ b/apps/web/src/settings/BillingCard.tsx
@@ -2,6 +2,7 @@ import { useAggregateEvents, useCustomer } from "autumn-js/react";
 import { useState } from "react";
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { useCancelBilling } from "../api.ts";
+import { signalAtHardCap } from "../billing.ts";
 import { Btn } from "../design/ui.tsx";
 
 // Autumn plan ids → display names (must match autumn.config.ts / pricing.ts).
@@ -109,14 +110,23 @@ export function BillingCard() {
   const scheduledName = scheduledSub ? (PLAN_NAMES[scheduledSub.planId] ?? scheduledSub.planId) : null;
   const scheduledAtMs = scheduledSub?.startedAt ?? activeSub?.currentPeriodEnd ?? null;
 
-  const balanceOf = (featureId: string) => check({ featureId }).balance;
+  // check() reads customer.flags[featureId] unguarded in autumn-js, so it throws
+  // on a not-yet-hydrated customer (e.g. a brand-new org). Fail open to a null
+  // balance so the billing page renders "—" meters instead of white-screening.
+  const balanceOf = (featureId: string): Balance => {
+    try {
+      return check({ featureId }).balance;
+    } catch {
+      return null;
+    }
+  };
 
   // True when any hard-capped signal (Free tier) is exhausted — ingest/usage is
-  // paused, so we surface the upgrade CTA.
-  const atLimit = ["investigations", "spans", "logs", "metric_points"].some((f) => {
-    const b = balanceOf(f);
-    return !!b && !b.unlimited && b.granted > 0 && !b.overageAllowed && b.usage >= b.granted;
-  });
+  // paused, so we surface the upgrade CTA. signalAtHardCap guards against
+  // autumn-js check() throwing on a not-yet-hydrated customer (see billing.ts).
+  const atLimit = ["investigations", "spans", "logs", "metric_points"].some((f) =>
+    signalAtHardCap(check, f),
+  );
 
   // Estimated current bill: plan base fee + this period's metered usage beyond
   // what the plan includes (granted). On paid plans telemetry has granted 0 (all


### PR DESCRIPTION
## Problem

When billing enforcement is on, `AuthenticatedApp` computes the app-wide "ingest paused" banner on **every** authenticated render by calling autumn-js `check({ featureId })` for `spans` / `logs` / `metric_points`.

autumn-js's `check` reads `customer.flags[featureId]` with **no guard** on `customer.flags` (its only guard is `!customer`). A brand-new org's billing customer comes back truthy but **without a `flags` object yet**, so `customer.flags["spans"]` throws:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'spans')
```

This throws during render, and with no error boundary the whole app unmounts — a **black screen right after a fresh user creates their first org**. (The same not-yet-provisioned state is what surfaces as a `no_customer_id` 401 from `getOrCreateCustomer`.)

## Fix

Add `signalAtHardCap(check, featureId)` (new `apps/web/src/billing.ts`): it wraps the `check()` call in try/catch and **fails open** — a signal whose balance can't be read is treated as "not capped". Billing/entitlement state can no longer white-screen the product; actual ingest/investigation enforcement is server-side, not in this banner.

- Use it in both call sites: the app-wide banner (`App.tsx`) and the billing settings card (`BillingCard.tsx`).
- Make the settings card's `balanceOf` fail open the same way, so its meters render `—` instead of crashing on a half-loaded customer.

## Tests

`apps/web/src/billing.test.ts` covers the hard-cap logic and the regression: `signalAtHardCap` returns `false` (never throws) when `check()` throws.

## Notes

- The crash only triggers when billing enforcement is enabled at the deployment level; the guard makes the client robust regardless of that flag.
- Follow-up (not in this PR): ensure a freshly created org's billing customer is provisioned before the client reads entitlements, so the 401/empty-`flags` window closes at the source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only defensive handling around billing display; enforcement remains server-side, and fail-open may briefly hide the ingest-paused banner until flags load.
> 
> **Overview**
> Fixes a **render-time crash** when autumn-js `check()` runs against a billing customer that exists but has no `flags` yet (common right after creating a first org). That uncaught throw could **black-screen** the whole authenticated app when billing enforcement is on.
> 
> Introduces shared **`signalAtHardCap`** in `billing.ts`: wraps `check()`, **fails open** (treats unreadable balances as not capped), and centralizes the hard-cap predicate used for the Free-tier “ingest paused” state. **`App.tsx`** uses it for the app-wide banner; **`BillingCard.tsx`** uses it for the upgrade CTA and wraps **`balanceOf`** in try/catch so meters show **—** instead of crashing.
> 
> Adds **`billing.test.ts`** for cap logic and the regression that `check()` throws are swallowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24de9cc09620ae352b350d3e3a54188f2838ee6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a render-time crash that white-screened the app when a new org’s billing customer existed but had no `flags`. Wraps `autumn-js` `check()` to fail open so unreadable balances are treated as not capped; server-side enforcement is unchanged.

- **Bug Fixes**
  - Added `signalAtHardCap(check, featureId)` in `billing.ts`; used for the ingest-paused banner (`App.tsx`) and upgrade CTA (`BillingCard.tsx`).
  - `BillingCard` now catches `check()` errors in `balanceOf` and returns `null`, so meters show — instead of crashing.
  - Added `billing.test.ts` to cover hard-cap logic and the regression where `check()` could throw.

<sup>Written for commit 24de9cc09620ae352b350d3e3a54188f2838ee6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

