### PR TITLE
web: point Enterprise contact CTA at the current booking link

### DIFF
--- a/apps/web/src/Pricing.test.ts
+++ b/apps/web/src/Pricing.test.ts
@@ -18,5 +18,5 @@ test("Enterprise plan links its CTA to the discovery call URL", () => {
   // Self-serve packs open the sign-up modal; Enterprise instead routes to the
   // booking link, so the plan must carry an explicit contact href.
   assert.match(source, /href:\s*ENTERPRISE_CONTACT_URL/);
-  assert.match(source, /ENTERPRISE_CONTACT_URL\s*=\s*"https:\/\/cal\.com\/pulsent\/superlog-discovery"/);
+  assert.match(source, /ENTERPRISE_CONTACT_URL\s*=\s*"https:\/\/cal\.com\/superlog\/yc"/);
 });

--- a/apps/web/src/Pricing.tsx
+++ b/apps/web/src/Pricing.tsx
@@ -8,7 +8,7 @@ type AuthMode = "sign-in" | "sign-up" | null;
 // Where the "Contact us" / "Talk to us about Enterprise" links route. Enterprise
 // is a contact-sales plan, so its CTA books a discovery call instead of opening
 // the sign-up modal.
-const ENTERPRISE_CONTACT_URL = "https://cal.com/pulsent/superlog-discovery";
+const ENTERPRISE_CONTACT_URL = "https://cal.com/superlog/yc";
 
 // Pay-as-you-go unit prices. Source of truth: packages/billing/src/pricing.ts —
 // keep in sync if those change.


### PR DESCRIPTION
The pricing page's Enterprise **Contact us** CTA, the **Contact us** button in the "Start free" section, and the inline **Talk to us about Enterprise** link all routed to a stale Cal.com handle (`cal.com/pulsent/superlog-discovery`). This updates the single `ENTERPRISE_CONTACT_URL` constant to the current `cal.com/superlog/yc` booking page, so all three sites update together.

- `apps/web/src/Pricing.tsx` — updated the constant.
- `apps/web/src/Pricing.test.ts` — updated the test that pins the exact URL (passes 3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)