### PR TITLE
api Dockerfile: copy @superlog/net-guard

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -9,6 +9,7 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/api/package.json apps/api/
 COPY packages/db/package.json packages/db/
 COPY packages/fingerprint/package.json packages/fingerprint/
+COPY packages/net-guard/package.json packages/net-guard/
 
 RUN pnpm install --frozen-lockfile --filter @superlog/api...
 
@@ -16,6 +17,7 @@ COPY tsconfig.base.json ./
 COPY apps/api apps/api
 COPY packages/db packages/db
 COPY packages/fingerprint packages/fingerprint
+COPY packages/net-guard packages/net-guard
 
 ENV PORT=4100
 EXPOSE 4100


### PR DESCRIPTION
The webhook SSRF hardening (#154) added `@superlog/net-guard` as a dependency of `apps/api/src/webhooks.ts`, but the API image copies an explicit package list that didn't include it. The image builds fine (there's no in-image typecheck) and then crash-loops at boot:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@superlog/net-guard' imported from /app/apps/api/src/webhooks.ts
```

ECS keeps the previous task definition serving while every new task fails, so deployments of any commit including #154 stall.

Two COPY lines added (manifest + source), matching the existing entries. `apps/api`'s workspace deps are now fully covered (db, fingerprint, net-guard); the other services don't import net-guard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the API Docker image to include `@superlog/net-guard`, preventing boot failures after the webhook SSRF hardening. New ECS tasks start successfully, so deployments no longer stall.

- **Bug Fixes**
  - Copy `packages/net-guard/package.json` and source in `apps/api/Dockerfile`.
  - Ensure all `apps/api` workspace deps (`db`, `fingerprint`, `net-guard`) are included.
  - Resolve `ERR_MODULE_NOT_FOUND` for `@superlog/net-guard` in `apps/api/src/webhooks.ts`.

<sup>Written for commit c84faefb1a65060be83996482ea852e1171c4d45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

