### PR TITLE
Redesign incident detail page

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -181,48 +181,35 @@ function AuthenticatedApp() {
     // signalAtHardCap swallows autumn-js check() throwing on a not-yet-hydrated
     // customer (e.g. a brand-new org) so billing state can't black-screen the app.
     ["spans", "logs", "metric_points"].some((f) => signalAtHardCap(check, f));
-  const showTopBar = impersonating || billingPaused;
-  // The banner is fixed-positioned so it doesn't shove the page below it (the
-  // fixed nav can't be pushed by document flow anyway). Instead, every piece
-  // of chrome that pins to the top reads --impersonation-h and shifts down by
-  // exactly the banner's height, and the top padding on RouteContainer grows
-  // to match. Setting it on the root keeps everything in sync without
-  // threading a prop through AppShell, which is shared with Landing.
-  useEffect(() => {
-    const root = document.documentElement;
-    if (showTopBar) root.style.setProperty("--impersonation-h", "1.75rem");
-    else root.style.removeProperty("--impersonation-h");
-    return () => {
-      root.style.removeProperty("--impersonation-h");
-    };
-  }, [showTopBar]);
   if (isPending) return null;
   if (!data) return <Landing />;
   return (
     <OnboardingGate>
-      {impersonating ? (
-        <ImpersonationBar email={data.user.email} />
-      ) : (
-        billingPaused && <BillingLimitBar />
-      )}
-      <AppShell nav={<TopNav />}>
-        <RouteContainer>
-          <Routes>
-            <Route path="/explore/*" element={<Explore />} />
-            <Route path="/incidents" element={<Issues />} />
-            <Route path="/incidents/:id" element={<Issues />} />
-            <Route path="/issues" element={<Issues />} />
-            <Route path="/issues/:id" element={<Issues />} />
-            <Route path="/alerts" element={<AlertsList />} />
-            <Route path="/alerts/new" element={<AlertEdit />} />
-            <Route path="/alerts/:id" element={<AlertEdit />} />
-            <Route path="/dashboards" element={<DashboardsList />} />
-            <Route path="/dashboards/:id" element={<DashboardView />} />
-            <Route path="/settings" element={<Settings />} />
-            <Route path="*" element={<Overview />} />
-          </Routes>
-        </RouteContainer>
-      </AppShell>
+      <div className="flex min-h-screen flex-col bg-bg">
+        {impersonating ? (
+          <ImpersonationBar email={data.user.email} />
+        ) : (
+          billingPaused && <BillingLimitBar />
+        )}
+        <AppShell nav={<TopNav />}>
+          <RouteContainer>
+            <Routes>
+              <Route path="/explore/*" element={<Explore />} />
+              <Route path="/incidents" element={<Issues />} />
+              <Route path="/incidents/:id" element={<Issues />} />
+              <Route path="/issues" element={<Issues />} />
+              <Route path="/issues/:id" element={<Issues />} />
+              <Route path="/alerts" element={<AlertsList />} />
+              <Route path="/alerts/new" element={<AlertEdit />} />
+              <Route path="/alerts/:id" element={<AlertEdit />} />
+              <Route path="/dashboards" element={<DashboardsList />} />
+              <Route path="/dashboards/:id" element={<DashboardView />} />
+              <Route path="/settings" element={<Settings />} />
+              <Route path="*" element={<Overview />} />
+            </Routes>
+          </RouteContainer>
+        </AppShell>
+      </div>
       <CommandPalette />
       <McpInstallPill />
     </OnboardingGate>
@@ -259,7 +246,7 @@ function useGlobalKeybinds(enabled: boolean) {
 
 function ImpersonationBar({ email }: { email: string }) {
   return (
-    <div className="fixed inset-x-0 top-0 z-[60] flex h-7 w-full items-center justify-center gap-3 bg-amber-500 px-3 font-mono text-[11px] text-black">
+    <div className="flex h-7 w-full items-center justify-center gap-3 bg-amber-500 px-3 font-mono text-[11px] text-black">
       <span className="uppercase tracking-[0.2em]">impersonating</span>
       <span className="font-medium">{email}</span>
       <span className="opacity-70">·</span>
@@ -280,7 +267,7 @@ function ImpersonationBar({ email }: { email: string }) {
 
 function BillingLimitBar() {
   return (
-    <div className="fixed inset-x-0 top-0 z-[60] flex h-7 w-full items-center justify-center gap-2 bg-danger px-3 text-[11px] text-white">
+    <div className="flex h-7 w-full items-center justify-center gap-2 bg-danger px-3 text-[11px] text-white">
       <span className="font-semibold">Ingest paused</span>
       <span className="opacity-90">You’ve hit your Free plan limits.</span>
       <Link
@@ -295,10 +282,14 @@ function BillingLimitBar() {
 
 function RouteContainer({ children }: { children: ReactNode }) {
   const { pathname } = useLocation();
+  const incidentDetail = /^\/incidents\/[^/]+/.test(pathname);
   const wide = pathname.startsWith("/dashboards/");
+  if (incidentDetail) {
+    return <div className="flex min-h-0 flex-1 flex-col">{children}</div>;
+  }
   return (
     <div
-      className={`mx-auto px-6 pb-24 pt-[calc(6rem+var(--impersonation-h,0px))] ${wide ? "max-w-[2400px]" : "max-w-6xl"}`}
+      className={`mx-auto w-full px-6 pb-24 pt-6 ${wide ? "max-w-[2400px]" : "max-w-6xl"}`}
     >
       {children}
     </div>

--- a/apps/web/src/Explore.tsx
+++ b/apps/web/src/Explore.tsx
@@ -282,7 +282,7 @@ function ExploreInner({ projectId }: { projectId: string }) {
   );
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="relative flex flex-col gap-6">
       <section className="flex flex-wrap items-center justify-between gap-4">
         <ExploreTabs />
         {/* Resources are inventory, not time-ranged telemetry — no range picker. */}

--- a/apps/web/src/FeedbackDialog.tsx
+++ b/apps/web/src/FeedbackDialog.tsx
@@ -1,3 +1,5 @@
+import { ChatFeedback01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useRef, useState } from "react";
 import { useSubmitFeedback } from "./api.ts";
 import { Btn } from "./design/ui.tsx";
@@ -15,11 +17,13 @@ export function FeedbackTrigger({
   refId,
   projectId,
   label = "Give feedback",
+  className = "",
 }: {
   kind: "incident" | "issue";
   refId: string;
   projectId?: string;
   label?: string;
+  className?: string;
 }) {
   const [open, setOpen] = useState(false);
   return (
@@ -27,9 +31,9 @@ export function FeedbackTrigger({
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="inline-flex h-7 items-center gap-1.5 rounded-md border border-border px-2.5 text-[12px] text-fg transition-colors hover:border-border-strong"
+        className={`inline-flex h-7 items-center gap-1.5 rounded-md border border-border px-2.5 text-[12px] text-fg transition-colors hover:border-border-strong ${className}`}
       >
-        <span aria-hidden>💬</span>
+        <HugeiconsIcon icon={ChatFeedback01Icon} size={14} aria-hidden />
         {label}
       </button>
       {open && (

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -1,4 +1,8 @@
-import { ChartIncreaseIcon, CheckmarkCircle02Icon } from "@hugeicons/core-free-icons";
+import {
+  ChartIncreaseIcon,
+  CheckmarkCircle02Icon,
+  ClipboardCopyIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   type ReactNode,
@@ -52,6 +56,10 @@ import {
   CollapsibleIncidentTranscript,
   IncidentSummaryTelemetry,
 } from "./incidents/IncidentTranscript.tsx";
+import {
+  type IncidentMetaRow,
+  buildIncidentDetailMeta,
+} from "./incidents/incident-detail-view-model.ts";
 import { getIssueIncidentLinkState } from "./issue-incident-link-state.ts";
 
 const IncidentPrDiffView = lazy(() => import("./IncidentPrDiffView.tsx"));
@@ -125,7 +133,13 @@ export function Issues() {
 
 function IssuesShell({ projectId }: { projectId: string }) {
   const tab = useTab();
+  const params = useParams<{ id?: string }>();
   const labels: Record<Tab, string> = { incidents: "Incidents", issues: "Issues" };
+
+  if (tab === "incidents" && params.id) {
+    return <IncidentsTab projectId={projectId} />;
+  }
+
   return (
     <div>
       <div className="mb-6 flex items-center gap-1">
@@ -636,6 +650,17 @@ function IncidentsTab({ projectId }: { projectId: string }) {
     else openItem(id, "incidents");
   }
 
+  if (selectedId) {
+    return (
+      <IncidentDetailPage
+        projectId={projectId}
+        incidentId={selectedId}
+        onClose={() => selectIncident(null)}
+        onViewIssue={(issueId) => openItem(issueId, "issues")}
+      />
+    );
+  }
+
   return (
     <div>
       <div className="mb-4 flex items-center justify-between">
@@ -712,15 +737,6 @@ function IncidentsTab({ projectId }: { projectId: string }) {
             </section>
           ))}
         </div>
-      )}
-
-      {selectedId && (
-        <IncidentDrawer
-          projectId={projectId}
-          incidentId={selectedId}
-          onClose={() => selectIncident(null)}
-          onViewIssue={(issueId) => openItem(issueId, "issues")}
-        />
       )}
 
       {newInvestigationOpen && (
@@ -882,7 +898,7 @@ export function IncidentRow({
   );
 }
 
-function IncidentDrawer({
+function IncidentDetailPage({
   projectId,
   incidentId,
   onClose,
@@ -893,37 +909,19 @@ function IncidentDrawer({
   onClose: () => void;
   onViewIssue: (issueId: string) => void;
 }) {
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
-
   return (
-    <div className="fixed inset-x-0 bottom-0 top-[var(--impersonation-h,0px)] z-50">
-      <button
-        type="button"
-        aria-label="close"
-        className="absolute inset-0 bg-black/60"
-        onClick={onClose}
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-bg">
+      <IncidentDetailBody
+        projectId={projectId}
+        incidentId={incidentId}
+        onClose={onClose}
+        onViewIssue={onViewIssue}
       />
-      <aside className="absolute inset-y-0 right-0 flex w-full max-w-[720px] flex-col border-l border-border bg-bg shadow-2xl">
-        <div className="flex-1 overflow-y-auto">
-          <IncidentDrawerBody
-            projectId={projectId}
-            incidentId={incidentId}
-            onClose={onClose}
-            onViewIssue={onViewIssue}
-          />
-        </div>
-      </aside>
     </div>
   );
 }
 
-function IncidentDrawerBody({
+function IncidentDetailBody({
   projectId,
   incidentId,
   onClose,
@@ -1110,10 +1108,12 @@ function CopyAgentPromptButton({
   incident,
   issues,
   agentRun,
+  className = "",
 }: {
   incident: Incident;
   issues: Issue[];
   agentRun: AgentRun | null;
+  className?: string;
 }) {
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState(false);
@@ -1135,10 +1135,18 @@ function CopyAgentPromptButton({
     <button
       type="button"
       onClick={handleCopy}
-      className="inline-flex h-7 items-center gap-1.5 rounded-md border border-border px-2.5 text-[12px] text-fg transition-colors hover:border-border-strong"
+      className={`inline-flex h-7 items-center gap-1.5 rounded-md border border-border px-2.5 text-[12px] text-fg transition-colors hover:border-border-strong ${className}`}
       title="Copy a ready-to-paste prompt that briefs an agent on this incident and points it at the Superlog MCP."
     >
-      <span aria-hidden>{error ? "⚠" : copied ? "✓" : "📋"}</span>
+      {error ? (
+        <span className="grid h-3.5 w-3.5 place-items-center text-[10px] leading-none" aria-hidden>
+          !
+        </span>
+      ) : copied ? (
+        <HugeiconsIcon icon={CheckmarkCircle02Icon} size={14} aria-hidden />
+      ) : (
+        <HugeiconsIcon icon={ClipboardCopyIcon} size={14} aria-hidden />
+      )}
       {error ? "Copy failed" : copied ? "Copied" : "Copy agent prompt"}
     </button>
   );
@@ -1511,8 +1519,24 @@ export function IncidentDetailContent({
    *  the agent's `agent.*` events are dropped from the timeline (lifecycle-only). */
   transcript?: ReactNode;
 }) {
-  const [detailTab, setDetailTab] = useState<"incident" | "pr">("incident");
+  const [detailTab, setDetailTab] = useState<IncidentDetailTab>("activity");
   const statusActions = getIncidentStatusActions(incident.status);
+  const problemResolvedAction =
+    statusActions.find((action) => action.label === "Problem resolved") ?? null;
+  const notAnIssueAction = statusActions.find((action) => action.label === "Not an issue") ?? null;
+  const otherStatusActions = statusActions.filter(
+    (action) => action.label !== "Problem resolved" && action.label !== "Not an issue",
+  );
+  const detailMeta = buildIncidentDetailMeta({
+    incident,
+    issueCount: issues.length || incident.issueCount,
+    agentRunState: agentRun?.state ?? null,
+    pendingRecovery: !!pendingResolutionProposal,
+  });
+  const sidebarSummary =
+    incident.agentSummary ??
+    agentRun?.result?.summary ??
+    "No investigation summary has been recorded yet.";
 
   // The agent's conversation renders as a Transcript section (self-rendered from
   // events, or an explicit override) — and is then dropped from the timeline.
@@ -1532,147 +1556,244 @@ export function IncidentDetailContent({
     ) : null);
 
   return (
-    <div className="space-y-8 p-4">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="mb-2 flex flex-wrap items-center gap-2">
-            <StatusChip status={incident.status} pendingResolution={!!pendingResolutionProposal} />
-            {incident.severity && <SeverityChip severity={incident.severity} />}
-            {incident.codename && (
-              <span className="font-mono text-[11px] text-muted">{incident.codename}</span>
-            )}
-          </div>
-          <h2 className="text-[15px] font-semibold leading-snug text-fg">{incident.title}</h2>
-        </div>
+    <div className="flex min-h-0 flex-1 flex-col bg-bg text-fg">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border bg-bg px-5 py-3">
+        <span className="text-[13px] text-muted">Incidents</span>
+        <span className="text-subtle">›</span>
+        <span className="min-w-0 flex-1 truncate text-[13px] text-fg">
+          {incident.title}
+        </span>
         <div className="flex shrink-0 items-center gap-3">
-          <CopyAgentPromptButton incident={incident} issues={issues} agentRun={agentRun} />
-          <FeedbackTrigger kind="incident" refId={incident.id} projectId={incident.projectId} />
+          {notAnIssueAction && (
+            <Btn
+              variant={notAnIssueAction.variant}
+              size="sm"
+              onClick={() => onStatusAction(notAnIssueAction)}
+              loading={updatingIncident}
+            >
+              {notAnIssueAction.label}
+            </Btn>
+          )}
+          {problemResolvedAction && (
+            <Btn
+              variant={problemResolvedAction.variant}
+              size="sm"
+              onClick={() => onStatusAction(problemResolvedAction)}
+              loading={updatingIncident}
+            >
+              {problemResolvedAction.label}
+            </Btn>
+          )}
           <button
             onClick={onClose}
             className="text-muted transition-colors hover:text-fg"
             aria-label="close"
           >
-            <svg
-              className="h-4 w-4"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <path d="M18 6 6 18M6 6l12 12" />
-            </svg>
+            <CloseIcon />
           </button>
         </div>
       </div>
 
-      <IncidentDetailTabs active={detailTab} onChange={setDetailTab} />
+      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[390px_minmax(0,1fr)]">
+        <aside className="flex min-w-0 flex-col border-b border-border bg-bg lg:border-b-0 lg:border-r">
+          <div className="px-7 pb-7 pt-7">
+            <div className="font-mono text-[11px] text-subtle">#{incident.codename}</div>
+            <h2 className="mt-2 break-words text-[20px] font-semibold leading-[1.1] tracking-tight text-fg">
+              {incident.title}
+            </h2>
+            <p className="mt-4 break-words text-[12px] leading-5 text-muted">{sidebarSummary}</p>
 
-      {detailTab === "incident" ? (
-        <>
-          <div className="space-y-2">
-            <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
-              <MetaInline label="Service" value={incident.service ?? "—"} />
-              <MetaInline label="Environment" value={incident.environment ?? "—"} />
+            <div className="mt-7 grid gap-3.5">
+              <IncidentSidebarMetaRows rows={detailMeta} />
             </div>
-            <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
-              <MetaInline label="First seen" value={fmtRelative(incident.firstSeen)} />
-              <MetaInline label="Last seen" value={fmtRelative(incident.lastSeen)} />
+
+            <div className="mt-7 grid gap-2">
+              <CopyAgentPromptButton
+                incident={incident}
+                issues={issues}
+                agentRun={agentRun}
+                className="w-full justify-center"
+              />
+              <FeedbackTrigger
+                kind="incident"
+                refId={incident.id}
+                projectId={incident.projectId}
+                className="w-full justify-center"
+              />
+              {otherStatusActions.map((action) => (
+                <Btn
+                  key={action.label}
+                  variant={action.variant}
+                  size="sm"
+                  onClick={() => onStatusAction(action)}
+                  loading={updatingIncident}
+                  className="w-full justify-center"
+                >
+                  {action.label}
+                </Btn>
+              ))}
             </div>
-          </div>
-
-          {alertEpisodes.length > 0 && (
-            <div className="space-y-3">
-              <SectionHeading>Triggered by</SectionHeading>
-              <TriggeredByAlertEpisodes episodes={alertEpisodes} />
-            </div>
-          )}
-
-          <IncidentActivityPanel projectId={incident.projectId} incidentId={incident.id} />
-
-          {pendingResolutionProposal && onDecideProposal && (
-            <ResolutionProposalBanner
-              proposal={pendingResolutionProposal}
-              onConfirm={() => onDecideProposal(pendingResolutionProposal.id, "confirm")}
-              onDismiss={() => onDecideProposal(pendingResolutionProposal.id, "dismiss")}
-              deciding={!!decidingProposal}
-            />
-          )}
-
-          <div className="space-y-3">
-            <SectionHeading>Issues in this incident</SectionHeading>
-            {issues.length === 0 ? (
-              <p className="text-[12px] text-muted">none</p>
-            ) : (
-              <IssueList issues={issues} onViewIssue={onViewIssue} />
+            {updateIncidentError && (
+              <p className="mt-3 rounded-sm border border-danger/40 bg-danger/10 px-3 py-2 text-[12px] text-danger">
+                Status update failed: {String(updateIncidentError)}
+              </p>
             )}
           </div>
+        </aside>
 
-          <AgentRunView
-            incident={incident}
-            agentRun={agentRun}
-            agentRuns={agentRuns}
-            events={events}
-            eventsError={eventsError}
-            eventsLoading={eventsLoading}
-            onRestart={onRestartAgentRun}
-            onRetryPrDelivery={onRetryPrDelivery}
-            restarting={restartingAgentRun}
-            retryingPrDelivery={retryingPrDelivery}
-            summaryTelemetry={summaryTelemetry}
-          />
+        <div className="min-w-0 bg-bg">
+          <IncidentDetailTabs active={detailTab} onChange={setDetailTab} />
 
-          {transcriptNode}
+          <div className="px-6 py-6 lg:px-8">
+            {detailTab === "activity" && (
+              <div className="space-y-8">
+                <IncidentActivityPanel projectId={incident.projectId} incidentId={incident.id} />
 
-          <div className={transcriptNode ? "mt-8" : "mt-8 border-t border-border pt-6"}>
-            <IncidentTimeline
-              events={events}
-              eventsError={eventsError}
-              eventsLoading={eventsLoading}
-              excludeAgentMessages={!!transcriptNode}
-            />
+                {transcriptNode}
+
+                <div className={transcriptNode ? "mt-8" : "mt-8 border-t border-border pt-6"}>
+                  <IncidentTimeline
+                    events={events}
+                    eventsError={eventsError}
+                    eventsLoading={eventsLoading}
+                    excludeAgentMessages={!!transcriptNode}
+                  />
+                </div>
+              </div>
+            )}
+
+            {detailTab === "findings" && (
+              <div className="space-y-8">
+                {alertEpisodes.length > 0 && (
+                  <div className="space-y-3">
+                    <SectionHeading>Triggered by</SectionHeading>
+                    <TriggeredByAlertEpisodes episodes={alertEpisodes} />
+                  </div>
+                )}
+
+                {pendingResolutionProposal && onDecideProposal && (
+                  <ResolutionProposalBanner
+                    proposal={pendingResolutionProposal}
+                    onConfirm={() => onDecideProposal(pendingResolutionProposal.id, "confirm")}
+                    onDismiss={() => onDecideProposal(pendingResolutionProposal.id, "dismiss")}
+                    deciding={!!decidingProposal}
+                  />
+                )}
+
+                <div className="space-y-3">
+                  <SectionHeading>Issues in this incident</SectionHeading>
+                  {issues.length === 0 ? (
+                    <p className="text-[12px] text-muted">none</p>
+                  ) : (
+                    <IssueList issues={issues} onViewIssue={onViewIssue} />
+                  )}
+                </div>
+
+                <AgentRunView
+                  incident={incident}
+                  agentRun={agentRun}
+                  agentRuns={agentRuns}
+                  events={events}
+                  eventsError={eventsError}
+                  eventsLoading={eventsLoading}
+                  onRestart={onRestartAgentRun}
+                  onRetryPrDelivery={onRetryPrDelivery}
+                  restarting={restartingAgentRun}
+                  retryingPrDelivery={retryingPrDelivery}
+                  summaryTelemetry={summaryTelemetry}
+                />
+              </div>
+            )}
+
+            {detailTab === "pr" && (
+              <IncidentPullRequestPanel projectId={incident.projectId} incidentId={incident.id} />
+            )}
           </div>
-
-          <div className="flex gap-2">
-            {statusActions.map((action) => (
-              <Btn
-                key={action.label}
-                variant={action.variant}
-                size="sm"
-                onClick={() => onStatusAction(action)}
-                loading={updatingIncident}
-                className="w-full justify-center"
-              >
-                {action.label}
-              </Btn>
-            ))}
-          </div>
-          {updateIncidentError && (
-            <p className="rounded-sm border border-danger/40 bg-danger/10 px-3 py-2 text-[12px] text-danger">
-              Status update failed: {String(updateIncidentError)}
-            </p>
-          )}
-        </>
-      ) : (
-        <IncidentPullRequestPanel projectId={incident.projectId} incidentId={incident.id} />
-      )}
+        </div>
+      </div>
     </div>
   );
 }
+
+function CloseIcon() {
+  return (
+    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M18 6 6 18M6 6l12 12" />
+    </svg>
+  );
+}
+
+function IncidentSidebarMetaRows({ rows }: { rows: IncidentMetaRow[] }) {
+  return (
+    <>
+      {rows.map((row) => (
+        <div
+          key={`${row.label}-${row.value}`}
+          className="grid grid-cols-[132px_minmax(0,1fr)] items-start gap-3 text-[13px]"
+        >
+          <div className="text-muted">{row.label}</div>
+          <div className="flex min-w-0 items-center gap-2 text-fg">
+            <IncidentMetaIcon row={row} />
+            <span className="min-w-0 break-words">{row.value}</span>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function IncidentMetaIcon({ row }: { row: IncidentMetaRow }) {
+  if (row.kind === "priority") return <PriorityBars />;
+  if (row.kind === "status") return <StatusDot />;
+  if (row.kind === "environment") return <EnvironmentDot />;
+  if (row.kind === "findings") return <FindingsDot />;
+  if (row.kind === "agent") return <AgentDot />;
+  return null;
+}
+
+function PriorityBars() {
+  return (
+    <span className="flex h-4 w-4 shrink-0 items-end gap-[2px] text-muted" aria-hidden>
+      <span className="h-1.5 w-[3px] bg-current" />
+      <span className="h-2.5 w-[3px] bg-current" />
+      <span className="h-4 w-[3px] bg-current" />
+    </span>
+  );
+}
+
+function StatusDot() {
+  return <span className="h-2 w-2 shrink-0 rounded-full bg-accent" aria-hidden />;
+}
+
+function EnvironmentDot() {
+  return <span className="h-2 w-2 shrink-0 rounded-full bg-success" aria-hidden />;
+}
+
+function FindingsDot() {
+  return <span className="h-2 w-2 shrink-0 rounded-full bg-warning" aria-hidden />;
+}
+
+function AgentDot() {
+  return <span className="h-2 w-2 shrink-0 rounded-full bg-accent" aria-hidden />;
+}
+
+type IncidentDetailTab = "activity" | "findings" | "pr";
 
 function IncidentDetailTabs({
   active,
   onChange,
 }: {
-  active: "incident" | "pr";
-  onChange: (tab: "incident" | "pr") => void;
+  active: IncidentDetailTab;
+  onChange: (tab: IncidentDetailTab) => void;
 }) {
-  const tabs: { id: "incident" | "pr"; label: string }[] = [
-    { id: "incident", label: "Incident" },
+  const tabs: { id: IncidentDetailTab; label: string }[] = [
+    { id: "activity", label: "Activity" },
+    { id: "findings", label: "Findings" },
     { id: "pr", label: "PR" },
   ];
   return (
-    <div className="-mx-4 border-b border-border px-4">
-      <div className="flex gap-9">
+    <div className="border-b border-border bg-bg px-6 lg:px-8">
+      <div className="flex h-16 flex-wrap items-end gap-2 pb-3">
         {tabs.map((tab) => {
           const selected = active === tab.id;
           return (
@@ -1680,14 +1801,13 @@ function IncidentDetailTabs({
               key={tab.id}
               type="button"
               onClick={() => onChange(tab.id)}
-              className={`relative h-11 text-[14px] font-medium transition-colors ${
-                selected ? "text-fg" : "text-muted hover:text-fg"
+              className={`rounded-lg border px-3.5 py-1.5 text-[13px] font-semibold transition-colors ${
+                selected
+                  ? "border-border-strong bg-surface-2 text-fg"
+                  : "border-border bg-surface text-muted hover:text-fg"
               }`}
             >
               {tab.label}
-              {selected && (
-                <span className="absolute inset-x-0 bottom-0 h-[3px] bg-fg" aria-hidden />
-              )}
             </button>
           );
         })}

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -141,7 +141,7 @@ function IssuesShell({ projectId }: { projectId: string }) {
   }
 
   return (
-    <div>
+    <div className="relative">
       <div className="mb-6 flex items-center gap-1">
         {(["incidents", "issues"] as const).map((t) => (
           <Link
@@ -354,7 +354,7 @@ export function IssueDrawer(props: IssueDetailProps) {
   }, [props.onClose]);
 
   return (
-    <div className="fixed inset-x-0 bottom-0 top-[var(--impersonation-h,0px)] z-50">
+    <div className="absolute inset-0">
       <button
         type="button"
         aria-label="close"
@@ -662,7 +662,7 @@ function IncidentsTab({ projectId }: { projectId: string }) {
   }
 
   return (
-    <div>
+    <div className="relative">
       <div className="mb-4 flex items-center justify-between">
         <div className="flex items-center gap-1">
           {tabs.map((t) => (
@@ -1641,10 +1641,10 @@ export function IncidentDetailContent({
           </div>
         </aside>
 
-        <div className="min-w-0 bg-bg">
+        <div className="flex min-h-0 min-w-0 flex-col bg-bg">
           <IncidentDetailTabs active={detailTab} onChange={setDetailTab} />
 
-          <div className="px-6 py-6 lg:px-8">
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6 lg:px-8">
             {detailTab === "activity" && (
               <div className="space-y-8">
                 <IncidentActivityPanel projectId={incident.projectId} incidentId={incident.id} />

--- a/apps/web/src/LogDetail.tsx
+++ b/apps/web/src/LogDetail.tsx
@@ -34,7 +34,7 @@ export function LogDrawer({
   if (!log) return null;
 
   return (
-    <div className="fixed inset-x-0 bottom-0 top-[var(--impersonation-h,0px)] z-50">
+    <div className="absolute inset-0">
       <button
         type="button"
         aria-label="close"

--- a/apps/web/src/TraceDetail.tsx
+++ b/apps/web/src/TraceDetail.tsx
@@ -35,7 +35,7 @@ export function TraceDrawer({
   if (!traceId) return null;
 
   return (
-    <div className="fixed inset-x-0 bottom-0 top-[var(--impersonation-h,0px)] z-50">
+    <div className="absolute inset-0">
       <button
         type="button"
         aria-label="close"

--- a/apps/web/src/design/investigations/Playground.tsx
+++ b/apps/web/src/design/investigations/Playground.tsx
@@ -13,6 +13,12 @@ import type {
 import { CountChart } from "../../dashboards/widgets/CountChart.tsx";
 import { DEFAULT_TOP_N } from "../../dashboards/widgets/series-topn.ts";
 import { Btn, Chip, type ChipTone, Tile } from "../ui.tsx";
+import {
+  CLOUDFLARE_PREFLIGHT_DETAIL,
+  type ReferenceActivityItem,
+  buildReferenceActivity,
+  referenceIncidentStats,
+} from "./incident-detail-reference-model.ts";
 
 // ---------------------------------------------------------------------------
 // Investigations playground — /design/investigations
@@ -30,10 +36,10 @@ import { Btn, Chip, type ChipTone, Tile } from "../ui.tsx";
 // data is mock. See /design/issues for the same pattern on the incident list.
 // ---------------------------------------------------------------------------
 
-type Surface = "list" | "full" | "drawer" | "real";
+type Surface = "detail" | "list" | "full" | "drawer" | "real";
 
 export function InvestigationsPlayground() {
-  const [surface, setSurface] = useState<Surface>("list");
+  const [surface, setSurface] = useState<Surface>("detail");
   const [modalOpen, setModalOpen] = useState(false);
 
   return (
@@ -41,6 +47,7 @@ export function InvestigationsPlayground() {
       <SubpageNav crumb="Investigations" />
       <SurfaceToolbar active={surface} onChange={setSurface} />
       <main className="mx-auto max-w-6xl px-6 pb-24 pt-8">
+        {surface === "detail" && <ReferenceIncidentDetailSurface />}
         {surface === "list" && <ListSurface onNew={() => setModalOpen(true)} onOpen={setSurface} />}
         {surface === "full" && <FullInvestigationSurface />}
         {surface === "drawer" && <DrawerSurface />}
@@ -85,6 +92,7 @@ function SubpageNav({ crumb }: { crumb: string }) {
 
 function SurfaceToolbar({ active, onChange }: { active: Surface; onChange: (s: Surface) => void }) {
   const options: { id: Surface; label: string }[] = [
+    { id: "detail", label: "Incident detail" },
     { id: "list", label: "Incident list" },
     { id: "full", label: "Full investigation" },
     { id: "drawer", label: "In-context drawer" },
@@ -300,6 +308,356 @@ function Segmented({ options }: { options: string[] }) {
         </button>
       ))}
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reference incident detail — local mockup from incident 285160df...
+// ---------------------------------------------------------------------------
+
+function ReferenceIncidentDetailSurface() {
+  const detail = CLOUDFLARE_PREFLIGHT_DETAIL;
+  const stats = referenceIncidentStats(detail);
+  const activity = buildReferenceActivity(detail);
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <div className="text-[12px] text-muted">Reference redesign</div>
+          <h1 className="mt-1 text-[24px] font-semibold tracking-tight text-fg">
+            Incident detail mockup
+          </h1>
+        </div>
+        <div className="font-mono text-[11px] text-subtle">{detail.incident.id}</div>
+      </div>
+
+      <div className="max-w-full min-w-0 overflow-hidden rounded-xl border border-border bg-surface text-fg shadow-[0_24px_70px_-42px_rgba(0,0,0,0.65)]">
+        <div className="flex h-12 min-w-0 items-center gap-2 border-b border-border bg-surface px-5">
+          <div className="grid h-4 w-4 place-items-center rounded border border-border-strong text-[10px] text-muted">
+            I
+          </div>
+          <span className="text-[14px] font-medium text-muted">Incidents</span>
+          <span className="text-subtle">›</span>
+          <span className="min-w-0 truncate text-[14px] font-semibold text-fg">
+            {detail.incident.title}
+          </span>
+          <div className="ml-auto hidden items-center gap-1.5 sm:flex">
+            {["AS", "AK", "JS"].map((initials) => (
+              <span
+                key={initials}
+                className="grid h-7 w-7 place-items-center rounded-full border-2 border-surface bg-surface-2 text-[10px] font-semibold text-muted"
+              >
+                {initials}
+              </span>
+            ))}
+            <button
+              type="button"
+              className="ml-1 grid h-7 w-7 place-items-center rounded-full border border-dashed border-border-strong text-[18px] leading-none text-muted"
+              aria-label="Add collaborator"
+            >
+              +
+            </button>
+          </div>
+        </div>
+
+        <div className="grid min-h-[760px] min-w-0 grid-cols-1 lg:grid-cols-[390px_minmax(0,1fr)]">
+          <aside className="min-w-0 border-b border-border lg:flex lg:flex-col lg:border-b-0 lg:border-r">
+            <div className="px-7 pb-8 pt-8">
+              <div className="grid h-[74px] w-[74px] place-items-center rounded-xl bg-warning/15 text-[24px] font-bold text-warning">
+                CF
+              </div>
+              <div className="mt-7 font-mono text-[13px] text-subtle">
+                #{detail.incident.codename}
+              </div>
+              <h2 className="mt-2 break-words text-[26px] font-semibold leading-[1.08] tracking-tight text-fg sm:text-[29px]">
+                {detail.incident.title}
+              </h2>
+              <p className="mt-5 break-words text-[15px] leading-6 text-muted">
+                {detail.incident.agentSummary}
+              </p>
+
+              <div className="mt-8 grid gap-4">
+                <ReferenceMetaRow label="Title" value={detail.incident.title} stackOnSmall />
+                <ReferenceMetaRow
+                  label="Priority"
+                  value={detail.incident.severity}
+                  icon={<TinyBars />}
+                />
+                <ReferenceMetaRow
+                  label="Assignee"
+                  value="Integration owner"
+                  icon={<AvatarDot label="IO" />}
+                />
+                <ReferenceMetaRow label="Status" value="Active" icon={<ReferenceStatusGlyph />} />
+                <ReferenceMetaRow
+                  label="Surface"
+                  value="Cloudflare Workers"
+                  icon={<CloudGlyph />}
+                />
+                <ReferenceMetaRow label="" value={detail.incident.service} icon={<ApiGlyph />} />
+              </div>
+            </div>
+
+            <div className="mt-auto border-t border-border px-7 py-7">
+              <div className="grid gap-4">
+                <ReferenceMetaRow label="Regression" value="Yes" icon={<RefreshGlyph />} />
+                <ReferenceMetaRow label="First detection" value={stats.firstDetectionLabel} />
+                <ReferenceMetaRow label="Latest detection" value={stats.latestDetectionLabel} />
+                <ReferenceMetaRow label="Duration" value={stats.durationLabel} />
+                <ReferenceMetaRow label="Findings" value={stats.issueCountLabel} chevron />
+              </div>
+            </div>
+          </aside>
+
+          <section className="min-w-0 bg-surface">
+            <div className="flex h-auto min-w-0 flex-wrap items-end gap-2 border-b border-border px-5 py-3 sm:h-[72px] sm:px-7 sm:pb-3 sm:pt-0">
+              {["Activity", "Sessions", "Findings"].map((label) => (
+                <button
+                  key={label}
+                  type="button"
+                  className={
+                    label === "Activity"
+                      ? "rounded-lg border border-border-strong bg-surface-2 px-4 py-2 text-[14px] font-semibold text-fg"
+                      : "rounded-lg border border-border bg-surface px-4 py-2 text-[14px] font-semibold text-muted"
+                  }
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            <div className="px-5 py-7 sm:px-8 sm:py-8">
+              <div className="relative pl-9">
+                <div className="absolute bottom-7 left-[15px] top-3 w-px bg-border" />
+                {activity.map((item) => (
+                  <ReferenceActivityEntry key={`${item.kind}-${item.timeLabel}`} item={item} />
+                ))}
+              </div>
+
+              <div className="ml-9 mt-7 rounded-xl border border-border bg-surface-2 px-5 py-4 shadow-[0_14px_28px_-24px_rgba(0,0,0,0.65)]">
+                <div className="mb-2 flex items-center gap-2 text-[14px] font-semibold text-muted">
+                  <AvatarDot label="SL" muted />
+                  Agent summary
+                  <span className="text-[13px] font-normal text-subtle">· 17:01 UTC</span>
+                </div>
+                <p className="break-words text-[15px] leading-6 text-fg">
+                  {detail.incident.rootCauseText}
+                </p>
+                <div className="mt-4 grid gap-3 md:grid-cols-2">
+                  <div className="rounded-lg border border-border bg-surface px-4 py-3">
+                    <div className="text-[12px] font-semibold text-muted">Impact</div>
+                    <p className="mt-1 text-[14px] leading-5 text-fg">
+                      {detail.incident.estimatedImpactText}
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-border bg-surface px-4 py-3">
+                    <div className="text-[12px] font-semibold text-muted">Sample event</div>
+                    <p className="mt-1 break-all font-mono text-[12px] leading-5 text-fg">
+                      trace {detail.issue.traceId}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ReferenceMetaRow({
+  label,
+  value,
+  icon,
+  chevron = false,
+  stackOnSmall = false,
+}: {
+  label: string;
+  value: string;
+  icon?: ReactNode;
+  chevron?: boolean;
+  stackOnSmall?: boolean;
+}) {
+  return (
+    <div
+      className={`grid items-start gap-3 text-[15px] ${
+        stackOnSmall
+          ? "grid-cols-1 sm:grid-cols-[138px_minmax(0,1fr)]"
+          : "grid-cols-[138px_minmax(0,1fr)]"
+      }`}
+    >
+      <div className="text-muted">{label}</div>
+      <div className="flex min-w-0 items-center gap-2 text-fg">
+        {icon}
+        <span className="min-w-0 break-words">{value}</span>
+        {chevron && <span className="text-subtle">›</span>}
+      </div>
+    </div>
+  );
+}
+
+function ReferenceActivityEntry({ item }: { item: ReferenceActivityItem }) {
+  return (
+    <div className="relative pb-7">
+      <span className="absolute -left-[34px] top-1 grid h-[20px] w-[20px] place-items-center rounded-full bg-surface">
+        <ReferenceActivityIcon kind={item.kind} />
+      </span>
+      <div className="flex flex-wrap items-baseline gap-2">
+        <span className="text-[15px] font-medium text-muted">{item.label}</span>
+        <span className="text-subtle">·</span>
+        <span className="text-[14px] text-subtle">{item.timeLabel}</span>
+      </div>
+      <p className="mt-2 max-w-[82ch] text-[16px] leading-6 text-fg">{item.body}</p>
+      {item.code && <ReferenceCodeDiff code={item.code} />}
+    </div>
+  );
+}
+
+function ReferenceCodeDiff({ code }: { code: NonNullable<ReferenceActivityItem["code"]> }) {
+  return (
+    <div className="mt-5 max-w-[820px] overflow-hidden rounded-lg border border-border bg-surface-2">
+      <div className="flex items-center gap-2 border-b border-border px-4 py-3 text-[14px] text-muted">
+        <GithubGlyph />
+        <span className="font-mono">{code.file}</span>
+      </div>
+      <div className="overflow-x-auto py-3 font-mono text-[14px] leading-6">
+        {code.context.slice(0, 2).map((line, index) => (
+          <ReferenceCodeLine key={`ctx-a-${line}`} lineNo={136 + index} text={line} />
+        ))}
+        {code.removed.map((line, index) => (
+          <ReferenceCodeLine key={`del-${line}`} lineNo={138 + index} text={line} tone="del" />
+        ))}
+        {code.added.map((line, index) => (
+          <ReferenceCodeLine key={`add-${line}`} lineNo={138 + index} text={line} tone="add" />
+        ))}
+        {code.context.slice(2).map((line, index) => (
+          <ReferenceCodeLine key={`ctx-b-${line}`} lineNo={141 + index} text={line} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ReferenceCodeLine({
+  lineNo,
+  text,
+  tone,
+}: {
+  lineNo: number;
+  text: string;
+  tone?: "add" | "del";
+}) {
+  const bg = tone === "add" ? "bg-success/10" : tone === "del" ? "bg-danger/10" : "";
+  const accent = tone === "add" ? "text-success" : tone === "del" ? "text-danger" : "text-subtle";
+  return (
+    <div
+      className={`grid grid-cols-[38px_24px_minmax(0,1fr)] px-2 sm:grid-cols-[46px_28px_minmax(0,1fr)] sm:px-3 ${bg}`}
+    >
+      <span className="select-none text-right text-subtle">{lineNo}</span>
+      <span className={`select-none text-center ${accent}`}>
+        {tone === "add" ? "+" : tone === "del" ? "-" : ""}
+      </span>
+      <span
+        className={tone === "add" ? "text-success" : tone === "del" ? "text-danger" : "text-muted"}
+      >
+        {text}
+      </span>
+    </div>
+  );
+}
+
+function ReferenceActivityIcon({ kind }: { kind: ReferenceActivityItem["kind"] }) {
+  const color =
+    kind === "finding" || kind === "status"
+      ? "var(--color-accent)"
+      : kind === "fix"
+        ? "var(--color-success)"
+        : "var(--color-subtle)";
+  return (
+    <span className="relative grid h-[12px] w-[12px] place-items-center">
+      <span className="absolute h-[5px] w-[5px] rounded-full" style={{ backgroundColor: color }} />
+      {(kind === "finding" || kind === "status") && (
+        <span className="h-[12px] w-[12px] rounded-full border border-accent" />
+      )}
+    </span>
+  );
+}
+
+function AvatarDot({ label, muted = false }: { label: string; muted?: boolean }) {
+  return (
+    <span
+      className={`grid h-6 w-6 shrink-0 place-items-center rounded-full text-[9px] font-semibold ${
+        muted ? "bg-surface-3 text-muted" : "bg-fg text-bg"
+      }`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function TinyBars() {
+  return (
+    <span className="flex h-5 w-5 shrink-0 items-end gap-[2px] text-muted" aria-hidden>
+      <span className="h-1.5 w-[3px] bg-current" />
+      <span className="h-3 w-[3px] bg-current" />
+      <span className="h-5 w-[3px] bg-current" />
+    </span>
+  );
+}
+
+function ReferenceStatusGlyph() {
+  return (
+    <span className="relative grid h-5 w-5 shrink-0 place-items-center" aria-hidden>
+      <span className="h-2 w-2 rounded-full bg-accent" />
+      <span className="absolute h-4 w-4 rounded-full border border-accent" />
+    </span>
+  );
+}
+
+function RefreshGlyph() {
+  return (
+    <svg
+      className="h-5 w-5 shrink-0 text-danger"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M20 12a8 8 0 0 1-14 5" />
+      <path d="M4 12a8 8 0 0 1 14-5" />
+      <path d="M18 3v4h-4M6 21v-4h4" />
+    </svg>
+  );
+}
+
+function CloudGlyph() {
+  return (
+    <span className="grid h-5 w-5 shrink-0 place-items-center rounded-full bg-[#f38020] text-[9px] font-bold text-white">
+      CF
+    </span>
+  );
+}
+
+function ApiGlyph() {
+  return (
+    <span className="grid h-5 w-5 shrink-0 place-items-center rounded-full bg-fg text-[9px] font-bold text-bg">
+      API
+    </span>
+  );
+}
+
+function GithubGlyph() {
+  return (
+    <svg
+      className="h-4 w-4 shrink-0 text-muted"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M12 .7a11.3 11.3 0 0 0-3.6 22c.6.1.8-.2.8-.5v-2c-3.3.7-4-1.4-4-1.4-.6-1.3-1.4-1.7-1.4-1.7-1.1-.8.1-.8.1-.8 1.2.1 1.9 1.3 1.9 1.3 1.1 1.9 2.9 1.3 3.6 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.4-1.3-5.4-5.6 0-1.2.4-2.2 1.2-3-.1-.3-.5-1.5.1-3 0 0 1-.3 3.1 1.1.9-.3 1.9-.4 2.8-.4 1 0 1.9.1 2.8.4 2.1-1.4 3.1-1.1 3.1-1.1.6 1.5.2 2.7.1 3 .8.8 1.2 1.8 1.2 3 0 4.4-2.8 5.3-5.4 5.6.4.4.8 1.1.8 2.2v3.7c0 .3.2.6.8.5A11.3 11.3 0 0 0 12 .7Z" />
+    </svg>
   );
 }
 

--- a/apps/web/src/design/investigations/incident-detail-reference-model.test.ts
+++ b/apps/web/src/design/investigations/incident-detail-reference-model.test.ts
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  CLOUDFLARE_PREFLIGHT_DETAIL,
+  buildReferenceActivity,
+  referenceIncidentStats,
+} from "./incident-detail-reference-model.ts";
+
+test("reference incident detail is pinned to the requested production incident", () => {
+  assert.equal(CLOUDFLARE_PREFLIGHT_DETAIL.incident.id, "285160df-0e1c-4119-a481-4a54f2e5e72c");
+  assert.equal(
+    CLOUDFLARE_PREFLIGHT_DETAIL.incident.title,
+    "Cloudflare integration setup fails — preflight check rejects OTLP intake",
+  );
+  assert.equal(CLOUDFLARE_PREFLIGHT_DETAIL.incident.codename, "opal-tanuki");
+});
+
+test("reference activity tells the preflight failure and fix story", () => {
+  const activity = buildReferenceActivity(CLOUDFLARE_PREFLIGHT_DETAIL);
+
+  assert.deepEqual(
+    activity.map((item) => item.kind),
+    ["detected", "status", "finding", "fact", "assignment", "priority", "fix"],
+  );
+  assert.match(activity[2]!.body, /skipPreflightCheck/);
+  assert.match(activity[6]!.body, /raw Cloudflare error array/);
+});
+
+test("reference stats summarize duration and linked findings", () => {
+  const stats = referenceIncidentStats(CLOUDFLARE_PREFLIGHT_DETAIL);
+
+  assert.equal(stats.issueCountLabel, "1 finding");
+  assert.equal(stats.durationLabel, "22 min 29 s");
+  assert.equal(stats.latestDetectionLabel, "16:39 UTC");
+});

--- a/apps/web/src/design/investigations/incident-detail-reference-model.ts
+++ b/apps/web/src/design/investigations/incident-detail-reference-model.ts
@@ -1,0 +1,203 @@
+export type ReferenceIncident = {
+  id: string;
+  projectId: string;
+  codename: string;
+  title: string;
+  service: string;
+  environment: string;
+  severity: "SEV-1" | "SEV-2" | "SEV-3";
+  status: "open" | "resolved";
+  firstSeen: string;
+  lastSeen: string;
+  issueCount: number;
+  agentSummary: string;
+  rootCauseText: string;
+  rootCauseConfidence: number;
+  estimatedImpactText: string;
+  slackChannelId: string | null;
+  slackThreadTs: string | null;
+};
+
+export type ReferenceIssue = {
+  id: string;
+  kind: "log" | "trace";
+  service: string;
+  exceptionType: string;
+  title: string;
+  message: string;
+  eventCount: number;
+  traceId: string | null;
+  spanId: string | null;
+  seenAt: string;
+  resourceInstance: string;
+};
+
+export type ReferenceAgentRun = {
+  id: string;
+  state: "complete" | "running" | "failed";
+  runtime: string;
+  selectedRepoFullName: string;
+  startedAt: string;
+  completedAt: string;
+};
+
+export type ReferenceIncidentDetail = {
+  incident: ReferenceIncident;
+  issue: ReferenceIssue;
+  agentRun: ReferenceAgentRun;
+};
+
+export type ReferenceActivityKind =
+  | "detected"
+  | "status"
+  | "finding"
+  | "fact"
+  | "assignment"
+  | "priority"
+  | "fix";
+
+export type ReferenceActivityItem = {
+  kind: ReferenceActivityKind;
+  label: string;
+  timeLabel: string;
+  body: string;
+  code?: {
+    file: string;
+    removed: string[];
+    added: string[];
+    context: string[];
+  };
+};
+
+export const CLOUDFLARE_PREFLIGHT_DETAIL: ReferenceIncidentDetail = {
+  incident: {
+    id: "285160df-0e1c-4119-a481-4a54f2e5e72c",
+    projectId: "b925b1df-5b78-43c8-a816-6f00afb174af",
+    codename: "opal-tanuki",
+    title: "Cloudflare integration setup fails — preflight check rejects OTLP intake",
+    service: "superlog-api",
+    environment: "production",
+    severity: "SEV-2",
+    status: "open",
+    firstSeen: "2026-06-30T16:39:01.388Z",
+    lastSeen: "2026-06-30T16:39:01.388Z",
+    issueCount: 1,
+    slackChannelId: "C0B8T8ZKMGV",
+    slackThreadTs: "1782837579.126859",
+    agentSummary:
+      "Cloudflare Connect provisioning fails for all users because Cloudflare's synthetic preflight check to the OTLP intake is rejected, causing every destination creation to return 400.",
+    rootCauseText:
+      "The Cloudflare Workers Observability Destinations API performs a synthetic preflight HTTP request before creating a destination. The probe hits the OTLP intake without a valid x-api-key header or proper OTLP payload, so traces, logs, and metrics destinations all fail.",
+    rootCauseConfidence: 8,
+    estimatedImpactText:
+      "Every user who clicks Connect Cloudflare and completes OAuth is redirected to the error state; the integration cannot be installed by anyone.",
+  },
+  issue: {
+    id: "b08fa0b6-8888-4efd-aa84-e3e992e5ffdd",
+    kind: "log",
+    service: "superlog-api",
+    exceptionType: "ERROR",
+    title: "ERROR: cloudflare provisioning failed",
+    message: "cloudflare provisioning failed",
+    eventCount: 1,
+    traceId: "37bdacb395b41b683917df3674f8a7b0",
+    spanId: "784778a2160850fb",
+    seenAt: "2026-06-30T16:39:01.388Z",
+    resourceInstance: "ip-10-0-12-68.us-west-2.compute.internal",
+  },
+  agentRun: {
+    id: "138e571a-a21b-4d66-a587-14dcabd94b2e",
+    state: "complete",
+    runtime: "anthropic",
+    selectedRepoFullName: "superloglabs/superlog",
+    startedAt: "2026-06-30T16:43:04.819Z",
+    completedAt: "2026-06-30T17:01:30.633Z",
+  },
+};
+
+export function buildReferenceActivity(detail: ReferenceIncidentDetail): ReferenceActivityItem[] {
+  return [
+    {
+      kind: "detected",
+      label: "Problem detected",
+      timeLabel: "16:39 UTC",
+      body: `${detail.issue.title}. Cloudflare OAuth completed, then provisioning failed before any telemetry destinations were created.`,
+    },
+    {
+      kind: "status",
+      label: "Status updated to Investigating",
+      timeLabel: "16:43 UTC",
+      body: "Investigation run started and selected the application repository for review.",
+    },
+    {
+      kind: "finding",
+      label: "Finding",
+      timeLabel: "16:52 UTC",
+      body: "Cloudflare's synthetic preflight probe is rejected by the OTLP intake. Add skipPreflightCheck: true when creating traces, logs, and metrics destinations.",
+      code: {
+        file: "apps/api/src/cloudflare-service.ts",
+        removed: ["enabled: true,"],
+        added: ["enabled: true,", "skipPreflightCheck: true,"],
+        context: [
+          "return {",
+          "  name: `Superlog ${input.signal}`,",
+          "  configuration: buildDestinationConfiguration(input),",
+          "};",
+        ],
+      },
+    },
+    {
+      kind: "fact",
+      label: "Fact",
+      timeLabel: "16:55 UTC",
+      body: 'All 3 signal destinations returned HTTP 400, so provisionInstallation threw "cloudflare connect: no telemetry destinations were created".',
+    },
+    {
+      kind: "assignment",
+      label: "Assigned",
+      timeLabel: "16:56 UTC",
+      body: "Assigned to the integration owner for review.",
+    },
+    {
+      kind: "priority",
+      label: "Priority set to SEV-2",
+      timeLabel: "16:57 UTC",
+      body: "The Cloudflare integration cannot be installed by any user until destination creation succeeds.",
+    },
+    {
+      kind: "fix",
+      label: "Suggested fix",
+      timeLabel: "17:01 UTC",
+      body: "Skip Cloudflare's preflight check for OTLP destinations and thread the raw Cloudflare error array into WARN logs so failed provisioning is diagnosable next time.",
+    },
+  ];
+}
+
+export function referenceIncidentStats(detail: ReferenceIncidentDetail) {
+  const durationMs =
+    Date.parse(detail.agentRun.completedAt) - Date.parse(detail.incident.firstSeen);
+  return {
+    issueCountLabel: `${detail.incident.issueCount} finding${detail.incident.issueCount === 1 ? "" : "s"}`,
+    durationLabel: formatDuration(durationMs),
+    firstDetectionLabel: formatUtcTime(detail.incident.firstSeen),
+    latestDetectionLabel: formatUtcTime(detail.incident.lastSeen),
+  };
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes} min ${seconds} s`;
+}
+
+function formatUtcTime(iso: string): string {
+  return (
+    new Intl.DateTimeFormat("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+      timeZone: "UTC",
+    }).format(new Date(iso)) + " UTC"
+  );
+}

--- a/apps/web/src/design/ui.tsx
+++ b/apps/web/src/design/ui.tsx
@@ -372,18 +372,14 @@ export function AppShell({
   children: ReactNode;
 }) {
   return (
-    // min-h subtracts the impersonation banner height so the page doesn't
-    // overflow by the banner's height (the banner is position:fixed, so it
-    // adds nothing to flow but still occupies viewport space the shell can't
-    // claim). Falls back to 0 for non-impersonating sessions.
-    <div className="relative min-h-[calc(100vh-var(--impersonation-h,0px))] bg-bg font-sans text-fg">
+    <div className="relative flex min-h-0 flex-1 flex-col bg-bg font-sans text-fg">
       {nav && (
-        <header className="fixed inset-x-0 top-[var(--impersonation-h,0px)] z-30 bg-bg">
+        <header className="shrink-0 bg-bg">
           <div className="px-6">{nav}</div>
           <div className="h-px bg-border" />
         </header>
       )}
-      <main className="relative">{children}</main>
+      <main className="relative flex min-h-0 flex-1 flex-col">{children}</main>
     </div>
   );
 }

--- a/apps/web/src/incident-status-action.test.ts
+++ b/apps/web/src/incident-status-action.test.ts
@@ -8,13 +8,13 @@ test("open incidents offer problem-resolved and not-an-issue", () => {
       label: "Problem resolved",
       targetStatus: "resolved",
       resolution: "problem_resolved",
-      variant: "secondary",
+      variant: "primary",
     },
     {
       label: "Not an issue",
       targetStatus: "resolved",
       resolution: "not_an_issue",
-      variant: "ghost",
+      variant: "secondary",
     },
   ]);
 });

--- a/apps/web/src/incident-status-action.ts
+++ b/apps/web/src/incident-status-action.ts
@@ -5,7 +5,7 @@ export type IncidentStatusAction = {
   // resolved (recurrence opens a new chained incident); not_an_issue silences
   // them (future occurrences are suppressed).
   resolution?: "problem_resolved" | "not_an_issue";
-  variant: "secondary" | "ghost";
+  variant: "primary" | "secondary" | "ghost";
 };
 
 export function getIncidentStatusActions(status: string): IncidentStatusAction[] {
@@ -15,13 +15,13 @@ export function getIncidentStatusActions(status: string): IncidentStatusAction[]
         label: "Problem resolved",
         targetStatus: "resolved",
         resolution: "problem_resolved",
-        variant: "secondary",
+        variant: "primary",
       },
       {
         label: "Not an issue",
         targetStatus: "resolved",
         resolution: "not_an_issue",
-        variant: "ghost",
+        variant: "secondary",
       },
     ];
   }

--- a/apps/web/src/incidents/incident-detail-view-model.test.ts
+++ b/apps/web/src/incidents/incident-detail-view-model.test.ts
@@ -72,3 +72,19 @@ test("buildIncidentDetailMeta returns one sidebar row list without duplicating t
     ],
   );
 });
+
+test("buildIncidentDetailMeta formats midnight UTC with hour zero", () => {
+  const meta = buildIncidentDetailMeta({
+    incident: {
+      ...incident,
+      firstSeen: "2026-06-30T00:05:00.000Z",
+      lastSeen: "2026-06-30T00:06:00.000Z",
+    },
+    issueCount: 1,
+    agentRunState: "complete",
+    pendingRecovery: false,
+  });
+
+  assert.equal(meta.find((row) => row.label === "First detection")?.value, "Jun 30, 00:05 UTC");
+  assert.equal(meta.find((row) => row.label === "Latest detection")?.value, "Jun 30, 00:06 UTC");
+});

--- a/apps/web/src/incidents/incident-detail-view-model.test.ts
+++ b/apps/web/src/incidents/incident-detail-view-model.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildIncidentDetailMeta,
+  formatIncidentDuration,
+  incidentDisplayStatus,
+} from "./incident-detail-view-model.ts";
+
+const incident = {
+  id: "inc_1",
+  projectId: "p1",
+  service: "superlog-api",
+  environment: "production",
+  title: "Cloudflare integration setup fails",
+  codename: "opal-tanuki",
+  severity: "SEV-2" as const,
+  status: "open",
+  noiseReason: null,
+  noiseResolvedAt: null,
+  firstSeen: "2026-06-30T16:39:01.388Z",
+  lastSeen: "2026-06-30T16:41:30.000Z",
+  issueCount: 1,
+  slackChannelId: null,
+  slackThreadTs: null,
+  agentSummary: "summary",
+  rootCauseText: null,
+  rootCauseConfidence: null,
+  estimatedImpactText: null,
+  estimatedImpactConfidence: null,
+  suggestedSeverity: null,
+  noiseClassification: null,
+  resolutionClassification: null,
+  findingsAgentRunId: null,
+  createdAt: "2026-06-30T16:39:01.388Z",
+  updatedAt: "2026-06-30T17:01:30.633Z",
+};
+
+test("incidentDisplayStatus uses active language for open incidents", () => {
+  assert.equal(incidentDisplayStatus("open", false), "Active");
+  assert.equal(incidentDisplayStatus("resolved", false), "Resolved");
+  assert.equal(incidentDisplayStatus("autoresolved_noise", false), "Noise");
+  assert.equal(incidentDisplayStatus("open", true), "Recovery detected");
+});
+
+test("formatIncidentDuration formats compact elapsed time", () => {
+  assert.equal(
+    formatIncidentDuration("2026-06-30T16:39:01.388Z", "2026-06-30T17:01:30.633Z"),
+    "22 min 29 s",
+  );
+});
+
+test("buildIncidentDetailMeta returns one sidebar row list without duplicating the title", () => {
+  const meta = buildIncidentDetailMeta({
+    incident,
+    issueCount: 1,
+    agentRunState: "complete",
+    pendingRecovery: false,
+  });
+
+  assert.deepEqual(
+    meta.map((row) => [row.label, row.value]),
+    [
+      ["Priority", "SEV-2"],
+      ["Status", "Active"],
+      ["Service", "superlog-api"],
+      ["Environment", "production"],
+      ["First detection", "Jun 30, 16:39 UTC"],
+      ["Latest detection", "Jun 30, 16:41 UTC"],
+      ["Duration", "2 min 29 s"],
+      ["Findings", "1 finding"],
+      ["Agent run", "complete"],
+    ],
+  );
+});

--- a/apps/web/src/incidents/incident-detail-view-model.ts
+++ b/apps/web/src/incidents/incident-detail-view-model.ts
@@ -63,8 +63,8 @@ function formatIncidentUtc(iso: string): string {
   const day = new Intl.DateTimeFormat("en-US", { day: "numeric", timeZone: "UTC" }).format(date);
   const time = new Intl.DateTimeFormat("en-US", {
     hour: "2-digit",
+    hourCycle: "h23",
     minute: "2-digit",
-    hour12: false,
     timeZone: "UTC",
   }).format(date);
   return `${month} ${day}, ${time} UTC`;

--- a/apps/web/src/incidents/incident-detail-view-model.ts
+++ b/apps/web/src/incidents/incident-detail-view-model.ts
@@ -1,0 +1,79 @@
+import type { AgentRun, Incident } from "../api.ts";
+
+export type IncidentMetaRow = {
+  label: string;
+  value: string;
+  kind?: "priority" | "status" | "environment" | "findings" | "agent";
+};
+
+export function incidentDisplayStatus(status: string, pendingRecovery: boolean): string {
+  if (pendingRecovery) return "Recovery detected";
+  if (status === "open") return "Active";
+  if (status === "resolved") return "Resolved";
+  if (status === "autoresolved_noise") return "Noise";
+  return titleizeStatus(status);
+}
+
+export function formatIncidentDuration(firstSeen: string, lastSeen: string): string {
+  const seconds = Math.max(0, Math.round((Date.parse(lastSeen) - Date.parse(firstSeen)) / 1000));
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const remainingSeconds = seconds % 60;
+
+  if (hours > 0) return `${hours} h ${minutes} min`;
+  if (minutes > 0) return `${minutes} min ${remainingSeconds} s`;
+  return `${remainingSeconds} s`;
+}
+
+export function buildIncidentDetailMeta({
+  incident,
+  issueCount,
+  agentRunState,
+  pendingRecovery,
+}: {
+  incident: Incident;
+  issueCount: number;
+  agentRunState: AgentRun["state"] | null;
+  pendingRecovery: boolean;
+}): IncidentMetaRow[] {
+  return [
+    { label: "Priority", value: incident.severity ?? "Unset", kind: "priority" },
+    {
+      label: "Status",
+      value: incidentDisplayStatus(incident.status, pendingRecovery),
+      kind: "status",
+    },
+    { label: "Service", value: incident.service ?? "Unknown" },
+    { label: "Environment", value: incident.environment ?? "Unknown", kind: "environment" },
+    { label: "First detection", value: formatIncidentUtc(incident.firstSeen) },
+    { label: "Latest detection", value: formatIncidentUtc(incident.lastSeen) },
+    { label: "Duration", value: formatIncidentDuration(incident.firstSeen, incident.lastSeen) },
+    { label: "Findings", value: formatFindingsCount(issueCount), kind: "findings" },
+    { label: "Agent run", value: agentRunState ?? "not queued", kind: "agent" },
+  ];
+}
+
+function formatFindingsCount(count: number): string {
+  return `${count.toLocaleString()} finding${count === 1 ? "" : "s"}`;
+}
+
+function formatIncidentUtc(iso: string): string {
+  const date = new Date(iso);
+  const month = new Intl.DateTimeFormat("en-US", { month: "short", timeZone: "UTC" }).format(date);
+  const day = new Intl.DateTimeFormat("en-US", { day: "numeric", timeZone: "UTC" }).format(date);
+  const time = new Intl.DateTimeFormat("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "UTC",
+  }).format(date);
+  return `${month} ${day}, ${time} UTC`;
+}
+
+function titleizeStatus(status: string): string {
+  return status
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}


### PR DESCRIPTION
## Summary
- replace the incident drawer with a full-page incident detail layout
- add a left-side incident summary rail and tabbed activity/findings/PR content
- keep the detail view grounded in a real incident reference model for the design playground
- simplify incident status actions and move page chrome to normal flex flow

## Validation
- `pnpm --dir superlog exec tsx --test apps/web/src/incident-status-action.test.ts apps/web/src/incidents/incident-detail-view-model.test.ts apps/web/src/design/investigations/incident-detail-reference-model.test.ts`
- `pnpm --dir superlog --filter @superlog/web typecheck`
- local browser render of `/incidents/285160df-0e1c-4119-a481-4a54f2e5e72c`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the incident detail from a drawer to a full-page view with a left summary rail and tabbed content (Activity, Findings, PR) for clearer investigation and faster actions. The layout moves app chrome into normal flow and promotes primary resolution actions.

- **New Features**
  - Full-page incident detail with a left summary rail (agent summary + priority/status/service/env/first/latest/duration/findings/agent run with small glyphs).
  - Tabs: Activity (timeline + transcript), Findings (alerts, issues, proposals, agent run), PR.
  - Header actions promote “Problem resolved” (primary) and “Not an issue” (secondary); other status actions live in the sidebar.
  - Copy agent prompt and feedback buttons now use `@hugeicons` and support full-width placement.
  - Direct routes to `/incidents/:id` render the full-page detail.
  - Design playground adds an “Incident detail” mock pinned to a real incident with tests for activity/story and stats.

- **Refactors**
  - Layout: removed fixed top banners; `AppShell` and route container now run in-flow flex; incident detail gets a full-height container; drawers use relative overlays.
  - View model: new `incidents/incident-detail-view-model` for sidebar meta and formatting, with tests.

<sup>Written for commit 56d2dd37e3cf96a9acd30ec8ffb5ac36aaa824af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

