### PR TITLE
fix(proxy): bound OTLP decompression to prevent a zip bomb

### DIFF
--- a/apps/proxy/src/otlp-decode.test.ts
+++ b/apps/proxy/src/otlp-decode.test.ts
@@ -116,3 +116,32 @@ test("decodeOtlpToRows returns null for an undecodable content type", () => {
     null,
   );
 });
+
+test("decodeOtlpToRows rejects a gzip decompression bomb over the cap", () => {
+  // ~4 MiB of zeros compresses to a few KB but blows past a small cap.
+  const bomb = gzipSync(Buffer.alloc(4 * 1024 * 1024, 0));
+  assert.throws(
+    () =>
+      decodeOtlpToRows({
+        path: "/v1/logs",
+        projectId: "proj-1",
+        contentType: "application/x-protobuf",
+        contentEncoding: "gzip",
+        body: bomb,
+        maxDecompressedBytes: 64 * 1024, // 64 KiB cap
+      }),
+    /ERR_BUFFER_TOO_LARGE|maxOutputLength|too large/i,
+  );
+})
+
+test("decodeOtlpToRows accepts a gzipped body under the cap", () => {
+  const out = decodeOtlpToRows({
+    path: "/v1/logs",
+    projectId: "proj-1",
+    contentType: "application/json",
+    contentEncoding: "gzip",
+    body: gzipSync(Buffer.from(jsonLogs, "utf8")),
+    maxDecompressedBytes: 16 * 1024 * 1024,
+  });
+  assert.ok(logRows(out).length >= 1);
+})

--- a/apps/proxy/src/otlp-decode.ts
+++ b/apps/proxy/src/otlp-decode.ts
@@ -70,12 +70,22 @@ export type DecodedRows =
   | { table: "otel_logs"; rows: OtelLogRow[] }
   | { table: "otel_traces"; rows: OtelTraceRow[] };
 
+// Cap on the decompressed size of a compressed ingest body. Without it,
+// gunzipSync/inflateSync expand a highly-compressible "zip bomb" (gzip reaches
+// ~1000x) to tens of GB synchronously, blocking the event loop and OOM-killing
+// the consumer — a single valid key could take down the fleet. 256 MiB is well
+// above any legitimate OTLP batch (bodies are already capped at 64 MiB
+// compressed) while refusing the pathological case. Overridable per-call.
+export const DEFAULT_MAX_DECOMPRESSED_BYTES = 256 * 1024 * 1024;
+
 export type DecodeInput = {
   path: string;
   projectId: string;
   contentType: string;
   contentEncoding?: string;
   body: Buffer;
+  /** Cap on decompressed body size; defaults to DEFAULT_MAX_DECOMPRESSED_BYTES. */
+  maxDecompressedBytes?: number;
 };
 
 // Decode an OTLP ingest payload into ClickHouse rows. Returns null for signals we
@@ -88,7 +98,11 @@ export function decodeOtlpToRows(input: DecodeInput): DecodedRows | null {
   const protobufContent = input.contentType.toLowerCase().includes("protobuf");
   if (!json && !protobufContent) return null;
 
-  const body = decompress(input.body, input.contentEncoding);
+  const body = decompress(
+    input.body,
+    input.contentEncoding,
+    input.maxDecompressedBytes ?? DEFAULT_MAX_DECOMPRESSED_BYTES,
+  );
 
   if (input.path === "/v1/logs") {
     const payload = json
@@ -110,10 +124,14 @@ function decodeProto(type: any, body: Buffer): unknown {
   return type.toObject(type.decode(body), PROTO_TO_OBJECT_OPTS);
 }
 
-function decompress(body: Buffer, encoding?: string): Buffer {
+// Bounded decompression. maxOutputLength makes zlib throw
+// RangeError[ERR_BUFFER_TOO_LARGE] instead of allocating past the cap, so a
+// decompression bomb fails fast; decodeOtlpToRows callers already treat a decode
+// throw as best-effort (log + forward to collector), so it degrades, not crashes.
+function decompress(body: Buffer, encoding: string | undefined, maxOutputLength: number): Buffer {
   if (!encoding) return body;
   const enc = encoding.toLowerCase();
-  if (enc === "gzip") return gunzipSync(body);
-  if (enc === "deflate") return inflateSync(body);
+  if (enc === "gzip") return gunzipSync(body, { maxOutputLength });
+  if (enc === "deflate") return inflateSync(body, { maxOutputLength });
   return body;
 }


### PR DESCRIPTION
## Problem
`decompress()` in `otlp-decode.ts` called `gunzipSync`/`inflateSync` with no output-size cap. On the direct-to-ClickHouse decode path a client with a valid ingest key can POST a small, highly-compressible gzip body (gzip reaches ~1000x) that inflates to tens of GB synchronously — blocking the event loop and OOM-killing the ingest consumer. One key can take down the consumer fleet.

## Fix
Pass zlib's `maxOutputLength` to both `gunzipSync` and `inflateSync` (default 256 MiB, overridable per-call via `DecodeInput.maxDecompressedBytes`). 256 MiB is well above any legitimate OTLP batch — bodies are already capped at 64 MiB *compressed*. zlib throws `RangeError[ERR_BUFFER_TOO_LARGE]` when the output would exceed the cap; `decodeOtlpToRows` callers already treat a decode throw as best-effort (log a warning and forward to the collector), so an oversized body is rejected without crashing or dropping.

## Tests
Added two cases to `otlp-decode.test.ts`: a 4 MiB-of-zeros bomb against a 64 KiB cap throws; a normal gzipped body under the cap decodes. Full file: 7/7 pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound OTLP body decompression in the proxy using `zlib`’s `maxOutputLength` to stop gzip/deflate zip bombs from expanding to huge sizes and taking down the ingest consumer. Oversized payloads now fail fast instead of blocking or OOM-ing the process.

- **Bug Fixes**
  - Apply `maxOutputLength` to `gunzipSync` and `inflateSync` in `decompress()`.
  - Add `DecodeInput.maxDecompressedBytes` to override the default cap.
  - Tests cover rejecting a gzip bomb and accepting a normal gzipped body.

<sup>Written for commit 82a9c63d386ca5f06ab887f26365fca9b326524e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

