### PR TITLE
web: re-add sign_up_clicked / sign_in_clicked PostHog events

### DIFF
--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -1,3 +1,4 @@
+import { usePostHog } from "posthog-js/react";
 import { useEffect, useRef, useState } from "react";
 import { AuthForm } from "./AuthForm.tsx";
 import { Btn, Chip, Label, Tile, Wordmark } from "./design/ui.tsx";
@@ -12,11 +13,14 @@ import { LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
 type AuthMode = "sign-in" | "sign-up" | null;
 
 export function Landing({ initialAuthMode }: { initialAuthMode?: AuthMode } = {}) {
+  const posthog = usePostHog();
   const [authMode, setAuthMode] = useState<AuthMode>(initialAuthMode ?? null);
   const openSignIn = () => {
+    posthog?.capture("sign_in_clicked", { surface: "landing" });
     setAuthMode("sign-in");
   };
   const openSignUp = () => {
+    posthog?.capture("sign_up_clicked", { surface: "landing" });
     setAuthMode("sign-up");
   };
 

--- a/apps/web/src/Pricing.tsx
+++ b/apps/web/src/Pricing.tsx
@@ -1,3 +1,4 @@
+import { usePostHog } from "posthog-js/react";
 import { useEffect, useState } from "react";
 import { AuthForm } from "./AuthForm.tsx";
 import { Btn, Label, Tile, Wordmark } from "./design/ui.tsx";
@@ -97,10 +98,13 @@ export function Pricing() {
     return null;
   });
 
+  const posthog = usePostHog();
   const openSignIn = () => {
+    posthog?.capture("sign_in_clicked", { surface: "pricing" });
     setAuthMode("sign-in");
   };
   const openSignUp = () => {
+    posthog?.capture("sign_up_clicked", { surface: "pricing" });
     setAuthMode("sign-up");
   };
 


### PR DESCRIPTION
## What

Re-adds the `sign_up_clicked` and `sign_in_clicked` PostHog captures to the sign-in / sign-up buttons on the landing page (`Landing.tsx`) and the pricing page (`Pricing.tsx`). Each event is tagged with a `surface` property (`"landing"` / `"pricing"`) so signup intent can be broken down by entry point.

## Why

These events used to fire on every auth-button click and were our top-of-funnel signup-*intent* signal. The capture calls were dropped when the repo history was recreated in early June, so the events have emitted nothing since — any insight or dashboard built on them reads as zero. Actual sign-ups never stopped; only the instrumentation went silent.

This restores the click-intent signal as the counterpart to the existing `user_signed_up` completion event (which only fires client-side at first-org creation and structurally undercounts).

## Notes

- Uses optional chaining (`posthog?.capture`) so a not-yet-initialized PostHog instance — e.g. no token configured in local/dev — is a no-op instead of a crash.
- Analytics stays best-effort: the capture never blocks opening the auth modal.
- `pnpm --filter @superlog/web typecheck` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only additions on marketing pages; no auth, billing, or data-path changes.
> 
> **Overview**
> Restores **top-of-funnel signup intent** tracking by firing PostHog `sign_in_clicked` and `sign_up_clicked` when users open the auth modal from the **landing** and **pricing** pages. Each event includes a `surface` property (`"landing"` or `"pricing"`) so intent can be split by entry point.
> 
> Captures use `posthog?.capture` and run before opening the modal, so missing PostHog in dev and the analytics call never block UX.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0c52981e195971cbb827155d28531a37b107e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-adds `sign_in_clicked` and `sign_up_clicked` PostHog events on the Landing and Pricing auth buttons to restore top-of-funnel signup intent tracking. Events are tagged with `surface` (`"landing"`/`"pricing"`), use `posthog?.capture` to avoid crashes when PostHog isn’t initialized, and never block opening the auth modal.

<sup>Written for commit f0c52981e195971cbb827155d28531a37b107e71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

