### PR TITLE
Return to the connector flow after a successful connect

### DIFF
--- a/apps/web/src/railwayCallbackModel.test.ts
+++ b/apps/web/src/railwayCallbackModel.test.ts
@@ -2,10 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { railwayCallbackView } from "./railwayCallbackModel.ts";
 
-test("installed renders a success view that opens the app cleanly", () => {
+test("installed carries the outcome back so the wizard resumes the Railway flow", () => {
   const view = railwayCallbackView("installed");
   assert.equal(view.tone, "success");
-  assert.equal(view.backHref, "/");
+  // The wizard reads `?railway=` on `/` to drop into the flow's connected
+  // panel (waiting for first events) instead of the integration chooser.
+  assert.equal(view.backHref, "/?railway=installed");
   assert.match(view.body, /pulling logs and infra metrics/i);
 });
 

--- a/apps/web/src/railwayCallbackModel.ts
+++ b/apps/web/src/railwayCallbackModel.ts
@@ -25,7 +25,10 @@ export function railwayCallbackView(raw: string | null | undefined): RailwayCall
         tone: "success",
         title: "Railway connected",
         body: "We're pulling logs and infra metrics from the Railway projects you shared. First events typically appear in Superlog within a minute — you can close this tab.",
-        backHref: "/",
+        // Carry the outcome so the onboarding wizard drops into the Railway
+        // flow's connected panel (which waits for first events) instead of
+        // bouncing back to the integration chooser.
+        backHref: "/?railway=installed",
         backLabel: "Open Superlog",
       };
     case "no_projects":

--- a/apps/web/src/vercelCallbackModel.test.ts
+++ b/apps/web/src/vercelCallbackModel.test.ts
@@ -3,11 +3,13 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { vercelCallbackView } from "./vercelCallbackModel.ts";
 
-test("installed renders a success view that links home", () => {
+test("installed carries the outcome back so the wizard resumes the Vercel flow", () => {
   const view = vercelCallbackView("installed");
   assert.equal(view.tone, "success");
   assert.match(view.title, /connected/i);
-  assert.equal(view.backHref, "/");
+  // The wizard reads `?vercel=` on `/` to drop into the flow's connected
+  // panel instead of the integration chooser.
+  assert.equal(view.backHref, "/?vercel=installed");
 });
 
 test("drains_unavailable spells out the Pro/Enterprise plan requirement", () => {

--- a/apps/web/src/vercelCallbackModel.ts
+++ b/apps/web/src/vercelCallbackModel.ts
@@ -30,7 +30,9 @@ export function vercelCallbackView(raw: string | null | undefined): VercelCallba
         tone: "success",
         title: "Vercel connected",
         body: "The trace and log drains are set up. Telemetry will appear in Superlog as your deployments serve traffic — you can close this tab.",
-        backHref: "/",
+        // Carry the outcome so the onboarding wizard drops into the Vercel
+        // flow's connected panel instead of bouncing back to the chooser.
+        backHref: "/?vercel=installed",
         backLabel: "Open Superlog",
       };
     case "drains_unavailable":


### PR DESCRIPTION
After approving a Railway/Vercel connect, the result page's "Open Superlog" linked to bare `/`, which mounts the onboarding chooser — so a user who connected in the same tab (or continued from the callback tab, the common path) bounced back to the integration selector instead of the flow's connected panel with its "waiting for first events" state.

Failure outcomes already carry `?railway=denied` etc. back to `/` for exactly this reason; this does the same for `installed` on both connectors. The wizard's `initialWebView` already routes on the param, and the flow components strip it after reading.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure users return to the connector flow after a successful Railway or Vercel connect by carrying the `installed` outcome back to `/`, avoiding the chooser bounce. This drops users into the flow’s connected panel that waits for first events.

- **Bug Fixes**
  - Callback views now set `backHref` to `/?railway=installed` and `/?vercel=installed`.
  - Matches existing failure handling (`?railway=denied`, etc.) so the wizard resumes the right step and strips the param.
  - Updated tests to assert the new `backHref` values.

<sup>Written for commit 476a34014039bb26d33ebb856ae7a8bd6fd5d362. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

