### PR TITLE
Add web design guidelines and product spec

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -1,0 +1,34 @@
+# Design guidelines
+
+House rules for the web UI. These are conventions every component and mockup
+should follow.
+
+## Typography
+
+### NEVER USE MONOSPACE CAPS
+
+Do **not** combine a monospace font with uppercased text. No
+`font-mono` + `uppercase`, no all-caps labels, eyebrows, table headers, badges,
+or section titles set in a monospace typeface — anywhere, in product UI or in
+design mockups.
+
+- **Why:** monospace caps read as cramped, dated, and "terminal-cosplay"; the
+  even glyph widths plus capital letterforms kill the hierarchy that small
+  labels are supposed to provide.
+- **Instead:** use the sans (Inter) for labels. If you need a quiet,
+  small label, reach for size, weight, color (`text-muted` / `text-subtle`),
+  and light letter-spacing — not monospace and not all-caps.
+- **Monospace is still fine** for genuinely monospaced content: code, log lines,
+  JSON, IDs, keys, numeric/tabular values. Just keep it in its natural case.
+- **All-caps is still fine** in the sans, used sparingly, for very small labels.
+
+```
+/* ✗ banned */
+<span class="font-mono uppercase tracking-[0.2em]">Telemetry sources</span>
+
+/* ✓ ok — sans label */
+<span class="text-[12px] font-medium text-muted">Telemetry sources</span>
+
+/* ✓ ok — monospace in its natural case (code / values) */
+<code class="font-mono">sl_public_…</code>
+```

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -35,7 +35,9 @@ An **Incident** starts a new **Agent Run**. During an **Agent Run** an LLM will 
 
 ## Issue grouping
 
-TBD
+Issue fingerprinting is, unfortunately, never exhaustive. We must be resilient to duplicate noisy issues. That is why, whenever a new Issue starts a new Incident, we must first compare the Issue to all currently open Incidents. 
+
+If the Issue is not a separate problem, but another manifestation of a root cause of another Incident, we should add this Issue to the Issues of that Incident. 
 
 
 ## Issue is Noise 
@@ -109,10 +111,10 @@ Humans and agents can add notes on various Superlog entities in order to:
 There are two ways to store memory in Superlog: comments and project memory
 
 ## Comments
-1. 
-
+Issues and Incidents have associated Comments. Humans and Agents can add Comments that are visible to the Agent Run investigating the Incident.
 
 ## Project memory
+Every Project has a list of Memories that can be added by humans and Agents. A Memory is a dated free-form text. All Project memories are are visible to the Agent Run investigating the Incident. Agents can add new Memories during investigations and in response to PR comments, Slack messages and other interactions with users.
 
 ### Approval propmt
 
@@ -122,10 +124,6 @@ An Approval prompt is a way for our agent to perform an agent in the client's in
 
 Once per week, Superlog must send to the connected Slack channel an update containing a global review of all issues, including the number of issues counted as noise. 
 
