### PR TITLE
web: add Docs link to landing top nav

### DIFF
--- a/apps/web/src/Landing.test.ts
+++ b/apps/web/src/Landing.test.ts
@@ -14,7 +14,10 @@ test("landing navbar uses the public Superlog docs URL", () => {
 test("landing top nav renders a Docs link wired to the docs URL", async () => {
   const source = await readFile(new URL("./Landing.tsx", import.meta.url), "utf8");
 
-  assert.match(source, /href=\{LANDING_DOCS_URL\}[\s\S]*?Docs\s*<\/a>/);
+  assert.match(
+    source,
+    /href=\{LANDING_DOCS_URL\}[\s\S]*?target="_blank"[\s\S]*?rel="noreferrer"[\s\S]*?Docs\s*<\/a>/,
+  );
 });
 
 test("landing top nav renders a GitHub link wired to the repository URL", async () => {
@@ -22,7 +25,7 @@ test("landing top nav renders a GitHub link wired to the repository URL", async 
 
   assert.match(
     source,
-    /href=\{LANDING_GITHUB_REPO_URL\}[\s\S]*<GitHubIcon \/>[\s\S]*GitHub\s*<\/a>/,
+    /href=\{LANDING_GITHUB_REPO_URL\}[\s\S]*?target="_blank"[\s\S]*?rel="noreferrer"[\s\S]*?<GitHubIcon \/>[\s\S]*?GitHub\s*<\/a>/,
   );
 });
 

--- a/apps/web/src/Landing.test.ts
+++ b/apps/web/src/Landing.test.ts
@@ -1,10 +1,20 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
+import { LANDING_DOCS_URL, LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
 
 test("landing navbar uses the public Superlog GitHub repository URL", () => {
   assert.equal(LANDING_GITHUB_REPO_URL, "https://github.com/superloglabs/superlog");
+});
+
+test("landing navbar uses the public Superlog docs URL", () => {
+  assert.equal(LANDING_DOCS_URL, "https://docs.superlog.sh");
+});
+
+test("landing top nav renders a Docs link wired to the docs URL", async () => {
+  const source = await readFile(new URL("./Landing.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /href=\{LANDING_DOCS_URL\}[\s\S]*?Docs\s*<\/a>/);
 });
 
 test("landing top nav renders a GitHub link wired to the repository URL", async () => {

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { AuthForm } from "./AuthForm.tsx";
 import { Btn, Chip, Label, Tile, Wordmark } from "./design/ui.tsx";
 import { INSTALL_PROMPT } from "./installPrompt.ts";
-import { LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
+import { LANDING_DOCS_URL, LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
 
 // ---------------------------------------------------------------------------
 // Landing — /
@@ -122,6 +122,14 @@ function TopNav({
             >
               <GitHubIcon />
               GitHub
+            </a>
+            <a
+              href={LANDING_DOCS_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg sm:inline"
+            >
+              Docs
             </a>
             <a
               href="/pricing"

--- a/apps/web/src/landingLinks.ts
+++ b/apps/web/src/landingLinks.ts
@@ -1,1 +1,2 @@
 export const LANDING_GITHUB_REPO_URL = "https://github.com/superloglabs/superlog";
+export const LANDING_DOCS_URL = "https://docs.superlog.sh";


### PR DESCRIPTION
## What
Adds a **Docs** link to the landing page top navigation, between the existing GitHub and Pricing links. It links to https://docs.superlog.sh and opens in a new tab.

## Why
Gives visitors a direct path from the marketing landing page to the documentation, alongside the existing GitHub link.

## Changes
- `landingLinks.ts` — add `LANDING_DOCS_URL`
- `Landing.tsx` — render the Docs link in the top nav (styled like the adjacent Pricing link)
- `Landing.test.ts` — cover the new URL constant and the rendered link

## Testing
- `tsx --test apps/web/src/Landing.test.ts` — 5/5 pass
- `tsc --noEmit` (web) — clean
- Ran the web dev server locally and confirmed the link renders between GitHub and Pricing and opens docs.superlog.sh in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)