### PR TITLE
fix(proxy): bound total request time to stop a slow-body permit DoS

### DIFF
--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -872,6 +872,17 @@ const server = serve({ fetch: app.fetch, port: PORT });
 if ("keepAliveTimeout" in server) {
   server.keepAliveTimeout = 75_000;
   server.headersTimeout = 76_000;
+  // Bound the whole request, including the body read. An admission permit is
+  // held across the body stream (there are only ~64), so without a cap a single
+  // valid key can open all of them and dribble bodies slowly (slowloris),
+  // pinning every permit and starving all other tenants. Node's default
+  // requestTimeout is a lax 300s; tighten it so a stalled body is aborted and
+  // its permit released. Kept well above headersTimeout and generous enough for
+  // a 64 MiB body over a slow link (~0.5 MB/s floor at the default).
+  server.requestTimeout = readNonNegativeIntEnv(
+    process.env.INGEST_REQUEST_TIMEOUT_MS,
+    120_000,
+  );
 }
 if (ingestQueue && ingestQueueConfig?.consumerEnabled) {
   ingestQueue.startConsumer(COLLECTOR_URL);


### PR DESCRIPTION
## Problem
An admission permit is acquired *before* the request body is read and released only after it's fully read/forwarded. There are only ~64 permits and they're shared across all tenants. The server set `keepAliveTimeout` and `headersTimeout` but no request/body-read timeout, and Node's default `requestTimeout` is a lax 300s — and headers complete instantly, so `headersTimeout` doesn't help against a slow *body*.

## Impact
With one valid ingest key, an attacker opens 64 connections to `/v1/traces` and sends the body a few bytes at a time (slowloris). All 64 permits stay pinned and every other tenant's requests queue behind them — cross-tenant denial of service from a single low-privilege key.

## Fix
Set `server.requestTimeout` (default 120s, overridable via `INGEST_REQUEST_TIMEOUT_MS`) so a stalled request is aborted and its permit released. Kept above `headersTimeout` (76s) and generous enough for a 64 MiB body over a slow link (~0.5 MB/s floor).

Note: this closes the slow-body vector. Per-tenant *rate* limiting (a separate noisy-neighbor concern) is intentionally out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound total request time to stop slow-body DoS that pinned admission permits across tenants. Adds `server.requestTimeout` (120s default, configurable via `INGEST_REQUEST_TIMEOUT_MS`) so stalled bodies are aborted and permits released.

- **Bug Fixes**
  - Covers body read to prevent a single key from holding ~64 permits by dribbling uploads.
  - Timeout stays above `headersTimeout` (76s) and is generous for ~64 MiB bodies on slow links.

<sup>Written for commit d290fc2d957dd52519776aa0aae0538f85829dff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

