### PR TITLE
feat(settings): add an "Install MCP" tab and flatten the settings nav

### DIFF
--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -92,6 +92,7 @@ import {
 import { AWS_REGIONS } from "./awsRegions.ts";
 import { Dropdown, type DropdownOption } from "./design/Dropdown.tsx";
 import { Btn, Chip, FieldLabel, Input, Label, Tile } from "./design/ui";
+import { McpInstallPanel } from "./onboarding/McpInstallDialog.tsx";
 import { AgentMemoriesCard } from "./settings/AgentMemoriesCard.tsx";
 import { BillingCard } from "./settings/BillingCard.tsx";
 import { CreateOrgCard } from "./settings/CreateOrgCard.tsx";
@@ -419,6 +420,14 @@ function SectionIcon({ scope, section }: { scope: SettingsScope; section: Sectio
           <path d="M12 18v4" />
         </svg>
       );
+    case "project:mcp-install":
+      return (
+        <svg {...props} aria-hidden="true">
+          <path d="M12 3v12" />
+          <path d="m8 11 4 4 4-4" />
+          <path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />
+        </svg>
+      );
     case "project:mcp-tokens":
       return (
         <svg {...props} aria-hidden="true">
@@ -655,6 +664,17 @@ function ProjectSectionView({
           subtitle="Project-scoped ingest keys for the OpenTelemetry exporter and CLI."
         >
           <ApiKeysCard projectId={projectId} />
+        </Section>
+      );
+    case "mcp-install":
+      return (
+        <Section
+          title="Install MCP server"
+          subtitle="Connect an MCP-aware agent to Superlog. Pick your agent below — the first connect runs a browser OAuth flow, no token required."
+        >
+          <Tile>
+            <McpInstallPanel />
+          </Tile>
         </Section>
       );
     case "mcp-tokens":

--- a/apps/web/src/onboarding/McpInstallDialog.tsx
+++ b/apps/web/src/onboarding/McpInstallDialog.tsx
@@ -32,6 +32,29 @@ codex mcp login superlog`,
   },
 ];
 
+/**
+ * The install instructions on their own — client tabs plus the follow-up
+ * notes. Rendered inline in Settings and inside {@link McpInstallDialog}.
+ */
+export function McpInstallPanel() {
+  return (
+    <div className="space-y-4">
+      <CodeTabs tabs={CLIENTS} />
+      <div className="space-y-1 text-[12px] text-subtle">
+        <p>
+          Using a different agent? Most MCP-aware tools accept the same{" "}
+          <code className="font-mono text-muted">https://api.superlog.sh/mcp</code> URL.
+        </p>
+        <p>
+          Prefer a static token over the OAuth flow? Generate a personal access token under{" "}
+          <span className="text-muted">Settings → Project → MCP tokens</span> and pass it as an{" "}
+          <code className="font-mono text-muted">Authorization: Bearer …</code> header.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 export function McpInstallDialog({ onClose }: { onClose: () => void }) {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -98,19 +121,7 @@ export function McpInstallDialog({ onClose }: { onClose: () => void }) {
         </div>
 
         <div className="px-[22px] py-[18px]">
-          <CodeTabs tabs={CLIENTS} />
-        </div>
-
-        <div className="space-y-1 border-t border-border px-[22px] py-3 text-[12px] text-subtle">
-          <p>
-            Using a different agent? Most MCP-aware tools accept the same{" "}
-            <code className="font-mono text-muted">https://api.superlog.sh/mcp</code> URL.
-          </p>
-          <p>
-            Prefer a static token over the OAuth flow? Generate a personal access token under{" "}
-            <span className="text-muted">Settings → Project → MCP tokens</span> and pass it as an{" "}
-            <code className="font-mono text-muted">Authorization: Bearer …</code> header.
-          </p>
+          <McpInstallPanel />
         </div>
       </div>
     </div>

--- a/apps/web/src/settings/nav.test.ts
+++ b/apps/web/src/settings/nav.test.ts
@@ -11,7 +11,7 @@ import {
   shouldShowProjectPicker,
 } from "./nav.ts";
 
-test("org nav groups: main group then More group, weekly digest folded into general", () => {
+test("org nav: single flat group, weekly digest folded into general", () => {
   const ids: string[] = ORG_NAV_GROUPS.flatMap((g) => g.items.map((i) => i.id));
   assert.deepEqual(ids, [
     "general",
@@ -21,12 +21,12 @@ test("org nav groups: main group then More group, weekly digest folded into gene
     "mgmt-keys",
     "github-install",
   ]);
+  assert.equal(ORG_NAV_GROUPS.length, 1);
   assert.equal(ORG_NAV_GROUPS[0]?.label, undefined);
-  assert.equal(ORG_NAV_GROUPS[1]?.label, "More");
   assert.ok(!ids.includes("weekly-digest"));
 });
 
-test("project nav groups: agent pages before integrations, keys/webhooks under More", () => {
+test("project nav: single flat group, Install MCP sits next to MCP tokens", () => {
   const ids = PROJECT_NAV_GROUPS.flatMap((g) => g.items.map((i) => i.id));
   assert.deepEqual(ids, [
     "general",
@@ -36,10 +36,12 @@ test("project nav groups: agent pages before integrations, keys/webhooks under M
     "issue-filter",
     "slack-channel",
     "api-keys",
+    "mcp-install",
     "mcp-tokens",
     "webhooks",
   ]);
-  assert.equal(PROJECT_NAV_GROUPS[1]?.label, "More");
+  assert.equal(PROJECT_NAV_GROUPS.length, 1);
+  assert.equal(PROJECT_NAV_GROUPS[0]?.label, undefined);
 });
 
 test("every org nav id resolves to itself", () => {

--- a/apps/web/src/settings/nav.ts
+++ b/apps/web/src/settings/nav.ts
@@ -25,6 +25,7 @@ export type ProjectSectionId =
   | "issue-filter"
   | "slack-channel"
   | "api-keys"
+  | "mcp-install"
   | "mcp-tokens"
   | "webhooks";
 
@@ -45,11 +46,6 @@ export const ORG_NAV_GROUPS: ReadonlyArray<NavGroup<OrgSectionId>> = [
       { id: "members", label: "Members" },
       { id: "billing", label: "Billing" },
       { id: "agent-guidance", label: "Agent guidance" },
-    ],
-  },
-  {
-    label: "More",
-    items: [
       { id: "mgmt-keys", label: "API keys" },
       { id: "github-install", label: "GitHub" },
     ],
@@ -65,12 +61,8 @@ export const PROJECT_NAV_GROUPS: ReadonlyArray<NavGroup<ProjectSectionId>> = [
       { id: "integrations", label: "Integrations" },
       { id: "issue-filter", label: "Issue filter" },
       { id: "slack-channel", label: "Slack channel" },
-    ],
-  },
-  {
-    label: "More",
-    items: [
       { id: "api-keys", label: "API keys" },
+      { id: "mcp-install", label: "Install MCP" },
       { id: "mcp-tokens", label: "MCP tokens" },
       { id: "webhooks", label: "Webhooks" },
     ],


### PR DESCRIPTION
## What

- Adds a dedicated **Install MCP** section to Project settings, sitting next to **MCP tokens**. It renders the MCP server install instructions (Claude Code / Codex / Cursor tabs, the connect command, and follow-up notes) inline in the page.
- Extracts the shared install content into an `McpInstallPanel` component, reused by both the new settings tab and the existing `McpInstallDialog` (the onboarding pill / setup-todos modal) so the two never drift.
- Flattens the settings sidebar into a single group, removing the **More** subheader in both the org and project scopes.

## Why

The install instructions previously only surfaced via a transient modal (onboarding pill / setup todos). Giving them a permanent home in settings means users can find "how do I connect my agent" any time, not just during onboarding.

## Testing

- `pnpm --filter @superlog/web typecheck`
- `node --test src/settings/nav.test.ts` (nav model updated + tests green)
- Manually verified in the browser: the **Install MCP** tab renders the panel inline with all three client tabs, and the sidebar shows one flat list with no "More" header.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a permanent Install MCP tab in Project settings with inline MCP server setup (Claude Code / Codex / Cursor). Also flattens the settings sidebar into a single group in both org and project, removing the “More” header.

- **New Features**
  - New “Install MCP” tab next to “MCP tokens” with client tabs, connect command, and notes; first connect uses OAuth.
  - Settings sidebar is now a single flat list (no “More”) for easier scanning.

- **Refactors**
  - Extracted shared `McpInstallPanel` reused by the settings tab and `McpInstallDialog` to keep install content in sync.

<sup>Written for commit 4a33b5a82ad48f04d08c96603176e37222264ac3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

