### PR TITLE
Decline agent-run merge into non-open incidents instead of failing the sync

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -23,6 +23,7 @@
     "test:agent-run-start": "tsx --test src/agent-runs/start.test.ts",
     "test:agent-run-status": "tsx --test src/agent-runs/status.test.ts",
     "test:agent-run-sync": "tsx --test src/agent-runs/sync.test.ts",
+    "test:agent-run-merge": "tsx --test src/agent-runs/merge.test.ts",
     "test:issue-domain": "tsx --test src/issues/domain.test.ts",
     "test:alerts-domain": "tsx --test src/alerts/domain.test.ts",
     "test:alerts-evaluate": "tsx --test src/alerts/evaluate.test.ts",

--- a/apps/worker/src/agent-runs/merge.test.ts
+++ b/apps/worker/src/agent-runs/merge.test.ts
@@ -1,0 +1,29 @@
+import "../agent-run.test-env.js";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { schema } from "@superlog/db";
+import { isMergeableIncidentPair } from "./merge.js";
+
+function statusOnly(status: schema.IncidentStatus): Pick<schema.Incident, "status"> {
+  return { status };
+}
+
+test("isMergeableIncidentPair allows an open source folding into an open target", () => {
+  assert.equal(isMergeableIncidentPair(statusOnly("open"), statusOnly("open")), true);
+});
+
+test("isMergeableIncidentPair rejects a resolved merge target", () => {
+  // loadMergeCandidates deliberately offers resolved incidents to the merge
+  // judge as context, but mergeIncidentsInTx only supports open→open. Folding
+  // into a resolved survivor must be declined here so the run completes
+  // standalone rather than throwing IllegalIncidentTransitionError, which the
+  // sync loop turns into a permanent `sync_failed`.
+  assert.equal(isMergeableIncidentPair(statusOnly("open"), statusOnly("resolved")), false);
+});
+
+test("isMergeableIncidentPair rejects a source that was closed while the run was in flight", () => {
+  for (const closed of ["resolved", "autoresolved_noise", "merged"] as const) {
+    assert.equal(isMergeableIncidentPair(statusOnly(closed), statusOnly("open")), false, closed);
+    assert.equal(isMergeableIncidentPair(statusOnly("open"), statusOnly(closed)), false, closed);
+  }
+});

--- a/apps/worker/src/agent-runs/merge.ts
+++ b/apps/worker/src/agent-runs/merge.ts
@@ -1,4 +1,11 @@
-import { type AgentRunResult, db, enqueueIncidentMerged, schema } from "@superlog/db";
+import {
+  type AgentRunResult,
+  IllegalIncidentTransitionError,
+  db,
+  enqueueIncidentMerged,
+  isActiveIncidentState,
+  schema,
+} from "@superlog/db";
 import { and, desc, eq, inArray } from "drizzle-orm";
 import type { AgentRunContext } from "../agent-run-context.js";
 import { createAgentRunLifecycle } from "../agent-run.js";
@@ -25,6 +32,23 @@ type MergeCandidateRow = {
   fixTargets: string[] | null;
   priorPrState: "open" | "closed" | "merged" | null;
 };
