### PR TITLE
Harden webhook delivery against SSRF

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -35,6 +35,7 @@
     "@scalar/hono-api-reference": "^0.10.19",
     "@superlog/db": "workspace:*",
     "@superlog/fingerprint": "workspace:*",
+    "@superlog/net-guard": "workspace:*",
     "autumn-js": "^1.2.27",
     "better-auth": "^1.6.11",
     "dotenv": "^17.4.2",

--- a/apps/api/src/webhooks.ts
+++ b/apps/api/src/webhooks.ts
@@ -245,10 +245,19 @@ export function mountWebhooks(app: Hono<any>): void {
     const id = c.req.param("id");
     const deliveryId = c.req.param("deliveryId");
     await requireProjectAccess(c, projectId);
+    // Scope the endpoint to projectId so a caller can't read a delivery under
+    // another project's endpoint by guessing its id + deliveryId.
+    const endpoint = await db.query.webhookEndpoints.findFirst({
+      where: and(
+        eq(schema.webhookEndpoints.id, id),
+        eq(schema.webhookEndpoints.projectId, projectId),
+      ),
+    });
+    if (!endpoint) throw new HTTPException(404, { message: "endpoint not found" });
     const delivery = await db.query.webhookDeliveries.findFirst({
       where: eq(schema.webhookDeliveries.id, deliveryId),
     });
-    if (!delivery || delivery.endpointId !== id) {
+    if (!delivery || delivery.endpointId !== endpoint.id) {
       throw new HTTPException(404, { message: "delivery not found" });
     }
     return c.json(toDeliveryView(delivery));
@@ -259,10 +268,19 @@ export function mountWebhooks(app: Hono<any>): void {
     const id = c.req.param("id");
     const deliveryId = c.req.param("deliveryId");
     await requireProjectAccess(c, projectId);
+    // Scope the endpoint to projectId so a caller can't redeliver under another
+    // project's endpoint by guessing its id + deliveryId.
+    const endpoint = await db.query.webhookEndpoints.findFirst({
+      where: and(
+        eq(schema.webhookEndpoints.id, id),
+        eq(schema.webhookEndpoints.projectId, projectId),
+      ),
+    });
+    if (!endpoint) throw new HTTPException(404, { message: "endpoint not found" });
     const original = await db.query.webhookDeliveries.findFirst({
       where: eq(schema.webhookDeliveries.id, deliveryId),
     });
-    if (!original || original.endpointId !== id) {
+    if (!original || original.endpointId !== endpoint.id) {
       throw new HTTPException(404, { message: "delivery not found" });
     }
     const fresh = await enqueueRedelivery(deliveryId);

--- a/apps/api/src/webhooks.ts
+++ b/apps/api/src/webhooks.ts
@@ -7,6 +7,7 @@ import {
   isWebhookEventType,
   schema,
 } from "@superlog/db";
+import { WebhookDestinationError, assertPublicWebhookUrl } from "@superlog/net-guard";
 import { and, desc, eq } from "drizzle-orm";
 import type { Hono } from "hono";
 import type { Context } from "hono";
@@ -32,6 +33,37 @@ function parseEnabledEvents(raw: unknown): schema.WebhookEventType[] {
     throw new HTTPException(400, { message: "enabledEvents must include at least one event" });
   }
   return WEBHOOK_EVENT_TYPES.filter((event) => requested.has(event));
+}
+
+// Reject a destination that isn't a public http(s) endpoint (SSRF guard). The
+// worker re-validates and pins the connection at delivery time; this is the
+// fail-fast check so a bad URL is rejected at create/update instead of silently
+// failing every delivery.
+async function assertWebhookUrl(url: string): Promise<void> {
+  try {
+    await assertPublicWebhookUrl(url);
+  } catch (err) {
+    if (err instanceof WebhookDestinationError) {
+      throw new HTTPException(400, { message: err.message });
+    }
+    throw err;
+  }
+}
+
+// Tenant-facing shape of a delivery record. Excludes lastResponseBody and
+// lastError — those hold raw upstream response content and are never returned.
+function toDeliveryView(d: schema.WebhookDelivery) {
+  return {
+    id: d.id,
+    eventType: d.eventType,
+    status: d.status,
+    attemptCount: d.attemptCount,
+    nextAttemptAt: d.nextAttemptAt,
+    lastAttemptAt: d.lastAttemptAt,
+    lastResponseStatus: d.lastResponseStatus,
+    deliveredAt: d.deliveredAt,
+    createdAt: d.createdAt,
+  };
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: Hono Variables invariance.
@@ -79,14 +111,7 @@ export function mountWebhooks(app: Hono<any>): void {
     };
     const url = typeof body.url === "string" ? body.url.trim() : "";
     if (!url) throw new HTTPException(400, { message: "url required" });
-    try {
-      const parsed = new URL(url);
-      if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
-        throw new Error("invalid protocol");
-      }
-    } catch {
-      throw new HTTPException(400, { message: "url must be a valid http(s) URL" });
-    }
+    await assertWebhookUrl(url);
     const description =
       typeof body.description === "string" ? body.description.slice(0, 500) : null;
     // Omitting enabledEvents falls back to the column default (so existing
@@ -124,11 +149,7 @@ export function mountWebhooks(app: Hono<any>): void {
     const patch: Partial<typeof schema.webhookEndpoints.$inferInsert> = { updatedAt: new Date() };
     if (typeof body.url === "string") {
       const url = body.url.trim();
-      try {
-        new URL(url);
-      } catch {
-        throw new HTTPException(400, { message: "invalid url" });
-      }
+      await assertWebhookUrl(url);
       patch.url = url;
     }
     if (typeof body.description === "string") patch.description = body.description.slice(0, 500);
@@ -213,21 +234,10 @@ export function mountWebhooks(app: Hono<any>): void {
       orderBy: [desc(schema.webhookDeliveries.createdAt)],
       limit: 50,
     });
-    return c.json(
-      rows.map((d) => ({
-        id: d.id,
-        eventType: d.eventType,
-        status: d.status,
-        attemptCount: d.attemptCount,
-        nextAttemptAt: d.nextAttemptAt,
-        lastAttemptAt: d.lastAttemptAt,
-        lastResponseStatus: d.lastResponseStatus,
-        lastResponseBody: d.lastResponseBody,
-        lastError: d.lastError,
-        deliveredAt: d.deliveredAt,
-        createdAt: d.createdAt,
-      })),
-    );
+    // Only the delivery outcome is exposed — never the raw upstream response
+    // body or connection error, which would turn deliveries into a read side
+    // channel for whatever the worker reached.
+    return c.json(rows.map(toDeliveryView));
   });
 
   app.get("/api/projects/:projectId/webhooks/:id/deliveries/:deliveryId", async (c) => {
@@ -241,7 +251,7 @@ export function mountWebhooks(app: Hono<any>): void {
     if (!delivery || delivery.endpointId !== id) {
       throw new HTTPException(404, { message: "delivery not found" });
     }
-    return c.json(delivery);
+    return c.json(toDeliveryView(delivery));
   });
 
   app.post("/api/projects/:projectId/webhooks/:id/deliveries/:deliveryId/redeliver", async (c) => {

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -4760,7 +4760,9 @@ function WebhookSchemaModal({ onClose }: { onClose: () => void }) {
                   <code>lastError = "endpoint disabled"</code>.
                 </li>
                 <li>
-                  Response bodies are captured and stored truncated to 2 KiB in the deliveries log.
+                  Deliveries record only the outcome (status + HTTP response code). Destinations
+                  must be public http(s) endpoints — private, loopback, and link-local addresses are
+                  rejected — and the upstream response body is never stored or shown.
                 </li>
               </ul>
             </section>
@@ -4987,12 +4989,6 @@ function DeliveryRow({
         <tr>
           <td colSpan={6} className="bg-surface-1 py-2 pr-3">
             <div className="space-y-1 font-mono text-[11px] text-muted">
-              {delivery.lastError && <div>error: {delivery.lastError}</div>}
-              {delivery.lastResponseBody && (
-                <div>
-                  body: <span className="break-all">{delivery.lastResponseBody}</span>
-                </div>
-              )}
               <div>next attempt: {new Date(delivery.nextAttemptAt).toLocaleString()}</div>
               {delivery.deliveredAt && (
                 <div>delivered: {new Date(delivery.deliveredAt).toLocaleString()}</div>

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -296,8 +296,6 @@ export type WebhookDelivery = {
   nextAttemptAt: string;
   lastAttemptAt: string | null;
   lastResponseStatus: number | null;
-  lastResponseBody: string | null;
-  lastError: string | null;
   deliveredAt: string | null;
   createdAt: string;
 };

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -62,6 +62,7 @@
     "@superlog/billing": "workspace:*",
     "@superlog/db": "workspace:*",
     "@superlog/fingerprint": "workspace:*",
+    "@superlog/net-guard": "workspace:*",
     "@superlog/topology": "workspace:*",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",

--- a/apps/worker/src/webhooks.ts
+++ b/apps/worker/src/webhooks.ts
@@ -1,5 +1,6 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { type DB, db as defaultDb, schema } from "@superlog/db";
+import { webhookFetch } from "@superlog/net-guard";
 import { and, asc, desc, eq, lte } from "drizzle-orm";
 import { logger } from "./logger.js";
 
@@ -16,7 +17,6 @@ export {
 const MAX_ATTEMPTS = 8;
 const BATCH = 20;
 const REQUEST_TIMEOUT_MS = 10_000;
-const RESPONSE_BODY_TRUNC = 2048;
 
 export function backoffDelayMs(attempt: number): number {
   // 30s, 1m, 2m, 5m, 15m, 1h, 6h, 24h — caller bumps `attempt` before lookup.
@@ -68,14 +68,19 @@ async function attemptDelivery(
   const now = new Date();
 
   let status: number | null = null;
-  let responseText: string | null = null;
   let errorMessage: string | null = null;
 
   try {
+    // webhookFetch is SSRF-guarded: it rejects non-public destinations and pins
+    // the connection to a validated IP, so a delivery to an internal host fails
+    // here with an error instead of proxying the request.
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
     try {
-      const res = await fetch(endpoint.url, {
+      // Response body is deliberately not read or stored — we only need whether
+      // delivery succeeded, and reflecting an internal response back to the
+      // tenant would defeat the point of the egress guard.
+      const res = await webhookFetch(endpoint.url, {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -88,8 +93,6 @@ async function attemptDelivery(
         signal: controller.signal,
       });
       status = res.status;
-      const text = await res.text().catch(() => "");
-      responseText = text.length > RESPONSE_BODY_TRUNC ? text.slice(0, RESPONSE_BODY_TRUNC) : text;
     } finally {
       clearTimeout(timer);
     }
@@ -107,7 +110,7 @@ async function attemptDelivery(
         lastAttemptAt: now,
         deliveredAt: now,
         lastResponseStatus: status,
-        lastResponseBody: responseText,
+        lastResponseBody: null,
         lastError: null,
       })
       .where(eq(schema.webhookDeliveries.id, delivery.id));
@@ -123,7 +126,7 @@ async function attemptDelivery(
       attemptCount,
       lastAttemptAt: now,
       lastResponseStatus: status,
-      lastResponseBody: responseText,
+      lastResponseBody: null,
       lastError: errorMessage,
       nextAttemptAt,
     })

--- a/packages/net-guard/package.json
+++ b/packages/net-guard/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@superlog/net-guard",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "tsx --test src/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "undici": "^7.16.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/net-guard/src/index.test.ts
+++ b/packages/net-guard/src/index.test.ts
@@ -69,6 +69,11 @@ describe("isBlockedAddress — IPv6", () => {
     "::ffff:127.0.0.1", // v4-mapped loopback
     "::ffff:169.254.169.254", // v4-mapped metadata
     "::ffff:10.0.0.1", // v4-mapped private
+    "2001::1", // Teredo 2001::/32
+    "2001:2::1", // benchmarking 2001:2::/48
+    "2002:c0a8:0101::1", // 6to4 2002::/16 wrapping 192.168.1.1
+    "3fff::1", // documentation 3fff::/20
+    "3fff:0fff::1", // documentation 3fff::/20 upper edge
   ];
   for (const ip of blocked) {
     it(`blocks ${ip}`, () => assert.equal(isBlockedAddress(ip), true));

--- a/packages/net-guard/src/index.test.ts
+++ b/packages/net-guard/src/index.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { WebhookDestinationError, assertPublicWebhookUrl, isBlockedAddress } from "./index.js";
+
+describe("isBlockedAddress — IPv4", () => {
+  const blocked = [
+    "0.0.0.0",
+    "0.1.2.3",
+    "10.0.0.1",
+    "10.255.255.254",
+    "100.64.0.1", // CGNAT
+    "100.127.255.255",
+    "127.0.0.1",
+    "127.1.2.3",
+    "169.254.169.254", // cloud metadata / link-local
+    "169.254.0.1",
+    "172.16.0.1",
+    "172.31.255.255",
+    "192.0.0.1",
+    "192.0.2.5", // TEST-NET-1
+    "192.88.99.1",
+    "192.168.0.1",
+    "192.168.1.1",
+    "198.18.0.1", // benchmarking
+    "198.51.100.1", // TEST-NET-2
+    "203.0.113.1", // TEST-NET-3
+    "224.0.0.1", // multicast
+    "239.255.255.255",
+    "240.0.0.1", // reserved
+    "255.255.255.255",
+  ];
+  for (const ip of blocked) {
+    it(`blocks ${ip}`, () => assert.equal(isBlockedAddress(ip), true));
+  }
+
+  const allowed = [
+    "1.1.1.1",
+    "8.8.8.8",
+    "93.184.216.34", // example.com
+    "172.15.255.255", // just below 172.16/12
+    "172.32.0.1", // just above 172.16/12
+    "100.63.255.255", // just below CGNAT
+    "100.128.0.1", // just above CGNAT
+    "11.0.0.1",
+    "126.255.255.255", // just below 127/8
+    "128.0.0.1", // just above 127/8
+    "169.253.255.255", // just below link-local
+    "169.255.0.1", // just above link-local
+    "192.0.1.255", // just below 192.0.2/24
+    "192.0.3.0", // just above 192.0.2/24
+  ];
+  for (const ip of allowed) {
+    it(`allows ${ip}`, () => assert.equal(isBlockedAddress(ip), false));
+  }
+});
+
+describe("isBlockedAddress — IPv6", () => {
+  const blocked = [
+    "::1", // loopback
+    "::", // unspecified
+    "fc00::1", // ULA
+    "fd12:3456:789a::1", // ULA
+    "fe80::1", // link-local
+    "febf::1", // link-local upper edge
+    "ff02::1", // multicast
+    "2001:db8::1", // documentation
+    "64:ff9b::a9fe:a9fe", // NAT64 wrapping 169.254.169.254
+    "64:ff9b::7f00:1", // NAT64 wrapping 127.0.0.1
+    "::ffff:127.0.0.1", // v4-mapped loopback
+    "::ffff:169.254.169.254", // v4-mapped metadata
+    "::ffff:10.0.0.1", // v4-mapped private
+  ];
+  for (const ip of blocked) {
+    it(`blocks ${ip}`, () => assert.equal(isBlockedAddress(ip), true));
+  }
+
+  const allowed = [
+    "2606:4700:4700::1111", // cloudflare dns
+    "2001:4860:4860::8888", // google dns
+    "2000::1", // low edge of global unicast
+    "::ffff:8.8.8.8", // v4-mapped public
+  ];
+  for (const ip of allowed) {
+    it(`allows ${ip}`, () => assert.equal(isBlockedAddress(ip), false));
+  }
+
+  it("blocks addresses outside global-unicast 2000::/3", () => {
+    assert.equal(isBlockedAddress("4000::1"), true);
+    assert.equal(isBlockedAddress("1000::1"), true);
+  });
+
+  it("blocks garbage that isn't an IP", () => {
+    assert.equal(isBlockedAddress("not-an-ip"), true);
+    assert.equal(isBlockedAddress(""), true);
+  });
+});
+
+describe("assertPublicWebhookUrl", () => {
+  const origEnv = process.env.WEBHOOK_ALLOW_PRIVATE_DESTINATIONS;
+  afterEach(() => {
+    process.env.WEBHOOK_ALLOW_PRIVATE_DESTINATIONS = origEnv ?? "";
+  });
+
+  async function rejects(url: string) {
+    await assert.rejects(() => assertPublicWebhookUrl(url), WebhookDestinationError);
+  }
+
+  it("rejects non-http(s) schemes", async () => {
+    await rejects("ftp://example.com/");
+    await rejects("file:///etc/passwd");
+    await rejects("gopher://example.com/");
+  });
+
+  it("rejects malformed urls", async () => {
+    await rejects("not a url");
+    await rejects("");
+  });
+
+  it("rejects embedded credentials", async () => {
+    await rejects("http://user:pass@example.com/");
+  });
+
+  it("rejects literal private / loopback / metadata IPs", async () => {
+    await rejects("http://127.0.0.1/");
+    await rejects("http://169.254.169.254/latest/meta-data/");
+    await rejects("http://10.0.0.5:8123/");
+    await rejects("http://[::1]/");
+    await rejects("http://[::ffff:127.0.0.1]/");
+    await rejects("https://192.168.1.1/");
+  });
+
+  it("accepts a public literal IP", async () => {
+    await assert.doesNotReject(() => assertPublicWebhookUrl("https://1.1.1.1/hook"));
+  });
+
+  it("still enforces scheme even with the private-destinations escape hatch on", async () => {
+    process.env.WEBHOOK_ALLOW_PRIVATE_DESTINATIONS = "1";
+    await rejects("ftp://127.0.0.1/");
+    // ...but a private literal is allowed once the hatch is open
+    await assert.doesNotReject(() => assertPublicWebhookUrl("http://127.0.0.1:8080/"));
+  });
+});

--- a/packages/net-guard/src/index.ts
+++ b/packages/net-guard/src/index.ts
@@ -1,0 +1,282 @@
+import { lookup } from "node:dns";
+import { isIP } from "node:net";
+import { Agent, type Dispatcher, fetch as undiciFetch } from "undici";
+
+// Guards outbound webhook delivery against SSRF. The destination host is
+// resolved and every resolved address is checked against a default-deny set of
+// non-public ranges (RFC1918, loopback, link-local / cloud-metadata, CGNAT,
+// ULA, multicast, reserved, documentation). The connection is then pinned to a
+// validated address so a second DNS answer can't rebind us onto an internal
+// host between the check and the connect.
+//
+// An operator escape hatch (WEBHOOK_ALLOW_PRIVATE_DESTINATIONS=1) exists for
+// local dev and self-hosters who deliberately point webhooks at private
+// infrastructure. It is off by default; scheme/credential checks still apply.
+
+export class WebhookDestinationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WebhookDestinationError";
+  }
+}
+
+function allowPrivateDestinations(): boolean {
+  const v = process.env.WEBHOOK_ALLOW_PRIVATE_DESTINATIONS;
+  return v === "1" || v === "true";
+}
+
+// --- IPv4 ---------------------------------------------------------------
+
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  let n = 0;
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const v = Number(part);
+    if (v > 255) return null;
+    n = (n << 8) | v;
+  }
+  return n >>> 0;
+}
+
+// [network, prefix-bits]
+const BLOCKED_V4: ReadonlyArray<readonly [string, number]> = [
+  ["0.0.0.0", 8], // "this" network
+  ["10.0.0.0", 8], // RFC1918
+  ["100.64.0.0", 10], // carrier-grade NAT
+  ["127.0.0.0", 8], // loopback
+  ["169.254.0.0", 16], // link-local + cloud metadata (169.254.169.254)
+  ["172.16.0.0", 12], // RFC1918
+  ["192.0.0.0", 24], // IETF protocol assignments
+  ["192.0.2.0", 24], // TEST-NET-1
+  ["192.88.99.0", 24], // 6to4 relay anycast
+  ["192.168.0.0", 16], // RFC1918
+  ["198.18.0.0", 15], // benchmarking
+  ["198.51.100.0", 24], // TEST-NET-2
+  ["203.0.113.0", 24], // TEST-NET-3
+  ["224.0.0.0", 4], // multicast
+  ["240.0.0.0", 4], // reserved (covers 255.255.255.255)
+];
+
+function inCidr4(ip: number, network: string, bits: number): boolean {
+  const base = ipv4ToInt(network);
+  if (base === null) return false;
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+  return (ip & mask) >>> 0 === (base & mask) >>> 0;
+}
+
+export function isBlockedIpv4(ip: string): boolean {
+  const n = ipv4ToInt(ip);
+  if (n === null) return true; // unparseable → fail closed
+  return BLOCKED_V4.some(([net, bits]) => inCidr4(n, net, bits));
+}
+
+// --- IPv6 ---------------------------------------------------------------
+
+// Parse into 8 16-bit groups, or null if malformed. Handles "::" compression,
+// zone ids, and embedded IPv4 (e.g. ::ffff:1.2.3.4).
+function parseIpv6(input: string): number[] | null {
+  let s = input;
+  const zone = s.indexOf("%");
+  if (zone >= 0) s = s.slice(0, zone);
+  if (s.length === 0) return null;
+
+  let ipv4Tail: [number, number] | null = null;
+  if (s.includes(".")) {
+    const colon = s.lastIndexOf(":");
+    if (colon < 0) return null;
+    const v4 = ipv4ToInt(s.slice(colon + 1));
+    if (v4 === null) return null;
+    ipv4Tail = [(v4 >>> 16) & 0xffff, v4 & 0xffff];
+    s = s.slice(0, colon);
+  }
+
+  const hextet = (h: string): number | null => {
+    if (!/^[0-9a-fA-F]{1,4}$/.test(h)) return null;
+    return Number.parseInt(h, 16);
+  };
+  const parseGroups = (str: string): number[] | null => {
+    if (str === "") return [];
+    const out: number[] = [];
+    for (const g of str.split(":")) {
+      const n = hextet(g);
+      if (n === null) return null;
+      out.push(n);
+    }
+    return out;
+  };
+
+  const dc = s.indexOf("::");
+  let groups: number[];
+  if (dc >= 0) {
+    if (s.indexOf("::", dc + 2) >= 0) return null; // only one "::" allowed
+    const head = parseGroups(s.slice(0, dc));
+    const tail = parseGroups(s.slice(dc + 2));
+    if (head === null || tail === null) return null;
+    const explicit = head.length + tail.length + (ipv4Tail ? 2 : 0);
+    const zeros = 8 - explicit;
+    if (zeros < 1) return null; // "::" must cover at least one group
+    groups = [...head, ...new Array(zeros).fill(0), ...tail, ...(ipv4Tail ?? [])];
+  } else {
+    const head = parseGroups(s);
+    if (head === null) return null;
+    groups = [...head, ...(ipv4Tail ?? [])];
+  }
+  if (groups.length !== 8) return null;
+  return groups;
+}
+
+function groupsToEmbeddedV4(g: number[]): string {
+  const hi = g[6] ?? 0;
+  const lo = g[7] ?? 0;
+  return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+}
+
+export function isBlockedIpv6(ip: string): boolean {
+  const g = parseIpv6(ip);
+  if (!g) return true; // unparseable → fail closed
+
+  // IPv4-mapped ::ffff:a.b.c.d — validate the embedded v4.
+  if (g[0] === 0 && g[1] === 0 && g[2] === 0 && g[3] === 0 && g[4] === 0 && g[5] === 0xffff) {
+    return isBlockedIpv4(groupsToEmbeddedV4(g));
+  }
+  // NAT64 64:ff9b::/96 — validate the embedded v4.
+  if (g[0] === 0x0064 && g[1] === 0xff9b && g[2] === 0 && g[3] === 0 && g[4] === 0 && g[5] === 0) {
+    return isBlockedIpv4(groupsToEmbeddedV4(g));
+  }
+  // :: (unspecified) and ::1 (loopback)
+  if (g.slice(0, 7).every((x) => x === 0) && (g[7] === 0 || g[7] === 1)) return true;
+
+  const first = g[0] ?? 0;
+  if ((first & 0xfe00) === 0xfc00) return true; // fc00::/7 ULA
+  if ((first & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+  if ((first & 0xff00) === 0xff00) return true; // ff00::/8 multicast
+  if (first === 0x2001 && g[1] === 0x0db8) return true; // 2001:db8::/32 documentation
+
+  // Default-deny: only allow global-unicast 2000::/3.
+  if ((first & 0xe000) !== 0x2000) return true;
+  return false;
+}
+
+// --- public API ---------------------------------------------------------
+
+export function isBlockedAddress(ip: string): boolean {
+  const fam = isIP(ip);
+  if (fam === 4) return isBlockedIpv4(ip);
+  if (fam === 6) return isBlockedIpv6(ip);
+  return true; // not a bare IP → fail closed
+}
+
+function lookupAll(host: string): Promise<{ address: string; family: number }[]> {
+  return new Promise((resolve, reject) => {
+    lookup(host, { all: true }, (err, addresses) => {
+      if (err) reject(err);
+      else resolve(addresses);
+    });
+  });
+}
+
+// Validate scheme/credentials and — unless the escape hatch is on — resolve the
+// host and reject if any resolved address is non-public. Throws
+// WebhookDestinationError on any violation. Used for fail-fast validation when a
+// webhook is created/updated; the delivery dispatcher re-validates and pins.
+export async function assertPublicWebhookUrl(raw: string): Promise<void> {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    throw new WebhookDestinationError("url must be a valid http(s) URL");
+  }
+  if (u.protocol !== "https:" && u.protocol !== "http:") {
+    throw new WebhookDestinationError("url must use http or https");
+  }
+  if (u.username !== "" || u.password !== "") {
+    throw new WebhookDestinationError("url must not contain credentials");
+  }
+  if (allowPrivateDestinations()) return;
+
+  const host = u.hostname.replace(/^\[/, "").replace(/\]$/, "");
+  if (isIP(host)) {
+    if (isBlockedAddress(host)) {
+      throw new WebhookDestinationError("destination address is not allowed");
+    }
+    return;
+  }
+  let addresses: { address: string }[];
+  try {
+    addresses = await lookupAll(host);
+  } catch {
+    throw new WebhookDestinationError("could not resolve destination host");
+  }
+  if (addresses.length === 0) {
+    throw new WebhookDestinationError("could not resolve destination host");
+  }
+  for (const a of addresses) {
+    if (isBlockedAddress(a.address)) {
+      throw new WebhookDestinationError("destination resolves to a disallowed address");
+    }
+  }
+}
+
+let dispatcher: Agent | null = null;
+
+// undici Agent whose connect step resolves the host, rejects if ANY resolved
+// address is non-public, then pins the connection to a validated address (so a
+// rebinding second answer can't slip through between validation and connect).
+function guardedDispatcher(): Agent {
+  if (dispatcher) return dispatcher;
+  dispatcher = new Agent({
+    connect: {
+      // biome-ignore lint/suspicious/noExplicitAny: matches Node's overloaded lookup signature
+      lookup(hostname: string, options: any, callback: any) {
+        if (allowPrivateDestinations()) {
+          lookup(hostname, options, callback);
+          return;
+        }
+        lookup(hostname, { ...options, all: true }, (err, addresses) => {
+          if (err) return callback(err, undefined, undefined);
+          const list = addresses as unknown as { address: string; family: number }[];
+          for (const a of list) {
+            if (isBlockedAddress(a.address)) {
+              return callback(new WebhookDestinationError("destination address is not allowed"));
+            }
+          }
+          const chosen = list[0];
+          if (!chosen) {
+            return callback(new WebhookDestinationError("could not resolve destination host"));
+          }
+          if (options?.all) return callback(null, list);
+          callback(null, chosen.address, chosen.family);
+        });
+      },
+    },
+  });
+  return dispatcher;
+}
+
+export type WebhookFetchInit = {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  signal?: AbortSignal;
+};
+
+// Deliver a webhook request through the SSRF-guarded, IP-pinned dispatcher.
+// Validates the destination up front (undici skips connect.lookup for literal
+// IPs, so a literal private IP would otherwise slip past the dispatcher check),
+// then re-validates and pins in the dispatcher for the hostname case. Redirects
+// are never followed — a 3xx is returned as-is (and treated as a non-2xx
+// failure by the caller) so a redirect can't bounce us to an internal host.
+export async function webhookFetch(url: string, init: WebhookFetchInit): Promise<Response> {
+  await assertPublicWebhookUrl(url);
+  const res = await undiciFetch(url, {
+    method: init.method,
+    headers: init.headers,
+    body: init.body,
+    signal: init.signal,
+    redirect: "manual",
+    dispatcher: guardedDispatcher() as Dispatcher,
+  });
+  return res as unknown as Response;
+}

--- a/packages/net-guard/src/index.ts
+++ b/packages/net-guard/src/index.ts
@@ -152,7 +152,15 @@ export function isBlockedIpv6(ip: string): boolean {
   if ((first & 0xfe00) === 0xfc00) return true; // fc00::/7 ULA
   if ((first & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
   if ((first & 0xff00) === 0xff00) return true; // ff00::/8 multicast
-  if (first === 0x2001 && g[1] === 0x0db8) return true; // 2001:db8::/32 documentation
+
+  // Special-purpose prefixes that fall inside global-unicast 2000::/3 but are
+  // not globally reachable (or can tunnel to arbitrary/internal v4).
+  const g1 = g[1] ?? 0;
+  if (first === 0x2001 && g1 === 0x0000) return true; // 2001::/32 Teredo
+  if (first === 0x2001 && g1 === 0x0002 && (g[2] ?? 0) === 0x0000) return true; // 2001:2::/48 benchmarking
+  if (first === 0x2001 && g1 === 0x0db8) return true; // 2001:db8::/32 documentation
+  if (first === 0x2002) return true; // 2002::/16 6to4 (embeds arbitrary v4)
+  if (first === 0x3fff && (g1 & 0xf000) === 0x0000) return true; // 3fff::/20 documentation
 
   // Default-deny: only allow global-unicast 2000::/3.
   if ((first & 0xe000) !== 0x2000) return true;
@@ -168,9 +176,23 @@ export function isBlockedAddress(ip: string): boolean {
   return true; // not a bare IP → fail closed
 }
 
-function lookupAll(host: string): Promise<{ address: string; family: number }[]> {
+function lookupAll(
+  host: string,
+  signal?: AbortSignal,
+): Promise<{ address: string; family: number }[]> {
   return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new WebhookDestinationError("destination lookup aborted"));
+      return;
+    }
+    // node:dns lookup can't be cancelled, but the caller's timeout signal must
+    // still bound how long we wait — otherwise a stalled resolver blocks the
+    // delivery past its request timeout. Stop waiting on abort; the in-flight
+    // lookup drains harmlessly.
+    const onAbort = () => reject(new WebhookDestinationError("destination lookup aborted"));
+    signal?.addEventListener("abort", onAbort, { once: true });
     lookup(host, { all: true }, (err, addresses) => {
+      signal?.removeEventListener("abort", onAbort);
       if (err) reject(err);
       else resolve(addresses);
     });
@@ -181,7 +203,7 @@ function lookupAll(host: string): Promise<{ address: string; family: number }[]>
 // host and reject if any resolved address is non-public. Throws
 // WebhookDestinationError on any violation. Used for fail-fast validation when a
 // webhook is created/updated; the delivery dispatcher re-validates and pins.
-export async function assertPublicWebhookUrl(raw: string): Promise<void> {
+export async function assertPublicWebhookUrl(raw: string, signal?: AbortSignal): Promise<void> {
   let u: URL;
   try {
     u = new URL(raw);
@@ -205,7 +227,7 @@ export async function assertPublicWebhookUrl(raw: string): Promise<void> {
   }
   let addresses: { address: string }[];
   try {
-    addresses = await lookupAll(host);
+    addresses = await lookupAll(host, signal);
   } catch {
     throw new WebhookDestinationError("could not resolve destination host");
   }
@@ -269,7 +291,7 @@ export type WebhookFetchInit = {
 // are never followed — a 3xx is returned as-is (and treated as a non-2xx
 // failure by the caller) so a redirect can't bounce us to an internal host.
 export async function webhookFetch(url: string, init: WebhookFetchInit): Promise<Response> {
-  await assertPublicWebhookUrl(url);
+  await assertPublicWebhookUrl(url, init.signal);
   const res = await undiciFetch(url, {
     method: init.method,
     headers: init.headers,

--- a/packages/net-guard/src/index.ts
+++ b/packages/net-guard/src/index.ts
@@ -160,7 +160,7 @@ export function isBlockedIpv6(ip: string): boolean {
   if (first === 0x2001 && g1 === 0x0002 && (g[2] ?? 0) === 0x0000) return true; // 2001:2::/48 benchmarking
   if (first === 0x2001 && g1 === 0x0db8) return true; // 2001:db8::/32 documentation
   if (first === 0x2002) return true; // 2002::/16 6to4 (embeds arbitrary v4)
-  if (first === 0x3fff && (g1 & 0xf000) === 0x0000) return true; // 3fff::/20 documentation
+  if (first === 0x3fff && (g1 & 0xf000) === 0x0000) return true; // 3fff::/20 IETF Protocol Assignments / 6bone
 
   // Default-deny: only allow global-unicast 2000::/3.
   if ((first & 0xe000) !== 0x2000) return true;

--- a/packages/net-guard/src/webhook-fetch.test.ts
+++ b/packages/net-guard/src/webhook-fetch.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { type Server, createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, it } from "node:test";
+import { webhookFetch } from "./index.js";
+
+function listen(
+  handler: Parameters<typeof createServer>[1],
+): Promise<{ server: Server; port: number }> {
+  return new Promise((resolve) => {
+    const server = createServer(handler);
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({ server, port });
+    });
+  });
+}
+
+describe("webhookFetch egress guard", () => {
+  const orig = process.env.WEBHOOK_ALLOW_PRIVATE_DESTINATIONS;
+  afterEach(() => {
+    process.env.WEBHOOK_ALLOW_PRIVATE_DESTINATIONS = orig ?? "";
+  });
+
+  it("blocks a loopback destination before the request is sent", async () => {
+    process.env.WEBHOOK_ALLOW_PRIVATE_DESTINATIONS = "";
+    let hit = false;
+    const { server, port } = await listen((_req, res) => {
+      hit = true;
+      res.end("ok");
+    });
+    try {
+      await assert.rejects(() =>
+        webhookFetch(`http://127.0.0.1:${port}/`, { method: "POST", body: "{}" }),
+      );
+      assert.equal(hit, false, "loopback server must never be reached");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("delivers to an allowed destination and returns the status (escape hatch on)", async () => {
+    process.env.WEBHOOK_ALLOW_PRIVATE_DESTINATIONS = "1";
+    const { server, port } = await listen((_req, res) => {
+      res.statusCode = 202;
+      res.end("thanks");
+    });
+    try {
+      const res = await webhookFetch(`http://127.0.0.1:${port}/`, { method: "POST", body: "{}" });
+      assert.equal(res.status, 202);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("does not follow redirects", async () => {
+    process.env.WEBHOOK_ALLOW_PRIVATE_DESTINATIONS = "1";
+    let followed = false;
+    const { server, port } = await listen((req, res) => {
+      if (req.url === "/start") {
+        res.statusCode = 302;
+        res.setHeader("location", `http://127.0.0.1:${port}/followed`);
+        res.end();
+        return;
+      }
+      followed = true;
+      res.end("should not happen");
+    });
+    try {
+      const res = await webhookFetch(`http://127.0.0.1:${port}/start`, {
+        method: "POST",
+        body: "{}",
+      });
+      assert.ok(res.status < 200 || res.status >= 300, "redirect must not count as success");
+      assert.equal(followed, false, "redirect target must never be fetched");
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/packages/net-guard/tsconfig.json
+++ b/packages/net-guard/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       '@superlog/fingerprint':
         specifier: workspace:*
         version: link:../../packages/fingerprint
+      '@superlog/net-guard':
+        specifier: workspace:*
+        version: link:../../packages/net-guard
       autumn-js:
         specifier: ^1.2.27
         version: 1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
@@ -462,6 +465,9 @@ importers:
       '@superlog/fingerprint':
         specifier: workspace:*
         version: link:../../packages/fingerprint
+      '@superlog/net-guard':
+        specifier: workspace:*
+        version: link:../../packages/net-guard
       '@superlog/topology':
         specifier: workspace:*
         version: link:../../packages/topology
@@ -541,6 +547,22 @@ importers:
         version: 5.9.3
 
   packages/fingerprint:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
+  packages/net-guard:
+    dependencies:
+      undici:
+        specifier: ^7.16.0
+        version: 7.28.0
     devDependencies:
       '@types/node':
         specifier: ^22.10.1
@@ -5760,6 +5782,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -11571,6 +11597,8 @@ snapshots:
   uint8array-extras@1.5.0: {}
 
   undici-types@6.21.0: {}
+
+  undici@7.28.0: {}
 
   unicorn-magic@0.3.0: {}
 


### PR DESCRIPTION
## Problem

Webhook endpoints accept any `http(s)` URL with no destination restriction beyond the scheme. The worker then fetches it with redirects followed and stores the response status, body (first 2 KiB), and connection error on the delivery record — all readable back through the deliveries API.

That lets any authenticated user register a webhook pointing at an internal or metadata address, trigger a delivery, and read the reflected response — a server-side read-SSRF plus a three-state internal port scanner (status+body = open, timeout = filtered, connection error = refused). Redirect following defeats a naive URL-only IP check, and the reflected body makes it a direct read rather than a blind request. On a default self-hosted setup the worker sits next to unauthenticated ClickHouse/Postgres, so this reads them directly.

The update (PATCH) path was worse than create — it did no scheme check at all.

## Fix

New shared package `@superlog/net-guard`:
- `isBlockedAddress()` — default-deny IP classifier: RFC1918, loopback (`127/8`), link-local + cloud metadata (`169.254/16`), CGNAT (`100.64/10`), IETF/TEST-NET/benchmark/6to4, multicast, reserved; IPv6 ULA (`fc00::/7`), link-local (`fe80::/10`), `::1`/`::`, v4-mapped, NAT64, and anything outside global-unicast `2000::/3`. Fails closed on anything unparseable.
- `assertPublicWebhookUrl()` — enforces `http(s)`, rejects embedded credentials, and rejects any literal or DNS-resolved non-public destination.
- `webhookFetch()` — delivers through an undici dispatcher that re-resolves, rejects if **any** resolved address is non-public, and **pins the connection to the validated IP** (DNS-rebinding defense), with `redirect: "manual"` so redirects are never followed.

Wiring:
- **Worker** delivery goes through `webhookFetch` and no longer reads or stores the upstream response body.
- **API** validates the destination on both create and update, and the deliveries endpoints return only the delivery outcome (status, HTTP code, attempt count, timestamps) — never the raw response body or connection error.
- **Web UI** drops the body/error display.

Operator escape hatch `WEBHOOK_ALLOW_PRIVATE_DESTINATIONS=1` re-enables private destinations for local dev / self-hosted setups; off by default, and scheme/credential checks still apply.

No schema change — `last_response_body` is retained but no longer populated.

## Tests

`packages/net-guard` — 66 tests: exhaustive IPv4/IPv6 range classification (incl. boundary cases), URL assertion (scheme, credentials, literal private/loopback/metadata IPs, escape hatch), and integration tests over a local server proving a loopback destination is blocked before the request is sent, an allowed destination returns its status, and redirects are not followed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure webhook delivery against SSRF. Only public http(s) endpoints are allowed, DNS is pinned, redirects are not followed, response bodies are dropped, and delivery APIs are scoped by project.

- **Bug Fixes**
  - Added `@superlog/net-guard` to validate webhook URLs and block private/loopback/link‑local/metadata ranges (IPv4/IPv6 incl. Teredo/6to4/benchmark/documentation, NAT64, and v4‑mapped). DNS is re‑resolved and pinned, redirects are not followed, and DNS re‑validation respects the request abort signal.
  - Worker delivers via `webhookFetch` and no longer reads or stores the upstream body.
  - API validates destinations on create and update, scopes delivery detail/redeliver routes by `projectId`, and deliveries endpoints return only outcome fields (status, HTTP code, attempts, timestamps).
  - Web UI removes response body and error display.

- **Migration**
  - Client code must not depend on `lastResponseBody` or `lastError`; these fields are no longer returned.
  - For private/internal targets in dev or self‑hosted setups, set `WEBHOOK_ALLOW_PRIVATE_DESTINATIONS=1`.
  - Destinations that relied on redirects must use a final URL. 3xx responses are returned as-is and treated as failures.

<sup>Written for commit ccb1e3610c7e3ee975e1f705bdf69584a2283f77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