-
-# TBD
-- Incident auto-close?
-- PR close -> issue reoccurs -> 
 
 # Changelog
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -1,0 +1,132 @@
+# Superlog Spec
+
+In this document, we'll maintain a description of what Superlog needs to do.
+
+
+# Issue
+
+Whenever a client sends us a new error trace or error log, we'll fingerprint them into **Issues**.
+
+Repeated ocurrences of the same error log or trace count as one **Issue**.
+
+## Issue states
+
+When an **Issue** is created, it starts as `open`. An `open` **Issue** should trigger an **Incident**. 
+
+- An **Issue** can be `silenced`, in which case any new ocurrences will not start new **Incidents**.
+- An **Issue** can be `under observation`. An **Issue** in `under observation` must have an `escalation trigger`.
+    - If an `escalation trigger` fires, the **Issue** becomes `open` again and triggers a new **Incident**.
+    - An `escalation trigger` can be:
+        - a rate of errors (errors per minute)
+        - an absolute count of events
+- An **Issue** can be `resolved`. New occurences of the same error will trigger an **Incident**. 
+
+
+# Incident 
+
+On any new `open` **Issue**, or on new ocurrences of a `resolved` **Issue**, Superlog opens a new **Incident**.
+
+An **Incident** starts a new **Agent Run**. During an **Agent Run** an LLM will examine the error, all relevant telemetry, code and infrastructure in order to understand the issue and resolve it. 
+
+## Incident states
+
+- `open`
+- `resolved`
+
+## Issue grouping
+
+TBD
+
+
+## Issue is Noise 
+The LLM agent can determine that an issue is 'noise'. 
+
+An issue counts as 'noise' if the system is behaving normally, no users are impacted, or users are not impacted in a meaningful way.
+
+For example, if a user is trying to access a page of a landing website that does not exist, and the system logs an error log, it is noise rather than a real issue.
+
+
+### Noise states
+
+### Intended behaviour / no impact
+
+If the issue indicates intended behaviour and there is no impact on users whatsoever, the agent must set the issue to `silenced`. The incident is then `resolved`. 
+
+### 'One-off' errors: Observation
+
+If the issue indicates a one-off non-critical event, the agent must set the issue to `under observation` and specify an `escalation trigger` after which we'll need to re-evaluate this issue.
+
+For example, if a user was soft-deleted by manual admin action and residual non-authorized calls of that user remain in logs, the user is slightly impacted, but the system is still behaving as intended. Superlog must place the issue under observation. If, subsequently, actions of all users are rejected as unauthorized due to a database error, the `escalation trigger` will cause Superlog to investigate that ocurrence separately. 
+
+
+### Counterexample: silencing errors in code
+
+Often, codebases contain many false-positive errors: error logs on 404s, unauthorized requests after JWT expiration. If Superlog starts to open pull requests to move all these logs to WARN, catch them or stop logging them, teams will quickly be overwhelmed. We must instead silence these errors.
+
+## Issue is Not Noise
+
+If the issue is not noise, that is to say:
+
+- end users are impacted in any way
+- performance is significantly degraded
+- a system that used to be running is inoperative without reason
+- internal users are impacted in a meaningful way
+
+the Superlog agent must attempt to resolve the issue. The resolution is a multi-step process that can involve the following actions:
+
+- Modifying the source code of the observed system and opening Pull Requests 
+    - Responding to comments on these PRs to adjust them
+    - Waiting for PRs to be merged
+    - Merging these PRs if instructed to by the Client (e.g. by a button on the PR messsage on Slack)
+    - Opening subsequent PRs
+- Opening Approval prompts 
+
+### Non-noise Incident states 
+
+An Incident can be `open` (during the execution of the Agent Run).
+
+#### Resolution by the agent
+
+Once the agent has performed all the actions necessary to mitigate the issue at hand, it can set the incident as `resolved`. For example, when the user merges the PR that the agent has proposed, and it was the only action necessary to resolve the issue, the agent should `resolve` the incident.
+
+If another PR or action is necessary, the agent should perform these actions and not close the PR.
+
+If the client closes the PR and it is obvious from the context that the issue is actually noise, the agent should `resolve` the Incident and `silence` the related issues or put them `under observation`.
+
+#### Resolution by a human
+
+The users of Superlog can also resolve Incidents by clicking the corresponding button.
+If the interface allows so, we should provide two buttons:
+- **Problem resolved** -> Incident goes to 'resolved', issues go to 'resolved'
+- **Not an issue** -> Incident goes to 'resolved', issues go to 'silenced'
+
+# Memory 
+
+Humans and agents can add notes on various Superlog entities in order to:
+- personalize Superlog for clients
+- improve investigation quality.
+
+There are two ways to store memory in Superlog: comments and project memory
+
+## Comments
+1. 
+
+
+## Project memory
+
+### Approval propmt
+
+An Approval prompt is a way for our agent to perform an agent in the client's infrastructure, databases and other systems with the user's approval. When Superlog has access to the customer's infrastructure, for example, their AWS account, Superlog must always send Approval Prompts before taking action. 
+
+# Weekly update
+
+Once per week, Superlog must send to the connected Slack channel an update containing a global review of all issues, including the number of issues counted as noise. 
+
+
+# TBD
+- Incident auto-close?
+- PR close -> issue reoccurs -> 
+
+# Changelog
+
+July 6, 2026 - initial commit

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -7,13 +7,13 @@ In this document, we'll maintain a description of what Superlog needs to do.
 
 Whenever a client sends us a new error trace or error log, we'll fingerprint them into **Issues**.
 
