### PR TITLE
Add Vercel drain connector

### DIFF
--- a/apps/api/src/cloudflare-service.ts
+++ b/apps/api/src/cloudflare-service.ts
@@ -14,8 +14,6 @@
 // wrapper that takes an injectable `fetch`, so the route layer (cloudflare.ts)
 // stays thin and the logic is unit-testable without a live Cloudflare account.
 
-import crypto from "node:crypto";
-
 export const CLOUDFLARE_OAUTH_AUTHORIZE_URL = "https://dash.cloudflare.com/oauth2/auth";
 export const CLOUDFLARE_OAUTH_TOKEN_URL = "https://dash.cloudflare.com/oauth2/token";
 export const CLOUDFLARE_OAUTH_REVOKE_URL = "https://dash.cloudflare.com/oauth2/revoke";
@@ -178,39 +176,12 @@ export function buildDestinationPayload(input: {
 }
 
 // ---------------------------------------------------------------------------
-// OAuth state (signed, short-lived) — mirrors the Slack connector's scheme so
-// the callback can trust org/project/user without a session cookie.
+// OAuth state (signed, short-lived) — the shared connector scheme lives in
+// oauth-state.ts; re-exported here so existing imports keep working.
 // ---------------------------------------------------------------------------
 
-export type CloudflareStatePayload = {
-  orgId: string;
-  projectId: string;
-  userId: string | null;
-};
-
-export function signState(p: CloudflareStatePayload, secret: string): string {
-  const body = `${p.orgId}.${p.projectId}.${p.userId ?? ""}.${Date.now()}`;
-  const sig = crypto.createHmac("sha256", secret).update(body).digest("base64url");
-  return `${Buffer.from(body, "utf8").toString("base64url")}.${sig}`;
-}
-
-export function verifyState(state: string, secret: string): CloudflareStatePayload | null {
-  const [payloadB64, sig] = state.split(".");
-  if (!payloadB64 || !sig) return null;
-  const body = Buffer.from(payloadB64, "base64url").toString("utf8");
-  const expected = crypto.createHmac("sha256", secret).update(body).digest("base64url");
-  const provided = Buffer.from(sig);
-  const expectedBuf = Buffer.from(expected);
-  if (provided.length !== expectedBuf.length) return null;
-  if (!crypto.timingSafeEqual(provided, expectedBuf)) return null;
-  const parts = body.split(".");
-  if (parts.length !== 4) return null;
-  const [orgId, projectId, userId, tsRaw] = parts as [string, string, string, string];
-  if (!orgId || !projectId || !tsRaw) return null;
-  const ts = Number(tsRaw);
-  if (!Number.isFinite(ts) || Date.now() - ts > 10 * 60 * 1000) return null;
-  return { orgId, projectId, userId: userId || null };
-}
+export type { OAuthStatePayload as CloudflareStatePayload } from "./oauth-state.js";
+export { signState, verifyState } from "./oauth-state.js";
 
 // ---------------------------------------------------------------------------
 // Response parsing

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -33,6 +33,7 @@ import { auth } from "./auth.js";
 import { shouldRunMigrationsOnBoot } from "./boot-migrations.js";
 import { mountCloudConnectionsAuthed } from "./cloud-connections.js";
 import { mountCloudflareAuthed, mountCloudflarePublic } from "./cloudflare.js";
+import { mountVercelAuthed, mountVercelPublic } from "./vercel.js";
 import { mountDashboards } from "./dashboards.js";
 import {
   demoOverlay,
@@ -279,6 +280,7 @@ mountLinearPublic(app);
 mountMcpPublic(app, ch);
 mountSlackPublic(app);
 mountCloudflarePublic(app);
+mountVercelPublic(app);
 mountFeedbackPublic(app);
 // Management API (org-key auth, /api/v1/*) registers its own middleware
 // before the session middleware below — the session middleware skips
@@ -316,6 +318,7 @@ mountGithubAuthed(app);
 mountLinearAuthed(app);
 mountSlackAuthed(app);
 mountCloudflareAuthed(app);
+mountVercelAuthed(app);
 mountSettingsAuthed(app);
 mountOrgKeyManagementAuthed(app);
 mountDashboards(app);

--- a/apps/api/src/ingest-filters-service.test.ts
+++ b/apps/api/src/ingest-filters-service.test.ts
@@ -8,30 +8,41 @@ import {
   ingestFilterStateSchema,
 } from "./ingest-filters-service.js";
 
-test("allIngestFilterPairs covers otlp×3 + aws×2", () => {
+test("allIngestFilterPairs covers otlp×3 + aws×2 + vercel×2", () => {
   const pairs = allIngestFilterPairs()
     .map((p) => ingestFilterKey(p.source, p.signal))
     .sort();
-  assert.deepEqual(pairs, ["aws:logs", "aws:metrics", "otlp:logs", "otlp:metrics", "otlp:traces"]);
+  assert.deepEqual(pairs, [
+    "aws:logs",
+    "aws:metrics",
+    "otlp:logs",
+    "otlp:metrics",
+    "otlp:traces",
+    "vercel:logs",
+    "vercel:traces",
+  ]);
 });
 
 test("empty disabled set → everything enabled", () => {
   assert.deepEqual(deriveIngestFilterState(new Set()), {
     otlp: { traces: true, logs: true, metrics: true },
     aws: { logs: true, metrics: true },
+    vercel: { traces: true, logs: true },
   });
 });
 
 test("disabled set flips exactly those pairs off", () => {
-  const state = deriveIngestFilterState(new Set(["aws:logs", "otlp:traces"]));
+  const state = deriveIngestFilterState(new Set(["aws:logs", "otlp:traces", "vercel:logs"]));
   assert.equal(state.aws.logs, false);
   assert.equal(state.otlp.traces, false);
+  assert.equal(state.vercel.logs, false);
+  assert.equal(state.vercel.traces, true);
   assert.equal(state.aws.metrics, true);
   assert.equal(state.otlp.logs, true);
 });
 
 test("disabledPairsFromState is the inverse of derive (round-trip)", () => {
-  const disabled = new Set(["aws:logs", "otlp:metrics"]);
+  const disabled = new Set(["aws:logs", "otlp:metrics", "vercel:traces"]);
   const state = deriveIngestFilterState(disabled);
   const back = new Set(
     disabledPairsFromState(state).map((p) => ingestFilterKey(p.source, p.signal)),
@@ -44,6 +55,7 @@ test("state schema rejects unknown source/signal keys", () => {
     ingestFilterStateSchema.safeParse({
       otlp: { traces: true, logs: true, metrics: true },
       aws: { logs: true, metrics: true },
+      vercel: { traces: true, logs: true },
     }).success,
     true,
   );
@@ -52,6 +64,7 @@ test("state schema rejects unknown source/signal keys", () => {
     ingestFilterStateSchema.safeParse({
       otlp: { traces: true, logs: true, metrics: true },
       aws: { logs: true, metrics: true, traces: true },
+      vercel: { traces: true, logs: true },
     }).success,
     false,
   );
@@ -60,6 +73,7 @@ test("state schema rejects unknown source/signal keys", () => {
     ingestFilterStateSchema.safeParse({
       otlp: { traces: true, logs: true },
       aws: { logs: true, metrics: true },
+      vercel: { traces: true, logs: true },
     }).success,
     false,
   );

--- a/apps/api/src/ingest-filters-service.ts
+++ b/apps/api/src/ingest-filters-service.ts
@@ -1,10 +1,12 @@
 import { z } from "zod";
 
 // The telemetry signals each ingest source can carry. OTLP (the SDK/exporter
-// path) carries all three; AWS (CloudWatch → Firehose) carries only logs+metrics.
+// path) carries all three; AWS (CloudWatch → Firehose) carries logs+metrics;
+// Vercel Drains carry traces+logs.
 export const INGEST_SOURCE_SIGNALS = {
   otlp: ["traces", "logs", "metrics"],
   aws: ["logs", "metrics"],
+  vercel: ["traces", "logs"],
 } as const;
 
 export type IngestSource = keyof typeof INGEST_SOURCE_SIGNALS;
@@ -13,6 +15,7 @@ export type IngestSignal = "traces" | "logs" | "metrics";
 export type IngestFilterState = {
   otlp: { traces: boolean; logs: boolean; metrics: boolean };
   aws: { logs: boolean; metrics: boolean };
+  vercel: { traces: boolean; logs: boolean };
 };
 
 /** Stable key for a (source, signal) pair — matches the proxy's filter key. */
@@ -39,6 +42,7 @@ export function deriveIngestFilterState(disabled: Set<string>): IngestFilterStat
       metrics: on("otlp", "metrics"),
     },
     aws: { logs: on("aws", "logs"), metrics: on("aws", "metrics") },
+    vercel: { traces: on("vercel", "traces"), logs: on("vercel", "logs") },
   };
 }
 
@@ -48,6 +52,7 @@ export const ingestFilterStateSchema = z
   .object({
     otlp: z.object({ traces: z.boolean(), logs: z.boolean(), metrics: z.boolean() }).strict(),
     aws: z.object({ logs: z.boolean(), metrics: z.boolean() }).strict(),
+    vercel: z.object({ traces: z.boolean(), logs: z.boolean() }).strict(),
   })
   .strict();
 

--- a/apps/api/src/ingest-filters.test.ts
+++ b/apps/api/src/ingest-filters.test.ts
@@ -64,6 +64,7 @@ test("defaults to everything enabled (no rows)", async () => {
   assert.deepEqual(await getState(app, project.id), {
     otlp: { traces: true, logs: true, metrics: true },
     aws: { logs: true, metrics: true },
+    vercel: { traces: true, logs: true },
   });
 });
 
@@ -74,6 +75,7 @@ test("PUT disables a pair, persists one sparse row, and reflects in GET", async 
   const desired: IngestFilterState = {
     otlp: { traces: true, logs: true, metrics: true },
     aws: { logs: false, metrics: true },
+    vercel: { traces: true, logs: true },
   };
   const res = await app.request(`/api/projects/${project.id}/ingest-filters`, {
     method: "PUT",
@@ -111,10 +113,12 @@ test("PUT is a full replace — re-enabling clears the row", async () => {
   await put({
     otlp: { traces: false, logs: true, metrics: true },
     aws: { logs: false, metrics: true },
+    vercel: { traces: true, logs: true },
   });
   await put({
     otlp: { traces: true, logs: true, metrics: true },
     aws: { logs: true, metrics: true },
+    vercel: { traces: true, logs: true },
   });
   const rows = await db.query.projectIngestFilters.findMany({
     where: eq(schema.projectIngestFilters.projectId, project.id),

--- a/apps/api/src/oauth-state.ts
+++ b/apps/api/src/oauth-state.ts
@@ -1,0 +1,36 @@
+// Signed, short-lived OAuth `state` shared by the connector callbacks
+// (Cloudflare, Vercel — mirroring the Slack connector's scheme). The state
+// carries org/project/user so the public callback can trust who initiated the
+// connect without a session cookie.
+
+import crypto from "node:crypto";
+
+export type OAuthStatePayload = {
+  orgId: string;
+  projectId: string;
+  userId: string | null;
+};
+
+export function signState(p: OAuthStatePayload, secret: string): string {
+  const body = `${p.orgId}.${p.projectId}.${p.userId ?? ""}.${Date.now()}`;
+  const sig = crypto.createHmac("sha256", secret).update(body).digest("base64url");
+  return `${Buffer.from(body, "utf8").toString("base64url")}.${sig}`;
+}
+
+export function verifyState(state: string, secret: string): OAuthStatePayload | null {
+  const [payloadB64, sig] = state.split(".");
+  if (!payloadB64 || !sig) return null;
+  const body = Buffer.from(payloadB64, "base64url").toString("utf8");
+  const expected = crypto.createHmac("sha256", secret).update(body).digest("base64url");
+  const provided = Buffer.from(sig);
+  const expectedBuf = Buffer.from(expected);
+  if (provided.length !== expectedBuf.length) return null;
+  if (!crypto.timingSafeEqual(provided, expectedBuf)) return null;
+  const parts = body.split(".");
+  if (parts.length !== 4) return null;
+  const [orgId, projectId, userId, tsRaw] = parts as [string, string, string, string];
+  if (!orgId || !projectId || !tsRaw) return null;
+  const ts = Number(tsRaw);
+  if (!Number.isFinite(ts) || Date.now() - ts > 10 * 60 * 1000) return null;
+  return { orgId, projectId, userId: userId || null };
+}

--- a/apps/api/src/system-capabilities.test.ts
+++ b/apps/api/src/system-capabilities.test.ts
@@ -10,6 +10,7 @@ test("system capabilities default to the open-core community edition", () => {
     ossAgents: true,
     cloudUpgradeLinks: true,
     cloudflareConnect: false,
+    vercelConnect: false,
   });
 });
 
@@ -54,6 +55,35 @@ test("system capabilities expose cloud billing and managed agents when explicitl
       ossAgents: true,
       cloudUpgradeLinks: false,
       cloudflareConnect: false,
+      vercelConnect: false,
     },
+  );
+});
+
+test("vercelConnect flips on only when all connector vars (incl. STATE_SIGNING_SECRET) are set", () => {
+  assert.equal(
+    buildSystemCapabilities({ VERCEL_CLIENT_ID: "id", VERCEL_CLIENT_SECRET: "secret" })
+      .vercelConnect,
+    false,
+  );
+  // Connector creds present but no slug → install-url can't be formed.
+  assert.equal(
+    buildSystemCapabilities({
+      VERCEL_CLIENT_ID: "id",
+      VERCEL_CLIENT_SECRET: "secret",
+      VERCEL_OTLP_INTAKE_URL: "https://intake.example.com",
+      STATE_SIGNING_SECRET: "state-secret",
+    }).vercelConnect,
+    false,
+  );
+  assert.equal(
+    buildSystemCapabilities({
+      VERCEL_CLIENT_ID: "id",
+      VERCEL_CLIENT_SECRET: "secret",
+      VERCEL_INTEGRATION_SLUG: "superlog",
+      VERCEL_OTLP_INTAKE_URL: "https://intake.example.com",
+      STATE_SIGNING_SECRET: "state-secret",
+    }).vercelConnect,
+    true,
   );
 });

--- a/apps/api/src/system-capabilities.ts
+++ b/apps/api/src/system-capabilities.ts
@@ -11,6 +11,9 @@ export type SystemCapabilities = {
   // environment (OAuth client + OTLP intake). The web uses this to gate the
   // Cloudflare onboarding option instead of offering a click that would 503.
   cloudflareConnect: boolean;
+  // Same gate for the Vercel connector (OAuth client + integration slug +
+  // OTLP intake).
+  vercelConnect: boolean;
 };
 
 type CapabilityEnv = Partial<
@@ -22,6 +25,10 @@ type CapabilityEnv = Partial<
     | "CLOUDFLARE_CLIENT_ID"
     | "CLOUDFLARE_CLIENT_SECRET"
     | "CLOUDFLARE_OTLP_INTAKE_URL"
+    | "VERCEL_CLIENT_ID"
+    | "VERCEL_CLIENT_SECRET"
+    | "VERCEL_INTEGRATION_SLUG"
+    | "VERCEL_OTLP_INTAKE_URL"
     | "STATE_SIGNING_SECRET"
   >
 >;
@@ -40,6 +47,15 @@ export function buildSystemCapabilities(env: CapabilityEnv = process.env): Syste
     env.CLOUDFLARE_OTLP_INTAKE_URL &&
     env.STATE_SIGNING_SECRET
   );
+  // Mirrors vercelConfigFromEnv's required-vars check plus the install-url
+  // route's STATE_SIGNING_SECRET requirement, same as the Cloudflare gate.
+  const vercelConnect = !!(
+    env.VERCEL_CLIENT_ID &&
+    env.VERCEL_CLIENT_SECRET &&
+    env.VERCEL_INTEGRATION_SLUG &&
+    env.VERCEL_OTLP_INTAKE_URL &&
+    env.STATE_SIGNING_SECRET
+  );
 
   return {
     edition,
@@ -48,6 +64,7 @@ export function buildSystemCapabilities(env: CapabilityEnv = process.env): Syste
     ossAgents: true,
     cloudUpgradeLinks: edition === "community",
     cloudflareConnect,
+    vercelConnect,
   };
 }
 

--- a/apps/api/src/vercel-service.test.ts
+++ b/apps/api/src/vercel-service.test.ts
@@ -1,0 +1,382 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import {
+  VERCEL_OAUTH_TOKEN_URL,
+  VERCEL_SIGNALS,
+  buildDrainPayload,
+  buildInstallUrl,
+  classifyDrainProvisioningFailure,
+  createDrain,
+  deleteConfiguration,
+  deleteDrain,
+  drainName,
+  exchangeCodeForToken,
+  fetchTeamName,
+  parseCreateDrainResponse,
+  parseTokenResponse,
+  signState,
+  staleDrainIds,
+  vercelConfigFromEnv,
+  verifyState,
+} from "./vercel-service.js";
+
+const SECRET = "test-state-secret";
+
+test("vercelConfigFromEnv returns null until required vars are set", () => {
+  assert.equal(vercelConfigFromEnv({}), null);
+  assert.equal(vercelConfigFromEnv({ VERCEL_CLIENT_ID: "id" }), null);
+  assert.equal(
+    vercelConfigFromEnv({
+      VERCEL_CLIENT_ID: "id",
+      VERCEL_CLIENT_SECRET: "secret",
+      VERCEL_OTLP_INTAKE_URL: "https://intake.example.com",
+    }),
+    null,
+    "integration slug is required (it forms the install URL)",
+  );
+  const cfg = vercelConfigFromEnv({
+    VERCEL_CLIENT_ID: "id",
+    VERCEL_CLIENT_SECRET: "secret",
+    VERCEL_INTEGRATION_SLUG: "superlog",
+    VERCEL_OTLP_INTAKE_URL: "https://intake.example.com/",
+  });
+  assert.ok(cfg);
+  // trailing slash trimmed; sensible defaults applied
+  assert.equal(cfg.intakeBaseUrl, "https://intake.example.com");
+  assert.equal(cfg.redirectUri, "http://localhost:4100/vercel/oauth/callback");
+  assert.equal(cfg.integrationSlug, "superlog");
+});
+
+test("buildInstallUrl targets the integration's external-flow install page with state", () => {
+  const url = buildInstallUrl({ integrationSlug: "superlog", state: "signed-state" });
+  const u = new URL(url);
+  assert.equal(`${u.origin}${u.pathname}`, "https://vercel.com/integrations/superlog/new");
+  assert.equal(u.searchParams.get("state"), "signed-state");
+});
+
+test("VERCEL_SIGNALS provisions traces and logs", () => {
+  assert.deepEqual(VERCEL_SIGNALS, ["traces", "logs"]);
+});
+
+test("classifyDrainProvisioningFailure detects Vercel plan-gated drains", () => {
+  assert.equal(
+    classifyDrainProvisioningFailure([
+      "Drains are not available for team 'team_123'",
+      "Not authorized",
+    ]),
+    "drains_unavailable",
+  );
+  assert.equal(classifyDrainProvisioningFailure(["Not authorized"]), "error");
+});
+
+test("drainName is project-scoped so two projects on one team don't collide", () => {
+  assert.equal(drainName("aa49a851-b727-4014-bbff-571dc282613c", "traces"), "superlog-aa49a851b727-traces");
+  assert.notEqual(
+    drainName("aa49a851-b727-4014-bbff-571dc282613c", "traces"),
+    drainName("1b480fe1-c652-4c2c-b4d2-593d278124f9", "traces"),
+  );
+});
+
+test("buildDrainPayload builds an OTLP/HTTP trace drain covering all team projects", () => {
+  const payload = buildDrainPayload({
+    signal: "traces",
+    intakeBaseUrl: "https://intake.example.com",
+    ingestKey: "sl_public_abc123",
+    projectId: "aa49a851-b727-4014-bbff-571dc282613c",
+  });
+  assert.equal(payload.name, "superlog-aa49a851b727-traces");
+  // All the team's projects stream in; per-project scoping happens on our side
+  // via the ingest key → Superlog project mapping.
+  assert.equal(payload.projects, "all");
+  assert.deepEqual(payload.schemas, { trace: { version: "v1" } });
+  assert.equal(payload.delivery.type, "otlphttp");
+  assert.deepEqual(payload.delivery.endpoint, {
+    traces: "https://intake.example.com/vercel/drains/traces",
+  });
+  assert.equal(payload.delivery.encoding, "proto");
+  assert.equal(payload.delivery.headers["x-api-key"], "sl_public_abc123");
+});
+
+test("buildDrainPayload builds an HTTP JSON log drain through the Vercel adapter", () => {
+  const payload = buildDrainPayload({
+    signal: "logs",
+    intakeBaseUrl: "https://intake.example.com",
+    ingestKey: "sl_public_abc123",
+    projectId: "aa49a851-b727-4014-bbff-571dc282613c",
+  });
+  assert.equal(payload.name, "superlog-aa49a851b727-logs");
+  assert.equal(payload.projects, "all");
+  assert.deepEqual(payload.schemas, { log: { version: "v1" } });
+  assert.equal(payload.delivery.type, "http");
+  assert.equal(payload.delivery.endpoint, "https://intake.example.com/vercel/drains/logs");
+  assert.equal(payload.delivery.encoding, "json");
+  assert.equal(payload.delivery.headers["x-api-key"], "sl_public_abc123");
+});
+
+test("signState/verifyState round-trips and rejects tampering", () => {
+  const state = signState({ orgId: "org-1", projectId: "proj-1", userId: "user-1" }, SECRET);
+  const decoded = verifyState(state, SECRET);
+  assert.ok(decoded);
+  assert.equal(decoded.projectId, "proj-1");
+  assert.equal(verifyState(state, "other-secret"), null);
+});
+
+test("parseTokenResponse extracts the token + installation identifiers", () => {
+  const ok = parseTokenResponse({
+    access_token: "at",
+    token_type: "Bearer",
+    installation_id: "icfg_123",
+    user_id: "user_abc",
+    team_id: "team_xyz",
+  });
+  assert.deepEqual(ok, {
+    ok: true,
+    accessToken: "at",
+    installationId: "icfg_123",
+    userId: "user_abc",
+    teamId: "team_xyz",
+  });
+  // Personal-account installs have no team.
+  const personal = parseTokenResponse({
+    access_token: "at",
+    installation_id: "icfg_123",
+    user_id: "user_abc",
+    team_id: null,
+  });
+  assert.ok(personal.ok);
+  if (personal.ok) assert.equal(personal.teamId, null);
+
+  assert.deepEqual(parseTokenResponse({ error: "invalid_grant" }), {
+    ok: false,
+    error: "invalid_grant",
+  });
+  // Vercel's standard error envelope is an object.
+  assert.deepEqual(parseTokenResponse({ error: { code: "bad_request", message: "nope" } }), {
+    ok: false,
+    error: "nope",
+  });
+  assert.deepEqual(parseTokenResponse(null), { ok: false, error: "invalid_response" });
+  assert.deepEqual(parseTokenResponse({}), { ok: false, error: "no_access_token" });
+  // A token without an installation id can't be managed (or torn down) later.
+  assert.deepEqual(parseTokenResponse({ access_token: "at" }), {
+    ok: false,
+    error: "no_installation_id",
+  });
+});
+
+test("parseCreateDrainResponse returns the drain id and surfaces error messages", () => {
+  assert.deepEqual(parseCreateDrainResponse({ id: "drn_1", name: "superlog-x-traces" }), {
+    ok: true,
+    id: "drn_1",
+  });
+  assert.deepEqual(parseCreateDrainResponse({ error: { code: "forbidden", message: "nope" } }), {
+    ok: false,
+    error: "nope",
+  });
+  assert.deepEqual(parseCreateDrainResponse({ error: { code: "forbidden" } }), {
+    ok: false,
+    error: "forbidden",
+  });
+  assert.deepEqual(parseCreateDrainResponse(null), { ok: false, error: "invalid_response" });
+  // A drain we can't identify can't be deleted on reconnect/uninstall — treat a
+  // response without an id as a failure rather than persist an unmanageable drain.
+  assert.deepEqual(parseCreateDrainResponse({ name: "superlog-x-traces" }), {
+    ok: false,
+    error: "no_drain_id",
+  });
+});
+
+test("staleDrainIds only deletes prior ids for signals that got a replacement", () => {
+  assert.deepEqual(staleDrainIds(null, { traces: "new-1" }), {});
+  assert.deepEqual(staleDrainIds({ traces: "old-t" }, { traces: "new-t" }), { traces: "old-t" });
+  // `traces` failed to recreate (absent from current) → its prior id is KEPT.
+  assert.deepEqual(staleDrainIds({ traces: "old-t" }, {}), {});
+  // Same id returned (idempotent create) → it's the live one, keep it.
+  assert.deepEqual(staleDrainIds({ traces: "same" }, { traces: "same" }), {});
+});
+
+test("exchangeCodeForToken posts form body to the token endpoint", async () => {
+  let capturedUrl = "";
+  let capturedBody = "";
+  const fakeFetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    capturedUrl = String(url);
+    capturedBody = String(init?.body ?? "");
+    return new Response(
+      JSON.stringify({
+        access_token: "at",
+        installation_id: "icfg_1",
+        user_id: "u1",
+        team_id: "t1",
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+
+  const result = await exchangeCodeForToken({
+    config: {
+      clientId: "cid",
+      clientSecret: "csecret",
+      integrationSlug: "superlog",
+      redirectUri: "https://api.example.com/vercel/oauth/callback",
+      intakeBaseUrl: "https://intake.example.com",
+    },
+    code: "the-code",
+    fetchImpl: fakeFetch,
+  });
+
+  assert.equal(capturedUrl, VERCEL_OAUTH_TOKEN_URL);
+  assert.ok(capturedBody.includes("code=the-code"));
+  assert.ok(capturedBody.includes("client_id=cid"));
+  assert.ok(capturedBody.includes("redirect_uri="));
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.accessToken, "at");
+});
+
+test("createDrain POSTs to /v1/drains with the team query when installed on a team", async () => {
+  let capturedUrl = "";
+  let authHeader = "";
+  const fakeFetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    capturedUrl = String(url);
+    authHeader = String((init?.headers as Record<string, string>)?.authorization ?? "");
+    return new Response(JSON.stringify({ id: "drn_9" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+
+  const result = await createDrain({
+    teamId: "team_1",
+    accessToken: "at",
+    payload: buildDrainPayload({
+      signal: "traces",
+      intakeBaseUrl: "https://intake.example.com",
+      ingestKey: "sl_public_x",
+      projectId: "aa49a851-b727-4014-bbff-571dc282613c",
+    }),
+    fetchImpl: fakeFetch,
+  });
+
+  assert.equal(capturedUrl, "https://api.vercel.com/v1/drains?teamId=team_1");
+  assert.equal(authHeader, "Bearer at");
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.id, "drn_9");
+});
+
+test("createDrain omits the team query for personal-account installs", async () => {
+  let capturedUrl = "";
+  const fakeFetch = (async (url: string | URL | Request) => {
+    capturedUrl = String(url);
+    return new Response(JSON.stringify({ id: "drn_9" }), { status: 200 });
+  }) as unknown as typeof fetch;
+
+  await createDrain({
+    teamId: null,
+    accessToken: "at",
+    payload: buildDrainPayload({
+      signal: "traces",
+      intakeBaseUrl: "https://intake.example.com",
+      ingestKey: "k",
+      projectId: "p",
+    }),
+    fetchImpl: fakeFetch,
+  });
+  assert.equal(capturedUrl, "https://api.vercel.com/v1/drains");
+});
+
+test("deleteDrain DELETEs the drain and never throws", async () => {
+  let capturedUrl = "";
+  let capturedMethod = "";
+  const fakeFetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    capturedUrl = String(url);
+    capturedMethod = String(init?.method ?? "");
+    return new Response(null, { status: 204 });
+  }) as unknown as typeof fetch;
+
+  const result = await deleteDrain({
+    teamId: "team_1",
+    accessToken: "at",
+    drainId: "drn_9",
+    fetchImpl: fakeFetch,
+  });
+  assert.equal(capturedMethod, "DELETE");
+  assert.equal(capturedUrl, "https://api.vercel.com/v1/drains/drn_9?teamId=team_1");
+  assert.equal(result.ok, true);
+
+  const boom = (async () => {
+    throw new Error("network down");
+  }) as unknown as typeof fetch;
+  const failed = await deleteDrain({
+    teamId: null,
+    accessToken: "at",
+    drainId: "x",
+    fetchImpl: boom,
+  });
+  assert.equal(failed.ok, false);
+});
+
+test("deleteConfiguration removes the integration install and never throws", async () => {
+  let capturedUrl = "";
+  let capturedMethod = "";
+  const fakeFetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    capturedUrl = String(url);
+    capturedMethod = String(init?.method ?? "");
+    return new Response(null, { status: 204 });
+  }) as unknown as typeof fetch;
+
+  const result = await deleteConfiguration({
+    teamId: "team_1",
+    accessToken: "at",
+    configurationId: "icfg_1",
+    fetchImpl: fakeFetch,
+  });
+  assert.equal(capturedMethod, "DELETE");
+  assert.equal(
+    capturedUrl,
+    "https://api.vercel.com/v1/integrations/configuration/icfg_1?teamId=team_1",
+  );
+  assert.equal(result.ok, true);
+
+  const boom = (async () => {
+    throw new Error("network down");
+  }) as unknown as typeof fetch;
+  const failed = await deleteConfiguration({
+    teamId: null,
+    accessToken: "at",
+    configurationId: "icfg_1",
+    fetchImpl: boom,
+  });
+  assert.equal(failed.ok, false);
+});
+
+test("fetchTeamName resolves the team display name and null on any failure", async () => {
+  const respond = (status: number, body: unknown) =>
+    (async () => new Response(JSON.stringify(body), { status })) as unknown as typeof fetch;
+
+  assert.equal(
+    await fetchTeamName({
+      teamId: "team_1",
+      accessToken: "at",
+      fetchImpl: respond(200, { id: "team_1", name: "Acme", slug: "acme" }),
+    }),
+    "Acme",
+  );
+  // Fall back to the slug when the name is empty.
+  assert.equal(
+    await fetchTeamName({
+      teamId: "team_1",
+      accessToken: "at",
+      fetchImpl: respond(200, { id: "team_1", slug: "acme" }),
+    }),
+    "acme",
+  );
+  assert.equal(
+    await fetchTeamName({
+      teamId: "team_1",
+      accessToken: "at",
+      fetchImpl: respond(403, { error: { code: "forbidden" } }),
+    }),
+    null,
+  );
+  // Personal installs have no team to look up.
+  assert.equal(await fetchTeamName({ teamId: null, accessToken: "at", fetchImpl: fetch }), null);
+});

--- a/apps/api/src/vercel-service.ts
+++ b/apps/api/src/vercel-service.ts
@@ -1,0 +1,400 @@
+// Pure helpers + thin (injectable-fetch) HTTP wrappers for the Vercel
+// integration. Vercel's connectable-account integrations are OAuth2 apps: the
+// user installs our integration from the external-flow install page, Vercel
+// redirects back with a single-use code, and we exchange it for a long-lived
+// token scoped to that installation. We then use the token to create a Drain
+// (`POST /v1/drains`) that streams the team's deployments' OTLP traces straight
+// to our intake — no copy-paste API tokens.
+//
+// Signals: Vercel's Drains support OTLP delivery (`type: "otlphttp"`) for
+// traces. Log drains deliver Vercel JSON/NDJSON, so we point them at our
+// Vercel-specific intake adapter, which translates to OTLP logs before the
+// normal ingest path stores them.
+//
+// Endpoints (from Vercel's integrations + drains REST docs):
+//   install:  https://vercel.com/integrations/<slug>/new   (external flow)
+//   token:    https://api.vercel.com/v2/oauth/access_token
+//   drains:   https://api.vercel.com/v1/drains[?teamId=…]
+//   config:   https://api.vercel.com/v1/integrations/configuration/<id>
+//
+// This module is deliberately IO-light: everything is a pure function or a
+// wrapper that takes an injectable `fetch`, so the route layer (vercel.ts)
+// stays thin and the logic is unit-testable without a live Vercel account.
+
+export const VERCEL_API_BASE = "https://api.vercel.com";
+export const VERCEL_OAUTH_TOKEN_URL = `${VERCEL_API_BASE}/v2/oauth/access_token`;
+export const VERCEL_INSTALL_BASE = "https://vercel.com/integrations";
+
+export type { OAuthStatePayload as VercelStatePayload } from "./oauth-state.js";
+export { signState, verifyState } from "./oauth-state.js";
+
+export type VercelSignal = "traces" | "logs";
+
+// signal → { Drain schema entry, our public intake path }.
+export const VERCEL_DRAIN_SIGNALS: Record<
+  VercelSignal,
+  { schema: string; version: string; path: string }
+> = {
+  traces: { schema: "trace", version: "v1", path: "/vercel/drains/traces" },
+  logs: { schema: "log", version: "v1", path: "/vercel/drains/logs" },
+};
+
+export const VERCEL_SIGNALS: VercelSignal[] = ["traces", "logs"];
+
+export type VercelConnectErrorOutcome =
+  | "error"
+  | "drains_unavailable";
+
+export class VercelProvisioningError extends Error {
+  constructor(
+    message: string,
+    readonly outcome: VercelConnectErrorOutcome,
+  ) {
+    super(message);
+  }
+}
+
+export function classifyDrainProvisioningFailure(errors: string[]): VercelConnectErrorOutcome {
+  if (errors.some((error) => /drains are not available/i.test(error))) {
+    return "drains_unavailable";
+  }
+  return "error";
+}
+
+export type VercelConnectConfig = {
+  clientId: string;
+  clientSecret: string;
+  /** Marketplace slug of our integration — forms the install URL. */
+  integrationSlug: string;
+  redirectUri: string;
+  /**
+   * Base URL of our public OTLP intake (trailing slash stripped), e.g.
+   * `https://intake.superlog.sh`. Created drains target the Vercel-specific
+   * adapter paths under `${intakeBaseUrl}/vercel/drains/*`.
+   */
+  intakeBaseUrl: string;
+};
+
+/** Read connector config from env; null (→ feature disabled) when unconfigured. */
+export function vercelConfigFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): VercelConnectConfig | null {
+  const clientId = env.VERCEL_CLIENT_ID;
+  const clientSecret = env.VERCEL_CLIENT_SECRET;
+  const integrationSlug = env.VERCEL_INTEGRATION_SLUG;
+  const intake = env.VERCEL_OTLP_INTAKE_URL;
+  if (!clientId || !clientSecret || !integrationSlug || !intake) return null;
+  const redirectUri =
+    env.VERCEL_OAUTH_REDIRECT_URL ?? "http://localhost:4100/vercel/oauth/callback";
+  return {
+    clientId,
+    clientSecret,
+    integrationSlug,
+    redirectUri,
+    intakeBaseUrl: intake.replace(/\/+$/, ""),
+  };
+}
+
+/**
+ * The external-flow install page for our integration. Vercel echoes `state`
+ * back to the redirect URL (which is registered on the integration itself, so
+ * it isn't a parameter here).
+ */
+export function buildInstallUrl(input: { integrationSlug: string; state: string }): string {
+  const url = new URL(`${VERCEL_INSTALL_BASE}/${input.integrationSlug}/new`);
+  url.searchParams.set("state", input.state);
+  return url.toString();
+}
+
+/**
+ * A drain name identifies the Superlog project on the customer's team, so a
+ * second project connecting the same team gets its own drain instead of an
+ * ambiguous duplicate. Same short project token scheme as the Cloudflare
+ * connector's destination names.
+ */
+export function projectDrainToken(projectId: string): string {
+  return projectId
+    .replace(/[^a-z0-9]/gi, "")
+    .slice(0, 12)
+    .toLowerCase();
+}
+
+export function drainName(projectId: string, signal: VercelSignal): string {
+  return `superlog-${projectDrainToken(projectId)}-${signal}`;
+}
+
+export function intakeUrlForSignal(base: string, signal: VercelSignal): string {
+  return `${base.replace(/\/+$/, "")}${VERCEL_DRAIN_SIGNALS[signal].path}`;
+}
+
+export type DrainPayload = {
+  name: string;
+  // "all": every project on the team streams in — per-project scoping happens
+  // on our side via the ingest key → Superlog project mapping (mirrors how the
+  // Cloudflare connector wires every Worker on the account).
+  projects: "all";
+  schemas: Record<string, { version: string }>;
+  delivery:
+    | {
+        type: "otlphttp";
+        endpoint: Record<string, string>;
+        encoding: "proto";
+        headers: Record<string, string>;
+      }
+    | {
+        type: "http";
+        endpoint: string;
+        encoding: "json";
+        headers: Record<string, string>;
+      };
+};
+
+/**
+ * Build the Drain payload for one signal: an OTLP/HTTP delivery pointed at our
+ * intake and authenticated with the project's ingest key via `x-api-key`.
+ */
+export function buildDrainPayload(input: {
+  signal: VercelSignal;
+  intakeBaseUrl: string;
+  ingestKey: string;
+  projectId: string;
+}): DrainPayload {
+  const sig = VERCEL_DRAIN_SIGNALS[input.signal];
+  const endpoint = intakeUrlForSignal(input.intakeBaseUrl, input.signal);
+  return {
+    name: drainName(input.projectId, input.signal),
+    projects: "all",
+    schemas: { [sig.schema]: { version: sig.version } },
+    delivery:
+      input.signal === "traces"
+        ? {
+            type: "otlphttp",
+            endpoint: { traces: endpoint },
+            encoding: "proto",
+            headers: { "x-api-key": input.ingestKey },
+          }
+        : {
+            type: "http",
+            endpoint,
+            encoding: "json",
+            headers: { "x-api-key": input.ingestKey },
+          },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Response parsing
+// ---------------------------------------------------------------------------
+
+/** Vercel's standard error envelope is `{ error: { code, message } }`. */
+function extractError(o: Record<string, unknown>): string | null {
+  const err = o.error;
+  if (typeof err === "string") return err;
+  if (err && typeof err === "object") {
+    const e = err as Record<string, unknown>;
+    if (typeof e.message === "string") return e.message;
+    if (typeof e.code === "string") return e.code;
+    return "request_failed";
+  }
+  return null;
+}
+
+export type VercelTokenResult =
+  | {
+      ok: true;
+      accessToken: string;
+      /** The integration configuration this token belongs to (`icfg_…`). */
+      installationId: string;
+      userId: string | null;
+      /** Null for personal-account installs; required as `?teamId=` otherwise. */
+      teamId: string | null;
+    }
+  | { ok: false; error: string };
+
+export function parseTokenResponse(json: unknown): VercelTokenResult {
+  if (!json || typeof json !== "object") return { ok: false, error: "invalid_response" };
+  const o = json as Record<string, unknown>;
+  const error = extractError(o);
+  if (error) return { ok: false, error };
+  if (typeof o.access_token !== "string" || !o.access_token) {
+    return { ok: false, error: "no_access_token" };
+  }
+  // Without the installation id we can't tie the token to a configuration (or
+  // tear the install down later) — refuse rather than persist an unmanageable
+  // grant.
+  if (typeof o.installation_id !== "string" || !o.installation_id) {
+    return { ok: false, error: "no_installation_id" };
+  }
+  return {
+    ok: true,
+    accessToken: o.access_token,
+    installationId: o.installation_id,
+    userId: typeof o.user_id === "string" ? o.user_id : null,
+    teamId: typeof o.team_id === "string" && o.team_id ? o.team_id : null,
+  };
+}
+
+export type CreateDrainResult = { ok: true; id: string } | { ok: false; error: string };
+
+export function parseCreateDrainResponse(json: unknown): CreateDrainResult {
+  if (!json || typeof json !== "object") return { ok: false, error: "invalid_response" };
+  const o = json as Record<string, unknown>;
+  const error = extractError(o);
+  if (error) return { ok: false, error };
+  // A drain we can't identify can't be deleted on reconnect/uninstall — treat a
+  // response without an id as a failure rather than persist an unmanageable one.
+  if (typeof o.id !== "string" || !o.id) return { ok: false, error: "no_drain_id" };
+  return { ok: true, id: o.id };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP wrappers (injectable fetch)
+// ---------------------------------------------------------------------------
+
+export type FetchImpl = typeof fetch;
+
+/** `?teamId=…` suffix for team installs; empty for personal-account installs. */
+function teamQuery(teamId: string | null): string {
+  return teamId ? `?teamId=${encodeURIComponent(teamId)}` : "";
+}
+
+export async function exchangeCodeForToken(input: {
+  config: VercelConnectConfig;
+  code: string;
+  fetchImpl?: FetchImpl;
+}): Promise<VercelTokenResult> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const res = await fetchImpl(VERCEL_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: input.config.clientId,
+      client_secret: input.config.clientSecret,
+      code: input.code,
+      redirect_uri: input.config.redirectUri,
+    }),
+  });
+  const json = await res.json().catch(() => null);
+  return parseTokenResponse(json);
+}
+
+export async function createDrain(input: {
+  teamId: string | null;
+  accessToken: string;
+  payload: DrainPayload;
+  fetchImpl?: FetchImpl;
+}): Promise<CreateDrainResult> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const res = await fetchImpl(`${VERCEL_API_BASE}/v1/drains${teamQuery(input.teamId)}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${input.accessToken}`,
+    },
+    body: JSON.stringify(input.payload),
+  });
+  const json = await res.json().catch(() => null);
+  const parsed = parseCreateDrainResponse(json);
+  // A non-OK status with an unparseable body still must not read as success.
+  if (!res.ok && parsed.ok) return { ok: false, error: `status_${res.status}` };
+  return parsed;
+}
+
+/**
+ * Delete a Drain by id. Best-effort (used when superseding a prior connect so
+ * we don't leave duplicate drains streaming): never throws, returns whether
+ * Vercel accepted the delete.
+ */
+export async function deleteDrain(input: {
+  teamId: string | null;
+  accessToken: string;
+  drainId: string;
+  fetchImpl?: FetchImpl;
+}): Promise<{ ok: boolean }> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  try {
+    const res = await fetchImpl(
+      `${VERCEL_API_BASE}/v1/drains/${encodeURIComponent(input.drainId)}${teamQuery(input.teamId)}`,
+      {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${input.accessToken}` },
+      },
+    );
+    return { ok: res.ok };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/**
+ * Delete the integration configuration (the install itself) — Vercel's analog
+ * of an OAuth token revoke: the token stops working and the install disappears
+ * from the user's team. Best-effort, never throws.
+ */
+export async function deleteConfiguration(input: {
+  teamId: string | null;
+  accessToken: string;
+  configurationId: string;
+  fetchImpl?: FetchImpl;
+}): Promise<{ ok: boolean }> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  try {
+    const res = await fetchImpl(
+      `${VERCEL_API_BASE}/v1/integrations/configuration/${encodeURIComponent(
+        input.configurationId,
+      )}${teamQuery(input.teamId)}`,
+      {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${input.accessToken}` },
+      },
+    );
+    return { ok: res.ok };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/**
+ * Resolve the team's display name for the connected chip in the UI. Purely
+ * cosmetic, so any failure (including personal installs, which have no team)
+ * resolves to null rather than throwing.
+ */
+export async function fetchTeamName(input: {
+  teamId: string | null;
+  accessToken: string;
+  fetchImpl?: FetchImpl;
+}): Promise<string | null> {
+  if (!input.teamId) return null;
+  const fetchImpl = input.fetchImpl ?? fetch;
+  try {
+    const res = await fetchImpl(
+      `${VERCEL_API_BASE}/v2/teams/${encodeURIComponent(input.teamId)}`,
+      { headers: { authorization: `Bearer ${input.accessToken}` } },
+    );
+    if (!res.ok) return null;
+    const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    if (!json) return null;
+    if (typeof json.name === "string" && json.name) return json.name;
+    if (typeof json.slug === "string" && json.slug) return json.slug;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Given the prior same-configuration drains and the ones we just (re)created,
+ * return the prior drain ids that are now stale and should be deleted remotely.
+ * Same guards as the Cloudflare connector: only signals that actually got a
+ * fresh drain this run are eligible, and an id that's still live is kept.
+ */
+export function staleDrainIds(
+  previous: Record<string, string> | null | undefined,
+  current: Record<string, string>,
+): Record<string, string> {
+  if (!previous) return {};
+  const liveIds = new Set(Object.values(current));
+  return Object.fromEntries(
+    Object.entries(previous).filter(([signal, id]) => signal in current && !liveIds.has(id)),
+  );
+}

--- a/apps/api/src/vercel.ts
+++ b/apps/api/src/vercel.ts
@@ -1,0 +1,528 @@
+// Vercel integration routes: a Slack-style OAuth "Connect Vercel" button.
+//
+// Flow (the authed routes are project-scoped — installs are per project, so the
+// project must be explicit in the path rather than inferred from the caller's
+// "active" project):
+//   1. (authed)  POST /api/projects/:projectId/vercel/install-url
+//                → external-flow install URL (signed state carries org/project/user)
+//   2. user approves the install on vercel.com
+//   3. (public)  GET  /vercel/oauth/callback   → exchange code, then use the
+//      granted token to create a Drain that exports OTLP traces to our intake
+//      with a project ingest key.
+//   4. (authed)  GET  /api/projects/:projectId/vercel/installation → status
+//                POST /api/projects/:projectId/vercel/uninstall → remove install
+//
+// The callback lives outside /api/* so it isn't behind the session middleware —
+// it's authenticated by the HMAC-signed `state`, exactly like the Cloudflare
+// and Slack connectors' callbacks.
+
+import {
+  db,
+  decryptIntegrationSecret,
+  encryptIntegrationSecret,
+  mintApiKey,
+  schema,
+} from "@superlog/db";
+import { and, desc, eq, isNull, ne } from "drizzle-orm";
+import type { Context, Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { logger } from "./logger.js";
+import { resolveActiveOrgContext } from "./org-context.js";
+import {
+  VERCEL_SIGNALS,
+  type VercelConnectConfig,
+  VercelProvisioningError,
+  buildDrainPayload,
+  buildInstallUrl,
+  classifyDrainProvisioningFailure,
+  createDrain,
+  deleteConfiguration,
+  deleteDrain,
+  exchangeCodeForToken,
+  fetchTeamName,
+  signState,
+  staleDrainIds,
+  vercelConfigFromEnv,
+  verifyState,
+} from "./vercel-service.js";
+
+const log = logger.child({ scope: "vercel" });
+
+type Vars = { userId: string; orgId: string | null };
+
+type VercelInstallationRow = typeof schema.vercelInstallations.$inferSelect;
+
+/** Public shape — never leaks token ciphertext. */
+function toPublic(row: VercelInstallationRow) {
+  return {
+    installed: true,
+    teamId: row.teamId ?? "",
+    teamName: row.teamName,
+    configurationId: row.configurationId,
+    drains: row.drains ?? {},
+    installedAt: row.createdAt,
+  };
+}
+
+// Resolve the project the request targets from the path param and confirm the
+// caller's active org owns it. Vercel installs are per-project (the table is
+// keyed by (project, configuration)), so the project must be explicit —
+// inferring the user's "active" project here would connect/disconnect the wrong
+// project when Settings is viewing a different one.
+async function requireProjectAccess(
+  c: Context<{ Variables: Vars }>,
+  projectId: string,
+): Promise<{ userId: string; orgId: string; projectId: string }> {
+  const userId = c.var.userId;
+  if (!userId) throw new HTTPException(401, { message: "unauthenticated" });
+  const project = await db.query.projects.findFirst({
+    where: eq(schema.projects.id, projectId),
+  });
+  if (!project) throw new HTTPException(404, { message: "project not found" });
+  const ctx = await resolveActiveOrgContext({ userId, preferredOrgId: c.var.orgId });
+  if (project.orgId !== ctx.org.id) throw new HTTPException(403, { message: "forbidden" });
+  return { userId: ctx.user.id, orgId: ctx.org.id, projectId };
+}
+
+// The single active install for a project. We enforce one active configuration
+// per project at provision time (see provisionInstallation), so this is
+// unambiguous; `orderBy` is belt-and-suspenders for any legacy multi-row state.
+async function findInstallation(projectId: string) {
+  return db.query.vercelInstallations.findFirst({
+    where: and(
+      eq(schema.vercelInstallations.projectId, projectId),
+      isNull(schema.vercelInstallations.revokedAt),
+    ),
+    orderBy: desc(schema.vercelInstallations.createdAt),
+  });
+}
+
+/**
+ * Get (or mint) the ingest key the drain authenticates with. Reuses the
+ * installation's stored key when it's still live so a reconnect doesn't orphan
+ * a working key; mints a fresh one otherwise.
+ */
+async function ensureIngestKey(
+  projectId: string,
+  existing: VercelInstallationRow | null,
+): Promise<{ ingestKey: string; apiKeyId: string; minted: boolean }> {
+  if (existing?.apiKeyId && existing.ingestKeyCiphertext && existing.ingestKeyNonce) {
+    const keyRow = await db.query.apiKeys.findFirst({
+      where: eq(schema.apiKeys.id, existing.apiKeyId),
+    });
+    if (keyRow && keyRow.revokedAt == null) {
+      const ingestKey = decryptIntegrationSecret({
+        ciphertext: existing.ingestKeyCiphertext,
+        nonce: existing.ingestKeyNonce,
+        keyVersion: existing.ingestKeyKeyVersion ?? 1,
+      });
+      return { ingestKey, apiKeyId: existing.apiKeyId, minted: false };
+    }
+  }
+  const minted = await mintApiKey({ projectId, name: "Vercel OTLP" });
+  return { ingestKey: minted.plaintext, apiKeyId: minted.id, minted: true };
+}
+
+/**
+ * Best-effort delete the drains we created under one installation (by id).
+ * Used both when re-provisioning the same configuration (so the new drains
+ * don't stack on top of the old ones) and when tearing down a superseded
+ * install. Empty ids are skipped.
+ */
+async function deleteRemoteDrains(input: {
+  teamId: string | null;
+  accessToken: string;
+  drains: Record<string, string> | null | undefined;
+  fetchImpl: typeof fetch;
+}): Promise<void> {
+  const ids = Object.values(input.drains ?? {}).filter((id) => id.length > 0);
+  for (const drainId of ids) {
+    const res = await deleteDrain({
+      teamId: input.teamId,
+      accessToken: input.accessToken,
+      drainId,
+      fetchImpl: input.fetchImpl,
+    });
+    if (!res.ok) {
+      log.warn({ drain_id: drainId, team_id: input.teamId }, "vercel drain delete failed");
+    }
+  }
+}
+
+/**
+ * Fully tear down one installation row: delete its remote drains, delete the
+ * integration configuration (Vercel's analog of a token revoke — the token
+ * stops working and the install disappears from the user's team), revoke the
+ * ingest key the drains authenticate with, and soft-revoke the row. Each remote
+ * step is best-effort (the install may already be gone); the ingest-key revoke
+ * is the backstop that actually stops telemetry being accepted at our intake.
+ * Shared by uninstall and configuration-switch supersede.
+ */
+async function teardownInstallation(
+  row: VercelInstallationRow,
+  deps: { fetchImpl: typeof fetch },
+): Promise<void> {
+  let accessToken: string | null = null;
+  try {
+    accessToken = decryptIntegrationSecret({
+      ciphertext: row.accessTokenCiphertext,
+      nonce: row.accessTokenNonce,
+      keyVersion: row.accessTokenKeyVersion,
+    });
+  } catch (e) {
+    log.warn({ err: e, configuration_id: row.configurationId }, "vercel token decrypt failed");
+  }
+
+  if (accessToken) {
+    await deleteRemoteDrains({
+      teamId: row.teamId,
+      accessToken,
+      drains: row.drains,
+      fetchImpl: deps.fetchImpl,
+    });
+    const res = await deleteConfiguration({
+      teamId: row.teamId,
+      accessToken,
+      configurationId: row.configurationId,
+      fetchImpl: deps.fetchImpl,
+    });
+    if (!res.ok) {
+      log.warn(
+        { configuration_id: row.configurationId },
+        "vercel configuration delete failed (may already be uninstalled)",
+      );
+    }
+  }
+
+  // Revoke the ingest key the drains authenticate with. Without this any drain
+  // we couldn't delete remotely keeps streaming into the project.
+  if (row.apiKeyId) {
+    await db
+      .update(schema.apiKeys)
+      .set({ revokedAt: new Date() })
+      .where(eq(schema.apiKeys.id, row.apiKeyId));
+  }
+
+  await db
+    .update(schema.vercelInstallations)
+    .set({ revokedAt: new Date(), updatedAt: new Date() })
+    .where(eq(schema.vercelInstallations.id, row.id));
+}
+
+export function mountVercelPublic(
+  app: Hono<{ Variables: Vars }>,
+  deps: { config?: VercelConnectConfig | null; fetchImpl?: typeof fetch } = {},
+): void {
+  const config = deps.config !== undefined ? deps.config : vercelConfigFromEnv();
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const stateSecret = process.env.STATE_SIGNING_SECRET;
+  const webOrigin = process.env.WEB_ORIGIN ?? "http://localhost:5173";
+
+  if (!config) {
+    log.warn(
+      "VERCEL_CLIENT_ID/SECRET/INTEGRATION_SLUG/OTLP_INTAKE_URL not set — Vercel connect disabled",
+    );
+  }
+
+  app.get("/vercel/oauth/callback", async (c) => {
+    if (!config || !stateSecret) {
+      return c.json({ error: "vercel not configured" }, 503);
+    }
+    const err = c.req.query("error");
+    if (err) {
+      log.warn({ error: err }, "vercel oauth callback denied");
+      return c.redirect(`${webOrigin}/?vercel=denied`, 302);
+    }
+    const code = c.req.query("code");
+    const state = c.req.query("state") ?? "";
+    if (!code) return c.redirect(`${webOrigin}/?vercel=error`, 302);
+
+    const decoded = verifyState(state, stateSecret);
+    if (!decoded) {
+      log.warn("vercel oauth callback rejected: invalid or expired state");
+      return c.redirect(`${webOrigin}/?vercel=error`, 302);
+    }
+
+    const token = await exchangeCodeForToken({ config, code, fetchImpl });
+    if (!token.ok) {
+      log.error({ error: token.error }, "vercel token exchange failed");
+      return c.redirect(`${webOrigin}/?vercel=error`, 302);
+    }
+
+    try {
+      await provisionInstallation({
+        projectId: decoded.projectId,
+        userId: decoded.userId,
+        token,
+        config,
+        fetchImpl,
+      });
+    } catch (e) {
+      // Provisioning throws when it can't produce a usable connection (e.g. the
+      // drain couldn't be created — we never persist a connection that can't
+      // receive telemetry, which would unlock onboarding as "connected" with
+      // nothing flowing). Surface as an error so the flow can reset rather than
+      // spin in the waiting state.
+      log.error({ err: e, project_id: decoded.projectId }, "vercel provisioning failed");
+      const outcome = e instanceof VercelProvisioningError ? e.outcome : "error";
+      return c.redirect(`${webOrigin}/?vercel=${outcome}`, 302);
+    }
+
+    log.info(
+      { project_id: decoded.projectId, team_id: token.teamId },
+      "vercel connected and drain provisioned",
+    );
+    return c.redirect(`${webOrigin}/?vercel=installed`, 302);
+  });
+}
+
+/**
+ * Exchange complete → create the OTLP drain and persist the install. Factored
+ * out of the route so the orchestration is one readable unit.
+ */
+async function provisionInstallation(input: {
+  projectId: string;
+  userId: string | null;
+  token: {
+    ok: true;
+    accessToken: string;
+    installationId: string;
+    userId: string | null;
+    teamId: string | null;
+  };
+  config: VercelConnectConfig;
+  fetchImpl: typeof fetch;
+}): Promise<void> {
+  const existing = (await findInstallation(input.projectId)) ?? null;
+  // Only reuse the stored ingest key when re-provisioning the *same*
+  // configuration (a replayed callback / re-consent on the same install); a new
+  // configuration must get a fresh key so the superseded install's key can be
+  // revoked independently (otherwise both installs share one live key).
+  const sameConfiguration =
+    existing?.configurationId === input.token.installationId ? existing : null;
+  const { ingestKey, apiKeyId, minted } = await ensureIngestKey(
+    input.projectId,
+    sameConfiguration,
+  );
+
+  // Undo everything this run created that isn't safely persisted to an install
+  // row: the new remote drains (minus any id the prior same-configuration row
+  // still owns), a freshly minted ingest key, and — when nothing got persisted —
+  // the just-installed configuration. Called on *every* pre-commit failure path
+  // so a connect never leaves an orphaned drain/key/install behind. Best-effort
+  // throughout.
+  const rollback = async (created: Record<string, string>): Promise<void> => {
+    const priorIds = new Set(Object.values(sameConfiguration?.drains ?? {}));
+    const orphaned = Object.fromEntries(
+      Object.entries(created).filter(([, id]) => !priorIds.has(id)),
+    );
+    await deleteRemoteDrains({
+      teamId: input.token.teamId,
+      accessToken: input.token.accessToken,
+      drains: orphaned,
+      fetchImpl: input.fetchImpl,
+    });
+    if (minted) {
+      await db
+        .update(schema.apiKeys)
+        .set({ revokedAt: new Date() })
+        .where(eq(schema.apiKeys.id, apiKeyId));
+    }
+    // Only delete the configuration when no install row depends on it — on a
+    // same-configuration re-provision the prior row's token is this token.
+    if (!sameConfiguration) {
+      await deleteConfiguration({
+        teamId: input.token.teamId,
+        accessToken: input.token.accessToken,
+        configurationId: input.token.installationId,
+        fetchImpl: input.fetchImpl,
+      });
+    }
+  };
+
+  // Create the new drains first; we only tear down any prior same-configuration
+  // drains *after* a replacement lands (see below). Deleting up front would
+  // leave the project "connected" with zero live drains if creation fails.
+  const drains: Record<string, string> = {};
+  const drainErrors: string[] = [];
+  for (const signal of VERCEL_SIGNALS) {
+    const result = await createDrain({
+      teamId: input.token.teamId,
+      accessToken: input.token.accessToken,
+      payload: buildDrainPayload({
+        signal,
+        intakeBaseUrl: input.config.intakeBaseUrl,
+        ingestKey,
+        projectId: input.projectId,
+      }),
+      fetchImpl: input.fetchImpl,
+    });
+    if (result.ok) {
+      drains[signal] = result.id;
+    } else {
+      drainErrors.push(result.error);
+      // Don't abort the whole connect on one signal — log and continue so the
+      // user still gets the signals Vercel accepted.
+      log.warn(
+        { signal, error: result.error, project_id: input.projectId },
+        "vercel drain creation failed for signal",
+      );
+    }
+  }
+
+  // Every signal failed: there's nothing to ingest, so don't persist a bogus
+  // "connected" install — roll back and surface the failure.
+  if (Object.keys(drains).length === 0) {
+    await rollback(drains);
+    throw new VercelProvisioningError(
+      "vercel connect: no drains were created",
+      classifyDrainProvisioningFailure(drainErrors),
+    );
+  }
+
+  // On a same-configuration reconnect, merge the prior ids under the new ones so
+  // a signal whose recreate *failed* keeps its existing drain.
+  const persistedDrains = sameConfiguration?.drains
+    ? { ...sameConfiguration.drains, ...drains }
+    : drains;
+
+  // Cosmetic; never blocks the connect.
+  const teamName = await fetchTeamName({
+    teamId: input.token.teamId,
+    accessToken: input.token.accessToken,
+    fetchImpl: input.fetchImpl,
+  });
+
+  // Encrypt + persist as one unit. Encryption is inside the boundary too: if it
+  // throws (e.g. a misconfigured secrets key) the drains/key/install created
+  // above are still rolled back.
+  try {
+    const accessCipher = encryptIntegrationSecret(input.token.accessToken);
+    const ingestCipher = encryptIntegrationSecret(ingestKey);
+    const now = new Date();
+
+    await db
+      .insert(schema.vercelInstallations)
+      .values({
+        projectId: input.projectId,
+        configurationId: input.token.installationId,
+        teamId: input.token.teamId,
+        teamName,
+        accessTokenCiphertext: accessCipher.ciphertext,
+        accessTokenNonce: accessCipher.nonce,
+        accessTokenKeyVersion: accessCipher.keyVersion,
+        apiKeyId,
+        ingestKeyCiphertext: ingestCipher.ciphertext,
+        ingestKeyNonce: ingestCipher.nonce,
+        ingestKeyKeyVersion: ingestCipher.keyVersion,
+        drains: persistedDrains,
+        installedByUserId: input.userId,
+      })
+      .onConflictDoUpdate({
+        target: [
+          schema.vercelInstallations.projectId,
+          schema.vercelInstallations.configurationId,
+        ],
+        set: {
+          teamId: input.token.teamId,
+          teamName,
+          accessTokenCiphertext: accessCipher.ciphertext,
+          accessTokenNonce: accessCipher.nonce,
+          accessTokenKeyVersion: accessCipher.keyVersion,
+          apiKeyId,
+          ingestKeyCiphertext: ingestCipher.ciphertext,
+          ingestKeyNonce: ingestCipher.nonce,
+          ingestKeyKeyVersion: ingestCipher.keyVersion,
+          drains: persistedDrains,
+          installedByUserId: input.userId,
+          revokedAt: null,
+          updatedAt: now,
+        },
+      });
+  } catch (e) {
+    await rollback(drains);
+    throw e;
+  }
+
+  // The install row is now committed and correct for this configuration. The
+  // remaining cleanup is best-effort housekeeping: a failure here must NOT turn
+  // an already-persisted connect into an error redirect, so we log and swallow.
+  try {
+    // Same-configuration reconnect: delete the prior drains we just replaced.
+    // `staleDrainIds` only targets prior ids for signals that actually got a
+    // replacement this run and never an id that's still live.
+    if (sameConfiguration?.drains) {
+      const stale = staleDrainIds(sameConfiguration.drains, drains);
+      await deleteRemoteDrains({
+        teamId: input.token.teamId,
+        accessToken: input.token.accessToken,
+        drains: stale,
+        fetchImpl: input.fetchImpl,
+      });
+    }
+
+    // Enforce a single active install per project: fully tear down any other
+    // active install rows for this project that point at a different
+    // configuration (delete their remote drains, delete their configuration,
+    // revoke their ingest key, soft-revoke the row). A bare DB revoke would
+    // leave the superseded install's drain streaming in with a still-valid key.
+    const superseded = await db.query.vercelInstallations.findMany({
+      where: and(
+        eq(schema.vercelInstallations.projectId, input.projectId),
+        ne(schema.vercelInstallations.configurationId, input.token.installationId),
+        isNull(schema.vercelInstallations.revokedAt),
+      ),
+    });
+    for (const row of superseded) {
+      await teardownInstallation(row, { fetchImpl: input.fetchImpl });
+    }
+  } catch (e) {
+    log.warn(
+      { err: e, project_id: input.projectId },
+      "vercel post-connect cleanup failed (connection persisted)",
+    );
+  }
+}
+
+export function mountVercelAuthed(
+  app: Hono<{ Variables: Vars }>,
+  deps: { config?: VercelConnectConfig | null; fetchImpl?: typeof fetch } = {},
+): void {
+  const config = deps.config !== undefined ? deps.config : vercelConfigFromEnv();
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const stateSecret = process.env.STATE_SIGNING_SECRET;
+
+  app.get("/api/projects/:projectId/vercel/installation", async (c) => {
+    const ctx = await requireProjectAccess(c, c.req.param("projectId"));
+    const row = await findInstallation(ctx.projectId);
+    if (!row) return c.json({ installed: false });
+    return c.json(toPublic(row));
+  });
+
+  app.post("/api/projects/:projectId/vercel/install-url", async (c) => {
+    if (!config || !stateSecret) {
+      return c.json({ error: "vercel not configured" }, 503);
+    }
+    const ctx = await requireProjectAccess(c, c.req.param("projectId"));
+
+    const state = signState(
+      { orgId: ctx.orgId, projectId: ctx.projectId, userId: ctx.userId },
+      stateSecret,
+    );
+    const url = buildInstallUrl({ integrationSlug: config.integrationSlug, state });
+    log.info({ org_id: ctx.orgId, project_id: ctx.projectId }, "vercel install url created");
+    return c.json({ url });
+  });
+
+  app.post("/api/projects/:projectId/vercel/uninstall", async (c) => {
+    const ctx = await requireProjectAccess(c, c.req.param("projectId"));
+    const row = await findInstallation(ctx.projectId);
+    if (!row) return c.json({ ok: true });
+
+    // Delete the remote drains, delete the integration configuration, revoke
+    // the ingest key, and soft-revoke the row so nothing keeps streaming after
+    // "Disconnect".
+    await teardownInstallation(row, { fetchImpl });
+    return c.json({ ok: true });
+  });
+}

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -29,6 +29,7 @@ import {
 } from "./clickhouse-writer.js";
 import { IngestQueue, getIngestQueueConfig } from "./ingest-queue.js";
 import {
+  type IngestSource,
   type TelemetrySignal,
   createIngestSourceFilter,
   ingestFilterKey,
@@ -37,6 +38,7 @@ import { logger } from "./logger.js";
 import { proxyOperationalRecorder } from "./operational-metrics.js";
 import { Semaphore } from "./semaphore.js";
 import { lookupOrgForProject, recordIngestRequest } from "./tenant-metrics.js";
+import { parseVercelLogDrainBody, vercelLogsToOtlp } from "./vercel-log-drain.js";
 
 const tracer = trace.getTracer("@superlog/proxy");
 
@@ -212,7 +214,7 @@ app.use("/v1/*", async (c, next) => {
   return next();
 });
 
-app.use("/v1/*", async (c, next) => {
+async function validateIngestKey(c: Context<{ Variables: Variables }>, next: () => Promise<void>) {
   return tracer.startActiveSpan("auth.validate", async (span) => {
     try {
       const key = extractApiKey(c);
@@ -225,7 +227,13 @@ app.use("/v1/*", async (c, next) => {
       if (isTestKey(key)) {
         span.setAttribute("auth.result", "test_key");
         const path = new URL(c.req.url).pathname;
-        if (path === "/v1/traces" || path === "/v1/logs" || path === "/v1/metrics") {
+        if (
+          path === "/v1/traces" ||
+          path === "/v1/logs" ||
+          path === "/v1/metrics" ||
+          path === "/vercel/drains/traces" ||
+          path === "/vercel/drains/logs"
+        ) {
           logger.info({ path }, "test key short-circuit");
           return new Response(new Uint8Array(0), {
             status: 200,
@@ -282,11 +290,29 @@ app.use("/v1/*", async (c, next) => {
       span.end();
     }
   });
-});
+}
+
+app.use("/v1/*", validateIngestKey);
+app.use("/vercel/drains/*", validateIngestKey);
 
 app.post("/v1/traces", (c) => forward(c, "/v1/traces", "resourceSpans"));
 app.post("/v1/logs", (c) => forward(c, "/v1/logs", "resourceLogs"));
 app.post("/v1/metrics", (c) => forward(c, "/v1/metrics", "resourceMetrics"));
+
+app.post("/vercel/drains/traces", (c) =>
+  forward(c, "/v1/traces", "resourceSpans", { source: "vercel" }),
+);
+app.post("/vercel/drains/logs", (c) =>
+  forward(c, "/v1/logs", "resourceLogs", {
+    source: "vercel",
+    bodyTransform: (body, contentType) => ({
+      body: Buffer.from(
+        JSON.stringify(vercelLogsToOtlp(parseVercelLogDrainBody(body, contentType))),
+      ),
+      contentType: "application/json",
+    }),
+  }),
+);
 
 // AWS Data Firehose HTTP-endpoint ingest (CloudWatch Metric Streams + Logs).
 // Firehose authenticates with X-Amz-Firehose-Access-Key (the project's ingest
@@ -383,15 +409,30 @@ function isTestKey(key: string | null): boolean {
   return key === "SUPERLOG_TEST" || (key?.startsWith("superlog_test_") ?? false);
 }
 
-async function forward(c: Context<{ Variables: Variables }>, path: string, rootKey: string) {
+type ForwardOptions = {
+  source?: IngestSource;
+  bodyTransform?: (
+    body: Buffer,
+    contentType: string,
+  ) => { body: Buffer; contentType: string; contentEncoding?: string };
+};
+
+async function forward(
+  c: Context<{ Variables: Variables }>,
+  path: string,
+  rootKey: string,
+  opts: ForwardOptions = {},
+) {
   return tracer.startActiveSpan("ingest.forward", async (span) => {
     const startedAt = performance.now();
     const projectId = c.var.projectId;
-    const contentType = c.req.header("content-type") ?? "application/x-protobuf";
-    const contentEncoding = c.req.header("content-encoding");
+    const source = opts.source ?? "otlp";
+    let contentType = c.req.header("content-type") ?? "application/x-protobuf";
+    let contentEncoding = c.req.header("content-encoding");
     let responseStatus = 500;
     let requestBytes = 0;
     let storage: "direct" | "inline" | "s3" = "direct";
+    let prebufferedBody: Buffer | null = null;
 
     // Route into the matching admission lane by declared body size, so a slow
     // oversize S3 upload can't head-of-line block a tiny request. Unknown size
@@ -424,12 +465,12 @@ async function forward(c: Context<{ Variables: Variables }>, path: string, rootK
       // intent). This precedes the quota gate so a disabled source is always a
       // clean 200, never a 402 the exporter would retry against.
       const otlpSignal = otlpSignalForPath(path);
-      if (otlpSignal && !ingestSourceFilter.allows(projectId, "otlp", otlpSignal)) {
+      if (otlpSignal && !ingestSourceFilter.allows(projectId, source, otlpSignal)) {
         responseStatus = 200;
         span.setAttribute("ingest.dropped", "source_filtered");
         logger.info(
-          { path, projectId, signal: otlpSignal },
-          "dropping OTLP ingest; source disabled",
+          { path, projectId, source, signal: otlpSignal },
+          "dropping ingest; source disabled",
         );
         return new Response(new Uint8Array(0), {
           status: 200,
@@ -455,12 +496,6 @@ async function forward(c: Context<{ Variables: Variables }>, path: string, rootK
         );
       }
 
-      const upstreamHeaders: Record<string, string> = {
-        "content-type": contentType,
-        "x-superlog-project-id": projectId,
-      };
-      if (contentEncoding) upstreamHeaders["content-encoding"] = contentEncoding;
-
       // Counter is best-effort — never block the ingest hot path on a metric or DB lookup.
       void recordIngestRequest(path, projectId).catch((err: unknown) => {
         logger.warn({ err, path, projectId }, "tenant counter increment failed");
@@ -473,6 +508,33 @@ async function forward(c: Context<{ Variables: Variables }>, path: string, rootK
         logger.warn({ path, projectId }, "dropping OTLP request with no body");
         return c.json({ error: EMPTY_BODY_ERROR_MESSAGE }, 400);
       }
+
+      if (opts.bodyTransform) {
+        try {
+          const original = await collectStreamWithCap(bodyStream, MAX_BODY_BYTES);
+          const transformed = opts.bodyTransform(original, contentType);
+          prebufferedBody = transformed.body;
+          contentType = transformed.contentType;
+          contentEncoding = transformed.contentEncoding;
+          requestBytes = prebufferedBody.byteLength;
+        } catch (err) {
+          const handled = handleIngestBodyError(err, c, span, path, projectId);
+          if (handled) {
+            responseStatus = handled.status;
+            return handled.response;
+          }
+          responseStatus = 400;
+          span.setAttribute("ingest.invalid_body", true);
+          logger.warn({ err, path, projectId, source }, "dropping invalid ingest request body");
+          return c.json({ error: "invalid ingest request body" }, 400);
+        }
+      }
+
+      const upstreamHeaders: Record<string, string> = {
+        "content-type": contentType,
+        "x-superlog-project-id": projectId,
+      };
+      if (contentEncoding) upstreamHeaders["content-encoding"] = contentEncoding;
 
       // Issue-fingerprint stamping deserializes the whole payload, so in queue mode it runs
       // on the consumer (ingest-queue.ts) right before the collector POST — not here on the
@@ -489,7 +551,7 @@ async function forward(c: Context<{ Variables: Variables }>, path: string, rootK
                 projectId,
                 contentType,
                 contentEncoding,
-                body: bodyStream,
+                body: prebufferedBody ? Readable.from([prebufferedBody]) : bodyStream,
               });
               queueSpan.setAttribute("ingest.queue.storage", r.storage);
               return r;
@@ -528,7 +590,7 @@ async function forward(c: Context<{ Variables: Variables }>, path: string, rootK
       // `permits × MAX_BODY_BYTES`; operators on small boxes should size those envs down.
       let bodyBuffer: Buffer;
       try {
-        bodyBuffer = await collectStreamWithCap(bodyStream, MAX_BODY_BYTES);
+        bodyBuffer = prebufferedBody ?? (await collectStreamWithCap(bodyStream, MAX_BODY_BYTES));
       } catch (err) {
         const handled = handleIngestBodyError(err, c, span, path, projectId);
         if (handled) {

--- a/apps/proxy/src/ingest-source-filter.ts
+++ b/apps/proxy/src/ingest-source-filter.ts
@@ -9,7 +9,7 @@
 // a few seconds to apply is fine; a DB hiccup silently dropping telemetry is not.
 import { logger } from "./logger.js";
 
-export type IngestSource = "otlp" | "aws";
+export type IngestSource = "otlp" | "aws" | "vercel";
 export type TelemetrySignal = "traces" | "logs" | "metrics";
 
 export const ingestFilterKey = (source: IngestSource, signal: TelemetrySignal): string =>

--- a/apps/proxy/src/vercel-log-drain.test.ts
+++ b/apps/proxy/src/vercel-log-drain.test.ts
@@ -1,0 +1,82 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import {
+  parseVercelLogDrainBody,
+  vercelLogsToOtlp,
+} from "./vercel-log-drain.js";
+import { otlpLogsToRows } from "./otlp-clickhouse.js";
+
+const vercelLogs = [
+  {
+    id: "1573817250283254651097202070",
+    deploymentId: "dpl_233NRGRjVZX1caZrXWtz5g1TAksD",
+    source: "lambda",
+    host: "my-app-abc123.vercel.app",
+    timestamp: 1573817250283,
+    projectId: "gdufoJxB6b9b1fEqr1jUtFkyavUU",
+    level: "error",
+    message: "API request failed",
+    entrypoint: "api/index.js",
+    requestId: "643af4e3-975a-4cc7-9e7a-1eda11539d90",
+    statusCode: 500,
+    path: "/api/users",
+    executionRegion: "sfo1",
+    environment: "production",
+    projectName: "my-app",
+    traceId: "1b02cd14bb8642fd092bc23f54c7ffcd",
+    spanId: "f24e8631bd11faa7",
+    proxy: {
+      method: "GET",
+      path: "/api/users?page=1",
+      statusCode: 500,
+      userAgent: ["Mozilla/5.0"],
+    },
+  },
+];
+
+test("parseVercelLogDrainBody accepts JSON arrays", () => {
+  assert.deepEqual(
+    parseVercelLogDrainBody(Buffer.from(JSON.stringify(vercelLogs)), "application/json"),
+    vercelLogs,
+  );
+});
+
+test("parseVercelLogDrainBody accepts NDJSON batches", () => {
+  const body = Buffer.from(vercelLogs.map((log) => JSON.stringify(log)).join("\n"));
+  assert.deepEqual(parseVercelLogDrainBody(body, "application/x-ndjson"), vercelLogs);
+});
+
+test("vercelLogsToOtlp maps Vercel logs to OTLP JSON logs", () => {
+  const payload = vercelLogsToOtlp(vercelLogs);
+  assert.equal(payload.resourceLogs?.length, 1);
+  const record = payload.resourceLogs?.[0]?.scopeLogs?.[0]?.logRecords?.[0];
+  assert.ok(record);
+  assert.equal(record.body?.stringValue, "API request failed");
+  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityNumber, 17);
+  assert.equal(record.timeUnixNano, "1573817250283000000");
+  assert.equal(record.traceId, "1b02cd14bb8642fd092bc23f54c7ffcd");
+  assert.equal(record.spanId, "f24e8631bd11faa7");
+
+  const attrs = Object.fromEntries(
+    (record.attributes ?? []).map((kv) => [kv.key, kv.value?.stringValue ?? kv.value?.intValue]),
+  );
+  assert.equal(attrs["vercel.source"], "lambda");
+  assert.equal(attrs["vercel.request_id"], "643af4e3-975a-4cc7-9e7a-1eda11539d90");
+  assert.equal(attrs["http.response.status_code"], "500");
+  assert.equal(attrs["vercel.proxy.path"], "/api/users?page=1");
+  assert.equal(attrs["vercel.proxy.user_agent"], '["Mozilla/5.0"]');
+});
+
+test("mapped Vercel logs become ClickHouse log rows with service and tenant attributes", () => {
+  const rows = otlpLogsToRows(vercelLogsToOtlp(vercelLogs), "superlog-project");
+  assert.equal(rows.length, 1);
+  const row = rows[0]!;
+  assert.equal(row.ServiceName, "my-app");
+  assert.equal(row.Body, "API request failed");
+  assert.equal(row.ResourceAttributes["superlog.project_id"], "superlog-project");
+  assert.equal(row.ResourceAttributes["service.name"], "my-app");
+  assert.equal(row.ResourceAttributes["vercel.project_id"], "gdufoJxB6b9b1fEqr1jUtFkyavUU");
+  assert.equal(row.LogAttributes["vercel.deployment_id"], "dpl_233NRGRjVZX1caZrXWtz5g1TAksD");
+});

--- a/apps/proxy/src/vercel-log-drain.ts
+++ b/apps/proxy/src/vercel-log-drain.ts
@@ -1,0 +1,203 @@
+type OtlpAnyValue = {
+  stringValue?: string;
+  intValue?: string;
+  doubleValue?: number;
+  boolValue?: boolean;
+  arrayValue?: { values: OtlpAnyValue[] };
+};
+
+type OtlpKeyValue = { key: string; value: OtlpAnyValue };
+
+type VercelLogRecord = Record<string, unknown> & {
+  timestamp?: unknown;
+  level?: unknown;
+  message?: unknown;
+  traceId?: unknown;
+  spanId?: unknown;
+  "trace.id"?: unknown;
+  "span.id"?: unknown;
+  projectName?: unknown;
+  host?: unknown;
+  projectId?: unknown;
+  deploymentId?: unknown;
+  source?: unknown;
+  proxy?: unknown;
+};
+
+export type VercelOtlpLogsExport = {
+  resourceLogs: Array<{
+    resource: { attributes: OtlpKeyValue[] };
+    scopeLogs: Array<{
+      scope: { name: string };
+      logRecords: Array<{
+        timeUnixNano: string;
+        observedTimeUnixNano: string;
+        severityText: string;
+        severityNumber: number;
+        traceId?: string;
+        spanId?: string;
+        body: OtlpAnyValue;
+        attributes: OtlpKeyValue[];
+      }>;
+    }>;
+  }>;
+};
+
+const LEVEL_TO_SEVERITY: Record<string, { text: string; number: number }> = {
+  info: { text: "INFO", number: 9 },
+  warning: { text: "WARN", number: 13 },
+  warn: { text: "WARN", number: 13 },
+  error: { text: "ERROR", number: 17 },
+  fatal: { text: "FATAL", number: 21 },
+};
+
+export function parseVercelLogDrainBody(body: Buffer, contentType: string): VercelLogRecord[] {
+  const text = body.toString("utf8").trim();
+  if (!text) return [];
+  const lower = contentType.toLowerCase();
+  if (lower.includes("ndjson") || lower.includes("x-ndjson")) {
+    return text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => coerceRecord(JSON.parse(line)));
+  }
+  const parsed = JSON.parse(text);
+  if (Array.isArray(parsed)) return parsed.map(coerceRecord);
+  return [coerceRecord(parsed)];
+}
+
+export function vercelLogsToOtlp(logs: VercelLogRecord[]): VercelOtlpLogsExport {
+  return {
+    resourceLogs: logs.map((log) => ({
+      resource: { attributes: resourceAttributes(log) },
+      scopeLogs: [
+        {
+          scope: { name: "vercel.drains.logs" },
+          logRecords: [
+            {
+              timeUnixNano: timestampMillisToNanos(log.timestamp),
+              observedTimeUnixNano: timestampMillisToNanos(log.timestamp),
+              ...severity(log.level),
+              traceId: hexId(log.traceId ?? log["trace.id"], 32),
+              spanId: hexId(log.spanId ?? log["span.id"], 16),
+              body: { stringValue: messageBody(log) },
+              attributes: logAttributes(log),
+            },
+          ],
+        },
+      ],
+    })),
+  };
+}
+
+function coerceRecord(value: unknown): VercelLogRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("invalid Vercel log record");
+  }
+  return value as VercelLogRecord;
+}
+
+function resourceAttributes(log: VercelLogRecord): OtlpKeyValue[] {
+  const serviceName = stringValue(log.projectName) || stringValue(log.host) || "vercel";
+  return [
+    kv("service.name", serviceName),
+    kv("telemetry.source", "vercel"),
+    kv("vercel.project_id", log.projectId),
+    kv("vercel.project_name", log.projectName),
+    kv("vercel.host", log.host),
+  ].filter(isKv);
+}
+
+function logAttributes(log: VercelLogRecord): OtlpKeyValue[] {
+  const attrs: Array<OtlpKeyValue | null> = [
+    kv("vercel.id", log.id),
+    kv("vercel.deployment_id", log.deploymentId),
+    kv("vercel.source", log.source),
+    kv("vercel.build_id", log.buildId),
+    kv("vercel.type", log.type),
+    kv("vercel.entrypoint", log.entrypoint),
+    kv("vercel.request_id", log.requestId),
+    kv("vercel.environment", log.environment),
+    kv("vercel.branch", log.branch),
+    kv("vercel.execution_region", log.executionRegion),
+    kv("http.route", log.path),
+    kv("http.response.status_code", log.statusCode),
+  ];
+
+  if (log.proxy && typeof log.proxy === "object" && !Array.isArray(log.proxy)) {
+    const proxy = log.proxy as Record<string, unknown>;
+    attrs.push(
+      kv("vercel.proxy.method", proxy.method),
+      kv("vercel.proxy.host", proxy.host),
+      kv("vercel.proxy.path", proxy.path),
+      kv("vercel.proxy.region", proxy.region),
+      kv("vercel.proxy.status_code", proxy.statusCode),
+      kv("vercel.proxy.client_ip", proxy.clientIp),
+      kv("vercel.proxy.scheme", proxy.scheme),
+      kv("vercel.proxy.cache", proxy.vercelCache),
+      kv("vercel.proxy.path_type", proxy.pathType),
+      kv("vercel.proxy.user_agent", proxy.userAgent),
+    );
+  }
+
+  return attrs.filter(isKv);
+}
+
+function severity(value: unknown): { severityText: string; severityNumber: number } {
+  const mapped = typeof value === "string" ? LEVEL_TO_SEVERITY[value.toLowerCase()] : undefined;
+  return { severityText: mapped?.text ?? "", severityNumber: mapped?.number ?? 0 };
+}
+
+function timestampMillisToNanos(value: unknown): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return `${BigInt(Math.trunc(value)) * 1_000_000n}`;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    return `${BigInt(value) * 1_000_000n}`;
+  }
+  return "0";
+}
+
+function messageBody(log: VercelLogRecord): string {
+  if (typeof log.message === "string") return log.message;
+  if (log.message !== undefined && log.message !== null) return stringify(log.message);
+  return stringify(log);
+}
+
+function hexId(value: unknown, length: 16 | 32): string | undefined {
+  return typeof value === "string" && new RegExp(`^[0-9a-fA-F]{${length}}$`).test(value)
+    ? value.toLowerCase()
+    : undefined;
+}
+
+function kv(key: string, value: unknown): OtlpKeyValue | null {
+  const otlpValue = anyValue(value);
+  return otlpValue ? { key, value: otlpValue } : null;
+}
+
+function isKv(value: OtlpKeyValue | null): value is OtlpKeyValue {
+  return value !== null;
+}
+
+function anyValue(value: unknown): OtlpAnyValue | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "string") return { stringValue: value };
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? { intValue: String(value) } : { doubleValue: value };
+  }
+  if (typeof value === "boolean") return { boolValue: value };
+  return { stringValue: stringify(value) };
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function stringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -78,13 +78,16 @@ import {
   useStartLinearInstall,
   useStartCloudflareInstall,
   useStartSlackInstall,
+  useStartVercelInstall,
   useTestWebhook,
   useUninstallLinear,
   useUninstallCloudflare,
   useUninstallSlack,
+  useUninstallVercel,
   useUpdateGithubRepoAccess,
   useUpdateOrgProject,
   useUpdateWebhook,
+  useVercelInstallation,
   useVerifyCloudConnection,
   useWebhookDeliveries,
   useWebhooks,
@@ -607,6 +610,7 @@ function ProjectSectionView({
             <SlackCard />
             <LinearCard />
             <CloudflareCard projectId={projectId} />
+            <VercelCard projectId={projectId} />
             <AwsCard projectId={projectId} />
             <IngestSourcesCard projectId={projectId} />
           </div>
@@ -1231,6 +1235,61 @@ function CloudflareCard({ projectId }: { projectId: string | undefined }) {
   );
 }
 
+function VercelCard({ projectId }: { projectId: string | undefined }) {
+  const install = useVercelInstallation(projectId);
+  const start = useStartVercelInstall(projectId);
+  const uninstall = useUninstallVercel(projectId);
+
+  const installed = install.data?.installed === true;
+
+  return (
+    <Tile label="Vercel">
+      <div className="space-y-3">
+        <p className="text-[13px] text-muted">
+          Install the Superlog integration on your Vercel team and we'll set up trace and log drains
+          that stream your deployments' telemetry into this project automatically.
+        </p>
+        <div>
+          {installed && install.data?.installed ? (
+            <Chip tone="success" dot>
+              {install.data.teamName ?? "Vercel team"}
+            </Chip>
+          ) : (
+            <Chip tone="muted" dot>
+              Not connected
+            </Chip>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <Btn
+            size="sm"
+            variant={installed ? "secondary" : "primary"}
+            loading={start.isPending}
+            disabled={!projectId || start.isPending}
+            onClick={async () => {
+              const { url } = await start.mutateAsync();
+              window.location.href = url;
+            }}
+          >
+            {installed ? "Reconnect" : "Connect Vercel"}
+          </Btn>
+          {installed && (
+            <Btn
+              size="sm"
+              variant="danger"
+              loading={uninstall.isPending}
+              disabled={!projectId || uninstall.isPending}
+              onClick={() => uninstall.mutate()}
+            >
+              Disconnect
+            </Btn>
+          )}
+        </div>
+      </div>
+    </Tile>
+  );
+}
+
 function SlackRoutingCard({ projectId }: { projectId: string | undefined }) {
   const install = useSlackInstallation();
   const installed = install.data?.installed === true;
@@ -1557,10 +1616,9 @@ const AWS_REGION_OPTIONS = AWS_REGIONS.map((r) => ({
   searchText: `${r.code} ${r.name}`,
 }));
 
-// Per-project ingest source toggles. Lets you turn a telemetry source (SDK/OTLP
-// or AWS CloudWatch) on/off per signal; the proxy ack-drops disabled telemetry
-// at the edge so it's never stored or billed. Useful to e.g. keep AWS metrics
-// but stop a noisy AWS log stream without tearing down the CloudFormation stack.
+// Per-project ingest source toggles. Lets you turn a telemetry source (SDK/OTLP,
+// AWS CloudWatch, or Vercel Drains) on/off per signal; the proxy ack-drops
+// disabled telemetry at the edge so it's never stored or billed.
 function IngestSourceRow({
   title,
   hint,
@@ -1601,7 +1659,7 @@ function IngestSourcesCard({ projectId }: { projectId: string | undefined }) {
   const setFilters = useSetIngestFilters(projectId ?? "");
   const state = filters.data;
 
-  const setSignal = (source: "otlp" | "aws", signal: string, next: boolean) => {
+  const setSignal = (source: "otlp" | "aws" | "vercel", signal: string, next: boolean) => {
     if (!state) return;
     const updated: IngestFilterState = {
       ...state,
@@ -1643,6 +1701,17 @@ function IngestSourcesCard({ projectId }: { projectId: string | undefined }) {
               state={state.aws}
               disabled={setFilters.isPending}
               onToggle={(signal, next) => setSignal("aws", signal, next)}
+            />
+            <IngestSourceRow
+              title="Vercel Drains"
+              hint="Trace and log drains created by the connected Vercel integration."
+              signals={[
+                { key: "traces", label: "Traces" },
+                { key: "logs", label: "Logs" },
+              ]}
+              state={state.vercel}
+              disabled={setFilters.isPending}
+              onToggle={(signal, next) => setSignal("vercel", signal, next)}
             />
           </div>
         )}

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -78,6 +78,7 @@ export type SystemCapabilities = {
   ossAgents: boolean;
   cloudUpgradeLinks: boolean;
   cloudflareConnect: boolean;
+  vercelConnect: boolean;
 };
 
 const SIGNUP_SOURCE_STORAGE_KEY = "superlog.signup_source";
@@ -876,6 +877,54 @@ export function useUninstallCloudflare(projectId: string | undefined) {
   });
 }
 
+export type VercelInstallation =
+  | { installed: false }
+  | {
+      installed: true;
+      teamId: string;
+      teamName: string | null;
+      configurationId: string;
+      drains: Record<string, string>;
+      installedAt: string;
+    };
+
+// Vercel installs are per-project, so every hook is scoped by projectId — the
+// query key includes it so switching projects refetches the right state instead
+// of briefly showing another project's connected team.
+export function useVercelInstallation(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  return useQuery({
+    queryKey: ["vercel-installation", projectId],
+    queryFn: () => fetcher<VercelInstallation>(`/api/projects/${projectId}/vercel/installation`),
+    enabled: !!projectId,
+    // Poll so the card flips to "connected" after the OAuth redirect without a
+    // manual refresh (same pattern as Slack/GitHub/Cloudflare).
+    refetchInterval: 15000,
+  });
+}
+
+export function useStartVercelInstall(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  return useMutation({
+    mutationFn: () =>
+      fetcher<{ url: string }>(`/api/projects/${projectId}/vercel/install-url`, {
+        method: "POST",
+      }),
+  });
+}
+
+export function useUninstallVercel(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      fetcher<{ ok: true }>(`/api/projects/${projectId}/vercel/uninstall`, { method: "POST" }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["vercel-installation", projectId] });
+    },
+  });
+}
+
 export function useSlackChannels(enabled: boolean) {
   const fetcher = useFetcher();
   return useQuery({
@@ -1074,11 +1123,12 @@ export function useDeleteCloudConnection(projectId: string) {
   });
 }
 
-// Per-project ingest source filters: turn a telemetry source (SDK/OTLP or AWS
-// CloudWatch) on/off per signal. The proxy ack-drops disabled telemetry.
+// Per-project ingest source filters: turn a telemetry source (SDK/OTLP, AWS
+// CloudWatch, or Vercel Drains) on/off per signal. The proxy ack-drops disabled telemetry.
 export type IngestFilterState = {
   otlp: { traces: boolean; logs: boolean; metrics: boolean };
   aws: { logs: boolean; metrics: boolean };
+  vercel: { traces: boolean; logs: boolean };
 };
 
 export function useIngestFilters(projectId: string | undefined) {

--- a/apps/web/src/onboarding/ConnectDataChooser.tsx
+++ b/apps/web/src/onboarding/ConnectDataChooser.tsx
@@ -6,11 +6,11 @@ import {
   type ConnectSection,
   connectSectionsFor,
 } from "./connectChoices.ts";
-import { AwsIcon, ChevronRightIcon, CloudflareIcon, TerminalIcon } from "./icons.tsx";
+import { AwsIcon, ChevronRightIcon, CloudflareIcon, TerminalIcon, VercelIcon } from "./icons.tsx";
 import { ExploreDemoLink, SOFT_LINE } from "./wizardChrome.tsx";
 
-// The path chooser: a flat, low-color list (modeled on a Plugins page). Three
-// peer lanes — the no-code integrations (AWS, Cloudflare, integration-first)
+// The path chooser: a flat, low-color list (modeled on a Plugins page). Peer
+// lanes — the no-code integrations (AWS, Cloudflare, Vercel, integration-first)
 // and the "I'm hosted elsewhere" fallback, which routes to the coding-agent
 // prompt. See design.md.
 
@@ -18,6 +18,7 @@ function ConnectGlyph({ icon }: { icon: ConnectIcon }) {
   const map: Record<ConnectIcon, typeof AwsIcon> = {
     aws: AwsIcon,
     cloudflare: CloudflareIcon,
+    vercel: VercelIcon,
     terminal: TerminalIcon,
   };
   const Glyph = map[icon];
@@ -98,10 +99,11 @@ export function ConnectDataChooser({
   onExploreDemo?: () => void;
 }) {
   // Gate connectors that need server-side config. Until capabilities load we
-  // treat Cloudflare as unavailable so we never offer a click that would 503.
+  // treat them as unavailable so we never offer a click that would 503.
   const capabilities = useSystemCapabilities();
   const sections = connectSectionsFor({
     cloudflare: capabilities.data?.cloudflareConnect ?? false,
+    vercel: capabilities.data?.vercelConnect ?? false,
   });
   return (
     <>

--- a/apps/web/src/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/onboarding/OnboardingWizard.tsx
@@ -16,6 +16,7 @@ import { getSkillOnboardingIntent } from "../skillOnboarding.ts";
 import { AwsConnectFlow } from "./AwsConnectFlow.tsx";
 import { CloudflareConnectFlow } from "./CloudflareConnectFlow.tsx";
 import { ConnectDataChooser } from "./ConnectDataChooser.tsx";
+import { VercelConnectFlow } from "./VercelConnectFlow.tsx";
 import type { ConnectAction } from "./connectChoices.ts";
 import { CheckIcon, GithubIcon, SlackIcon, SpinnerIcon } from "./icons.tsx";
 import {
@@ -42,16 +43,20 @@ import {
 
 type Mode = "web" | "agent";
 // Web-mode landing fork: choose a source, then either a no-code integration
-// flow (AWS / Cloudflare) or the coding-agent install → deploy flow.
-type WebView = "chooser" | "aws" | "cloudflare" | "code" | "deploy";
+// flow (AWS / Cloudflare / Vercel) or the coding-agent install → deploy flow.
+type WebView = "chooser" | "aws" | "cloudflare" | "vercel" | "code" | "deploy";
 
-// The Cloudflare OAuth callback redirects back to the app with `?cloudflare=...`.
-// When that lands we want to drop straight into the Cloudflare flow (which reads
-// the outcome + install status), not the chooser — otherwise the user is bounced
-// back to "Connect your data" and has to click Cloudflare again to see progress.
+// The Cloudflare / Vercel OAuth callbacks redirect back to the app with
+// `?cloudflare=...` / `?vercel=...`. When that lands we want to drop straight
+// into the matching flow (which reads the outcome + install status), not the
+// chooser — otherwise the user is bounced back to "Connect your data" and has
+// to click the integration again to see progress.
 function initialWebView(): WebView {
   if (typeof window === "undefined") return "chooser";
-  return new URLSearchParams(window.location.search).has("cloudflare") ? "cloudflare" : "chooser";
+  const params = new URLSearchParams(window.location.search);
+  if (params.has("cloudflare")) return "cloudflare";
+  if (params.has("vercel")) return "vercel";
+  return "chooser";
 }
 
 export function OnboardingWizard({
@@ -85,14 +90,16 @@ export function OnboardingWizard({
   const github = useGithubInstallation();
   const slack = useSlackInstallation();
 
-  // Route a chooser selection to the matching view. AWS / Cloudflare get their
-  // no-code integration flows; "I'm hosted elsewhere" (action "code") opens the
-  // coding-agent install prompt.
+  // Route a chooser selection to the matching view. AWS / Cloudflare / Vercel
+  // get their no-code integration flows; "I'm hosted elsewhere" (action "code")
+  // opens the coding-agent install prompt.
   const handlePick = (action: ConnectAction) => {
     if (action === "aws") {
       setWebView("aws");
     } else if (action === "cloudflare") {
       setWebView("cloudflare");
+    } else if (action === "vercel") {
+      setWebView("vercel");
     } else {
       setWebView("code");
     }
@@ -159,6 +166,14 @@ export function OnboardingWizard({
             />
           ) : webView === "cloudflare" ? (
             <CloudflareConnectFlow
+              projectId={projectId}
+              eventsArrived={eventsArrived}
+              onBack={() => setWebView("chooser")}
+              onDone={onComplete}
+              onExploreDemo={onExploreDemo}
+            />
+          ) : webView === "vercel" ? (
+            <VercelConnectFlow
               projectId={projectId}
               eventsArrived={eventsArrived}
               onBack={() => setWebView("chooser")}

--- a/apps/web/src/onboarding/VercelConnectFlow.tsx
+++ b/apps/web/src/onboarding/VercelConnectFlow.tsx
@@ -1,0 +1,297 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useStartVercelInstall, useVercelInstallation } from "../api.ts";
+import { Btn } from "../design/ui.tsx";
+import { CheckIcon, ExternalLinkIcon, SpinnerIcon } from "./icons.tsx";
+import {
+  type VercelPhase,
+  canContinueVercel,
+  parseVercelOutcome,
+  vercelOutcomeMessage,
+  vercelPhase,
+  vercelStatusText,
+} from "./vercelConnectModel.ts";
+import {
+  ExploreDemoLink,
+  SOFT_LINE,
+  STRONG_LINE,
+  StepFooter,
+  StepHeader,
+} from "./wizardChrome.tsx";
+
+// Open the Vercel install screen in a new tab, falling back to a same-tab
+// navigation if the popup was blocked. Same opener-severing trick as the AWS /
+// Cloudflare launch helpers so we keep the security guarantee without
+// window.open returning null (which would make every launch also navigate the
+// current tab).
+function openInstall(url: string) {
+  const win = window.open(url, "_blank");
+  if (win) {
+    win.opener = null;
+  } else {
+    window.location.assign(url);
+  }
+}
+
+export function VercelConnectFlow({
+  projectId,
+  eventsArrived,
+  onBack,
+  onDone,
+  onExploreDemo,
+}: {
+  projectId: string;
+  // Whether the real project has ingested telemetry yet (from the parent's
+  // `me.project.hasIngested`). NOT derived from the stats endpoint, which is
+  // demo-overlaid for un-ingested projects and would falsely report events.
+  eventsArrived: boolean;
+  onBack: () => void;
+  onDone: () => void;
+  onExploreDemo?: () => void;
+}) {
+  // Whether we've opened the install screen this session. Drives the transition
+  // from the "start" call-to-action to the "connecting" waiting state while the
+  // installation poll (every 15s) catches the round-trip landing.
+  const [launched, setLaunched] = useState(false);
+  // A failure surfaced by the OAuth callback redirect (`?vercel=denied|error`).
+  const [outcomeError, setOutcomeError] = useState<string | null>(null);
+
+  const install = useVercelInstallation(projectId);
+  const start = useStartVercelInstall(projectId);
+
+  // The callback redirects back to the app with `?vercel=...`. When the install
+  // was opened in the same tab (popup blocked), a denial/error lands here —
+  // surface it and drop back out of the waiting state instead of spinning
+  // forever. Strip the param so a refresh doesn't re-trigger it.
+  const [searchParams, setSearchParams] = useSearchParams();
+  useEffect(() => {
+    const outcome = parseVercelOutcome(searchParams.get("vercel"));
+    if (!outcome) return;
+    if (outcome === "denied" || outcome === "error" || outcome === "drains_unavailable") {
+      setLaunched(false);
+      setOutcomeError(vercelOutcomeMessage(outcome));
+    }
+    const next = new URLSearchParams(searchParams);
+    next.delete("vercel");
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  const installed = install.data?.installed === true;
+  const phase = vercelPhase({ installed, launched });
+
+  const connect = () => {
+    if (start.isPending) return;
+    setOutcomeError(null);
+    start.mutate(undefined, {
+      onSuccess: ({ url }) => {
+        setLaunched(true);
+        openInstall(url);
+      },
+    });
+  };
+
+  const header = headerForPhase(phase);
+
+  return (
+    <>
+      <StepHeader title={header.title} sub={header.sub} />
+
+      {phase === "start" && (
+        <StartPanel
+          onConnect={connect}
+          pending={start.isPending}
+          error={outcomeError ?? (start.error ? String(start.error) : null)}
+        />
+      )}
+
+      {phase === "connecting" && (
+        <ConnectingPanel
+          statusText={vercelStatusText(phase, eventsArrived)}
+          onReopen={connect}
+          reopening={start.isPending}
+        />
+      )}
+
+      {phase === "connected" && install.data?.installed && (
+        <ConnectedPanel
+          teamName={install.data.teamName}
+          teamId={install.data.teamId}
+          drains={install.data.drains}
+          eventsArrived={eventsArrived}
+        />
+      )}
+
+      <StepFooter
+        onBack={onBack}
+        onNext={onDone}
+        nextLabel={canContinueVercel(phase) ? "Continue" : "Waiting for Vercel…"}
+        nextDisabled={!canContinueVercel(phase)}
+      />
+      {!canContinueVercel(phase) && <ExploreDemoLink onExploreDemo={onExploreDemo} />}
+    </>
+  );
+}
+
+function headerForPhase(phase: VercelPhase): { title: string; sub: string } {
+  switch (phase) {
+    case "start":
+      return {
+        title: "Connect Vercel",
+        sub: "Authorize Vercel once. We set up trace and log drains that stream your deployments' telemetry into Superlog — no agent, no code changes.",
+      };
+    case "connecting":
+      return {
+        title: "Finish in Vercel",
+        sub: "Approve the install in the Vercel tab we opened. Once you do, we create the drains automatically — keep this tab open.",
+      };
+    default:
+      return {
+        title: "You're connected",
+        sub: "The Vercel drains are set up. Telemetry will appear as your deployments serve traffic — discovery keeps working in the background.",
+      };
+  }
+}
+
+function StartPanel({
+  onConnect,
+  pending,
+  error,
+}: {
+  onConnect: () => void;
+  pending: boolean;
+  error: string | null;
+}) {
+  return (
+    <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+      <div className={`border-b px-[22px] py-[18px] ${SOFT_LINE}`}>
+        <p className="m-0 text-[13px] leading-[1.55] text-muted">
+          We never ask for an API token. Vercel's OAuth grants a scoped, revocable token that we use
+          only to create and manage the drains — you can disconnect any time from settings.
+          Drains require a Vercel Pro or Enterprise plan.
+        </p>
+      </div>
+      <div className="flex items-center justify-between gap-3 px-[22px] py-[16px]">
+        <span className="text-[12.5px] text-muted">
+          Opens the Vercel install screen in a new tab.
+        </span>
+        <Btn
+          variant="primary"
+          size="md"
+          onClick={onConnect}
+          loading={pending}
+          className="!h-[36px] !rounded-[8px] !px-[14px] !text-[13px]"
+        >
+          {pending ? "Preparing…" : "Connect Vercel account"}
+          {!pending && <ExternalLinkIcon size={13} />}
+        </Btn>
+      </div>
+      {error && (
+        <div className={`border-t px-[22px] py-[12px] ${SOFT_LINE}`}>
+          <p className="m-0 text-[12.5px] text-danger">{error}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConnectingPanel({
+  statusText,
+  onReopen,
+  reopening,
+}: {
+  statusText: string;
+  onReopen: () => void;
+  reopening: boolean;
+}) {
+  return (
+    <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+      <div
+        className={`flex items-center gap-2.5 border-b px-[18px] py-[12px] ${SOFT_LINE} text-[12px]`}
+      >
+        <span className="text-[#8C98F0]">
+          <SpinnerIcon size={13} />
+        </span>
+        <span className="text-muted">{statusText}</span>
+      </div>
+      <div className="px-[22px] py-[18px]">
+        <ol className="m-0 list-decimal space-y-1.5 pl-4 text-[13px] leading-[1.5] text-muted">
+          <li>Review the access request in the Vercel tab and approve it.</li>
+          <li>We create the Vercel drains automatically.</li>
+          <li>This panel updates on its own once the connection lands.</li>
+        </ol>
+        <button
+          type="button"
+          onClick={onReopen}
+          disabled={reopening}
+          className="mt-3 inline-flex items-center gap-1.5 text-[12.5px] font-medium text-[#8C98F0] transition-colors hover:text-fg disabled:opacity-50"
+        >
+          <ExternalLinkIcon size={13} /> Reopen Vercel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ConnectedPanel({
+  teamName,
+  teamId,
+  drains,
+  eventsArrived,
+}: {
+  teamName: string | null;
+  teamId: string;
+  drains: Record<string, string>;
+  eventsArrived: boolean;
+}) {
+  const signals = Object.keys(drains);
+  return (
+    <div className="flex flex-col gap-4">
+      <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+        <div className={`border-b px-[18px] py-[10px] ${SOFT_LINE}`}>
+          <span className="font-mono text-[12px] text-muted">{teamName ?? `Team ${teamId}`}</span>
+        </div>
+        <div className="divide-y divide-[rgba(255,255,255,0.07)]">
+          {signals.length === 0 ? (
+            <div className="px-[18px] py-[14px] text-[12.5px] text-muted">
+              Setting up the drains…
+            </div>
+          ) : (
+            signals.map((signal) => (
+              <div key={signal} className="flex items-center gap-3 px-[18px] py-[13px]">
+                <span className="text-success">
+                  <CheckIcon size={14} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-[13px] font-medium capitalize text-fg">{signal}</span>
+                  <span className="block text-[12px] text-muted">Vercel drain created</span>
+                </span>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {eventsArrived ? (
+        <div className="flex items-center gap-2.5 rounded-[10px] border border-[rgba(65,209,149,0.35)] bg-[rgba(65,209,149,0.06)] px-4 py-3">
+          <span className="text-success">
+            <CheckIcon size={14} />
+          </span>
+          <div className="flex-1 text-[12.5px] text-fg">
+            First events received. <span className="text-muted">You're flowing.</span>
+          </div>
+        </div>
+      ) : (
+        <div
+          className={`flex items-center gap-2.5 rounded-[10px] border border-dashed px-4 py-3 ${STRONG_LINE}`}
+        >
+          <span className="text-[#8C98F0]">
+            <SpinnerIcon size={14} />
+          </span>
+          <div className="flex-1 text-[12.5px] text-muted">
+            The drains are live. First events will appear as your deployments serve traffic.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/onboarding/connectChoices.test.ts
+++ b/apps/web/src/onboarding/connectChoices.test.ts
@@ -16,9 +16,9 @@ function findOption(sections: ReturnType<typeof connectSectionsFor>, id: string)
   return undefined;
 }
 
-test("the chooser offers exactly three lanes: AWS, Cloudflare, and 'I'm hosted elsewhere'", () => {
+test("the chooser offers exactly four lanes: AWS, Cloudflare, Vercel, and 'I'm hosted elsewhere'", () => {
   const ids = CONNECT_SECTIONS.flatMap((s) => s.options.map((o) => o.id));
-  assert.deepEqual(ids, ["aws", "cloudflare", "elsewhere"]);
+  assert.deepEqual(ids, ["aws", "cloudflare", "vercel", "elsewhere"]);
 });
 
 test("there is no coming-soon grid", () => {
@@ -41,8 +41,8 @@ test("integration-first: the primary option is a no-code integration (AWS)", () 
   assert.equal(primary.action, "aws");
 });
 
-test("every lane is actionable when its connector is configured", () => {
-  const sections = connectSectionsFor({ cloudflare: true });
+test("every lane is actionable when its connectors are configured", () => {
+  const sections = connectSectionsFor({ cloudflare: true, vercel: true });
   for (const section of sections) {
     for (const option of section.options) {
       assert.notEqual(option.action, null, `${option.id} should be actionable`);
@@ -54,24 +54,39 @@ test("every lane is actionable when its connector is configured", () => {
 test("connectActionFor resolves known ids and returns null for unknown", () => {
   assert.equal(connectActionFor("aws"), "aws");
   assert.equal(connectActionFor("cloudflare"), "cloudflare");
+  assert.equal(connectActionFor("vercel"), "vercel");
   assert.equal(connectActionFor("elsewhere"), "code");
   assert.equal(connectActionFor("does-not-exist"), null);
 });
 
 test("connectSectionsFor disables Cloudflare when the connector isn't configured", () => {
-  const gated = connectSectionsFor({ cloudflare: false });
+  const gated = connectSectionsFor({ cloudflare: false, vercel: true });
   const cloudflare = findOption(gated, "cloudflare");
   assert.ok(cloudflare);
   assert.equal(cloudflare.action, null, "cloudflare should not be actionable when unavailable");
   assert.equal(isComingSoon(cloudflare), true);
   // Other lanes are untouched.
   assert.equal(findOption(gated, "aws")?.action, "aws");
+  assert.equal(findOption(gated, "vercel")?.action, "vercel");
   assert.equal(findOption(gated, "elsewhere")?.action, "code");
 });
 
-test("connectSectionsFor leaves Cloudflare actionable when configured", () => {
-  const enabled = connectSectionsFor({ cloudflare: true });
+test("connectSectionsFor disables Vercel when the connector isn't configured", () => {
+  const gated = connectSectionsFor({ cloudflare: true, vercel: false });
+  const vercel = findOption(gated, "vercel");
+  assert.ok(vercel);
+  assert.equal(vercel.action, null, "vercel should not be actionable when unavailable");
+  assert.equal(isComingSoon(vercel), true);
+  // Other lanes are untouched.
+  assert.equal(findOption(gated, "aws")?.action, "aws");
+  assert.equal(findOption(gated, "cloudflare")?.action, "cloudflare");
+  assert.equal(findOption(gated, "elsewhere")?.action, "code");
+});
+
+test("connectSectionsFor leaves configured connectors actionable", () => {
+  const enabled = connectSectionsFor({ cloudflare: true, vercel: true });
   assert.equal(findOption(enabled, "cloudflare")?.action, "cloudflare");
+  assert.equal(findOption(enabled, "vercel")?.action, "vercel");
 });
 
 test("every option id is unique", () => {

--- a/apps/web/src/onboarding/connectChoices.ts
+++ b/apps/web/src/onboarding/connectChoices.ts
@@ -4,17 +4,17 @@
 //
 // Design principle (see design.md): integration-first. A connected, no-code
 // integration beats hand-written instrumentation for time-to-value, so the
-// no-code integrations (AWS, Cloudflare) come first and the "I'm hosted
+// no-code integrations (AWS, Cloudflare, Vercel) come first and the "I'm hosted
 // elsewhere" fallback — which routes to the coding-agent prompt — comes last.
 
 // What activating a row does. `null` => not yet available (coming soon), so the
 // row renders disabled and is not actionable. "code" opens the coding-agent
 // prompt (paste into Cursor / Claude Code / Codex).
-export type ConnectAction = "aws" | "cloudflare" | "code";
+export type ConnectAction = "aws" | "cloudflare" | "vercel" | "code";
 
 // Glyph key resolved to a neutral monochrome icon by the component. Kept as a
 // string union (not a component) so this module stays free of JSX/React.
-export type ConnectIcon = "aws" | "cloudflare" | "terminal";
+export type ConnectIcon = "aws" | "cloudflare" | "vercel" | "terminal";
 
 export type ConnectOption = {
   id: string;
@@ -57,10 +57,18 @@ export const CONNECT_SECTIONS: ConnectSection[] = [
         action: "cloudflare",
       },
       {
+        id: "vercel",
+        title: "Vercel",
+        description:
+          "Install the Superlog integration once and we set up trace and log drains that stream your deployments' telemetry in. No agent, no code.",
+        icon: "vercel",
+        action: "vercel",
+      },
+      {
         id: "elsewhere",
         title: "I'm hosted elsewhere",
         description:
-          "Vercel, Fly, a VM, your laptop — anywhere. Paste a prompt into Cursor, Claude Code, or Codex and it installs the SDK, instruments your app, and opens a PR.",
+          "Fly, Render, a VM, your laptop — anywhere. Paste a prompt into Cursor, Claude Code, or Codex and it installs the SDK, instruments your app, and opens a PR.",
         icon: "terminal",
         action: "code",
       },
@@ -69,20 +77,24 @@ export const CONNECT_SECTIONS: ConnectSection[] = [
 ];
 
 // Runtime availability for connectors that depend on server-side config. The
-// backend self-disables the Cloudflare connector when its OAuth client / OTLP
-// intake env isn't set (see system-capabilities), so the chooser must not offer
-// a click that would 503 — it renders the tile as "coming soon" until the API
-// reports the connector is configured.
+// backend self-disables the Cloudflare / Vercel connectors when their OAuth
+// client / OTLP intake env isn't set (see system-capabilities), so the chooser
+// must not offer a click that would 503 — it renders the tile as "coming soon"
+// until the API reports the connector is configured.
 export type ConnectAvailability = {
   cloudflare: boolean;
+  vercel: boolean;
 };
 
 export function connectSectionsFor(availability: ConnectAvailability): ConnectSection[] {
-  if (availability.cloudflare) return CONNECT_SECTIONS;
+  const unavailable = new Set<string>();
+  if (!availability.cloudflare) unavailable.add("cloudflare");
+  if (!availability.vercel) unavailable.add("vercel");
+  if (unavailable.size === 0) return CONNECT_SECTIONS;
   return CONNECT_SECTIONS.map((section) => ({
     ...section,
     options: section.options.map((option) =>
-      option.id === "cloudflare"
+      unavailable.has(option.id)
         ? { ...option, action: null, description: "Coming soon", badge: undefined }
         : option,
     ),

--- a/apps/web/src/onboarding/vercelConnectModel.test.ts
+++ b/apps/web/src/onboarding/vercelConnectModel.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  type VercelPhase,
+  canContinueVercel,
+  parseVercelOutcome,
+  vercelOutcomeMessage,
+  vercelPhase,
+  vercelStatusText,
+} from "./vercelConnectModel.ts";
+
+test("phase starts at 'start' before the install screen is opened", () => {
+  assert.equal(vercelPhase({ installed: false, launched: false }), "start");
+});
+
+test("phase moves to 'connecting' once the install screen is launched", () => {
+  assert.equal(vercelPhase({ installed: false, launched: true }), "connecting");
+});
+
+test("phase is 'connected' as soon as the install lands, regardless of launch flag", () => {
+  assert.equal(vercelPhase({ installed: true, launched: false }), "connected");
+  assert.equal(vercelPhase({ installed: true, launched: true }), "connected");
+});
+
+test("Continue unlocks only when connected", () => {
+  assert.equal(canContinueVercel("start"), false);
+  assert.equal(canContinueVercel("connecting"), false);
+  assert.equal(canContinueVercel("connected"), true);
+});
+
+test("status text reflects phase and whether events have arrived", () => {
+  const phases: VercelPhase[] = ["start", "connecting", "connected"];
+  for (const p of phases) {
+    assert.equal(typeof vercelStatusText(p, false), "string");
+  }
+  assert.notEqual(vercelStatusText("connected", true), vercelStatusText("connected", false));
+});
+
+test("parseVercelOutcome only accepts the known callback values", () => {
+  assert.equal(parseVercelOutcome("installed"), "installed");
+  assert.equal(parseVercelOutcome("denied"), "denied");
+  assert.equal(parseVercelOutcome("error"), "error");
+  assert.equal(parseVercelOutcome("drains_unavailable"), "drains_unavailable");
+  assert.equal(parseVercelOutcome("bogus"), null);
+  assert.equal(parseVercelOutcome(null), null);
+  assert.equal(parseVercelOutcome(undefined), null);
+});
+
+test("only failure outcomes produce a user-facing message", () => {
+  assert.equal(typeof vercelOutcomeMessage("denied"), "string");
+  assert.equal(typeof vercelOutcomeMessage("error"), "string");
+  assert.match(vercelOutcomeMessage("drains_unavailable") ?? "", /Pro or Enterprise/);
+  assert.equal(vercelOutcomeMessage("installed"), null);
+  assert.equal(vercelOutcomeMessage(null), null);
+});

--- a/apps/web/src/onboarding/vercelConnectModel.ts
+++ b/apps/web/src/onboarding/vercelConnectModel.ts
@@ -1,0 +1,75 @@
+// Pure phase model for the onboarding Vercel connect flow, split out of the
+// component so the transitions are unit-testable (the `.tsx` can't be imported
+// by the node:test runner). Mirrors cloudflareConnectModel.ts.
+//
+// Like Cloudflare (and unlike AWS's CloudFormation stack + role verify), Vercel
+// connect is a single OAuth round-trip: the user installs our integration, we
+// create the drains that stream their deployments' telemetry, and the
+// install row appears. So the milestone that unlocks "Continue" is simply that
+// the account is connected (`installed`) — telemetry arrival is surfaced as a
+// bonus but never blocks.
+
+export type VercelPhase = "start" | "connecting" | "connected";
+
+/**
+ * Resolve the flow phase:
+ *  - `installed`  → the OAuth round-trip finished and drains were created.
+ *  - `launched`   → the user opened the install screen but we haven't seen the
+ *                   install land yet (waiting on the round-trip).
+ *  - otherwise    → the initial "connect" call to action.
+ */
+export function vercelPhase(input: { installed: boolean; launched: boolean }): VercelPhase {
+  if (input.installed) return "connected";
+  if (input.launched) return "connecting";
+  return "start";
+}
+
+/** Continue unlocks once the account is connected. */
+export function canContinueVercel(phase: VercelPhase): boolean {
+  return phase === "connected";
+}
+
+// The OAuth callback redirects back with `?vercel=installed|denied|error|...`.
+// `installed` is handled by the install poll flipping to "connected"; failure
+// outcomes reset out of the waiting state rather than spin forever.
+export type VercelOutcome = "installed" | "denied" | "error" | "drains_unavailable" | null;
+
+export function parseVercelOutcome(value: string | null | undefined): VercelOutcome {
+  if (
+    value === "installed" ||
+    value === "denied" ||
+    value === "error" ||
+    value === "drains_unavailable"
+  ) {
+    return value;
+  }
+  return null;
+}
+
+/** User-facing message for a failure outcome (null when not a failure). */
+export function vercelOutcomeMessage(outcome: VercelOutcome): string | null {
+  switch (outcome) {
+    case "denied":
+      return "Vercel authorization was declined. Reconnect to try again.";
+    case "error":
+      return "We couldn't finish connecting Vercel. Reconnect to try again.";
+    case "drains_unavailable":
+      return "Vercel Drains aren't available for that team. Drains require a Vercel Pro or Enterprise team; upgrade in Vercel or install on an eligible team.";
+    default:
+      return null;
+  }
+}
+
+/** Status text for the small banner in the "connecting" / "connected" states. */
+export function vercelStatusText(phase: VercelPhase, eventsArrived: boolean): string {
+  switch (phase) {
+    case "start":
+      return "Not connected yet.";
+    case "connecting":
+      return "Waiting for you to approve access in the Vercel tab…";
+    default:
+      return eventsArrived
+        ? "Connected — telemetry from Vercel is arriving."
+        : "Connected — the Vercel drains are set up. First events will appear as your deployments serve traffic.";
+  }
+}

--- a/packages/db/migrations/0079_chemical_santa_claus.sql
+++ b/packages/db/migrations/0079_chemical_santa_claus.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "vercel_installations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"project_id" uuid NOT NULL,
+	"configuration_id" text NOT NULL,
+	"team_id" text,
+	"team_name" text,
+	"access_token_ciphertext" "bytea" NOT NULL,
+	"access_token_nonce" "bytea" NOT NULL,
+	"access_token_key_version" integer DEFAULT 1 NOT NULL,
+	"api_key_id" uuid,
+	"ingest_key_ciphertext" "bytea",
+	"ingest_key_nonce" "bytea",
+	"ingest_key_key_version" integer,
+	"drains" jsonb,
+	"installed_by_user_id" uuid,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "vercel_installations" ADD CONSTRAINT "vercel_installations_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vercel_installations" ADD CONSTRAINT "vercel_installations_api_key_id_api_keys_id_fk" FOREIGN KEY ("api_key_id") REFERENCES "public"."api_keys"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vercel_installations" ADD CONSTRAINT "vercel_installations_installed_by_user_id_users_id_fk" FOREIGN KEY ("installed_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "vercel_installations_project_configuration_idx" ON "vercel_installations" USING btree ("project_id","configuration_id");

--- a/packages/db/migrations/meta/0079_snapshot.json
+++ b/packages/db/migrations/meta/0079_snapshot.json
@@ -1,0 +1,7969 @@
+{
+  "id": "07e527d2-ce80-44f8-a0a2-164b6fee9a81",
+  "prevId": "991d8aab-9973-4392-81d3-8b48eed8f2a3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_provider_account_idx": {
+          "name": "accounts_provider_account_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_idx": {
+          "name": "accounts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_ticket_events": {
+      "name": "agent_linear_ticket_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_linear_ticket_id": {
+          "name": "agent_linear_ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_linear_id": {
+          "name": "actor_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_ticket_events_ticket_idx": {
+          "name": "agent_linear_ticket_events_ticket_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_ticket_events_provider_event_idx": {
+          "name": "agent_linear_ticket_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk": {
+          "name": "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk",
+          "tableFrom": "agent_linear_ticket_events",
+          "tableTo": "agent_linear_tickets",
+          "columnsFrom": [
+            "agent_linear_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_tickets": {
+      "name": "agent_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_identifier": {
+          "name": "ticket_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_name": {
+          "name": "assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_linear_id": {
+          "name": "assignee_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_tickets_incident_idx": {
+          "name": "agent_linear_tickets_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_agent_run_idx": {
+          "name": "agent_linear_tickets_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_workspace_ticket_idx": {
+          "name": "agent_linear_tickets_workspace_ticket_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_tickets_incident_id_incidents_id_fk": {
+          "name": "agent_linear_tickets_incident_id_incidents_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_linear_tickets_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_installation_id_linear_installations_id_fk": {
+          "name": "agent_linear_tickets_installation_id_linear_installations_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "linear_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memories": {
+      "name": "agent_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source_agent_run_id": {
+          "name": "source_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memories_org_status_idx": {
+          "name": "agent_memories_org_status_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_memories_org_id_orgs_id_fk": {
+          "name": "agent_memories_org_id_orgs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_id_projects_id_fk": {
+          "name": "agent_memories_project_id_projects_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_memories_source_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "source_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_user_id_users_id_fk": {
+          "name": "agent_memories_source_user_id_users_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "source_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_org_fk": {
+          "name": "agent_memories_project_org_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_memories_single_source_check": {
+          "name": "agent_memories_single_source_check",
+          "value": "NOT (source_agent_run_id IS NOT NULL AND source_user_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_pr_events": {
+      "name": "agent_pr_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_pr_id": {
+          "name": "agent_pr_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_login": {
+          "name": "actor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_github_id": {
+          "name": "actor_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pr_events_pr_idx": {
+          "name": "agent_pr_events_pr_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pr_events_provider_event_idx": {
+          "name": "agent_pr_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk": {
+          "name": "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk",
+          "tableFrom": "agent_pr_events",
+          "tableTo": "agent_pull_requests",
+          "columnsFrom": [
+            "agent_pr_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_pull_requests": {
+      "name": "agent_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_node_id": {
+          "name": "pr_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_login": {
+          "name": "merged_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_github_id": {
+          "name": "merged_by_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pull_requests_incident_idx": {
+          "name": "agent_pull_requests_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_agent_run_idx": {
+          "name": "agent_pull_requests_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_repo_pr_idx": {
+          "name": "agent_pull_requests_repo_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pull_requests_incident_id_incidents_id_fk": {
+          "name": "agent_pull_requests_incident_id_incidents_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_pull_requests_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_installation_id_github_installations_id_fk": {
+          "name": "agent_pull_requests_installation_id_github_installations_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'incident'"
+        },
+        "trigger_detail": {
+          "name": "trigger_detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_status": {
+          "name": "provider_session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_full_name": {
+          "name": "selected_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_url": {
+          "name": "selected_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_base_branch": {
+          "name": "selected_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_score": {
+          "name": "selected_repo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cumulative_runtime_minutes": {
+          "name": "cumulative_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resume_count": {
+          "name": "resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_runs_incident_idx": {
+          "name": "agent_runs_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_provider_session_idx": {
+          "name": "agent_runs_provider_session_idx",
+          "columns": [
+            {
+              "expression": "provider_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_incident_id_incidents_id_fk": {
+          "name": "agent_runs_incident_id_incidents_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_episodes": {
+      "name": "alert_episodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'firing'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_observed_value": {
+          "name": "open_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_observed_value": {
+          "name": "peak_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_value": {
+          "name": "last_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_firing_at": {
+          "name": "last_firing_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alert_episodes_alert_started_idx": {
+          "name": "alert_episodes_alert_started_idx",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_episodes_incident_idx": {
+          "name": "alert_episodes_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_episodes_open_uniq": {
+          "name": "alert_episodes_open_uniq",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "state = 'firing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_episodes_alert_id_alerts_id_fk": {
+          "name": "alert_episodes_alert_id_alerts_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_project_id_projects_id_fk": {
+          "name": "alert_episodes_project_id_projects_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_issue_id_issues_id_fk": {
+          "name": "alert_episodes_issue_id_issues_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_incident_id_incidents_id_fk": {
+          "name": "alert_episodes_incident_id_incidents_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_firings": {
+      "name": "alert_firings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_value": {
+          "name": "observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluated_at": {
+          "name": "evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_firings_alert_group_idx": {
+          "name": "alert_firings_alert_group_idx",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_firings_alert_id_alerts_id_fk": {
+          "name": "alert_firings_alert_id_alerts_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_firings_issue_id_issues_id_fk": {
+          "name": "alert_firings_issue_id_issues_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_name": {
+          "name": "metric_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "group_by": {
+          "name": "group_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mode": {
+          "name": "group_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single'"
+        },
+        "aggregation": {
+          "name": "aggregation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparator": {
+          "name": "comparator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "evaluation_interval_seconds": {
+          "name": "evaluation_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alerts_project_idx": {
+          "name": "alerts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alerts_enabled_idx": {
+          "name": "alerts_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alerts_project_id_projects_id_fk": {
+          "name": "alerts_project_id_projects_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alerts_created_by_users_id_fk": {
+          "name": "alerts_created_by_users_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions": {
+      "name": "cli_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cli_sessions_user_id_users_id_fk": {
+          "name": "cli_sessions_user_id_users_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_org_id_orgs_id_fk": {
+          "name": "cli_sessions_org_id_orgs_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_sessions_token_hash_unique": {
+          "name": "cli_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_connections": {
+      "name": "cloud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scrape_role_arn": {
+          "name": "scrape_role_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id_ciphertext": {
+          "name": "external_id_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_nonce": {
+          "name": "external_id_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_key_version": {
+          "name": "external_id_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloud_connections_project_idx": {
+          "name": "cloud_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_connections_active_role_idx": {
+          "name": "cloud_connections_active_role_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scrape_role_arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_connections_project_id_projects_id_fk": {
+          "name": "cloud_connections_project_id_projects_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_connections_created_by_users_id_fk": {
+          "name": "cloud_connections_created_by_users_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_resources": {
+      "name": "cloud_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arn": {
+          "name": "arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_fetched_at": {
+          "name": "config_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_resources_project_arn_idx": {
+          "name": "cloud_resources_project_arn_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_project_idx": {
+          "name": "cloud_resources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_connection_idx": {
+          "name": "cloud_resources_connection_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_resources_project_id_projects_id_fk": {
+          "name": "cloud_resources_project_id_projects_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_resources_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_resources_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_stream_keys": {
+      "name": "cloud_stream_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_ciphertext": {
+          "name": "key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_nonce": {
+          "name": "key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_key_version": {
+          "name": "key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_stream_keys_connection_kind_idx": {
+          "name": "cloud_stream_keys_connection_kind_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_stream_keys_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_stream_keys_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_stream_keys",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_stream_keys_api_key_id_api_keys_id_fk": {
+          "name": "cloud_stream_keys_api_key_id_api_keys_id_fk",
+          "tableFrom": "cloud_stream_keys",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_installations": {
+      "name": "cloudflare_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_token_ciphertext": {
+          "name": "refresh_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_nonce": {
+          "name": "refresh_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_key_version": {
+          "name": "refresh_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destinations": {
+          "name": "destinations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloudflare_installations_project_account_idx": {
+          "name": "cloudflare_installations_project_account_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_installations_project_id_projects_id_fk": {
+          "name": "cloudflare_installations_project_id_projects_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloudflare_installations_api_key_id_api_keys_id_fk": {
+          "name": "cloudflare_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cloudflare_installations_installed_by_user_id_users_id_fk": {
+          "name": "cloudflare_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_widgets": {
+      "name": "dashboard_widgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboard_widgets_dashboard_idx": {
+          "name": "dashboard_widgets_dashboard_idx",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_widgets_dashboard_id_dashboards_id_fk": {
+          "name": "dashboard_widgets_dashboard_id_dashboards_id_fk",
+          "tableFrom": "dashboard_widgets",
+          "tableTo": "dashboards",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboards": {
+      "name": "dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboards_project_slug_idx": {
+          "name": "dashboards_project_slug_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboards_project_idx": {
+          "name": "dashboards_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboards_project_id_projects_id_fk": {
+          "name": "dashboards_project_id_projects_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboards_created_by_users_id_fk": {
+          "name": "dashboards_created_by_users_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_repo": {
+          "name": "ref_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_external": {
+          "name": "author_external",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "triaged_by_user_id": {
+          "name": "triaged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_status_created_idx": {
+          "name": "feedback_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_kind_ref_idx": {
+          "name": "feedback_kind_ref_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_user_id_users_id_fk": {
+          "name": "feedback_author_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_org_id_orgs_id_fk": {
+          "name": "feedback_org_id_orgs_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_project_id_projects_id_fk": {
+          "name": "feedback_project_id_projects_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_triaged_by_user_id_users_id_fk": {
+          "name": "feedback_triaged_by_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triaged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repos": {
+          "name": "repos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_enabled": {
+          "name": "agent_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "repo_access": {
+          "name": "repo_access",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_name": {
+          "name": "commit_author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_email": {
+          "name": "commit_author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_login": {
+          "name": "commit_author_github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_id": {
+          "name": "commit_author_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_avatar_url": {
+          "name": "commit_author_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_by_user_id": {
+          "name": "commit_author_set_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_at": {
+          "name": "commit_author_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_project_installation_idx": {
+          "name": "github_installations_project_installation_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NOT NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_installation_idx": {
+          "name": "github_installations_org_installation_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_idx": {
+          "name": "github_installations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_org_id_orgs_id_fk": {
+          "name": "github_installations_org_id_orgs_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_project_id_projects_id_fk": {
+          "name": "github_installations_project_id_projects_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_commit_author_set_by_user_id_users_id_fk": {
+          "name": "github_installations_commit_author_set_by_user_id_users_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "commit_author_set_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_events": {
+      "name": "incident_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_posted_at": {
+          "name": "slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_events_agent_run_idx": {
+          "name": "incident_events_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_idx": {
+          "name": "incident_events_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_provider_event_idx": {
+          "name": "incident_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_provider_event_idx": {
+          "name": "incident_events_incident_provider_event_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_dedupe_idx": {
+          "name": "incident_events_dedupe_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_dedupe_idx": {
+          "name": "incident_events_incident_dedupe_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_events_agent_run_id_agent_runs_id_fk": {
+          "name": "incident_events_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_events_incident_id_incidents_id_fk": {
+          "name": "incident_events_incident_id_incidents_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "incident_events_parentage_check": {
+          "name": "incident_events_parentage_check",
+          "value": "agent_run_id IS NOT NULL OR incident_id IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.incident_issues": {
+      "name": "incident_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_issues_issue_idx": {
+          "name": "incident_issues_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_issues_incident_idx": {
+          "name": "incident_issues_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_issues_incident_id_incidents_id_fk": {
+          "name": "incident_issues_incident_id_incidents_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_issues_issue_id_issues_id_fk": {
+          "name": "incident_issues_issue_id_issues_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_resolution_proposals": {
+      "name": "incident_resolution_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sweep'"
+        },
+        "proposed_reason_code": {
+          "name": "proposed_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_reason_text": {
+          "name": "proposed_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_at": {
+          "name": "proposed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_slack_user_id": {
+          "name": "decided_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_resolution_proposals_incident_idx": {
+          "name": "incident_resolution_proposals_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proposed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_resolution_proposals_slack_msg_idx": {
+          "name": "incident_resolution_proposals_slack_msg_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_message_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_channel_id IS NOT NULL AND slack_message_ts IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_resolution_proposals_incident_id_incidents_id_fk": {
+          "name": "incident_resolution_proposals_incident_id_incidents_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk": {
+          "name": "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_decided_by_user_id_users_id_fk": {
+          "name": "incident_resolution_proposals_decided_by_user_id_users_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "noise_reason": {
+          "name": "noise_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_resolved_at": {
+          "name": "noise_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_into_id": {
+          "name": "merged_into_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_investigate_suppressed_until": {
+          "name": "auto_investigate_suppressed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autorecovery_last_evaluated_at": {
+          "name": "autorecovery_last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_summary": {
+          "name": "agent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_text": {
+          "name": "root_cause_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_confidence": {
+          "name": "root_cause_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_text": {
+          "name": "estimated_impact_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_confidence": {
+          "name": "estimated_impact_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_severity": {
+          "name": "suggested_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_classification": {
+          "name": "noise_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_classification": {
+          "name": "resolution_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_agent_run_id": {
+          "name": "findings_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_kind": {
+          "name": "resolved_by_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_slack_user_id": {
+          "name": "resolved_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_code": {
+          "name": "resolved_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_text": {
+          "name": "resolved_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incidents_project_status_seen_idx": {
+          "name": "incidents_project_status_seen_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_autorecovery_eval_idx": {
+          "name": "incidents_autorecovery_eval_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "autorecovery_last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_slack_thread_idx": {
+          "name": "incidents_slack_thread_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_project_codename_idx": {
+          "name": "incidents_project_codename_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "codename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "codename <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_project_id_projects_id_fk": {
+          "name": "incidents_project_id_projects_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incidents_merged_into_id_incidents_id_fk": {
+          "name": "incidents_merged_into_id_incidents_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "merged_into_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_slack_installation_id_slack_installations_id_fk": {
+          "name": "incidents_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_findings_agent_run_id_agent_runs_id_fk": {
+          "name": "incidents_findings_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "findings_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_resolved_by_user_id_users_id_fk": {
+          "name": "incidents_resolved_by_user_id_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_org_idx": {
+          "name": "invitations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_org_id_orgs_id_fk": {
+          "name": "invitations_org_id_orgs_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'span'"
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_type": {
+          "name": "exception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_frame": {
+          "name": "top_frame",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_frames": {
+          "name": "normalized_frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_sample": {
+          "name": "last_sample",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "silenced_at": {
+          "name": "silenced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_alerted_at": {
+          "name": "last_alerted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "grouping_state": {
+          "name": "grouping_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'grouped'"
+        },
+        "grouping_source": {
+          "name": "grouping_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_reason": {
+          "name": "grouping_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempted_at": {
+          "name": "grouping_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempt_count": {
+          "name": "grouping_attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_project_fingerprint_idx": {
+          "name": "issues_project_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "silenced_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_grouping_state_idx": {
+          "name": "issues_grouping_state_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grouping_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grouping_state IN ('pending', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_installations": {
+      "name": "linear_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_url_key": {
+          "name": "workspace_url_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_vault_id": {
+          "name": "anthropic_vault_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_credential_id": {
+          "name": "anthropic_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_required_at": {
+          "name": "reauth_required_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_reason": {
+          "name": "reauth_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linear_installations_project_active_idx": {
+          "name": "linear_installations_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_installations_project_id_projects_id_fk": {
+          "name": "linear_installations_project_id_projects_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_installations_actor_user_id_users_id_fk": {
+          "name": "linear_installations_actor_user_id_users_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_codes": {
+      "name": "mcp_oauth_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_codes_client_idx": {
+          "name": "mcp_oauth_codes_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_user_id_users_id_fk": {
+          "name": "mcp_oauth_codes_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_project_id_projects_id_fk": {
+          "name": "mcp_oauth_codes_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_tokens": {
+      "name": "mcp_oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "access_hash": {
+          "name": "access_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_hash": {
+          "name": "refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_tokens_client_idx": {
+          "name": "mcp_oauth_tokens_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_tokens_user_idx": {
+          "name": "mcp_oauth_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_user_id_users_id_fk": {
+          "name": "mcp_oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_project_id_projects_id_fk": {
+          "name": "mcp_oauth_tokens_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_tokens_access_hash_unique": {
+          "name": "mcp_oauth_tokens_access_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_hash"
+          ]
+        },
+        "mcp_oauth_tokens_refresh_hash_unique": {
+          "name": "mcp_oauth_tokens_refresh_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_agent_settings": {
+      "name": "org_agent_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "digest_enabled": {
+          "name": "digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "digest_slack_installation_id": {
+          "name": "digest_slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_id": {
+          "name": "digest_slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_name": {
+          "name": "digest_slack_channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_last_run_at": {
+          "name": "digest_last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_agent_settings_org_idx": {
+          "name": "org_agent_settings_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_agent_settings_org_id_orgs_id_fk": {
+          "name": "org_agent_settings_org_id_orgs_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk": {
+          "name": "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "digest_slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_api_keys": {
+      "name": "org_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_api_keys_org_idx": {
+          "name": "org_api_keys_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_api_keys_org_id_orgs_id_fk": {
+          "name": "org_api_keys_org_id_orgs_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_api_keys_created_by_user_id_users_id_fk": {
+          "name": "org_api_keys_created_by_user_id_users_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_api_keys_key_hash_unique": {
+          "name": "org_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integration_secrets": {
+      "name": "org_integration_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_integration_id": {
+          "name": "org_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_name": {
+          "name": "secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integration_secrets_unique_idx": {
+          "name": "org_integration_secrets_unique_idx",
+          "columns": [
+            {
+              "expression": "org_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integration_secrets_org_integration_id_org_integrations_id_fk": {
+          "name": "org_integration_secrets_org_integration_id_org_integrations_id_fk",
+          "tableFrom": "org_integration_secrets",
+          "tableTo": "org_integrations",
+          "columnsFrom": [
+            "org_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integrations": {
+      "name": "org_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integrations_org_slug_idx": {
+          "name": "org_integrations_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_integrations_org_enabled_idx": {
+          "name": "org_integrations_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integrations_org_id_orgs_id_fk": {
+          "name": "org_integrations_org_id_orgs_id_fk",
+          "tableFrom": "org_integrations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_members_org_user_idx": {
+          "name": "org_members_org_user_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_org_id_orgs_id_fk": {
+          "name": "org_members_org_id_orgs_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_members_user_id_users_id_fk": {
+          "name": "org_members_user_id_users_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_setup_skipped_at": {
+          "name": "github_setup_skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_source": {
+          "name": "signup_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_return_url_hosts": {
+          "name": "allowed_return_url_hosts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_slug_unique": {
+          "name": "orgs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "orgs_clerk_org_id_unique": {
+          "name": "orgs_clerk_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personal_access_tokens_user_idx": {
+          "name": "personal_access_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personal_access_tokens_project_idx": {
+          "name": "personal_access_tokens_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_users_id_fk": {
+          "name": "personal_access_tokens_user_id_users_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personal_access_tokens_project_id_projects_id_fk": {
+          "name": "personal_access_tokens_project_id_projects_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_automation_settings": {
+      "name": "project_automation_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_investigate_issues_enabled": {
+          "name": "auto_investigate_issues_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "agent_run_provider": {
+          "name": "agent_run_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "max_runtime_minutes": {
+          "name": "max_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "max_human_resume_count": {
+          "name": "max_human_resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_follow_up_enabled": {
+          "name": "auto_follow_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "linear_ticket_instructions": {
+          "name": "linear_ticket_instructions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_base_branch": {
+          "name": "pr_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_merge_fix_prs": {
+          "name": "auto_merge_fix_prs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'never'"
+        },
+        "auto_merge_method": {
+          "name": "auto_merge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'squash'"
+        },
+        "issue_filter": {
+          "name": "issue_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "issue_filter_config": {
+          "name": "issue_filter_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"includeLogs\":[],\"includeSpans\":[],\"excludeLogs\":[],\"excludeSpans\":[]}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_automation_settings_project_idx": {
+          "name": "project_automation_settings_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_automation_settings_project_id_projects_id_fk": {
+          "name": "project_automation_settings_project_id_projects_id_fk",
+          "tableFrom": "project_automation_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_github_repos": {
+      "name": "project_github_repos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_full_name": {
+          "name": "github_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_github_repos_project_repo_idx": {
+          "name": "project_github_repos_project_repo_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_github_repos_installation_idx": {
+          "name": "project_github_repos_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_github_repos_project_id_projects_id_fk": {
+          "name": "project_github_repos_project_id_projects_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_github_repos_installation_id_github_installations_id_fk": {
+          "name": "project_github_repos_installation_id_github_installations_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_ingest_filters": {
+      "name": "project_ingest_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal": {
+          "name": "signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_ingest_filters_project_source_signal_idx": {
+          "name": "project_ingest_filters_project_source_signal_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_ingest_filters_project_id_projects_id_fk": {
+          "name": "project_ingest_filters_project_id_projects_id_fk",
+          "tableFrom": "project_ingest_filters",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_topologies": {
+      "name": "project_topologies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment": {
+          "name": "enrichment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_requested_at": {
+          "name": "refresh_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_topologies_project_idx": {
+          "name": "project_topologies_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_topologies_project_id_projects_id_fk": {
+          "name": "project_topologies_project_id_projects_id_fk",
+          "tableFrom": "project_topologies",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_context": {
+          "name": "project_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_idx": {
+          "name": "projects_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_org_id_orgs_id_fk": {
+          "name": "projects_org_id_orgs_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_id_org_uniq": {
+          "name": "projects_id_org_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_orgs_id_fk": {
+          "name": "sessions_active_organization_id_orgs_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signup_intents": {
+      "name": "signup_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_project_id": {
+          "name": "claimed_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signup_intents_claimed_project_id_projects_id_fk": {
+          "name": "signup_intents_claimed_project_id_projects_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "claimed_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "signup_intents_claimed_by_user_id_users_id_fk": {
+          "name": "signup_intents_claimed_by_user_id_users_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signup_intents_key_hash_unique": {
+          "name": "signup_intents_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slack_installations_project_team_idx": {
+          "name": "slack_installations_project_team_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_project_id_projects_id_fk": {
+          "name": "slack_installations_project_id_projects_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_installations_installed_by_user_id_users_id_fk": {
+          "name": "slack_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_map_artifacts": {
+      "name": "source_map_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dist": {
+          "name": "dist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug_id": {
+          "name": "debug_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_file": {
+          "name": "bundle_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_file": {
+          "name": "map_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_hash": {
+          "name": "source_map_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_bytes": {
+          "name": "source_map_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_bucket": {
+          "name": "storage_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_encoding": {
+          "name": "content_encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gzip'"
+        },
+        "uploaded_by_org_api_key_id": {
+          "name": "uploaded_by_org_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_map_artifacts_project_debug_id_idx": {
+          "name": "source_map_artifacts_project_debug_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "debug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "debug_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_map_artifacts_project_release_idx": {
+          "name": "source_map_artifacts_project_release_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "release",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_map_artifacts_project_id_projects_id_fk": {
+          "name": "source_map_artifacts_project_id_projects_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk": {
+          "name": "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "org_api_keys",
+          "columnsFrom": [
+            "uploaded_by_org_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_notifications": {
+      "name": "usage_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_notifications_org_period_threshold_idx": {
+          "name": "usage_notifications_org_period_threshold_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "threshold",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_notifications_org_id_orgs_id_fk": {
+          "name": "usage_notifications_org_id_orgs_id_fk",
+          "tableFrom": "usage_notifications",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_project_id": {
+          "name": "active_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_org_id": {
+          "name": "active_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_org_id": {
+          "name": "favorite_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_project_id": {
+          "name": "favorite_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_active_project_id_projects_id_fk": {
+          "name": "users_active_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "active_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_active_org_id_orgs_id_fk": {
+          "name": "users_active_org_id_orgs_id_fk",
+          "tableFrom": "users",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_favorite_org_id_orgs_id_fk": {
+          "name": "users_favorite_org_id_orgs_id_fk",
+          "tableFrom": "users",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "favorite_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_favorite_project_id_projects_id_fk": {
+          "name": "users_favorite_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "favorite_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_installations": {
+      "name": "vercel_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_id": {
+          "name": "configuration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drains": {
+          "name": "drains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vercel_installations_project_configuration_idx": {
+          "name": "vercel_installations_project_configuration_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configuration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_installations_project_id_projects_id_fk": {
+          "name": "vercel_installations_project_id_projects_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vercel_installations_api_key_id_api_keys_id_fk": {
+          "name": "vercel_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vercel_installations_installed_by_user_id_users_id_fk": {
+          "name": "vercel_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_status": {
+          "name": "last_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_endpoint_idx": {
+          "name": "webhook_deliveries_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_events": {
+          "name": "enabled_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"incident.created\",\"incident.updated\"]'::jsonb"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_endpoints_project_idx": {
+          "name": "webhook_endpoints_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_endpoints_project_id_projects_id_fk": {
+          "name": "webhook_endpoints_project_id_projects_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_state": {
+      "name": "worker_state",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -554,6 +554,13 @@
       "when": 1782760770343,
       "tag": "0078_slippery_steel_serpent",
       "breakpoints": true
+    },
+    {
+      "idx": 79,
+      "version": "7",
+      "when": 1783087922400,
+      "tag": "0079_chemical_santa_claus",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2084,11 +2084,67 @@ export const cloudflareInstallations = pgTable(
 
 export type CloudflareInstallation = typeof cloudflareInstallations.$inferSelect;
 
+// A connected Vercel account via a connectable-account integration install.
+// One row per (project, integration configuration) — Vercel issues a
+// configuration id (`icfg_…`) per install and the long-lived OAuth token is
+// scoped to it. On connect we use the token to create a Drain that streams the
+// team's deployments' OTLP traces to our intake authenticated by a project
+// ingest key, so the customer's Vercel telemetry flows into Superlog with no
+// copy-paste. Tokens/keys are encrypted at rest with the same AES-256-GCM
+// scheme as the Cloudflare connector.
+export const vercelInstallations = pgTable(
+  "vercel_installations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    projectId: uuid("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    // The integration configuration the token is scoped to (`icfg_…`).
+    configurationId: text("configuration_id").notNull(),
+    // Null for personal-account installs; team installs need it as `?teamId=`
+    // on every API call.
+    teamId: text("team_id"),
+    teamName: text("team_name"),
+    // Long-lived delegated OAuth token, encrypted at rest (Vercel integration
+    // tokens have no refresh token / expiry).
+    accessTokenCiphertext: bytea("access_token_ciphertext").notNull(),
+    accessTokenNonce: bytea("access_token_nonce").notNull(),
+    accessTokenKeyVersion: integer("access_token_key_version").notNull().default(1),
+    // The ingest key the created drain authenticates with, stored encrypted so
+    // a re-sync reuses the same key instead of minting a new one each connect.
+    apiKeyId: uuid("api_key_id").references(() => apiKeys.id, { onDelete: "set null" }),
+    ingestKeyCiphertext: bytea("ingest_key_ciphertext"),
+    ingestKeyNonce: bytea("ingest_key_nonce"),
+    ingestKeyKeyVersion: integer("ingest_key_key_version"),
+    // The Drains we created, keyed by signal: { traces, logs } → Vercel drain id.
+    drains: jsonb("drains").$type<Record<string, string>>(),
+    installedByUserId: uuid("installed_by_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    // One live install per (project, configuration); a replayed callback for the
+    // same configuration refreshes the row (see the upsert in
+    // apps/api/src/vercel.ts). Also serves project-scoped lookups via its
+    // left-most `project_id` prefix.
+    projectConfigurationUniq: uniqueIndex("vercel_installations_project_configuration_idx").on(
+      t.projectId,
+      t.configurationId,
+    ),
+  }),
+);
+
+export type VercelInstallation = typeof vercelInstallations.$inferSelect;
+
 // Per-project ingest source filters. A row means the given (source, signal) is
 // DISABLED for the project — the proxy ack-drops that telemetry at the edge.
 // Sparse by design: no row = enabled, so a new project ingests everything.
-//   source: "otlp" (SDK/OTLP exporters) | "aws" (CloudWatch → Firehose)
-//   signal: "traces" | "logs" | "metrics"  (aws carries only logs/metrics)
+//   source: "otlp" (SDK/OTLP exporters) | "aws" (CloudWatch → Firehose) |
+//           "vercel" (Vercel Drains)
+//   signal: "traces" | "logs" | "metrics"
 export const projectIngestFilters = pgTable(
   "project_ingest_filters",
   {
@@ -2096,7 +2152,7 @@ export const projectIngestFilters = pgTable(
     projectId: uuid("project_id")
       .notNull()
       .references(() => projects.id, { onDelete: "cascade" }),
-    source: text("source").$type<"otlp" | "aws">().notNull(),
+    source: text("source").$type<"otlp" | "aws" | "vercel">().notNull(),
     signal: text("signal").$type<"traces" | "logs" | "metrics">().notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   },


### PR DESCRIPTION
## Summary
- Add a Vercel connect flow that exchanges integration OAuth callbacks and provisions Vercel Drains for traces and logs.
- Add a Vercel log-drain adapter in the ingest proxy and source-level ingest toggles for Vercel telemetry.
- Add onboarding/settings UI for connecting and managing the Vercel integration.
- Persist Vercel installations and created drain metadata with a generated Drizzle migration.

## Validation
- `pnpm exec tsx --test src/vercel-service.test.ts src/ingest-filters-service.test.ts src/system-capabilities.test.ts` in `apps/api`
- `pnpm exec tsx --test src/onboarding/vercelConnectModel.test.ts src/onboarding/connectChoices.test.ts` in `apps/web`
- `pnpm --filter @superlog/proxy exec tsx --test src/vercel-log-drain.test.ts src/ingest-source-filter.test.ts`
- `pnpm --filter @superlog/proxy typecheck && pnpm --filter @superlog/api typecheck && pnpm --filter @superlog/web typecheck && pnpm --filter @superlog/db typecheck`
- `pnpm --filter @superlog/db test:migrations`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Vercel integration that lets projects connect a Vercel team and auto-provision drains for OTLP traces and logs, streaming directly into our intake. Includes a guided onboarding flow, settings management, and DB persistence.

- **New Features**
  - OAuth connect flow and routes to generate the Vercel install URL, handle the callback, exchange tokens, and create/delete drains; installs are stored per project with encrypted credentials (`apps/api`).
  - Proxy adapter to accept Vercel log drains and translate them to OTLP logs; ingest filtering extended with `vercel:traces` and `vercel:logs` (`apps/proxy`).
  - Onboarding and settings UI to connect, view status, and uninstall the integration (`apps/web`).
  - System capability flag `vercelConnect` gated by required env vars (client ID/secret, integration slug, OTLP intake URL, `STATE_SIGNING_SECRET`) (`apps/api`, `apps/web`).
  - Shared HMAC-signed OAuth state extracted to `oauth-state.ts` and reused across connectors (`apps/api`).

- **Migration**
  - Add `vercel_installations` table to store installation metadata, encrypted access tokens and ingest keys, and created drain IDs (`packages/db`).

<sup>Written for commit 63de300e9fa82ccc1a2c0f69d7ed0158372d4460. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

