### PR TITLE
AWS connect: report back via an in-stack Lambda so zero-paste works in any region

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -59,8 +59,9 @@ LINEAR_OAUTH_REDIRECT_URL=http://localhost:4100/linear/oauth/callback
 # public template), so prod topology stays out of the open-core repo.
 SUPERLOG_AWS_ACCOUNT_ID=
 AWS_CONNECT_TEMPLATE_URL=
-# Optional: SNS topic ARN for zero-paste connect (role ARN reported back via SNS).
-AWS_CONNECT_SERVICE_TOKEN=
+# Optional: callback URL for zero-paste connect. The stack's in-stack Lambda POSTs
+# the created role ARN here (e.g. https://<api-host>/api/cloud-connections/callback).
+AWS_CONNECT_CALLBACK_URL=
 # One-step combined connect (all three required together):
 AWS_CONNECT_STACK_TEMPLATE_URL=
 AWS_FIREHOSE_METRICS_INTAKE_URL=

--- a/apps/api/src/cloud-connections-service.test.ts
+++ b/apps/api/src/cloud-connections-service.test.ts
@@ -115,7 +115,7 @@ test("buildCombinedConnectLaunchUrl carries scrape + both streams in one stack",
     superlogAccountId: "123456789012",
     externalId: "ext-abc",
     connectionId: "conn-1",
-    serviceToken: "arn:aws:sns:us-west-2:123456789012:superlog-connect",
+    callbackUrl: "https://api.example.com/api/cloud-connections/callback",
     metricsIntakeUrl: "https://intake.example.com/aws/firehose/metrics",
     logsIntakeUrl: "https://intake.example.com/aws/firehose/logs",
     metricsIngestKey: "sl_public_metrics",
@@ -132,8 +132,8 @@ test("buildCombinedConnectLaunchUrl carries scrape + both streams in one stack",
   assert.equal(frag.get("param_ExternalId"), "ext-abc");
   assert.equal(frag.get("param_ConnectionId"), "conn-1");
   assert.equal(
-    frag.get("param_SuperlogServiceToken"),
-    "arn:aws:sns:us-west-2:123456789012:superlog-connect",
+    frag.get("param_SuperlogCallbackUrl"),
+    "https://api.example.com/api/cloud-connections/callback",
   );
   // Streaming on by default, both intake URLs + dedicated keys present.
   assert.equal(frag.get("param_EnableMetrics"), "true");
@@ -165,8 +165,8 @@ test("buildCombinedConnectLaunchUrl can disable a stream and pass a log filter",
   assert.equal(frag.get("param_EnableMetrics"), "false");
   assert.equal(frag.get("param_EnableLogs"), "true");
   assert.equal(frag.get("param_LogsFilterPattern"), "?ERROR ?WARN");
-  // No SNS topic supplied → no zero-paste param (manual paste fallback).
-  assert.equal(frag.get("param_SuperlogServiceToken"), null);
+  // No callback URL supplied → no zero-paste param (manual paste fallback).
+  assert.equal(frag.get("param_SuperlogCallbackUrl"), null);
 });
 
 test("buildMetricsStreamLaunchUrl rejects a hostname-hijacking region", () => {

--- a/apps/api/src/cloud-connections-service.ts
+++ b/apps/api/src/cloud-connections-service.ts
@@ -105,8 +105,12 @@ export type CombinedConnectLaunchInput = {
   externalId: string;
   /** Connection this stack completes (zero-paste callback + reporting). */
   connectionId: string;
-  /** Our SNS topic ARN for zero-paste reporting. Omitted → manual role-ARN paste. */
-  serviceToken?: string;
+  /**
+   * Superlog callback URL the stack's in-stack Lambda reports its role ARN to
+   * (zero-paste). Omitted → the reporting resources are skipped and the customer
+   * pastes the role ARN by hand.
+   */
+  callbackUrl?: string;
   /** Firehose intake URLs (proxy `/aws/firehose/*` routes). */
   metricsIntakeUrl: string;
   logsIntakeUrl: string;
@@ -125,8 +129,8 @@ export type CombinedConnectLaunchInput = {
  * (`superlog-connect-stack.cfn.yaml`): scrape role + metric streaming + log
  * streaming in a single CloudFormation stack named `superlog-connect`. Streaming
  * defaults on but each signal toggles off via a parameter. Everything
- * prod-specific (account id, intake URLs, ingest keys, SNS topic) is a parameter
- * value, never baked into the committed template.
+ * prod-specific (account id, intake URLs, ingest keys, callback URL) is a
+ * parameter value, never baked into the committed template.
  */
 export function buildCombinedConnectLaunchUrl(input: CombinedConnectLaunchInput): string {
   const params: Record<string, string> = {
@@ -140,7 +144,7 @@ export function buildCombinedConnectLaunchUrl(input: CombinedConnectLaunchInput)
     MetricsIngestKey: input.metricsIngestKey,
     LogsIngestKey: input.logsIngestKey,
   };
-  if (input.serviceToken) params.SuperlogServiceToken = input.serviceToken;
+  if (input.callbackUrl) params.SuperlogCallbackUrl = input.callbackUrl;
   if (input.logsFilterPattern) params.LogsFilterPattern = input.logsFilterPattern;
   return buildConnectQuickCreateUrl({
     region: input.region,

--- a/apps/api/src/cloud-connections.test.ts
+++ b/apps/api/src/cloud-connections.test.ts
@@ -74,7 +74,7 @@ const COMBINED_CONFIG: CloudConnectConfig = {
   connectStackTemplateUrl: "https://cfn.example/connect-stack.yaml",
   metricsIntakeUrl: "https://intake.example.com/aws/firehose/metrics",
   logsIntakeUrl: "https://intake.example.com/aws/firehose/logs",
-  serviceToken: "arn:aws:sns:us-west-2:123456789012:superlog-connect",
+  callbackUrl: "https://api.example.com/api/cloud-connections/callback",
 };
 
 function appWith(
@@ -432,7 +432,7 @@ test("one-step connect launches the combined stack + mints both stream keys", as
 
   assert.ok(created.launchUrl, "expected a launch url");
   const frag = fragOf(created.launchUrl);
-  // One combined stack, streaming on by default, with both intakes + the SNS topic.
+  // One combined stack, streaming on by default, with both intakes + the callback URL.
   assert.equal(frag.get("templateURL"), "https://cfn.example/connect-stack.yaml");
   assert.equal(frag.get("stackName"), "superlog-connect");
   assert.equal(frag.get("param_EnableMetrics"), "true");
@@ -443,8 +443,8 @@ test("one-step connect launches the combined stack + mints both stream keys", as
   );
   assert.equal(frag.get("param_LogsIntakeUrl"), "https://intake.example.com/aws/firehose/logs");
   assert.equal(
-    frag.get("param_SuperlogServiceToken"),
-    "arn:aws:sns:us-west-2:123456789012:superlog-connect",
+    frag.get("param_SuperlogCallbackUrl"),
+    "https://api.example.com/api/cloud-connections/callback",
   );
   // Dedicated per-signal keys, distinct, both embedded in the launch URL.
   const mKey = frag.get("param_MetricsIngestKey");
@@ -647,7 +647,7 @@ test("a user cannot create a connection on another org's project", async () => {
   assert.equal(res.status, 403);
 });
 
-// --- zero-paste callback (CloudFormation custom resource → SNS → bridge) -------
+// --- zero-paste callback (CloudFormation custom resource → in-stack Lambda) ----
 
 test("callback with the right connectionId + externalId connects (no session)", async () => {
   const { org, user, project } = await seedProject();

--- a/apps/api/src/cloud-connections.ts
+++ b/apps/api/src/cloud-connections.ts
@@ -43,12 +43,13 @@ export type CloudConnectConfig = {
   /** Public HTTPS URL of the CloudFormation template. */
   templateUrl: string;
   /**
-   * Our SNS topic ARN, used as the custom-resource `ServiceToken` for zero-paste
-   * connect (the stack reports its role ARN back to us via SNS). Optional — when
-   * unset, the launch URL omits it and the template's custom resource is skipped,
-   * so the customer falls back to pasting the role ARN.
+   * Superlog callback URL passed to the stack for zero-paste connect. The
+   * template stands up a small in-stack Lambda that POSTs the freshly-created
+   * role ARN here (and signals CloudFormation), so it works in any region.
+   * Optional — when unset, the launch URL omits it and the reporting resources
+   * are skipped, so the customer falls back to pasting the role ARN.
    */
-  serviceToken?: string;
+  callbackUrl?: string;
   /**
    * Public HTTPS URL of the metrics-streaming CloudFormation template
    * (`superlog-metrics-stream.cfn.yaml`). Optional — when unset, the
@@ -93,7 +94,7 @@ export function cloudConnectConfigFromEnv(
   return {
     superlogAccountId,
     templateUrl,
-    serviceToken: env.AWS_CONNECT_SERVICE_TOKEN || undefined,
+    callbackUrl: env.AWS_CONNECT_CALLBACK_URL || undefined,
     metricsTemplateUrl: env.AWS_METRICS_TEMPLATE_URL || undefined,
     metricsIntakeUrl: env.AWS_FIREHOSE_METRICS_INTAKE_URL || undefined,
     logsTemplateUrl: env.AWS_LOGS_TEMPLATE_URL || undefined,
@@ -372,7 +373,7 @@ export function mountCloudConnectionsAuthed(
         superlogAccountId: config.superlogAccountId,
         externalId,
         connectionId: row.id,
-        serviceToken: config.serviceToken,
+        callbackUrl: config.callbackUrl,
         metricsIntakeUrl: config.metricsIntakeUrl,
         logsIntakeUrl: config.logsIntakeUrl,
         metricsIngestKey: metricsKey.ingestKey,
@@ -385,9 +386,10 @@ export function mountCloudConnectionsAuthed(
         SuperlogAccountId: config.superlogAccountId,
         ConnectionId: row.id,
       };
-      // When we have an SNS topic, pass it so the template's custom resource reports
-      // the role ARN back automatically (zero-paste). Otherwise the customer pastes.
-      if (config.serviceToken) params.SuperlogServiceToken = config.serviceToken;
+      // When we have a callback URL, pass it so the template's in-stack Lambda
+      // reports the role ARN back automatically (zero-paste). Otherwise the
+      // customer pastes.
+      if (config.callbackUrl) params.SuperlogCallbackUrl = config.callbackUrl;
       launchUrl = buildConnectQuickCreateUrl({
         region: parsed.data.region,
         templateUrl: config.templateUrl,
@@ -476,7 +478,7 @@ export function mountCloudConnectionsAuthed(
         superlogAccountId: config.superlogAccountId,
         externalId,
         connectionId: row.id,
-        serviceToken: config.serviceToken,
+        callbackUrl: config.callbackUrl,
         metricsIntakeUrl: config.metricsIntakeUrl,
         logsIntakeUrl: config.logsIntakeUrl,
         metricsIngestKey: metricsKey.ingestKey,
@@ -556,11 +558,12 @@ export function mountCloudConnectionsAuthed(
     );
   });
 
-  // Zero-paste callback: the CloudFormation custom resource (via our SNS topic →
-  // bridge) reports the freshly-created role ARN. No session — authenticated by
-  // connectionId + a constant-time match on the stored external ID. AssumeRole is
-  // still the real trust gate (a forged ARN we can't assume just stays `failed`).
-  // NOTE: the path is allowlisted in index.ts's session middleware.
+  // Zero-paste callback: the stack's in-stack Lambda (behind a CloudFormation
+  // custom resource) reports the freshly-created role ARN. No session —
+  // authenticated by connectionId + a constant-time match on the stored external
+  // ID. AssumeRole is still the real trust gate (a forged ARN we can't assume
+  // just stays `failed`). NOTE: the path is allowlisted in index.ts's session
+  // middleware.
   app.post("/api/cloud-connections/callback", async (c) => {
     const parsed = callbackSchema.safeParse(await c.req.json().catch(() => ({})));
     if (!parsed.success) throw new HTTPException(400, { message: "invalid body" });

--- a/infra/aws-connect/superlog-connect-stack.cfn.yaml
+++ b/infra/aws-connect/superlog-connect-stack.cfn.yaml
@@ -197,7 +197,10 @@ Resources:
                 Action:
                   - "logs:CreateLogStream"
                   - "logs:PutLogEvents"
-                Resource: !GetAtt SuperlogCallbackLogGroup.Arn
+                # Streams live *under* the log group, so scope to the group's
+                # child resources (:log-stream:*), not the bare group ARN — else
+                # the function can't create/write its own log stream.
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/superlog-connect-cb-${ConnectionId}:log-stream:*"
 
   SuperlogCallbackFunction:
     Type: AWS::Lambda::Function
@@ -244,9 +247,13 @@ Resources:
             });
           }
 
-          // PUT the custom-resource result to CloudFormation's pre-signed S3 URL.
-          // The URL comes straight from the CFN invocation event (not attacker
-          // input); the pre-signed PUT must carry an empty content-type.
+          // PUT the custom-resource result to CloudFormation's pre-signed S3 URL,
+          // retrying a few times. The URL comes straight from the CFN invocation
+          // event (not attacker input); the pre-signed PUT must carry an empty
+          // content-type. S3 returns 2xx on success, so a non-2xx (e.g. an expired
+          // URL) means CloudFormation never saw the signal — retry, and if every
+          // attempt fails, throw so the caller can surface it rather than silently
+          // leaving the stack to hang until timeout.
           async function signalCfn(event, status, reason) {
             const body = JSON.stringify({
               Status: status,
@@ -258,10 +265,21 @@ Resources:
               LogicalResourceId: event.LogicalResourceId,
               Data: {},
             });
-            await httpRequest("PUT", event.ResponseURL, body, {
-              "content-type": "",
-              "content-length": Buffer.byteLength(body),
-            });
+            let lastErr;
+            for (let attempt = 1; attempt <= 3; attempt++) {
+              try {
+                const res = await httpRequest("PUT", event.ResponseURL, body, {
+                  "content-type": "",
+                  "content-length": Buffer.byteLength(body),
+                });
+                if (res.status >= 200 && res.status < 300) return;
+                lastErr = new Error("CFN response PUT returned HTTP " + res.status);
+              } catch (err) {
+                lastErr = err;
+              }
+              console.error("CFN signal attempt " + attempt + " failed", lastErr);
+            }
+            throw lastErr;
           }
 
           exports.handler = async (event) => {
@@ -292,6 +310,11 @@ Resources:
               console.error("handler error (continuing)", err);
             }
             // Always signal so the stack never hangs waiting on the response URL.
+            // signalCfn retries internally; if every attempt fails it throws, which
+            // fails the invocation loudly (and gives Lambda's async retry one more
+            // shot). We never swallow — the only way to tell CloudFormation "done"
+            // is a successful PUT, so reporting a success we didn't deliver would be
+            // worse than erroring.
             await signalCfn(
               event,
               "SUCCESS",

--- a/infra/aws-connect/superlog-connect-stack.cfn.yaml
+++ b/infra/aws-connect/superlog-connect-stack.cfn.yaml
@@ -34,12 +34,12 @@ Parameters:
     Type: String
     Description: Superlog connection this stack completes (used by the callback).
     Default: ""
-  SuperlogServiceToken:
+  SuperlogCallbackUrl:
     Type: String
     Description: >-
-      Superlog SNS topic ARN. When set, this stack reports the new role ARN back
-      to Superlog automatically (zero-paste). Leave blank to paste the ScrapeRoleArn
-      output by hand.
+      Superlog callback URL. When set, this stack creates a small Lambda that
+      reports the new role ARN back to Superlog automatically (zero-paste). Leave
+      blank to paste the ScrapeRoleArn output by hand.
     Default: ""
 
   # --- Streaming toggles + delivery -----------------------------------------
@@ -85,9 +85,9 @@ Parameters:
     Default: ""
 
 Conditions:
-  # Auto-report only when both the SNS topic and a connection id are supplied.
+  # Auto-report only when both the callback URL and a connection id are supplied.
   ReportBack: !And
-    - !Not [!Equals [!Ref SuperlogServiceToken, ""]]
+    - !Not [!Equals [!Ref SuperlogCallbackUrl, ""]]
     - !Not [!Equals [!Ref ConnectionId, ""]]
   CreateMetrics: !Equals [!Ref EnableMetrics, "true"]
   CreateLogs: !Equals [!Ref EnableLogs, "true"]
@@ -163,11 +163,147 @@ Resources:
                   - "dynamodb:Scan"
                 Resource: "*"
 
+  # Zero-paste reporting. A tiny in-stack Lambda POSTs the freshly-created role ARN
+  # to Superlog and signals CloudFormation. It runs in *this* account and region,
+  # so zero-paste works no matter where the stack is launched. The function makes a
+  # single outbound HTTPS call to SuperlogCallbackUrl (passed at launch); its code
+  # is inline below so a security reviewer can read exactly what it does. The whole
+  # block is skipped when SuperlogCallbackUrl is blank (manual paste flow).
+  SuperlogCallbackLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: ReportBack
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/superlog-connect-cb-${ConnectionId}"
+      RetentionInDays: 7
+
+  SuperlogCallbackFunctionRole:
+    Type: AWS::IAM::Role
+    Condition: ReportBack
+    Properties:
+      Description: Execution role for the Superlog connect callback function (logging only).
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: "sts:AssumeRole"
+      Policies:
+        - PolicyName: WriteOwnLogs
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource: !GetAtt SuperlogCallbackLogGroup.Arn
+
+  SuperlogCallbackFunction:
+    Type: AWS::Lambda::Function
+    Condition: ReportBack
+    DependsOn: SuperlogCallbackLogGroup
+    Properties:
+      FunctionName: !Sub "superlog-connect-cb-${ConnectionId}"
+      Description: Reports the scrape role ARN back to Superlog and signals CloudFormation.
+      Runtime: nodejs20.x
+      Handler: index.handler
+      Timeout: 30
+      Role: !GetAtt SuperlogCallbackFunctionRole.Arn
+      Environment:
+        Variables:
+          CALLBACK_URL: !Ref SuperlogCallbackUrl
+      Code:
+        ZipFile: |
+          const https = require("node:https");
+          const CALLBACK_URL = process.env.CALLBACK_URL;
+          const TIMEOUT_MS = 8000;
+
+          function httpRequest(method, urlStr, body, headers) {
+            return new Promise((resolve, reject) => {
+              const u = new URL(urlStr);
+              const req = https.request(
+                {
+                  method,
+                  hostname: u.hostname,
+                  path: u.pathname + u.search,
+                  port: 443,
+                  headers,
+                  timeout: TIMEOUT_MS,
+                },
+                (res) => {
+                  let data = "";
+                  res.on("data", (d) => { data += d; });
+                  res.on("end", () => resolve({ status: res.statusCode, body: data }));
+                },
+              );
+              req.on("timeout", () => req.destroy(new Error("request timed out")));
+              req.on("error", reject);
+              if (body) req.write(body);
+              req.end();
+            });
+          }
+
+          // PUT the custom-resource result to CloudFormation's pre-signed S3 URL.
+          // The URL comes straight from the CFN invocation event (not attacker
+          // input); the pre-signed PUT must carry an empty content-type.
+          async function signalCfn(event, status, reason) {
+            const body = JSON.stringify({
+              Status: status,
+              Reason: reason,
+              PhysicalResourceId:
+                event.PhysicalResourceId || event.LogicalResourceId || "superlog-connect",
+              StackId: event.StackId,
+              RequestId: event.RequestId,
+              LogicalResourceId: event.LogicalResourceId,
+              Data: {},
+            });
+            await httpRequest("PUT", event.ResponseURL, body, {
+              "content-type": "",
+              "content-length": Buffer.byteLength(body),
+            });
+          }
+
+          exports.handler = async (event) => {
+            try {
+              // Report the role on create/update. Best-effort: a callback failure
+              // must NOT roll back the stack — we still signal SUCCESS and the
+              // connection reconciles via the manual paste path.
+              if (event.RequestType !== "Delete") {
+                const p = event.ResourceProperties || {};
+                try {
+                  const res = await httpRequest(
+                    "POST",
+                    CALLBACK_URL,
+                    JSON.stringify({
+                      connectionId: p.ConnectionId,
+                      externalId: p.ExternalId,
+                      roleArn: p.RoleArn,
+                      accountId: p.AccountId,
+                    }),
+                    { "content-type": "application/json" },
+                  );
+                  console.log("superlog callback status", res.status);
+                } catch (err) {
+                  console.error("superlog callback failed (continuing)", err);
+                }
+              }
+            } catch (err) {
+              console.error("handler error (continuing)", err);
+            }
+            // Always signal so the stack never hangs waiting on the response URL.
+            await signalCfn(
+              event,
+              "SUCCESS",
+              event.RequestType === "Delete" ? "delete acknowledged" : "registered with Superlog",
+            );
+          };
+
   RegisterWithSuperlog:
     Type: Custom::SuperlogConnect
     Condition: ReportBack
     Properties:
-      ServiceToken: !Ref SuperlogServiceToken
+      ServiceToken: !GetAtt SuperlogCallbackFunction.Arn
       RoleArn: !GetAtt ScrapeRole.Arn
       AccountId: !Ref "AWS::AccountId"
       Region: !Ref "AWS::Region"

--- a/infra/aws-connect/superlog-scrape-role.cfn.yaml
+++ b/infra/aws-connect/superlog-scrape-role.cfn.yaml
@@ -155,7 +155,10 @@ Resources:
                 Action:
                   - "logs:CreateLogStream"
                   - "logs:PutLogEvents"
-                Resource: !GetAtt SuperlogCallbackLogGroup.Arn
+                # Streams live *under* the log group, so scope to the group's
+                # child resources (:log-stream:*), not the bare group ARN — else
+                # the function can't create/write its own log stream.
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/superlog-connect-cb-${ConnectionId}:log-stream:*"
 
   SuperlogCallbackFunction:
     Type: AWS::Lambda::Function
@@ -202,9 +205,13 @@ Resources:
             });
           }
 
-          // PUT the custom-resource result to CloudFormation's pre-signed S3 URL.
-          // The URL comes straight from the CFN invocation event (not attacker
-          // input); the pre-signed PUT must carry an empty content-type.
+          // PUT the custom-resource result to CloudFormation's pre-signed S3 URL,
+          // retrying a few times. The URL comes straight from the CFN invocation
+          // event (not attacker input); the pre-signed PUT must carry an empty
+          // content-type. S3 returns 2xx on success, so a non-2xx (e.g. an expired
+          // URL) means CloudFormation never saw the signal — retry, and if every
+          // attempt fails, throw so the caller can surface it rather than silently
+          // leaving the stack to hang until timeout.
           async function signalCfn(event, status, reason) {
             const body = JSON.stringify({
               Status: status,
@@ -216,10 +223,21 @@ Resources:
               LogicalResourceId: event.LogicalResourceId,
               Data: {},
             });
-            await httpRequest("PUT", event.ResponseURL, body, {
-              "content-type": "",
-              "content-length": Buffer.byteLength(body),
-            });
+            let lastErr;
+            for (let attempt = 1; attempt <= 3; attempt++) {
+              try {
+                const res = await httpRequest("PUT", event.ResponseURL, body, {
+                  "content-type": "",
+                  "content-length": Buffer.byteLength(body),
+                });
+                if (res.status >= 200 && res.status < 300) return;
+                lastErr = new Error("CFN response PUT returned HTTP " + res.status);
+              } catch (err) {
+                lastErr = err;
+              }
+              console.error("CFN signal attempt " + attempt + " failed", lastErr);
+            }
+            throw lastErr;
           }
 
           exports.handler = async (event) => {
@@ -250,6 +268,11 @@ Resources:
               console.error("handler error (continuing)", err);
             }
             // Always signal so the stack never hangs waiting on the response URL.
+            // signalCfn retries internally; if every attempt fails it throws, which
+            // fails the invocation loudly (and gives Lambda's async retry one more
+            // shot). We never swallow — the only way to tell CloudFormation "done"
+            // is a successful PUT, so reporting a success we didn't deliver would be
+            // worse than erroring.
             await signalCfn(
               event,
               "SUCCESS",

--- a/infra/aws-connect/superlog-scrape-role.cfn.yaml
+++ b/infra/aws-connect/superlog-scrape-role.cfn.yaml
@@ -26,18 +26,18 @@ Parameters:
     Type: String
     Description: Superlog connection this stack completes (used by the callback).
     Default: ""
-  SuperlogServiceToken:
+  SuperlogCallbackUrl:
     Type: String
     Description: >-
-      Superlog SNS topic ARN. When set, this stack reports the new role ARN back
-      to Superlog automatically (zero-paste). Leave blank to instead copy the
-      ScrapeRoleArn output into Superlog by hand.
+      Superlog callback URL. When set, this stack creates a small Lambda that
+      reports the new role ARN back to Superlog automatically (zero-paste). Leave
+      blank to instead copy the ScrapeRoleArn output into Superlog by hand.
     Default: ""
 
 Conditions:
-  # Auto-report only when both the SNS topic and a connection id are supplied.
+  # Auto-report only when both the callback URL and a connection id are supplied.
   ReportBack: !And
-    - !Not [!Equals [!Ref SuperlogServiceToken, ""]]
+    - !Not [!Equals [!Ref SuperlogCallbackUrl, ""]]
     - !Not [!Equals [!Ref ConnectionId, ""]]
 
 Resources:
@@ -121,16 +121,147 @@ Resources:
                   - "dynamodb:Scan"
                 Resource: "*"
 
-  # Zero-paste reporting. CloudFormation publishes this custom resource's request
-  # (including RoleArn below + a response URL) to Superlog's SNS topic; Superlog's
-  # bridge records the role ARN, verifies it, and signals success back to CFN. No
-  # Lambda or outbound internet runs in this account — only a message to an SNS
-  # topic. Skipped entirely when SuperlogServiceToken is blank (manual flow).
+  # Zero-paste reporting. A tiny in-stack Lambda POSTs the freshly-created role ARN
+  # to Superlog and signals CloudFormation. It runs in *this* account and region,
+  # so zero-paste works no matter where the stack is launched. The function makes a
+  # single outbound HTTPS call to SuperlogCallbackUrl (passed at launch); its code
+  # is inline below so a security reviewer can read exactly what it does. The whole
+  # block is skipped when SuperlogCallbackUrl is blank (manual paste flow).
+  SuperlogCallbackLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: ReportBack
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/superlog-connect-cb-${ConnectionId}"
+      RetentionInDays: 7
+
+  SuperlogCallbackFunctionRole:
+    Type: AWS::IAM::Role
+    Condition: ReportBack
+    Properties:
+      Description: Execution role for the Superlog connect callback function (logging only).
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: "sts:AssumeRole"
+      Policies:
+        - PolicyName: WriteOwnLogs
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource: !GetAtt SuperlogCallbackLogGroup.Arn
+
+  SuperlogCallbackFunction:
+    Type: AWS::Lambda::Function
+    Condition: ReportBack
+    DependsOn: SuperlogCallbackLogGroup
+    Properties:
+      FunctionName: !Sub "superlog-connect-cb-${ConnectionId}"
+      Description: Reports the scrape role ARN back to Superlog and signals CloudFormation.
+      Runtime: nodejs20.x
+      Handler: index.handler
+      Timeout: 30
+      Role: !GetAtt SuperlogCallbackFunctionRole.Arn
+      Environment:
+        Variables:
+          CALLBACK_URL: !Ref SuperlogCallbackUrl
+      Code:
+        ZipFile: |
+          const https = require("node:https");
+          const CALLBACK_URL = process.env.CALLBACK_URL;
+          const TIMEOUT_MS = 8000;
+
+          function httpRequest(method, urlStr, body, headers) {
+            return new Promise((resolve, reject) => {
+              const u = new URL(urlStr);
+              const req = https.request(
+                {
+                  method,
+                  hostname: u.hostname,
+                  path: u.pathname + u.search,
+                  port: 443,
+                  headers,
+                  timeout: TIMEOUT_MS,
+                },
+                (res) => {
+                  let data = "";
+                  res.on("data", (d) => { data += d; });
+                  res.on("end", () => resolve({ status: res.statusCode, body: data }));
+                },
+              );
+              req.on("timeout", () => req.destroy(new Error("request timed out")));
+              req.on("error", reject);
+              if (body) req.write(body);
+              req.end();
+            });
+          }
+
+          // PUT the custom-resource result to CloudFormation's pre-signed S3 URL.
+          // The URL comes straight from the CFN invocation event (not attacker
+          // input); the pre-signed PUT must carry an empty content-type.
+          async function signalCfn(event, status, reason) {
+            const body = JSON.stringify({
+              Status: status,
+              Reason: reason,
+              PhysicalResourceId:
+                event.PhysicalResourceId || event.LogicalResourceId || "superlog-connect",
+              StackId: event.StackId,
+              RequestId: event.RequestId,
+              LogicalResourceId: event.LogicalResourceId,
+              Data: {},
+            });
+            await httpRequest("PUT", event.ResponseURL, body, {
+              "content-type": "",
+              "content-length": Buffer.byteLength(body),
+            });
+          }
+
+          exports.handler = async (event) => {
+            try {
+              // Report the role on create/update. Best-effort: a callback failure
+              // must NOT roll back the stack — we still signal SUCCESS and the
+              // connection reconciles via the manual paste path.
+              if (event.RequestType !== "Delete") {
+                const p = event.ResourceProperties || {};
+                try {
+                  const res = await httpRequest(
+                    "POST",
+                    CALLBACK_URL,
+                    JSON.stringify({
+                      connectionId: p.ConnectionId,
+                      externalId: p.ExternalId,
+                      roleArn: p.RoleArn,
+                      accountId: p.AccountId,
+                    }),
+                    { "content-type": "application/json" },
+                  );
+                  console.log("superlog callback status", res.status);
+                } catch (err) {
+                  console.error("superlog callback failed (continuing)", err);
+                }
+              }
+            } catch (err) {
+              console.error("handler error (continuing)", err);
+            }
+            // Always signal so the stack never hangs waiting on the response URL.
+            await signalCfn(
+              event,
+              "SUCCESS",
+              event.RequestType === "Delete" ? "delete acknowledged" : "registered with Superlog",
+            );
+          };
+
   RegisterWithSuperlog:
     Type: Custom::SuperlogConnect
     Condition: ReportBack
     Properties:
-      ServiceToken: !Ref SuperlogServiceToken
+      ServiceToken: !GetAtt SuperlogCallbackFunction.Arn
       RoleArn: !GetAtt ScrapeRole.Arn
       AccountId: !Ref "AWS::AccountId"
       Region: !Ref "AWS::Region"


### PR DESCRIPTION
## Problem

The zero-paste "Connect AWS" callback was an **SNS-backed** CloudFormation custom resource whose `ServiceToken` was a single-region SNS topic ARN. SNS-backed custom resources require the topic to be in the **same region as the stack**, so launching the connect stack in any other region fails at CREATE with:

```
Invalid parameter: TopicArn (Service: AmazonSNS; Status Code: 400; Error Code: InvalidParameter)
```

Only the reporting resource fails — the IAM scrape role is created fine — but the connection never reports back, so zero-paste silently breaks outside the topic's region.

## Fix

Replace the SNS-backed custom resource with a **tiny Lambda created inside the customer's own stack**. It runs in whatever region the stack is launched, `POST`s the created scrape-role ARN to the Superlog callback URL, and signals CloudFormation via the pre-signed response URL. Zero-paste now works from **any region** with no per-region infrastructure.

Design notes:
- The function code is **inline in the template** so a security reviewer can read exactly what it does. It makes a single outbound HTTPS call and writes only its own logs (logging-only execution role, log group with 7-day retention).
- Everything is gated by the existing `ReportBack` condition — blank callback URL → the whole block is skipped and the customer uses the manual role-ARN paste flow (unchanged).
- The callback endpoint, the trust model (`connectionId` + external id, with AssumeRole as the real gate), and the manual-paste fallback are all unchanged.

## Changes
- **Templates** (`superlog-scrape-role.cfn.yaml`, `superlog-connect-stack.cfn.yaml`): `SuperlogServiceToken` (SNS ARN) parameter → `SuperlogCallbackUrl`; add the callback Lambda + execution role + log group.
- **API**: config/env `AWS_CONNECT_SERVICE_TOKEN` → `AWS_CONNECT_CALLBACK_URL`; launch URLs pass `SuperlogCallbackUrl`.

## Testing
- `apps/api` typecheck clean.
- `cloud-connections-service.test.ts` (18/18) and DB-backed `cloud-connections.test.ts` (18/18) pass.
- Both templates' inline Lambda bodies extracted and `node --check`ed; template structure validated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-account onboarding and deploys customer-account Lambda with outbound HTTPS to Superlog; callback trust is unchanged but operators must migrate env/template params from SNS to callback URL.
> 
> **Overview**
> Fixes zero-paste **Connect AWS** failing outside the SNS topic’s region by dropping the SNS-backed custom resource and using a **region-local in-stack Lambda** instead.
> 
> **CloudFormation** (`superlog-scrape-role.cfn.yaml`, `superlog-connect-stack.cfn.yaml`): `SuperlogServiceToken` becomes **`SuperlogCallbackUrl`**. When `ReportBack` is on, the stack adds a small inline Lambda (logging-only IAM, 7-day log group) that **POST**s `connectionId`, `externalId`, `roleArn`, and `accountId` to that URL, then signals CloudFormation via the pre-signed response URL. Callback errors are best-effort so the stack still completes and manual ARN paste remains the fallback.
> 
> **API**: config/env **`AWS_CONNECT_SERVICE_TOKEN` → `AWS_CONNECT_CALLBACK_URL`**; launch URLs pass **`param_SuperlogCallbackUrl`**. The **`/api/cloud-connections/callback`** handler and its auth model are unchanged.
> 
> **Migration**: set `AWS_CONNECT_CALLBACK_URL` (e.g. `https://<api>/api/cloud-connections/callback`) instead of the SNS ARN; update any direct template parameters the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf46b3719eb7a56e9a841637790cce352e931e06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make zero-paste “Connect AWS” work in any region by replacing the SNS-backed custom resource with an in-stack Lambda that posts the role ARN to a callback URL and signals CloudFormation. Removes the single‑region SNS constraint; the manual paste flow is unchanged.

- **Bug Fixes**
  - CloudFormation templates: replace `SuperlogServiceToken` with `SuperlogCallbackUrl`; add a tiny inline Lambda, a logging‑only role, and a 7‑day log group behind `ReportBack`. Tightened the Lambda’s log permissions to its own log streams and made the CloudFormation signal validate the pre‑signed PUT and retry up to 3×.
  - API: rename env/config `AWS_CONNECT_SERVICE_TOKEN` to `AWS_CONNECT_CALLBACK_URL`; launch URLs now pass `SuperlogCallbackUrl`.
  - Tests updated to use the callback URL path; no changes to the callback endpoint or trust model.

- **Migration**
  - Replace `AWS_CONNECT_SERVICE_TOKEN` with `AWS_CONNECT_CALLBACK_URL` in your environment.
  - If you pass template parameters directly, switch `SuperlogServiceToken` to `SuperlogCallbackUrl`.
  - No action needed if you rely on manual role ARN paste.

<sup>Written for commit cf46b3719eb7a56e9a841637790cce352e931e06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

