### PR TITLE
fix(gateway): generate device user_code with a CSPRNG

### DIFF
--- a/apps/api/src/gateway.ts
+++ b/apps/api/src/gateway.ts
@@ -1,3 +1,4 @@
+import { randomInt } from "node:crypto";
 import type { ClickHouseClient } from "@clickhouse/client";
 import {
   db,
@@ -602,8 +603,11 @@ async function requireUserFromSession(
 }
 
 function humanCode(): string {
+  // Use a CSPRNG: the user_code is the sole secret an approver checks, so a
+  // predictable PRNG (Math.random) would let an attacker guess in-flight codes
+  // and approve a victim's pending device. randomInt is unbiased over the range.
   const alphabet = "ABCDEFGHJKMNPQRSTVWXYZ23456789";
-  const pick = () => alphabet[Math.floor(Math.random() * alphabet.length)];
+  const pick = () => alphabet[randomInt(alphabet.length)];
   return `${pick()}${pick()}${pick()}${pick()}-${pick()}${pick()}${pick()}${pick()}`;
 }
 


### PR DESCRIPTION
## Problem
The device-authorization `user_code` (`humanCode()`) was generated with `Math.random()` — a non-cryptographic PRNG — over an 8-character / 30-symbol alphabet. The `user_code` is the sole secret an approver verifies at `/activate/approve`.

## Impact
`Math.random()`'s internal state is recoverable from observed outputs, so an attacker can predict in-flight `user_code`s within the code's TTL and call `/activate/approve` for a victim's pending device. Approval binds the attacker's org plus a freshly minted CLI session token and ingest key onto the victim's device session — silently redirecting the victim's CLI/telemetry into the attacker's project. (The `device_code` token pickup already used `nanoid`, so only the human-visible code was affected.)

## Fix
Generate `user_code` with `crypto.randomInt` over the same alphabet (CSPRNG, unbiased).

Follow-up worth considering separately: rate-limit `/activate/approve` by IP/code. With a CSPRNG over ~30^8 the code space is now infeasible to brute-force, so this is defense-in-depth.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate the device-authorization user_code with a CSPRNG using `crypto.randomInt` to remove predictability. This prevents attackers from guessing in-flight codes and approving a victim’s device.

<sup>Written for commit aba7ab8a6faf29fbcae59184029f11814a460642. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