-Repeated ocurrences of the same error log or trace count as one **Issue**.
+Repeated occurrences of the same error log or trace count as one **Issue**.
 
 ## Issue states
 
 When an **Issue** is created, it starts as `open`. An `open` **Issue** should trigger an **Incident**. 
 
-- An **Issue** can be `silenced`, in which case any new ocurrences will not start new **Incidents**.
+- An **Issue** can be `silenced`, in which case any new occurrences will not start new **Incidents**.
 - An **Issue** can be `under observation`. An **Issue** in `under observation` must have an `escalation trigger`.
     - If an `escalation trigger` fires, the **Issue** becomes `open` again and triggers a new **Incident**.
     - An `escalation trigger` can be:
@@ -24,7 +24,7 @@ When an **Issue** is created, it starts as `open`. An `open` **Issue** should tr
 
 # Incident 
 
-On any new `open` **Issue**, or on new ocurrences of a `resolved` **Issue**, Superlog opens a new **Incident**.
+On any new `open` **Issue**, or on new occurrences of a `resolved` **Issue**, Superlog opens a new **Incident**.
 
 An **Incident** starts a new **Agent Run**. During an **Agent Run** an LLM will examine the error, all relevant telemetry, code and infrastructure in order to understand the issue and resolve it. 
 
@@ -79,7 +79,7 @@ the Superlog agent must attempt to resolve the issue. The resolution is a multi-
 - Modifying the source code of the observed system and opening Pull Requests 
     - Responding to comments on these PRs to adjust them
     - Waiting for PRs to be merged
-    - Merging these PRs if instructed to by the Client (e.g. by a button on the PR messsage on Slack)
+    - Merging these PRs if instructed to by the Client (e.g. by a button on the PR message on Slack)
     - Opening subsequent PRs
 - Opening Approval prompts 
 
@@ -114,11 +114,11 @@ There are two ways to store memory in Superlog: comments and project memory
 Issues and Incidents have associated Comments. Humans and Agents can add Comments that are visible to the Agent Run investigating the Incident.
 
 ## Project memory
-Every Project has a list of Memories that can be added by humans and Agents. A Memory is a dated free-form text. All Project memories are are visible to the Agent Run investigating the Incident. Agents can add new Memories during investigations and in response to PR comments, Slack messages and other interactions with users.
+Every Project has a list of Memories that can be added by humans and Agents. A Memory is a dated free-form text. All Project memories are visible to the Agent Run investigating the Incident. Agents can add new Memories during investigations and in response to PR comments, Slack messages and other interactions with users.
 
-### Approval propmt
+### Approval prompt
 
-An Approval prompt is a way for our agent to perform an agent in the client's infrastructure, databases and other systems with the user's approval. When Superlog has access to the customer's infrastructure, for example, their AWS account, Superlog must always send Approval Prompts before taking action. 
+An Approval prompt is a way for our agent to make changes in the client's infrastructure, databases and other systems with the user's approval. When Superlog has access to the customer's infrastructure, for example, their AWS account, Superlog must always send Approval Prompts before taking action. 
 
 # Weekly update
 


### PR DESCRIPTION
Adds two docs:

- `apps/web/DESIGN.md` — web UI typography conventions (no monospace caps; use the sans for small labels).
- `specs/SPEC.md` — product model for Issues, Incidents, Agent Runs, noise handling, memory, and weekly updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes web UI typography and expands the Superlog spec for incident grouping and noise handling.

- **New Features**
  - Added `apps/web/DESIGN.md` with typography rules: never use monospace caps; use Inter for small labels; keep monospace for code/values in natural case.
  - Added `specs/SPEC.md` covering: Issue/Incident lifecycles; grouping new Issues into open Incidents; noise handling (silence, observe with escalation triggers); Agent Runs and resolutions (agent or human); comments and project memory; approval prompts; weekly Slack updates. Fixed typos and wording.

<sup>Written for commit 9968a5a44e1ceb8640e73727e30ea9fe6a251ec2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

