### PR TITLE
fix(explore): re-probe rollup table existence instead of caching "absent" forever

### DIFF
--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -306,6 +306,47 @@ test("queryTracesAggregated falls back to the raw scan when the derived tables a
   assert.doesNotMatch(capture.query ?? "", /otel_traces_summary/);
 });
 
+test("queryTracesAggregated re-probes and picks up the rollup after the tables appear (no stale 'absent' cache)", async () => {
+  // A negative EXISTS result must not be cached forever: the derived tables are
+  // created by a migration that can land after the process boots. `state` flips
+  // from absent to present between the two calls on the SAME client.
+  const state = { present: false };
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+  const ch = {
+    async query(input: { query: string; query_params?: Record<string, unknown> }) {
+      if (/EXISTS TABLE/i.test(input.query)) {
+        return {
+          async json() {
+            return [{ result: state.present ? 1 : 0 }];
+          },
+        };
+      }
+      if (/count\(\) AS c/i.test(input.query)) {
+        return {
+          async json() {
+            return [{ c: 1 }];
+          },
+        };
+      }
+      capture.query = input.query;
+      capture.params = input.query_params;
+      return {
+        async json() {
+          return [];
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+
+  const filter = { range: { since: "now() - INTERVAL 24 HOUR", until: "now()" }, limit: 100 };
+  await queryTracesAggregated(ch, "project-1", filter);
+  assert.match(capture.query ?? "", /FROM otel_traces\b/); // absent → raw
+
+  state.present = true;
+  await queryTracesAggregated(ch, "project-1", filter);
+  assert.match(capture.query ?? "", /recent_ids/); // now present → fast path
+});
+
 test("queryTracesAggregated falls back to the raw scan when the rollup does not yet cover the window", async () => {
   const capture: { query?: string; params?: Record<string, unknown> } = {};
 

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -1335,34 +1335,44 @@ export function pickStep(rangeSeconds: number, targetBuckets = 120): Step {
 
 const tableExistsMemo = new WeakMap<ClickHouseClient, Map<string, Promise<boolean>>>();
 
-// Memoized `EXISTS TABLE <name>` probe, per client + table. Derived tables
+// `EXISTS TABLE <name>` probe, per client + table. Derived tables
 // (events_per_minute, otel_traces_summary, …) are not part of the collector's
 // auto-created schema, so deployments without them must fall back to the raw
 // scan without a per-request penalty. `table` is always a hardcoded literal
 // here — never interpolate user input into this.
+//
+// Only a positive result is cached (a table won't disappear from under a
+// running process). A negative or errored probe is NOT cached: it's evicted once
+// it resolves so the next call re-probes. This matters because these tables are
+// created by a manual migration that can land AFTER the app boots — caching
+// "absent" forever would pin the process to the raw scan until it restarts, even
+// though the fast path became available. The probe is a cheap metadata lookup,
+// and concurrent callers still share the one in-flight promise.
 function tableExists(ch: ClickHouseClient, table: string): Promise<boolean> {
   let byTable = tableExistsMemo.get(ch);
   if (!byTable) {
     byTable = new Map();
     tableExistsMemo.set(ch, byTable);
   }
-  let probe = byTable.get(table);
-  if (!probe) {
-    probe = (async () => {
-      try {
-        const r = await ch.query({ query: `EXISTS TABLE ${table}`, format: "JSONEachRow" });
-        const rows = (await r.json()) as { result: number | string }[];
-        return Number(rows[0]?.result) === 1;
-      } catch {
-        // A failed probe (e.g. ClickHouse briefly unreachable) says nothing
-        // about whether the table exists — drop the memo so the next call
-        // re-probes instead of pinning the raw path until restart.
-        byTable?.delete(table);
-        return false;
-      }
-    })();
-    byTable.set(table, probe);
-  }
+  const cached = byTable.get(table);
+  if (cached) return cached;
+  const probe = (async () => {
+    try {
+      const r = await ch.query({ query: `EXISTS TABLE ${table}`, format: "JSONEachRow" });
+      const rows = (await r.json()) as { result: number | string }[];
+      return Number(rows[0]?.result) === 1;
+    } catch {
+      return false;
+    }
+  })();
+  byTable.set(table, probe);
+  // Keep only a cached `true`; drop `false`/errored probes so a later call
+  // re-checks (self-heals once the migration lands).
+  probe
+    .then((exists) => {
+      if (!exists) byTable?.delete(table);
+    })
+    .catch(() => byTable?.delete(table));
   return probe;
 }
 


### PR DESCRIPTION
`tableExists` (trace-list fast path + `events_per_minute` chart rollup) memoized **every** probe result, including "table absent". The derived rollup tables are created by a **manual ClickHouse migration that can land after the app boots** — when it does, every running task stays pinned to the slow raw scan until restart, even though the fast path is now live.

Observed in prod today: the api tasks booted ~8 min before migration 005 was applied, cached "otel_traces_recent absent", and kept serving the raw scan (a force-restart worked around it). This makes that self-heal instead.

**Fix:** cache only a positive result (a table won't disappear from under a live process); evict negative/errored probes once they resolve so the next call re-checks. Cheap metadata probe, concurrent callers still share one in-flight promise, steady-state cost unchanged once the table exists.

Adds a test that flips EXISTS absent→present across two calls on the same client and asserts the second call takes the fast path.

- [x] `pnpm --filter @superlog/api test` (34/34)
- [x] typecheck + biome clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ac414bc25da1d2720b0a0e976dc879984359f8de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop caching a missing rollup table as “absent” forever so the API can switch to the fast path automatically after ClickHouse migrations create the tables. This prevents long-running raw scans and removes the need for restarts.

- **Bug Fixes**
  - `tableExists` now caches only a positive result; negative or errored probes are evicted so later calls re-probe and self-heal.
  - Added a test that flips `EXISTS` from absent to present on the same client and verifies the second call uses the rollup fast path (`recent_ids`), not the raw scan.

<sup>Written for commit ac414bc25da1d2720b0a0e976dc879984359f8de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

