### PR TITLE
Railway connector: OAuth connect + worker-side log/metrics puller

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -69,3 +69,10 @@ AWS_FIREHOSE_LOGS_INTAKE_URL=
 # Legacy per-signal stream templates (only if not using the combined stack):
 AWS_METRICS_TEMPLATE_URL=
 AWS_LOGS_TEMPLATE_URL=
+
+# Railway connector ("Login with Railway" OAuth app). Both required to enable
+# the connector; the callback URL must exactly match a redirect URI registered
+# on the OAuth app (defaults to http://localhost:4100/railway/oauth/callback).
+RAILWAY_CLIENT_ID=
+RAILWAY_CLIENT_SECRET=
+RAILWAY_OAUTH_REDIRECT_URL=

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -34,6 +34,7 @@
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@scalar/hono-api-reference": "^0.10.19",
     "@superlog/db": "workspace:*",
+    "@superlog/railway": "workspace:*",
     "@superlog/fingerprint": "workspace:*",
     "@superlog/net-guard": "workspace:*",
     "autumn-js": "^1.2.27",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -104,6 +104,7 @@ import {
   VALID_MANUAL_MERGE_METHODS,
   mergeAgentPullRequestAndResolveIncident,
 } from "./pr-merge-service.js";
+import { mountRailwayAuthed, mountRailwayPublic } from "./railway.js";
 import { mountSettingsAuthed } from "./settings.js";
 import { normalizeSignupIntentKeyHash, normalizeSignupIntentKeyPrefix } from "./signup-intents.js";
 import { mountSlackAuthed, mountSlackPublic } from "./slack.js";
@@ -112,7 +113,6 @@ import { userIsStaff } from "./staff.js";
 import { symbolicateIssueSample, symbolicateTelemetrySample } from "./symbolication.js";
 import { buildSystemCapabilities } from "./system-capabilities.js";
 import { mountTopology } from "./topology.js";
-import { mountRailwayAuthed, mountRailwayPublic } from "./railway.js";
 import { mountVercelAuthed, mountVercelPublic } from "./vercel.js";
 import { mountWebhooks } from "./webhooks.js";
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -112,6 +112,7 @@ import { userIsStaff } from "./staff.js";
 import { symbolicateIssueSample, symbolicateTelemetrySample } from "./symbolication.js";
 import { buildSystemCapabilities } from "./system-capabilities.js";
 import { mountTopology } from "./topology.js";
+import { mountRailwayAuthed, mountRailwayPublic } from "./railway.js";
 import { mountVercelAuthed, mountVercelPublic } from "./vercel.js";
 import { mountWebhooks } from "./webhooks.js";
 
@@ -288,6 +289,7 @@ mountMcpPublic(app, ch);
 mountSlackPublic(app);
 mountCloudflarePublic(app);
 mountVercelPublic(app);
+mountRailwayPublic(app);
 mountFeedbackPublic(app);
 // Management API (org-key auth, /api/v1/*) registers its own middleware
 // before the session middleware below — the session middleware skips
@@ -326,6 +328,7 @@ mountLinearAuthed(app);
 mountSlackAuthed(app);
 mountCloudflareAuthed(app);
 mountVercelAuthed(app);
+mountRailwayAuthed(app);
 mountSettingsAuthed(app);
 mountOrgKeyManagementAuthed(app);
 mountDashboards(app);

--- a/apps/api/src/ingest-filters-service.test.ts
+++ b/apps/api/src/ingest-filters-service.test.ts
@@ -8,7 +8,7 @@ import {
   ingestFilterStateSchema,
 } from "./ingest-filters-service.js";
 
-test("allIngestFilterPairs covers otlp×3 + aws×2 + vercel×2", () => {
+test("allIngestFilterPairs covers otlp×3 + aws×2 + vercel×2 + railway×2", () => {
   const pairs = allIngestFilterPairs()
     .map((p) => ingestFilterKey(p.source, p.signal))
     .sort();
@@ -18,6 +18,8 @@ test("allIngestFilterPairs covers otlp×3 + aws×2 + vercel×2", () => {
     "otlp:logs",
     "otlp:metrics",
     "otlp:traces",
+    "railway:logs",
+    "railway:metrics",
     "vercel:logs",
     "vercel:traces",
   ]);
@@ -28,6 +30,7 @@ test("empty disabled set → everything enabled", () => {
     otlp: { traces: true, logs: true, metrics: true },
     aws: { logs: true, metrics: true },
     vercel: { traces: true, logs: true },
+    railway: { logs: true, metrics: true },
   });
 });
 
@@ -56,6 +59,8 @@ test("state schema rejects unknown source/signal keys", () => {
       otlp: { traces: true, logs: true, metrics: true },
       aws: { logs: true, metrics: true },
       vercel: { traces: true, logs: true },
+      railway: { logs: true, metrics: true },
+    railway: { logs: true, metrics: true },
     }).success,
     true,
   );
@@ -65,6 +70,8 @@ test("state schema rejects unknown source/signal keys", () => {
       otlp: { traces: true, logs: true, metrics: true },
       aws: { logs: true, metrics: true, traces: true },
       vercel: { traces: true, logs: true },
+      railway: { logs: true, metrics: true },
+    railway: { logs: true, metrics: true },
     }).success,
     false,
   );
@@ -74,6 +81,8 @@ test("state schema rejects unknown source/signal keys", () => {
       otlp: { traces: true, logs: true },
       aws: { logs: true, metrics: true },
       vercel: { traces: true, logs: true },
+      railway: { logs: true, metrics: true },
+    railway: { logs: true, metrics: true },
     }).success,
     false,
   );

--- a/apps/api/src/ingest-filters-service.test.ts
+++ b/apps/api/src/ingest-filters-service.test.ts
@@ -60,7 +60,6 @@ test("state schema rejects unknown source/signal keys", () => {
       aws: { logs: true, metrics: true },
       vercel: { traces: true, logs: true },
       railway: { logs: true, metrics: true },
-    railway: { logs: true, metrics: true },
     }).success,
     true,
   );
@@ -71,7 +70,6 @@ test("state schema rejects unknown source/signal keys", () => {
       aws: { logs: true, metrics: true, traces: true },
       vercel: { traces: true, logs: true },
       railway: { logs: true, metrics: true },
-    railway: { logs: true, metrics: true },
     }).success,
     false,
   );
@@ -82,7 +80,6 @@ test("state schema rejects unknown source/signal keys", () => {
       aws: { logs: true, metrics: true },
       vercel: { traces: true, logs: true },
       railway: { logs: true, metrics: true },
-    railway: { logs: true, metrics: true },
     }).success,
     false,
   );

--- a/apps/api/src/ingest-filters-service.ts
+++ b/apps/api/src/ingest-filters-service.ts
@@ -2,11 +2,12 @@ import { z } from "zod";
 
 // The telemetry signals each ingest source can carry. OTLP (the SDK/exporter
 // path) carries all three; AWS (CloudWatch → Firehose) carries logs+metrics;
-// Vercel Drains carry traces+logs.
+// Vercel Drains carry traces+logs; the Railway API puller carries logs+metrics.
 export const INGEST_SOURCE_SIGNALS = {
   otlp: ["traces", "logs", "metrics"],
   aws: ["logs", "metrics"],
   vercel: ["traces", "logs"],
+  railway: ["logs", "metrics"],
 } as const;
 
 export type IngestSource = keyof typeof INGEST_SOURCE_SIGNALS;
@@ -16,6 +17,7 @@ export type IngestFilterState = {
   otlp: { traces: boolean; logs: boolean; metrics: boolean };
   aws: { logs: boolean; metrics: boolean };
   vercel: { traces: boolean; logs: boolean };
+  railway: { logs: boolean; metrics: boolean };
 };
 
 /** Stable key for a (source, signal) pair — matches the proxy's filter key. */
@@ -43,6 +45,7 @@ export function deriveIngestFilterState(disabled: Set<string>): IngestFilterStat
     },
     aws: { logs: on("aws", "logs"), metrics: on("aws", "metrics") },
     vercel: { traces: on("vercel", "traces"), logs: on("vercel", "logs") },
+    railway: { logs: on("railway", "logs"), metrics: on("railway", "metrics") },
   };
 }
 
@@ -53,6 +56,7 @@ export const ingestFilterStateSchema = z
     otlp: z.object({ traces: z.boolean(), logs: z.boolean(), metrics: z.boolean() }).strict(),
     aws: z.object({ logs: z.boolean(), metrics: z.boolean() }).strict(),
     vercel: z.object({ traces: z.boolean(), logs: z.boolean() }).strict(),
+    railway: z.object({ logs: z.boolean(), metrics: z.boolean() }).strict(),
   })
   .strict();
 

--- a/apps/api/src/ingest-filters.test.ts
+++ b/apps/api/src/ingest-filters.test.ts
@@ -65,6 +65,7 @@ test("defaults to everything enabled (no rows)", async () => {
     otlp: { traces: true, logs: true, metrics: true },
     aws: { logs: true, metrics: true },
     vercel: { traces: true, logs: true },
+    railway: { logs: true, metrics: true },
   });
 });
 
