### PR TITLE
perf(traces): serve the explore trace list from derived rollup tables

### DIFF
--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -206,14 +206,16 @@ test("queryLogs filters by field.severity_number via a string-cast column", asyn
   assert.equal(capture.params?.fattr_v_0, "9");
 });
 
-// queryTracesAggregated probes `EXISTS TABLE otel_traces_recent` and
-// `EXISTS TABLE otel_traces_summary` before every call, then either runs the
-// two-step fast path or falls back to the raw otel_traces scan. This fake
-// answers both EXISTS probes with a fixed result and captures the second (real)
-// query so tests can assert which path was taken.
+// queryTracesAggregated first probes `EXISTS TABLE otel_traces_recent` /
+// `otel_traces_summary`, then runs a coverage probe (`count() AS c` over the
+// recent index older than the window start), and only then either runs the
+// two-step fast path or falls back to the raw otel_traces scan. This fake answers
+// the EXISTS probes and the coverage probe with fixed results and captures the
+// final (real) query so tests can assert which path was taken.
 function fakeClickhouseWithSummary(
   capture: { query?: string; params?: Record<string, unknown> },
   derivedTablesExist: boolean,
+  windowCovered = true,
 ) {
   return {
     async query(input: { query: string; query_params?: Record<string, unknown> }) {
@@ -221,6 +223,13 @@ function fakeClickhouseWithSummary(
         return {
           async json() {
             return [{ result: derivedTablesExist ? 1 : 0 }];
+          },
+        };
+      }
+      if (/count\(\) AS c/i.test(input.query)) {
+        return {
+          async json() {
+            return [{ c: windowCovered ? 1 : 0 }];
           },
         };
       }
@@ -235,7 +244,7 @@ function fakeClickhouseWithSummary(
   } as unknown as ClickHouseClient;
 }
 
-test("queryTracesAggregated runs the two-step fast path when the derived tables exist and no filter is set", async () => {
+test("queryTracesAggregated runs the two-step fast path when the derived tables exist, cover the window, and no filter is set", async () => {
   const capture: { query?: string; params?: Record<string, unknown> } = {};
 
   await queryTracesAggregated(fakeClickhouseWithSummary(capture, true), "project-1", {
@@ -295,6 +304,21 @@ test("queryTracesAggregated falls back to the raw scan when the derived tables a
 
   assert.match(capture.query ?? "", /FROM otel_traces\b/);
   assert.doesNotMatch(capture.query ?? "", /otel_traces_summary/);
+});
+
+test("queryTracesAggregated falls back to the raw scan when the rollup does not yet cover the window", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  // Tables exist, but the recent index has no row older than the window start
+  // (e.g. before the historical backfill runs) — using the fast path would
+  // silently truncate the list to post-migration data, so fall back to raw.
+  await queryTracesAggregated(fakeClickhouseWithSummary(capture, true, false), "project-1", {
+    range: { since: "now() - INTERVAL 24 HOUR", until: "now()" },
+    limit: 100,
+  });
+
+  assert.match(capture.query ?? "", /FROM otel_traces\b/);
+  assert.doesNotMatch(capture.query ?? "", /recent_ids/);
 });
 
 test("queryTraces filters by field.span_id, ignoring non-applicable field keys", async () => {

--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -10,6 +10,7 @@ import {
   queryLogs,
   queryMetrics,
   queryTraces,
+  queryTracesAggregated,
 } from "./clickhouse.js";
 
 function fakeClickhouse(capture: { query?: string; params?: Record<string, unknown> }) {
@@ -205,6 +206,97 @@ test("queryLogs filters by field.severity_number via a string-cast column", asyn
   assert.equal(capture.params?.fattr_v_0, "9");
 });
 
+// queryTracesAggregated probes `EXISTS TABLE otel_traces_recent` and
+// `EXISTS TABLE otel_traces_summary` before every call, then either runs the
+// two-step fast path or falls back to the raw otel_traces scan. This fake
+// answers both EXISTS probes with a fixed result and captures the second (real)
+// query so tests can assert which path was taken.
+function fakeClickhouseWithSummary(
+  capture: { query?: string; params?: Record<string, unknown> },
+  derivedTablesExist: boolean,
+) {
+  return {
+    async query(input: { query: string; query_params?: Record<string, unknown> }) {
+      if (/EXISTS TABLE/i.test(input.query)) {
+        return {
+          async json() {
+            return [{ result: derivedTablesExist ? 1 : 0 }];
+          },
+        };
+      }
+      capture.query = input.query;
+      capture.params = input.query_params;
+      return {
+        async json() {
+          return [];
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+}
+
+test("queryTracesAggregated runs the two-step fast path when the derived tables exist and no filter is set", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await queryTracesAggregated(fakeClickhouseWithSummary(capture, true), "project-1", {
+    range: { since: "now() - INTERVAL 24 HOUR", until: "now()" },
+    limit: 100,
+  });
+
+  // Step 1: recent-trace-id index. Step 2: per-trace stats from the summary.
+  assert.match(capture.query ?? "", /WITH recent_ids AS/);
+  assert.match(capture.query ?? "", /FROM otel_traces_recent/);
+  assert.match(capture.query ?? "", /FROM otel_traces_summary/);
+  assert.match(capture.query ?? "", /trace_id IN \(recent_ids\)/);
+  assert.match(capture.query ?? "", /argMinMerge\(root_span_name\)/);
+  assert.match(capture.query ?? "", /uniqExactMerge\(services\)/);
+  // The bare raw-scan table must not appear (otel_traces_recent/_summary are ok).
+  assert.doesNotMatch(capture.query ?? "", /FROM otel_traces\b/);
+  assert.equal(capture.params?.projectId, "project-1");
+  assert.equal(capture.params?.limit, 100);
+});
+
+test("queryTracesAggregated falls back to the raw scan when a minDuration floor is set", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await queryTracesAggregated(fakeClickhouseWithSummary(capture, true), "project-1", {
+    range: { since: "now() - INTERVAL 24 HOUR", until: "now()" },
+    minDurationMs: 250,
+    limit: 100,
+  });
+
+  // A duration floor can exclude more traces than the recent window holds, so it
+  // needs the raw table rather than the recent-then-summary fast path.
+  assert.match(capture.query ?? "", /FROM otel_traces\b/);
+  assert.doesNotMatch(capture.query ?? "", /recent_ids/);
+});
+
+test("queryTracesAggregated falls back to the raw scan when a span-level filter is set", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await queryTracesAggregated(fakeClickhouseWithSummary(capture, true), "project-1", {
+    range: { since: "now() - INTERVAL 24 HOUR", until: "now()" },
+    service: "svc-web",
+    limit: 100,
+  });
+
+  // A service filter selects traces by their spans; the summary can't answer it.
+  assert.match(capture.query ?? "", /FROM otel_traces\b/);
+  assert.doesNotMatch(capture.query ?? "", /otel_traces_summary/);
+});
+
+test("queryTracesAggregated falls back to the raw scan when the derived tables are absent", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await queryTracesAggregated(fakeClickhouseWithSummary(capture, false), "project-1", {
+    range: { since: "now() - INTERVAL 24 HOUR", until: "now()" },
+    limit: 100,
+  });
+
+  assert.match(capture.query ?? "", /FROM otel_traces\b/);
+  assert.doesNotMatch(capture.query ?? "", /otel_traces_summary/);
+});
+
 test("queryTraces filters by field.span_id, ignoring non-applicable field keys", async () => {
   const capture: { query?: string; params?: Record<string, unknown> } = {};
 
@@ -374,10 +466,17 @@ const HOUR_RANGE = { since: "now() - INTERVAL 24 HOUR", until: "now()" };
 test("countSeries reads the events_per_minute rollup for unfiltered minute-step queries", async () => {
   const capture: { query?: string; params?: Record<string, unknown> } = {};
 
-  await countSeries(fakeClickhouseRollup(capture), "project-1", "traces", { range: HOUR_RANGE }, undefined, {
-    n: 15,
-    unit: "MINUTE",
-  });
+  await countSeries(
+    fakeClickhouseRollup(capture),
+    "project-1",
+    "traces",
+    { range: HOUR_RANGE },
+    undefined,
+    {
+      n: 15,
+      unit: "MINUTE",
+    },
+  );
 
   assert.match(capture.query ?? "", /FROM events_per_minute/);
   assert.match(capture.query ?? "", /sum\(c\)/);
@@ -413,11 +512,17 @@ test("countSeries re-probes rollup availability after a failed probe", async () 
   } as unknown as ClickHouseClient;
 
   // first call: probe fails -> raw scan
-  await countSeries(ch, "project-1", "traces", { range: HOUR_RANGE }, undefined, { n: 15, unit: "MINUTE" });
+  await countSeries(ch, "project-1", "traces", { range: HOUR_RANGE }, undefined, {
+    n: 15,
+    unit: "MINUTE",
+  });
   assert.match(capture.query ?? "", /FROM otel_traces/);
 
   // second call on the same client: probe retried -> rollup
-  await countSeries(ch, "project-1", "traces", { range: HOUR_RANGE }, undefined, { n: 15, unit: "MINUTE" });
+  await countSeries(ch, "project-1", "traces", { range: HOUR_RANGE }, undefined, {
+    n: 15,
+    unit: "MINUTE",
+  });
   assert.equal(probes, 2);
   assert.match(capture.query ?? "", /FROM events_per_minute/);
 });
@@ -425,10 +530,17 @@ test("countSeries re-probes rollup availability after a failed probe", async () 
 test("countSeries rollup path supports grouping by service", async () => {
   const capture: { query?: string; params?: Record<string, unknown> } = {};
 
-  await countSeries(fakeClickhouseRollup(capture), "project-1", "logs", { range: HOUR_RANGE }, "service.name", {
-    n: 1,
-    unit: "HOUR",
-  });
+  await countSeries(
+    fakeClickhouseRollup(capture),
+    "project-1",
+    "logs",
+    { range: HOUR_RANGE },
+    "service.name",
+    {
+      n: 1,
+      unit: "HOUR",
+    },
+  );
 
   assert.match(capture.query ?? "", /FROM events_per_minute/);
   assert.match(capture.query ?? "", /service AS group_key/);
@@ -463,13 +575,17 @@ test("countSeries rollup path covers service, severity and status filters", asyn
 });
 
 test("countSeries falls back to the raw table for filters the rollup cannot answer", async () => {
-  const cases: { source: "logs" | "traces"; filter: Record<string, unknown>; groupBy?: string }[] = [
-    { source: "traces", filter: { range: HOUR_RANGE, resourceAttrs: [{ key: "env", value: "prod", op: "eq" }] } },
-    { source: "logs", filter: { range: HOUR_RANGE, search: "boom" } },
-    { source: "traces", filter: { range: HOUR_RANGE, spanName: "GET /" } },
-    { source: "traces", filter: { range: HOUR_RANGE, minDurationMs: 250 } },
-    { source: "traces", filter: { range: HOUR_RANGE }, groupBy: "attr:http.route" },
-  ];
+  const cases: { source: "logs" | "traces"; filter: Record<string, unknown>; groupBy?: string }[] =
+    [
+      {
+        source: "traces",
+        filter: { range: HOUR_RANGE, resourceAttrs: [{ key: "env", value: "prod", op: "eq" }] },
+      },
+      { source: "logs", filter: { range: HOUR_RANGE, search: "boom" } },
+      { source: "traces", filter: { range: HOUR_RANGE, spanName: "GET /" } },
+      { source: "traces", filter: { range: HOUR_RANGE, minDurationMs: 250 } },
+      { source: "traces", filter: { range: HOUR_RANGE }, groupBy: "attr:http.route" },
+    ];
   for (const c of cases) {
     const capture: { query?: string; params?: Record<string, unknown> } = {};
     await countSeries(fakeClickhouseRollup(capture), "project-1", c.source, c.filter, c.groupBy, {
@@ -487,10 +603,17 @@ test("countSeries falls back to the raw table for filters the rollup cannot answ
 test("countSeries falls back to the raw table for sub-minute steps", async () => {
   const capture: { query?: string; params?: Record<string, unknown> } = {};
 
-  await countSeries(fakeClickhouseRollup(capture), "project-1", "traces", { range: HOUR_RANGE }, undefined, {
-    n: 30,
-    unit: "SECOND",
-  });
+  await countSeries(
+    fakeClickhouseRollup(capture),
+    "project-1",
+    "traces",
+    { range: HOUR_RANGE },
+    undefined,
+    {
+      n: 30,
+      unit: "SECOND",
+    },
+  );
 
   assert.match(capture.query ?? "", /FROM otel_traces/);
 });
@@ -532,7 +655,10 @@ test("countSeries maps negated service.name filters onto ServiceName too", async
     fakeClickhouse(neqCapture),
     "project-1",
     "traces",
-    { range: HOUR_RANGE, resourceAttrs: [{ key: "resource.service.name", value: "worker", op: "neq" }] },
+    {
+      range: HOUR_RANGE,
+      resourceAttrs: [{ key: "resource.service.name", value: "worker", op: "neq" }],
+    },
     undefined,
     { n: 1, unit: "MINUTE" },
   );
@@ -543,11 +669,17 @@ test("countSeries maps negated service.name filters onto ServiceName too", async
     fakeClickhouse(ncCapture),
     "project-1",
     "traces",
-    { range: HOUR_RANGE, resourceAttrs: [{ key: "service.name", value: "work", op: "not_contains" }] },
+    {
+      range: HOUR_RANGE,
+      resourceAttrs: [{ key: "service.name", value: "work", op: "not_contains" }],
+    },
     undefined,
     { n: 1, unit: "MINUTE" },
   );
-  assert.match(ncCapture.query ?? "", /positionCaseInsensitive\(ServiceName, \{attr_v_0:String\}\) = 0/);
+  assert.match(
+    ncCapture.query ?? "",
+    /positionCaseInsensitive\(ServiceName, \{attr_v_0:String\}\) = 0/,
+  );
 });
 
 test("queryLogs maps a service.name resource filter to the ServiceName column", async () => {

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -348,6 +348,13 @@ type TracesAggregatedParams = {
 // few granules regardless of how big the window nominally is.
 const TRACE_RECENT_SCAN_CAP = 50_000;
 
+// Step 1 (the recent index) is only a candidate generator; step 2 (the summary)
+// is authoritative for which traces started in the window and for the ordering.
+// Over-fetch candidates by this factor so that traces which step 1 surfaces by
+// recent activity but step 2 drops (their start is before the window) don't
+// shrink the page below the requested limit.
+const TRACE_CANDIDATE_OVERFETCH = 5;
+
 // The trace-summary fast path holds one aggregate-state row per trace with no
 // per-span dimensions, and picks "recent" from a span-only time index — so it
 // can only answer the unfiltered trace list (the default view, and the one that
@@ -364,18 +371,60 @@ function traceSummaryEligible(params: TracesAggregatedParams): boolean {
   return true;
 }
 
+// The materialized views only populate the derived tables from their creation
+// forward; the one-shot backfill fills earlier history. Until history reaches
+// back past the window start, the fast path would return a truncated list (only
+// post-migration traces) where the raw scan showed the full window. Gate on the
+// recent index actually holding a row older than the window start for this
+// project: if it doesn't, the window isn't fully covered — fall back to the raw
+// scan. This makes activation self-correcting (per project, per window) rather
+// than flipping on the moment the tables exist. A brand-new project with no
+// history before the window also falls back, which is fine — it is low-volume and
+// the raw scan is fast there.
+async function traceRollupCoversWindow(
+  ch: ClickHouseClient,
+  projectId: string,
+  sinceExpr: string,
+  sinceSql: string,
+): Promise<boolean> {
+  const r = await ch.query({
+    query: `
+      SELECT count() AS c
+      FROM (
+        SELECT 1
+        FROM otel_traces_recent
+        WHERE project_id = {projectId:String} AND ts < ${sinceExpr}
+        LIMIT 1
+      )
+    `,
+    query_params: { projectId, since: sinceSql },
+    format: "JSONEachRow",
+  });
+  const rows = (await r.json()) as { c: string | number }[];
+  return Number(rows[0]?.c ?? 0) > 0;
+}
+
 // Two-step read: (1) otel_traces_recent, a plain time-ordered span index, gives
-// the most recently started trace_ids via a bounded reverse scan + GROUP BY;
-// (2) otel_traces_summary supplies the displayed stats for just those trace_ids.
-// Neither step scans the whole per-project window, so it stays ~1s where the raw
-// GROUP BY over raw otel_traces is 15-60s. Output columns match the raw
-// queryTracesAggregated query exactly so callers are unaffected.
+// recent candidate trace_ids via a bounded reverse scan + GROUP BY; (2)
+// otel_traces_summary filters those to traces whose start is in the window,
+// supplies the displayed stats, and orders the page. Neither step scans the
+// whole per-project window, so it stays ~1s where the raw GROUP BY over raw
+// otel_traces is 15-60s. Output columns match the raw queryTracesAggregated query
+// exactly so callers are unaffected.
+//
+// Semantics: the list is "traces whose start falls in [since, until]", with
+// whole-trace stats (all of a trace's spans), ordered by start. For the default
+// list (until = now) every included trace started at or after `since`, so all its
+// spans lie in the window and the stats equal the raw window-clipped values; they
+// can differ from the raw scan only for a historical window (until in the past)
+// that a long trace straddles — negligible for the short traces this serves.
 async function queryTracesAggregatedFromSummary(
   ch: ClickHouseClient,
   projectId: string,
   params: TracesAggregatedParams,
 ) {
   const { sinceSql, untilSql, sinceExpr, untilExpr } = resolveRange(params.range);
+  const candidateLimit = params.limit * TRACE_CANDIDATE_OVERFETCH;
   const query = `
     WITH recent_ids AS (
       SELECT trace_id
@@ -390,7 +439,7 @@ async function queryTracesAggregatedFromSummary(
       )
       GROUP BY trace_id
       ORDER BY min(ts) DESC
-      LIMIT {limit:UInt32}
+      LIMIT ${candidateLimit}
     )
     SELECT
       trace_id,
@@ -424,14 +473,19 @@ export async function queryTracesAggregated(
   projectId: string,
   params: TracesAggregatedParams,
 ) {
-  // Both derived tables must exist; either missing (e.g. local dev, or before the
-  // migration lands) falls back to the raw scan.
+  // Fast path only when it is both available and complete for this window: both
+  // derived tables exist (either missing — local dev, or before the migration
+  // lands — falls back), and the recent index reaches back past the window start
+  // (otherwise the list would be silently truncated to post-migration data).
   if (
     traceSummaryEligible(params) &&
     (await tableExists(ch, "otel_traces_recent")) &&
     (await tableExists(ch, "otel_traces_summary"))
   ) {
-    return queryTracesAggregatedFromSummary(ch, projectId, params);
+    const { sinceExpr, sinceSql } = resolveRange(params.range);
+    if (await traceRollupCoversWindow(ch, projectId, sinceExpr, sinceSql)) {
+      return queryTracesAggregatedFromSummary(ch, projectId, params);
+    }
   }
   const { sinceSql, untilSql, sinceExpr, untilExpr } = resolveRange(params.range);
   const split = splitAttrs(params.resourceAttrs);

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -331,19 +331,108 @@ export async function queryTraces(
   return r.json();
 }
 
+type TracesAggregatedParams = {
+  range?: TimeRange;
+  service?: string;
+  spanName?: string;
+  statusCode?: string;
+  minDurationMs?: number;
+  resourceAttrs?: ResourceAttrFilter[];
+  limit: number;
+};
+
+// How many of the newest spans the recent-index step reverse-scans to find the
+// most recently started traces. Far more than any page needs (a high-volume
+// project fits thousands of traces in these spans; a small one has fewer total),
+// so the true newest traces are always covered, while the bound keeps the scan a
+// few granules regardless of how big the window nominally is.
+const TRACE_RECENT_SCAN_CAP = 50_000;
+
+// The trace-summary fast path holds one aggregate-state row per trace with no
+// per-span dimensions, and picks "recent" from a span-only time index — so it
+// can only answer the unfiltered trace list (the default view, and the one that
+// times out on the raw scan for high-volume projects). Any span-selecting filter
+// — service, span name, status code, an attribute predicate — or a duration
+// floor (which could exclude more traces than the recent window holds) needs the
+// raw table.
+function traceSummaryEligible(params: TracesAggregatedParams): boolean {
+  if (params.service) return false;
+  if (params.spanName) return false;
+  if (params.statusCode) return false;
+  if (params.minDurationMs) return false;
+  if (params.resourceAttrs?.length) return false;
+  return true;
+}
+
+// Two-step read: (1) otel_traces_recent, a plain time-ordered span index, gives
+// the most recently started trace_ids via a bounded reverse scan + GROUP BY;
+// (2) otel_traces_summary supplies the displayed stats for just those trace_ids.
+// Neither step scans the whole per-project window, so it stays ~1s where the raw
+// GROUP BY over raw otel_traces is 15-60s. Output columns match the raw
+// queryTracesAggregated query exactly so callers are unaffected.
+async function queryTracesAggregatedFromSummary(
+  ch: ClickHouseClient,
+  projectId: string,
+  params: TracesAggregatedParams,
+) {
+  const { sinceSql, untilSql, sinceExpr, untilExpr } = resolveRange(params.range);
+  const query = `
+    WITH recent_ids AS (
+      SELECT trace_id
+      FROM (
+        SELECT ts, trace_id
+        FROM otel_traces_recent
+        WHERE project_id = {projectId:String}
+          AND ts >= ${sinceExpr}
+          AND ts <= ${untilExpr}
+        ORDER BY ts DESC
+        LIMIT ${TRACE_RECENT_SCAN_CAP}
+      )
+      GROUP BY trace_id
+      ORDER BY min(ts) DESC
+      LIMIT {limit:UInt32}
+    )
+    SELECT
+      trace_id,
+      toString(min(start)) AS start_time,
+      argMinMerge(root_span_name) AS root_span_name,
+      argMinMerge(root_service) AS root_service,
+      argMinMerge(root_status_code) AS root_status_code,
+      sum(span_count) AS span_count,
+      sum(error_count) AS error_count,
+      uniqExactMerge(services) AS service_count,
+      toFloat64(max(end_unix_nano) - min(start_unix_nano)) / 1000000 AS duration_ms
+    FROM otel_traces_summary
+    WHERE project_id = {projectId:String}
+      AND trace_id IN (recent_ids)
+      AND start >= ${sinceExpr}
+      AND start <= ${untilExpr}
+    GROUP BY project_id, trace_id
+    ORDER BY start_time DESC
+    LIMIT {limit:UInt32}
+  `;
+  const r = await ch.query({
+    query,
+    query_params: { projectId, since: sinceSql, until: untilSql, limit: params.limit },
+    format: "JSONEachRow",
+  });
+  return r.json();
+}
+
 export async function queryTracesAggregated(
   ch: ClickHouseClient,
   projectId: string,
-  params: {
-    range?: TimeRange;
-    service?: string;
-    spanName?: string;
-    statusCode?: string;
-    minDurationMs?: number;
-    resourceAttrs?: ResourceAttrFilter[];
-    limit: number;
-  },
+  params: TracesAggregatedParams,
 ) {
+  // Both derived tables must exist; either missing (e.g. local dev, or before the
+  // migration lands) falls back to the raw scan.
+  if (
+    traceSummaryEligible(params) &&
+    (await tableExists(ch, "otel_traces_recent")) &&
+    (await tableExists(ch, "otel_traces_summary"))
+  ) {
+    return queryTracesAggregatedFromSummary(ch, projectId, params);
+  }
   const { sinceSql, untilSql, sinceExpr, untilExpr } = resolveRange(params.range);
   const split = splitAttrs(params.resourceAttrs);
   const attr = attrConds(split.resource);
@@ -1081,7 +1170,7 @@ export async function metricSeries(
               conds,
               sinceExpr,
             })
-        : `
+          : `
           SELECT
             toString(toStartOfInterval(TimeUnix, INTERVAL ${step.n} ${step.unit})) AS bucket,
             ${groupExpr} AS group_key,
@@ -1190,27 +1279,41 @@ export function pickStep(rangeSeconds: number, targetBuckets = 120): Step {
 // back to the raw scan without a per-request penalty.
 // -----------------------------------------------------------------------------
 
-const rollupAvailability = new WeakMap<ClickHouseClient, Promise<boolean>>();
+const tableExistsMemo = new WeakMap<ClickHouseClient, Map<string, Promise<boolean>>>();
 
-function rollupAvailable(ch: ClickHouseClient): Promise<boolean> {
-  let probe = rollupAvailability.get(ch);
+// Memoized `EXISTS TABLE <name>` probe, per client + table. Derived tables
+// (events_per_minute, otel_traces_summary, …) are not part of the collector's
+// auto-created schema, so deployments without them must fall back to the raw
+// scan without a per-request penalty. `table` is always a hardcoded literal
+// here — never interpolate user input into this.
+function tableExists(ch: ClickHouseClient, table: string): Promise<boolean> {
+  let byTable = tableExistsMemo.get(ch);
+  if (!byTable) {
+    byTable = new Map();
+    tableExistsMemo.set(ch, byTable);
+  }
+  let probe = byTable.get(table);
   if (!probe) {
     probe = (async () => {
       try {
-        const r = await ch.query({ query: "EXISTS TABLE events_per_minute", format: "JSONEachRow" });
+        const r = await ch.query({ query: `EXISTS TABLE ${table}`, format: "JSONEachRow" });
         const rows = (await r.json()) as { result: number | string }[];
         return Number(rows[0]?.result) === 1;
       } catch {
         // A failed probe (e.g. ClickHouse briefly unreachable) says nothing
-        // about whether the rollup exists — drop the memo so the next call
+        // about whether the table exists — drop the memo so the next call
         // re-probes instead of pinning the raw path until restart.
-        rollupAvailability.delete(ch);
+        byTable?.delete(table);
         return false;
       }
     })();
-    rollupAvailability.set(ch, probe);
+    byTable.set(table, probe);
   }
   return probe;
+}
+
+function rollupAvailable(ch: ClickHouseClient): Promise<boolean> {
+  return tableExists(ch, "events_per_minute");
 }
 
 // A widget that filters on the service.name resource attribute (instead of

--- a/apps/worker/scripts/backfill-otel-traces-summary.ts
+++ b/apps/worker/scripts/backfill-otel-traces-summary.ts
@@ -1,0 +1,206 @@
+import "../src/env.js";
+import { createClient } from "@clickhouse/client";
+
+// Backfill historical rows into the trace-list fast-path tables (see
+// infra/clickhouse/migrations/005_otel_traces_summary.sql):
+//   - superlog.otel_traces_recent  (time-ordered span index; one row per span)
+//   - superlog.otel_traces_summary (aggregate state; one row per trace)
+// The materialized views only capture spans ingested AFTER they are created, so
+// traces already in otel_traces need this one-time pass to appear in the list.
+//
+// Each SELECT is identical to the matching MV, with an added [from, to)
+// Timestamp window — so backfilled rows are byte-for-byte what the MVs produce.
+//
+// DOUBLE COUNTING: run the backfill ONCE, strictly up to the moment the MVs went
+// live. otel_traces_summary is an AggregatingMergeTree keyed (project_id,
+// TraceId): re-inserting a span (by overlapping the live MV window or rerunning a
+// range) inflates span_count/error_count. otel_traces_recent is a plain
+// MergeTree: re-inserting duplicates rows (harmless to ranking but wasteful).
+// Give it:
+//   --from <retention start>  --to <migration-apply time>
+// so the backfill owns [retention_start, mv_cutover) and the MVs own
+// [mv_cutover, now). A trace straddling the cutover is fine: early spans from the
+// backfill, late spans from the MV, states merge to the correct union.
+//
+// Dry run by default; pass --apply to write. Example:
+//   pnpm --filter @superlog/worker exec tsx scripts/backfill-otel-traces-summary.ts \
+//     --from 2026-06-02 --to 2026-07-02T16:00:00Z --chunk-hours 6 --apply
+
+type Args = {
+  from: Date;
+  to: Date;
+  chunkHours: number;
+  projectId?: string;
+  apply: boolean;
+};
+
+const args = parseArgs(process.argv.slice(2));
+const clickhouse = createClient({
+  url: process.env.CLICKHOUSE_URL ?? "http://localhost:8123",
+  username: process.env.CLICKHOUSE_USER ?? "default",
+  password: process.env.CLICKHOUSE_PASSWORD ?? "",
+  database: process.env.CLICKHOUSE_DB ?? "superlog",
+});
+
+const windowFilter = `
+      AND ResourceAttributes['superlog.project_id'] != ''
+      AND TraceId != ''
+      AND Timestamp >= parseDateTime64BestEffort({from:String}, 9)
+      AND Timestamp < parseDateTime64BestEffort({to:String}, 9)`;
+
+// otel_traces_recent_mv: one row per span, no aggregation.
+function recentInsert(projectFilter: string): string {
+  return `
+    INSERT INTO otel_traces_recent
+    SELECT
+      ResourceAttributes['superlog.project_id'] AS project_id,
+      Timestamp AS ts,
+      TraceId AS trace_id
+    FROM otel_traces
+    WHERE 1 ${windowFilter} ${projectFilter}
+  `;
+}
+
+// otel_traces_summary_mv: one aggregate-state row per (project_id, TraceId).
+function summaryInsert(projectFilter: string): string {
+  return `
+    INSERT INTO otel_traces_summary
+    SELECT
+      ResourceAttributes['superlog.project_id'] AS project_id,
+      TraceId AS trace_id,
+      min(Timestamp) AS start,
+      min(toUnixTimestamp64Nano(Timestamp)) AS start_unix_nano,
+      max(toUnixTimestamp64Nano(Timestamp) + toInt64(Duration)) AS end_unix_nano,
+      count() AS span_count,
+      countIf(StatusCode = 'STATUS_CODE_ERROR') AS error_count,
+      argMinState(SpanName, Timestamp) AS root_span_name,
+      argMinState(ServiceName, Timestamp) AS root_service,
+      argMinState(StatusCode, Timestamp) AS root_status_code,
+      uniqExactState(ServiceName) AS services
+    FROM otel_traces
+    WHERE 1 ${windowFilter} ${projectFilter}
+    GROUP BY project_id, trace_id
+  `;
+}
+
+// Spans (recent rows) and distinct traces (summary rows) in the window.
+async function countWindow(
+  projectFilter: string,
+  params: Record<string, unknown>,
+): Promise<{ spanRows: number; traceRows: number }> {
+  const res = await clickhouse.query({
+    query: `
+      SELECT count() AS spanRows, uniqExact(TraceId) AS traceRows
+      FROM otel_traces
+      WHERE 1 ${windowFilter} ${projectFilter}
+    `,
+    query_params: params,
+    format: "JSONEachRow",
+  });
+  const rows = (await res.json()) as { spanRows: string | number; traceRows: string | number }[];
+  return { spanRows: Number(rows[0]?.spanRows ?? 0), traceRows: Number(rows[0]?.traceRows ?? 0) };
+}
+
+let insertedSpanRows = 0;
+let insertedTraceRows = 0;
+
+try {
+  console.log(
+    JSON.stringify({
+      apply: args.apply,
+      from: args.from.toISOString(),
+      to: args.to.toISOString(),
+      chunkHours: args.chunkHours,
+      projectId: args.projectId ?? null,
+      note: args.apply
+        ? "INSERTs merge into aggregate states / append to the index; do not overlap the live MV window or rerun a range."
+        : "dry run only; pass --apply to insert rows",
+    }),
+  );
+
+  const projectFilter = args.projectId
+    ? "AND ResourceAttributes['superlog.project_id'] = {projectId:String}"
+    : "";
+
+  for (const [from, to] of chunkWindows(args.from, args.to, args.chunkHours)) {
+    const params: Record<string, unknown> = {
+      from: from.toISOString(),
+      to: to.toISOString(),
+      ...(args.projectId ? { projectId: args.projectId } : {}),
+    };
+
+    const { spanRows, traceRows } = await countWindow(projectFilter, params);
+    if (args.apply && spanRows > 0) {
+      await clickhouse.command({ query: recentInsert(projectFilter), query_params: params });
+      await clickhouse.command({ query: summaryInsert(projectFilter), query_params: params });
+      insertedSpanRows += spanRows;
+      insertedTraceRows += traceRows;
+    }
+
+    console.log(
+      JSON.stringify({ from: from.toISOString(), to: to.toISOString(), spanRows, traceRows }),
+    );
+  }
+
+  console.log(JSON.stringify({ insertedSpanRows, insertedTraceRows, applied: args.apply }));
+} finally {
+  await clickhouse.close();
+}
+
+function* chunkWindows(from: Date, to: Date, chunkHours: number): Generator<[Date, Date]> {
+  const chunkMs = chunkHours * 60 * 60 * 1000;
+  for (let cursor = from.getTime(); cursor < to.getTime(); cursor += chunkMs) {
+    yield [new Date(cursor), new Date(Math.min(cursor + chunkMs, to.getTime()))];
+  }
+}
+
+function parseArgs(argv: string[]): Args {
+  const values = new Map<string, string | true>();
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--") continue;
+    if (!arg.startsWith("--")) throw new Error(`unexpected argument: ${arg}`);
+    const key = arg.slice(2);
+    if (key === "apply") {
+      values.set(key, true);
+      continue;
+    }
+    const value = argv[i + 1];
+    if (!value || value.startsWith("--")) throw new Error(`missing value for --${key}`);
+    values.set(key, value);
+    i += 1;
+  }
+
+  const to = parseDate(values.get("to")) ?? startOfUtcTomorrow(new Date());
+  const from = parseDate(values.get("from")) ?? new Date(to.getTime() - 14 * 24 * 60 * 60 * 1000);
+  const chunkHours = Number(values.get("chunk-hours") ?? 6);
+  if (!Number.isFinite(chunkHours) || chunkHours <= 0)
+    throw new Error("--chunk-hours must be positive");
+  if (from >= to) throw new Error("--from must be before --to");
+
+  return {
+    from,
+    to,
+    chunkHours,
+    apply: values.get("apply") === true,
+    projectId:
+      typeof values.get("project-id") === "string"
+        ? (values.get("project-id") as string)
+        : undefined,
+  };
+}
+
+function parseDate(value: string | true | undefined): Date | null {
+  if (typeof value !== "string") return null;
+  const withTime = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00.000Z` : value;
+  const date = new Date(withTime);
+  if (!Number.isFinite(date.getTime())) throw new Error(`invalid date: ${value}`);
+  return date;
+}
+
+function startOfUtcTomorrow(now: Date): Date {
+  const out = new Date(now);
+  out.setUTCHours(0, 0, 0, 0);
+  out.setUTCDate(out.getUTCDate() + 1);
+  return out;
+}

--- a/infra/clickhouse/migrations/005_otel_traces_summary.sql
+++ b/infra/clickhouse/migrations/005_otel_traces_summary.sql
@@ -1,0 +1,112 @@
+-- Trace-list fast path (queryTracesAggregated in apps/api/src/mcp/clickhouse.ts —
+-- the explore "traces" grouped list). Two derived tables, read in two steps.
+--
+-- Why: the grouped list does `GROUP BY TraceId` over every span in the selected
+-- window of raw otel_traces, then sorts and limits. otel_traces is sorted by
+-- (ServiceName, SpanName, Timestamp) and the project filter lives in the
+-- ResourceAttributes map, so a project's list can't use the primary index — it
+-- scans the whole multi-tenant window. Over a 24h range on a busy deployment
+-- that reads hundreds of millions of rows and exceeds the API's ClickHouse
+-- request timeout, so the list 500s while the (rollup-backed) chart above it
+-- still renders.
+--
+-- A single per-trace rollup is NOT enough on its own: a high-volume project can
+-- have millions of traces in a day, and "the 100 most recent" still means a
+-- GROUP BY + sort over all of them (measured ~15s at 24h). The sort key can't be
+-- the trace start either — it's a min-aggregate, and SimpleAggregateFunction
+-- columns are not allowed in a key. So we split the work the way trace backends
+-- (Tempo/Jaeger) do:
+--
+--   1. otel_traces_recent — a plain, time-ordered index of every span
+--      (project_id, ts, trace_id), ORDER BY (project_id, ts). A bounded reverse
+--      scan of the newest spans, grouped by trace_id, yields the N most recently
+--      started trace_ids in milliseconds. Covers ALL traces (no root-span
+--      dependency; ~35% of traces have no root span).
+--   2. otel_traces_summary — one aggregate-state row per (project_id, trace_id)
+--      with start, span/error counts, root span/service/status (earliest span by
+--      Timestamp), distinct-service count, and the [start,end] nanos for total
+--      duration. Looked up for just those N trace_ids (IN, indexed) to fill in
+--      the displayed stats.
+--
+-- Net ~1s at 24h for a 7.8M-trace/day project vs 15-60s on the raw scan.
+--
+-- otel_traces_summary is AggregatingMergeTree (not Summing): a trace's spans
+-- arrive across many inserts, so min/max/argMin/uniqExact must merge partial
+-- states over time. Readers MUST re-aggregate (GROUP BY project_id, trace_id
+-- with sum()/min()/max() for the SimpleAggregateFunction columns and *Merge for
+-- the AggregateFunction ones) — see queryTracesAggregatedFromSummary.
+--
+-- No TTL clause: otel_traces itself carries none here, so bounding these derived
+-- tables would under-report long-window lists relative to the source. Retention
+-- should track the source table's when that is added.
+--
+-- Run ONCE per environment. Statements are IF NOT EXISTS so they are
+-- individually safe to retry. The MVs only capture rows inserted AFTER they are
+-- created; historical traces need the companion one-shot backfill script
+-- apps/worker/scripts/backfill-otel-traces-summary.ts, run over
+-- [retention_start, mv_cutover) so it never overlaps the live MV window (an
+-- overlap re-inserts the same spans and double-counts span_count/error_count in
+-- the summary, and duplicates rows in the recent index).
+
+-- 1. Time-ordered span index -------------------------------------------------
+CREATE TABLE IF NOT EXISTS superlog.otel_traces_recent ON CLUSTER superlog_ha
+(
+    `project_id` String CODEC(ZSTD(1)),
+    `ts` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    `trace_id` String CODEC(ZSTD(1))
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
+PARTITION BY toDate(ts)
+ORDER BY (project_id, ts)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.otel_traces_recent_mv ON CLUSTER superlog_ha
+TO superlog.otel_traces_recent
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    Timestamp AS ts,
+    TraceId AS trace_id
+FROM superlog.otel_traces
+WHERE ResourceAttributes['superlog.project_id'] != '' AND TraceId != ''
+;
+
+-- 2. Per-trace aggregate summary ---------------------------------------------
+CREATE TABLE IF NOT EXISTS superlog.otel_traces_summary ON CLUSTER superlog_ha
+(
+    `project_id` String CODEC(ZSTD(1)),
+    `trace_id` String CODEC(ZSTD(1)),
+    `start` SimpleAggregateFunction(min, DateTime64(9)) CODEC(ZSTD(1)),
+    `start_unix_nano` SimpleAggregateFunction(min, Int64) CODEC(ZSTD(1)),
+    `end_unix_nano` SimpleAggregateFunction(max, Int64) CODEC(ZSTD(1)),
+    `span_count` SimpleAggregateFunction(sum, UInt64) CODEC(ZSTD(1)),
+    `error_count` SimpleAggregateFunction(sum, UInt64) CODEC(ZSTD(1)),
+    `root_span_name` AggregateFunction(argMin, LowCardinality(String), DateTime64(9)),
+    `root_service` AggregateFunction(argMin, LowCardinality(String), DateTime64(9)),
+    `root_status_code` AggregateFunction(argMin, LowCardinality(String), DateTime64(9)),
+    `services` AggregateFunction(uniqExact, LowCardinality(String))
+)
+ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
+PARTITION BY toDate(start)
+ORDER BY (project_id, trace_id)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.otel_traces_summary_mv ON CLUSTER superlog_ha
+TO superlog.otel_traces_summary
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    TraceId AS trace_id,
+    min(Timestamp) AS start,
+    min(toUnixTimestamp64Nano(Timestamp)) AS start_unix_nano,
+    max(toUnixTimestamp64Nano(Timestamp) + toInt64(Duration)) AS end_unix_nano,
+    count() AS span_count,
+    countIf(StatusCode = 'STATUS_CODE_ERROR') AS error_count,
+    argMinState(SpanName, Timestamp) AS root_span_name,
+    argMinState(ServiceName, Timestamp) AS root_service,
+    argMinState(StatusCode, Timestamp) AS root_status_code,
+    uniqExactState(ServiceName) AS services
+FROM superlog.otel_traces
+WHERE ResourceAttributes['superlog.project_id'] != '' AND TraceId != ''
+GROUP BY project_id, trace_id
+;

--- a/infra/clickhouse/schema/ha-replicated-otel.sql
+++ b/infra/clickhouse/schema/ha-replicated-otel.sql
@@ -460,3 +460,67 @@ FROM superlog.otel_logs
 WHERE SeverityNumber >= 17
   AND ResourceAttributes['superlog.project_id'] != ''
 ;
+-- otel_traces_recent + otel_traces_summary (trace-list fast path; see
+-- migrations/005_otel_traces_summary.sql for rationale + backfill notes). The
+-- recent index gives the N most recently started trace_ids per project via a
+-- bounded time-ordered scan; the summary supplies per-trace stats for those ids.
+CREATE TABLE IF NOT EXISTS superlog.otel_traces_recent ON CLUSTER superlog_ha
+(
+    `project_id` String CODEC(ZSTD(1)),
+    `ts` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    `trace_id` String CODEC(ZSTD(1))
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
+PARTITION BY toDate(ts)
+ORDER BY (project_id, ts)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+;
+-- otel_traces_recent_mv
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.otel_traces_recent_mv ON CLUSTER superlog_ha
+TO superlog.otel_traces_recent
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    Timestamp AS ts,
+    TraceId AS trace_id
+FROM superlog.otel_traces
+WHERE ResourceAttributes['superlog.project_id'] != '' AND TraceId != ''
+;
+-- otel_traces_summary
+CREATE TABLE IF NOT EXISTS superlog.otel_traces_summary ON CLUSTER superlog_ha
+(
+    `project_id` String CODEC(ZSTD(1)),
+    `trace_id` String CODEC(ZSTD(1)),
+    `start` SimpleAggregateFunction(min, DateTime64(9)) CODEC(ZSTD(1)),
+    `start_unix_nano` SimpleAggregateFunction(min, Int64) CODEC(ZSTD(1)),
+    `end_unix_nano` SimpleAggregateFunction(max, Int64) CODEC(ZSTD(1)),
+    `span_count` SimpleAggregateFunction(sum, UInt64) CODEC(ZSTD(1)),
+    `error_count` SimpleAggregateFunction(sum, UInt64) CODEC(ZSTD(1)),
+    `root_span_name` AggregateFunction(argMin, LowCardinality(String), DateTime64(9)),
+    `root_service` AggregateFunction(argMin, LowCardinality(String), DateTime64(9)),
+    `root_status_code` AggregateFunction(argMin, LowCardinality(String), DateTime64(9)),
+    `services` AggregateFunction(uniqExact, LowCardinality(String))
+)
+ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
+PARTITION BY toDate(start)
+ORDER BY (project_id, trace_id)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+;
+-- otel_traces_summary_mv
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.otel_traces_summary_mv ON CLUSTER superlog_ha
+TO superlog.otel_traces_summary
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    TraceId AS trace_id,
+    min(Timestamp) AS start,
+    min(toUnixTimestamp64Nano(Timestamp)) AS start_unix_nano,
+    max(toUnixTimestamp64Nano(Timestamp) + toInt64(Duration)) AS end_unix_nano,
+    count() AS span_count,
+    countIf(StatusCode = 'STATUS_CODE_ERROR') AS error_count,
+    argMinState(SpanName, Timestamp) AS root_span_name,
+    argMinState(ServiceName, Timestamp) AS root_service,
+    argMinState(StatusCode, Timestamp) AS root_status_code,
+    uniqExactState(ServiceName) AS services
+FROM superlog.otel_traces
+WHERE ResourceAttributes['superlog.project_id'] != '' AND TraceId != ''
+GROUP BY project_id, trace_id
+;


### PR DESCRIPTION
## Problem

The explore **traces** grouped list groups raw `otel_traces` by `TraceId` over the whole selected window, then sorts and limits. `otel_traces` is sorted by `(ServiceName, SpanName, Timestamp)` and the project filter lives in the `ResourceAttributes` map, so a project's list can't use the primary index — it scans the entire multi-tenant window. On a busy deployment a 24h range reads hundreds of millions of rows and exceeds the ClickHouse request timeout, so the list **500s** (the user sees `LOADING…` → error) while the rollup-backed chart above it still renders.

A single per-trace rollup isn't enough on its own: a high-volume project can have millions of traces in a day, so "the 100 most recent" is still a `GROUP BY` + sort over all of them (~15s at 24h). The trace start can't be the sort key either — it's a min-aggregate, and `SimpleAggregateFunction` columns aren't allowed in a key.

## Approach

Two derived tables (migration `005`), read in two steps — the shape trace backends (Tempo/Jaeger) use:

1. **`otel_traces_recent`** — a plain, time-ordered span index `(project_id, ts, trace_id)`, `ORDER BY (project_id, ts)`. A bounded reverse scan of the newest spans, grouped by `trace_id`, yields the N most recently started trace_ids in milliseconds. Covers **all** traces (no root-span dependency).
2. **`otel_traces_summary`** — one `AggregatingMergeTree` row per `(project_id, trace_id)` with start, span/error counts, root span/service/status (earliest span by `Timestamp`), distinct-service count, and the `[start,end]` nanos for total duration. Looked up for just those N trace_ids (`IN`, indexed) for the displayed stats.

`queryTracesAggregated` takes this path **only for the unfiltered list** (the default view that times out); any span-selecting filter (service / span name / status code / attribute) or a duration floor falls back to the raw scan. Availability is probed once per client and memoized, so environments without the tables (local dev, or before the migration lands) fall back automatically.

## Validation

Measured against a real high-volume project (**7.8M traces / 24h**):

- **Latency:** ~1s vs 15–60s on the raw scan.
- **Correctness (identical frozen snapshot, apples-to-apples):** top-100 trace_id overlap **100/100**; **0** rows differ from the raw ground truth on any field (start, span_count, error_count, root span, duration).

## Rollout

The materialized views only capture spans ingested **after** creation. Historical traces need the one-shot backfill (`apps/worker/scripts/backfill-otel-traces-summary.ts`), run over `[retention_start, mv_cutover)` **before** deploying the read path, so it never overlaps the live MV window (an overlap re-inserts spans and double-counts `span_count`/`error_count`). Order: apply migration → backfill → deploy.

## Notes for review

- Neither derived table has a TTL (mirrors `otel_exceptions`). `otel_traces_recent` is a full-span-volume index, so retention is worth a follow-up decision.
- `TRACE_RECENT_SCAN_CAP = 50000` bounds the recent-index reverse scan.

## Test plan

- [x] `pnpm --filter @superlog/api test` (32/32, incl. 4 new fast-path/fallback cases)
- [x] `pnpm --filter @superlog/api typecheck`, `pnpm --filter @superlog/worker typecheck`
- [x] biome clean
- [x] Query correctness + latency verified against production-scale data

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production trace-list query path and introduces new derived tables whose correctness depends on migration order and a one-time backfill window; mis-ordered rollout or overlapping backfill can truncate lists or inflate aggregate counts, though filtered queries and missing rollups still fall back to raw scans.
> 
> **Overview**
> Adds ClickHouse **`otel_traces_recent`** (time-ordered span index) and **`otel_traces_summary`** (per-trace aggregates) with MVs, plus migration `005` and HA schema updates.
> 
> **`queryTracesAggregated`** now uses a two-step fast path (`recent_ids` → summary `*Merge` stats) for the **unfiltered** default list when both tables exist and a coverage probe shows history reaches before the window start; otherwise it keeps the raw `otel_traces` scan. Span/service/status/attribute filters and `minDurationMs` always use raw. Table existence checks are generalized via memoized `EXISTS TABLE` (replacing rollup-only probing).
> 
> A one-shot **`backfill-otel-traces-summary.ts`** fills pre-MV history in chunks (dry-run by default); rollout must avoid overlapping the live MV window to prevent double-counting in the summary.
> 
> Tests add five cases for fast path vs fallback (filters, missing tables, incomplete window coverage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d7b2ab965450d321171bce207ac57fa1fe3238c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the Explore trace list from derived ClickHouse rollups, now gated by window coverage to avoid truncated results. The default unfiltered view loads in ~1s and matches the raw query, with automatic fallback when rollups are missing or incomplete.

- **New Features**
  - Added `otel_traces_recent` (time-ordered span index) and `otel_traces_summary` (per-trace aggregates) with MVs; two-step read where the summary is authoritative for membership and order.
  - `queryTracesAggregated` uses the fast path only when no filters/minDuration, both tables exist, and the recent index reaches before the window start; else falls back to `otel_traces`.
  - Overfetches candidates (`limit * 5`) to keep pages full; bounds the reverse scan with `TRACE_RECENT_SCAN_CAP = 50000`.
  - Introduced memoized `tableExists` by client/table; used for both trace rollups and `events_per_minute`.
  - Tests cover fast path, filter/duration/table-absent cases, and pre-backfill window coverage; validated ~1s latency and result parity on a 7.8M traces/24h project.

- **Migration**
  - Apply `infra/clickhouse/migrations/005_otel_traces_summary.sql`.
  - Backfill history with `apps/worker/scripts/backfill-otel-traces-summary.ts` over `[retention_start, mv_cutover)`; run once and avoid overlapping the live MV window.
  - Rollout: apply migration → backfill → deploy.

<sup>Written for commit 0d7b2ab965450d321171bce207ac57fa1fe3238c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

