### PR TITLE
Steering an idle session skips gracefully when the model is mid-flight

### DIFF
--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import {
   mobileRegressionGateState,
   mobileRegressionGateTerminatedSummary,
+  isSessionBusyError,
   mobileRegressionRepairPrompt,
   terminalOutcomeNudgePrompt,
   needsMobileRegressionRepair,
@@ -315,4 +316,39 @@ test("terminalOutcomeNudgePrompt names every terminal outcome tool", () => {
     assert.ok(prompt.includes(name), `missing ${name}`);
   }
   assert.match(prompt, /exactly ONE/);
+});
+
+test("isSessionBusyError matches the mid-flight steer rejection only", () => {
+  assert.equal(
+    isSessionBusyError(
+      new Error(
+        '400 {"type":"error","error":{"type":"invalid_request_error","message":"Invalid user.message event at events[0]: waiting on responses to events [sevt_x]; only `user.custom_tool_result` may be sent"}}',
+      ),
+    ),
+    true,
+  );
+  assert.equal(isSessionBusyError(new Error("read ECONNRESET")), false);
+});
+
+test("steerIdleRunnerWithPendingContext skips (and keeps events pending) on a busy session", async () => {
+  const processed: string[][] = [];
+  const steered = await steerIdleRunnerWithPendingContext({
+    snapshotStatus: "idle",
+    pendingContextEvents: [{ id: "evt-1", summary: "Issue A joined." }],
+    runner: {
+      async steer() {
+        throw new Error("400 ... waiting on responses to events [sevt_1] ...");
+      },
+    },
+    sessionId: "session-1",
+    incidentId: "inc-1",
+    async markEventsProcessed(ids) {
+      processed.push(ids);
+    },
+    async notifySteered() {
+      throw new Error("must not notify when the steer was skipped");
+    },
+  });
+  assert.equal(steered, false);
+  assert.deepEqual(processed, []);
 });

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -38,7 +38,7 @@ test("steerIdleRunnerWithPendingContext steers idle sessions with joined context
     },
   });
 
-  assert.equal(didSteer, true);
+  assert.equal(didSteer, "steered");
   assert.deepEqual(steered, [
     { sessionId: "session-1", message: "Issue A joined.\nIssue B joined." },
   ]);
@@ -66,7 +66,7 @@ test("steerIdleRunnerWithPendingContext waits unless the runner is idle with pen
       snapshotStatus: "running",
       pendingContextEvents: [{ id: "evt-1", summary: "Issue joined." }],
     }),
-    false,
+    "not_applicable",
   );
   assert.equal(
     await steerIdleRunnerWithPendingContext({
@@ -74,7 +74,7 @@ test("steerIdleRunnerWithPendingContext waits unless the runner is idle with pen
       snapshotStatus: "idle",
       pendingContextEvents: [],
     }),
-    false,
+    "not_applicable",
   );
   assert.equal(steerCount, 0);
 });
@@ -96,7 +96,7 @@ test("steerIdleRunnerWithPendingContext sends a fallback delta when summaries ar
     async notifySteered() {},
   });
 
-  assert.equal(didSteer, true);
+  assert.equal(didSteer, "steered");
   assert.equal(message, "New issues joined the incident.");
 });
 
@@ -349,6 +349,6 @@ test("steerIdleRunnerWithPendingContext skips (and keeps events pending) on a bu
       throw new Error("must not notify when the steer was skipped");
     },
   });
-  assert.equal(steered, false);
+  assert.equal(steered, "busy");
   assert.deepEqual(processed, []);
 });

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -27,6 +27,18 @@ export type PendingContextEvent = {
   summary: string | null;
 };
 
