### PR TITLE
Share the terminal-nudge marker so collectors can recognize the nudge

### DIFF
--- a/apps/worker/src/agent-outcome-tools.ts
+++ b/apps/worker/src/agent-outcome-tools.ts
@@ -41,6 +41,13 @@ export type OutcomeToolDefinition = {
 
 export const REPORT_FINDINGS_TOOL_NAME = "report_findings";
 
+// Opening sentence of the worker's idle terminal-outcome nudge. Shared so
+// collectors can recognize the nudge in a session's user.message stream and
+// treat it as a poke (never a turn reset): a nudge that lands milliseconds
+// after the model's own terminal call must not invalidate that call.
+export const TERMINAL_NUDGE_MARKER =
+  "You ended your turn without calling a terminal outcome tool";
+
 export const TERMINAL_OUTCOME_TOOL_NAMES = [
   "propose_pr",
   "silence_as_noise",

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -1,5 +1,6 @@
 import { type AgentRunResult, db, schema } from "@superlog/db";
 import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
+import { TERMINAL_NUDGE_MARKER } from "../agent-outcome-tools.js";
 import type { AgentRunContext } from "../agent-run-context.js";
 import { createAgentRunLifecycle } from "../agent-run.js";
 import { type AgentRunOutcome, recordAgentRunCompletion } from "../ai-usage.js";
@@ -156,7 +157,7 @@ export function mobileRegressionRepairPrompt(): string {
 // most once per session; the runtime/wall-clock budgets stay the hard floor.
 export function terminalOutcomeNudgePrompt(): string {
   return [
-    "You ended your turn without calling a terminal outcome tool, so your investigation has no recorded result.",
+    `${TERMINAL_NUDGE_MARKER}, so your investigation has no recorded result.`,
     "Call `report_findings` now if you have findings to record, then end your turn by calling exactly ONE terminal outcome tool: `propose_pr`, `silence_as_noise`, `place_under_observation`, `mark_already_resolved`, `complete_investigation`, `ask_human`, or `report_failure`.",
   ].join("\n");
 }


### PR DESCRIPTION
Observed in a live session: the model called `propose_pr`; the idle-nudge `user.message` landed 14ms later in the event stream; a collector that resets captured turn state on every `user.message` wiped both the captured terminal call AND its pending ack — the session then sat in `requires_action` forever (the ack never arrives), unreachable by the spent one-shot nudge.

Two changes:
- `TERMINAL_NUDGE_MARKER` exported from `agent-outcome-tools.ts` (the shared contract module) and used as the nudge prompt's opening sentence, so collectors can recognize nudge messages and treat them as pokes that never reset state.
- No functional change to sync.ts beyond composing the prompt from the shared constant.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exports a shared `TERMINAL_NUDGE_MARKER` and uses it to build the idle terminal nudge so collectors can spot nudge `user.message`s and avoid resetting turn state. This prevents the race where a terminal tool call is wiped and the session gets stuck in `requires_action`.

<sup>Written for commit e28a542f30c8a3c9dc75faade91e746105853a30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

