### PR TITLE
fix(mcp): enforce org token scope on dashboard and alert tools

### DIFF
--- a/apps/api/src/mcp/alerts.ts
+++ b/apps/api/src/mcp/alerts.ts
@@ -17,7 +17,7 @@ import {
   testAlertById,
   updateAlertRecord,
 } from "../alerts-service.js";
-import { assertProjectAccess } from "./projects.js";
+import { assertProjectAccess, assertTokenScope } from "./projects.js";
 
 const projectIdSchema = z
   .string()
@@ -125,11 +125,12 @@ const text = (v: unknown) => ({ content: [{ type: "text" as const, text: JSON.st
 
 export function registerAlertTools(
   server: McpServer,
-  session: { userId: string; activeProjectId: string },
+  session: { userId: string; activeProjectId: string; allowedOrgId?: string },
   ch: ClickHouseClient,
 ): void {
   const resolve = async (explicit: string | undefined): Promise<string> => {
     const id = explicit ?? session.activeProjectId;
+    await assertTokenScope(session.allowedOrgId, id);
     await assertProjectAccess(session.userId, id);
     return id;
   };

--- a/apps/api/src/mcp/dashboards.ts
+++ b/apps/api/src/mcp/dashboards.ts
@@ -16,7 +16,7 @@ import {
   updateDashboard,
   updateDashboardWidget,
 } from "../dashboards-service.js";
-import { assertProjectAccess } from "./projects.js";
+import { assertProjectAccess, assertTokenScope } from "./projects.js";
 
 const projectIdSchema = z
   .string()
@@ -47,10 +47,11 @@ const text = (v: unknown) => ({ content: [{ type: "text" as const, text: JSON.st
 
 export function registerDashboardTools(
   server: McpServer,
-  session: { userId: string; activeProjectId: string },
+  session: { userId: string; activeProjectId: string; allowedOrgId?: string },
 ): void {
   const resolve = async (explicit: string | undefined): Promise<string> => {
     const id = explicit ?? session.activeProjectId;
+    await assertTokenScope(session.allowedOrgId, id);
     await assertProjectAccess(session.userId, id);
     return id;
   };

--- a/apps/api/src/mcp/projects.ts
+++ b/apps/api/src/mcp/projects.ts
@@ -55,6 +55,24 @@ export async function assertProjectAccess(userId: string, projectId: string): Pr
   if (!membership) throw new HTTPException(403, { message: "no access to project" });
 }
 
+// Enforce the org boundary carried by an org-scoped MCP token (OAuth/PAT with a
+// `superlog:org:<id>` scope). A user who belongs to several orgs can mint a
+// token scoped to one of them and delegate it; without this check a tool that
+// only calls assertProjectAccess would let that token reach the user's *other*
+// orgs, escaping the token's declared scope. No-op for unscoped tokens.
+export async function assertTokenScope(
+  allowedOrgId: string | undefined,
+  projectId: string,
+): Promise<void> {
+  if (!allowedOrgId) return;
+  const project = await db.query.projects.findFirst({
+    where: eq(schema.projects.id, projectId),
+  });
+  if (!project || project.orgId !== allowedOrgId) {
+    throw new HTTPException(403, { message: "project is outside this MCP token's org scope" });
+  }
+}
+
 export async function setActiveProjectForToken(
   tokenId: string,
   userId: string,


### PR DESCRIPTION
## Problem
The dashboard and alert MCP tool groups resolved a project with only `assertProjectAccess(userId, id)` and never enforced the org boundary carried by an org-scoped token (OAuth/PAT with a `superlog:org:<id>` scope). The telemetry, incident, and agent-config tools all enforce this via `assertTokenScope`; dashboards and alerts were the two that didn't.

## Impact
A user who belongs to more than one org can mint/authorize a token scoped to org A, then call `list_alerts` / `get_dashboard` / `create_alert` / etc. with a `project_id` in org B and succeed — escaping the token's declared scope. It's not cross-*user* (the human is in both orgs), but it defeats the scoping control, which is the security boundary when the token is delegated (e.g. to an agent).

## Fix
- Add a shared `assertTokenScope(allowedOrgId, projectId)` helper in `mcp/projects.ts` (403 when the project's org != the token's allowed org; no-op for unscoped tokens).
- Call it in both `registerDashboardTools` and `registerAlertTools` `resolve()` before `assertProjectAccess`, and thread `allowedOrgId` through their session type. The full session already carries `allowedOrgId` at runtime, so no call-site change is needed.

Typechecks clean. No behavior change for unscoped tokens.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces org-scoped token boundaries for MCP dashboard and alert tools. Tokens scoped to one org can no longer access projects in another; mismatches now return 403.

- **Bug Fixes**
  - Added `assertTokenScope(allowedOrgId, projectId)` in `mcp/projects.ts`.
  - Called `assertTokenScope` in `registerDashboardTools` and `registerAlertTools` `resolve()` before `assertProjectAccess`.
  - Extended session types to include optional `allowedOrgId` (already present at runtime).
  - No behavior change for unscoped tokens.

<sup>Written for commit 5e5c947883bdc9d5dd0d4a1b999b4fc4885f78aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

