### PR TITLE
Avoid AWS connect resource name collisions

### DIFF
--- a/apps/api/src/cloud-connections-service.test.ts
+++ b/apps/api/src/cloud-connections-service.test.ts
@@ -90,6 +90,7 @@ test("buildMetricsStreamLaunchUrl carries intake URL, ingest key, and connection
   assert.equal(frag.get("param_IntakeUrl"), "https://intake.example.com/aws/firehose/metrics");
   assert.equal(frag.get("param_IngestKey"), "sl_public_abc123");
   assert.equal(frag.get("param_ConnectionId"), "conn-7");
+  assert.equal(frag.get("param_ResourcePrefix"), "superlog-metrics-conn7");
 });
 
 test("buildLogsStreamLaunchUrl targets the logs stack with the same params", () => {
@@ -106,6 +107,7 @@ test("buildLogsStreamLaunchUrl targets the logs stack with the same params", () 
   assert.equal(frag.get("param_IntakeUrl"), "https://intake.example.com/aws/firehose/logs");
   assert.equal(frag.get("param_IngestKey"), "sl_public_xyz");
   assert.equal(frag.get("param_ConnectionId"), "conn-9");
+  assert.equal(frag.get("param_ResourcePrefix"), "superlog-logs-conn9");
 });
 
 test("buildCombinedConnectLaunchUrl carries scrape + both streams in one stack", () => {
@@ -131,6 +133,7 @@ test("buildCombinedConnectLaunchUrl carries scrape + both streams in one stack",
   assert.equal(frag.get("param_SuperlogAccountId"), "123456789012");
   assert.equal(frag.get("param_ExternalId"), "ext-abc");
   assert.equal(frag.get("param_ConnectionId"), "conn-1");
+  assert.equal(frag.get("param_RoleName"), "SuperlogScrapeRole-conn1");
   assert.equal(
     frag.get("param_SuperlogCallbackUrl"),
     "https://api.example.com/api/cloud-connections/callback",
@@ -145,6 +148,8 @@ test("buildCombinedConnectLaunchUrl carries scrape + both streams in one stack",
   assert.equal(frag.get("param_LogsIntakeUrl"), "https://intake.example.com/aws/firehose/logs");
   assert.equal(frag.get("param_MetricsIngestKey"), "sl_public_metrics");
   assert.equal(frag.get("param_LogsIngestKey"), "sl_public_logs");
+  assert.equal(frag.get("param_MetricsResourcePrefix"), "superlog-metrics-conn1");
+  assert.equal(frag.get("param_LogsResourcePrefix"), "superlog-logs-conn1");
 });
 
 test("buildCombinedConnectLaunchUrl can disable a stream and pass a log filter", () => {

--- a/apps/api/src/cloud-connections-service.ts
+++ b/apps/api/src/cloud-connections-service.ts
@@ -10,6 +10,19 @@ export function generateExternalId(): string {
   return randomBytes(32).toString("base64url");
 }
 
+function connectionResourceSuffix(connectionId: string): string {
+  const compact = connectionId.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return (compact || "default").slice(0, 7);
+}
+
+function streamResourcePrefix(kind: "metrics" | "logs", connectionId: string): string {
+  return `superlog-${kind}-${connectionResourceSuffix(connectionId)}`;
+}
+
+export function awsConnectScrapeRoleName(connectionId: string): string {
+  return `SuperlogScrapeRole-${connectionResourceSuffix(connectionId)}`;
+}
+
 export type QuickCreateUrlInput = {
   /** Region the stack is created in. Metric streams / Firehose are regional. */
   region: string;
@@ -80,6 +93,10 @@ function buildStreamLaunchUrl(stackName: string, input: StreamLaunchInput): stri
       IntakeUrl: input.intakeUrl,
       IngestKey: input.ingestKey,
       ConnectionId: input.connectionId,
+      ResourcePrefix: streamResourcePrefix(
+        stackName === "superlog-metrics-stream" ? "metrics" : "logs",
+        input.connectionId,
+      ),
     },
   });
 }
@@ -137,8 +154,11 @@ export function buildCombinedConnectLaunchUrl(input: CombinedConnectLaunchInput)
     SuperlogAccountId: input.superlogAccountId,
     ExternalId: input.externalId,
     ConnectionId: input.connectionId,
+    RoleName: awsConnectScrapeRoleName(input.connectionId),
     EnableMetrics: (input.enableMetrics ?? true) ? "true" : "false",
     EnableLogs: (input.enableLogs ?? true) ? "true" : "false",
+    MetricsResourcePrefix: streamResourcePrefix("metrics", input.connectionId),
+    LogsResourcePrefix: streamResourcePrefix("logs", input.connectionId),
     MetricsIntakeUrl: input.metricsIntakeUrl,
     LogsIntakeUrl: input.logsIntakeUrl,
     MetricsIngestKey: input.metricsIngestKey,

--- a/apps/api/src/cloud-connections.ts
+++ b/apps/api/src/cloud-connections.ts
@@ -12,6 +12,7 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 import {
   type StsVerifier,
+  awsConnectScrapeRoleName,
   buildCombinedConnectLaunchUrl,
   buildConnectQuickCreateUrl,
   buildLogsStreamLaunchUrl,
@@ -385,6 +386,7 @@ export function mountCloudConnectionsAuthed(
         ExternalId: externalId,
         SuperlogAccountId: config.superlogAccountId,
         ConnectionId: row.id,
+        RoleName: awsConnectScrapeRoleName(row.id),
       };
       // When we have a callback URL, pass it so the template's in-stack Lambda
       // reports the role ARN back automatically (zero-paste). Otherwise the

--- a/infra/aws-connect/superlog-connect-stack.cfn.yaml
+++ b/infra/aws-connect/superlog-connect-stack.cfn.yaml
@@ -83,6 +83,16 @@ Parameters:
       CloudWatch Logs filter pattern. Empty forwards everything; narrow it (e.g.
       ?ERROR ?WARN) to cut log volume and cost. Embedded safely via Fn::ToJsonString.
     Default: ""
+  MetricsResourcePrefix:
+    Type: String
+    Description: Name prefix for metric-stream resources. Supplied by Superlog to avoid name collisions across connections.
+    Default: superlog-metrics
+    AllowedPattern: "^[a-z0-9][a-z0-9-]{2,24}$"
+  LogsResourcePrefix:
+    Type: String
+    Description: Name prefix for log-stream resources. Supplied by Superlog to avoid name collisions across connections.
+    Default: superlog-logs
+    AllowedPattern: "^[a-z0-9][a-z0-9-]{2,24}$"
 
 Conditions:
   # Auto-report only when both the callback URL and a connection id are supplied.
@@ -364,7 +374,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Condition: CreateMetrics
     Properties:
-      LogGroupName: "/aws/kinesisfirehose/superlog-metrics"
+      LogGroupName: !Sub "/aws/kinesisfirehose/${MetricsResourcePrefix}"
       RetentionInDays: 7
 
   MetricsFirehoseLogStream:
@@ -407,13 +417,13 @@ Resources:
                 Action: "logs:PutLogEvents"
                 # PutLogEvents authorizes against the log *stream* ARN, not the
                 # log-group ARN, so scope to the group's streams explicitly.
-                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/kinesisfirehose/superlog-metrics:log-stream:*"
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/kinesisfirehose/${MetricsResourcePrefix}:log-stream:*"
 
   MetricsDeliveryStream:
     Type: AWS::KinesisFirehose::DeliveryStream
     Condition: CreateMetrics
     Properties:
-      DeliveryStreamName: "superlog-metrics-stream"
+      DeliveryStreamName: !Sub "${MetricsResourcePrefix}-stream"
       DeliveryStreamType: DirectPut
       HttpEndpointDestinationConfiguration:
         EndpointConfiguration:
@@ -467,7 +477,7 @@ Resources:
     Type: AWS::CloudWatch::MetricStream
     Condition: CreateMetrics
     Properties:
-      Name: "superlog-metrics-stream"
+      Name: !Sub "${MetricsResourcePrefix}-stream"
       FirehoseArn: !GetAtt MetricsDeliveryStream.Arn
       RoleArn: !GetAtt MetricStreamRole.Arn
       OutputFormat: opentelemetry1.0
@@ -523,7 +533,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Condition: CreateLogs
     Properties:
-      LogGroupName: "/aws/kinesisfirehose/superlog-logs"
+      LogGroupName: !Sub "/aws/kinesisfirehose/${LogsResourcePrefix}"
       RetentionInDays: 7
 
   LogsFirehoseLogStream:
@@ -566,13 +576,13 @@ Resources:
                 Action: "logs:PutLogEvents"
                 # PutLogEvents authorizes against the log *stream* ARN, not the
                 # log-group ARN, so scope to the group's streams explicitly.
-                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/kinesisfirehose/superlog-logs:log-stream:*"
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/kinesisfirehose/${LogsResourcePrefix}:log-stream:*"
 
   LogsDeliveryStream:
     Type: AWS::KinesisFirehose::DeliveryStream
     Condition: CreateLogs
     Properties:
-      DeliveryStreamName: "superlog-logs-stream"
+      DeliveryStreamName: !Sub "${LogsResourcePrefix}-stream"
       DeliveryStreamType: DirectPut
       HttpEndpointDestinationConfiguration:
         EndpointConfiguration:
@@ -637,10 +647,10 @@ Resources:
     Type: AWS::Logs::AccountPolicy
     Condition: CreateLogs
     Properties:
-      PolicyName: "superlog-logs-subscription"
+      PolicyName: !Sub "${LogsResourcePrefix}-subscription"
       PolicyType: SUBSCRIPTION_FILTER_POLICY
       Scope: ALL
-      SelectionCriteria: 'LogGroupName NOT IN ["/aws/kinesisfirehose/superlog-logs"]'
+      SelectionCriteria: !Sub 'LogGroupName NOT IN ["/aws/kinesisfirehose/${LogsResourcePrefix}"]'
       PolicyDocument:
         Fn::ToJsonString:
           DestinationArn: !GetAtt LogsDeliveryStream.Arn


### PR DESCRIPTION
## Summary

- derive per-connection AWS resource names for connect stack launches
- pass those names as CloudFormation parameters for role, metric stream, log stream, Firehose, and account-policy resources
- update the combined AWS connect template to use the supplied prefixes instead of fixed physical names

## Why

The combined AWS connect stack used fixed physical names such as `superlog-metrics-stream`, `superlog-logs-stream`, and `/aws/kinesisfirehose/superlog-*`. A relaunch or second connection attempt in the same AWS account/region can fail CloudFormation validation with name conflicts before the stack creates anything.

The launch URL already carries a unique connection id, so this uses a short deterministic suffix from that id to keep resource names stable for a connection while avoiding collisions across attempts.

## Validation

- `pnpm --dir superlog --filter @superlog/api exec tsx --test src/cloud-connections-service.test.ts`
- `pnpm --dir superlog --filter @superlog/api typecheck`
- `pnpm --dir superlog exec biome check apps/api/src/cloud-connections.ts apps/api/src/cloud-connections-service.ts apps/api/src/cloud-connections-service.test.ts infra/aws-connect/superlog-connect-stack.cfn.yaml`
- `aws cloudformation validate-template` on the AWS connect templates earlier in the workspace


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate per-connection AWS Connect resource names to prevent CloudFormation name collisions on relaunch. Names are stable per connection and allow multiple launches in the same account/region.

- **Bug Fixes**
  - Derive a short deterministic suffix from the connection id and build per-connection prefixes (`superlog-metrics-<suffix>`, `superlog-logs-<suffix>`) and role name (`SuperlogScrapeRole-<suffix>`).
  - Pass prefixes in launch URLs: `ResourcePrefix` for single-stream stacks; `MetricsResourcePrefix`, `LogsResourcePrefix`, and `RoleName` for the combined stack.
  - Update `infra/aws-connect/superlog-connect-stack.cfn.yaml` to use supplied prefixes for DeliveryStream, MetricStream, LogGroup, and AccountPolicy names and related ARNs.

<sup>Written for commit 2dff05b23b817b5d260c10398dd1ecb2b9512bae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

