### PR TITLE
fix(slack): scope incident resolve/decide clicks to the owning workspace

### DIFF
--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -355,6 +355,28 @@ async function handleSlackBlockActions(payload: SlackInteractivityPayload): Prom
 // The user can always reopen via recurrence; what we don't want is the DB
 // saying open while Slack thinks resolved (or vice-versa) on a transient
 // failure.
+// Defence-in-depth tenant guard for incident-scoped Slack button clicks. The
+// interactivity payload is authenticated by the app signing secret and Slack
+// only signs action_ids from a workspace's own messages, so an ordinary user
+// can't forge a foreign incident id here. But the resolve/decide helpers mutate
+// by bare id with no project predicate, so this asserts that the workspace that
+// sent the click actually owns the pinned installation for the target before we
+// mutate — a click can only ever act within its own workspace. Returns false
+// (caller bails) on a cross-workspace mismatch. Unpinned/legacy rows fall through
+// to the existing team-scoped fallback, so they're unchanged.
+async function clickWorkspaceOwnsPin(
+  pinnedInstallationId: string | null,
+  payloadTeamId: string | null | undefined,
+): Promise<boolean> {
+  if (!pinnedInstallationId) return true;
+  const pinned = await db.query.slackInstallations.findFirst({
+    where: eq(schema.slackInstallations.id, pinnedInstallationId),
+    columns: { teamId: true },
+  });
+  if (!pinned) return true;
+  return Boolean(payloadTeamId) && pinned.teamId === payloadTeamId;
+}
+
 async function handleSlackResolveIncident(
   incidentId: string,
   payload: SlackInteractivityPayload,
@@ -365,6 +387,13 @@ async function handleSlackResolveIncident(
   });
   if (!incident) {
     log.warn({ incidentId }, "resolve_incident click for unknown incident");
+    return;
+  }
+  if (!(await clickWorkspaceOwnsPin(incident.slackInstallationId, payload.team?.id))) {
+    log.warn(
+      { incidentId, team_id: payload.team?.id },
+      "resolve_incident click from a workspace that does not own the incident; ignoring",
+    );
     return;
   }
   if (resolveSlackResolveClickDisposition(incident.status) === "refresh_side_effects") {
@@ -526,6 +555,19 @@ async function handleProposalDecision(
   const slackUserId = payload.user?.id ?? null;
   const slackUserName = payload.user?.name ?? null;
   const actor = { slackUserId, displayName: slackUserName };
+  // Tenant guard before mutating: the proposal is decided by bare id, so verify
+  // the clicking workspace owns the proposal's pinned installation first.
+  const target = await db.query.incidentResolutionProposals.findFirst({
+    where: eq(schema.incidentResolutionProposals.id, proposalId),
+    columns: { slackInstallationId: true },
+  });
+  if (target && !(await clickWorkspaceOwnsPin(target.slackInstallationId, payload.team?.id))) {
+    log.warn(
+      { proposalId, team_id: payload.team?.id },
+      "proposal decision from a workspace that does not own the proposal; ignoring",
+    );
+    return;
+  }
   const result =
     decision === "confirm"
       ? await confirmResolutionProposal({ proposalId, actor })


### PR DESCRIPTION
## Problem
`handleSlackResolveIncident` and `handleProposalDecision` look up the incident/proposal by bare id and resolve/close it **before** consulting any installation, and the DB helpers (`resolveIncident`, `confirm/dismissResolutionProposal`) filter on id only — no project/tenant predicate. So the only thing binding a resolve click to a tenant is the Slack signing-secret check on the request.

## Impact
Latent cross-workspace write: an interactivity payload carrying another tenant's incident/proposal id would resolve or silence their incident. It is **not** forgeable by an ordinary user — Slack signs only the action_ids our app set on that workspace's own messages — so this is defence-in-depth against a signing-secret compromise or a future refactor that lets an id flow from user-editable input. The dashboard-side equivalents already scope correctly; this closes the inconsistency.

## Fix
Add `clickWorkspaceOwnsPin(pinnedInstallationId, payloadTeamId)`: before mutating, assert the clicking workspace owns the target's **pinned** Slack installation (its `team_id` matches `payload.team.id`). Cross-workspace clicks are logged and ignored. Unpinned/legacy rows return true and fall through to the existing team-scoped fallback, so legitimate same-workspace clicks are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Slack incident resolve/decision clicks to the owning workspace to prevent cross-workspace mutations. Cross-tenant clicks are logged and ignored; same-workspace and legacy/unpinned rows continue to work.

- **Bug Fixes**
  - Added `clickWorkspaceOwnsPin(...)` to verify the clicking workspace (`payload.team.id`) matches the target’s pinned installation (`slack_installations.team_id`) before any mutation.
  - Guarded `handleSlackResolveIncident` and `handleProposalDecision` with this check to close a latent cross-workspace write gap.

<sup>Written for commit 894337a1fbc53c3e1fd14a001ee5b5e16de1e937. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

