### PR TITLE
Dockerfiles: copy all workspace packages and typecheck in-image

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -7,17 +7,22 @@ RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/api/package.json apps/api/
-COPY packages/db/package.json packages/db/
-COPY packages/fingerprint/package.json packages/fingerprint/
-COPY packages/net-guard/package.json packages/net-guard/
+# Copy every workspace package rather than enumerating them: three separate
+# deploys have broken when a new package (topology, net-guard, railway) was
+# added as an app dependency without extending a hand-maintained COPY list.
+# The install layer re-runs more often, but images stop silently missing
+# packages.
+COPY packages packages
 
 RUN pnpm install --frozen-lockfile --filter @superlog/api...
 
 COPY tsconfig.base.json ./
 COPY apps/api apps/api
-COPY packages/db packages/db
-COPY packages/fingerprint packages/fingerprint
-COPY packages/net-guard packages/net-guard
+
+# Fail the build, not the deployed task, when a module cannot resolve — a
+# missing workspace package previously produced an image that crash-looped
+# at boot (ERR_MODULE_NOT_FOUND) while ECS kept the old task set serving.
+RUN pnpm --filter @superlog/api typecheck
 
 ENV PORT=4100
 EXPOSE 4100

--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -7,15 +7,12 @@ RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/proxy/package.json apps/proxy/
-COPY packages/db/package.json packages/db/
-COPY packages/fingerprint/package.json packages/fingerprint/
+COPY packages packages
 
 RUN pnpm install --frozen-lockfile --filter @superlog/proxy...
 
 COPY tsconfig.base.json ./
 COPY apps/proxy apps/proxy
-COPY packages/db packages/db
-COPY packages/fingerprint packages/fingerprint
 
 ENV PORT=4000
 EXPOSE 4000
@@ -27,5 +24,7 @@ EXPOSE 4000
 # visibility timeout before redelivering (the ingest-lag sawtooth that paged on
 # every deploy). Running node as the container's main process delivers SIGTERM
 # straight to the handler. Mirrors the package.json "start" script.
+RUN pnpm --filter @superlog/proxy typecheck
+
 WORKDIR /app/apps/proxy
 CMD ["node", "--import", "tsx", "--import", "./tracing.ts", "src/index.ts"]

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -12,14 +12,13 @@ RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/worker/package.json apps/worker/
-COPY packages/db/package.json packages/db/
-COPY packages/fingerprint/package.json packages/fingerprint/
+COPY packages packages
 
 RUN pnpm install --frozen-lockfile --filter @superlog/worker...
 
 COPY tsconfig.base.json ./
 COPY apps/worker apps/worker
-COPY packages/db packages/db
-COPY packages/fingerprint packages/fingerprint
+
+RUN pnpm --filter @superlog/worker typecheck
 
 CMD ["pnpm", "--filter", "@superlog/worker", "start"]


### PR DESCRIPTION
Three deploys broke in one day because app images enumerate workspace package COPYs by hand: a new package added as an app dependency (`topology` historically, then `net-guard` via #154, then `railway` via #166) ships in the repo but not in the image. The api image also had no in-image typecheck, so its miss surfaced as an `ERR_MODULE_NOT_FOUND` crash-loop at boot (ECS kept the old task set serving) instead of a failed build.

Class fix:
- **api/proxy/worker images `COPY packages packages`** — the install layer rebuilds more often, but an image can no longer silently miss a workspace package.
- **api and proxy gain the in-image `typecheck`** the worker image already runs — future resolution gaps fail the build, not the deployed task.

The `railway` package from #166 is covered automatically by the wholesale copy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Copy all workspace packages into the app images and run in-image typechecks so builds fail early instead of crash-looping at runtime. This prevents missing package issues seen in recent deploys (including `railway` from #166).

- **Bug Fixes**
  - Copy `packages/` wholesale in `api`, `proxy`, and `worker` Dockerfiles to stop silently missing workspace deps (e.g., `topology`, `net-guard`, `railway`).
  - Add in-image `pnpm typecheck` for `@superlog/api` and `@superlog/proxy` (worker already had it) so resolution errors fail the build, not production.
  - Note: the install layer may rebuild more often.

<sup>Written for commit 0485c838a55ab40d8b8db949164a751363c58329. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

