### PR TITLE
chore(clickhouse): 30d TTL on the trace-list rollup tables

### DIFF
--- a/infra/clickhouse/migrations/006_otel_traces_rollup_ttl.sql
+++ b/infra/clickhouse/migrations/006_otel_traces_rollup_ttl.sql
@@ -1,0 +1,18 @@
+-- Match the source retention on the trace-list rollup tables (005). otel_traces
+-- carries a 30-day TTL (`toDateTime(Timestamp) + toIntervalDay(30)`); the derived
+-- tables were created without one, so they would grow unbounded — and
+-- otel_traces_recent is one row per span, i.e. the full span history. Give both
+-- the same 30-day TTL so the rollup ages out in lockstep with the spans it
+-- summarizes.
+--
+-- MODIFY TTL is idempotent and, with ttl_only_drop_parts = 1 (set at creation),
+-- enforces by dropping whole expired parts rather than rewriting rows. Apply once
+-- against the HA cluster.
+
+ALTER TABLE superlog.otel_traces_recent ON CLUSTER superlog_ha
+  MODIFY TTL toDateTime(ts) + toIntervalDay(30)
+;
+
+ALTER TABLE superlog.otel_traces_summary ON CLUSTER superlog_ha
+  MODIFY TTL toDateTime(start) + toIntervalDay(30)
+;

--- a/infra/clickhouse/migrations/006_otel_traces_rollup_ttl.sql
+++ b/infra/clickhouse/migrations/006_otel_traces_rollup_ttl.sql
@@ -1,9 +1,19 @@
--- Match the source retention on the trace-list rollup tables (005). otel_traces
--- carries a 30-day TTL (`toDateTime(Timestamp) + toIntervalDay(30)`); the derived
--- tables were created without one, so they would grow unbounded — and
--- otel_traces_recent is one row per span, i.e. the full span history. Give both
--- the same 30-day TTL so the rollup ages out in lockstep with the spans it
--- summarizes.
+-- Bound the growth of the trace-list rollup tables (005) with a 30-day
+-- retention. otel_traces_recent is one row per span, i.e. the full span history,
+-- so without a TTL it accumulates forever; otel_traces_summary is one row per
+-- trace. Capping the derived tables (rather than the raw table) is safe because
+-- the read path's coverage gate falls back to the raw scan for any window the
+-- rollup no longer covers, so a shorter derived retention never under-reports —
+-- it just serves older windows the slow way.
+--
+-- Anchor choice matters:
+--   * otel_traces_recent expires each span row 30 days after that span's own ts.
+--   * otel_traces_summary must expire 30 days after the trace's LAST span, not
+--     its first — otherwise a trace whose spans span several days would lose its
+--     summary row while later otel_traces_recent rows for the same trace still
+--     exist, leaving the fast path able to find the trace_id but with no stats.
+--     `end_unix_nano` is the trace's max span end, so anchoring on it makes the
+--     summary outlive (or expire with) the last recent row.
 --
 -- MODIFY TTL is idempotent and, with ttl_only_drop_parts = 1 (set at creation),
 -- enforces by dropping whole expired parts rather than rewriting rows. Apply once
@@ -14,5 +24,5 @@ ALTER TABLE superlog.otel_traces_recent ON CLUSTER superlog_ha
 ;
 
 ALTER TABLE superlog.otel_traces_summary ON CLUSTER superlog_ha
-  MODIFY TTL toDateTime(start) + toIntervalDay(30)
+  MODIFY TTL toDateTime(fromUnixTimestamp64Nano(end_unix_nano)) + toIntervalDay(30)
 ;

--- a/infra/clickhouse/schema/ha-replicated-otel.sql
+++ b/infra/clickhouse/schema/ha-replicated-otel.sql
@@ -504,7 +504,10 @@ CREATE TABLE IF NOT EXISTS superlog.otel_traces_summary ON CLUSTER superlog_ha
 ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
 PARTITION BY toDate(start)
 ORDER BY (project_id, trace_id)