+
+/**
+ * A merge folds an open source incident into an open survivor. `mergeIncidentsInTx`
+ * enforces open→open (see incident-state), but the merge judge is deliberately
+ * shown resolved incidents as candidates (loadMergeCandidates) so a fresh
+ * lookalike of an already-fixed root cause can be recognized. Guard here so a
+ * verdict targeting a non-open incident — or a source that was resolved while the
+ * run was in flight — is declined gracefully instead of throwing
+ * `IllegalIncidentTransitionError`, which the sync loop reports as `sync_failed`
+ * and which permanently kills the investigation.
+ */
+export function isMergeableIncidentPair(
+  source: Pick<schema.Incident, "status">,
+  target: Pick<schema.Incident, "status">,
+): boolean {
+  return isActiveIncidentState(source.status) && isActiveIncidentState(target.status);
+}
 
 function changedFilesFromResult(result: unknown): string[] | null {
   const pr = (result as { pr?: { changedFiles?: unknown } | null } | null)?.pr ?? null;
@@ -206,14 +230,51 @@ export async function tryMergeAfterAgentRun(
   const targetRow = candidateRows.find((r) => r.incident.id === verdict.targetIncidentId);
   if (!targetRow) return false;
 
-  await applyMergeOutcome({
-    ctx,
-    result,
-    target: targetRow.incident,
-    evidence: verdict.evidence,
-    sessionId,
-    runtimeMinutes,
-  });
+  if (!isMergeableIncidentPair(ctx.incident, targetRow.incident)) {
+    logger.info(
+      {
+        scope: "agent_run.merge",
+        agent_run_id: ctx.agentRun.id,
+        source_incident_id: ctx.incident.id,
+        source_status: ctx.incident.status,
+        target_incident_id: targetRow.incident.id,
+        target_status: targetRow.incident.status,
+      },
+      "merge judge chose a non-open incident; completing standalone instead of merging",
+    );
+    return false;
+  }
+
+  try {
+    await applyMergeOutcome({
+      ctx,
+      result,
+      target: targetRow.incident,
+      evidence: verdict.evidence,
+      sessionId,
+      runtimeMinutes,
+    });
+  } catch (err) {
+    // Belt-and-suspenders for the TOCTOU race: the source or target can be
+    // resolved between candidate load and the merge transaction. The merge is
+    // atomic and its state assertion runs before any write, so a rejected merge
+    // leaves the run `running` — fall through to standalone completion instead
+    // of letting this surface as a `sync_failed`.
+    if (err instanceof IllegalIncidentTransitionError) {
+      logger.warn(
+        {
+          scope: "agent_run.merge",
+          agent_run_id: ctx.agentRun.id,
+          source_incident_id: ctx.incident.id,
+          target_incident_id: targetRow.incident.id,
+          err: err.message,
+        },
+        "incident state changed under the merge; completing standalone",
+      );
+      return false;
+    }
+    throw err;
+  }
   return true;
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -177,6 +177,7 @@ export {
   isActiveIncidentState,
   buildAgentRunIncidentPatch,
   buildManualReopenPatch,
+  IllegalIncidentTransitionError,
   INCIDENT_ACTIVE_STATES,
   INCIDENT_CLOSED_STATES,
   type AgentRunIncidentPatch,


### PR DESCRIPTION
## Problem

Investigations were terminating with `sync_failed` — a permanent failure that kills the run even when the agent produced a valid result.

Root cause: when an investigation finishes, `tryMergeAfterAgentRun` asks an LLM judge whether the incident is a duplicate of another one, and merges if so. `loadMergeCandidates` **deliberately** offers both `open` and `resolved` incidents as candidates, so a fresh incident can be recognized as a duplicate of an already-fixed root cause:

```ts
inArray(schema.incidents.status, ["open", "resolved"])
```

But the merge mutation `mergeIncidentsInTx` only supports an `open → open` transition and throws `IllegalIncidentTransitionError` if the source or target is not open. When the judge picked a **resolved** incident as the merge target — or the source incident was resolved while the run was in flight — that error propagated up, hit the catch-all in the sync loop, and was recorded as a terminal `sync_failed`. The investigation's result was thrown away.

The two modules contradicted each other: candidate selection allowed resolved incidents, the merge invariant forbade them.

## Fix

Guard the merge at the application layer, keeping the domain invariant strict (merge stays `open → open`):

- `isMergeableIncidentPair(source, target)` — both must be active (open). New pure, unit-tested helper.
- In `tryMergeAfterAgentRun`, if the pair isn't mergeable, log and **decline the merge**, returning `false` so the run completes standalone (opens/records its own result) instead of throwing.
- Belt-and-suspenders: catch `IllegalIncidentTransitionError` around the merge transaction for the TOCTOU race where state changes between candidate load and the merge. The merge tx is atomic and asserts before any write, so a declined merge leaves the run `running` and standalone completion proceeds on the same tick.

Resolved incidents are still shown to the judge as *context* (useful for "this was already fixed") — they're just no longer a valid merge **target**.

## Tests

- New `merge.test.ts` covering `isMergeableIncidentPair` for open/open, resolved target, and a source closed mid-run.
- Existing `incident-state.test.ts` (merge rejects closed source/target), `sync.test.ts`, `agent-run.test.ts` still pass. `@superlog/db` + `@superlog/worker` typecheck clean.

## Follow-up (not in this PR)

When the judge decides a live incident is a duplicate of an already-**resolved** one, that's a recurrence signal. Today we complete standalone, which can open a duplicate PR for an already-fixed problem. A better long-term behavior is to chain the recurrence to the prior incident rather than merge into it or re-fix it. Logged at `agent_run.merge` so the frequency is measurable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declines merges into non-open incidents after an agent run, so valid investigations no longer end in `sync_failed`. Runs now complete standalone when the judge picks a resolved target or state changes mid-merge.

- **Bug Fixes**
  - Added `isMergeableIncidentPair` to require both incidents are active (`open`), keeping merge open→open.
  - In `tryMergeAfterAgentRun`, log and return `false` for non-mergeable pairs to complete standalone.
  - Catch `IllegalIncidentTransitionError` around the merge to handle TOCTOU races and avoid `sync_failed`.
  - Exported `IllegalIncidentTransitionError` from `@superlog/db`; added `merge.test.ts` and a test script in `@superlog/worker`.
  - Resolved incidents remain as context for the judge but are no longer valid merge targets.

<sup>Written for commit 2842cf7af52c4b4b1ca4de139160752b431e6097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