+// A session can report "idle" while the model is actually mid-flight: the
+// collector acks a tool call, the model immediately issues its next one, and
+// a user.message steer sent in the same tick 400s with "waiting on responses
+// to events [...]". That race is inherent to steering from a poller — the
+// only correct handling is to skip this tick and retry on the next, when the
+// session is genuinely quiescent. Treating the 400 as fatal killed real runs
+// with `sync_failed`.
+export function isSessionBusyError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes("waiting on responses to events");
+}
+
 export async function steerIdleRunnerWithPendingContext(opts: {
   snapshotStatus: string;
   pendingContextEvents: PendingContextEvent[];
@@ -43,7 +55,16 @@ export async function steerIdleRunnerWithPendingContext(opts: {
     .map((event) => event.summary)
     .filter((value): value is string => !!value)
     .join("\n");
-  await opts.runner.steer(opts.sessionId, delta || "New issues joined the incident.");
+  try {
+    await opts.runner.steer(opts.sessionId, delta || "New issues joined the incident.");
+  } catch (err) {
+    if (isSessionBusyError(err)) {
+      // Model is mid-tool-call despite the idle status; leave the events
+      // unprocessed so the next tick retries the steer.
+      return false;
+    }
+    throw err;
+  }
   await opts.markEventsProcessed(opts.pendingContextEvents.map((event) => event.id));
   await opts.notifySteered(opts.incidentId);
   return true;
@@ -332,7 +353,12 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
           }
 
           if (snapshot.status === "idle") {
-            await runner.steer(sessionId, mobileRegressionRepairPrompt());
+            try {
+              await runner.steer(sessionId, mobileRegressionRepairPrompt());
+            } catch (err) {
+              if (isSessionBusyError(err)) return;
+              throw err;
+            }
             logger.info(
               {
                 agent_run_id: ctx.agentRun.id,
@@ -525,6 +551,12 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
               .delete(schema.incidentEvents)
               .where(eq(schema.incidentEvents.id, claimedRow.id))
               .catch(() => undefined);
+            if (isSessionBusyError(err)) {
+              // The model is still working (it produced a tool call between
+              // our collect pass and this steer) — not idle-stuck at all.
+              // Skip; the next tick re-evaluates.
+              return;
+            }
             throw err;
           }
         }

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -39,6 +39,12 @@ export function isSessionBusyError(err: unknown): boolean {
   return msg.includes("waiting on responses to events");
 }
 
+// "steered": the delta was delivered and the caller must stop this tick.
+// "busy": the session rejected the steer mid-flight; events stay pending and
+// the caller must ALSO stop this tick — proceeding could complete the run out
+// from under a pending human reply. "not_applicable": nothing to steer.
+export type IdleSteerOutcome = "steered" | "busy" | "not_applicable";
+
 export async function steerIdleRunnerWithPendingContext(opts: {
   snapshotStatus: string;
   pendingContextEvents: PendingContextEvent[];
@@ -47,9 +53,9 @@ export async function steerIdleRunnerWithPendingContext(opts: {
   incidentId: string;
   markEventsProcessed(ids: string[]): Promise<void>;
   notifySteered(incidentId: string): Promise<void>;
-}): Promise<boolean> {
+}): Promise<IdleSteerOutcome> {
   if (opts.snapshotStatus !== "idle" || opts.pendingContextEvents.length === 0) {
-    return false;
+    return "not_applicable";
   }
   const delta = opts.pendingContextEvents
     .map((event) => event.summary)
@@ -61,13 +67,13 @@ export async function steerIdleRunnerWithPendingContext(opts: {
     if (isSessionBusyError(err)) {
       // Model is mid-tool-call despite the idle status; leave the events
       // unprocessed so the next tick retries the steer.
-      return false;
+      return "busy";
     }
     throw err;
   }
   await opts.markEventsProcessed(opts.pendingContextEvents.map((event) => event.id));
   await opts.notifySteered(opts.incidentId);
-  return true;
+  return "steered";
 }
 
 const MOBILE_FILE_PREFIXES = ["app/", "ios/", "android/", "components/", "screens/"];
@@ -271,7 +277,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
       // Oldest → newest so the steered conversation reads in chronological order.
       orderBy: [asc(schema.incidentEvents.createdAt)],
     });
-    const steeredHuman = await steerIdleRunnerWithPendingContext({
+    const steeredHumanOutcome = await steerIdleRunnerWithPendingContext({
       snapshotStatus: snapshot.status,
       pendingContextEvents: pendingHumanReplies,
       runner,
@@ -285,7 +291,10 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
       },
       notifySteered: async () => {},
     });
-    if (steeredHuman) {
+    if (steeredHumanOutcome !== "not_applicable") {
+      // Steered: the reply is in the session, wait for its turn. Busy: the
+      // reply is still pending — do NOT fall through to completion, or the
+      // run would finish out from under it; retry next tick.
       return;
     }
 
@@ -485,7 +494,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
       ),
       orderBy: [desc(schema.incidentEvents.createdAt)],
     });
-    const steered = await steerIdleRunnerWithPendingContext({
+    const steeredContextOutcome = await steerIdleRunnerWithPendingContext({
       snapshotStatus: snapshot.status,
       pendingContextEvents,
       runner,
@@ -504,7 +513,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         );
       },
     });
-    if (steered) {
+    if (steeredContextOutcome !== "not_applicable") {
       return;
     }
 


### PR DESCRIPTION
Fixes a fatal race introduced with the terminal-outcome nudge and latent in the other steer paths.

A session can report `idle` while the model is actually between tool calls: the collector acks a tool call, the model immediately issues its next one, and a `user.message` steer sent from the same sync tick is rejected with:

```
400 invalid_request_error: Invalid user.message event at events[0]: waiting on responses
to events [sevt_...]; only user.tool_confirmation, user.custom_tool_result, ... may be sent
```

`syncRunningAgentRun`'s catch treated that 400 as fatal → `failAgentRun(sync_failed)` — killing runs that were actively mid-investigation (observed on real runs within an hour of the per-outcome contract deploy, which made steering much more frequent via the idle nudge).

All three steer paths (pending-context delta, mobile-regression repair, terminal-outcome nudge) now recognize the busy-session rejection via `isSessionBusyError`, skip the tick, and retry on the next one when the session is genuinely quiescent. The nudge releases its once-per-session claim on the skip; the pending-context path leaves its events unprocessed so they re-steer later.

Tests: busy-error matcher, pending-context skip keeps events pending and does not notify.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip steering when an “idle” session is actually mid-flight to avoid `sync_failed` runs, and halt the tick on a busy rejection so runs don’t complete under pending replies.

- **Bug Fixes**
  - Added `isSessionBusyError` to detect 400 “waiting on responses…” rejections.
  - `steerIdleRunnerWithPendingContext` now returns `steered` | `busy` | `not_applicable`; callers stop the tick on `steered` and `busy`.
  - All steer paths (pending-context, mobile-regression repair, terminal-outcome nudge) skip on busy and retry next tick; pending-context keeps events unprocessed, and the nudge releases its once-per-session claim.
  - Tests cover the busy-error matcher and the pending-context skip behavior.

<sup>Written for commit 6fb98fb16ddbc73fe90ce9abbb8e8363cddc365c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

