### PR TITLE
feat(onboarding): AWS, Cloudflare, and a "hosted elsewhere" prompt lane

### DIFF
--- a/apps/web/src/onboarding/ConnectDataChooser.tsx
+++ b/apps/web/src/onboarding/ConnectDataChooser.tsx
@@ -6,31 +6,19 @@ import {
   type ConnectSection,
   connectSectionsFor,
 } from "./connectChoices.ts";
-import {
-  AgentSparkIcon,
-  AwsIcon,
-  ChevronRightIcon,
-  CloudflareIcon,
-  GithubActionsIcon,
-  KubernetesIcon,
-  OtelIcon,
-  VercelIcon,
-} from "./icons.tsx";
+import { AwsIcon, ChevronRightIcon, CloudflareIcon, TerminalIcon } from "./icons.tsx";
 import { ExploreDemoLink, SOFT_LINE } from "./wizardChrome.tsx";
 
-// The path chooser: a flat, low-color list (modeled on a Plugins page) that
-// forks new users between no-code integrations (AWS first — integration-first)
-// and the coding-agent skill. See design.md.
+// The path chooser: a flat, low-color list (modeled on a Plugins page). Three
+// peer lanes — the no-code integrations (AWS, Cloudflare, integration-first)
+// and the "I'm hosted elsewhere" fallback, which routes to the coding-agent
+// prompt. See design.md.
 
 function ConnectGlyph({ icon }: { icon: ConnectIcon }) {
   const map: Record<ConnectIcon, typeof AwsIcon> = {
     aws: AwsIcon,
-    otel: OtelIcon,
-    agent: AgentSparkIcon,
-    vercel: VercelIcon,
-    kubernetes: KubernetesIcon,
     cloudflare: CloudflareIcon,
-    githubActions: GithubActionsIcon,
+    terminal: TerminalIcon,
   };
   const Glyph = map[icon];
   return <Glyph size={18} />;
@@ -77,20 +65,6 @@ function ListRow({
   );
 }
 
-function GridTile({ option }: { option: ConnectOption }) {
-  return (
-    <div
-      className={`flex items-center gap-3 rounded-[12px] border bg-surface px-3.5 py-3 ${SOFT_LINE}`}
-    >
-      <IconTile icon={option.icon} />
-      <span className="min-w-0">
-        <span className="block text-[13px] font-medium text-fg">{option.title}</span>
-        <span className="block text-[11.5px] text-subtle">{option.description}</span>
-      </span>
-    </div>
-  );
-}
-
 function SectionLabel({ children }: { children: string }) {
   return <div className="mb-2.5 text-[13px] font-medium text-muted">{children}</div>;
 }
@@ -104,22 +78,14 @@ function Section({
 }) {
   return (
     <div>
-      <SectionLabel>{section.label}</SectionLabel>
-      {section.variant === "grid" ? (
-        <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
-          {section.options.map((option) => (
-            <GridTile key={option.id} option={option} />
-          ))}
-        </div>
-      ) : (
-        <div
-          className={`divide-y divide-[rgba(255,255,255,0.07)] overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}
-        >
-          {section.options.map((option) => (
-            <ListRow key={option.id} option={option} onPick={onPick} />
-          ))}
-        </div>
-      )}
+      {section.label ? <SectionLabel>{section.label}</SectionLabel> : null}
+      <div
+        className={`divide-y divide-[rgba(255,255,255,0.07)] overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}
+      >
+        {section.options.map((option) => (
+          <ListRow key={option.id} option={option} onPick={onPick} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/onboarding/OnboardingWizard.tsx
@@ -11,17 +11,16 @@ import {
   useStartSlackInstall,
 } from "../api.ts";
 import { authClient, useSession } from "../auth-client.ts";
-import { Btn, Wordmark } from "../design/ui.tsx";
-import { INSTALL_PROMPT, buildInstallPrompt } from "../installPrompt.ts";
+import { Wordmark } from "../design/ui.tsx";
 import { getSkillOnboardingIntent } from "../skillOnboarding.ts";
 import { AwsConnectFlow } from "./AwsConnectFlow.tsx";
 import { CloudflareConnectFlow } from "./CloudflareConnectFlow.tsx";
 import { ConnectDataChooser } from "./ConnectDataChooser.tsx";
-import { TruncatedKey } from "./TruncatedKey.tsx";
 import type { ConnectAction } from "./connectChoices.ts";
-import { CheckIcon, CopyIcon, GithubIcon, SlackIcon, SpinnerIcon } from "./icons.tsx";
+import { CheckIcon, GithubIcon, SlackIcon, SpinnerIcon } from "./icons.tsx";
 import {
   ExploreDemoLink,
+  InstallPromptCard,
   SOFT_LINE,
   STRONG_LINE,
   StepFooter,
@@ -34,16 +33,17 @@ import {
 //   Body:   centered, max-w 640. Title + subtitle, step content, footer.
 //   Footer: border-top, Skip and CTA right-aligned together.
 //
-// Two steps:
-//   1. Install — copy a self-contained agent prompt with a fresh API key.
-//   2. Deploy  — poll for first telemetry, advance once it arrives.
+// Steps:
+//   1. Connect — pick a lane: the AWS / Cloudflare no-code integrations, or
+//      "I'm hosted elsewhere", which opens the coding-agent prompt.
+//   2. Install — copy a self-contained agent prompt with a fresh API key.
+//   3. Deploy  — poll for first telemetry, advance once it arrives.
 // Completion calls onComplete; the gate only allows it after telemetry arrives.
 
-type Step = "install" | "deploy";
 type Mode = "web" | "agent";
-// Web-mode landing fork: choose a source, then either the AWS integration flow
-// or the coding-agent install/deploy flow.
-type WebView = "chooser" | "aws" | "cloudflare" | "code";
+// Web-mode landing fork: choose a source, then either a no-code integration
+// flow (AWS / Cloudflare) or the coding-agent install → deploy flow.
+type WebView = "chooser" | "aws" | "cloudflare" | "code" | "deploy";
 
 // The Cloudflare OAuth callback redirects back to the app with `?cloudflare=...`.
 // When that lands we want to drop straight into the Cloudflare flow (which reads
@@ -79,32 +79,31 @@ export function OnboardingWizard({
   // ahead and explore sample data instead of instrumenting first.
   onExploreDemo?: () => void;
 }) {
-  const [step, setStep] = useState<Step>("install");
   const [webView, setWebView] = useState<WebView>(initialWebView);
 
   const createKey = useCreateKey(projectId ?? "");
   const github = useGithubInstallation();
   const slack = useSlackInstallation();
 
-  // Route a chooser selection to the matching flow. OpenTelemetry/SDK shares the
-  // coding-agent install flow (both hand back an SDK + ingest key); AWS gets its
-  // own no-code integration flow.
+  // Route a chooser selection to the matching view. AWS / Cloudflare get their
+  // no-code integration flows; "I'm hosted elsewhere" (action "code") opens the
+  // coding-agent install prompt.
   const handlePick = (action: ConnectAction) => {
     if (action === "aws") {
       setWebView("aws");
     } else if (action === "cloudflare") {
       setWebView("cloudflare");
     } else {
-      setStep("install");
       setWebView("code");
     }
   };
 
   // Mint exactly once per mount, and only after we have a project to mint into
-  // *and* the user has chosen the code/SDK path — the no-code AWS integration
-  // never uses an ingest key, so minting on chooser entry would leave an unused
-  // key on the project. The ref guard makes the mint a strict per-mount
-  // one-shot, independent of mutation state identity or polling re-renders.
+  // *and* the user has chosen the coding-agent path — the no-code AWS /
+  // Cloudflare integrations never use an ingest key, so minting on chooser
+  // entry would leave an unused key on the project. The ref guard makes the
+  // mint a strict per-mount one-shot, independent of mutation state identity or
+  // polling re-renders.
   const minted = useRef(false);
   useEffect(() => {
     if (mode !== "web") return;
@@ -166,19 +165,19 @@ export function OnboardingWizard({
               onDone={onComplete}
               onExploreDemo={onExploreDemo}
             />
-          ) : step === "install" ? (
+          ) : webView === "code" ? (
             <InstallStep
               apiKey={createKey.data?.plaintext ?? null}
               minting={createKey.isPending && !createKey.data}
               error={createKey.error ? String(createKey.error) : null}
               onBack={() => setWebView("chooser")}
-              onNext={() => setStep("deploy")}
+              onNext={() => setWebView("deploy")}
               onExploreDemo={onExploreDemo}
             />
           ) : (
             <DeployStep
               eventsArrived={eventsArrived}
-              onBack={() => setStep("install")}
+              onBack={() => setWebView("code")}
               onDone={onComplete}
               onExploreDemo={onExploreDemo}
             />
@@ -603,19 +602,6 @@ function InstallStep({
   onNext: () => void;
   onExploreDemo?: () => void;
 }) {
-  const [copied, setCopied] = useState(false);
-  const prompt = apiKey ? buildInstallPrompt(apiKey) : INSTALL_PROMPT;
-
-  const copy = () => {
-    try {
-      navigator.clipboard?.writeText(prompt);
-    } catch {
-      /* clipboard unavailable */
-    }
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1600);
-  };
-
   return (
     <>
       <StepHeader
@@ -623,53 +609,7 @@ function InstallStep({
         sub="Paste this prompt in Cursor, Claude Code, Codex, or any agent. It runs the install skill end-to-end — adds the SDK, instruments your code, opens a PR."
       />
 
-      <div className={`overflow-hidden rounded-[14px] border bg-[#0a0a0c] ${SOFT_LINE}`}>
-        <div
-          className={`flex items-center justify-between gap-2.5 border-b px-[18px] py-[8px] ${SOFT_LINE}`}
-        >
-          <div className="flex items-center gap-2.5">
-            <span className="flex gap-1.5">
-              <span className="h-[10px] w-[10px] rounded-full bg-[#3b3b3e]" />
-              <span className="h-[10px] w-[10px] rounded-full bg-[#3b3b3e]" />
-              <span className="h-[10px] w-[10px] rounded-full bg-[#3b3b3e]" />
-            </span>
-            <span className="ml-2 text-[11px] uppercase tracking-[0.08em] text-subtle">
-              coding agent
-            </span>
-          </div>
-          <Btn
-            variant="primary"
-            size="sm"
-            onClick={copy}
-            disabled={!apiKey}
-            className="!h-[26px] !rounded-[8px] !px-[10px]"
-          >
-            {copied ? <CheckIcon size={13} /> : <CopyIcon size={13} />}
-            {copied ? "Copied" : "Copy"}
-          </Btn>
-        </div>
-        <div className="px-[22px] py-[18px]">
-          <div className="text-[13.5px] leading-[1.5] text-fg">
-            <p className="m-0 break-words">{INSTALL_PROMPT}</p>
-            {minting ? (
-              <p className="m-0 mt-1 inline-flex items-center gap-2 text-muted">
-                <SpinnerIcon size={13} /> Provisioning your API key…
-              </p>
-            ) : error ? (
-              <p className="m-0 mt-1 text-danger">{error}</p>
-            ) : apiKey ? (
-              <p className="m-0 mt-1 whitespace-nowrap">
-                Use API key{" "}
-                <TruncatedKey value={apiKey} className="font-mono text-[12px] text-[#8C98F0]" />.
-              </p>
-            ) : null}
-          </div>
-          <p className="mt-2.5 text-[11.5px] leading-[1.5] text-subtle">
-            The key is write-only — it can only ingest events, not read them — and you can rotate it
-            any time from settings. Safe to drop straight into your agent.
-          </p>
-        </div>
-      </div>
+      <InstallPromptCard apiKey={apiKey} minting={minting} error={error} />
 
       <StepFooter onBack={onBack} onNext={onNext} nextLabel="The agent is done" />
       <ExploreDemoLink onExploreDemo={onExploreDemo} />

--- a/apps/web/src/onboarding/connectChoices.test.ts
+++ b/apps/web/src/onboarding/connectChoices.test.ts
@@ -16,39 +16,45 @@ function findOption(sections: ReturnType<typeof connectSectionsFor>, id: string)
   return undefined;
 }
 
-test("integration-first: the primary option is a no-code integration (AWS), not the coding agent", () => {
+test("the chooser offers exactly three lanes: AWS, Cloudflare, and 'I'm hosted elsewhere'", () => {
+  const ids = CONNECT_SECTIONS.flatMap((s) => s.options.map((o) => o.id));
+  assert.deepEqual(ids, ["aws", "cloudflare", "elsewhere"]);
+});
+
+test("there is no coming-soon grid", () => {
+  assert.equal(
+    CONNECT_SECTIONS.find((s) => s.id === "more"),
+    undefined,
+    "no 'more integrations' coming-soon grid",
+  );
+});
+
+test("the 'hosted elsewhere' lane routes to the coding-agent prompt (action 'code')", () => {
+  const elsewhere = findOption(CONNECT_SECTIONS, "elsewhere");
+  assert.ok(elsewhere);
+  assert.equal(elsewhere.action, "code");
+});
+
+test("integration-first: the primary option is a no-code integration (AWS)", () => {
   const primary = primaryConnectOption();
   assert.equal(primary.id, "aws");
   assert.equal(primary.action, "aws");
 });
 
-test("the recommended section is listed before the coding-agent section", () => {
-  const recommendedIdx = CONNECT_SECTIONS.findIndex((s) => s.id === "recommended");
-  const codeIdx = CONNECT_SECTIONS.findIndex((s) => s.id === "code");
-  assert.ok(recommendedIdx >= 0 && codeIdx >= 0);
-  assert.ok(recommendedIdx < codeIdx, "recommended integrations come first");
-});
-
-test("recommended + code options are all actionable; 'more' are coming soon", () => {
-  for (const section of CONNECT_SECTIONS) {
+test("every lane is actionable when its connector is configured", () => {
+  const sections = connectSectionsFor({ cloudflare: true });
+  for (const section of sections) {
     for (const option of section.options) {
-      if (section.id === "more") {
-        assert.equal(option.action, null, `${option.id} should be coming soon`);
-        assert.equal(isComingSoon(option), true);
-      } else {
-        assert.notEqual(option.action, null, `${option.id} should be actionable`);
-        assert.equal(isComingSoon(option), false);
-      }
+      assert.notEqual(option.action, null, `${option.id} should be actionable`);
+      assert.equal(isComingSoon(option), false);
     }
   }
 });
 
-test("connectActionFor resolves known ids and returns null for coming-soon / unknown", () => {
+test("connectActionFor resolves known ids and returns null for unknown", () => {
   assert.equal(connectActionFor("aws"), "aws");
   assert.equal(connectActionFor("cloudflare"), "cloudflare");
-  assert.equal(connectActionFor("otel"), "otel");
-  assert.equal(connectActionFor("agent"), "code");
-  assert.equal(connectActionFor("vercel"), null);
+  assert.equal(connectActionFor("elsewhere"), "code");
   assert.equal(connectActionFor("does-not-exist"), null);
 });
 
@@ -58,8 +64,9 @@ test("connectSectionsFor disables Cloudflare when the connector isn't configured
   assert.ok(cloudflare);
   assert.equal(cloudflare.action, null, "cloudflare should not be actionable when unavailable");
   assert.equal(isComingSoon(cloudflare), true);
-  // Other options are untouched.
+  // Other lanes are untouched.
   assert.equal(findOption(gated, "aws")?.action, "aws");
+  assert.equal(findOption(gated, "elsewhere")?.action, "code");
 });
 
 test("connectSectionsFor leaves Cloudflare actionable when configured", () => {

--- a/apps/web/src/onboarding/connectChoices.ts
+++ b/apps/web/src/onboarding/connectChoices.ts
@@ -4,23 +4,17 @@
 //
 // Design principle (see design.md): integration-first. A connected, no-code
 // integration beats hand-written instrumentation for time-to-value, so the
-// recommended no-code sources come first and the coding-agent path is the
-// secondary option.
+// no-code integrations (AWS, Cloudflare) come first and the "I'm hosted
+// elsewhere" fallback — which routes to the coding-agent prompt — comes last.
 
 // What activating a row does. `null` => not yet available (coming soon), so the
-// row renders disabled and is not actionable.
-export type ConnectAction = "aws" | "cloudflare" | "otel" | "code";
+// row renders disabled and is not actionable. "code" opens the coding-agent
+// prompt (paste into Cursor / Claude Code / Codex).
+export type ConnectAction = "aws" | "cloudflare" | "code";
 
 // Glyph key resolved to a neutral monochrome icon by the component. Kept as a
 // string union (not a component) so this module stays free of JSX/React.
-export type ConnectIcon =
-  | "aws"
-  | "otel"
-  | "agent"
-  | "vercel"
-  | "kubernetes"
-  | "cloudflare"
-  | "githubActions";
+export type ConnectIcon = "aws" | "cloudflare" | "terminal";
 
 export type ConnectOption = {
   id: string;
@@ -41,8 +35,9 @@ export type ConnectSection = {
 
 export const CONNECT_SECTIONS: ConnectSection[] = [
   {
-    id: "recommended",
-    label: "Recommended · no code",
+    id: "sources",
+    // No section label — the three lanes read as peers under the page subtitle.
+    label: "",
     variant: "list",
     options: [
       {
@@ -62,54 +57,12 @@ export const CONNECT_SECTIONS: ConnectSection[] = [
         action: "cloudflare",
       },
       {
-        id: "otel",
-        title: "OpenTelemetry / SDK",
-        description: "Point any OTLP exporter at Superlog with a write-only ingest key.",
-        icon: "otel",
-        action: "otel",
-      },
-    ],
-  },
-  {
-    id: "code",
-    label: "Or instrument with code",
-    variant: "list",
-    options: [
-      {
-        id: "agent",
-        title: "Use your coding agent",
+        id: "elsewhere",
+        title: "I'm hosted elsewhere",
         description:
-          "Paste a prompt into Cursor, Claude Code, or Codex — it installs the SDK, instruments your app, and opens a PR.",
-        icon: "agent",
+          "Vercel, Fly, a VM, your laptop — anywhere. Paste a prompt into Cursor, Claude Code, or Codex and it installs the SDK, instruments your app, and opens a PR.",
+        icon: "terminal",
         action: "code",
-      },
-    ],
-  },
-  {
-    id: "more",
-    label: "More integrations",
-    variant: "grid",
-    options: [
-      {
-        id: "vercel",
-        title: "Vercel",
-        description: "Coming soon",
-        icon: "vercel",
-        action: null,
-      },
-      {
-        id: "kubernetes",
-        title: "Kubernetes",
-        description: "Coming soon",
-        icon: "kubernetes",
-        action: null,
-      },
-      {
-        id: "github-actions",
-        title: "GitHub Actions",
-        description: "Coming soon",
-        icon: "githubActions",
-        action: null,
       },
     ],
   },

--- a/apps/web/src/onboarding/wizardChrome.tsx
+++ b/apps/web/src/onboarding/wizardChrome.tsx
@@ -1,6 +1,8 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { Btn } from "../design/ui.tsx";
-import { ArrowIcon, ArrowLeftIcon } from "./icons.tsx";
+import { INSTALL_PROMPT, buildInstallPrompt } from "../installPrompt.ts";
+import { TruncatedKey } from "./TruncatedKey.tsx";
+import { ArrowIcon, ArrowLeftIcon, CheckIcon, CopyIcon, SpinnerIcon } from "./icons.tsx";
 
 // Shared chrome for the onboarding wizard steps, extracted so the install /
 // deploy flow and the new "Connect your data" views render identical headers,
@@ -72,6 +74,83 @@ export function StepFooter({
           {nextLabel}
           <ArrowIcon />
         </Btn>
+      </div>
+    </div>
+  );
+}
+
+// The copyable coding-agent prompt, terminal-styled. Shared so the "Connect
+// your data" chooser can render it inline and the deploy dialog can reuse the
+// same block. The `apiKey` is minted by the caller and baked into the copied
+// text; the key is write-only, so it's safe to surface directly.
+export function InstallPromptCard({
+  apiKey,
+  minting,
+  error,
+}: {
+  apiKey: string | null;
+  minting: boolean;
+  error: string | null;
+}) {
+  const [copied, setCopied] = useState(false);
+  const prompt = apiKey ? buildInstallPrompt(apiKey) : INSTALL_PROMPT;
+
+  const copy = () => {
+    try {
+      navigator.clipboard?.writeText(prompt);
+    } catch {
+      /* clipboard unavailable */
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1600);
+  };
+
+  return (
+    <div className={`overflow-hidden rounded-[14px] border bg-[#0a0a0c] ${SOFT_LINE}`}>
+      <div
+        className={`flex items-center justify-between gap-2.5 border-b px-[18px] py-[8px] ${SOFT_LINE}`}
+      >
+        <div className="flex items-center gap-2.5">
+          <span className="flex gap-1.5">
+            <span className="h-[10px] w-[10px] rounded-full bg-[#3b3b3e]" />
+            <span className="h-[10px] w-[10px] rounded-full bg-[#3b3b3e]" />
+            <span className="h-[10px] w-[10px] rounded-full bg-[#3b3b3e]" />
+          </span>
+          <span className="ml-2 text-[11px] uppercase tracking-[0.08em] text-subtle">
+            coding agent
+          </span>
+        </div>
+        <Btn
+          variant="primary"
+          size="sm"
+          onClick={copy}
+          disabled={!apiKey}
+          className="!h-[26px] !rounded-[8px] !px-[10px]"
+        >
+          {copied ? <CheckIcon size={13} /> : <CopyIcon size={13} />}
+          {copied ? "Copied" : "Copy"}
+        </Btn>
+      </div>
+      <div className="px-[22px] py-[18px]">
+        <div className="text-[13.5px] leading-[1.5] text-fg">
+          <p className="m-0 break-words">{INSTALL_PROMPT}</p>
+          {minting ? (
+            <p className="m-0 mt-1 inline-flex items-center gap-2 text-muted">
+              <SpinnerIcon size={13} /> Provisioning your API key…
+            </p>
+          ) : error ? (
+            <p className="m-0 mt-1 text-danger">{error}</p>
+          ) : apiKey ? (
+            <p className="m-0 mt-1 whitespace-nowrap">
+              Use API key{" "}
+              <TruncatedKey value={apiKey} className="font-mono text-[12px] text-[#8C98F0]" />.
+            </p>
+          ) : null}
+        </div>
+        <p className="mt-2.5 text-[11.5px] leading-[1.5] text-subtle">
+          The key is write-only — it can only ingest events, not read them — and you can rotate it
+          any time from settings. Safe to drop straight into your agent.
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## What

Reworks the "Connect your data" onboarding chooser into three peer lanes:

- **Amazon Web Services** — no-code CloudWatch logs/metrics + resource discovery from one CloudFormation stack.
- **Cloudflare** — no-code Workers Observability destinations (disabled/"coming soon" until the connector is configured).
- **I'm hosted elsewhere** — opens the coding-agent install prompt (copy a self-contained prompt with a fresh write-only ingest key), then the deploy / wait-for-first-event step.

## Why

The previous chooser mixed a no-code section (AWS, Cloudflare, OpenTelemetry/SDK), a separate coding-agent section, and a "coming soon" grid (Vercel, Kubernetes, GitHub Actions). Collapsing to three peer lanes makes the fork clearer: two no-code integrations, plus one catch-all for anyone running their app anywhere else.

## Changes

- `connectChoices.ts` — three lanes (`aws`, `cloudflare`, `elsewhere`→`code`); `ConnectAction`/`ConnectIcon` narrowed; removed the coming-soon grid and the OTel/SDK row.
- `ConnectDataChooser.tsx` — single 3-row list, terminal glyph for the hosted-elsewhere lane, optional section label.
- `wizardChrome.tsx` — extract a shared `InstallPromptCard`.
- `OnboardingWizard.tsx` — the `code` lane routes to the install prompt step (reusing `InstallPromptCard`) → deploy step. The ingest key mints only when the hosted-elsewhere lane is chosen, so the no-code integrations don't leave an unused key on the project.
- `connectChoices.test.ts` — rewritten to the three-lane contract (9 tests).

## Test

- `node --test` on `connectChoices.test.ts` — 9 passing.
- `tsc --noEmit` clean; biome clean.
- Verified in a browser via a fresh sign-up: chooser shows the three rows, "I'm hosted elsewhere" opens the prompt with a minted key, "The agent is done" advances to the waiting-for-first-event step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding-only UX and routing changes; ingest key behavior is tightened, with no new auth or backend surface area.
> 
> **Overview**
> Reworks **Connect your data** into three peer list rows: **AWS**, **Cloudflare**, and **I'm hosted elsewhere** (→ coding-agent install). The old multi-section layout, **OpenTelemetry/SDK** row, separate “instrument with code” block, and **coming-soon** grid are removed; the chooser is list-only with a terminal icon for the catch-all lane.
> 
> **OnboardingWizard** now routes the hosted-elsewhere path through `webView` (`code` → `deploy`) instead of a separate install/deploy step state, and still mints the write-only ingest key **only** after that lane is chosen so AWS/Cloudflare do not create unused keys.
> 
> The copyable agent prompt UI moves into shared **`InstallPromptCard`** in `wizardChrome.tsx` (used by the install step). **`connectChoices.test.ts`** is updated to lock in the three-lane contract and Cloudflare gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58e999fd3766caddb0a07e42b1b0b5526f341b1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked the “Connect your data” onboarding into three peer lanes—AWS, Cloudflare, and “I’m hosted elsewhere”—to make the path clear and prevent minting unused ingest keys. The hosted-elsewhere lane opens the coding‑agent prompt, then the deploy step; Cloudflare is gated until the connector is configured.

- **New Features**
  - Three-lane chooser: AWS, Cloudflare, and “I’m hosted elsewhere” → coding‑agent prompt.
  - Cloudflare lane is disabled (“coming soon”) when the connector isn’t configured.
  - Ingest key mints only after choosing the hosted‑elsewhere lane; no-key for AWS/Cloudflare flows.
  - Shared InstallPromptCard renders the copyable agent prompt in both chooser flow and install step.

- **Refactors**
  - Removed the OpenTelemetry/SDK row and the “More integrations” coming‑soon grid (Vercel, Kubernetes, GitHub Actions).
  - Simplified chooser UI to a single 3-row list; narrowed ConnectAction/ConnectIcon types.
  - Wizard routing now uses views: chooser → aws/cloudflare or code → deploy.
  - Tests rewritten for the three‑lane contract (9 passing).

<sup>Written for commit 58e999fd3766caddb0a07e42b1b0b5526f341b1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