-TTL toDateTime(start) + toIntervalDay(30)
+-- Anchored on the trace's last span (end), not its start, so the summary row
+-- outlives the last otel_traces_recent row for the same trace (a trace whose
+-- spans span days would otherwise lose its stats while recent still has it).
+TTL toDateTime(fromUnixTimestamp64Nano(end_unix_nano)) + toIntervalDay(30)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 ;
 -- otel_traces_summary_mv

--- a/infra/clickhouse/schema/ha-replicated-otel.sql
+++ b/infra/clickhouse/schema/ha-replicated-otel.sql
@@ -473,6 +473,7 @@ CREATE TABLE IF NOT EXISTS superlog.otel_traces_recent ON CLUSTER superlog_ha
 ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
 PARTITION BY toDate(ts)
 ORDER BY (project_id, ts)
+TTL toDateTime(ts) + toIntervalDay(30)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 ;
 -- otel_traces_recent_mv
@@ -503,6 +504,7 @@ CREATE TABLE IF NOT EXISTS superlog.otel_traces_summary ON CLUSTER superlog_ha
 ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
 PARTITION BY toDate(start)
 ORDER BY (project_id, trace_id)
+TTL toDateTime(start) + toIntervalDay(30)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 ;
 -- otel_traces_summary_mv


### PR DESCRIPTION
Follow-up to #136. The rollup tables (`otel_traces_recent`, `otel_traces_summary`) were created without a TTL, so they'd grow unbounded — and `otel_traces_recent` holds one row per span (the full span history). Give both the **same 30-day TTL as `otel_traces`** (`toDateTime(<ts>) + toIntervalDay(30)`) so the derived data ages out in lockstep with the spans it summarizes.

- `migrations/006_otel_traces_rollup_ttl.sql` — `ALTER … MODIFY TTL` for existing clusters (idempotent; `ttl_only_drop_parts = 1` keeps enforcement to whole-part drops).
- Bootstrap schema updated inline so fresh clusters get the TTL at creation.

No app code change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infrastructure-only ClickHouse retention on derived tables; read path already falls back to raw traces when rollups don’t cover the window.
> 
> **Overview**
> Adds **30-day retention** on the trace-list rollup tables `otel_traces_recent` and `otel_traces_summary` so they no longer grow without bound (especially `otel_traces_recent`, which stores one row per span).
> 
> **`otel_traces_recent`** expires rows 30 days after each span’s `ts`. **`otel_traces_summary`** uses **`end_unix_nano`** (last span end), not trace start, so long-running traces don’t lose summary stats while recent rows for the same `trace_id` still exist.
> 
> Existing HA clusters get idempotent `ALTER … MODIFY TTL` in `006_otel_traces_rollup_ttl.sql`; fresh installs pick up the same rules in `ha-replicated-otel.sql`, still with `ttl_only_drop_parts = 1`. No application changes—older windows that rollups no longer cover keep using the existing raw `otel_traces` fallback via the coverage gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c3fe5230b0bd48c5246c567854f4b5d3fa297bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 30-day TTL to the ClickHouse rollup tables `otel_traces_recent` and `otel_traces_summary` to cap storage. The summary TTL anchors on the trace end so fast-path stats stay consistent; older windows fall back to the raw scan.

- **Migration**
  - Adds `infra/clickhouse/migrations/006_otel_traces_rollup_ttl.sql` to `ALTER ... MODIFY TTL` on `superlog.otel_traces_recent` and `superlog.otel_traces_summary` across the `superlog_ha` cluster.
  - TTL rules: `toDateTime(ts) + toIntervalDay(30)` on `otel_traces_recent`; `toDateTime(fromUnixTimestamp64Nano(end_unix_nano)) + toIntervalDay(30)` on `otel_traces_summary`.
  - Bootstrap schema updated so new clusters get the TTL; keeps `ttl_only_drop_parts = 1` for whole-part drops.

<sup>Written for commit 2c3fe5230b0bd48c5246c567854f4b5d3fa297bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

