### PR TITLE
Clarify issue lifecycle wording in product spec

### DIFF
--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -15,11 +15,12 @@ When an **Issue** is created, it starts as `open`. An `open` **Issue** should tr
 
 - An **Issue** can be `silenced`, in which case any new occurrences will not start new **Incidents**.
 - An **Issue** can be `under observation`. An **Issue** in `under observation` must have an `escalation trigger`.
-    - If an `escalation trigger` fires, the **Issue** becomes `open` again and triggers a new **Incident**.
+    - If an `escalation trigger` fires, the **Issue** becomes `open` again and triggers a new **Incident**. The new Incident has access to previously gathered context. 
     - An `escalation trigger` can be:
         - a rate of errors (errors per minute)
         - an absolute count of events
-- An **Issue** can be `resolved`. New occurences of the same error will trigger an **Incident**. 
+    - Reoccurences of the Issue `under observation` do not cause anything until the `escalation trigger` trips.
+- An **Issue** can be `resolved`. New occurences of the same error will trigger an **Incident**. The investigations of the reoccuring issue will be able to consult previous findings if necessary.
 
 
 # Incident 
@@ -83,15 +84,20 @@ the Superlog agent must attempt to resolve the issue. The resolution is a multi-
     - Opening subsequent PRs
 - Opening Approval prompts 
 
+### Approval prompt
+
+An Approval prompt is a way for our agent to make changes in the client's infrastructure, databases and other systems with the user's approval. When Superlog has access to the customer's infrastructure, for example, their AWS account, Superlog must always send Approval Prompts before taking action. 
+
+
 ### Non-noise Incident states 
 
 An Incident can be `open` (during the execution of the Agent Run).
 
 #### Resolution by the agent
 
-Once the agent has performed all the actions necessary to mitigate the issue at hand, it can set the incident as `resolved`. For example, when the user merges the PR that the agent has proposed, and it was the only action necessary to resolve the issue, the agent should `resolve` the incident.
+Once the agent has performed all the actions necessary to mitigate the issue at hand, it can set the Incident as `resolved`. For example, when the user merges the PR that the agent has proposed, and it was the only action necessary to resolve the issue, the agent should `resolve` the Incident.
 
-If another PR or action is necessary, the agent should perform these actions and not close the PR.
+If another PR or action is necessary, the agent should perform these actions and not resolve the Incident.
 
 If the client closes the PR and it is obvious from the context that the issue is actually noise, the agent should `resolve` the Incident and `silence` the related issues or put them `under observation`.
 
@@ -115,10 +121,6 @@ Issues and Incidents have associated Comments. Humans and Agents can add Comment
 
 ## Project memory
 Every Project has a list of Memories that can be added by humans and Agents. A Memory is a dated free-form text. All Project memories are visible to the Agent Run investigating the Incident. Agents can add new Memories during investigations and in response to PR comments, Slack messages and other interactions with users.
-
-### Approval prompt
-
-An Approval prompt is a way for our agent to make changes in the client's infrastructure, databases and other systems with the user's approval. When Superlog has access to the customer's infrastructure, for example, their AWS account, Superlog must always send Approval Prompts before taking action. 
 
 # Weekly update
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -19,7 +19,7 @@ When an **Issue** is created, it starts as `open`. An `open` **Issue** should tr
     - An `escalation trigger` can be:
         - a rate of errors (errors per minute)
         - an absolute count of events
-    - Reoccurences of the Issue `under observation` do not cause anything until the `escalation trigger` trips.
+    - Occurrences of the Issue `under observation` do not cause anything until the `escalation trigger` trips.
 - An **Issue** can be `resolved`. New occurrences of the same error will trigger an **Incident**. The investigations of the recurring issue will be able to consult previous findings if necessary.
 
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -20,7 +20,7 @@ When an **Issue** is created, it starts as `open`. An `open` **Issue** should tr
         - a rate of errors (errors per minute)
         - an absolute count of events
     - Reoccurences of the Issue `under observation` do not cause anything until the `escalation trigger` trips.
-- An **Issue** can be `resolved`. New occurences of the same error will trigger an **Incident**. The investigations of the reoccuring issue will be able to consult previous findings if necessary.
+- An **Issue** can be `resolved`. New occurrences of the same error will trigger an **Incident**. The investigations of the recurring issue will be able to consult previous findings if necessary.
 
 
 # Incident 


### PR DESCRIPTION
Follow-up edits to `specs/SPEC.md`:

- Escalation triggers and resolved-issue recurrences open a new Incident that has access to previously gathered context / prior findings.
- Occurrences of an issue under observation do nothing until the escalation trigger trips.
- Fixed "not close the PR" to "not resolve the Incident" in the agent-resolution section.
- Moved the Approval prompt section out of Project memory and into the resolution actions section where it belongs.
- Capitalization consistency for Incident.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the Issue/Incident lifecycle in `specs/SPEC.md`: defines when new Incidents are created (on escalation or recurrence) and that they reuse prior context, plus tightens wording and capitalization.

- **Refactors**
  - While `under observation`, occurrences do nothing until the escalation trigger fires; when it fires or after a resolved recurrence, a new Incident starts with access to prior context and findings.
  - Use "not resolve the Incident" phrasing and capitalize "Incident" consistently.
  - Move Approval prompt docs from Project memory into the Resolution actions section.

<sup>Written for commit 02096bd90b1fa20cdf89495cfdeb679cdfcbc074. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

