### PR TITLE
Fix issue lifecycle backfill duplicate link collapse

### DIFF
--- a/packages/db/migrations/0081_issue_lifecycle_backfill.sql
+++ b/packages/db/migrations/0081_issue_lifecycle_backfill.sql
@@ -64,7 +64,38 @@ SET event_count = i.event_count + losses.extra_events,
 FROM losses
 WHERE i.id = losses.survivor_id;--> statement-breakpoint
 
--- 2b. Repoint loser incident links to the survivor so incident history keeps
+-- 2b. If multiple loser issue rows from the same duplicate group are linked to
+-- the same incident, they would all update to the same (incident_id, survivor)
+-- pair and violate incident_issues_pair_idx. Keep one link for that target; the
+-- rest are redundant because the loser issue rows are about to be deleted.
+WITH ranked AS (
+  SELECT id, project_id, fingerprint,
+         row_number() OVER (
+           PARTITION BY project_id, fingerprint
+           ORDER BY (silenced_at IS NULL) DESC, last_seen DESC, created_at DESC
+         ) AS rn
+  FROM issues
+),
+pairs AS (
+  SELECT l.id AS loser_id, s.id AS survivor_id
+  FROM ranked l
+  JOIN ranked s
+    ON s.project_id = l.project_id AND s.fingerprint = l.fingerprint AND s.rn = 1
+  WHERE l.rn > 1
+),
+ranked_links AS (
+  SELECT ii.id,
+         row_number() OVER (
+           PARTITION BY ii.incident_id, p.survivor_id
+           ORDER BY ii.created_at DESC, ii.id DESC
+         ) AS rn
+  FROM incident_issues ii
+  JOIN pairs p ON p.loser_id = ii.issue_id
+)
+DELETE FROM incident_issues
+WHERE id IN (SELECT id FROM ranked_links WHERE rn > 1);--> statement-breakpoint
+
+-- 2c. Repoint loser incident links to the survivor so incident history keeps
 -- an issue row, skipping incidents already linked to the survivor.
 WITH ranked AS (
   SELECT id, project_id, fingerprint,
@@ -90,7 +121,7 @@ WHERE ii.issue_id = p.loser_id
     WHERE x.incident_id = ii.incident_id AND x.issue_id = p.survivor_id
   );--> statement-breakpoint
 
--- 2c. Delete loser rows (cascades any incident_issues links that could not be
+-- 2d. Delete loser rows (cascades any incident_issues links that could not be
 -- repointed because the survivor already covered that incident).
 WITH ranked AS (
   SELECT id,

--- a/packages/db/src/issue-lifecycle-backfill.test.ts
+++ b/packages/db/src/issue-lifecycle-backfill.test.ts
@@ -97,9 +97,19 @@ async function insertIncidentRaw(
   return one(rowsOf<{ id: string }>(result));
 }
 
-async function linkRaw(db: RawDb, incidentId: string, issueId: string): Promise<void> {
+async function linkRaw(
+  db: RawDb,
+  incidentId: string,
+  issueId: string,
+  createdAt?: Date,
+): Promise<void> {
   await db.execute(sql`
-    INSERT INTO incident_issues (incident_id, issue_id) VALUES (${incidentId}, ${issueId})
+    INSERT INTO incident_issues (incident_id, issue_id, created_at)
+    VALUES (
+      ${incidentId},
+      ${issueId},
+      COALESCE(${createdAt ? createdAt.toISOString() : null}::timestamptz, now())
+    )
   `);
 }
 
@@ -241,6 +251,15 @@ test("issue lifecycle backfill migrates prod-shaped data and the unique index la
     });
     await linkRaw(db, sharedIncident.id, dupMid.id);
     await linkRaw(db, sharedIncident.id, dupActive.id);
+    const loserOnlyIncident = await insertIncidentRaw(db, {
+      projectId: project.id,
+      title: "loser-only incident",
+      status: "open",
+      firstSeen: now,
+      lastSeen: now,
+    });
+    await linkRaw(db, loserOnlyIncident.id, dupOld.id, earlier);
+    await linkRaw(db, loserOnlyIncident.id, dupMid.id, now);
 
     // --- Apply the backfill (0081) and the full unique index (0082+) ---
     await migrate(db, { migrationsFolder: MIGRATIONS });
@@ -260,11 +279,20 @@ test("issue lifecycle backfill migrates prod-shaped data and the unique index la
 
     // The repointable loser link now points at the survivor; the shared
     // incident kept a single link to the survivor (duplicate cascaded away).
+    // The loser-only incident had two loser links and no survivor link before
+    // the backfill; it must also end up with exactly one survivor link.
     const survivorLinks = await db.query.incidentIssues.findMany({
       where: (t, { eq: eqOp }) => eqOp(t.issueId, dupActive.id),
     });
     const linkedIncidentIds = survivorLinks.map((l) => l.incidentId).sort();
-    assert.deepEqual(linkedIncidentIds, [dupIncident.id, sharedIncident.id].sort());
+    assert.deepEqual(
+      linkedIncidentIds,
+      [dupIncident.id, loserOnlyIncident.id, sharedIncident.id].sort(),
+    );
+    const loserOnlySurvivorLink = one(
+      survivorLinks.filter((l) => l.incidentId === loserOnlyIncident.id),
+    );
+    assert.equal(loserOnlySurvivorLink.createdAt.toISOString(), now.toISOString());
 
     // Status backfill.
     const byId = async (id: string) =>


### PR DESCRIPTION
## Summary
- cover duplicate loser issue links that target the same survivor during the issue lifecycle backfill
- delete redundant loser links before repointing the remaining link to the survivor
- add a regression fixture for loser-only incident links in the migration test

## Root cause
When multiple duplicate issue rows for the same fingerprint were linked to the same incident, the backfill could try to repoint more than one link to the same surviving issue. That conflicts with the new unique incident/issue pair index.

## Tests
- pnpm --filter @superlog/db test -- issue-lifecycle-backfill.test.ts
- pnpm --filter @superlog/db typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the issue lifecycle backfill by collapsing duplicate loser incident links per (incident, survivor) before repointing, keeping the newest link and preventing unique (incident_id, issue_id) conflicts. Preserves incident history and link timestamps by repointing the kept link to the survivor.

- **Bug Fixes**
  - Collapse duplicate loser links for each (incident, survivor); keep the most recent by created_at, delete the rest, then repoint the kept link.
  - Add regression in `@superlog/db` for loser-only incidents with multiple loser links; result is exactly one survivor link with the latest created_at.

<sup>Written for commit c750b480c80b8e47de3c315b5030b3e18d430a31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

