### PR TITLE
Vercel connect: land the OAuth callback on an explicit result page

### DIFF
--- a/apps/api/src/vercel-service.test.ts
+++ b/apps/api/src/vercel-service.test.ts
@@ -6,6 +6,7 @@ import {
   buildDrainPayload,
   buildInstallUrl,
   classifyDrainProvisioningFailure,
+  connectResultPath,
   createDrain,
   deleteConfiguration,
   deleteDrain,
@@ -67,6 +68,22 @@ test("classifyDrainProvisioningFailure detects Vercel plan-gated drains", () => 
     "drains_unavailable",
   );
   assert.equal(classifyDrainProvisioningFailure(["Not authorized"]), "error");
+});
+
+test("connectResultPath lands every outcome on the dedicated result page", () => {
+  assert.equal(connectResultPath("installed"), "/connect/vercel?vercel=installed");
+  assert.equal(
+    connectResultPath("drains_unavailable"),
+    "/connect/vercel?vercel=drains_unavailable",
+  );
+  assert.equal(connectResultPath("denied"), "/connect/vercel?vercel=denied");
+});
+
+test("the oauth callback never redirects to bare `/` (where the outcome is invisible)", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(new URL("./vercel.ts", import.meta.url), "utf8");
+  assert.doesNotMatch(source, /\/\?vercel=/);
+  assert.match(source, /connectResultPath/);
 });
 
 test("drainName is project-scoped so two projects on one team don't collide", () => {

--- a/apps/api/src/vercel-service.ts
+++ b/apps/api/src/vercel-service.ts
@@ -61,6 +61,17 @@ export function classifyDrainProvisioningFailure(errors: string[]): VercelConnec
   return "error";
 }
 
+/**
+ * Web path the OAuth callback redirects to. Always the dedicated result page —
+ * the callback usually lands in a fresh tab (the install opens via
+ * window.open), so redirecting to `/` with a query param renders whatever `/`
+ * shows and the outcome goes unseen unless the onboarding wizard happens to be
+ * mounted there.
+ */
+export function connectResultPath(outcome: string): string {
+  return `/connect/vercel?vercel=${encodeURIComponent(outcome)}`;
+}
+
 export type VercelConnectConfig = {
   clientId: string;
   clientSecret: string;

--- a/apps/api/src/vercel.ts
+++ b/apps/api/src/vercel.ts
@@ -35,6 +35,7 @@ import {
   buildDrainPayload,
   buildInstallUrl,
   classifyDrainProvisioningFailure,
+  connectResultPath,
   createDrain,
   deleteConfiguration,
   deleteDrain,
@@ -231,22 +232,22 @@ export function mountVercelPublic(
     const err = c.req.query("error");
     if (err) {
       log.warn({ error: err }, "vercel oauth callback denied");
-      return c.redirect(`${webOrigin}/?vercel=denied`, 302);
+      return c.redirect(`${webOrigin}${connectResultPath("denied")}`, 302);
     }
     const code = c.req.query("code");
     const state = c.req.query("state") ?? "";
-    if (!code) return c.redirect(`${webOrigin}/?vercel=error`, 302);
+    if (!code) return c.redirect(`${webOrigin}${connectResultPath("error")}`, 302);
 
     const decoded = verifyState(state, stateSecret);
     if (!decoded) {
       log.warn("vercel oauth callback rejected: invalid or expired state");
-      return c.redirect(`${webOrigin}/?vercel=error`, 302);
+      return c.redirect(`${webOrigin}${connectResultPath("error")}`, 302);
     }
 
     const token = await exchangeCodeForToken({ config, code, fetchImpl });
     if (!token.ok) {
       log.error({ error: token.error }, "vercel token exchange failed");
-      return c.redirect(`${webOrigin}/?vercel=error`, 302);
+      return c.redirect(`${webOrigin}${connectResultPath("error")}`, 302);
     }
 
     try {
@@ -265,14 +266,14 @@ export function mountVercelPublic(
       // spin in the waiting state.
       log.error({ err: e, project_id: decoded.projectId }, "vercel provisioning failed");
       const outcome = e instanceof VercelProvisioningError ? e.outcome : "error";
-      return c.redirect(`${webOrigin}/?vercel=${outcome}`, 302);
+      return c.redirect(`${webOrigin}${connectResultPath(outcome)}`, 302);
     }
 
     log.info(
       { project_id: decoded.projectId, team_id: token.teamId },
       "vercel connected and drain provisioned",
     );
-    return c.redirect(`${webOrigin}/?vercel=installed`, 302);
+    return c.redirect(`${webOrigin}${connectResultPath("installed")}`, 302);
   });
 }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -19,6 +19,7 @@ import { PrivacyPolicy } from "./PrivacyPolicy.tsx";
 import { ResetPassword } from "./ResetPassword.tsx";
 import { Settings } from "./Settings.tsx";
 import { TermsOfService } from "./TermsOfService.tsx";
+import { VercelCallback } from "./VercelCallback.tsx";
 import { AlertEdit } from "./alerts/AlertEdit.tsx";
 import { AlertsList } from "./alerts/AlertsList.tsx";
 import { useMe } from "./api.ts";
@@ -134,6 +135,10 @@ export function App() {
         <Route path="/reset-password" element={<ResetPassword />} />
         {/* Public, no-auth feedback link reached from agent-opened PR descriptions. */}
         <Route path="/feedback/pr/:owner/:repo/:number" element={<PrFeedback />} />
+        {/* Landing target of the Vercel OAuth callback — public so the result
+            shows even when the callback lands in a fresh, gated, or logged-out
+            tab (the install opens via window.open). */}
+        <Route path="/connect/vercel" element={<VercelCallback />} />
         <Route path="*" element={<AuthenticatedApp />} />
       </Routes>
     </>

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -95,6 +95,8 @@ import {
 import { AWS_REGIONS } from "./awsRegions.ts";
 import { Dropdown, type DropdownOption } from "./design/Dropdown.tsx";
 import { Btn, Chip, FieldLabel, Input, Label, Tile } from "./design/ui";
+import { InfoIcon } from "./onboarding/icons.tsx";
+import { VERCEL_PLAN_REQUIREMENT } from "./onboarding/vercelConnectModel.ts";
 import { AgentMemoriesCard } from "./settings/AgentMemoriesCard.tsx";
 import { BillingCard } from "./settings/BillingCard.tsx";
 import { CreateOrgCard } from "./settings/CreateOrgCard.tsx";
@@ -1249,6 +1251,12 @@ function VercelCard({ projectId }: { projectId: string | undefined }) {
           Install the Superlog integration on your Vercel team and we'll set up trace and log drains
           that stream your deployments' telemetry into this project automatically.
         </p>
+        <div className="flex items-center gap-2 text-[12.5px]">
+          <span className="text-[#8C98F0]">
+            <InfoIcon size={13} />
+          </span>
+          <span className="text-fg">{VERCEL_PLAN_REQUIREMENT}</span>
+        </div>
         <div>
           {installed && install.data?.installed ? (
             <Chip tone="success" dot>

--- a/apps/web/src/VercelCallback.tsx
+++ b/apps/web/src/VercelCallback.tsx
@@ -1,0 +1,70 @@
+// Landing page for the Vercel OAuth callback redirect (`/connect/vercel`).
+// The install opens in a new tab, so this is often the only surface the user
+// sees after approving (or failing) the install — it must state the result
+// explicitly rather than relying on the onboarding wizard being mounted.
+
+import { Btn, Wordmark } from "./design/ui.tsx";
+import { CheckIcon } from "./onboarding/icons.tsx";
+import { vercelCallbackView } from "./vercelCallbackModel.ts";
+
+const SOFT_LINE = "border-[rgba(255,255,255,0.07)]";
+
+export function VercelCallback() {
+  const params = new URLSearchParams(window.location.search);
+  const view = vercelCallbackView(params.get("vercel"));
+
+  return (
+    <div className="min-h-screen bg-bg font-sans text-fg">
+      <header className="px-8 py-5">
+        <Wordmark size="md" />
+      </header>
+
+      <main className="flex justify-center px-8 pb-16 pt-12">
+        <div className="w-full max-w-[560px]">
+          <div className="mb-7 px-1">
+            <h1 className="m-0 text-[22px] font-semibold leading-[1.2] tracking-[-0.015em] text-fg">
+              {view.title}
+            </h1>
+          </div>
+
+          {view.tone === "success" ? (
+            <div className="flex items-start gap-2.5 rounded-[10px] border border-[rgba(65,209,149,0.35)] bg-[rgba(65,209,149,0.06)] px-4 py-3">
+              <span className="mt-[2px] text-success">
+                <CheckIcon size={14} />
+              </span>
+              <p className="m-0 flex-1 text-[13px] leading-[1.55] text-fg">{view.body}</p>
+            </div>
+          ) : (
+            <div className="flex items-start gap-2.5 rounded-[10px] border border-[rgba(240,98,98,0.35)] bg-[rgba(240,98,98,0.06)] px-4 py-3">
+              <span className="mt-[2px] text-danger" aria-hidden>
+                <ErrorIcon size={14} />
+              </span>
+              <p className="m-0 flex-1 text-[13px] leading-[1.55] text-fg">{view.body}</p>
+            </div>
+          )}
+
+          <div className={`mt-9 flex items-center justify-end border-t pt-5 ${SOFT_LINE}`}>
+            <Btn
+              variant="primary"
+              size="md"
+              onClick={() => window.location.assign(view.backHref)}
+              className="!h-[36px] !rounded-[8px] !px-[14px] !text-[13px]"
+            >
+              {view.backLabel}
+            </Btn>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function ErrorIcon({ size }: { size: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none">
+      <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M8 5v3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <circle cx="8" cy="11" r="0.9" fill="currentColor" />
+    </svg>
+  );
+}

--- a/apps/web/src/onboarding/VercelConnectFlow.tsx
+++ b/apps/web/src/onboarding/VercelConnectFlow.tsx
@@ -2,8 +2,9 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useStartVercelInstall, useVercelInstallation } from "../api.ts";
 import { Btn } from "../design/ui.tsx";
-import { CheckIcon, ExternalLinkIcon, SpinnerIcon } from "./icons.tsx";
+import { CheckIcon, ExternalLinkIcon, InfoIcon, SpinnerIcon } from "./icons.tsx";
 import {
+  VERCEL_PLAN_REQUIREMENT,
   type VercelPhase,
   canContinueVercel,
   parseVercelOutcome,
@@ -167,8 +168,15 @@ function StartPanel({
         <p className="m-0 text-[13px] leading-[1.55] text-muted">
           We never ask for an API token. Vercel's OAuth grants a scoped, revocable token that we use
           only to create and manage the drains — you can disconnect any time from settings.
-          Drains require a Vercel Pro or Enterprise plan.
         </p>
+      </div>
+      <div
+        className={`flex items-center gap-2.5 border-b px-[22px] py-[12px] ${SOFT_LINE} bg-[rgba(255,255,255,0.02)]`}
+      >
+        <span className="text-[#8C98F0]">
+          <InfoIcon size={13} />
+        </span>
+        <p className="m-0 text-[12.5px] leading-[1.5] text-fg">{VERCEL_PLAN_REQUIREMENT}</p>
       </div>
       <div className="flex items-center justify-between gap-3 px-[22px] py-[16px]">
         <span className="text-[12.5px] text-muted">

--- a/apps/web/src/onboarding/icons.tsx
+++ b/apps/web/src/onboarding/icons.tsx
@@ -177,6 +177,26 @@ export function CheckIcon({ size = 14, className }: IconProps) {
   );
 }
 
+export function InfoIcon({ size = 14, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="7" cy="7" r="5.6" />
+      <path d="M7 6.4v3" />
+      <circle cx="7" cy="4.4" r="0.2" fill="currentColor" />
+    </svg>
+  );
+}
+
 export function ChevronRightIcon({ size = 16, className }: IconProps) {
   return (
     <svg

--- a/apps/web/src/onboarding/vercelConnectModel.test.ts
+++ b/apps/web/src/onboarding/vercelConnectModel.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import {
+  VERCEL_PLAN_REQUIREMENT,
   type VercelPhase,
   canContinueVercel,
   parseVercelOutcome,
@@ -52,4 +54,19 @@ test("only failure outcomes produce a user-facing message", () => {
   assert.match(vercelOutcomeMessage("drains_unavailable") ?? "", /Pro or Enterprise/);
   assert.equal(vercelOutcomeMessage("installed"), null);
   assert.equal(vercelOutcomeMessage(null), null);
+});
+
+test("the plan requirement names the eligible tiers and the gated one", () => {
+  assert.match(VERCEL_PLAN_REQUIREMENT, /Pro or Enterprise/);
+  assert.match(VERCEL_PLAN_REQUIREMENT, /Hobby/);
+});
+
+test("both pre-connect surfaces render the shared plan-requirement copy", async () => {
+  // Onboarding wizard start panel and the settings Vercel card must both show
+  // the plan gate BEFORE the user launches the install — a Hobby-team user
+  // otherwise only learns about it after a failed OAuth round-trip.
+  const flow = await readFile(new URL("./VercelConnectFlow.tsx", import.meta.url), "utf8");
+  const settings = await readFile(new URL("../Settings.tsx", import.meta.url), "utf8");
+  assert.match(flow, /VERCEL_PLAN_REQUIREMENT/);
+  assert.match(settings, /VERCEL_PLAN_REQUIREMENT/);
 });

--- a/apps/web/src/onboarding/vercelConnectModel.ts
+++ b/apps/web/src/onboarding/vercelConnectModel.ts
@@ -11,6 +11,13 @@
 
 export type VercelPhase = "start" | "connecting" | "connected";
 
+// Shown on every pre-connect surface (onboarding start panel, settings card)
+// so a Hobby-team user learns about the gate before the OAuth round-trip, not
+// from the drains_unavailable failure after it. Vercel only offers Drains —
+// the mechanism the integration streams telemetry through — on paid teams.
+export const VERCEL_PLAN_REQUIREMENT =
+  "Requires a Vercel Pro or Enterprise team — Vercel doesn't offer Drains on the Hobby (free) plan.";
+
 /**
  * Resolve the flow phase:
  *  - `installed`  → the OAuth round-trip finished and drains were created.

--- a/apps/web/src/onboarding/vercelConnectModel.ts
+++ b/apps/web/src/onboarding/vercelConnectModel.ts
@@ -29,9 +29,10 @@ export function canContinueVercel(phase: VercelPhase): boolean {
   return phase === "connected";
 }
 
-// The OAuth callback redirects back with `?vercel=installed|denied|error|...`.
-// `installed` is handled by the install poll flipping to "connected"; failure
-// outcomes reset out of the waiting state rather than spin forever.
+// The OAuth callback lands on the /connect/vercel result page, whose
+// "Back to Superlog" link carries `?vercel=installed|denied|error|...` back to
+// `/`. `installed` is handled by the install poll flipping to "connected";
+// failure outcomes reset out of the waiting state rather than spin forever.
 export type VercelOutcome = "installed" | "denied" | "error" | "drains_unavailable" | null;
 
 export function parseVercelOutcome(value: string | null | undefined): VercelOutcome {

--- a/apps/web/src/vercelCallbackModel.test.ts
+++ b/apps/web/src/vercelCallbackModel.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { vercelCallbackView } from "./vercelCallbackModel.ts";
+
+test("installed renders a success view that links home", () => {
+  const view = vercelCallbackView("installed");
+  assert.equal(view.tone, "success");
+  assert.match(view.title, /connected/i);
+  assert.equal(view.backHref, "/");
+});
+
+test("drains_unavailable spells out the Pro/Enterprise plan requirement", () => {
+  const view = vercelCallbackView("drains_unavailable");
+  assert.equal(view.tone, "error");
+  assert.match(view.title, /drains aren't available/i);
+  assert.match(view.body, /Pro or Enterprise/);
+  assert.match(view.body, /Hobby|free/i);
+  // Failure back-links carry the outcome so the onboarding wizard (which reads
+  // `?vercel=` on `/`) resets out of its waiting state when the user returns.
+  assert.equal(view.backHref, "/?vercel=drains_unavailable");
+});
+
+test("denied and error render explicit retry guidance", () => {
+  for (const outcome of ["denied", "error"] as const) {
+    const view = vercelCallbackView(outcome);
+    assert.equal(view.tone, "error");
+    assert.match(view.body, /try again|reconnect/i);
+    assert.equal(view.backHref, `/?vercel=${outcome}`);
+  }
+});
+
+test("unknown or missing outcomes fall back to a neutral error view", () => {
+  for (const raw of [null, "", "bogus"]) {
+    const view = vercelCallbackView(raw);
+    assert.equal(view.tone, "error");
+    assert.equal(view.backHref, "/");
+  }
+});
+
+test("the /connect/vercel route is registered as a public route", async () => {
+  const appSource = await readFile(new URL("./App.tsx", import.meta.url), "utf8");
+  assert.match(appSource, /<Route path="\/connect\/vercel" element=\{<VercelCallback \/>\} \/>/);
+});

--- a/apps/web/src/vercelCallbackModel.ts
+++ b/apps/web/src/vercelCallbackModel.ts
@@ -1,0 +1,69 @@
+// Pure content model for the /connect/vercel result page — the landing target
+// of the Vercel OAuth callback redirect. Split from the `.tsx` so the copy per
+// outcome is unit-testable (mirrors vercelConnectModel.ts).
+//
+// Why a dedicated page: the install screen opens in a new tab, so the callback
+// redirect lands there — not in the tab running the onboarding wizard. The old
+// `/?vercel=…` redirect rendered whatever `/` shows (usually the dashboard) and
+// the outcome was invisible. This page states the result explicitly.
+
+import { type VercelOutcome, parseVercelOutcome } from "./onboarding/vercelConnectModel.ts";
+
+export type VercelCallbackView = {
+  tone: "success" | "error";
+  title: string;
+  body: string;
+  /**
+   * Where "Back to Superlog" goes. Failures carry the outcome back to `/` so
+   * the onboarding wizard (which reads `?vercel=` there) resets out of its
+   * waiting state when the install happened in the same tab.
+   */
+  backHref: string;
+  backLabel: string;
+};
+
+export function vercelCallbackView(raw: string | null | undefined): VercelCallbackView {
+  const outcome: VercelOutcome = parseVercelOutcome(raw ?? null);
+  switch (outcome) {
+    case "installed":
+      return {
+        tone: "success",
+        title: "Vercel connected",
+        body: "The trace and log drains are set up. Telemetry will appear in Superlog as your deployments serve traffic — you can close this tab.",
+        backHref: "/",
+        backLabel: "Open Superlog",
+      };
+    case "drains_unavailable":
+      return {
+        tone: "error",
+        title: "Vercel Drains aren't available on your plan",
+        body: "Your Vercel team is on the Hobby (free) plan, and Vercel only offers Drains — the mechanism we use to stream your telemetry — on Pro or Enterprise teams. Nothing was connected. To finish, upgrade the team in Vercel or reinstall on a Pro or Enterprise team, then connect again.",
+        backHref: "/?vercel=drains_unavailable",
+        backLabel: "Back to Superlog",
+      };
+    case "denied":
+      return {
+        tone: "error",
+        title: "Vercel authorization was declined",
+        body: "The install was cancelled on Vercel's side, so nothing was connected. You can try again from Superlog whenever you're ready.",
+        backHref: "/?vercel=denied",
+        backLabel: "Back to Superlog",
+      };
+    case "error":
+      return {
+        tone: "error",
+        title: "We couldn't finish connecting Vercel",
+        body: "Something went wrong completing the install, and nothing was connected. Go back to Superlog and try again — if it keeps failing, contact us.",
+        backHref: "/?vercel=error",
+        backLabel: "Back to Superlog",
+      };
+    default:
+      return {
+        tone: "error",
+        title: "No connection result found",
+        body: "This page shows the result of a Vercel install, but the link is missing its outcome. Head back to Superlog and check the integration's status in settings.",
+        backHref: "/",
+        backLabel: "Back to Superlog",
+      };
+  }
+}


### PR DESCRIPTION
## Problem

The Vercel install screen opens in a new tab, so the OAuth callback redirect lands in that tab — not in the tab running the onboarding wizard. The callback redirected to `/?vercel=<outcome>`, and the only consumer of that query param is the onboarding wizard component. For any user past onboarding, the new tab just rendered the dashboard and the outcome was silently dropped.

The worst case is `drains_unavailable`: Vercel only offers Drains on Pro/Enterprise teams, so a Hobby-team install fails after the OAuth approval succeeds — and the user saw nothing at all. From their side the connect flow just went quiet.

## Fix

Redirect every callback outcome to a dedicated public `/connect/vercel` result page that states what happened explicitly:

- `installed` → success ("drains are set up, you can close this tab")
- `drains_unavailable` → explains the Hobby-plan gate, that nothing was connected, and how to proceed (upgrade the team or reinstall on a Pro/Enterprise team)
- `denied` / `error` → explicit retry guidance
- missing/unknown outcome → neutral fallback pointing at settings

Failure back-links carry `?vercel=<outcome>` back to `/`, so the onboarding wizard still resets out of its waiting state when the install happened in the same tab (popup-blocked fallback).

## Implementation

- `apps/api/src/vercel-service.ts`: new pure `connectResultPath(outcome)` helper; all six callback redirects in `vercel.ts` route through it.
- `apps/web/src/vercelCallbackModel.ts`: pure content model (unit-tested) for the page copy per outcome, reusing `parseVercelOutcome` from the onboarding model.
- `apps/web/src/VercelCallback.tsx`: the page, registered as a public route so the result shows even in a fresh, gated, or logged-out tab.
- Tests: model tests for every outcome + a source-level test asserting the callback never redirects to bare `/` again.

## Testing

- `tsx --test` on `vercel-service.test.ts` (19 pass) and `vercelCallbackModel.test.ts` (5 pass); `tsc --noEmit` clean on web + api.
- Verified in a real browser (headless Chromium) that all four outcomes render the correct title/body on `/connect/vercel`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect the Vercel OAuth callback to a dedicated public result page at `/connect/vercel`, with clear outcomes and guidance. Also surface the Pro/Enterprise plan requirement before users start connecting to avoid silent failures on Hobby teams.

- **New Features**
  - Added `VercelCallback` page and public route `/connect/vercel` with outcome-specific copy for `installed`, `drains_unavailable`, `denied`, `error`, and unknown.
  - All OAuth callbacks now use `connectResultPath(outcome)` to land on the result page; failure links pass `?vercel=<outcome>` back to `/` so the onboarding wizard exits its waiting state.
  - Show the plan gate upfront: shared `VERCEL_PLAN_REQUIREMENT` copy on the onboarding start panel and the Settings Vercel card.
  - Tests cover outcome routing, that callbacks never redirect to bare `/`, the route is public, and the plan requirement’s wording appears in both surfaces.

<sup>Written for commit 41747a5972fc29d06539d72ab3f7484885fa48d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

