### PR TITLE
Forward Vercel callbacks from web origin

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,6 +29,7 @@ import { DashboardsList } from "./dashboards/DashboardsList.tsx";
 import { AppShell, ThemeToggle, Wordmark } from "./design/ui.tsx";
 import { McpInstallPill } from "./onboarding/McpInstallPill.tsx";
 import { OnboardingGate } from "./onboarding/OnboardingGate.tsx";
+import { externalOAuthCallbackForwardUrl } from "./oauthCallbackForwarding.ts";
 import { parseAttribution, persistFirstTouchAttribution } from "./signupAttribution.ts";
 import { startSkillOnboarding } from "./skillOnboarding.ts";
 
@@ -68,6 +69,15 @@ function GithubInstallCallbackForwarder() {
     const params = new URLSearchParams(window.location.search);
     if (!params.has("installation_id") || !params.has("state")) return;
     window.location.replace(`${API_URL}/github/install/callback${window.location.search}`);
+  }, []);
+  return null;
+}
+
+function ExternalOAuthCallbackForwarder() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const url = externalOAuthCallbackForwardUrl(window.location, API_URL);
+    if (url) window.location.replace(url);
   }, []);
   return null;
 }
@@ -120,6 +130,7 @@ export function App() {
     <>
       <SignupSourceCapture />
       <GithubInstallCallbackForwarder />
+      <ExternalOAuthCallbackForwarder />
       <PostHogUserSync />
       <ActiveOrgSync />
       <Routes>

--- a/apps/web/src/oauthCallbackForwarding.test.ts
+++ b/apps/web/src/oauthCallbackForwarding.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { externalOAuthCallbackForwardUrl } from "./oauthCallbackForwarding.ts";
+
+test("forwards Vercel OAuth callbacks from the web origin to the API origin", () => {
+  assert.equal(
+    externalOAuthCallbackForwardUrl(
+      { pathname: "/vercel/oauth/callback", search: "?code=c&state=s&teamId=t" },
+      "https://api.superlog.sh/",
+    ),
+    "https://api.superlog.sh/vercel/oauth/callback?code=c&state=s&teamId=t",
+  );
+});
+
+test("ignores non-Vercel callback paths", () => {
+  assert.equal(
+    externalOAuthCallbackForwardUrl(
+      { pathname: "/settings", search: "?vercel=connected" },
+      "https://api.superlog.sh",
+    ),
+    null,
+  );
+});

--- a/apps/web/src/oauthCallbackForwarding.ts
+++ b/apps/web/src/oauthCallbackForwarding.ts
@@ -1,0 +1,9 @@
+type LocationLike = Pick<Location, "pathname" | "search">;
+
+export function externalOAuthCallbackForwardUrl(
+  location: LocationLike,
+  apiUrl: string,
+): string | null {
+  if (location.pathname !== "/vercel/oauth/callback") return null;
+  return `${apiUrl.replace(/\/+$/, "")}/vercel/oauth/callback${location.search}`;
+}


### PR DESCRIPTION
## Summary
- Forward `/vercel/oauth/callback` requests that land on the web origin to the API callback origin.
- Preserve the full Vercel OAuth query string so the existing callback handler can exchange the code and complete setup.

## Validation
- `pnpm exec tsx --test src/oauthCallbackForwarding.test.ts` in `apps/web`
- `pnpm --filter @superlog/web typecheck`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward Vercel OAuth callbacks that land on the web app to the API callback endpoint, preserving the full query string. Prevents failed setup when users are redirected to the web domain.

- **Bug Fixes**
  - Forward /vercel/oauth/callback from web origin to the API origin with the original query string.
  - Added a client-side forwarder component and integrated it into App to redirect on load.
  - Added unit tests for forwarding behavior and non-matching paths.

<sup>Written for commit 63c463867891082c164e9a25c332dbeaebcac25f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