@@ -76,6 +77,7 @@ test("PUT disables a pair, persists one sparse row, and reflects in GET", async 
     otlp: { traces: true, logs: true, metrics: true },
     aws: { logs: false, metrics: true },
     vercel: { traces: true, logs: true },
+    railway: { logs: true, metrics: true },
   };
   const res = await app.request(`/api/projects/${project.id}/ingest-filters`, {
     method: "PUT",
@@ -114,11 +116,13 @@ test("PUT is a full replace — re-enabling clears the row", async () => {
     otlp: { traces: false, logs: true, metrics: true },
     aws: { logs: false, metrics: true },
     vercel: { traces: true, logs: true },
+    railway: { logs: true, metrics: true },
   });
   await put({
     otlp: { traces: true, logs: true, metrics: true },
     aws: { logs: true, metrics: true },
     vercel: { traces: true, logs: true },
+    railway: { logs: true, metrics: true },
   });
   const rows = await db.query.projectIngestFilters.findMany({
     where: eq(schema.projectIngestFilters.projectId, project.id),

--- a/apps/api/src/railway.ts
+++ b/apps/api/src/railway.ts
@@ -247,10 +247,7 @@ async function provisionInstallation(input: {
     fetchImpl: input.fetchImpl,
   });
   if (!granted.ok) {
-    throw new RailwayProvisioningError(
-      `railway grant discovery failed: ${granted.error}`,
-      "error",
-    );
+    throw new RailwayProvisioningError(`railway grant discovery failed: ${granted.error}`, "error");
   }
   if (granted.projects.length === 0) {
     throw new RailwayProvisioningError("railway grant has no projects", "no_projects");
@@ -263,10 +260,7 @@ async function provisionInstallation(input: {
       isNull(schema.railwayInstallations.revokedAt),
     ),
   });
-  const { ingestKey, apiKeyId, minted } = await ensureIngestKey(
-    input.projectId,
-    existing ?? null,
-  );
+  const { ingestKey, apiKeyId, minted } = await ensureIngestKey(input.projectId, existing ?? null);
 
   try {
     const accessCipher = encryptIntegrationSecret(input.token.accessToken);
@@ -300,10 +294,7 @@ async function provisionInstallation(input: {
         installedByUserId: input.userId,
       })
       .onConflictDoUpdate({
-        target: [
-          schema.railwayInstallations.projectId,
-          schema.railwayInstallations.railwayUserId,
-        ],
+        target: [schema.railwayInstallations.projectId, schema.railwayInstallations.railwayUserId],
         set: {
           grantedProjects: granted.projects,
           accessTokenCiphertext: accessCipher.ciphertext,

--- a/apps/api/src/railway.ts
+++ b/apps/api/src/railway.ts
@@ -138,14 +138,19 @@ async function ensureIngestKey(
  * the ingest key stops our intake accepting anything the puller would
  * forward, and the soft-revoke stops the puller reading Railway at all.
  */
-async function teardownInstallation(row: RailwayInstallationRow): Promise<void> {
+type DbExecutor = Pick<typeof db, "update">;
+
+async function teardownInstallation(
+  row: RailwayInstallationRow,
+  executor: DbExecutor = db,
+): Promise<void> {
   if (row.apiKeyId) {
-    await db
+    await executor
       .update(schema.apiKeys)
       .set({ revokedAt: new Date() })
       .where(eq(schema.apiKeys.id, row.apiKeyId));
   }
-  await db
+  await executor
     .update(schema.railwayInstallations)
     .set({ revokedAt: new Date(), updatedAt: new Date() })
     .where(eq(schema.railwayInstallations.id, row.id));
@@ -273,29 +278,16 @@ async function provisionInstallation(input: {
       ? new Date(now.getTime() + input.token.expiresInSeconds * 1000)
       : null;
 
-    await db
-      .insert(schema.railwayInstallations)
-      .values({
-        projectId: input.projectId,
-        railwayUserId,
-        grantedProjects: granted.projects,
-        accessTokenCiphertext: accessCipher.ciphertext,
-        accessTokenNonce: accessCipher.nonce,
-        accessTokenKeyVersion: accessCipher.keyVersion,
-        refreshTokenCiphertext: refreshCipher?.ciphertext ?? null,
-        refreshTokenNonce: refreshCipher?.nonce ?? null,
-        refreshTokenKeyVersion: refreshCipher?.keyVersion ?? null,
-        tokenExpiresAt,
-        scope: input.token.scope,
-        apiKeyId,
-        ingestKeyCiphertext: ingestCipher.ciphertext,
-        ingestKeyNonce: ingestCipher.nonce,
-        ingestKeyKeyVersion: ingestCipher.keyVersion,
-        installedByUserId: input.userId,
-      })
-      .onConflictDoUpdate({
-        target: [schema.railwayInstallations.projectId, schema.railwayInstallations.railwayUserId],
-        set: {
+    // One transaction for the upsert AND the supersede of other active rows,
+    // so "a project has exactly one active install" holds even across a crash
+    // between the two writes or two concurrent connects — the superseded
+    // install can't keep pulling with a live ingest key.
+    await db.transaction(async (tx) => {
+      await tx
+        .insert(schema.railwayInstallations)
+        .values({
+          projectId: input.projectId,
+          railwayUserId,
           grantedProjects: granted.projects,
           accessTokenCiphertext: accessCipher.ciphertext,
           accessTokenNonce: accessCipher.nonce,
@@ -310,14 +302,53 @@ async function provisionInstallation(input: {
           ingestKeyNonce: ingestCipher.nonce,
           ingestKeyKeyVersion: ingestCipher.keyVersion,
           installedByUserId: input.userId,
-          // A re-consent resurrects a previously revoked install and resets
-          // the puller's checkpoints (the old cursor may be far in the past).
-          logCursor: null,
-          metricsCursor: null,
-          revokedAt: null,
-          updatedAt: now,
-        },
-      });
+        })
+        .onConflictDoUpdate({
+          target: [
+            schema.railwayInstallations.projectId,
+            schema.railwayInstallations.railwayUserId,
+          ],
+          set: {
+            grantedProjects: granted.projects,
+            accessTokenCiphertext: accessCipher.ciphertext,
+            accessTokenNonce: accessCipher.nonce,
+            accessTokenKeyVersion: accessCipher.keyVersion,
+            refreshTokenCiphertext: refreshCipher?.ciphertext ?? null,
+            refreshTokenNonce: refreshCipher?.nonce ?? null,
+            refreshTokenKeyVersion: refreshCipher?.keyVersion ?? null,
+            tokenExpiresAt,
+            scope: input.token.scope,
+            apiKeyId,
+            ingestKeyCiphertext: ingestCipher.ciphertext,
+            ingestKeyNonce: ingestCipher.nonce,
+            ingestKeyKeyVersion: ingestCipher.keyVersion,
+            installedByUserId: input.userId,
+            // A re-consent resurrects a previously revoked install and resets
+            // the puller's checkpoints (the old cursor may be far in the past).
+            logCursor: null,
+            metricsCursor: null,
+            revokedAt: null,
+            updatedAt: now,
+          },
+        });
+
+      // Enforce a single active install per project inside the same
+      // transaction: soft-revoke rows keyed to a different Railway user and
+      // revoke their ingest keys.
+      const superseded = await tx
+        .select()
+        .from(schema.railwayInstallations)
+        .where(
+          and(
+            eq(schema.railwayInstallations.projectId, input.projectId),
+            ne(schema.railwayInstallations.railwayUserId, railwayUserId),
+            isNull(schema.railwayInstallations.revokedAt),
+          ),
+        );
+      for (const row of superseded) {
+        await teardownInstallation(row, tx);
+      }
+    });
   } catch (e) {
     // Roll back a key we minted for this connect; a reused key predates the
     // failure and stays.
@@ -328,27 +359,6 @@ async function provisionInstallation(input: {
         .where(eq(schema.apiKeys.id, apiKeyId));
     }
     throw e;
-  }
-
-  // Enforce a single active install per project: soft-revoke rows keyed to a
-  // different Railway user. Best-effort — never turns a persisted connect into
-  // an error redirect.
-  try {
-    const superseded = await db.query.railwayInstallations.findMany({
-      where: and(
-        eq(schema.railwayInstallations.projectId, input.projectId),
-        ne(schema.railwayInstallations.railwayUserId, railwayUserId),
-        isNull(schema.railwayInstallations.revokedAt),
-      ),
-    });
-    for (const row of superseded) {
-      await teardownInstallation(row);
-    }
-  } catch (e) {
-    log.warn(
-      { err: e, project_id: input.projectId },
-      "railway post-connect cleanup failed (connection persisted)",
-    );
   }
 }
 

--- a/apps/api/src/railway.ts
+++ b/apps/api/src/railway.ts
@@ -1,0 +1,404 @@
+// Railway integration routes: a "Connect Railway" button via Login with
+// Railway OAuth. Mirrors the Vercel/Cloudflare connector conventions, with one
+// structural difference: Railway has no drain/export product, so nothing is
+// provisioned on Railway's side. The OAuth grant itself is the integration —
+// a `project:viewer` token that the worker-side puller (apps/worker) uses to
+// read logs and metrics from the granted Railway projects and forward them to
+// our intake with the ingest key minted here.
+//
+// Flow:
+//   1. (authed)  POST /api/projects/:projectId/railway/install-url
+//                → Railway consent URL (signed state carries org/project/user)
+//   2. user approves on railway.com, picking which Railway projects to share
+//   3. (public)  GET  /railway/oauth/callback → exchange code, snapshot the
+//      granted projects, mint the ingest key, persist the install
+//   4. (authed)  GET  /api/projects/:projectId/railway/installation → status
+//                POST /api/projects/:projectId/railway/uninstall → remove
+//
+// The callback lives outside /api/* so it isn't behind the session middleware —
+// it's authenticated by the HMAC-signed `state`, exactly like the other
+// connectors' callbacks.
+
+import {
+  db,
+  decryptIntegrationSecret,
+  encryptIntegrationSecret,
+  mintApiKey,
+  schema,
+} from "@superlog/db";
+import {
+  type RailwayOAuthConfig,
+  buildAuthorizeUrl,
+  decodeIdTokenSub,
+  exchangeCodeForToken,
+  fetchGrantedProjects,
+  fetchViewer,
+  railwayConfigFromEnv,
+} from "@superlog/railway";
+import { and, desc, eq, isNull, ne } from "drizzle-orm";
+import type { Context, Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { logger } from "./logger.js";
+import { signState, verifyState } from "./oauth-state.js";
+import { resolveActiveOrgContext } from "./org-context.js";
+
+const log = logger.child({ scope: "railway" });
+
+type Vars = { userId: string; orgId: string | null };
+
+type RailwayInstallationRow = typeof schema.railwayInstallations.$inferSelect;
+
+export type RailwayConnectOutcome = "installed" | "denied" | "error" | "no_projects";
+
+/** Web path the OAuth callback redirects to — the dedicated result page. */
+export function connectResultPath(outcome: RailwayConnectOutcome | string): string {
+  return `/connect/railway?railway=${encodeURIComponent(outcome)}`;
+}
+
+class RailwayProvisioningError extends Error {
+  constructor(
+    message: string,
+    readonly outcome: RailwayConnectOutcome,
+  ) {
+    super(message);
+  }
+}
+
+/** Public shape — never leaks token ciphertext. */
+function toPublic(row: RailwayInstallationRow) {
+  return {
+    installed: true,
+    railwayUserId: row.railwayUserId,
+    grantedProjects: row.grantedProjects ?? [],
+    scope: row.scope,
+    installedAt: row.createdAt,
+  };
+}
+
+// Resolve the project the request targets from the path param and confirm the
+// caller's active org owns it (same discipline as the Vercel connector —
+// installs are per-project, so the project must be explicit).
+async function requireProjectAccess(
+  c: Context<{ Variables: Vars }>,
+  projectId: string,
+): Promise<{ userId: string; orgId: string; projectId: string }> {
+  const userId = c.var.userId;
+  if (!userId) throw new HTTPException(401, { message: "unauthenticated" });
+  const project = await db.query.projects.findFirst({
+    where: eq(schema.projects.id, projectId),
+  });
+  if (!project) throw new HTTPException(404, { message: "project not found" });
+  const ctx = await resolveActiveOrgContext({ userId, preferredOrgId: c.var.orgId });
+  if (project.orgId !== ctx.org.id) throw new HTTPException(403, { message: "forbidden" });
+  return { userId: ctx.user.id, orgId: ctx.org.id, projectId };
+}
+
+// The single active install for a project (enforced at provision time by the
+// supersede step; `orderBy` is belt-and-suspenders).
+async function findInstallation(projectId: string) {
+  return db.query.railwayInstallations.findFirst({
+    where: and(
+      eq(schema.railwayInstallations.projectId, projectId),
+      isNull(schema.railwayInstallations.revokedAt),
+    ),
+    orderBy: desc(schema.railwayInstallations.createdAt),
+  });
+}
+
+/**
+ * Get (or mint) the ingest key the puller forwards telemetry with. Reuses the
+ * installation's stored key when it's still live so a re-consent doesn't
+ * orphan a working key; mints a fresh one otherwise.
+ */
+async function ensureIngestKey(
+  projectId: string,
+  existing: RailwayInstallationRow | null,
+): Promise<{ ingestKey: string; apiKeyId: string; minted: boolean }> {
+  if (existing?.apiKeyId && existing.ingestKeyCiphertext && existing.ingestKeyNonce) {
+    const keyRow = await db.query.apiKeys.findFirst({
+      where: eq(schema.apiKeys.id, existing.apiKeyId),
+    });
+    if (keyRow && keyRow.revokedAt == null) {
+      const ingestKey = decryptIntegrationSecret({
+        ciphertext: existing.ingestKeyCiphertext,
+        nonce: existing.ingestKeyNonce,
+        keyVersion: existing.ingestKeyKeyVersion ?? 1,
+      });
+      return { ingestKey, apiKeyId: existing.apiKeyId, minted: false };
+    }
+  }
+  const minted = await mintApiKey({ projectId, name: "Railway puller" });
+  return { ingestKey: minted.plaintext, apiKeyId: minted.id, minted: true };
+}
+
+/**
+ * Tear down one installation row. There is nothing to delete on Railway's
+ * side (no drains, and Railway exposes no token-revocation endpoint — the
+ * user can revoke the grant under railway.com → Authorized Apps); revoking
+ * the ingest key stops our intake accepting anything the puller would
+ * forward, and the soft-revoke stops the puller reading Railway at all.
+ */
+async function teardownInstallation(row: RailwayInstallationRow): Promise<void> {
+  if (row.apiKeyId) {
+    await db
+      .update(schema.apiKeys)
+      .set({ revokedAt: new Date() })
+      .where(eq(schema.apiKeys.id, row.apiKeyId));
+  }
+  await db
+    .update(schema.railwayInstallations)
+    .set({ revokedAt: new Date(), updatedAt: new Date() })
+    .where(eq(schema.railwayInstallations.id, row.id));
+}
+
+export function mountRailwayPublic(
+  app: Hono<{ Variables: Vars }>,
+  deps: { config?: RailwayOAuthConfig | null; fetchImpl?: typeof fetch } = {},
+): void {
+  const config = deps.config !== undefined ? deps.config : railwayConfigFromEnv();
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const stateSecret = process.env.STATE_SIGNING_SECRET;
+  const webOrigin = process.env.WEB_ORIGIN ?? "http://localhost:5173";
+
+  if (!config) {
+    log.warn("RAILWAY_CLIENT_ID/SECRET not set — Railway connect disabled");
+  }
+
+  app.get("/railway/oauth/callback", async (c) => {
+    if (!config || !stateSecret) {
+      return c.json({ error: "railway not configured" }, 503);
+    }
+    const err = c.req.query("error");
+    if (err) {
+      log.warn({ error: err }, "railway oauth callback denied");
+      return c.redirect(`${webOrigin}${connectResultPath("denied")}`, 302);
+    }
+    const code = c.req.query("code");
+    const state = c.req.query("state") ?? "";
+    if (!code) return c.redirect(`${webOrigin}${connectResultPath("error")}`, 302);
+
+    const decoded = verifyState(state, stateSecret);
+    if (!decoded) {
+      log.warn("railway oauth callback rejected: invalid or expired state");
+      return c.redirect(`${webOrigin}${connectResultPath("error")}`, 302);
+    }
+
+    const token = await exchangeCodeForToken({ config, code, fetchImpl });
+    if (!token.ok) {
+      log.error({ error: token.error }, "railway token exchange failed");
+      return c.redirect(`${webOrigin}${connectResultPath("error")}`, 302);
+    }
+
+    try {
+      await provisionInstallation({
+        projectId: decoded.projectId,
+        userId: decoded.userId,
+        token,
+        fetchImpl,
+      });
+    } catch (e) {
+      log.error({ err: e, project_id: decoded.projectId }, "railway provisioning failed");
+      const outcome = e instanceof RailwayProvisioningError ? e.outcome : "error";
+      return c.redirect(`${webOrigin}${connectResultPath(outcome)}`, 302);
+    }
+
+    log.info({ project_id: decoded.projectId }, "railway connected");
+    return c.redirect(`${webOrigin}${connectResultPath("installed")}`, 302);
+  });
+}
+
+/**
+ * Exchange complete → snapshot the grant and persist the install. Unlike the
+ * Vercel flow there are no remote resources to create, so the only rollback
+ * concern is a freshly minted ingest key.
+ */
+async function provisionInstallation(input: {
+  projectId: string;
+  userId: string | null;
+  token: {
+    ok: true;
+    accessToken: string;
+    refreshToken: string | null;
+    expiresInSeconds: number | null;
+    scope: string | null;
+    idToken: string | null;
+  };
+  fetchImpl: typeof fetch;
+}): Promise<void> {
+  // The consenting Railway user keys the install row. The id_token usually
+  // carries it; fall back to the API otherwise.
+  let railwayUserId = decodeIdTokenSub(input.token.idToken);
+  if (!railwayUserId) {
+    const viewer = await fetchViewer({
+      accessToken: input.token.accessToken,
+      fetchImpl: input.fetchImpl,
+    });
+    if (!viewer.ok) {
+      throw new RailwayProvisioningError(`railway viewer lookup failed: ${viewer.error}`, "error");
+    }
+    railwayUserId = viewer.viewer.id;
+  }
+
+  // Snapshot what the grant can see. An empty grant would leave the puller
+  // with nothing to read — surface it so the user re-consents with projects
+  // selected instead of landing on a "connected" install that never ingests.
+  const granted = await fetchGrantedProjects({
+    accessToken: input.token.accessToken,
+    fetchImpl: input.fetchImpl,
+  });
+  if (!granted.ok) {
+    throw new RailwayProvisioningError(
+      `railway grant discovery failed: ${granted.error}`,
+      "error",
+    );
+  }
+  if (granted.projects.length === 0) {
+    throw new RailwayProvisioningError("railway grant has no projects", "no_projects");
+  }
+
+  const existing = await db.query.railwayInstallations.findFirst({
+    where: and(
+      eq(schema.railwayInstallations.projectId, input.projectId),
+      eq(schema.railwayInstallations.railwayUserId, railwayUserId),
+      isNull(schema.railwayInstallations.revokedAt),
+    ),
+  });
+  const { ingestKey, apiKeyId, minted } = await ensureIngestKey(
+    input.projectId,
+    existing ?? null,
+  );
+
+  try {
+    const accessCipher = encryptIntegrationSecret(input.token.accessToken);
+    const refreshCipher = input.token.refreshToken
+      ? encryptIntegrationSecret(input.token.refreshToken)
+      : null;
+    const ingestCipher = encryptIntegrationSecret(ingestKey);
+    const now = new Date();
+    const tokenExpiresAt = input.token.expiresInSeconds
+      ? new Date(now.getTime() + input.token.expiresInSeconds * 1000)
+      : null;
+
+    await db
+      .insert(schema.railwayInstallations)
+      .values({
+        projectId: input.projectId,
+        railwayUserId,
+        grantedProjects: granted.projects,
+        accessTokenCiphertext: accessCipher.ciphertext,
+        accessTokenNonce: accessCipher.nonce,
+        accessTokenKeyVersion: accessCipher.keyVersion,
+        refreshTokenCiphertext: refreshCipher?.ciphertext ?? null,
+        refreshTokenNonce: refreshCipher?.nonce ?? null,
+        refreshTokenKeyVersion: refreshCipher?.keyVersion ?? null,
+        tokenExpiresAt,
+        scope: input.token.scope,
+        apiKeyId,
+        ingestKeyCiphertext: ingestCipher.ciphertext,
+        ingestKeyNonce: ingestCipher.nonce,
+        ingestKeyKeyVersion: ingestCipher.keyVersion,
+        installedByUserId: input.userId,
+      })
+      .onConflictDoUpdate({
+        target: [
+          schema.railwayInstallations.projectId,
+          schema.railwayInstallations.railwayUserId,
+        ],
+        set: {
+          grantedProjects: granted.projects,
+          accessTokenCiphertext: accessCipher.ciphertext,
+          accessTokenNonce: accessCipher.nonce,
+          accessTokenKeyVersion: accessCipher.keyVersion,
+          refreshTokenCiphertext: refreshCipher?.ciphertext ?? null,
+          refreshTokenNonce: refreshCipher?.nonce ?? null,
+          refreshTokenKeyVersion: refreshCipher?.keyVersion ?? null,
+          tokenExpiresAt,
+          scope: input.token.scope,
+          apiKeyId,
+          ingestKeyCiphertext: ingestCipher.ciphertext,
+          ingestKeyNonce: ingestCipher.nonce,
+          ingestKeyKeyVersion: ingestCipher.keyVersion,
+          installedByUserId: input.userId,
+          // A re-consent resurrects a previously revoked install and resets
+          // the puller's checkpoints (the old cursor may be far in the past).
+          logCursor: null,
+          metricsCursor: null,
+          revokedAt: null,
+          updatedAt: now,
+        },
+      });
+  } catch (e) {
+    // Roll back a key we minted for this connect; a reused key predates the
+    // failure and stays.
+    if (minted) {
+      await db
+        .update(schema.apiKeys)
+        .set({ revokedAt: new Date() })
+        .where(eq(schema.apiKeys.id, apiKeyId));
+    }
+    throw e;
+  }
+
+  // Enforce a single active install per project: soft-revoke rows keyed to a
+  // different Railway user. Best-effort — never turns a persisted connect into
+  // an error redirect.
+  try {
+    const superseded = await db.query.railwayInstallations.findMany({
+      where: and(
+        eq(schema.railwayInstallations.projectId, input.projectId),
+        ne(schema.railwayInstallations.railwayUserId, railwayUserId),
+        isNull(schema.railwayInstallations.revokedAt),
+      ),
+    });
+    for (const row of superseded) {
+      await teardownInstallation(row);
+    }
+  } catch (e) {
+    log.warn(
+      { err: e, project_id: input.projectId },
+      "railway post-connect cleanup failed (connection persisted)",
+    );
+  }
+}
+
+export function mountRailwayAuthed(
+  app: Hono<{ Variables: Vars }>,
+  deps: { config?: RailwayOAuthConfig | null } = {},
+): void {
+  const config = deps.config !== undefined ? deps.config : railwayConfigFromEnv();
+  const stateSecret = process.env.STATE_SIGNING_SECRET;
+
+  app.get("/api/projects/:projectId/railway/installation", async (c) => {
+    const ctx = await requireProjectAccess(c, c.req.param("projectId"));
+    const row = await findInstallation(ctx.projectId);
+    if (!row) return c.json({ installed: false });
+    return c.json(toPublic(row));
+  });
+
+  app.post("/api/projects/:projectId/railway/install-url", async (c) => {
+    if (!config || !stateSecret) {
+      return c.json({ error: "railway not configured" }, 503);
+    }
+    const ctx = await requireProjectAccess(c, c.req.param("projectId"));
+
+    const state = signState(
+      { orgId: ctx.orgId, projectId: ctx.projectId, userId: ctx.userId },
+      stateSecret,
+    );
+    const url = buildAuthorizeUrl({
+      clientId: config.clientId,
+      redirectUri: config.redirectUri,
+      state,
+    });
+    log.info({ org_id: ctx.orgId, project_id: ctx.projectId }, "railway install url created");
+    return c.json({ url });
+  });
+
+  app.post("/api/projects/:projectId/railway/uninstall", async (c) => {
+    const ctx = await requireProjectAccess(c, c.req.param("projectId"));
+    const row = await findInstallation(ctx.projectId);
+    if (!row) return c.json({ ok: true });
+    await teardownInstallation(row);
+    return c.json({ ok: true });
+  });
+}

--- a/apps/api/src/system-capabilities.test.ts
+++ b/apps/api/src/system-capabilities.test.ts
@@ -15,10 +15,20 @@ test("system capabilities default to the open-core community edition", () => {
   });
 });
 
-test("railwayConnect flips on only when client creds + STATE_SIGNING_SECRET are set", () => {
+test("railwayConnect flips on only when client creds + both platform secrets are set", () => {
   assert.equal(
     buildSystemCapabilities({ RAILWAY_CLIENT_ID: "id", RAILWAY_CLIENT_SECRET: "secret" })
       .railwayConnect,
+    false,
+  );
+  // Provisioning encrypts secrets at rest, so AGENT_SECRETS_KEY is part of the
+  // gate — without it the connect flow throws after consent.
+  assert.equal(
+    buildSystemCapabilities({
+      RAILWAY_CLIENT_ID: "id",
+      RAILWAY_CLIENT_SECRET: "secret",
+      STATE_SIGNING_SECRET: "s",
+    }).railwayConnect,
     false,
   );
   assert.equal(
@@ -26,6 +36,7 @@ test("railwayConnect flips on only when client creds + STATE_SIGNING_SECRET are 
       RAILWAY_CLIENT_ID: "id",
       RAILWAY_CLIENT_SECRET: "secret",
       STATE_SIGNING_SECRET: "s",
+      AGENT_SECRETS_KEY: "k",
     }).railwayConnect,
     true,
   );
@@ -53,6 +64,7 @@ test("cloudflareConnect flips on only when all connector vars (incl. STATE_SIGNI
       CLOUDFLARE_CLIENT_SECRET: "secret",
       CLOUDFLARE_OTLP_INTAKE_URL: "https://intake.example.com",
       STATE_SIGNING_SECRET: "state-secret",
+      AGENT_SECRETS_KEY: "k",
     }).cloudflareConnect,
     true,
   );
@@ -101,6 +113,7 @@ test("vercelConnect flips on only when all connector vars (incl. STATE_SIGNING_S
       VERCEL_INTEGRATION_SLUG: "superlog",
       VERCEL_OTLP_INTAKE_URL: "https://intake.example.com",
       STATE_SIGNING_SECRET: "state-secret",
+      AGENT_SECRETS_KEY: "k",
     }).vercelConnect,
     true,
   );

--- a/apps/api/src/system-capabilities.test.ts
+++ b/apps/api/src/system-capabilities.test.ts
@@ -11,7 +11,24 @@ test("system capabilities default to the open-core community edition", () => {
     cloudUpgradeLinks: true,
     cloudflareConnect: false,
     vercelConnect: false,
+    railwayConnect: false,
   });
+});
+
+test("railwayConnect flips on only when client creds + STATE_SIGNING_SECRET are set", () => {
+  assert.equal(
+    buildSystemCapabilities({ RAILWAY_CLIENT_ID: "id", RAILWAY_CLIENT_SECRET: "secret" })
+      .railwayConnect,
+    false,
+  );
+  assert.equal(
+    buildSystemCapabilities({
+      RAILWAY_CLIENT_ID: "id",
+      RAILWAY_CLIENT_SECRET: "secret",
+      STATE_SIGNING_SECRET: "s",
+    }).railwayConnect,
+    true,
+  );
 });
 
 test("cloudflareConnect flips on only when all connector vars (incl. STATE_SIGNING_SECRET) are set", () => {
@@ -56,6 +73,7 @@ test("system capabilities expose cloud billing and managed agents when explicitl
       cloudUpgradeLinks: false,
       cloudflareConnect: false,
       vercelConnect: false,
+      railwayConnect: false,
     },
   );
 });

--- a/apps/api/src/system-capabilities.ts
+++ b/apps/api/src/system-capabilities.ts
@@ -35,6 +35,7 @@ type CapabilityEnv = Partial<
     | "RAILWAY_CLIENT_ID"
     | "RAILWAY_CLIENT_SECRET"
     | "STATE_SIGNING_SECRET"
+    | "AGENT_SECRETS_KEY"
   >
 >;
 
@@ -46,11 +47,15 @@ export function buildSystemCapabilities(env: CapabilityEnv = process.env): Syste
   // module stays dependency-free) AND the install-url route's STATE_SIGNING_SECRET
   // requirement — without the latter the connector would advertise as available
   // but `install-url` would 503. The connector self-disables without all of these.
+  // All three OAuth connectors also need AGENT_SECRETS_KEY — provisioning
+  // encrypts the granted tokens/ingest keys at rest and throws without it, so
+  // advertising the connector would offer a connect that can never complete.
   const cloudflareConnect = !!(
     env.CLOUDFLARE_CLIENT_ID &&
     env.CLOUDFLARE_CLIENT_SECRET &&
     env.CLOUDFLARE_OTLP_INTAKE_URL &&
-    env.STATE_SIGNING_SECRET
+    env.STATE_SIGNING_SECRET &&
+    env.AGENT_SECRETS_KEY
   );
   // Mirrors vercelConfigFromEnv's required-vars check plus the install-url
   // route's STATE_SIGNING_SECRET requirement, same as the Cloudflare gate.
@@ -59,13 +64,15 @@ export function buildSystemCapabilities(env: CapabilityEnv = process.env): Syste
     env.VERCEL_CLIENT_SECRET &&
     env.VERCEL_INTEGRATION_SLUG &&
     env.VERCEL_OTLP_INTAKE_URL &&
-    env.STATE_SIGNING_SECRET
+    env.STATE_SIGNING_SECRET &&
+    env.AGENT_SECRETS_KEY
   );
   // Mirrors railwayConfigFromEnv's required-vars check plus STATE_SIGNING_SECRET.
   const railwayConnect = !!(
     env.RAILWAY_CLIENT_ID &&
     env.RAILWAY_CLIENT_SECRET &&
-    env.STATE_SIGNING_SECRET
+    env.STATE_SIGNING_SECRET &&
+    env.AGENT_SECRETS_KEY
   );
 
   return {

--- a/apps/api/src/system-capabilities.ts
+++ b/apps/api/src/system-capabilities.ts
@@ -14,6 +14,9 @@ export type SystemCapabilities = {
   // Same gate for the Vercel connector (OAuth client + integration slug +
   // OTLP intake).
   vercelConnect: boolean;
+  // Same gate for the Railway connector (OAuth client only — telemetry is
+  // pulled by the worker, so there's no intake URL to configure here).
+  railwayConnect: boolean;
 };
 
 type CapabilityEnv = Partial<
@@ -29,6 +32,8 @@ type CapabilityEnv = Partial<
     | "VERCEL_CLIENT_SECRET"
     | "VERCEL_INTEGRATION_SLUG"
     | "VERCEL_OTLP_INTAKE_URL"
+    | "RAILWAY_CLIENT_ID"
+    | "RAILWAY_CLIENT_SECRET"
     | "STATE_SIGNING_SECRET"
   >
 >;
@@ -56,6 +61,12 @@ export function buildSystemCapabilities(env: CapabilityEnv = process.env): Syste
     env.VERCEL_OTLP_INTAKE_URL &&
     env.STATE_SIGNING_SECRET
   );
+  // Mirrors railwayConfigFromEnv's required-vars check plus STATE_SIGNING_SECRET.
+  const railwayConnect = !!(
+    env.RAILWAY_CLIENT_ID &&
+    env.RAILWAY_CLIENT_SECRET &&
+    env.STATE_SIGNING_SECRET
+  );
 
   return {
     edition,
@@ -65,6 +76,7 @@ export function buildSystemCapabilities(env: CapabilityEnv = process.env): Syste
     cloudUpgradeLinks: edition === "community",
     cloudflareConnect,
     vercelConnect,
+    railwayConnect,
   };
 }
 

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -294,6 +294,7 @@ async function validateIngestKey(c: Context<{ Variables: Variables }>, next: () 
 
 app.use("/v1/*", validateIngestKey);
 app.use("/vercel/drains/*", validateIngestKey);
+app.use("/railway/pull/*", validateIngestKey);
 
 app.post("/v1/traces", (c) => forward(c, "/v1/traces", "resourceSpans"));
 app.post("/v1/logs", (c) => forward(c, "/v1/logs", "resourceLogs"));
@@ -312,6 +313,16 @@ app.post("/vercel/drains/logs", (c) =>
       contentType: "application/json",
     }),
   }),
+);
+
+// Railway puller ingest: the worker-side puller reads logs/metrics from
+// Railway's API, transforms to OTLP JSON, and forwards here with the
+// installation's ingest key — same tenant resolution and per-source filter
+// discipline as the Vercel drains, just pushed by our own worker instead of
+// the vendor.
+app.post("/railway/pull/logs", (c) => forward(c, "/v1/logs", "resourceLogs", { source: "railway" }));
+app.post("/railway/pull/metrics", (c) =>
+  forward(c, "/v1/metrics", "resourceMetrics", { source: "railway" }),
 );
 
 // AWS Data Firehose HTTP-endpoint ingest (CloudWatch Metric Streams + Logs).

--- a/apps/proxy/src/ingest-source-filter.ts
+++ b/apps/proxy/src/ingest-source-filter.ts
@@ -9,7 +9,7 @@
 // a few seconds to apply is fine; a DB hiccup silently dropping telemetry is not.
 import { logger } from "./logger.js";
 
-export type IngestSource = "otlp" | "aws" | "vercel";
+export type IngestSource = "otlp" | "aws" | "vercel" | "railway";
 export type TelemetrySignal = "traces" | "logs" | "metrics";
 
 export const ingestFilterKey = (source: IngestSource, signal: TelemetrySignal): string =>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,6 +16,7 @@ import { Overview } from "./Overview.tsx";
 import { PrFeedback } from "./PrFeedback.tsx";
 import { Pricing } from "./Pricing.tsx";
 import { PrivacyPolicy } from "./PrivacyPolicy.tsx";
+import { RailwayCallback } from "./RailwayCallback.tsx";
 import { ResetPassword } from "./ResetPassword.tsx";
 import { Settings } from "./Settings.tsx";
 import { TermsOfService } from "./TermsOfService.tsx";
@@ -139,6 +140,7 @@ export function App() {
             shows even when the callback lands in a fresh, gated, or logged-out
             tab (the install opens via window.open). */}
         <Route path="/connect/vercel" element={<VercelCallback />} />
+        <Route path="/connect/railway" element={<RailwayCallback />} />
         <Route path="*" element={<AuthenticatedApp />} />
       </Routes>
     </>
@@ -288,9 +290,7 @@ function RouteContainer({ children }: { children: ReactNode }) {
     return <div className="flex min-h-0 flex-1 flex-col">{children}</div>;
   }
   return (
-    <div
-      className={`mx-auto w-full px-6 pb-24 pt-6 ${wide ? "max-w-[2400px]" : "max-w-6xl"}`}
-    >
+    <div className={`mx-auto w-full px-6 pb-24 pt-6 ${wide ? "max-w-[2400px]" : "max-w-6xl"}`}>
       {children}
     </div>
   );

--- a/apps/web/src/RailwayCallback.tsx
+++ b/apps/web/src/RailwayCallback.tsx
@@ -1,0 +1,70 @@
+// Landing page for the Railway OAuth callback redirect (`/connect/railway`).
+// The consent screen opens in a new tab, so this is often the only surface the
+// user sees after approving (or failing) the connection — it must state the
+// result explicitly rather than relying on the onboarding wizard being mounted.
+
+import { Btn, Wordmark } from "./design/ui.tsx";
+import { CheckIcon } from "./onboarding/icons.tsx";
+import { railwayCallbackView } from "./railwayCallbackModel.ts";
+
+const SOFT_LINE = "border-[rgba(255,255,255,0.07)]";
+
+export function RailwayCallback() {
+  const params = new URLSearchParams(window.location.search);
+  const view = railwayCallbackView(params.get("railway"));
+
+  return (
+    <div className="min-h-screen bg-bg font-sans text-fg">
+      <header className="px-8 py-5">
+        <Wordmark size="md" />
+      </header>
+
+      <main className="flex justify-center px-8 pb-16 pt-12">
+        <div className="w-full max-w-[560px]">
+          <div className="mb-7 px-1">
+            <h1 className="m-0 text-[22px] font-semibold leading-[1.2] tracking-[-0.015em] text-fg">
+              {view.title}
+            </h1>
+          </div>
+
+          {view.tone === "success" ? (
+            <div className="flex items-start gap-2.5 rounded-[10px] border border-[rgba(65,209,149,0.35)] bg-[rgba(65,209,149,0.06)] px-4 py-3">
+              <span className="mt-[2px] text-success">
+                <CheckIcon size={14} />
+              </span>
+              <p className="m-0 flex-1 text-[13px] leading-[1.55] text-fg">{view.body}</p>
+            </div>
+          ) : (
+            <div className="flex items-start gap-2.5 rounded-[10px] border border-[rgba(240,98,98,0.35)] bg-[rgba(240,98,98,0.06)] px-4 py-3">
+              <span className="mt-[2px] text-danger" aria-hidden>
+                <ErrorIcon size={14} />
+              </span>
+              <p className="m-0 flex-1 text-[13px] leading-[1.55] text-fg">{view.body}</p>
+            </div>
+          )}
+
+          <div className={`mt-9 flex items-center justify-end border-t pt-5 ${SOFT_LINE}`}>
+            <Btn
+              variant="primary"
+              size="md"
+              onClick={() => window.location.assign(view.backHref)}
+              className="!h-[36px] !rounded-[8px] !px-[14px] !text-[13px]"
+            >
+              {view.backLabel}
+            </Btn>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function ErrorIcon({ size }: { size: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" role="presentation">
+      <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M8 5v3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <circle cx="8" cy="11" r="0.9" fill="currentColor" />
+    </svg>
+  );
+}

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -21,6 +21,7 @@ import {
   useAgentSettings,
   useCloudConnections,
   useCloudStackHealth,
+  useCloudflareInstallation,
   useCreateCloudConnection,
   useCreateKey,
   useCreateMcpToken,
@@ -51,6 +52,7 @@ import {
   useOrgGithubInstallRepos,
   useOrgGithubInstallations,
   useOrgProjects,
+  useRailwayInstallation,
   useRedeliverWebhook,
   useRemoveIntegration,
   useResetGithubCommitAuthor,
@@ -63,7 +65,6 @@ import {
   useRunOrgDigestNow,
   useSaveAgentSettings,
   useSaveIntegration,
-  useCloudflareInstallation,
   useSaveOrgAgentSettings,
   useSaveOrgDigest,
   useSetIngestFilters,
@@ -72,16 +73,18 @@ import {
   useSlackChannels,
   useSlackInstallation,
   useSlackRoute,
+  useStartCloudflareInstall,
   useStartGithubAccessLogin,
   useStartGithubAuthorLogin,
   useStartGithubInstall,
   useStartLinearInstall,
-  useStartCloudflareInstall,
+  useStartRailwayInstall,
   useStartSlackInstall,
   useStartVercelInstall,
   useTestWebhook,
-  useUninstallLinear,
   useUninstallCloudflare,
+  useUninstallLinear,
+  useUninstallRailway,
   useUninstallSlack,
   useUninstallVercel,
   useUpdateGithubRepoAccess,
@@ -95,9 +98,9 @@ import {
 import { AWS_REGIONS } from "./awsRegions.ts";
 import { Dropdown, type DropdownOption } from "./design/Dropdown.tsx";
 import { Btn, Chip, FieldLabel, Input, Label, Tile } from "./design/ui";
+import { McpInstallPanel } from "./onboarding/McpInstallDialog.tsx";
 import { InfoIcon } from "./onboarding/icons.tsx";
 import { VERCEL_PLAN_REQUIREMENT } from "./onboarding/vercelConnectModel.ts";
-import { McpInstallPanel } from "./onboarding/McpInstallDialog.tsx";
 import { AgentMemoriesCard } from "./settings/AgentMemoriesCard.tsx";
 import { BillingCard } from "./settings/BillingCard.tsx";
 import { CreateOrgCard } from "./settings/CreateOrgCard.tsx";
@@ -622,6 +625,7 @@ function ProjectSectionView({
             <LinearCard />
             <CloudflareCard projectId={projectId} />
             <VercelCard projectId={projectId} />
+            <RailwayCard projectId={projectId} />
             <AwsCard projectId={projectId} />
             <IngestSourcesCard projectId={projectId} />
           </div>
@@ -1318,6 +1322,62 @@ function VercelCard({ projectId }: { projectId: string | undefined }) {
   );
 }
 
+function RailwayCard({ projectId }: { projectId: string | undefined }) {
+  const install = useRailwayInstallation(projectId);
+  const start = useStartRailwayInstall(projectId);
+  const uninstall = useUninstallRailway(projectId);
+
+  const installed = install.data?.installed === true;
+  const grantedCount = install.data?.installed ? install.data.grantedProjects.length : 0;
+
+  return (
+    <Tile label="Railway">
+      <div className="space-y-3">
+        <p className="text-[13px] text-muted">
+          Authorize Railway and pick the projects to share — we pull your services' logs and infra
+          metrics from Railway's API into this project automatically. Read-only, revocable any time.
+        </p>
+        <div>
+          {installed ? (
+            <Chip tone="success" dot>
+              {grantedCount === 1 ? "1 Railway project" : `${grantedCount} Railway projects`}
+            </Chip>
+          ) : (
+            <Chip tone="muted" dot>
+              Not connected
+            </Chip>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <Btn
+            size="sm"
+            variant={installed ? "secondary" : "primary"}
+            loading={start.isPending}
+            disabled={!projectId || start.isPending}
+            onClick={async () => {
+              const { url } = await start.mutateAsync();
+              window.location.href = url;
+            }}
+          >
+            {installed ? "Reconnect" : "Connect Railway"}
+          </Btn>
+          {installed && (
+            <Btn
+              size="sm"
+              variant="danger"
+              loading={uninstall.isPending}
+              disabled={!projectId || uninstall.isPending}
+              onClick={() => uninstall.mutate()}
+            >
+              Disconnect
+            </Btn>
+          )}
+        </div>
+      </div>
+    </Tile>
+  );
+}
+
 function SlackRoutingCard({ projectId }: { projectId: string | undefined }) {
   const install = useSlackInstallation();
   const installed = install.data?.installed === true;
@@ -1687,7 +1747,11 @@ function IngestSourcesCard({ projectId }: { projectId: string | undefined }) {
   const setFilters = useSetIngestFilters(projectId ?? "");
   const state = filters.data;
 
-  const setSignal = (source: "otlp" | "aws" | "vercel", signal: string, next: boolean) => {
+  const setSignal = (
+    source: "otlp" | "aws" | "vercel" | "railway",
+    signal: string,
+    next: boolean,
+  ) => {
     if (!state) return;
     const updated: IngestFilterState = {
       ...state,
@@ -1740,6 +1804,17 @@ function IngestSourcesCard({ projectId }: { projectId: string | undefined }) {
               state={state.vercel}
               disabled={setFilters.isPending}
               onToggle={(signal, next) => setSignal("vercel", signal, next)}
+            />
+            <IngestSourceRow
+              title="Railway"
+              hint="Logs and infra metrics pulled from the connected Railway projects."
+              signals={[
+                { key: "logs", label: "Logs" },
+                { key: "metrics", label: "Metrics" },
+              ]}
+              state={state.railway}
+              disabled={setFilters.isPending}
+              onToggle={(signal, next) => setSignal("railway", signal, next)}
             />
           </div>
         )}

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -79,6 +79,7 @@ export type SystemCapabilities = {
   cloudUpgradeLinks: boolean;
   cloudflareConnect: boolean;
   vercelConnect: boolean;
+  railwayConnect: boolean;
 };
 
 const SIGNUP_SOURCE_STORAGE_KEY = "superlog.signup_source";
@@ -923,6 +924,56 @@ export function useUninstallVercel(projectId: string | undefined) {
   });
 }
 
+export type RailwayInstallation =
+  | { installed: false }
+  | {
+      installed: true;
+      railwayUserId: string;
+      grantedProjects: Array<{
+        id: string;
+        name: string;
+        workspaceId: string | null;
+        workspaceName: string | null;
+      }>;
+      scope: string | null;
+      installedAt: string;
+    };
+
+// Railway installs are per-project, same scoping discipline as Vercel.
+export function useRailwayInstallation(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  return useQuery({
+    queryKey: ["railway-installation", projectId],
+    queryFn: () => fetcher<RailwayInstallation>(`/api/projects/${projectId}/railway/installation`),
+    enabled: !!projectId,
+    // Poll so the card flips to "connected" after the OAuth redirect without a
+    // manual refresh (same pattern as Slack/GitHub/Cloudflare/Vercel).
+    refetchInterval: 15000,
+  });
+}
+
+export function useStartRailwayInstall(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  return useMutation({
+    mutationFn: () =>
+      fetcher<{ url: string }>(`/api/projects/${projectId}/railway/install-url`, {
+        method: "POST",
+      }),
+  });
+}
+
+export function useUninstallRailway(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      fetcher<{ ok: true }>(`/api/projects/${projectId}/railway/uninstall`, { method: "POST" }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["railway-installation", projectId] });
+    },
+  });
+}
+
 export function useSlackChannels(enabled: boolean) {
   const fetcher = useFetcher();
   return useQuery({
@@ -1122,11 +1173,13 @@ export function useDeleteCloudConnection(projectId: string) {
 }
 
 // Per-project ingest source filters: turn a telemetry source (SDK/OTLP, AWS
-// CloudWatch, or Vercel Drains) on/off per signal. The proxy ack-drops disabled telemetry.
+// CloudWatch, Vercel Drains, or the Railway puller) on/off per signal. The
+// proxy ack-drops disabled telemetry.
 export type IngestFilterState = {
   otlp: { traces: boolean; logs: boolean; metrics: boolean };
   aws: { logs: boolean; metrics: boolean };
   vercel: { traces: boolean; logs: boolean };
+  railway: { logs: boolean; metrics: boolean };
 };
 
 export function useIngestFilters(projectId: string | undefined) {

--- a/apps/web/src/onboarding/ConnectDataChooser.tsx
+++ b/apps/web/src/onboarding/ConnectDataChooser.tsx
@@ -6,7 +6,14 @@ import {
   type ConnectSection,
   connectSectionsFor,
 } from "./connectChoices.ts";
-import { AwsIcon, ChevronRightIcon, CloudflareIcon, TerminalIcon, VercelIcon } from "./icons.tsx";
+import {
+  AwsIcon,
+  ChevronRightIcon,
+  CloudflareIcon,
+  RailwayIcon,
+  TerminalIcon,
+  VercelIcon,
+} from "./icons.tsx";
 import { ExploreDemoLink, SOFT_LINE } from "./wizardChrome.tsx";
 
 // The path chooser: a flat, low-color list (modeled on a Plugins page). Peer
@@ -19,6 +26,7 @@ function ConnectGlyph({ icon }: { icon: ConnectIcon }) {
     aws: AwsIcon,
     cloudflare: CloudflareIcon,
     vercel: VercelIcon,
+    railway: RailwayIcon,
     terminal: TerminalIcon,
   };
   const Glyph = map[icon];
@@ -104,6 +112,7 @@ export function ConnectDataChooser({
   const sections = connectSectionsFor({
     cloudflare: capabilities.data?.cloudflareConnect ?? false,
     vercel: capabilities.data?.vercelConnect ?? false,
+    railway: capabilities.data?.railwayConnect ?? false,
   });
   return (
     <>

--- a/apps/web/src/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/onboarding/OnboardingWizard.tsx
@@ -16,6 +16,7 @@ import { getSkillOnboardingIntent } from "../skillOnboarding.ts";
 import { AwsConnectFlow } from "./AwsConnectFlow.tsx";
 import { CloudflareConnectFlow } from "./CloudflareConnectFlow.tsx";
 import { ConnectDataChooser } from "./ConnectDataChooser.tsx";
+import { RailwayConnectFlow } from "./RailwayConnectFlow.tsx";
 import { VercelConnectFlow } from "./VercelConnectFlow.tsx";
 import type { ConnectAction } from "./connectChoices.ts";
 import { CheckIcon, GithubIcon, SlackIcon, SpinnerIcon } from "./icons.tsx";
@@ -44,7 +45,7 @@ import {
 type Mode = "web" | "agent";
 // Web-mode landing fork: choose a source, then either a no-code integration
 // flow (AWS / Cloudflare / Vercel) or the coding-agent install → deploy flow.
-type WebView = "chooser" | "aws" | "cloudflare" | "vercel" | "code" | "deploy";
+type WebView = "chooser" | "aws" | "cloudflare" | "vercel" | "railway" | "code" | "deploy";
 
 // The Cloudflare / Vercel OAuth callbacks redirect back to the app with
 // `?cloudflare=...` / `?vercel=...`. When that lands we want to drop straight
@@ -56,6 +57,7 @@ function initialWebView(): WebView {
   const params = new URLSearchParams(window.location.search);
   if (params.has("cloudflare")) return "cloudflare";
   if (params.has("vercel")) return "vercel";
+  if (params.has("railway")) return "railway";
   return "chooser";
 }
 
@@ -100,6 +102,8 @@ export function OnboardingWizard({
       setWebView("cloudflare");
     } else if (action === "vercel") {
       setWebView("vercel");
+    } else if (action === "railway") {
+      setWebView("railway");
     } else {
       setWebView("code");
     }
@@ -174,6 +178,14 @@ export function OnboardingWizard({
             />
           ) : webView === "vercel" ? (
             <VercelConnectFlow
+              projectId={projectId}
+              eventsArrived={eventsArrived}
+              onBack={() => setWebView("chooser")}
+              onDone={onComplete}
+              onExploreDemo={onExploreDemo}
+            />
+          ) : webView === "railway" ? (
+            <RailwayConnectFlow
               projectId={projectId}
               eventsArrived={eventsArrived}
               onBack={() => setWebView("chooser")}

--- a/apps/web/src/onboarding/RailwayConnectFlow.tsx
+++ b/apps/web/src/onboarding/RailwayConnectFlow.tsx
@@ -1,0 +1,296 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useRailwayInstallation, useStartRailwayInstall } from "../api.ts";
+import { Btn } from "../design/ui.tsx";
+import { CheckIcon, ExternalLinkIcon, SpinnerIcon } from "./icons.tsx";
+import {
+  type RailwayPhase,
+  canContinueRailway,
+  parseRailwayOutcome,
+  railwayOutcomeMessage,
+  railwayPhase,
+  railwayStatusText,
+} from "./railwayConnectModel.ts";
+import {
+  ExploreDemoLink,
+  SOFT_LINE,
+  STRONG_LINE,
+  StepFooter,
+  StepHeader,
+} from "./wizardChrome.tsx";
+
+// Open the Railway consent screen in a new tab, falling back to a same-tab
+// navigation if the popup was blocked. Same opener-severing trick as the other
+// connector launch helpers.
+function openConsent(url: string) {
+  const win = window.open(url, "_blank");
+  if (win) {
+    win.opener = null;
+  } else {
+    window.location.assign(url);
+  }
+}
+
+export function RailwayConnectFlow({
+  projectId,
+  eventsArrived,
+  onBack,
+  onDone,
+  onExploreDemo,
+}: {
+  projectId: string;
+  // Whether the real project has ingested telemetry yet (from the parent's
+  // `me.project.hasIngested`). NOT derived from the stats endpoint, which is
+  // demo-overlaid for un-ingested projects and would falsely report events.
+  eventsArrived: boolean;
+  onBack: () => void;
+  onDone: () => void;
+  onExploreDemo?: () => void;
+}) {
+  // Whether we've opened the consent screen this session. Drives the
+  // transition from "start" to the "connecting" waiting state while the
+  // installation poll catches the round-trip landing.
+  const [launched, setLaunched] = useState(false);
+  // A failure surfaced by the OAuth callback redirect (`?railway=denied|…`).
+  const [outcomeError, setOutcomeError] = useState<string | null>(null);
+
+  const install = useRailwayInstallation(projectId);
+  const start = useStartRailwayInstall(projectId);
+
+  // The callback redirects back to the app with `?railway=...`. When the
+  // consent screen was opened in the same tab (popup blocked), a failure lands
+  // here — surface it and drop out of the waiting state instead of spinning
+  // forever. Strip the param so a refresh doesn't re-trigger it.
+  const [searchParams, setSearchParams] = useSearchParams();
+  useEffect(() => {
+    const outcome = parseRailwayOutcome(searchParams.get("railway"));
+    if (!outcome) return;
+    if (outcome === "denied" || outcome === "error" || outcome === "no_projects") {
+      setLaunched(false);
+      setOutcomeError(railwayOutcomeMessage(outcome));
+    }
+    const next = new URLSearchParams(searchParams);
+    next.delete("railway");
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  const installed = install.data?.installed === true;
+  const phase = railwayPhase({ installed, launched });
+
+  const connect = () => {
+    if (start.isPending) return;
+    setOutcomeError(null);
+    start.mutate(undefined, {
+      onSuccess: ({ url }) => {
+        setLaunched(true);
+        openConsent(url);
+      },
+    });
+  };
+
+  const header = headerForPhase(phase);
+
+  return (
+    <>
+      <StepHeader title={header.title} sub={header.sub} />
+
+      {phase === "start" && (
+        <StartPanel
+          onConnect={connect}
+          pending={start.isPending}
+          error={outcomeError ?? (start.error ? String(start.error) : null)}
+        />
+      )}
+
+      {phase === "connecting" && (
+        <ConnectingPanel
+          statusText={railwayStatusText(phase, eventsArrived)}
+          onReopen={connect}
+          reopening={start.isPending}
+        />
+      )}
+
+      {phase === "connected" && install.data?.installed && (
+        <ConnectedPanel
+          grantedProjects={install.data.grantedProjects}
+          eventsArrived={eventsArrived}
+        />
+      )}
+
+      <StepFooter
+        onBack={onBack}
+        onNext={onDone}
+        nextLabel={canContinueRailway(phase) ? "Continue" : "Waiting for Railway…"}
+        nextDisabled={!canContinueRailway(phase)}
+      />
+      {!canContinueRailway(phase) && <ExploreDemoLink onExploreDemo={onExploreDemo} />}
+    </>
+  );
+}
+
+function headerForPhase(phase: RailwayPhase): { title: string; sub: string } {
+  switch (phase) {
+    case "start":
+      return {
+        title: "Connect Railway",
+        sub: "Authorize Railway once and pick the projects to share. We pull your services' logs and infra metrics from Railway's API — no agent, no code changes.",
+      };
+    case "connecting":
+      return {
+        title: "Finish in Railway",
+        sub: "Approve the access request in the Railway tab we opened, and select the projects you want to share — keep this tab open.",
+      };
+    default:
+      return {
+        title: "You're connected",
+        sub: "We're pulling logs and metrics from your Railway projects. First events typically appear within a minute.",
+      };
+  }
+}
+
+function StartPanel({
+  onConnect,
+  pending,
+  error,
+}: {
+  onConnect: () => void;
+  pending: boolean;
+  error: string | null;
+}) {
+  return (
+    <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+      <div className={`border-b px-[22px] py-[18px] ${SOFT_LINE}`}>
+        <p className="m-0 text-[13px] leading-[1.55] text-muted">
+          We never ask for an API token. Railway's OAuth grants a scoped, read-only token limited to
+          the projects you select on the consent screen — you can disconnect any time from settings,
+          or revoke the grant under Railway's Authorized Apps.
+        </p>
+      </div>
+      <div className="flex items-center justify-between gap-3 px-[22px] py-[16px]">
+        <span className="text-[12.5px] text-muted">
+          Opens the Railway consent screen in a new tab.
+        </span>
+        <Btn
+          variant="primary"
+          size="md"
+          onClick={onConnect}
+          loading={pending}
+          className="!h-[36px] !rounded-[8px] !px-[14px] !text-[13px]"
+        >
+          {pending ? "Preparing…" : "Connect Railway account"}
+          {!pending && <ExternalLinkIcon size={13} />}
+        </Btn>
+      </div>
+      {error && (
+        <div className={`border-t px-[22px] py-[12px] ${SOFT_LINE}`}>
+          <p className="m-0 text-[12.5px] text-danger">{error}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConnectingPanel({
+  statusText,
+  onReopen,
+  reopening,
+}: {
+  statusText: string;
+  onReopen: () => void;
+  reopening: boolean;
+}) {
+  return (
+    <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+      <div
+        className={`flex items-center gap-2.5 border-b px-[18px] py-[12px] ${SOFT_LINE} text-[12px]`}
+      >
+        <span className="text-[#8C98F0]">
+          <SpinnerIcon size={13} />
+        </span>
+        <span className="text-muted">{statusText}</span>
+      </div>
+      <div className="px-[22px] py-[18px]">
+        <ol className="m-0 list-decimal space-y-1.5 pl-4 text-[13px] leading-[1.5] text-muted">
+          <li>Review the access request in the Railway tab.</li>
+          <li>Select the Railway projects you want to share, then approve.</li>
+          <li>This panel updates on its own once the connection lands.</li>
+        </ol>
+        <button
+          type="button"
+          onClick={onReopen}
+          disabled={reopening}
+          className="mt-3 inline-flex items-center gap-1.5 text-[12.5px] font-medium text-[#8C98F0] transition-colors hover:text-fg disabled:opacity-50"
+        >
+          <ExternalLinkIcon size={13} /> Reopen Railway
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ConnectedPanel({
+  grantedProjects,
+  eventsArrived,
+}: {
+  grantedProjects: Array<{ id: string; name: string; workspaceName: string | null }>;
+  eventsArrived: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+        <div className={`border-b px-[18px] py-[10px] ${SOFT_LINE}`}>
+          <span className="font-mono text-[12px] text-muted">
+            {grantedProjects.length === 1
+              ? "1 Railway project shared"
+              : `${grantedProjects.length} Railway projects shared`}
+          </span>
+        </div>
+        <div className="divide-y divide-[rgba(255,255,255,0.07)]">
+          {grantedProjects.length === 0 ? (
+            <div className="px-[18px] py-[14px] text-[12.5px] text-muted">
+              Reading the granted projects…
+            </div>
+          ) : (
+            grantedProjects.map((project) => (
+              <div key={project.id} className="flex items-center gap-3 px-[18px] py-[13px]">
+                <span className="text-success">
+                  <CheckIcon size={14} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-[13px] font-medium text-fg">{project.name}</span>
+                  <span className="block text-[12px] text-muted">
+                    {project.workspaceName
+                      ? `${project.workspaceName} — logs + metrics`
+                      : "logs + metrics"}
+                  </span>
+                </span>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {eventsArrived ? (
+        <div className="flex items-center gap-2.5 rounded-[10px] border border-[rgba(65,209,149,0.35)] bg-[rgba(65,209,149,0.06)] px-4 py-3">
+          <span className="text-success">
+            <CheckIcon size={14} />
+          </span>
+          <div className="flex-1 text-[12.5px] text-fg">
+            First events received. <span className="text-muted">You're flowing.</span>
+          </div>
+        </div>
+      ) : (
+        <div
+          className={`flex items-center gap-2.5 rounded-[10px] border border-dashed px-4 py-3 ${STRONG_LINE}`}
+        >
+          <span className="text-[#8C98F0]">
+            <SpinnerIcon size={14} />
+          </span>
+          <div className="flex-1 text-[12.5px] text-muted">
+            The pull is live. First logs and metrics typically appear within a minute.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/onboarding/connectChoices.test.ts
+++ b/apps/web/src/onboarding/connectChoices.test.ts
@@ -16,9 +16,9 @@ function findOption(sections: ReturnType<typeof connectSectionsFor>, id: string)
   return undefined;
 }
 
-test("the chooser offers exactly four lanes: AWS, Cloudflare, Vercel, and 'I'm hosted elsewhere'", () => {
+test("the chooser offers exactly five lanes: AWS, Cloudflare, Vercel, Railway, and 'I'm hosted elsewhere'", () => {
   const ids = CONNECT_SECTIONS.flatMap((s) => s.options.map((o) => o.id));
-  assert.deepEqual(ids, ["aws", "cloudflare", "vercel", "elsewhere"]);
+  assert.deepEqual(ids, ["aws", "cloudflare", "vercel", "railway", "elsewhere"]);
 });
 
 test("there is no coming-soon grid", () => {
@@ -42,7 +42,7 @@ test("integration-first: the primary option is a no-code integration (AWS)", () 
 });
 
 test("every lane is actionable when its connectors are configured", () => {
-  const sections = connectSectionsFor({ cloudflare: true, vercel: true });
+  const sections = connectSectionsFor({ cloudflare: true, vercel: true, railway: true });
   for (const section of sections) {
     for (const option of section.options) {
       assert.notEqual(option.action, null, `${option.id} should be actionable`);
@@ -55,12 +55,13 @@ test("connectActionFor resolves known ids and returns null for unknown", () => {
   assert.equal(connectActionFor("aws"), "aws");
   assert.equal(connectActionFor("cloudflare"), "cloudflare");
   assert.equal(connectActionFor("vercel"), "vercel");
+  assert.equal(connectActionFor("railway"), "railway");
   assert.equal(connectActionFor("elsewhere"), "code");
   assert.equal(connectActionFor("does-not-exist"), null);
 });
 
 test("connectSectionsFor disables Cloudflare when the connector isn't configured", () => {
-  const gated = connectSectionsFor({ cloudflare: false, vercel: true });
+  const gated = connectSectionsFor({ cloudflare: false, vercel: true, railway: true });
   const cloudflare = findOption(gated, "cloudflare");
   assert.ok(cloudflare);
   assert.equal(cloudflare.action, null, "cloudflare should not be actionable when unavailable");
@@ -72,7 +73,7 @@ test("connectSectionsFor disables Cloudflare when the connector isn't configured
 });
 
 test("connectSectionsFor disables Vercel when the connector isn't configured", () => {
-  const gated = connectSectionsFor({ cloudflare: true, vercel: false });
+  const gated = connectSectionsFor({ cloudflare: true, vercel: false, railway: true });
   const vercel = findOption(gated, "vercel");
   assert.ok(vercel);
   assert.equal(vercel.action, null, "vercel should not be actionable when unavailable");
@@ -83,10 +84,23 @@ test("connectSectionsFor disables Vercel when the connector isn't configured", (
   assert.equal(findOption(gated, "elsewhere")?.action, "code");
 });
 
+test("connectSectionsFor disables Railway when the connector isn't configured", () => {
+  const gated = connectSectionsFor({ cloudflare: true, vercel: true, railway: false });
+  const railway = findOption(gated, "railway");
+  assert.ok(railway);
+  assert.equal(railway.action, null, "railway should not be actionable when unavailable");
+  assert.equal(isComingSoon(railway), true);
+  // Other lanes are untouched.
+  assert.equal(findOption(gated, "aws")?.action, "aws");
+  assert.equal(findOption(gated, "vercel")?.action, "vercel");
+  assert.equal(findOption(gated, "elsewhere")?.action, "code");
+});
+
 test("connectSectionsFor leaves configured connectors actionable", () => {
-  const enabled = connectSectionsFor({ cloudflare: true, vercel: true });
+  const enabled = connectSectionsFor({ cloudflare: true, vercel: true, railway: true });
   assert.equal(findOption(enabled, "cloudflare")?.action, "cloudflare");
   assert.equal(findOption(enabled, "vercel")?.action, "vercel");
+  assert.equal(findOption(enabled, "railway")?.action, "railway");
 });
 
 test("every option id is unique", () => {

--- a/apps/web/src/onboarding/connectChoices.ts
+++ b/apps/web/src/onboarding/connectChoices.ts
@@ -10,11 +10,11 @@
 // What activating a row does. `null` => not yet available (coming soon), so the
 // row renders disabled and is not actionable. "code" opens the coding-agent
 // prompt (paste into Cursor / Claude Code / Codex).
-export type ConnectAction = "aws" | "cloudflare" | "vercel" | "code";
+export type ConnectAction = "aws" | "cloudflare" | "vercel" | "railway" | "code";
 
 // Glyph key resolved to a neutral monochrome icon by the component. Kept as a
 // string union (not a component) so this module stays free of JSX/React.
-export type ConnectIcon = "aws" | "cloudflare" | "vercel" | "terminal";
+export type ConnectIcon = "aws" | "cloudflare" | "vercel" | "railway" | "terminal";
 
 export type ConnectOption = {
   id: string;
@@ -65,6 +65,14 @@ export const CONNECT_SECTIONS: ConnectSection[] = [
         action: "vercel",
       },
       {
+        id: "railway",
+        title: "Railway",
+        description:
+          "Authorize Railway once and pick the projects to share — we pull your services' logs and infra metrics from Railway's API. No agent, no code.",
+        icon: "railway",
+        action: "railway",
+      },
+      {
         id: "elsewhere",
         title: "I'm hosted elsewhere",
         description:
@@ -84,12 +92,14 @@ export const CONNECT_SECTIONS: ConnectSection[] = [
 export type ConnectAvailability = {
   cloudflare: boolean;
   vercel: boolean;
+  railway: boolean;
 };
 
 export function connectSectionsFor(availability: ConnectAvailability): ConnectSection[] {
   const unavailable = new Set<string>();
   if (!availability.cloudflare) unavailable.add("cloudflare");
   if (!availability.vercel) unavailable.add("vercel");
+  if (!availability.railway) unavailable.add("railway");
   if (unavailable.size === 0) return CONNECT_SECTIONS;
   return CONNECT_SECTIONS.map((section) => ({
     ...section,

--- a/apps/web/src/onboarding/icons.tsx
+++ b/apps/web/src/onboarding/icons.tsx
@@ -323,6 +323,28 @@ export function VercelIcon({ size = 18, className }: IconProps) {
   );
 }
 
+export function RailwayIcon({ size = 18, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 18 18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      className={className}
+      aria-hidden="true"
+    >
+      {/* Simplified Railway mark: a rail curving through a window. */}
+      <path d="M2.5 7.5h6.8a2.6 2.6 0 0 1 2.6 2.6v5.4" />
+      <path d="M2.9 11h3.4" />
+      <path d="M4 14h2.6" />
+      <path d="M2.7 4.5h7.2a5.6 5.6 0 0 1 5.6 5.6v5.4" />
+    </svg>
+  );
+}
+
 export function KubernetesIcon({ size = 18, className }: IconProps) {
   return (
     <svg

--- a/apps/web/src/onboarding/railwayConnectModel.test.ts
+++ b/apps/web/src/onboarding/railwayConnectModel.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  canContinueRailway,
+  parseRailwayOutcome,
+  railwayOutcomeMessage,
+  railwayPhase,
+  railwayStatusText,
+} from "./railwayConnectModel.ts";
+
+test("phase starts at 'start' before the consent screen is opened", () => {
+  assert.equal(railwayPhase({ installed: false, launched: false }), "start");
+});
+
+test("phase moves to 'connecting' once the consent screen is launched", () => {
+  assert.equal(railwayPhase({ installed: false, launched: true }), "connecting");
+});
+
+test("phase is 'connected' as soon as the install lands, regardless of launch flag", () => {
+  assert.equal(railwayPhase({ installed: true, launched: false }), "connected");
+  assert.equal(railwayPhase({ installed: true, launched: true }), "connected");
+});
+
+test("Continue unlocks only when connected", () => {
+  assert.equal(canContinueRailway("start"), false);
+  assert.equal(canContinueRailway("connecting"), false);
+  assert.equal(canContinueRailway("connected"), true);
+});
+
+test("outcome parsing accepts only known outcomes", () => {
+  assert.equal(parseRailwayOutcome("installed"), "installed");
+  assert.equal(parseRailwayOutcome("denied"), "denied");
+  assert.equal(parseRailwayOutcome("error"), "error");
+  assert.equal(parseRailwayOutcome("no_projects"), "no_projects");
+  assert.equal(parseRailwayOutcome("surprise"), null);
+  assert.equal(parseRailwayOutcome(null), null);
+});
+
+test("failure outcomes carry a user-facing message; success does not", () => {
+  assert.equal(railwayOutcomeMessage("installed"), null);
+  assert.equal(railwayOutcomeMessage(null), null);
+  for (const outcome of ["denied", "error", "no_projects"] as const) {
+    const message = railwayOutcomeMessage(outcome);
+    assert.ok(message && message.length > 0, `${outcome} needs a message`);
+  }
+  assert.match(railwayOutcomeMessage("no_projects") ?? "", /select at least one project/i);
+});
+
+test("status text reflects pull-based ingestion once connected", () => {
+  assert.match(railwayStatusText("connected", false), /pulling logs and metrics/i);
+  assert.match(railwayStatusText("connected", true), /arriving/i);
+  assert.match(railwayStatusText("connecting", false), /Railway tab/i);
+});

--- a/apps/web/src/onboarding/railwayConnectModel.ts
+++ b/apps/web/src/onboarding/railwayConnectModel.ts
@@ -1,0 +1,71 @@
+// Pure phase model for the onboarding Railway connect flow, split out of the
+// component so the transitions are unit-testable (the `.tsx` can't be imported
+// by the node:test runner). Mirrors vercelConnectModel.ts.
+//
+// Railway connect is a single OAuth round-trip like Vercel/Cloudflare, but
+// nothing is provisioned on Railway's side — Railway has no drains, so once
+// the grant lands our worker starts pulling logs and infra metrics from the
+// projects the user selected on Railway's consent screen. The milestone that
+// unlocks "Continue" is that the account is connected (`installed`); telemetry
+// arrival is surfaced as a bonus but never blocks.
+
+export type RailwayPhase = "start" | "connecting" | "connected";
+
+/**
+ * Resolve the flow phase:
+ *  - `installed`  → the OAuth round-trip finished and the grant is stored.
+ *  - `launched`   → the user opened the consent screen but we haven't seen the
+ *                   install land yet (waiting on the round-trip).
+ *  - otherwise    → the initial "connect" call to action.
+ */
+export function railwayPhase(input: { installed: boolean; launched: boolean }): RailwayPhase {
+  if (input.installed) return "connected";
+  if (input.launched) return "connecting";
+  return "start";
+}
+
+/** Continue unlocks once the account is connected. */
+export function canContinueRailway(phase: RailwayPhase): boolean {
+  return phase === "connected";
+}
+
+// The OAuth callback lands on the /connect/railway result page, whose
+// "Back to Superlog" link carries `?railway=installed|denied|error|no_projects`
+// back to `/`. `installed` is handled by the install poll flipping to
+// "connected"; failure outcomes reset out of the waiting state.
+export type RailwayOutcome = "installed" | "denied" | "error" | "no_projects" | null;
+
+export function parseRailwayOutcome(value: string | null | undefined): RailwayOutcome {
+  if (value === "installed" || value === "denied" || value === "error" || value === "no_projects") {
+    return value;
+  }
+  return null;
+}
+
+/** User-facing message for a failure outcome (null when not a failure). */
+export function railwayOutcomeMessage(outcome: RailwayOutcome): string | null {
+  switch (outcome) {
+    case "denied":
+      return "Railway authorization was declined. Reconnect to try again.";
+    case "error":
+      return "We couldn't finish connecting Railway. Reconnect to try again.";
+    case "no_projects":
+      return "The Railway grant didn't include any projects. Reconnect and select at least one project on Railway's consent screen.";
+    default:
+      return null;
+  }
+}
+
+/** Status text for the small banner in the "connecting" / "connected" states. */
+export function railwayStatusText(phase: RailwayPhase, eventsArrived: boolean): string {
+  switch (phase) {
+    case "start":
+      return "Not connected yet.";
+    case "connecting":
+      return "Waiting for you to approve access in the Railway tab…";
+    default:
+      return eventsArrived
+        ? "Connected — telemetry from Railway is arriving."
+        : "Connected — we're pulling logs and metrics from your Railway projects. First events typically appear within a minute.";
+  }
+}

--- a/apps/web/src/railwayCallbackModel.test.ts
+++ b/apps/web/src/railwayCallbackModel.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { railwayCallbackView } from "./railwayCallbackModel.ts";
+
+test("installed renders a success view that opens the app cleanly", () => {
+  const view = railwayCallbackView("installed");
+  assert.equal(view.tone, "success");
+  assert.equal(view.backHref, "/");
+  assert.match(view.body, /pulling logs and infra metrics/i);
+});
+
+test("failure outcomes carry the outcome back to / so the wizard resets", () => {
+  for (const outcome of ["denied", "error", "no_projects"] as const) {
+    const view = railwayCallbackView(outcome);
+    assert.equal(view.tone, "error", outcome);
+    assert.equal(view.backHref, `/?railway=${outcome}`);
+  }
+});
+
+test("no_projects explains the consent-screen project picker", () => {
+  assert.match(railwayCallbackView("no_projects").body, /consent screen/i);
+});
+
+test("missing or unknown outcomes render the fallback view", () => {
+  for (const raw of [null, undefined, "", "wat"]) {
+    const view = railwayCallbackView(raw);
+    assert.equal(view.tone, "error");
+    assert.equal(view.backHref, "/");
+  }
+});

--- a/apps/web/src/railwayCallbackModel.ts
+++ b/apps/web/src/railwayCallbackModel.ts
@@ -1,0 +1,64 @@
+// Pure content model for the /connect/railway result page — the landing target
+// of the Railway OAuth callback redirect. Split from the `.tsx` so the copy per
+// outcome is unit-testable (mirrors vercelCallbackModel.ts).
+
+import { type RailwayOutcome, parseRailwayOutcome } from "./onboarding/railwayConnectModel.ts";
+
+export type RailwayCallbackView = {
+  tone: "success" | "error";
+  title: string;
+  body: string;
+  /**
+   * Where "Back to Superlog" goes. Failures carry the outcome back to `/` so
+   * the onboarding wizard (which reads `?railway=` there) resets out of its
+   * waiting state when the consent happened in the same tab.
+   */
+  backHref: string;
+  backLabel: string;
+};
+
+export function railwayCallbackView(raw: string | null | undefined): RailwayCallbackView {
+  const outcome: RailwayOutcome = parseRailwayOutcome(raw ?? null);
+  switch (outcome) {
+    case "installed":
+      return {
+        tone: "success",
+        title: "Railway connected",
+        body: "We're pulling logs and infra metrics from the Railway projects you shared. First events typically appear in Superlog within a minute — you can close this tab.",
+        backHref: "/",
+        backLabel: "Open Superlog",
+      };
+    case "no_projects":
+      return {
+        tone: "error",
+        title: "No Railway projects were shared",
+        body: "The grant went through, but no projects were selected on Railway's consent screen, so there is nothing to pull telemetry from. Nothing was connected. Connect again and pick at least one project.",
+        backHref: "/?railway=no_projects",
+        backLabel: "Back to Superlog",
+      };
+    case "denied":
+      return {
+        tone: "error",
+        title: "Railway authorization was declined",
+        body: "The request was cancelled on Railway's side, so nothing was connected. You can try again from Superlog whenever you're ready.",
+        backHref: "/?railway=denied",
+        backLabel: "Back to Superlog",
+      };
+    case "error":
+      return {
+        tone: "error",
+        title: "We couldn't finish connecting Railway",
+        body: "Something went wrong completing the connection, and nothing was connected. Go back to Superlog and try again — if it keeps failing, contact us.",
+        backHref: "/?railway=error",
+        backLabel: "Back to Superlog",
+      };
+    default:
+      return {
+        tone: "error",
+        title: "No connection result found",
+        body: "This page shows the result of a Railway connection, but the link is missing its outcome. Head back to Superlog and check the integration's status in settings.",
+        backHref: "/",
+        backLabel: "Back to Superlog",
+      };
+  }
+}

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -17,3 +17,10 @@ GITHUB_APP_PRIVATE_KEY=
 GITHUB_APP_PRIVATE_KEY_BASE64=
 LINEAR_CLIENT_ID=
 LINEAR_CLIENT_SECRET=
+
+# Railway connector: the puller job refreshes OAuth tokens (same app as the
+# api) and forwards pulled telemetry to the proxy intake. RAILWAY_INTAKE_URL
+# defaults to the local proxy (http://localhost:$PROXY_APP_PORT or :4000).
+RAILWAY_CLIENT_ID=
+RAILWAY_CLIENT_SECRET=
+RAILWAY_INTAKE_URL=

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -65,6 +65,7 @@
     "@superlog/db": "workspace:*",
     "@superlog/fingerprint": "workspace:*",
     "@superlog/net-guard": "workspace:*",
+    "@superlog/railway": "workspace:*",
     "@superlog/topology": "workspace:*",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",

--- a/apps/worker/src/jobs/railway-pull.ts
+++ b/apps/worker/src/jobs/railway-pull.ts
@@ -9,10 +9,10 @@
 // Railway OAuth client is configured — without it tokens can't be refreshed,
 // so pulling would strand within the hour anyway.
 
-import { db, decryptIntegrationSecret, encryptIntegrationSecret, schema } from "@superlog/db";
+import { decryptIntegrationSecret, encryptIntegrationSecret, schema } from "@superlog/db";
 import { railwayConfigFromEnv } from "@superlog/railway";
 import { eq, isNull } from "drizzle-orm";
-import type { JobDefinition } from "../jobs.js";
+import type { JobDefinition, JobDeps } from "../jobs.js";
 import { logger } from "../logger.js";
 import {
   type RailwayPullerInstallation,
@@ -29,103 +29,108 @@ function intakeBaseUrlFromEnv(env: NodeJS.ProcessEnv = process.env): string {
   return `http://localhost:${proxyPort}`;
 }
 
-const store: RailwayPullerStore = {
-  async listActiveInstallations(): Promise<RailwayPullerInstallation[]> {
-    const rows = await db.query.railwayInstallations.findMany({
-      where: isNull(schema.railwayInstallations.revokedAt),
-    });
-    const installations: RailwayPullerInstallation[] = [];
-    for (const row of rows) {
-      try {
-        installations.push({
-          id: row.id,
-          projectId: row.projectId,
-          accessToken: decryptIntegrationSecret({
-            ciphertext: row.accessTokenCiphertext,
-            nonce: row.accessTokenNonce,
-            keyVersion: row.accessTokenKeyVersion,
-          }),
-          refreshToken:
-            row.refreshTokenCiphertext && row.refreshTokenNonce
-              ? decryptIntegrationSecret({
-                  ciphertext: row.refreshTokenCiphertext,
-                  nonce: row.refreshTokenNonce,
-                  keyVersion: row.refreshTokenKeyVersion ?? 1,
-                })
-              : null,
-          tokenExpiresAt: row.tokenExpiresAt,
-          ingestKey:
-            row.ingestKeyCiphertext && row.ingestKeyNonce
-              ? decryptIntegrationSecret({
-                  ciphertext: row.ingestKeyCiphertext,
-                  nonce: row.ingestKeyNonce,
-                  keyVersion: row.ingestKeyKeyVersion ?? 1,
-                })
-              : null,
-          grantedProjects: row.grantedProjects ?? [],
-          logCursor: row.logCursor ?? {},
-          metricsCursor: row.metricsCursor ?? {},
-        });
-      } catch (err) {
-        // A row whose secrets can't be decrypted (e.g. key rotation gone
-        // wrong) must not block the other installations.
-        log.error(
-          { installation_id: row.id, err: err instanceof Error ? err.message : String(err) },
-          "railway install secrets decrypt failed; skipping",
-        );
+// Built from JobDeps.db (not the module-level import) so the job follows the
+// jobs contract and can run against an injected/test database.
+function createStore(db: JobDeps["db"]): RailwayPullerStore {
+  return {
+    async listActiveInstallations(): Promise<RailwayPullerInstallation[]> {
+      const rows = await db.query.railwayInstallations.findMany({
+        where: isNull(schema.railwayInstallations.revokedAt),
+      });
+      const installations: RailwayPullerInstallation[] = [];
+      for (const row of rows) {
+        try {
+          installations.push({
+            id: row.id,
+            projectId: row.projectId,
+            accessToken: decryptIntegrationSecret({
+              ciphertext: row.accessTokenCiphertext,
+              nonce: row.accessTokenNonce,
+              keyVersion: row.accessTokenKeyVersion,
+            }),
+            refreshToken:
+              row.refreshTokenCiphertext && row.refreshTokenNonce
+                ? decryptIntegrationSecret({
+                    ciphertext: row.refreshTokenCiphertext,
+                    nonce: row.refreshTokenNonce,
+                    keyVersion: row.refreshTokenKeyVersion ?? 1,
+                  })
+                : null,
+            tokenExpiresAt: row.tokenExpiresAt,
+            ingestKey:
+              row.ingestKeyCiphertext && row.ingestKeyNonce
+                ? decryptIntegrationSecret({
+                    ciphertext: row.ingestKeyCiphertext,
+                    nonce: row.ingestKeyNonce,
+                    keyVersion: row.ingestKeyKeyVersion ?? 1,
+                  })
+                : null,
+            grantedProjects: row.grantedProjects ?? [],
+            logCursor: row.logCursor ?? {},
+            metricsCursor: row.metricsCursor ?? {},
+          });
+        } catch (err) {
+          // A row whose secrets can't be decrypted (e.g. key rotation gone
+          // wrong) must not block the other installations.
+          log.error(
+            { installation_id: row.id, err: err instanceof Error ? err.message : String(err) },
+            "railway install secrets decrypt failed; skipping",
+          );
+        }
       }
-    }
-    return installations;
-  },
+      return installations;
+    },
 
-  async saveTokens(id, tokens) {
-    const accessCipher = encryptIntegrationSecret(tokens.accessToken);
-    const refreshCipher = tokens.refreshToken
-      ? encryptIntegrationSecret(tokens.refreshToken)
-      : null;
-    await db
-      .update(schema.railwayInstallations)
-      .set({
-        accessTokenCiphertext: accessCipher.ciphertext,
-        accessTokenNonce: accessCipher.nonce,
-        accessTokenKeyVersion: accessCipher.keyVersion,
-        refreshTokenCiphertext: refreshCipher?.ciphertext ?? null,
-        refreshTokenNonce: refreshCipher?.nonce ?? null,
-        refreshTokenKeyVersion: refreshCipher?.keyVersion ?? null,
-        tokenExpiresAt: tokens.tokenExpiresAt,
-        updatedAt: new Date(),
-      })
-      .where(eq(schema.railwayInstallations.id, id));
-  },
+    async saveTokens(id, tokens) {
+      const accessCipher = encryptIntegrationSecret(tokens.accessToken);
+      const refreshCipher = tokens.refreshToken
+        ? encryptIntegrationSecret(tokens.refreshToken)
+        : null;
+      await db
+        .update(schema.railwayInstallations)
+        .set({
+          accessTokenCiphertext: accessCipher.ciphertext,
+          accessTokenNonce: accessCipher.nonce,
+          accessTokenKeyVersion: accessCipher.keyVersion,
+          refreshTokenCiphertext: refreshCipher?.ciphertext ?? null,
+          refreshTokenNonce: refreshCipher?.nonce ?? null,
+          refreshTokenKeyVersion: refreshCipher?.keyVersion ?? null,
+          tokenExpiresAt: tokens.tokenExpiresAt,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.railwayInstallations.id, id));
+    },
 
-  async saveGrantedProjects(id, projects) {
-    await db
-      .update(schema.railwayInstallations)
-      .set({ grantedProjects: projects, updatedAt: new Date() })
-      .where(eq(schema.railwayInstallations.id, id));
-  },
+    async saveGrantedProjects(id, projects) {
+      await db
+        .update(schema.railwayInstallations)
+        .set({ grantedProjects: projects, updatedAt: new Date() })
+        .where(eq(schema.railwayInstallations.id, id));
+    },
 
-  async saveCursors(id, cursors) {
-    await db
-      .update(schema.railwayInstallations)
-      .set({
-        logCursor: cursors.logCursor,
-        metricsCursor: cursors.metricsCursor,
-        updatedAt: new Date(),
-      })
-      .where(eq(schema.railwayInstallations.id, id));
-  },
-};
+    async saveCursors(id, cursors) {
+      await db
+        .update(schema.railwayInstallations)
+        .set({
+          logCursor: cursors.logCursor,
+          metricsCursor: cursors.metricsCursor,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.railwayInstallations.id, id));
+    },
+  };
+}
 
 export const job: JobDefinition = {
   name: "railway-pull",
   schedule: "* * * * *",
-  create: () => {
+  create: (deps) => {
     const config = railwayConfigFromEnv();
     if (!config) {
       log.info({}, "RAILWAY_CLIENT_ID/SECRET not set — railway pull job disabled");
       return null;
     }
+    const store = createStore(deps.db);
     const intakeBaseUrl = intakeBaseUrlFromEnv();
     return async () => {
       const stats = await runRailwayPullOnce({ store, config, intakeBaseUrl, log });

--- a/apps/worker/src/jobs/railway-pull.ts
+++ b/apps/worker/src/jobs/railway-pull.ts
@@ -1,0 +1,137 @@
+// Scheduled job: pull logs + infra metrics from Railway for every active
+// installation and forward them to our intake (see ../railway/puller.ts for
+// the pull logic; this file is only the wiring — drizzle-backed store,
+// decrypted secrets, env config).
+//
+// Every minute is the latency floor for Railway logs (pg-boss cron is
+// minute-granular); metrics are gated inside the puller to one poll per
+// service per ~5 minutes. Opts out (returns null → not scheduled) unless the
+// Railway OAuth client is configured — without it tokens can't be refreshed,
+// so pulling would strand within the hour anyway.
+
+import { db, decryptIntegrationSecret, encryptIntegrationSecret, schema } from "@superlog/db";
+import { railwayConfigFromEnv } from "@superlog/railway";
+import { eq, isNull } from "drizzle-orm";
+import type { JobDefinition } from "../jobs.js";
+import { logger } from "../logger.js";
+import {
+  type RailwayPullerInstallation,
+  type RailwayPullerStore,
+  runRailwayPullOnce,
+} from "../railway/puller.js";
+
+const log = logger.child({ scope: "railway-pull" });
+
+function intakeBaseUrlFromEnv(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.RAILWAY_INTAKE_URL) return env.RAILWAY_INTAKE_URL;
+  // Local default: the proxy on this machine (portless injects its app port).
+  const proxyPort = env.PROXY_APP_PORT ?? "4000";
+  return `http://localhost:${proxyPort}`;
+}
+
+const store: RailwayPullerStore = {
+  async listActiveInstallations(): Promise<RailwayPullerInstallation[]> {
+    const rows = await db.query.railwayInstallations.findMany({
+      where: isNull(schema.railwayInstallations.revokedAt),
+    });
+    const installations: RailwayPullerInstallation[] = [];
+    for (const row of rows) {
+      try {
+        installations.push({
+          id: row.id,
+          projectId: row.projectId,
+          accessToken: decryptIntegrationSecret({
+            ciphertext: row.accessTokenCiphertext,
+            nonce: row.accessTokenNonce,
+            keyVersion: row.accessTokenKeyVersion,
+          }),
+          refreshToken:
+            row.refreshTokenCiphertext && row.refreshTokenNonce
+              ? decryptIntegrationSecret({
+                  ciphertext: row.refreshTokenCiphertext,
+                  nonce: row.refreshTokenNonce,
+                  keyVersion: row.refreshTokenKeyVersion ?? 1,
+                })
+              : null,
+          tokenExpiresAt: row.tokenExpiresAt,
+          ingestKey:
+            row.ingestKeyCiphertext && row.ingestKeyNonce
+              ? decryptIntegrationSecret({
+                  ciphertext: row.ingestKeyCiphertext,
+                  nonce: row.ingestKeyNonce,
+                  keyVersion: row.ingestKeyKeyVersion ?? 1,
+                })
+              : null,
+          grantedProjects: row.grantedProjects ?? [],
+          logCursor: row.logCursor ?? {},
+          metricsCursor: row.metricsCursor ?? {},
+        });
+      } catch (err) {
+        // A row whose secrets can't be decrypted (e.g. key rotation gone
+        // wrong) must not block the other installations.
+        log.error(
+          { installation_id: row.id, err: err instanceof Error ? err.message : String(err) },
+          "railway install secrets decrypt failed; skipping",
+        );
+      }
+    }
+    return installations;
+  },
+
+  async saveTokens(id, tokens) {
+    const accessCipher = encryptIntegrationSecret(tokens.accessToken);
+    const refreshCipher = tokens.refreshToken
+      ? encryptIntegrationSecret(tokens.refreshToken)
+      : null;
+    await db
+      .update(schema.railwayInstallations)
+      .set({
+        accessTokenCiphertext: accessCipher.ciphertext,
+        accessTokenNonce: accessCipher.nonce,
+        accessTokenKeyVersion: accessCipher.keyVersion,
+        refreshTokenCiphertext: refreshCipher?.ciphertext ?? null,
+        refreshTokenNonce: refreshCipher?.nonce ?? null,
+        refreshTokenKeyVersion: refreshCipher?.keyVersion ?? null,
+        tokenExpiresAt: tokens.tokenExpiresAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.railwayInstallations.id, id));
+  },
+
+  async saveGrantedProjects(id, projects) {
+    await db
+      .update(schema.railwayInstallations)
+      .set({ grantedProjects: projects, updatedAt: new Date() })
+      .where(eq(schema.railwayInstallations.id, id));
+  },
+
+  async saveCursors(id, cursors) {
+    await db
+      .update(schema.railwayInstallations)
+      .set({
+        logCursor: cursors.logCursor,
+        metricsCursor: cursors.metricsCursor,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.railwayInstallations.id, id));
+  },
+};
+
+export const job: JobDefinition = {
+  name: "railway-pull",
+  schedule: "* * * * *",
+  create: () => {
+    const config = railwayConfigFromEnv();
+    if (!config) {
+      log.info({}, "RAILWAY_CLIENT_ID/SECRET not set — railway pull job disabled");
+      return null;
+    }
+    const intakeBaseUrl = intakeBaseUrlFromEnv();
+    return async () => {
+      const stats = await runRailwayPullOnce({ store, config, intakeBaseUrl, log });
+      if (stats.installations > 0) {
+        log.info({ ...stats }, "railway pull pass complete");
+      }
+    };
+  },
+};

--- a/apps/worker/src/railway/puller.test.ts
+++ b/apps/worker/src/railway/puller.test.ts
@@ -1,0 +1,288 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import {
+  RAILWAY_GRAPHQL_URL,
+  RAILWAY_OAUTH_TOKEN_URL,
+} from "@superlog/railway";
+import {
+  type RailwayPullerInstallation,
+  type RailwayPullerStore,
+  runRailwayPullOnce,
+} from "./puller.js";
+
+const NOW = new Date("2026-07-07T15:00:00.000Z");
+const CONFIG = { clientId: "cid", clientSecret: "cs", redirectUri: "https://r" };
+const LOGGER = { info() {}, warn() {}, error() {} };
+
+function installation(
+  overrides: Partial<RailwayPullerInstallation> = {},
+): RailwayPullerInstallation {
+  return {
+    id: "inst-1",
+    projectId: "superlog-project",
+    accessToken: "at",
+    refreshToken: "rt",
+    tokenExpiresAt: new Date(NOW.getTime() + 60 * 60 * 1000),
+    ingestKey: "sl_public_test",
+    grantedProjects: [
+      { id: "rp-1", name: "blackbird", workspaceId: "ws", workspaceName: "Superlog" },
+    ],
+    logCursor: {},
+    metricsCursor: {},
+    ...overrides,
+  };
+}
+
+type StoreCalls = {
+  tokens: Array<{ id: string; accessToken: string; refreshToken: string | null }>;
+  cursors: Array<{ id: string; logCursor: Record<string, string>; metricsCursor: Record<string, number> }>;
+  granted: number;
+};
+
+function fakeStore(rows: RailwayPullerInstallation[]): { store: RailwayPullerStore; calls: StoreCalls } {
+  const calls: StoreCalls = { tokens: [], cursors: [], granted: 0 };
+  return {
+    calls,
+    store: {
+      async listActiveInstallations() {
+        return rows;
+      },
+      async saveTokens(id, tokens) {
+        calls.tokens.push({ id, accessToken: tokens.accessToken, refreshToken: tokens.refreshToken });
+      },
+      async saveGrantedProjects() {
+        calls.granted += 1;
+      },
+      async saveCursors(id, cursors) {
+        calls.cursors.push({ id, ...cursors });
+      },
+    },
+  };
+}
+
+type Forwarded = Array<{ url: string; apiKey: string | null; payload: any }>;
+
+/**
+ * Fake fetch that routes token / GraphQL / intake requests. GraphQL responses
+ * are dispatched on query content.
+ */
+function fakeFetch(opts: {
+  logs?: unknown[];
+  metrics?: unknown[];
+  forwarded: Forwarded;
+  intakeStatus?: number;
+  refreshResponse?: Record<string, unknown>;
+}): typeof fetch {
+  return (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    if (u === RAILWAY_OAUTH_TOKEN_URL) {
+      return new Response(
+        JSON.stringify(
+          opts.refreshResponse ?? {
+            access_token: "at-new",
+            refresh_token: "rt-new",
+            expires_in: 3600,
+          },
+        ),
+        { status: 200 },
+      );
+    }
+    if (u === RAILWAY_GRAPHQL_URL) {
+      const body = JSON.parse(String(init?.body)) as { query: string };
+      if (body.query.includes("externalWorkspaces")) {
+        return gql({
+          externalWorkspaces: [
+            { id: "ws", name: "Superlog", projects: [{ id: "rp-1", name: "blackbird" }] },
+          ],
+        });
+      }
+      if (body.query.includes("environments { edges")) {
+        return gql({
+          project: {
+            environments: { edges: [{ node: { id: "env-1", name: "production" } }] },
+            services: { edges: [{ node: { id: "svc-1", name: "blackbird-app" } }] },
+          },
+        });
+      }
+      if (body.query.includes("environmentLogs")) {
+        return gql({ environmentLogs: opts.logs ?? [] });
+      }
+      if (body.query.includes("metrics(")) {
+        return gql({ metrics: opts.metrics ?? [] });
+      }
+      throw new Error(`unrouted GraphQL query: ${body.query.slice(0, 60)}`);
+    }
+    // Intake forward.
+    opts.forwarded.push({
+      url: u,
+      apiKey: new Headers(init?.headers).get("x-api-key"),
+      payload: JSON.parse(String(init?.body)),
+    });
+    return new Response("{}", { status: opts.intakeStatus ?? 200 });
+  }) as typeof fetch;
+
+  function gql(data: unknown): Response {
+    return new Response(JSON.stringify({ data }), { status: 200 });
+  }
+}
+
+const LOG_LINE = {
+  timestamp: "2026-07-07T14:59:59.5Z",
+  severity: "info",
+  message: "hello",
+  tags: { serviceId: "svc-1", environmentId: "env-1", deploymentId: "dep-1" },
+  attributes: [],
+};
+
+test("forwards fresh logs to the intake with the ingest key and advances the cursor", async () => {
+  const { store, calls } = fakeStore([
+    installation({ logCursor: { "env-1": "2026-07-07T14:59:00Z" } }),
+  ]);
+  const forwarded: Forwarded = [];
+  const stats = await runRailwayPullOnce({
+    store,
+    config: CONFIG,
+    intakeBaseUrl: "https://intake.test/",
+    log: LOGGER,
+    now: () => NOW,
+    fetchImpl: fakeFetch({ logs: [LOG_LINE], forwarded }),
+    metricsIntervalSeconds: 999999,
+    metricsPollState: new Map([["inst-1:svc-1", Math.floor(NOW.getTime() / 1000)]]),
+  });
+
+  assert.equal(stats.logsForwarded, 1);
+  assert.equal(stats.errors, 0);
+  assert.equal(forwarded.length, 1);
+  assert.equal(forwarded[0]!.url, "https://intake.test/railway/pull/logs");
+  assert.equal(forwarded[0]!.apiKey, "sl_public_test");
+  const record = forwarded[0]!.payload.resourceLogs[0].scopeLogs[0].logRecords[0];
+  assert.equal(record.body.stringValue, "hello");
+  assert.equal(calls.cursors.length, 1);
+  assert.equal(calls.cursors[0]!.logCursor["env-1"], "2026-07-07T14:59:59.5Z");
+});
+
+test("seeds the log cursor on first pull so history isn't re-read", async () => {
+  const { store, calls } = fakeStore([installation()]);
+  const forwarded: Forwarded = [];
+  await runRailwayPullOnce({
+    store,
+    config: CONFIG,
+    intakeBaseUrl: "https://intake.test",
+    log: LOGGER,
+    now: () => NOW,
+    fetchImpl: fakeFetch({ logs: [LOG_LINE], forwarded }),
+    metricsIntervalSeconds: 999999,
+    metricsPollState: new Map([["inst-1:svc-1", Math.floor(NOW.getTime() / 1000)]]),
+  });
+  // Seed batch is forwarded once, and the cursor lands on its max timestamp.
+  assert.equal(forwarded.length, 1);
+  assert.equal(calls.cursors[0]!.logCursor["env-1"], "2026-07-07T14:59:59.5Z");
+});
+
+test("does not advance the cursor when the intake rejects the batch", async () => {
+  const { store, calls } = fakeStore([
+    installation({ logCursor: { "env-1": "2026-07-07T14:59:00Z" } }),
+  ]);
+  const forwarded: Forwarded = [];
+  const stats = await runRailwayPullOnce({
+    store,
+    config: CONFIG,
+    intakeBaseUrl: "https://intake.test",
+    log: LOGGER,
+    now: () => NOW,
+    fetchImpl: fakeFetch({ logs: [LOG_LINE], forwarded, intakeStatus: 503 }),
+    metricsIntervalSeconds: 999999,
+    metricsPollState: new Map([["inst-1:svc-1", Math.floor(NOW.getTime() / 1000)]]),
+  });
+  assert.ok(stats.errors >= 1);
+  assert.equal(calls.cursors.length, 0, "cursor must not advance past unforwarded logs");
+});
+
+test("refreshes an expiring token and persists the rotated refresh token first", async () => {
+  const { store, calls } = fakeStore([
+    installation({ tokenExpiresAt: new Date(NOW.getTime() + 30 * 1000) }),
+  ]);
+  const forwarded: Forwarded = [];
+  await runRailwayPullOnce({
+    store,
+    config: CONFIG,
+    intakeBaseUrl: "https://intake.test",
+    log: LOGGER,
+    now: () => NOW,
+    fetchImpl: fakeFetch({ logs: [], forwarded }),
+    metricsIntervalSeconds: 999999,
+    metricsPollState: new Map([["inst-1:svc-1", Math.floor(NOW.getTime() / 1000)]]),
+  });
+  assert.equal(calls.tokens.length, 1);
+  assert.equal(calls.tokens[0]!.accessToken, "at-new");
+  assert.equal(calls.tokens[0]!.refreshToken, "rt-new");
+});
+
+test("skips an installation whose token expired with no refresh token", async () => {
+  const { store, calls } = fakeStore([
+    installation({ refreshToken: null, tokenExpiresAt: new Date(NOW.getTime() - 1000) }),
+  ]);
+  const forwarded: Forwarded = [];
+  const stats = await runRailwayPullOnce({
+    store,
+    config: CONFIG,
+    intakeBaseUrl: "https://intake.test",
+    log: LOGGER,
+    now: () => NOW,
+    fetchImpl: fakeFetch({ logs: [LOG_LINE], forwarded }),
+  });
+  assert.equal(stats.logsForwarded, 0);
+  assert.equal(forwarded.length, 0);
+  assert.equal(calls.cursors.length, 0);
+});
+
+test("polls metrics on the interval, forwards gauges, and advances the sample cursor", async () => {
+  const { store, calls } = fakeStore([
+    installation({ logCursor: { "env-1": "2026-07-07T15:00:00Z" } }),
+  ]);
+  const forwarded: Forwarded = [];
+  const nowSec = Math.floor(NOW.getTime() / 1000);
+  const stats = await runRailwayPullOnce({
+    store,
+    config: CONFIG,
+    intakeBaseUrl: "https://intake.test",
+    log: LOGGER,
+    now: () => NOW,
+    fetchImpl: fakeFetch({
+      logs: [],
+      metrics: [
+        {
+          measurement: "CPU_USAGE",
+          values: [{ ts: nowSec - 60, value: 0.5 }],
+          tags: { serviceId: "svc-1" },
+        },
+      ],
+      forwarded,
+    }),
+    metricsPollState: new Map(),
+  });
+  assert.equal(stats.metricPointsForwarded, 1);
+  const metricsPost = forwarded.find((f) => f.url.endsWith("/railway/pull/metrics"));
+  assert.ok(metricsPost);
+  const metric = metricsPost.payload.resourceMetrics[0].scopeMetrics[0].metrics[0];
+  assert.equal(metric.name, "railway.cpu.usage");
+  assert.equal(metric.gauge.dataPoints[0].asDouble, 0.5);
+  assert.equal(calls.cursors.at(-1)!.metricsCursor["svc-1"], nowSec - 60);
+
+  // A second pass inside the interval must not poll metrics again.
+  const forwardedBefore = forwarded.length;
+  await runRailwayPullOnce({
+    store,
+    config: CONFIG,
+    intakeBaseUrl: "https://intake.test",
+    log: LOGGER,
+    now: () => new Date(NOW.getTime() + 60 * 1000),
+    fetchImpl: fakeFetch({ logs: [], metrics: [], forwarded }),
+    metricsPollState: new Map([["inst-1:svc-1", nowSec]]),
+  });
+  assert.equal(
+    forwarded.filter((f) => f.url.endsWith("/railway/pull/metrics")).length,
+    forwarded.slice(0, forwardedBefore).filter((f) => f.url.endsWith("/railway/pull/metrics"))
+      .length,
+  );
+});

--- a/apps/worker/src/railway/puller.test.ts
+++ b/apps/worker/src/railway/puller.test.ts
@@ -177,7 +177,7 @@ test("forwards fresh logs to the intake with the ingest key and advances the cur
     now: () => NOW,
     fetchImpl: fakeFetch({ logs: [LOG_LINE], forwarded }),
     metricsIntervalSeconds: 999999,
-    metricsPollState: new Map([["inst-1:svc-1", Math.floor(NOW.getTime() / 1000)]]),
+    metricsPollState: new Map([["inst-1:env-1:svc-1", Math.floor(NOW.getTime() / 1000)]]),
   });
 
   assert.equal(stats.logsForwarded, 1);
@@ -202,7 +202,7 @@ test("seeds the log cursor on first pull so history isn't re-read", async () => 
     now: () => NOW,
     fetchImpl: fakeFetch({ logs: [LOG_LINE], forwarded }),
     metricsIntervalSeconds: 999999,
-    metricsPollState: new Map([["inst-1:svc-1", Math.floor(NOW.getTime() / 1000)]]),
+    metricsPollState: new Map([["inst-1:env-1:svc-1", Math.floor(NOW.getTime() / 1000)]]),
   });
   // Seed batch is forwarded once, and the cursor lands on its max timestamp.
   assert.equal(forwarded.length, 1);
@@ -222,7 +222,7 @@ test("does not advance the cursor when the intake rejects the batch", async () =
     now: () => NOW,
     fetchImpl: fakeFetch({ logs: [LOG_LINE], forwarded, intakeStatus: 503 }),
     metricsIntervalSeconds: 999999,
-    metricsPollState: new Map([["inst-1:svc-1", Math.floor(NOW.getTime() / 1000)]]),
+    metricsPollState: new Map([["inst-1:env-1:svc-1", Math.floor(NOW.getTime() / 1000)]]),
   });
   assert.ok(stats.errors >= 1);
   assert.equal(calls.cursors.length, 0, "cursor must not advance past unforwarded logs");
@@ -241,7 +241,7 @@ test("refreshes an expiring token and persists the rotated refresh token first",
     now: () => NOW,
     fetchImpl: fakeFetch({ logs: [], forwarded }),
     metricsIntervalSeconds: 999999,
-    metricsPollState: new Map([["inst-1:svc-1", Math.floor(NOW.getTime() / 1000)]]),
+    metricsPollState: new Map([["inst-1:env-1:svc-1", Math.floor(NOW.getTime() / 1000)]]),
   });
   assert.equal(calls.tokens.length, 1);
   assert.equal(at(calls.tokens, 0).accessToken, "at-new");
@@ -297,7 +297,7 @@ test("polls metrics on the interval, forwards gauges, and advances the sample cu
   const metric = at(at(at(metricsPost.payload.resourceMetrics, 0).scopeMetrics, 0).metrics, 0);
   assert.equal(metric.name, "railway.cpu.usage");
   assert.equal(at(metric.gauge.dataPoints, 0).asDouble, 0.5);
-  assert.equal(at(calls.cursors, calls.cursors.length - 1).metricsCursor["svc-1"], nowSec - 60);
+  assert.equal(at(calls.cursors, calls.cursors.length - 1).metricsCursor["env-1:svc-1"], nowSec - 60);
 
   // A second pass inside the interval must not poll metrics again.
   const forwardedBefore = forwarded.length;
@@ -308,7 +308,7 @@ test("polls metrics on the interval, forwards gauges, and advances the sample cu
     log: LOGGER,
     now: () => new Date(NOW.getTime() + 60 * 1000),
     fetchImpl: fakeFetch({ logs: [], metrics: [], forwarded }),
-    metricsPollState: new Map([["inst-1:svc-1", nowSec]]),
+    metricsPollState: new Map([["inst-1:env-1:svc-1", nowSec]]),
   });
   assert.equal(
     forwarded.filter((f) => f.url.endsWith("/railway/pull/metrics")).length,

--- a/apps/worker/src/railway/puller.test.ts
+++ b/apps/worker/src/railway/puller.test.ts
@@ -1,9 +1,6 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
-import {
-  RAILWAY_GRAPHQL_URL,
-  RAILWAY_OAUTH_TOKEN_URL,
-} from "@superlog/railway";
+import { RAILWAY_GRAPHQL_URL, RAILWAY_OAUTH_TOKEN_URL } from "@superlog/railway";
 import {
   type RailwayPullerInstallation,
   type RailwayPullerStore,
@@ -35,11 +32,18 @@ function installation(
 
 type StoreCalls = {
   tokens: Array<{ id: string; accessToken: string; refreshToken: string | null }>;
-  cursors: Array<{ id: string; logCursor: Record<string, string>; metricsCursor: Record<string, number> }>;
+  cursors: Array<{
+    id: string;
+    logCursor: Record<string, string>;
+    metricsCursor: Record<string, number>;
+  }>;
   granted: number;
 };
 
-function fakeStore(rows: RailwayPullerInstallation[]): { store: RailwayPullerStore; calls: StoreCalls } {
+function fakeStore(rows: RailwayPullerInstallation[]): {
+  store: RailwayPullerStore;
+  calls: StoreCalls;
+} {
   const calls: StoreCalls = { tokens: [], cursors: [], granted: 0 };
   return {
     calls,
@@ -48,7 +52,11 @@ function fakeStore(rows: RailwayPullerInstallation[]): { store: RailwayPullerSto
         return rows;
       },
       async saveTokens(id, tokens) {
-        calls.tokens.push({ id, accessToken: tokens.accessToken, refreshToken: tokens.refreshToken });
+        calls.tokens.push({
+          id,
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+        });
       },
       async saveGrantedProjects() {
         calls.granted += 1;
@@ -60,7 +68,29 @@ function fakeStore(rows: RailwayPullerInstallation[]): { store: RailwayPullerSto
   };
 }
 
-type Forwarded = Array<{ url: string; apiKey: string | null; payload: any }>;
+type ForwardedPayload = {
+  resourceLogs?: Array<{
+    scopeLogs: Array<{ logRecords: Array<{ body: { stringValue?: string } }> }>;
+  }>;
+  resourceMetrics?: Array<{
+    scopeMetrics: Array<{
+      metrics: Array<{
+        name: string;
+        unit: string;
+        gauge: { dataPoints: Array<{ timeUnixNano: string; asDouble: number }> };
+      }>;
+    }>;
+  }>;
+};
+
+type Forwarded = Array<{ url: string; apiKey: string | null; payload: ForwardedPayload }>;
+
+// Index into an array with narrowing (strict indexing forbids bare [0]).
+function at<T>(items: readonly T[] | undefined, index: number): T {
+  const item = items?.[index];
+  assert.ok(item !== undefined, `expected item at index ${index}`);
+  return item;
+}
 
 /**
  * Fake fetch that routes token / GraphQL / intake requests. GraphQL responses
@@ -153,12 +183,12 @@ test("forwards fresh logs to the intake with the ingest key and advances the cur
   assert.equal(stats.logsForwarded, 1);
   assert.equal(stats.errors, 0);
   assert.equal(forwarded.length, 1);
-  assert.equal(forwarded[0]!.url, "https://intake.test/railway/pull/logs");
-  assert.equal(forwarded[0]!.apiKey, "sl_public_test");
-  const record = forwarded[0]!.payload.resourceLogs[0].scopeLogs[0].logRecords[0];
+  assert.equal(at(forwarded, 0).url, "https://intake.test/railway/pull/logs");
+  assert.equal(at(forwarded, 0).apiKey, "sl_public_test");
+  const record = at(at(at(at(forwarded, 0).payload.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
   assert.equal(record.body.stringValue, "hello");
   assert.equal(calls.cursors.length, 1);
-  assert.equal(calls.cursors[0]!.logCursor["env-1"], "2026-07-07T14:59:59.5Z");
+  assert.equal(at(calls.cursors, 0).logCursor["env-1"], "2026-07-07T14:59:59.5Z");
 });
 
 test("seeds the log cursor on first pull so history isn't re-read", async () => {
@@ -176,7 +206,7 @@ test("seeds the log cursor on first pull so history isn't re-read", async () => 
   });
   // Seed batch is forwarded once, and the cursor lands on its max timestamp.
   assert.equal(forwarded.length, 1);
-  assert.equal(calls.cursors[0]!.logCursor["env-1"], "2026-07-07T14:59:59.5Z");
+  assert.equal(at(calls.cursors, 0).logCursor["env-1"], "2026-07-07T14:59:59.5Z");
 });
 
 test("does not advance the cursor when the intake rejects the batch", async () => {
@@ -214,8 +244,8 @@ test("refreshes an expiring token and persists the rotated refresh token first",
     metricsPollState: new Map([["inst-1:svc-1", Math.floor(NOW.getTime() / 1000)]]),
   });
   assert.equal(calls.tokens.length, 1);
-  assert.equal(calls.tokens[0]!.accessToken, "at-new");
-  assert.equal(calls.tokens[0]!.refreshToken, "rt-new");
+  assert.equal(at(calls.tokens, 0).accessToken, "at-new");
+  assert.equal(at(calls.tokens, 0).refreshToken, "rt-new");
 });
 
 test("skips an installation whose token expired with no refresh token", async () => {
@@ -264,10 +294,10 @@ test("polls metrics on the interval, forwards gauges, and advances the sample cu
   assert.equal(stats.metricPointsForwarded, 1);
   const metricsPost = forwarded.find((f) => f.url.endsWith("/railway/pull/metrics"));
   assert.ok(metricsPost);
-  const metric = metricsPost.payload.resourceMetrics[0].scopeMetrics[0].metrics[0];
+  const metric = at(at(at(metricsPost.payload.resourceMetrics, 0).scopeMetrics, 0).metrics, 0);
   assert.equal(metric.name, "railway.cpu.usage");
-  assert.equal(metric.gauge.dataPoints[0].asDouble, 0.5);
-  assert.equal(calls.cursors.at(-1)!.metricsCursor["svc-1"], nowSec - 60);
+  assert.equal(at(metric.gauge.dataPoints, 0).asDouble, 0.5);
+  assert.equal(at(calls.cursors, calls.cursors.length - 1).metricsCursor["svc-1"], nowSec - 60);
 
   // A second pass inside the interval must not poll metrics again.
   const forwardedBefore = forwarded.length;

--- a/apps/worker/src/railway/puller.ts
+++ b/apps/worker/src/railway/puller.ts
@@ -1,0 +1,325 @@
+// Railway telemetry puller — the ingest half of the Railway connector.
+// Railway has no drains, so instead of the vendor pushing to our intake, this
+// module reads logs and infra metrics from Railway's GraphQL API for every
+// active installation and forwards them (as OTLP JSON) to our own intake,
+// authenticated with the installation's project ingest key. Runs as a
+// scheduled job (jobs/railway-pull.ts): one bounded pass per fire, cursors in
+// the installation row make restarts gap- and duplicate-free.
+//
+// IO is behind narrow ports (store + fetch) so the pull logic is unit-testable
+// without Postgres or a live Railway account.
+
+import {
+  type RailwayGrantedProject,
+  type RailwayOAuthConfig,
+  advanceLogCursor,
+  advanceMetricsCursor,
+  fetchEnvironmentLogs,
+  fetchGrantedProjects,
+  fetchProjectInventory,
+  fetchServiceMetrics,
+  filterLogsAfterCursor,
+  filterMetricsAfterCursor,
+  railwayLogsToOtlp,
+  railwayMetricsToOtlp,
+  refreshAccessToken,
+} from "@superlog/railway";
+
+export type RailwayPullerInstallation = {
+  id: string;
+  projectId: string;
+  accessToken: string;
+  refreshToken: string | null;
+  tokenExpiresAt: Date | null;
+  ingestKey: string | null;
+  grantedProjects: RailwayGrantedProject[];
+  logCursor: Record<string, string>;
+  metricsCursor: Record<string, number>;
+};
+
+export type RailwayPullerStore = {
+  listActiveInstallations(): Promise<RailwayPullerInstallation[]>;
+  /** Persist a refreshed (rotated!) token pair immediately. */
+  saveTokens(
+    id: string,
+    tokens: { accessToken: string; refreshToken: string | null; tokenExpiresAt: Date | null },
+  ): Promise<void>;
+  saveGrantedProjects(id: string, projects: RailwayGrantedProject[]): Promise<void>;
+  saveCursors(
+    id: string,
+    cursors: { logCursor: Record<string, string>; metricsCursor: Record<string, number> },
+  ): Promise<void>;
+};
+
+type PullerLogger = {
+  info(fields: Record<string, unknown>, msg: string): void;
+  warn(fields: Record<string, unknown>, msg: string): void;
+  error(fields: Record<string, unknown>, msg: string): void;
+};
+
+export type RailwayPullerDeps = {
+  store: RailwayPullerStore;
+  config: RailwayOAuthConfig;
+  /** Base URL of our proxy intake, e.g. https://intake.superlog.sh */
+  intakeBaseUrl: string;
+  log: PullerLogger;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+  /** Max log lines per environment per pass. */
+  logBatchLimit?: number;
+  /** Minimum seconds between metrics polls per service. */
+  metricsIntervalSeconds?: number;
+  metricsSampleRateSeconds?: number;
+  /**
+   * Per-service last-poll clock (epoch seconds), process-lived. Keeps idle
+   * services from being polled every pass; on worker restart the worst case is
+   * one early poll per service, deduped by the sample cursor anyway.
+   */
+  metricsPollState?: Map<string, number>;
+};
+
+export type RailwayPullStats = {
+  installations: number;
+  logsForwarded: number;
+  metricPointsForwarded: number;
+  errors: number;
+};
+
+// Refresh when less than this remains — one pass must never outlive the token.
+const TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+// First pull seeds from recent history rather than the beginning of time.
+const METRICS_FIRST_LOOKBACK_S = 15 * 60;
+const METRICS_MAX_LOOKBACK_S = 30 * 60;
+
+export async function runRailwayPullOnce(deps: RailwayPullerDeps): Promise<RailwayPullStats> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const now = deps.now ?? (() => new Date());
+  const logBatchLimit = deps.logBatchLimit ?? 1000;
+  const metricsInterval = deps.metricsIntervalSeconds ?? 300;
+  const sampleRate = deps.metricsSampleRateSeconds ?? 60;
+  const pollState = deps.metricsPollState ?? sharedMetricsPollState;
+  const intake = deps.intakeBaseUrl.replace(/\/+$/, "");
+
+  const stats: RailwayPullStats = {
+    installations: 0,
+    logsForwarded: 0,
+    metricPointsForwarded: 0,
+    errors: 0,
+  };
+
+  const installations = await deps.store.listActiveInstallations();
+  for (const installation of installations) {
+    stats.installations += 1;
+    try {
+      await pullInstallation(installation);
+    } catch (err) {
+      stats.errors += 1;
+      deps.log.error(
+        { installation_id: installation.id, err: err instanceof Error ? err.message : String(err) },
+        "railway pull failed for installation",
+      );
+    }
+  }
+  return stats;
+
+  async function pullInstallation(installation: RailwayPullerInstallation): Promise<void> {
+    if (!installation.ingestKey) {
+      deps.log.warn({ installation_id: installation.id }, "railway install has no ingest key");
+      return;
+    }
+
+    // --- Token freshness -------------------------------------------------
+    let accessToken = installation.accessToken;
+    const expiresAt = installation.tokenExpiresAt?.getTime() ?? null;
+    if (expiresAt !== null && expiresAt - now().getTime() < TOKEN_REFRESH_MARGIN_MS) {
+      if (!installation.refreshToken) {
+        deps.log.warn(
+          { installation_id: installation.id },
+          "railway token expiring and no refresh token — skipping (user must reconnect)",
+        );
+        return;
+      }
+      const refreshed = await refreshAccessToken({
+        config: deps.config,
+        refreshToken: installation.refreshToken,
+        fetchImpl,
+      });
+      if (!refreshed.ok) {
+        stats.errors += 1;
+        deps.log.error(
+          { installation_id: installation.id, error: refreshed.error },
+          "railway token refresh failed",
+        );
+        return;
+      }
+      accessToken = refreshed.accessToken;
+      // Rotating refresh tokens: persist the replacement before doing anything
+      // else — losing it would strand the installation at access-token expiry.
+      await deps.store.saveTokens(installation.id, {
+        accessToken: refreshed.accessToken,
+        refreshToken: refreshed.refreshToken ?? installation.refreshToken,
+        tokenExpiresAt: refreshed.expiresInSeconds
+          ? new Date(now().getTime() + refreshed.expiresInSeconds * 1000)
+          : null,
+      });
+    }
+
+    // --- Grant snapshot ---------------------------------------------------
+    let grantedProjects = installation.grantedProjects;
+    const granted = await fetchGrantedProjects({ accessToken, fetchImpl });
+    if (granted.ok) {
+      grantedProjects = granted.projects;
+      await deps.store.saveGrantedProjects(installation.id, granted.projects);
+    } else {
+      deps.log.warn(
+        { installation_id: installation.id, error: granted.error },
+        "railway grant refresh failed; using stored snapshot",
+      );
+    }
+
+    let logCursor = installation.logCursor;
+    let metricsCursor = installation.metricsCursor;
+    let cursorsDirty = false;
+
+    for (const project of grantedProjects) {
+      const inventory = await fetchProjectInventory({
+        accessToken,
+        projectId: project.id,
+        fetchImpl,
+      });
+      if (!inventory.ok) {
+        stats.errors += 1;
+        deps.log.warn(
+          { installation_id: installation.id, railway_project: project.id, error: inventory.error },
+          "railway inventory read failed; skipping project this pass",
+        );
+        continue;
+      }
+      const serviceNamesById = Object.fromEntries(inventory.services.map((s) => [s.id, s.name]));
+
+      for (const environment of inventory.environments) {
+        const ctx = {
+          serviceNamesById,
+          projectId: project.id,
+          projectName: project.name,
+          environmentId: environment.id,
+          environmentName: environment.name,
+        };
+
+        // --- Logs ---------------------------------------------------------
+        const cursorTs = logCursor[environment.id];
+        const logsRead = await fetchEnvironmentLogs({
+          accessToken,
+          environmentId: environment.id,
+          ...(cursorTs
+            ? { afterDate: cursorTs }
+            : { anchorDate: now().toISOString() }),
+          limit: logBatchLimit,
+          fetchImpl,
+        });
+        if (!logsRead.ok) {
+          stats.errors += 1;
+          deps.log.warn(
+            { installation_id: installation.id, environment_id: environment.id, error: logsRead.error },
+            "railway log read failed",
+          );
+        } else {
+          const fresh = filterLogsAfterCursor(logCursor, environment.id, logsRead.logs);
+          const forwarded =
+            fresh.length === 0
+              ? true
+              : await forwardOtlp(
+                  `${intake}/railway/pull/logs`,
+                  railwayLogsToOtlp(fresh, ctx),
+                  installation.ingestKey,
+                );
+          if (forwarded) {
+            // Seed the cursor even when the first batch is empty so the next
+            // pass reads forward instead of re-anchoring.
+            const next = advanceLogCursor(logCursor, environment.id, logsRead.logs);
+            const seeded =
+              next[environment.id] === undefined
+                ? { ...next, [environment.id]: now().toISOString() }
+                : next;
+            if (seeded !== logCursor) {
+              logCursor = seeded;
+              cursorsDirty = true;
+            }
+            stats.logsForwarded += fresh.length;
+          } else {
+            stats.errors += 1;
+          }
+        }
+
+        // --- Metrics --------------------------------------------------------
+        for (const service of inventory.services) {
+          const pollKey = `${installation.id}:${service.id}`;
+          const nowSec = Math.floor(now().getTime() / 1000);
+          const lastPoll = pollState.get(pollKey) ?? 0;
+          if (nowSec - lastPoll < metricsInterval) continue;
+          pollState.set(pollKey, nowSec);
+
+          const lastSample = metricsCursor[service.id];
+          const startSec = lastSample
+            ? Math.max(lastSample + 1, nowSec - METRICS_MAX_LOOKBACK_S)
+            : nowSec - METRICS_FIRST_LOOKBACK_S;
+          const metricsRead = await fetchServiceMetrics({
+            accessToken,
+            environmentId: environment.id,
+            serviceId: service.id,
+            startDate: new Date(startSec * 1000).toISOString(),
+            endDate: now().toISOString(),
+            sampleRateSeconds: sampleRate,
+            fetchImpl,
+          });
+          if (!metricsRead.ok) {
+            stats.errors += 1;
+            deps.log.warn(
+              { installation_id: installation.id, service_id: service.id, error: metricsRead.error },
+              "railway metrics read failed",
+            );
+            continue;
+          }
+          const freshResults = filterMetricsAfterCursor(metricsCursor, service.id, metricsRead.results);
+          const points = freshResults.reduce((n, r) => n + r.values.length, 0);
+          if (points === 0) continue;
+          const forwarded = await forwardOtlp(
+            `${intake}/railway/pull/metrics`,
+            railwayMetricsToOtlp(freshResults, { ...ctx, serviceId: service.id }),
+            installation.ingestKey,
+          );
+          if (!forwarded) {
+            stats.errors += 1;
+            continue;
+          }
+          metricsCursor = advanceMetricsCursor(metricsCursor, service.id, freshResults);
+          cursorsDirty = true;
+          stats.metricPointsForwarded += points;
+        }
+      }
+    }
+
+    if (cursorsDirty) {
+      await deps.store.saveCursors(installation.id, { logCursor, metricsCursor });
+    }
+  }
+
+  async function forwardOtlp(url: string, payload: unknown, ingestKey: string): Promise<boolean> {
+    try {
+      const res = await fetchImpl(url, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-api-key": ingestKey },
+        body: JSON.stringify(payload),
+      });
+      return res.ok;
+    } catch (err) {
+      deps.log.warn(
+        { url, err: err instanceof Error ? err.message : String(err) },
+        "railway intake forward failed",
+      );
+      return false;
+    }
+  }
+}
+
+const sharedMetricsPollState = new Map<string, number>();

--- a/apps/worker/src/railway/puller.ts
+++ b/apps/worker/src/railway/puller.ts
@@ -211,16 +211,18 @@ export async function runRailwayPullOnce(deps: RailwayPullerDeps): Promise<Railw
         const logsRead = await fetchEnvironmentLogs({
           accessToken,
           environmentId: environment.id,
-          ...(cursorTs
-            ? { afterDate: cursorTs }
-            : { anchorDate: now().toISOString() }),
+          ...(cursorTs ? { afterDate: cursorTs } : { anchorDate: now().toISOString() }),
           limit: logBatchLimit,
           fetchImpl,
         });
         if (!logsRead.ok) {
           stats.errors += 1;
           deps.log.warn(
-            { installation_id: installation.id, environment_id: environment.id, error: logsRead.error },
+            {
+              installation_id: installation.id,
+              environment_id: environment.id,
+              error: logsRead.error,
+            },
             "railway log read failed",
           );
         } else {
@@ -275,12 +277,20 @@ export async function runRailwayPullOnce(deps: RailwayPullerDeps): Promise<Railw
           if (!metricsRead.ok) {
             stats.errors += 1;
             deps.log.warn(
-              { installation_id: installation.id, service_id: service.id, error: metricsRead.error },
+              {
+                installation_id: installation.id,
+                service_id: service.id,
+                error: metricsRead.error,
+              },
               "railway metrics read failed",
             );
             continue;
           }
-          const freshResults = filterMetricsAfterCursor(metricsCursor, service.id, metricsRead.results);
+          const freshResults = filterMetricsAfterCursor(
+            metricsCursor,
+            service.id,
+            metricsRead.results,
+          );
           const points = freshResults.reduce((n, r) => n + r.values.length, 0);
           if (points === 0) continue;
           const forwarded = await forwardOtlp(

--- a/apps/worker/src/railway/puller.ts
+++ b/apps/worker/src/railway/puller.ts
@@ -321,6 +321,9 @@ export async function runRailwayPullOnce(deps: RailwayPullerDeps): Promise<Railw
         headers: { "content-type": "application/json", "x-api-key": ingestKey },
         body: JSON.stringify(payload),
       });
+      if (!res.ok) {
+        deps.log.warn({ url, status: res.status }, "railway intake forward rejected");
+      }
       return res.ok;
     } catch (err) {
       deps.log.warn(

--- a/apps/worker/src/railway/puller.ts
+++ b/apps/worker/src/railway/puller.ts
@@ -255,13 +255,18 @@ export async function runRailwayPullOnce(deps: RailwayPullerDeps): Promise<Railw
 
         // --- Metrics --------------------------------------------------------
         for (const service of inventory.services) {
-          const pollKey = `${installation.id}:${service.id}`;
+          // Metrics are read per (environment, service) — a service deployed
+          // to several environments has independent series, so both the poll
+          // clock and the sample cursor must be keyed by the pair or the
+          // second environment starves / dedupes against the first.
+          const envServiceKey = `${environment.id}:${service.id}`;
+          const pollKey = `${installation.id}:${envServiceKey}`;
           const nowSec = Math.floor(now().getTime() / 1000);
           const lastPoll = pollState.get(pollKey) ?? 0;
           if (nowSec - lastPoll < metricsInterval) continue;
           pollState.set(pollKey, nowSec);
 
-          const lastSample = metricsCursor[service.id];
+          const lastSample = metricsCursor[envServiceKey];
           const startSec = lastSample
             ? Math.max(lastSample + 1, nowSec - METRICS_MAX_LOOKBACK_S)
             : nowSec - METRICS_FIRST_LOOKBACK_S;
@@ -288,7 +293,7 @@ export async function runRailwayPullOnce(deps: RailwayPullerDeps): Promise<Railw
           }
           const freshResults = filterMetricsAfterCursor(
             metricsCursor,
-            service.id,
+            envServiceKey,
             metricsRead.results,
           );
           const points = freshResults.reduce((n, r) => n + r.values.length, 0);
@@ -302,7 +307,7 @@ export async function runRailwayPullOnce(deps: RailwayPullerDeps): Promise<Railw
             stats.errors += 1;
             continue;
           }
-          metricsCursor = advanceMetricsCursor(metricsCursor, service.id, freshResults);
+          metricsCursor = advanceMetricsCursor(metricsCursor, envServiceKey, freshResults);
           cursorsDirty = true;
           stats.metricPointsForwarded += points;
         }

--- a/packages/db/migrations/0085_numerous_warlock.sql
+++ b/packages/db/migrations/0085_numerous_warlock.sql
@@ -1,0 +1,29 @@
+CREATE TABLE "railway_installations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"project_id" uuid NOT NULL,
+	"railway_user_id" text NOT NULL,
+	"granted_projects" jsonb,
+	"access_token_ciphertext" "bytea" NOT NULL,
+	"access_token_nonce" "bytea" NOT NULL,
+	"access_token_key_version" integer DEFAULT 1 NOT NULL,
+	"refresh_token_ciphertext" "bytea",
+	"refresh_token_nonce" "bytea",
+	"refresh_token_key_version" integer,
+	"token_expires_at" timestamp with time zone,
+	"scope" text,
+	"api_key_id" uuid,
+	"ingest_key_ciphertext" "bytea",
+	"ingest_key_nonce" "bytea",
+	"ingest_key_key_version" integer,
+	"log_cursor" jsonb,
+	"metrics_cursor" jsonb,
+	"installed_by_user_id" uuid,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "railway_installations" ADD CONSTRAINT "railway_installations_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "railway_installations" ADD CONSTRAINT "railway_installations_api_key_id_api_keys_id_fk" FOREIGN KEY ("api_key_id") REFERENCES "public"."api_keys"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "railway_installations" ADD CONSTRAINT "railway_installations_installed_by_user_id_users_id_fk" FOREIGN KEY ("installed_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "railway_installations_project_user_idx" ON "railway_installations" USING btree ("project_id","railway_user_id");

--- a/packages/db/migrations/meta/0085_snapshot.json
+++ b/packages/db/migrations/meta/0085_snapshot.json
@@ -1,0 +1,8311 @@
+{
+  "id": "011da9f9-9468-4ff8-985f-91cda73b9b1e",
+  "prevId": "ae3af402-ee94-435e-8f88-ef895b5bae35",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_provider_account_idx": {
+          "name": "accounts_provider_account_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_idx": {
+          "name": "accounts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_ticket_events": {
+      "name": "agent_linear_ticket_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_linear_ticket_id": {
+          "name": "agent_linear_ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_linear_id": {
+          "name": "actor_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_ticket_events_ticket_idx": {
+          "name": "agent_linear_ticket_events_ticket_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_ticket_events_provider_event_idx": {
+          "name": "agent_linear_ticket_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk": {
+          "name": "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk",
+          "tableFrom": "agent_linear_ticket_events",
+          "tableTo": "agent_linear_tickets",
+          "columnsFrom": [
+            "agent_linear_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_tickets": {
+      "name": "agent_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_identifier": {
+          "name": "ticket_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_name": {
+          "name": "assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_linear_id": {
+          "name": "assignee_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_tickets_incident_idx": {
+          "name": "agent_linear_tickets_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_agent_run_idx": {
+          "name": "agent_linear_tickets_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_workspace_ticket_idx": {
+          "name": "agent_linear_tickets_workspace_ticket_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_tickets_incident_id_incidents_id_fk": {
+          "name": "agent_linear_tickets_incident_id_incidents_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_linear_tickets_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_installation_id_linear_installations_id_fk": {
+          "name": "agent_linear_tickets_installation_id_linear_installations_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "linear_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memories": {
+      "name": "agent_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source_agent_run_id": {
+          "name": "source_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memories_org_status_idx": {
+          "name": "agent_memories_org_status_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_memories_org_id_orgs_id_fk": {
+          "name": "agent_memories_org_id_orgs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_id_projects_id_fk": {
+          "name": "agent_memories_project_id_projects_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_memories_source_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "source_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_user_id_users_id_fk": {
+          "name": "agent_memories_source_user_id_users_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "source_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_org_fk": {
+          "name": "agent_memories_project_org_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_memories_single_source_check": {
+          "name": "agent_memories_single_source_check",
+          "value": "NOT (source_agent_run_id IS NOT NULL AND source_user_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_pr_events": {
+      "name": "agent_pr_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_pr_id": {
+          "name": "agent_pr_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_login": {
+          "name": "actor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_github_id": {
+          "name": "actor_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pr_events_pr_idx": {
+          "name": "agent_pr_events_pr_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pr_events_provider_event_idx": {
+          "name": "agent_pr_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk": {
+          "name": "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk",
+          "tableFrom": "agent_pr_events",
+          "tableTo": "agent_pull_requests",
+          "columnsFrom": [
+            "agent_pr_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_pull_requests": {
+      "name": "agent_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_node_id": {
+          "name": "pr_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_login": {
+          "name": "merged_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_github_id": {
+          "name": "merged_by_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pull_requests_incident_idx": {
+          "name": "agent_pull_requests_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_agent_run_idx": {
+          "name": "agent_pull_requests_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_repo_pr_idx": {
+          "name": "agent_pull_requests_repo_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pull_requests_incident_id_incidents_id_fk": {
+          "name": "agent_pull_requests_incident_id_incidents_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_pull_requests_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_installation_id_github_installations_id_fk": {
+          "name": "agent_pull_requests_installation_id_github_installations_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'incident'"
+        },
+        "trigger_detail": {
+          "name": "trigger_detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_status": {
+          "name": "provider_session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_full_name": {
+          "name": "selected_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_url": {
+          "name": "selected_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_base_branch": {
+          "name": "selected_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_score": {
+          "name": "selected_repo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cumulative_runtime_minutes": {
+          "name": "cumulative_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resume_count": {
+          "name": "resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_runs_incident_idx": {
+          "name": "agent_runs_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_provider_session_idx": {
+          "name": "agent_runs_provider_session_idx",
+          "columns": [
+            {
+              "expression": "provider_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_incident_id_incidents_id_fk": {
+          "name": "agent_runs_incident_id_incidents_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_episodes": {
+      "name": "alert_episodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'firing'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_observed_value": {
+          "name": "open_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_observed_value": {
+          "name": "peak_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_value": {
+          "name": "last_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_firing_at": {
+          "name": "last_firing_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alert_episodes_alert_started_idx": {
+          "name": "alert_episodes_alert_started_idx",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_episodes_incident_idx": {
+          "name": "alert_episodes_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_episodes_open_uniq": {
+          "name": "alert_episodes_open_uniq",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "state = 'firing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_episodes_alert_id_alerts_id_fk": {
+          "name": "alert_episodes_alert_id_alerts_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_project_id_projects_id_fk": {
+          "name": "alert_episodes_project_id_projects_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_issue_id_issues_id_fk": {
+          "name": "alert_episodes_issue_id_issues_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_incident_id_incidents_id_fk": {
+          "name": "alert_episodes_incident_id_incidents_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_firings": {
+      "name": "alert_firings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_value": {
+          "name": "observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluated_at": {
+          "name": "evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_firings_alert_group_idx": {
+          "name": "alert_firings_alert_group_idx",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_firings_alert_id_alerts_id_fk": {
+          "name": "alert_firings_alert_id_alerts_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_firings_issue_id_issues_id_fk": {
+          "name": "alert_firings_issue_id_issues_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_name": {
+          "name": "metric_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "group_by": {
+          "name": "group_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mode": {
+          "name": "group_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single'"
+        },
+        "aggregation": {
+          "name": "aggregation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparator": {
+          "name": "comparator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "evaluation_interval_seconds": {
+          "name": "evaluation_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alerts_project_idx": {
+          "name": "alerts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alerts_enabled_idx": {
+          "name": "alerts_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alerts_project_id_projects_id_fk": {
+          "name": "alerts_project_id_projects_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alerts_created_by_users_id_fk": {
+          "name": "alerts_created_by_users_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions": {
+      "name": "cli_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cli_sessions_user_id_users_id_fk": {
+          "name": "cli_sessions_user_id_users_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_org_id_orgs_id_fk": {
+          "name": "cli_sessions_org_id_orgs_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_sessions_token_hash_unique": {
+          "name": "cli_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_connections": {
+      "name": "cloud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scrape_role_arn": {
+          "name": "scrape_role_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id_ciphertext": {
+          "name": "external_id_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_nonce": {
+          "name": "external_id_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_key_version": {
+          "name": "external_id_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloud_connections_project_idx": {
+          "name": "cloud_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_connections_active_role_idx": {
+          "name": "cloud_connections_active_role_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scrape_role_arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_connections_project_id_projects_id_fk": {
+          "name": "cloud_connections_project_id_projects_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_connections_created_by_users_id_fk": {
+          "name": "cloud_connections_created_by_users_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_resources": {
+      "name": "cloud_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arn": {
+          "name": "arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_fetched_at": {
+          "name": "config_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_resources_project_arn_idx": {
+          "name": "cloud_resources_project_arn_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_project_idx": {
+          "name": "cloud_resources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_connection_idx": {
+          "name": "cloud_resources_connection_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_resources_project_id_projects_id_fk": {
+          "name": "cloud_resources_project_id_projects_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_resources_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_resources_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_stream_keys": {
+      "name": "cloud_stream_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_ciphertext": {
+          "name": "key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_nonce": {
+          "name": "key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_key_version": {
+          "name": "key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_stream_keys_connection_kind_idx": {
+          "name": "cloud_stream_keys_connection_kind_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_stream_keys_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_stream_keys_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_stream_keys",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_stream_keys_api_key_id_api_keys_id_fk": {
+          "name": "cloud_stream_keys_api_key_id_api_keys_id_fk",
+          "tableFrom": "cloud_stream_keys",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_installations": {
+      "name": "cloudflare_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_token_ciphertext": {
+          "name": "refresh_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_nonce": {
+          "name": "refresh_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_key_version": {
+          "name": "refresh_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destinations": {
+          "name": "destinations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloudflare_installations_project_account_idx": {
+          "name": "cloudflare_installations_project_account_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_installations_project_id_projects_id_fk": {
+          "name": "cloudflare_installations_project_id_projects_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloudflare_installations_api_key_id_api_keys_id_fk": {
+          "name": "cloudflare_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cloudflare_installations_installed_by_user_id_users_id_fk": {
+          "name": "cloudflare_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_widgets": {
+      "name": "dashboard_widgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboard_widgets_dashboard_idx": {
+          "name": "dashboard_widgets_dashboard_idx",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_widgets_dashboard_id_dashboards_id_fk": {
+          "name": "dashboard_widgets_dashboard_id_dashboards_id_fk",
+          "tableFrom": "dashboard_widgets",
+          "tableTo": "dashboards",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboards": {
+      "name": "dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboards_project_slug_idx": {
+          "name": "dashboards_project_slug_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboards_project_idx": {
+          "name": "dashboards_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboards_project_id_projects_id_fk": {
+          "name": "dashboards_project_id_projects_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboards_created_by_users_id_fk": {
+          "name": "dashboards_created_by_users_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_repo": {
+          "name": "ref_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_external": {
+          "name": "author_external",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "triaged_by_user_id": {
+          "name": "triaged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_status_created_idx": {
+          "name": "feedback_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_kind_ref_idx": {
+          "name": "feedback_kind_ref_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_user_id_users_id_fk": {
+          "name": "feedback_author_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_org_id_orgs_id_fk": {
+          "name": "feedback_org_id_orgs_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_project_id_projects_id_fk": {
+          "name": "feedback_project_id_projects_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_triaged_by_user_id_users_id_fk": {
+          "name": "feedback_triaged_by_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triaged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repos": {
+          "name": "repos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_enabled": {
+          "name": "agent_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "repo_access": {
+          "name": "repo_access",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_name": {
+          "name": "commit_author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_email": {
+          "name": "commit_author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_login": {
+          "name": "commit_author_github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_id": {
+          "name": "commit_author_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_avatar_url": {
+          "name": "commit_author_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_by_user_id": {
+          "name": "commit_author_set_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_at": {
+          "name": "commit_author_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_project_installation_idx": {
+          "name": "github_installations_project_installation_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NOT NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_installation_idx": {
+          "name": "github_installations_org_installation_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_idx": {
+          "name": "github_installations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_org_id_orgs_id_fk": {
+          "name": "github_installations_org_id_orgs_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_project_id_projects_id_fk": {
+          "name": "github_installations_project_id_projects_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_commit_author_set_by_user_id_users_id_fk": {
+          "name": "github_installations_commit_author_set_by_user_id_users_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "commit_author_set_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_events": {
+      "name": "incident_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_posted_at": {
+          "name": "slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_events_agent_run_idx": {
+          "name": "incident_events_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_idx": {
+          "name": "incident_events_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_provider_event_idx": {
+          "name": "incident_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_provider_event_idx": {
+          "name": "incident_events_incident_provider_event_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_dedupe_idx": {
+          "name": "incident_events_dedupe_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_dedupe_idx": {
+          "name": "incident_events_incident_dedupe_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_events_agent_run_id_agent_runs_id_fk": {
+          "name": "incident_events_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_events_incident_id_incidents_id_fk": {
+          "name": "incident_events_incident_id_incidents_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "incident_events_parentage_check": {
+          "name": "incident_events_parentage_check",
+          "value": "agent_run_id IS NOT NULL OR incident_id IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.incident_issues": {
+      "name": "incident_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_issues_pair_idx": {
+          "name": "incident_issues_pair_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_issues_incident_idx": {
+          "name": "incident_issues_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_issues_issue_lookup_idx": {
+          "name": "incident_issues_issue_lookup_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_issues_incident_id_incidents_id_fk": {
+          "name": "incident_issues_incident_id_incidents_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_issues_issue_id_issues_id_fk": {
+          "name": "incident_issues_issue_id_issues_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_resolution_proposals": {
+      "name": "incident_resolution_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sweep'"
+        },
+        "proposed_reason_code": {
+          "name": "proposed_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_reason_text": {
+          "name": "proposed_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_at": {
+          "name": "proposed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_slack_user_id": {
+          "name": "decided_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_resolution_proposals_incident_idx": {
+          "name": "incident_resolution_proposals_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proposed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_resolution_proposals_slack_msg_idx": {
+          "name": "incident_resolution_proposals_slack_msg_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_message_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_channel_id IS NOT NULL AND slack_message_ts IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_resolution_proposals_incident_id_incidents_id_fk": {
+          "name": "incident_resolution_proposals_incident_id_incidents_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk": {
+          "name": "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_decided_by_user_id_users_id_fk": {
+          "name": "incident_resolution_proposals_decided_by_user_id_users_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "noise_reason": {
+          "name": "noise_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_resolved_at": {
+          "name": "noise_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_into_id": {
+          "name": "merged_into_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_incident_id": {
+          "name": "previous_incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_investigate_suppressed_until": {
+          "name": "auto_investigate_suppressed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autorecovery_last_evaluated_at": {
+          "name": "autorecovery_last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_summary": {
+          "name": "agent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_text": {
+          "name": "root_cause_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_confidence": {
+          "name": "root_cause_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_text": {
+          "name": "estimated_impact_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_confidence": {
+          "name": "estimated_impact_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_severity": {
+          "name": "suggested_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_classification": {
+          "name": "noise_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_classification": {
+          "name": "resolution_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_agent_run_id": {
+          "name": "findings_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_kind": {
+          "name": "resolved_by_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_slack_user_id": {
+          "name": "resolved_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_code": {
+          "name": "resolved_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_text": {
+          "name": "resolved_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incidents_project_status_seen_idx": {
+          "name": "incidents_project_status_seen_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_autorecovery_eval_idx": {
+          "name": "incidents_autorecovery_eval_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "autorecovery_last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_slack_thread_idx": {
+          "name": "incidents_slack_thread_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_project_codename_idx": {
+          "name": "incidents_project_codename_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "codename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "codename <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_project_id_projects_id_fk": {
+          "name": "incidents_project_id_projects_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incidents_merged_into_id_incidents_id_fk": {
+          "name": "incidents_merged_into_id_incidents_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "merged_into_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_previous_incident_id_incidents_id_fk": {
+          "name": "incidents_previous_incident_id_incidents_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "previous_incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_slack_installation_id_slack_installations_id_fk": {
+          "name": "incidents_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_findings_agent_run_id_agent_runs_id_fk": {
+          "name": "incidents_findings_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "findings_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_resolved_by_user_id_users_id_fk": {
+          "name": "incidents_resolved_by_user_id_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_org_idx": {
+          "name": "invitations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_org_id_orgs_id_fk": {
+          "name": "invitations_org_id_orgs_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'span'"
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_type": {
+          "name": "exception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_frame": {
+          "name": "top_frame",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_frames": {
+          "name": "normalized_frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_sample": {
+          "name": "last_sample",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "silenced_at": {
+          "name": "silenced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_trigger": {
+          "name": "escalation_trigger",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_started_at": {
+          "name": "observation_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_baseline_event_count": {
+          "name": "observation_baseline_event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_last_evaluated_at": {
+          "name": "observation_last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_last_event_count": {
+          "name": "observation_last_event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_alerted_at": {
+          "name": "last_alerted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "grouping_state": {
+          "name": "grouping_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'grouped'"
+        },
+        "grouping_source": {
+          "name": "grouping_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_reason": {
+          "name": "grouping_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempted_at": {
+          "name": "grouping_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempt_count": {
+          "name": "grouping_attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_project_fingerprint_idx": {
+          "name": "issues_project_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_grouping_state_idx": {
+          "name": "issues_grouping_state_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grouping_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grouping_state IN ('pending', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_observation_idx": {
+          "name": "issues_observation_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observation_started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'under_observation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_project_status_idx": {
+          "name": "issues_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_installations": {
+      "name": "linear_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_url_key": {
+          "name": "workspace_url_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_vault_id": {
+          "name": "anthropic_vault_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_credential_id": {
+          "name": "anthropic_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_required_at": {
+          "name": "reauth_required_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_reason": {
+          "name": "reauth_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linear_installations_project_active_idx": {
+          "name": "linear_installations_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_installations_project_id_projects_id_fk": {
+          "name": "linear_installations_project_id_projects_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_installations_actor_user_id_users_id_fk": {
+          "name": "linear_installations_actor_user_id_users_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_codes": {
+      "name": "mcp_oauth_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_codes_client_idx": {
+          "name": "mcp_oauth_codes_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_user_id_users_id_fk": {
+          "name": "mcp_oauth_codes_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_project_id_projects_id_fk": {
+          "name": "mcp_oauth_codes_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_tokens": {
+      "name": "mcp_oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "access_hash": {
+          "name": "access_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_hash": {
+          "name": "refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_tokens_client_idx": {
+          "name": "mcp_oauth_tokens_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_tokens_user_idx": {
+          "name": "mcp_oauth_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_user_id_users_id_fk": {
+          "name": "mcp_oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_project_id_projects_id_fk": {
+          "name": "mcp_oauth_tokens_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_tokens_access_hash_unique": {
+          "name": "mcp_oauth_tokens_access_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_hash"
+          ]
+        },
+        "mcp_oauth_tokens_refresh_hash_unique": {
+          "name": "mcp_oauth_tokens_refresh_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_agent_settings": {
+      "name": "org_agent_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "digest_enabled": {
+          "name": "digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "digest_slack_installation_id": {
+          "name": "digest_slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_id": {
+          "name": "digest_slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_name": {
+          "name": "digest_slack_channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_last_run_at": {
+          "name": "digest_last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_agent_settings_org_idx": {
+          "name": "org_agent_settings_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_agent_settings_org_id_orgs_id_fk": {
+          "name": "org_agent_settings_org_id_orgs_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk": {
+          "name": "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "digest_slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_api_keys": {
+      "name": "org_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_api_keys_org_idx": {
+          "name": "org_api_keys_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_api_keys_org_id_orgs_id_fk": {
+          "name": "org_api_keys_org_id_orgs_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_api_keys_created_by_user_id_users_id_fk": {
+          "name": "org_api_keys_created_by_user_id_users_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_api_keys_key_hash_unique": {
+          "name": "org_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integration_secrets": {
+      "name": "org_integration_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_integration_id": {
+          "name": "org_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_name": {
+          "name": "secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integration_secrets_unique_idx": {
+          "name": "org_integration_secrets_unique_idx",
+          "columns": [
+            {
+              "expression": "org_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integration_secrets_org_integration_id_org_integrations_id_fk": {
+          "name": "org_integration_secrets_org_integration_id_org_integrations_id_fk",
+          "tableFrom": "org_integration_secrets",
+          "tableTo": "org_integrations",
+          "columnsFrom": [
+            "org_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integrations": {
+      "name": "org_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integrations_org_slug_idx": {
+          "name": "org_integrations_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_integrations_org_enabled_idx": {
+          "name": "org_integrations_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integrations_org_id_orgs_id_fk": {
+          "name": "org_integrations_org_id_orgs_id_fk",
+          "tableFrom": "org_integrations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_members_org_user_idx": {
+          "name": "org_members_org_user_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_org_id_orgs_id_fk": {
+          "name": "org_members_org_id_orgs_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_members_user_id_users_id_fk": {
+          "name": "org_members_user_id_users_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_setup_skipped_at": {
+          "name": "github_setup_skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_source": {
+          "name": "signup_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_return_url_hosts": {
+          "name": "allowed_return_url_hosts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_slug_unique": {
+          "name": "orgs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "orgs_clerk_org_id_unique": {
+          "name": "orgs_clerk_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personal_access_tokens_user_idx": {
+          "name": "personal_access_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personal_access_tokens_project_idx": {
+          "name": "personal_access_tokens_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_users_id_fk": {
+          "name": "personal_access_tokens_user_id_users_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personal_access_tokens_project_id_projects_id_fk": {
+          "name": "personal_access_tokens_project_id_projects_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_automation_settings": {
+      "name": "project_automation_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_investigate_issues_enabled": {
+          "name": "auto_investigate_issues_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "agent_run_provider": {
+          "name": "agent_run_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "max_runtime_minutes": {
+          "name": "max_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "max_human_resume_count": {
+          "name": "max_human_resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_follow_up_enabled": {
+          "name": "auto_follow_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "linear_ticket_instructions": {
+          "name": "linear_ticket_instructions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "linear_default_team_id": {
+          "name": "linear_default_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_base_branch": {
+          "name": "pr_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_merge_fix_prs": {
+          "name": "auto_merge_fix_prs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'never'"
+        },
+        "auto_merge_method": {
+          "name": "auto_merge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'squash'"
+        },
+        "issue_filter": {
+          "name": "issue_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "issue_filter_config": {
+          "name": "issue_filter_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"includeLogs\":[],\"includeSpans\":[],\"excludeLogs\":[],\"excludeSpans\":[]}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_automation_settings_project_idx": {
+          "name": "project_automation_settings_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_automation_settings_project_id_projects_id_fk": {
+          "name": "project_automation_settings_project_id_projects_id_fk",
+          "tableFrom": "project_automation_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_github_repos": {
+      "name": "project_github_repos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_full_name": {
+          "name": "github_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_github_repos_project_repo_idx": {
+          "name": "project_github_repos_project_repo_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_github_repos_installation_idx": {
+          "name": "project_github_repos_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_github_repos_project_id_projects_id_fk": {
+          "name": "project_github_repos_project_id_projects_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_github_repos_installation_id_github_installations_id_fk": {
+          "name": "project_github_repos_installation_id_github_installations_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_ingest_filters": {
+      "name": "project_ingest_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal": {
+          "name": "signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_ingest_filters_project_source_signal_idx": {
+          "name": "project_ingest_filters_project_source_signal_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_ingest_filters_project_id_projects_id_fk": {
+          "name": "project_ingest_filters_project_id_projects_id_fk",
+          "tableFrom": "project_ingest_filters",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_topologies": {
+      "name": "project_topologies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment": {
+          "name": "enrichment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_requested_at": {
+          "name": "refresh_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_topologies_project_idx": {
+          "name": "project_topologies_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_topologies_project_id_projects_id_fk": {
+          "name": "project_topologies_project_id_projects_id_fk",
+          "tableFrom": "project_topologies",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_context": {
+          "name": "project_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_idx": {
+          "name": "projects_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_org_id_orgs_id_fk": {
+          "name": "projects_org_id_orgs_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_id_org_uniq": {
+          "name": "projects_id_org_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.railway_installations": {
+      "name": "railway_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "railway_user_id": {
+          "name": "railway_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_projects": {
+          "name": "granted_projects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_token_ciphertext": {
+          "name": "refresh_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_nonce": {
+          "name": "refresh_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_key_version": {
+          "name": "refresh_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_cursor": {
+          "name": "log_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_cursor": {
+          "name": "metrics_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "railway_installations_project_user_idx": {
+          "name": "railway_installations_project_user_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "railway_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "railway_installations_project_id_projects_id_fk": {
+          "name": "railway_installations_project_id_projects_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "railway_installations_api_key_id_api_keys_id_fk": {
+          "name": "railway_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "railway_installations_installed_by_user_id_users_id_fk": {
+          "name": "railway_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_orgs_id_fk": {
+          "name": "sessions_active_organization_id_orgs_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signup_intents": {
+      "name": "signup_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_project_id": {
+          "name": "claimed_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signup_intents_claimed_project_id_projects_id_fk": {
+          "name": "signup_intents_claimed_project_id_projects_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "claimed_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "signup_intents_claimed_by_user_id_users_id_fk": {
+          "name": "signup_intents_claimed_by_user_id_users_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signup_intents_key_hash_unique": {
+          "name": "signup_intents_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slack_installations_project_team_idx": {
+          "name": "slack_installations_project_team_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_project_id_projects_id_fk": {
+          "name": "slack_installations_project_id_projects_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_installations_installed_by_user_id_users_id_fk": {
+          "name": "slack_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_map_artifacts": {
+      "name": "source_map_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dist": {
+          "name": "dist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug_id": {
+          "name": "debug_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_file": {
+          "name": "bundle_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_file": {
+          "name": "map_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_hash": {
+          "name": "source_map_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_bytes": {
+          "name": "source_map_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_bucket": {
+          "name": "storage_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_encoding": {
+          "name": "content_encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gzip'"
+        },
+        "uploaded_by_org_api_key_id": {
+          "name": "uploaded_by_org_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_map_artifacts_project_debug_id_idx": {
+          "name": "source_map_artifacts_project_debug_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "debug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "debug_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_map_artifacts_project_release_idx": {
+          "name": "source_map_artifacts_project_release_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "release",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_map_artifacts_project_id_projects_id_fk": {
+          "name": "source_map_artifacts_project_id_projects_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk": {
+          "name": "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "org_api_keys",
+          "columnsFrom": [
+            "uploaded_by_org_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_notifications": {
+      "name": "usage_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_notifications_org_period_threshold_idx": {
+          "name": "usage_notifications_org_period_threshold_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "threshold",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_notifications_org_id_orgs_id_fk": {
+          "name": "usage_notifications_org_id_orgs_id_fk",
+          "tableFrom": "usage_notifications",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_project_id": {
+          "name": "active_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_org_id": {
+          "name": "active_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_org_id": {
+          "name": "favorite_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_project_id": {
+          "name": "favorite_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_active_project_id_projects_id_fk": {
+          "name": "users_active_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "active_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_active_org_id_orgs_id_fk": {
+          "name": "users_active_org_id_orgs_id_fk",
+          "tableFrom": "users",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_favorite_org_id_orgs_id_fk": {
+          "name": "users_favorite_org_id_orgs_id_fk",
+          "tableFrom": "users",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "favorite_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_favorite_project_id_projects_id_fk": {
+          "name": "users_favorite_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "favorite_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_installations": {
+      "name": "vercel_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_id": {
+          "name": "configuration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drains": {
+          "name": "drains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vercel_installations_project_configuration_idx": {
+          "name": "vercel_installations_project_configuration_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configuration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_installations_project_id_projects_id_fk": {
+          "name": "vercel_installations_project_id_projects_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vercel_installations_api_key_id_api_keys_id_fk": {
+          "name": "vercel_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vercel_installations_installed_by_user_id_users_id_fk": {
+          "name": "vercel_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_status": {
+          "name": "last_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_endpoint_idx": {
+          "name": "webhook_deliveries_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_events": {
+          "name": "enabled_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"incident.created\",\"incident.updated\"]'::jsonb"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_endpoints_project_idx": {
+          "name": "webhook_endpoints_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_endpoints_project_id_projects_id_fk": {
+          "name": "webhook_endpoints_project_id_projects_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_state": {
+      "name": "worker_state",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -596,6 +596,13 @@
       "when": 1783426655358,
       "tag": "0084_groovy_gamma_corps",
       "breakpoints": true
+    },
+    {
+      "idx": 85,
+      "version": "7",
+      "when": 1783437015070,
+      "tag": "0085_numerous_warlock",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2217,11 +2217,85 @@ export const vercelInstallations = pgTable(
 
 export type VercelInstallation = typeof vercelInstallations.$inferSelect;
 
+// A connected Railway account via "Login with Railway" OAuth. One row per
+// (project, Railway user) — Railway has no per-grant id, so the OIDC `sub` of
+// the consenting user is the stable install key; a re-consent by the same user
+// refreshes the row. Unlike the Vercel/Cloudflare connectors there is nothing
+// to provision on Railway's side: Railway has no drains, so a worker-side
+// puller reads logs (GraphQL subscription/query) and metrics (query) from the
+// granted projects and forwards them to our intake authenticated by the
+// project ingest key. Access tokens live 1h; the rotating refresh token is
+// re-persisted on every refresh. Tokens/keys are encrypted at rest with the
+// same AES-256-GCM scheme as the Cloudflare connector.
+export const railwayInstallations = pgTable(
+  "railway_installations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    projectId: uuid("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    // OIDC `sub` of the Railway user who consented — the stable install key.
+    railwayUserId: text("railway_user_id").notNull(),
+    // Snapshot of what the grant can see (from `externalWorkspaces`), refreshed
+    // by the puller: workspaces and the granted projects with their
+    // environments. Display + pull-planning only, never authorization.
+    grantedProjects: jsonb("granted_projects").$type<
+      Array<{
+        id: string;
+        name: string;
+        workspaceId: string | null;
+        workspaceName: string | null;
+      }>
+    >(),
+    // Delegated OAuth tokens, encrypted at rest. Railway access tokens expire
+    // after ~1h; refresh tokens rotate on every use (the puller persists the
+    // replacement immediately). Refresh token nullable: consent without
+    // `offline_access` yields none and the install degrades at expiry.
+    accessTokenCiphertext: bytea("access_token_ciphertext").notNull(),
+    accessTokenNonce: bytea("access_token_nonce").notNull(),
+    accessTokenKeyVersion: integer("access_token_key_version").notNull().default(1),
+    refreshTokenCiphertext: bytea("refresh_token_ciphertext"),
+    refreshTokenNonce: bytea("refresh_token_nonce"),
+    refreshTokenKeyVersion: integer("refresh_token_key_version"),
+    tokenExpiresAt: timestamp("token_expires_at", { withTimezone: true }),
+    scope: text("scope"),
+    // The ingest key the puller forwards telemetry with, stored encrypted so a
+    // re-connect reuses the same key instead of minting a new one.
+    apiKeyId: uuid("api_key_id").references(() => apiKeys.id, { onDelete: "set null" }),
+    ingestKeyCiphertext: bytea("ingest_key_ciphertext"),
+    ingestKeyNonce: bytea("ingest_key_nonce"),
+    ingestKeyKeyVersion: integer("ingest_key_key_version"),
+    // Puller checkpoint: Railway environment id → RFC3339 timestamp of the last
+    // forwarded log line, so restarts resume without gaps or duplicates.
+    logCursor: jsonb("log_cursor").$type<Record<string, string>>(),
+    // Puller checkpoint for metrics: Railway service id → epoch seconds of the
+    // last forwarded sample.
+    metricsCursor: jsonb("metrics_cursor").$type<Record<string, number>>(),
+    installedByUserId: uuid("installed_by_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    // One live install per (project, Railway user); a re-consent refreshes the
+    // row (see the upsert in apps/api/src/railway.ts). Also serves
+    // project-scoped lookups via its left-most `project_id` prefix.
+    projectUserUniq: uniqueIndex("railway_installations_project_user_idx").on(
+      t.projectId,
+      t.railwayUserId,
+    ),
+  }),
+);
+
+export type RailwayInstallation = typeof railwayInstallations.$inferSelect;
+
 // Per-project ingest source filters. A row means the given (source, signal) is
 // DISABLED for the project — the proxy ack-drops that telemetry at the edge.
 // Sparse by design: no row = enabled, so a new project ingests everything.
 //   source: "otlp" (SDK/OTLP exporters) | "aws" (CloudWatch → Firehose) |
-//           "vercel" (Vercel Drains)
+//           "vercel" (Vercel Drains) | "railway" (Railway API puller)
 //   signal: "traces" | "logs" | "metrics"
 export const projectIngestFilters = pgTable(
   "project_ingest_filters",
@@ -2230,7 +2304,7 @@ export const projectIngestFilters = pgTable(
     projectId: uuid("project_id")
       .notNull()
       .references(() => projects.id, { onDelete: "cascade" }),
-    source: text("source").$type<"otlp" | "aws" | "vercel">().notNull(),
+    source: text("source").$type<"otlp" | "aws" | "vercel" | "railway">().notNull(),
     signal: text("signal").$type<"traces" | "logs" | "metrics">().notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   },

--- a/packages/railway/package.json
+++ b/packages/railway/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@superlog/railway",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "tsx --test src/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/railway/src/graphql.test.ts
+++ b/packages/railway/src/graphql.test.ts
@@ -1,0 +1,143 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import {
+  RAILWAY_GRAPHQL_URL,
+  fetchEnvironmentLogs,
+  fetchGrantedProjects,
+  fetchProjectInventory,
+  fetchServiceMetrics,
+  fetchViewer,
+  railwayGraphQL,
+} from "./graphql.js";
+
+function gqlResponder(data: unknown): typeof fetch {
+  return (async (url: string | URL | Request, init?: RequestInit) => {
+    gqlResponder.lastUrl = String(url);
+    gqlResponder.lastBody = JSON.parse(String(init?.body));
+    gqlResponder.lastAuth = new Headers(init?.headers).get("authorization");
+    return new Response(JSON.stringify({ data }), { status: 200 });
+  }) as typeof fetch;
+}
+gqlResponder.lastUrl = "";
+gqlResponder.lastBody = null as unknown;
+gqlResponder.lastAuth = null as string | null;
+
+test("railwayGraphQL sends a bearer-authed POST and surfaces Not Authorized", async () => {
+  const ok = await railwayGraphQL({
+    accessToken: "tok",
+    query: "query { me { id } }",
+    fetchImpl: gqlResponder({ me: { id: "u1" } }),
+  });
+  assert.ok(ok.ok);
+  assert.equal(gqlResponder.lastUrl, RAILWAY_GRAPHQL_URL);
+  assert.equal(gqlResponder.lastAuth, "Bearer tok");
+
+  const denied = await railwayGraphQL({
+    accessToken: "tok",
+    query: "query { projects { edges { node { id } } } }",
+    fetchImpl: (async () =>
+      new Response(
+        JSON.stringify({ errors: [{ message: "Not Authorized" }], data: null }),
+        { status: 200 },
+      )) as typeof fetch,
+  });
+  assert.ok(!denied.ok);
+  assert.equal(denied.notAuthorized, true);
+});
+
+test("fetchGrantedProjects flattens externalWorkspaces into granted projects", async () => {
+  const result = await fetchGrantedProjects({
+    accessToken: "tok",
+    fetchImpl: gqlResponder({
+      externalWorkspaces: [
+        {
+          id: "ws-1",
+          name: "Superlog",
+          projects: [
+            { id: "p1", name: "blackbird" },
+            { id: "p2", name: "neo" },
+          ],
+        },
+      ],
+    }),
+  });
+  assert.ok(result.ok);
+  assert.deepEqual(result.projects, [
+    { id: "p1", name: "blackbird", workspaceId: "ws-1", workspaceName: "Superlog" },
+    { id: "p2", name: "neo", workspaceId: "ws-1", workspaceName: "Superlog" },
+  ]);
+});
+
+test("fetchProjectInventory returns environments and services", async () => {
+  const result = await fetchProjectInventory({
+    accessToken: "tok",
+    projectId: "p1",
+    fetchImpl: gqlResponder({
+      project: {
+        id: "p1",
+        name: "blackbird",
+        environments: { edges: [{ node: { id: "env-1", name: "production" } }] },
+        services: { edges: [{ node: { id: "svc-1", name: "blackbird-app" } }] },
+      },
+    }),
+  });
+  assert.ok(result.ok);
+  assert.deepEqual(result.environments, [{ id: "env-1", name: "production" }]);
+  assert.deepEqual(result.services, [{ id: "svc-1", name: "blackbird-app" }]);
+});
+
+test("fetchEnvironmentLogs paginates forward from the cursor", async () => {
+  const result = await fetchEnvironmentLogs({
+    accessToken: "tok",
+    environmentId: "env-1",
+    afterDate: "2026-07-07T14:10:31.058154105Z",
+    limit: 500,
+    fetchImpl: gqlResponder({
+      environmentLogs: [
+        {
+          timestamp: "2026-07-07T14:10:32Z",
+          severity: "info",
+          message: "hello",
+          tags: { serviceId: "svc-1" },
+          attributes: [],
+        },
+      ],
+    }),
+  });
+  assert.ok(result.ok);
+  assert.equal(result.logs.length, 1);
+  const body = gqlResponder.lastBody as { variables: Record<string, unknown> };
+  assert.equal(body.variables.environmentId, "env-1");
+  assert.equal(body.variables.afterDate, "2026-07-07T14:10:31.058154105Z");
+  assert.equal(body.variables.afterLimit, 500);
+});
+
+test("fetchServiceMetrics requests the infra measurements", async () => {
+  const result = await fetchServiceMetrics({
+    accessToken: "tok",
+    environmentId: "env-1",
+    serviceId: "svc-1",
+    startDate: "2026-07-07T13:00:00Z",
+    endDate: "2026-07-07T14:00:00Z",
+    sampleRateSeconds: 60,
+    fetchImpl: gqlResponder({
+      metrics: [
+        { measurement: "CPU_USAGE", values: [{ ts: 1, value: 0.5 }], tags: { serviceId: "svc-1" } },
+      ],
+    }),
+  });
+  assert.ok(result.ok);
+  assert.equal(result.results.length, 1);
+  const body = gqlResponder.lastBody as { variables: Record<string, unknown> };
+  assert.equal(body.variables.serviceId, "svc-1");
+  assert.ok(Array.isArray(body.variables.measurements));
+});
+
+test("fetchViewer returns the Railway user for install keying", async () => {
+  const result = await fetchViewer({
+    accessToken: "tok",
+    fetchImpl: gqlResponder({ me: { id: "u1", name: "Ash", email: "a@b.c" } }),
+  });
+  assert.ok(result.ok);
+  assert.equal(result.viewer.id, "u1");
+});

--- a/packages/railway/src/graphql.test.ts
+++ b/packages/railway/src/graphql.test.ts
@@ -36,10 +36,9 @@ test("railwayGraphQL sends a bearer-authed POST and surfaces Not Authorized", as
     accessToken: "tok",
     query: "query { projects { edges { node { id } } } }",
     fetchImpl: (async () =>
-      new Response(
-        JSON.stringify({ errors: [{ message: "Not Authorized" }], data: null }),
-        { status: 200 },
-      )) as typeof fetch,
+      new Response(JSON.stringify({ errors: [{ message: "Not Authorized" }], data: null }), {
+        status: 200,
+      })) as typeof fetch,
   });
   assert.ok(!denied.ok);
   assert.equal(denied.notAuthorized, true);

--- a/packages/railway/src/graphql.test.ts
+++ b/packages/railway/src/graphql.test.ts
@@ -111,6 +111,50 @@ test("fetchEnvironmentLogs paginates forward from the cursor", async () => {
   assert.equal(body.variables.afterLimit, 500);
 });
 
+test("fetchEnvironmentLogs reads backwards from the anchor when no cursor exists (first pull)", async () => {
+  const result = await fetchEnvironmentLogs({
+    accessToken: "tok",
+    environmentId: "env-1",
+    anchorDate: "2026-07-07T15:00:00.000Z",
+    limit: 500,
+    fetchImpl: gqlResponder({ environmentLogs: [] }),
+  });
+  assert.ok(result.ok);
+  const body = gqlResponder.lastBody as { query: string; variables: Record<string, unknown> };
+  assert.match(body.query, /anchorDate/);
+  assert.match(body.query, /beforeLimit/);
+  assert.equal(body.variables.anchorDate, "2026-07-07T15:00:00.000Z");
+  assert.equal(body.variables.beforeLimit, 500);
+  assert.equal(body.variables.afterDate, undefined);
+});
+
+test("fetchEnvironmentLogs drops malformed records instead of aborting the batch", async () => {
+  const result = await fetchEnvironmentLogs({
+    accessToken: "tok",
+    environmentId: "env-1",
+    afterDate: "2026-07-07T14:00:00Z",
+    limit: 100,
+    fetchImpl: gqlResponder({
+      environmentLogs: [
+        // attributes missing entirely; tags is a string — both normalized.
+        { timestamp: "2026-07-07T14:01:00Z", severity: "info", message: "ok", tags: "bogus" },
+        // no timestamp → dropped.
+        { severity: "info", message: "no-ts" },
+        null,
+      ],
+    }),
+  });
+  assert.ok(result.ok);
+  assert.equal(result.logs.length, 1);
+  assert.deepEqual(result.logs[0], {
+    timestamp: "2026-07-07T14:01:00Z",
+    severity: "info",
+    message: "ok",
+    tags: null,
+    attributes: [],
+  });
+});
+
 test("fetchServiceMetrics requests the infra measurements", async () => {
   const result = await fetchServiceMetrics({
     accessToken: "tok",

--- a/packages/railway/src/graphql.ts
+++ b/packages/railway/src/graphql.ts
@@ -234,9 +234,39 @@ export async function fetchEnvironmentLogs(input: {
         },
   });
   if (!result.ok) return { ok: false, error: result.error };
+  const raw = Array.isArray(result.data.environmentLogs) ? result.data.environmentLogs : [];
   return {
     ok: true,
-    logs: Array.isArray(result.data.environmentLogs) ? result.data.environmentLogs : [],
+    logs: raw.map(normalizeLog).filter((log): log is RailwayLog => log !== null),
+  };
+}
+
+// environmentLogs is undocumented API surface — normalize each item instead of
+// trusting the cast, so one malformed record can't abort the pull for a whole
+// installation downstream (e.g. `log.attributes.map` throwing).
+function normalizeLog(value: unknown): RailwayLog | null {
+  if (!value || typeof value !== "object") return null;
+  const o = value as Record<string, unknown>;
+  if (typeof o.timestamp !== "string" || !o.timestamp) return null;
+  const tags =
+    o.tags && typeof o.tags === "object" && !Array.isArray(o.tags)
+      ? (o.tags as RailwayLog["tags"])
+      : null;
+  const attributes = Array.isArray(o.attributes)
+    ? o.attributes.filter(
+        (a): a is { key: string; value: string } =>
+          !!a &&
+          typeof a === "object" &&
+          typeof (a as { key?: unknown }).key === "string" &&
+          typeof (a as { value?: unknown }).value === "string",
+      )
+    : [];
+  return {
+    timestamp: o.timestamp,
+    severity: typeof o.severity === "string" ? o.severity : null,
+    message: typeof o.message === "string" ? o.message : "",
+    tags,
+    attributes,
   };
 }
 

--- a/packages/railway/src/graphql.ts
+++ b/packages/railway/src/graphql.ts
@@ -37,7 +37,11 @@ export async function railwayGraphQL<T = unknown>(input: {
       body: JSON.stringify({ query: input.query, variables: input.variables ?? {} }),
     });
   } catch (e) {
-    return { ok: false, error: e instanceof Error ? e.message : "fetch_failed", notAuthorized: false };
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : "fetch_failed",
+      notAuthorized: false,
+    };
   }
   const json = (await res.json().catch(() => null)) as {
     data?: T | null;
@@ -83,7 +87,7 @@ export async function fetchGrantedProjects(input: {
     }>;
   }>({
     ...input,
-    query: `query { externalWorkspaces { id name projects { id name } } }`,
+    query: "query { externalWorkspaces { id name projects { id name } } }",
   });
   if (!result.ok) return { ok: false, error: result.error };
   const workspaces = Array.isArray(result.data.externalWorkspaces)
@@ -154,7 +158,7 @@ export async function fetchViewer(input: {
 > {
   const result = await railwayGraphQL<{
     me: { id?: unknown; name?: unknown; email?: unknown } | null;
-  }>({ ...input, query: `query { me { id name email } }` });
+  }>({ ...input, query: "query { me { id name email } }" });
   if (!result.ok) return { ok: false, error: result.error };
   const me = result.data.me;
   if (typeof me?.id !== "string" || !me.id) return { ok: false, error: "no_viewer" };

--- a/packages/railway/src/graphql.ts
+++ b/packages/railway/src/graphql.ts
@@ -1,0 +1,284 @@
+// Thin injectable-fetch wrappers over Railway's public GraphQL API
+// (backboard.railway.com/graphql/v2) — the same API that powers Railway's
+// dashboard. Only the queries the connector needs, shaped for an OAuth
+// `project:viewer` token:
+//
+//  - `externalWorkspaces` is how an OAuth app discovers what it was granted —
+//    the blanket `projects` / `me.workspaces` queries are Not Authorized for
+//    OAuth tokens, and the grant list is not in the token claims.
+//  - `environmentLogs` reads app logs (also available as a WebSocket
+//    subscription — see puller); `metrics` reads per-service infra series.
+//    Both are live public-schema surface but formally undocumented, so parse
+//    defensively.
+
+import type { FetchImpl } from "./oauth.js";
+
+export const RAILWAY_GRAPHQL_URL = "https://backboard.railway.com/graphql/v2";
+
+export type GraphQLResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string; notAuthorized: boolean };
+
+export async function railwayGraphQL<T = unknown>(input: {
+  accessToken: string;
+  query: string;
+  variables?: Record<string, unknown>;
+  fetchImpl?: FetchImpl;
+}): Promise<GraphQLResult<T>> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await fetchImpl(RAILWAY_GRAPHQL_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${input.accessToken}`,
+      },
+      body: JSON.stringify({ query: input.query, variables: input.variables ?? {} }),
+    });
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "fetch_failed", notAuthorized: false };
+  }
+  const json = (await res.json().catch(() => null)) as {
+    data?: T | null;
+    errors?: Array<{ message?: unknown }>;
+  } | null;
+  if (!json) return { ok: false, error: `status_${res.status}`, notAuthorized: false };
+  if (json.errors?.length) {
+    const messages = json.errors
+      .map((e) => (typeof e.message === "string" ? e.message : "error"))
+      .join("; ");
+    return {
+      ok: false,
+      error: messages,
+      notAuthorized: /not authorized/i.test(messages),
+    };
+  }
+  if (!res.ok || json.data == null) {
+    return { ok: false, error: `status_${res.status}`, notAuthorized: false };
+  }
+  return { ok: true, data: json.data };
+}
+
+// ---------------------------------------------------------------------------
+// Grant discovery + inventory
+// ---------------------------------------------------------------------------
+
+export type RailwayGrantedProject = {
+  id: string;
+  name: string;
+  workspaceId: string | null;
+  workspaceName: string | null;
+};
+
+export async function fetchGrantedProjects(input: {
+  accessToken: string;
+  fetchImpl?: FetchImpl;
+}): Promise<{ ok: true; projects: RailwayGrantedProject[] } | { ok: false; error: string }> {
+  const result = await railwayGraphQL<{
+    externalWorkspaces: Array<{
+      id?: unknown;
+      name?: unknown;
+      projects?: Array<{ id?: unknown; name?: unknown }>;
+    }>;
+  }>({
+    ...input,
+    query: `query { externalWorkspaces { id name projects { id name } } }`,
+  });
+  if (!result.ok) return { ok: false, error: result.error };
+  const workspaces = Array.isArray(result.data.externalWorkspaces)
+    ? result.data.externalWorkspaces
+    : [];
+  const projects: RailwayGrantedProject[] = [];
+  for (const ws of workspaces) {
+    for (const p of ws.projects ?? []) {
+      if (typeof p.id !== "string" || !p.id) continue;
+      projects.push({
+        id: p.id,
+        name: typeof p.name === "string" ? p.name : p.id,
+        workspaceId: typeof ws.id === "string" ? ws.id : null,
+        workspaceName: typeof ws.name === "string" ? ws.name : null,
+      });
+    }
+  }
+  return { ok: true, projects };
+}
+
+export type RailwayEnvironment = { id: string; name: string };
+export type RailwayService = { id: string; name: string };
+
+export async function fetchProjectInventory(input: {
+  accessToken: string;
+  projectId: string;
+  fetchImpl?: FetchImpl;
+}): Promise<
+  | { ok: true; environments: RailwayEnvironment[]; services: RailwayService[] }
+  | { ok: false; error: string }
+> {
+  const result = await railwayGraphQL<{
+    project: {
+      environments?: { edges?: Array<{ node?: { id?: unknown; name?: unknown } }> };
+      services?: { edges?: Array<{ node?: { id?: unknown; name?: unknown } }> };
+    } | null;
+  }>({
+    ...input,
+    query: `query ($id: String!) {
+      project(id: $id) {
+        environments { edges { node { id name } } }
+        services { edges { node { id name } } }
+      }
+    }`,
+    variables: { id: input.projectId },
+  });
+  if (!result.ok) return { ok: false, error: result.error };
+  const nodes = (
+    edges: Array<{ node?: { id?: unknown; name?: unknown } }> | undefined,
+  ): Array<{ id: string; name: string }> =>
+    (edges ?? [])
+      .map((e) => e.node)
+      .filter((n): n is { id: string; name: string } => typeof n?.id === "string")
+      .map((n) => ({ id: n.id, name: typeof n.name === "string" ? n.name : n.id }));
+  return {
+    ok: true,
+    environments: nodes(result.data.project?.environments?.edges),
+    services: nodes(result.data.project?.services?.edges),
+  };
+}
+
+export async function fetchViewer(input: {
+  accessToken: string;
+  fetchImpl?: FetchImpl;
+}): Promise<
+  | { ok: true; viewer: { id: string; name: string | null; email: string | null } }
+  | { ok: false; error: string }
+> {
+  const result = await railwayGraphQL<{
+    me: { id?: unknown; name?: unknown; email?: unknown } | null;
+  }>({ ...input, query: `query { me { id name email } }` });
+  if (!result.ok) return { ok: false, error: result.error };
+  const me = result.data.me;
+  if (typeof me?.id !== "string" || !me.id) return { ok: false, error: "no_viewer" };
+  return {
+    ok: true,
+    viewer: {
+      id: me.id,
+      name: typeof me.name === "string" ? me.name : null,
+      email: typeof me.email === "string" ? me.email : null,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry reads
+// ---------------------------------------------------------------------------
+
+export type RailwayLog = {
+  timestamp: string;
+  severity: string | null;
+  message: string;
+  tags: {
+    projectId?: string | null;
+    environmentId?: string | null;
+    serviceId?: string | null;
+    deploymentId?: string | null;
+    deploymentInstanceId?: string | null;
+    snapshotId?: string | null;
+  } | null;
+  attributes: Array<{ key: string; value: string }>;
+};
+
+export const ENVIRONMENT_LOGS_SELECTION = `
+  timestamp severity message
+  tags { projectId environmentId serviceId deploymentId deploymentInstanceId snapshotId }
+  attributes { key value }
+`;
+
+export async function fetchEnvironmentLogs(input: {
+  accessToken: string;
+  environmentId: string;
+  /** Exclusive-ish lower bound; callers still dedupe against their cursor. */
+  afterDate?: string;
+  /** Anchor for a backwards read of the most recent lines (first pull). */
+  anchorDate?: string;
+  limit: number;
+  filter?: string;
+  fetchImpl?: FetchImpl;
+}): Promise<{ ok: true; logs: RailwayLog[] } | { ok: false; error: string }> {
+  const backwards = !input.afterDate;
+  const result = await railwayGraphQL<{ environmentLogs: RailwayLog[] }>({
+    accessToken: input.accessToken,
+    fetchImpl: input.fetchImpl,
+    query: backwards
+      ? `query ($environmentId: String!, $filter: String!, $anchorDate: String!, $beforeLimit: Int!) {
+          environmentLogs(environmentId: $environmentId, filter: $filter, anchorDate: $anchorDate, beforeLimit: $beforeLimit) { ${ENVIRONMENT_LOGS_SELECTION} }
+        }`
+      : `query ($environmentId: String!, $filter: String!, $afterDate: String!, $afterLimit: Int!) {
+          environmentLogs(environmentId: $environmentId, filter: $filter, afterDate: $afterDate, afterLimit: $afterLimit) { ${ENVIRONMENT_LOGS_SELECTION} }
+        }`,
+    variables: backwards
+      ? {
+          environmentId: input.environmentId,
+          filter: input.filter ?? "",
+          anchorDate: input.anchorDate ?? new Date().toISOString(),
+          beforeLimit: input.limit,
+        }
+      : {
+          environmentId: input.environmentId,
+          filter: input.filter ?? "",
+          afterDate: input.afterDate,
+          afterLimit: input.limit,
+        },
+  });
+  if (!result.ok) return { ok: false, error: result.error };
+  return {
+    ok: true,
+    logs: Array.isArray(result.data.environmentLogs) ? result.data.environmentLogs : [],
+  };
+}
+
+export type RailwayMetricsResult = {
+  measurement: string;
+  values: Array<{ ts: number; value: number }>;
+  tags: { serviceId?: string | null } & Record<string, unknown>;
+};
+
+/** The infra measurements the connector forwards. */
+export const RAILWAY_MEASUREMENTS = [
+  "CPU_USAGE",
+  "MEMORY_USAGE_GB",
+  "NETWORK_RX_GB",
+  "NETWORK_TX_GB",
+  "DISK_USAGE_GB",
+] as const;
+
+export async function fetchServiceMetrics(input: {
+  accessToken: string;
+  environmentId: string;
+  serviceId: string;
+  startDate: string;
+  endDate: string;
+  sampleRateSeconds: number;
+  fetchImpl?: FetchImpl;
+}): Promise<{ ok: true; results: RailwayMetricsResult[] } | { ok: false; error: string }> {
+  const result = await railwayGraphQL<{ metrics: RailwayMetricsResult[] }>({
+    accessToken: input.accessToken,
+    fetchImpl: input.fetchImpl,
+    query: `query ($environmentId: String!, $serviceId: String!, $startDate: DateTime!, $endDate: DateTime!, $sampleRateSeconds: Int!, $measurements: [MetricMeasurement!]!) {
+      metrics(environmentId: $environmentId, serviceId: $serviceId, startDate: $startDate, endDate: $endDate, sampleRateSeconds: $sampleRateSeconds, measurements: $measurements) {
+        measurement
+        values { ts value }
+        tags { serviceId }
+      }
+    }`,
+    variables: {
+      environmentId: input.environmentId,
+      serviceId: input.serviceId,
+      startDate: input.startDate,
+      endDate: input.endDate,
+      sampleRateSeconds: input.sampleRateSeconds,
+      measurements: [...RAILWAY_MEASUREMENTS],
+    },
+  });
+  if (!result.ok) return { ok: false, error: result.error };
+  return { ok: true, results: Array.isArray(result.data.metrics) ? result.data.metrics : [] };
+}

--- a/packages/railway/src/index.ts
+++ b/packages/railway/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./oauth.js";
+export * from "./graphql.js";
+export * from "./transform.js";

--- a/packages/railway/src/oauth.test.ts
+++ b/packages/railway/src/oauth.test.ts
@@ -1,0 +1,145 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import {
+  RAILWAY_OAUTH_AUTH_URL,
+  RAILWAY_OAUTH_SCOPES,
+  RAILWAY_OAUTH_TOKEN_URL,
+  buildAuthorizeUrl,
+  decodeIdTokenSub,
+  exchangeCodeForToken,
+  parseTokenResponse,
+  railwayConfigFromEnv,
+  refreshAccessToken,
+} from "./oauth.js";
+
+test("railwayConfigFromEnv returns null until client id + secret are set", () => {
+  assert.equal(railwayConfigFromEnv({}), null);
+  assert.equal(railwayConfigFromEnv({ RAILWAY_CLIENT_ID: "id" }), null);
+  const cfg = railwayConfigFromEnv({
+    RAILWAY_CLIENT_ID: "id",
+    RAILWAY_CLIENT_SECRET: "secret",
+  });
+  assert.ok(cfg);
+  assert.equal(cfg.clientId, "id");
+  assert.equal(cfg.redirectUri, "http://localhost:4100/railway/oauth/callback");
+  const custom = railwayConfigFromEnv({
+    RAILWAY_CLIENT_ID: "id",
+    RAILWAY_CLIENT_SECRET: "secret",
+    RAILWAY_OAUTH_REDIRECT_URL: "https://api.example.com/railway/oauth/callback",
+  });
+  assert.equal(custom?.redirectUri, "https://api.example.com/railway/oauth/callback");
+});
+
+test("buildAuthorizeUrl requests resource scopes and forces the consent screen", () => {
+  const url = new URL(
+    buildAuthorizeUrl({
+      clientId: "cid",
+      redirectUri: "https://api.example.com/railway/oauth/callback",
+      state: "signed-state",
+    }),
+  );
+  assert.equal(`${url.origin}${url.pathname}`, RAILWAY_OAUTH_AUTH_URL);
+  assert.equal(url.searchParams.get("client_id"), "cid");
+  assert.equal(url.searchParams.get("response_type"), "code");
+  assert.equal(url.searchParams.get("state"), "signed-state");
+  assert.equal(url.searchParams.get("scope"), RAILWAY_OAUTH_SCOPES);
+  // Railway silently drops `offline_access` (no refresh token!) unless the
+  // consent screen is forced.
+  assert.equal(url.searchParams.get("prompt"), "consent");
+  // The grant must include the project picker scope, and offline_access so the
+  // puller can refresh past the 1h access-token expiry.
+  assert.ok(RAILWAY_OAUTH_SCOPES.includes("project:viewer"));
+  assert.ok(RAILWAY_OAUTH_SCOPES.includes("offline_access"));
+});
+
+test("parseTokenResponse extracts tokens, expiry and scope", () => {
+  const parsed = parseTokenResponse({
+    access_token: "at",
+    refresh_token: "rt",
+    expires_in: 3600,
+    scope: "openid email profile offline_access project:viewer",
+    token_type: "Bearer",
+  });
+  assert.ok(parsed.ok);
+  assert.equal(parsed.accessToken, "at");
+  assert.equal(parsed.refreshToken, "rt");
+  assert.equal(parsed.expiresInSeconds, 3600);
+  assert.ok(parsed.scope?.includes("project:viewer"));
+});
+
+test("parseTokenResponse tolerates a missing refresh token but not a missing access token", () => {
+  const noRefresh = parseTokenResponse({ access_token: "at", expires_in: 3600 });
+  assert.ok(noRefresh.ok);
+  assert.equal(noRefresh.refreshToken, null);
+
+  const bad = parseTokenResponse({ error: "invalid_grant" });
+  assert.ok(!bad.ok);
+  assert.equal(bad.error, "invalid_grant");
+  assert.ok(!parseTokenResponse(null).ok);
+  assert.ok(!parseTokenResponse({}).ok);
+});
+
+test("decodeIdTokenSub reads the sub claim without verifying (direct-channel response)", () => {
+  const claims = Buffer.from(JSON.stringify({ sub: "user-123" }), "utf8").toString("base64url");
+  assert.equal(decodeIdTokenSub(`header.${claims}.sig`), "user-123");
+  assert.equal(decodeIdTokenSub("garbage"), null);
+  assert.equal(decodeIdTokenSub(undefined), null);
+});
+
+test("exchangeCodeForToken posts the code with client credentials", async () => {
+  const captured = { url: "", body: new URLSearchParams() };
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    captured.url = String(url);
+    captured.body = new URLSearchParams(String(init?.body));
+    return new Response(
+      JSON.stringify({ access_token: "at", refresh_token: "rt", expires_in: 3600 }),
+      { status: 200 },
+    );
+  }) as typeof fetch;
+
+  const result = await exchangeCodeForToken({
+    config: { clientId: "cid", clientSecret: "cs", redirectUri: "https://r" },
+    code: "the-code",
+    fetchImpl,
+  });
+  assert.ok(result.ok);
+  assert.equal(captured.url, RAILWAY_OAUTH_TOKEN_URL);
+  assert.equal(captured.body.get("grant_type"), "authorization_code");
+  assert.equal(captured.body.get("code"), "the-code");
+  assert.equal(captured.body.get("client_id"), "cid");
+  assert.equal(captured.body.get("client_secret"), "cs");
+  assert.equal(captured.body.get("redirect_uri"), "https://r");
+});
+
+test("refreshAccessToken posts the rotating refresh token", async () => {
+  let captured = new URLSearchParams();
+  const fetchImpl = (async (_url: string | URL | Request, init?: RequestInit) => {
+    captured = new URLSearchParams(String(init?.body));
+    return new Response(
+      JSON.stringify({ access_token: "at2", refresh_token: "rt2", expires_in: 3600 }),
+      { status: 200 },
+    );
+  }) as typeof fetch;
+
+  const result = await refreshAccessToken({
+    config: { clientId: "cid", clientSecret: "cs", redirectUri: "https://r" },
+    refreshToken: "rt1",
+    fetchImpl,
+  });
+  assert.ok(result.ok);
+  assert.equal(result.accessToken, "at2");
+  // Rotation: the new refresh token replaces the old one and must be persisted.
+  assert.equal(result.refreshToken, "rt2");
+  assert.equal(captured.get("grant_type"), "refresh_token");
+  assert.equal(captured.get("refresh_token"), "rt1");
+});
+
+test("exchangeCodeForToken reports non-OK statuses even with an unparseable body", async () => {
+  const fetchImpl = (async () => new Response("nope", { status: 500 })) as typeof fetch;
+  const result = await exchangeCodeForToken({
+    config: { clientId: "cid", clientSecret: "cs", redirectUri: "https://r" },
+    code: "c",
+    fetchImpl,
+  });
+  assert.ok(!result.ok);
+});

--- a/packages/railway/src/oauth.ts
+++ b/packages/railway/src/oauth.ts
@@ -1,0 +1,166 @@
+// "Login with Railway" OAuth 2.0 client. Railway has no drain/export product,
+// so unlike the Vercel connector nothing is provisioned on Railway's side at
+// connect time: the OAuth grant itself *is* the integration — a `project:viewer`
+// token the worker-side puller uses to read logs and metrics from the granted
+// projects via the GraphQL API.
+//
+// Endpoints (from Railway's OAuth docs):
+//   authorize: https://backboard.railway.com/oauth/auth
+//   token:     https://backboard.railway.com/oauth/token
+//
+// Token model: access tokens expire after ~1h; refresh tokens rotate on every
+// use (persist the replacement immediately) and live ~1 year. Two consent
+// gotchas discovered empirically: unknown scopes are dropped *silently*, and
+// `offline_access` is only honored when `prompt=consent` forces the consent
+// screen — without it the response simply has no refresh token.
+//
+// This module is deliberately IO-light (pure functions + injectable fetch),
+// mirroring the Vercel/Cloudflare connector services.
+
+export const RAILWAY_OAUTH_AUTH_URL = "https://backboard.railway.com/oauth/auth";
+export const RAILWAY_OAUTH_TOKEN_URL = "https://backboard.railway.com/oauth/token";
+
+// `project:viewer` puts a project picker on the consent screen and grants
+// read access to exactly the projects the user selects — logs and metrics
+// included. `offline_access` gets the refresh token the puller lives on.
+export const RAILWAY_OAUTH_SCOPES = "openid email profile offline_access project:viewer";
+
+export type FetchImpl = typeof fetch;
+
+export type RailwayOAuthConfig = {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+};
+
+/** Read connector config from env; null (→ feature disabled) when unconfigured. */
+export function railwayConfigFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): RailwayOAuthConfig | null {
+  const clientId = env.RAILWAY_CLIENT_ID;
+  const clientSecret = env.RAILWAY_CLIENT_SECRET;
+  if (!clientId || !clientSecret) return null;
+  return {
+    clientId,
+    clientSecret,
+    redirectUri:
+      env.RAILWAY_OAUTH_REDIRECT_URL ?? "http://localhost:4100/railway/oauth/callback",
+  };
+}
+
+export function buildAuthorizeUrl(input: {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+}): string {
+  const url = new URL(RAILWAY_OAUTH_AUTH_URL);
+  url.searchParams.set("client_id", input.clientId);
+  url.searchParams.set("redirect_uri", input.redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", RAILWAY_OAUTH_SCOPES);
+  // Force the consent screen: it's where the user picks projects, and Railway
+  // only issues a refresh token when consent is (re-)prompted.
+  url.searchParams.set("prompt", "consent");
+  url.searchParams.set("state", input.state);
+  return url.toString();
+}
+
+export type RailwayTokenResult =
+  | {
+      ok: true;
+      accessToken: string;
+      /** Null when the grant lacked offline_access — the install then degrades at expiry. */
+      refreshToken: string | null;
+      expiresInSeconds: number | null;
+      scope: string | null;
+      /** OIDC id_token, when present — carries the user's `sub`. */
+      idToken: string | null;
+    }
+  | { ok: false; error: string };
+
+export function parseTokenResponse(json: unknown): RailwayTokenResult {
+  if (!json || typeof json !== "object") return { ok: false, error: "invalid_response" };
+  const o = json as Record<string, unknown>;
+  if (typeof o.error === "string") return { ok: false, error: o.error };
+  if (typeof o.access_token !== "string" || !o.access_token) {
+    return { ok: false, error: "no_access_token" };
+  }
+  return {
+    ok: true,
+    accessToken: o.access_token,
+    refreshToken: typeof o.refresh_token === "string" && o.refresh_token ? o.refresh_token : null,
+    expiresInSeconds:
+      typeof o.expires_in === "number" && Number.isFinite(o.expires_in) ? o.expires_in : null,
+    scope: typeof o.scope === "string" ? o.scope : null,
+    idToken: typeof o.id_token === "string" && o.id_token ? o.id_token : null,
+  };
+}
+
+/**
+ * Read the `sub` claim out of an id_token without signature verification —
+ * acceptable here because the token arrives over the direct TLS channel from
+ * Railway's token endpoint, not from the browser.
+ */
+export function decodeIdTokenSub(idToken: string | null | undefined): string | null {
+  if (!idToken) return null;
+  const payload = idToken.split(".")[1];
+  if (!payload) return null;
+  try {
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Record<
+      string,
+      unknown
+    >;
+    return typeof claims.sub === "string" && claims.sub ? claims.sub : null;
+  } catch {
+    return null;
+  }
+}
+
+async function postTokenRequest(
+  body: URLSearchParams,
+  fetchImpl: FetchImpl,
+): Promise<RailwayTokenResult> {
+  const res = await fetchImpl(RAILWAY_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  const json = await res.json().catch(() => null);
+  const parsed = parseTokenResponse(json);
+  // A non-OK status with an unparseable body still must not read as success.
+  if (!res.ok && parsed.ok) return { ok: false, error: `status_${res.status}` };
+  return parsed;
+}
+
+export async function exchangeCodeForToken(input: {
+  config: RailwayOAuthConfig;
+  code: string;
+  fetchImpl?: FetchImpl;
+}): Promise<RailwayTokenResult> {
+  return postTokenRequest(
+    new URLSearchParams({
+      grant_type: "authorization_code",
+      code: input.code,
+      redirect_uri: input.config.redirectUri,
+      client_id: input.config.clientId,
+      client_secret: input.config.clientSecret,
+    }),
+    input.fetchImpl ?? fetch,
+  );
+}
+
+export async function refreshAccessToken(input: {
+  config: RailwayOAuthConfig;
+  refreshToken: string;
+  fetchImpl?: FetchImpl;
+}): Promise<RailwayTokenResult> {
+  return postTokenRequest(
+    new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: input.refreshToken,
+      client_id: input.config.clientId,
+      client_secret: input.config.clientSecret,
+    }),
+    input.fetchImpl ?? fetch,
+  );
+}

--- a/packages/railway/src/oauth.ts
+++ b/packages/railway/src/oauth.ts
@@ -43,8 +43,7 @@ export function railwayConfigFromEnv(
   return {
     clientId,
     clientSecret,
-    redirectUri:
-      env.RAILWAY_OAUTH_REDIRECT_URL ?? "http://localhost:4100/railway/oauth/callback",
+    redirectUri: env.RAILWAY_OAUTH_REDIRECT_URL ?? "http://localhost:4100/railway/oauth/callback",
   };
 }
 

--- a/packages/railway/src/oauth.ts
+++ b/packages/railway/src/oauth.ts
@@ -43,7 +43,9 @@ export function railwayConfigFromEnv(
   return {
     clientId,
     clientSecret,
-    redirectUri: env.RAILWAY_OAUTH_REDIRECT_URL ?? "http://localhost:4100/railway/oauth/callback",
+    // `||` so a blank value (e.g. an uncommented `.env.example` line) falls
+    // back too, not just an unset one.
+    redirectUri: env.RAILWAY_OAUTH_REDIRECT_URL || "http://localhost:4100/railway/oauth/callback",
   };
 }
 

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -1,0 +1,143 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import {
+  advanceLogCursor,
+  advanceMetricsCursor,
+  filterLogsAfterCursor,
+  filterMetricsAfterCursor,
+  railwayLogsToOtlp,
+  railwayMetricsToOtlp,
+  rfc3339ToNanos,
+} from "./transform.js";
+
+const NAMES = {
+  serviceNamesById: { "svc-1": "blackbird-app" },
+  projectName: "blackbird",
+  projectId: "proj-1",
+  environmentName: "production",
+  environmentId: "env-1",
+};
+
+const LOG = {
+  timestamp: "2026-07-07T14:10:31.058154105Z",
+  severity: "info",
+  message: "--> GET / \u001b[32m200\u001b[0m 1ms",
+  tags: {
+    projectId: "proj-1",
+    environmentId: "env-1",
+    serviceId: "svc-1",
+    deploymentId: "dep-1",
+    deploymentInstanceId: "inst-1",
+    snapshotId: null,
+  },
+  attributes: [{ key: "level", value: "info" }],
+};
+
+test("rfc3339ToNanos keeps sub-millisecond precision", () => {
+  assert.equal(rfc3339ToNanos("2026-07-07T14:10:31.058154105Z"), 1783433431058154105n);
+  assert.equal(rfc3339ToNanos("2026-07-07T14:10:31Z"), 1783433431000000000n);
+  assert.equal(rfc3339ToNanos("garbage"), null);
+});
+
+test("railwayLogsToOtlp maps a Railway log line to an OTLP log record", () => {
+  const out = railwayLogsToOtlp([LOG], NAMES);
+  assert.equal(out.resourceLogs.length, 1);
+  const rl = out.resourceLogs[0]!;
+  const resourceAttrs = Object.fromEntries(
+    rl.resource.attributes.map((a) => [a.key, a.value.stringValue]),
+  );
+  assert.equal(resourceAttrs["service.name"], "blackbird-app");
+  assert.equal(resourceAttrs["telemetry.source"], "railway");
+  assert.equal(resourceAttrs["railway.project_name"], "blackbird");
+  assert.equal(resourceAttrs["railway.environment_name"], "production");
+
+  const record = rl.scopeLogs[0]!.logRecords[0]!;
+  assert.equal(record.timeUnixNano, "1783433431058154105");
+  assert.equal(record.severityText, "INFO");
+  assert.equal(record.severityNumber, 9);
+  // ANSI escapes are stripped from the body.
+  assert.equal(record.body.stringValue, "--> GET / 200 1ms");
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["railway.deployment_id"], "dep-1");
+});
+
+test("railwayLogsToOtlp falls back to a railway service name when unmapped", () => {
+  const out = railwayLogsToOtlp(
+    [{ ...LOG, tags: { ...LOG.tags, serviceId: "unknown-svc" } }],
+    NAMES,
+  );
+  const attrs = Object.fromEntries(
+    out.resourceLogs[0]!.resource.attributes.map((a) => [a.key, a.value.stringValue]),
+  );
+  assert.equal(attrs["service.name"], "railway");
+});
+
+test("log cursor advances to the max timestamp and filters replays", () => {
+  const older = { ...LOG, timestamp: "2026-07-07T14:10:30Z" };
+  const cursor = advanceLogCursor({}, "env-1", [older, LOG]);
+  assert.equal(cursor["env-1"], "2026-07-07T14:10:31.058154105Z");
+
+  // Re-delivery of already-forwarded lines is dropped.
+  const fresh = filterLogsAfterCursor(cursor, "env-1", [older, LOG]);
+  assert.equal(fresh.length, 0);
+  const newer = { ...LOG, timestamp: "2026-07-07T14:10:32Z" };
+  assert.deepEqual(filterLogsAfterCursor(cursor, "env-1", [older, newer]), [newer]);
+  // A cursor never moves backwards.
+  const stale = advanceLogCursor(cursor, "env-1", [older]);
+  assert.equal(stale["env-1"], "2026-07-07T14:10:31.058154105Z");
+});
+
+test("railwayMetricsToOtlp maps measurements to gauges with railway names", () => {
+  const out = railwayMetricsToOtlp(
+    [
+      {
+        measurement: "CPU_USAGE",
+        values: [{ ts: 1783436400, value: 0.25 }],
+        tags: { serviceId: "svc-1" },
+      },
+      {
+        measurement: "MEMORY_USAGE_GB",
+        values: [{ ts: 1783436400, value: 0.135 }],
+        tags: { serviceId: "svc-1" },
+      },
+    ],
+    NAMES,
+  );
+  assert.equal(out.resourceMetrics.length, 1);
+  const rm = out.resourceMetrics[0]!;
+  const resourceAttrs = Object.fromEntries(
+    rm.resource.attributes.map((a) => [a.key, a.value.stringValue]),
+  );
+  assert.equal(resourceAttrs["service.name"], "blackbird-app");
+  assert.equal(resourceAttrs["telemetry.source"], "railway");
+
+  const metrics = rm.scopeMetrics[0]!.metrics;
+  assert.deepEqual(
+    metrics.map((m) => m.name),
+    ["railway.cpu.usage", "railway.memory.usage"],
+  );
+  const cpu = metrics[0]!;
+  assert.equal(cpu.unit, "{vCPU}");
+  assert.equal(cpu.gauge.dataPoints[0]!.timeUnixNano, "1783436400000000000");
+  assert.equal(cpu.gauge.dataPoints[0]!.asDouble, 0.25);
+});
+
+test("metrics cursor drops already-forwarded samples per service", () => {
+  const results = [
+    {
+      measurement: "CPU_USAGE",
+      values: [
+        { ts: 100, value: 1 },
+        { ts: 200, value: 2 },
+      ],
+      tags: { serviceId: "svc-1" },
+    },
+  ];
+  const filtered = filterMetricsAfterCursor({ "svc-1": 100 }, "svc-1", results);
+  assert.deepEqual(filtered[0]!.values, [{ ts: 200, value: 2 }]);
+
+  const cursor = advanceMetricsCursor({ "svc-1": 100 }, "svc-1", results);
+  assert.equal(cursor["svc-1"], 200);
+  // Empty results keep the cursor untouched.
+  assert.equal(advanceMetricsCursor(cursor, "svc-1", [])["svc-1"], 200);
+});

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -10,6 +10,13 @@ import {
   rfc3339ToNanos,
 } from "./transform.js";
 
+// Index into an array with narrowing (strict indexing forbids bare [0]).
+function at<T>(items: readonly T[] | undefined, index: number): T {
+  const item = items?.[index];
+  assert.ok(item !== undefined, `expected item at index ${index}`);
+  return item;
+}
+
 const NAMES = {
   serviceNamesById: { "svc-1": "blackbird-app" },
   projectName: "blackbird",
@@ -42,7 +49,7 @@ test("rfc3339ToNanos keeps sub-millisecond precision", () => {
 test("railwayLogsToOtlp maps a Railway log line to an OTLP log record", () => {
   const out = railwayLogsToOtlp([LOG], NAMES);
   assert.equal(out.resourceLogs.length, 1);
-  const rl = out.resourceLogs[0]!;
+  const rl = at(out.resourceLogs, 0);
   const resourceAttrs = Object.fromEntries(
     rl.resource.attributes.map((a) => [a.key, a.value.stringValue]),
   );
@@ -51,7 +58,7 @@ test("railwayLogsToOtlp maps a Railway log line to an OTLP log record", () => {
   assert.equal(resourceAttrs["railway.project_name"], "blackbird");
   assert.equal(resourceAttrs["railway.environment_name"], "production");
 
-  const record = rl.scopeLogs[0]!.logRecords[0]!;
+  const record = at(at(rl.scopeLogs, 0).logRecords, 0);
   assert.equal(record.timeUnixNano, "1783433431058154105");
   assert.equal(record.severityText, "INFO");
   assert.equal(record.severityNumber, 9);
@@ -67,7 +74,7 @@ test("railwayLogsToOtlp falls back to a railway service name when unmapped", () 
     NAMES,
   );
   const attrs = Object.fromEntries(
-    out.resourceLogs[0]!.resource.attributes.map((a) => [a.key, a.value.stringValue]),
+    at(out.resourceLogs, 0).resource.attributes.map((a) => [a.key, a.value.stringValue]),
   );
   assert.equal(attrs["service.name"], "railway");
 });
@@ -104,22 +111,22 @@ test("railwayMetricsToOtlp maps measurements to gauges with railway names", () =
     NAMES,
   );
   assert.equal(out.resourceMetrics.length, 1);
-  const rm = out.resourceMetrics[0]!;
+  const rm = at(out.resourceMetrics, 0);
   const resourceAttrs = Object.fromEntries(
     rm.resource.attributes.map((a) => [a.key, a.value.stringValue]),
   );
   assert.equal(resourceAttrs["service.name"], "blackbird-app");
   assert.equal(resourceAttrs["telemetry.source"], "railway");
 
-  const metrics = rm.scopeMetrics[0]!.metrics;
+  const metrics = at(rm.scopeMetrics, 0).metrics;
   assert.deepEqual(
     metrics.map((m) => m.name),
     ["railway.cpu.usage", "railway.memory.usage"],
   );
-  const cpu = metrics[0]!;
+  const cpu = at(metrics, 0);
   assert.equal(cpu.unit, "{vCPU}");
-  assert.equal(cpu.gauge.dataPoints[0]!.timeUnixNano, "1783436400000000000");
-  assert.equal(cpu.gauge.dataPoints[0]!.asDouble, 0.25);
+  assert.equal(at(cpu.gauge.dataPoints, 0).timeUnixNano, "1783436400000000000");
+  assert.equal(at(cpu.gauge.dataPoints, 0).asDouble, 0.25);
 });
 
 test("metrics cursor drops already-forwarded samples per service", () => {
@@ -134,7 +141,7 @@ test("metrics cursor drops already-forwarded samples per service", () => {
     },
   ];
   const filtered = filterMetricsAfterCursor({ "svc-1": 100 }, "svc-1", results);
-  assert.deepEqual(filtered[0]!.values, [{ ts: 200, value: 2 }]);
+  assert.deepEqual(at(filtered, 0).values, [{ ts: 200, value: 2 }]);
 
   const cursor = advanceMetricsCursor({ "svc-1": 100 }, "svc-1", results);
   assert.equal(cursor["svc-1"], 200);

--- a/packages/railway/src/transform.ts
+++ b/packages/railway/src/transform.ts
@@ -1,0 +1,278 @@
+// Railway → OTLP transforms plus the puller's cursor arithmetic. Pure
+// functions only; the worker-side puller wires them to IO. The OTLP JSON
+// shapes mirror the Vercel log-drain adapter's.
+
+import type { RailwayLog, RailwayMetricsResult } from "./graphql.js";
+
+type OtlpAnyValue = {
+  stringValue?: string;
+  intValue?: string;
+  doubleValue?: number;
+  boolValue?: boolean;
+};
+
+type OtlpKeyValue = { key: string; value: OtlpAnyValue };
+
+export type RailwayOtlpLogsExport = {
+  resourceLogs: Array<{
+    resource: { attributes: OtlpKeyValue[] };
+    scopeLogs: Array<{
+      scope: { name: string };
+      logRecords: Array<{
+        timeUnixNano: string;
+        observedTimeUnixNano: string;
+        severityText: string;
+        severityNumber: number;
+        body: OtlpAnyValue;
+        attributes: OtlpKeyValue[];
+      }>;
+    }>;
+  }>;
+};
+
+export type RailwayOtlpMetricsExport = {
+  resourceMetrics: Array<{
+    resource: { attributes: OtlpKeyValue[] };
+    scopeMetrics: Array<{
+      scope: { name: string };
+      metrics: Array<{
+        name: string;
+        unit: string;
+        gauge: { dataPoints: Array<{ timeUnixNano: string; asDouble: number }> };
+      }>;
+    }>;
+  }>;
+};
+
+/** Names resolved from inventory so telemetry is labeled, not just id-tagged. */
+export type RailwayNameContext = {
+  serviceNamesById: Record<string, string>;
+  projectId: string;
+  projectName: string;
+  environmentId: string;
+  environmentName: string;
+};
+
+const SEVERITY: Record<string, { text: string; number: number }> = {
+  trace: { text: "TRACE", number: 1 },
+  debug: { text: "DEBUG", number: 5 },
+  info: { text: "INFO", number: 9 },
+  warning: { text: "WARN", number: 13 },
+  warn: { text: "WARN", number: 13 },
+  error: { text: "ERROR", number: 17 },
+  fatal: { text: "FATAL", number: 21 },
+};
+
+/**
+ * RFC3339 → epoch nanos as bigint, preserving Railway's sub-millisecond
+ * precision (Date.parse alone truncates to ms). Null on unparseable input.
+ */
+export function rfc3339ToNanos(timestamp: string): bigint | null {
+  const match = timestamp.match(/^(.*?)(?:\.(\d{1,9}))?(Z|[+-]\d\d:\d\d)$/);
+  if (!match) return null;
+  const [, base, fraction, zone] = match;
+  const ms = Date.parse(`${base}${zone}`);
+  if (!Number.isFinite(ms)) return null;
+  const nanosFraction = BigInt((fraction ?? "").padEnd(9, "0") || "0");
+  return BigInt(ms) * 1_000_000n - (BigInt(ms % 1000) * 1_000_000n) + nanosFraction;
+}
+
+// Strip ANSI color/control sequences Railway passes through from app stdout.
+// Control-char regex is intentional here.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes start with ESC (\u001b)
+const ANSI_PATTERN = /\u001b\[[0-9;]*[A-Za-z]/g;
+
+export function stripAnsi(value: string): string {
+  return value.replace(ANSI_PATTERN, "");
+}
+
+export function railwayLogsToOtlp(
+  logs: RailwayLog[],
+  ctx: RailwayNameContext,
+): RailwayOtlpLogsExport {
+  return {
+    resourceLogs: logs.map((log) => {
+      const serviceId = log.tags?.serviceId ?? null;
+      const serviceName = (serviceId && ctx.serviceNamesById[serviceId]) || "railway";
+      const nanos = rfc3339ToNanos(log.timestamp) ?? 0n;
+      return {
+        resource: {
+          attributes: [
+            kv("service.name", serviceName),
+            kv("telemetry.source", "railway"),
+            kv("railway.project_id", ctx.projectId),
+            kv("railway.project_name", ctx.projectName),
+            kv("railway.environment_id", ctx.environmentId),
+            kv("railway.environment_name", ctx.environmentName),
+            kv("railway.service_id", serviceId),
+          ].filter(isKv),
+        },
+        scopeLogs: [
+          {
+            scope: { name: "railway.pull.logs" },
+            logRecords: [
+              {
+                timeUnixNano: nanos.toString(),
+                observedTimeUnixNano: nanos.toString(),
+                ...severity(log.severity),
+                body: { stringValue: stripAnsi(log.message) },
+                attributes: [
+                  kv("railway.deployment_id", log.tags?.deploymentId),
+                  kv("railway.deployment_instance_id", log.tags?.deploymentInstanceId),
+                  kv("railway.snapshot_id", log.tags?.snapshotId),
+                  ...log.attributes.map((a) => kv(`railway.attr.${a.key}`, a.value)),
+                ].filter(isKv),
+              },
+            ],
+          },
+        ],
+      };
+    }),
+  };
+}
+
+// measurement → OTLP gauge name + unit. Values arrive in Railway's units
+// (vCPU cores, gigabytes); forwarded as-is with explicit units.
+const MEASUREMENT_METRICS: Record<string, { name: string; unit: string }> = {
+  CPU_USAGE: { name: "railway.cpu.usage", unit: "{vCPU}" },
+  CPU_LIMIT: { name: "railway.cpu.limit", unit: "{vCPU}" },
+  MEMORY_USAGE_GB: { name: "railway.memory.usage", unit: "GBy" },
+  MEMORY_LIMIT_GB: { name: "railway.memory.limit", unit: "GBy" },
+  NETWORK_RX_GB: { name: "railway.network.rx", unit: "GBy" },
+  NETWORK_TX_GB: { name: "railway.network.tx", unit: "GBy" },
+  DISK_USAGE_GB: { name: "railway.disk.usage", unit: "GBy" },
+  EPHEMERAL_DISK_USAGE_GB: { name: "railway.ephemeral_disk.usage", unit: "GBy" },
+};
+
+export function railwayMetricsToOtlp(
+  results: RailwayMetricsResult[],
+  ctx: RailwayNameContext & { serviceId?: string },
+): RailwayOtlpMetricsExport {
+  const serviceId = ctx.serviceId ?? results.find((r) => r.tags?.serviceId)?.tags?.serviceId ?? null;
+  const serviceName = (serviceId && ctx.serviceNamesById[serviceId]) || "railway";
+  const metrics = results
+    .map((result) => {
+      const mapped = MEASUREMENT_METRICS[result.measurement];
+      if (!mapped || result.values.length === 0) return null;
+      return {
+        name: mapped.name,
+        unit: mapped.unit,
+        gauge: {
+          dataPoints: result.values.map((v) => ({
+            timeUnixNano: `${BigInt(Math.trunc(v.ts)) * 1_000_000_000n}`,
+            asDouble: v.value,
+          })),
+        },
+      };
+    })
+    .filter((m): m is NonNullable<typeof m> => m !== null);
+  if (metrics.length === 0) return { resourceMetrics: [] };
+  return {
+    resourceMetrics: [
+      {
+        resource: {
+          attributes: [
+            kv("service.name", serviceName),
+            kv("telemetry.source", "railway"),
+            kv("railway.project_id", ctx.projectId),
+            kv("railway.project_name", ctx.projectName),
+            kv("railway.environment_id", ctx.environmentId),
+            kv("railway.environment_name", ctx.environmentName),
+            kv("railway.service_id", serviceId),
+          ].filter(isKv),
+        },
+        scopeMetrics: [{ scope: { name: "railway.pull.metrics" }, metrics }],
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cursors — dedupe on re-delivery (subscription reconnects replay the last
+// line; afterDate bounds are not trusted to be exclusive) and never move
+// backwards.
+// ---------------------------------------------------------------------------
+
+export function filterLogsAfterCursor(
+  cursor: Record<string, string>,
+  environmentId: string,
+  logs: RailwayLog[],
+): RailwayLog[] {
+  const last = cursor[environmentId];
+  if (!last) return logs;
+  const lastNanos = rfc3339ToNanos(last);
+  if (lastNanos === null) return logs;
+  return logs.filter((log) => {
+    const nanos = rfc3339ToNanos(log.timestamp);
+    return nanos !== null && nanos > lastNanos;
+  });
+}
+
+export function advanceLogCursor(
+  cursor: Record<string, string>,
+  environmentId: string,
+  logs: RailwayLog[],
+): Record<string, string> {
+  let maxTimestamp = cursor[environmentId] ?? null;
+  let maxNanos = maxTimestamp ? rfc3339ToNanos(maxTimestamp) : null;
+  for (const log of logs) {
+    const nanos = rfc3339ToNanos(log.timestamp);
+    if (nanos === null) continue;
+    if (maxNanos === null || nanos > maxNanos) {
+      maxNanos = nanos;
+      maxTimestamp = log.timestamp;
+    }
+  }
+  if (maxTimestamp == null) return cursor;
+  return { ...cursor, [environmentId]: maxTimestamp };
+}
+
+export function filterMetricsAfterCursor(
+  cursor: Record<string, number>,
+  serviceId: string,
+  results: RailwayMetricsResult[],
+): RailwayMetricsResult[] {
+  const last = cursor[serviceId];
+  if (last === undefined) return results;
+  return results
+    .map((r) => ({ ...r, values: r.values.filter((v) => v.ts > last) }))
+    .filter((r) => r.values.length > 0);
+}
+
+export function advanceMetricsCursor(
+  cursor: Record<string, number>,
+  serviceId: string,
+  results: RailwayMetricsResult[],
+): Record<string, number> {
+  let max = cursor[serviceId] ?? null;
+  for (const r of results) {
+    for (const v of r.values) {
+      if (max === null || v.ts > max) max = v.ts;
+    }
+  }
+  if (max == null) return cursor;
+  return { ...cursor, [serviceId]: max };
+}
+
+// ---------------------------------------------------------------------------
+
+function kv(key: string, value: unknown): OtlpKeyValue | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "string") return value ? { key, value: { stringValue: value } } : null;
+  if (typeof value === "number") {
+    return Number.isInteger(value)
+      ? { key, value: { intValue: String(value) } }
+      : { key, value: { doubleValue: value } };
+  }
+  if (typeof value === "boolean") return { key, value: { boolValue: value } };
+  return { key, value: { stringValue: String(value) } };
+}
+
+function isKv(value: OtlpKeyValue | null): value is OtlpKeyValue {
+  return value !== null;
+}
+
+function severity(value: string | null): { severityText: string; severityNumber: number } {
+  const mapped = value ? SEVERITY[value.toLowerCase()] : undefined;
+  return { severityText: mapped?.text ?? "", severityNumber: mapped?.number ?? 0 };
+}

--- a/packages/railway/src/transform.ts
+++ b/packages/railway/src/transform.ts
@@ -74,7 +74,7 @@ export function rfc3339ToNanos(timestamp: string): bigint | null {
   const ms = Date.parse(`${base}${zone}`);
   if (!Number.isFinite(ms)) return null;
   const nanosFraction = BigInt((fraction ?? "").padEnd(9, "0") || "0");
-  return BigInt(ms) * 1_000_000n - (BigInt(ms % 1000) * 1_000_000n) + nanosFraction;
+  return BigInt(ms) * 1_000_000n - BigInt(ms % 1000) * 1_000_000n + nanosFraction;
 }
 
 // Strip ANSI color/control sequences Railway passes through from app stdout.
@@ -148,7 +148,8 @@ export function railwayMetricsToOtlp(
   results: RailwayMetricsResult[],
   ctx: RailwayNameContext & { serviceId?: string },
 ): RailwayOtlpMetricsExport {
-  const serviceId = ctx.serviceId ?? results.find((r) => r.tags?.serviceId)?.tags?.serviceId ?? null;
+  const serviceId =
+    ctx.serviceId ?? results.find((r) => r.tags?.serviceId)?.tags?.serviceId ?? null;
   const serviceName = (serviceId && ctx.serviceNamesById[serviceId]) || "railway";
   const metrics = results
     .map((result) => {

--- a/packages/railway/tsconfig.json
+++ b/packages/railway/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,6 +471,9 @@ importers:
       '@superlog/net-guard':
         specifier: workspace:*
         version: link:../../packages/net-guard
+      '@superlog/railway':
+        specifier: workspace:*
+        version: link:../../packages/railway
       '@superlog/topology':
         specifier: workspace:*
         version: link:../../packages/topology

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       '@superlog/net-guard':
         specifier: workspace:*
         version: link:../../packages/net-guard
+      '@superlog/railway':
+        specifier: workspace:*
+        version: link:../../packages/railway
       autumn-js:
         specifier: ^1.2.27
         version: 1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
@@ -563,6 +566,18 @@ importers:
       undici:
         specifier: ^7.16.0
         version: 7.28.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
+  packages/railway:
     devDependencies:
       '@types/node':
         specifier: ^22.10.1

--- a/scripts/worktree-bootstrap.sh
+++ b/scripts/worktree-bootstrap.sh
@@ -203,10 +203,22 @@ EOF
 fi
 
 # The worker decrypts the same integration secrets (e.g. the Railway puller's
-# tokens), so it needs the same AGENT_SECRETS_KEY the api encrypted with.
-if [[ ! -e apps/worker/.env && -e apps/api/.env ]] && grep -q '^AGENT_SECRETS_KEY=' apps/api/.env; then
-  grep '^AGENT_SECRETS_KEY=' apps/api/.env > apps/worker/.env
-  echo "  wrote apps/worker/.env (AGENT_SECRETS_KEY shared with api)"
+# tokens), so it needs the same AGENT_SECRETS_KEY the api encrypted with. Kept
+# in sync on every run (not just first write) so a regenerated apps/api/.env
+# can't leave the worker holding a stale key.
+if [[ -e apps/api/.env ]] && grep -q '^AGENT_SECRETS_KEY=' apps/api/.env; then
+  api_agent_key_line=$(grep '^AGENT_SECRETS_KEY=' apps/api/.env | head -1)
+  if [[ ! -e apps/worker/.env ]]; then
+    printf '%s\n' "$api_agent_key_line" > apps/worker/.env
+    echo "  wrote apps/worker/.env (AGENT_SECRETS_KEY shared with api)"
+  elif ! grep -qxF "$api_agent_key_line" apps/worker/.env; then
+    worker_env_tmp=$(mktemp)
+    grep -v '^AGENT_SECRETS_KEY=' apps/worker/.env > "$worker_env_tmp" || true
+    printf '%s\n' "$api_agent_key_line" >> "$worker_env_tmp"
+    cat "$worker_env_tmp" > apps/worker/.env
+    rm -f "$worker_env_tmp"
+    echo "  synced AGENT_SECRETS_KEY into apps/worker/.env (matched to api)"
+  fi
 fi
 
 # -----------------------------------------------------------------------------

--- a/scripts/worktree-bootstrap.sh
+++ b/scripts/worktree-bootstrap.sh
@@ -189,10 +189,24 @@ if [[ "$SKIP_LINK" -eq 0 ]]; then
 fi
 
 if [[ ! -e apps/api/.env ]]; then
-  echo "==> apps/api/.env missing; writing dev-only BETTER_AUTH_SECRET fallback"
+  echo "==> apps/api/.env missing; writing dev-only secret fallbacks"
+  # STATE_SIGNING_SECRET signs connector OAuth `state` (Cloudflare / Vercel /
+  # Railway); AGENT_SECRETS_KEY encrypts integration secrets at rest. Without
+  # them every connector callback 503s or dies at the encrypt step, so a fresh
+  # worktree can't exercise any connect flow. Dev-only values — prod supplies
+  # real ones.
   cat > apps/api/.env <<EOF
 BETTER_AUTH_SECRET=${WT_NAME}-local-dev-better-auth-secret
+STATE_SIGNING_SECRET=${WT_NAME}-local-dev-state-signing-secret
+AGENT_SECRETS_KEY=$(openssl rand -base64 32)
 EOF
+fi
+
+# The worker decrypts the same integration secrets (e.g. the Railway puller's
+# tokens), so it needs the same AGENT_SECRETS_KEY the api encrypted with.
+if [[ ! -e apps/worker/.env && -e apps/api/.env ]] && grep -q '^AGENT_SECRETS_KEY=' apps/api/.env; then
+  grep '^AGENT_SECRETS_KEY=' apps/api/.env > apps/worker/.env
+  echo "  wrote apps/worker/.env (AGENT_SECRETS_KEY shared with api)"
 fi
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Adds a Railway integration alongside the existing Vercel/Cloudflare connectors. Railway has no drain/export product, so unlike those connectors nothing is provisioned on Railway's side — the OAuth grant itself is the integration, and a worker job pulls telemetry from Railway's GraphQL API.

## Connect flow

- "Login with Railway" OAuth (`project:viewer offline_access`, `prompt=consent` — Railway silently drops `offline_access` without it): the user picks which Railway projects to share on Railway's consent screen.
- Same conventions as the other connectors: HMAC-signed state, public callback outside `/api/*`, encrypted tokens at rest (AES-256-GCM), per-project install with supersede, `/connect/railway` result page, onboarding lane + settings card gated by a `railwayConnect` capability.
- Grant discovery uses `externalWorkspaces` (the blanket `projects` query is Not Authorized for OAuth tokens, and the grant list is not in the token claims).
- New `railway_installations` table (migration 0085): encrypted access + rotating refresh token, granted-project snapshot, puller cursors, ingest key.

## Pull path (new pattern)

- `@superlog/railway` package: OAuth client, GraphQL wrappers (grant discovery, inventory, `environmentLogs`, `metrics`), Railway→OTLP transforms (ANSI-stripped log bodies, nanosecond timestamps, `railway.*` gauges with units), and pure cursor arithmetic. Shared by api (connect) and worker (pull).
- Worker job `railway-pull` (every minute): refreshes the access token inside a 5-minute expiry margin and persists the rotated refresh token immediately; reads logs per environment from the cursor (seed batch anchored at connect time); polls CPU/memory/network/disk metrics per service every ~5 minutes; forwards OTLP JSON to the proxy's new `/railway/pull/logs|metrics` routes with the installation's ingest key. Cursors only advance after the intake accepts a batch, so restarts and rejections re-deliver instead of dropping.
- `railway` joins the per-project ingest source filters (logs + metrics), so the proxy ack-drops disabled signals at the edge like the other sources.

## Verified end-to-end

Connected a real Railway workspace (3 projects) through the full OAuth flow in a dev stack: seed pass forwarded 3,003 log lines + 400 metric points with 0 errors; the next pass forwarded only the 2 new lines (cursor dedupe). Logs land in ClickHouse tagged `telemetry.source=railway` with correct service names and project attribution; metrics land as `railway.cpu.usage` / `railway.memory.usage` / `railway.network.rx|tx` / `railway.disk.usage` gauges.

## Also

- `worktree-bootstrap.sh` now seeds dev-only `STATE_SIGNING_SECRET` and `AGENT_SECRETS_KEY` (shared with the worker) — without them no OAuth connector can be exercised in a fresh worktree; this was found the hard way during verification.
- `.env.example` documents the new `RAILWAY_*` vars. The connector self-disables when they're unset.

Not in scope (documented decisions): traces (Railway exposes nothing to pull; env-var injection for app-level OTel is a possible follow-up), `httpLogs` (Not Authorized at `project:viewer`), deploy-event webhooks (dashboard-configured and unsigned), and a WebSocket `environmentLogs` subscription (the 1-minute poll is the latency floor for now; the subscription is a straightforward follow-up if we want sub-minute logs without touching customer API quota).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Railway connector that authenticates via OAuth and pulls logs and infra metrics from Railway’s GraphQL API into our OTLP intake. Improves reliability with per‑environment metric cursors, transactional install supersede, capability gating on required secrets, and defensive log parsing.

- **New Features**
  - OAuth connect with HMAC‑signed state, per‑project install, encrypted/rotating tokens; gated by `railwayConnect` (requires `RAILWAY_CLIENT_ID`/`SECRET`, `STATE_SIGNING_SECRET`, and `AGENT_SECRETS_KEY`; empty `RAILWAY_OAUTH_REDIRECT_URL` is treated as unset).
  - New `@superlog/railway` package (OAuth client, GraphQL wrappers with normalizer, OTLP transforms).
  - Worker job `railway-pull`: refreshes tokens, reads env logs and per‑environment/per‑service metrics (~5 min), cursor‑safe, forwards to `/railway/pull/logs|metrics` with the project ingest key; logs forward rejections; builds its store from `JobDeps.db`.
  - Proxy adds `/railway/pull/*`; per‑project ingest source filters include `railway` (logs + metrics).
  - New `railway_installations` table storing tokens, granted‑project snapshots, cursors, and ingest keys; installs supersede in a single transaction; UI adds onboarding lane, settings card, and a callback page.

- **Migration**
  - Run DB migration 0085.
  - Set `RAILWAY_CLIENT_ID` and `RAILWAY_CLIENT_SECRET` in both api and worker; optionally set `RAILWAY_OAUTH_REDIRECT_URL` (api) and `RAILWAY_INTAKE_URL` (worker).
  - Ensure `STATE_SIGNING_SECRET` and `AGENT_SECRETS_KEY` are set in both api and worker; dev bootstrap seeds and keeps them in sync.
  - The connector self‑disables when these vars are unset.

<sup>Written for commit 683d7a75d191f6520885f4a8bec1ddd8148432b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

