### PR TITLE
Defer steering for a tick after collect sends custom-tool acks

### DIFF
--- a/apps/worker/src/agent-runner-backend.ts
+++ b/apps/worker/src/agent-runner-backend.ts
@@ -112,6 +112,12 @@ export type AgentRunnerSnapshot = {
   // with an error result so the session can leave requires_action; sync.ts
   // then fails the run with `unknown_custom_tool` so we can audit them later.
   unknownCustomTools: Array<{ toolUseId: string; name: string }>;
+  // How many custom_tool_result acks this collect pass sent. When > 0 the
+  // `status` above is stale — it was captured before the acks went out and
+  // the model is about to resume with the tool results. sync.ts uses this to
+  // defer steering for a tick (see shouldDeferSteering). Optional so runners
+  // without a collect-time ack step are unaffected.
+  sentToolAckCount?: number;
   latestMessage: string | null;
   modelUsage: {
     inputTokens: number;

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -2,13 +2,14 @@ import "../agent-run.test-env.js";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  isSessionBusyError,
   mobileRegressionGateState,
   mobileRegressionGateTerminatedSummary,
-  isSessionBusyError,
   mobileRegressionRepairPrompt,
-  terminalOutcomeNudgePrompt,
   needsMobileRegressionRepair,
+  shouldDeferSteering,
   steerIdleRunnerWithPendingContext,
+  terminalOutcomeNudgePrompt,
 } from "./sync.js";
 
 test("steerIdleRunnerWithPendingContext steers idle sessions with joined context deltas", async () => {
@@ -300,6 +301,27 @@ test("mobileRegressionRepairPrompt tells the agent exactly how to repair the res
   assert.match(prompt, /propose_pr/);
   assert.match(prompt, /revyl_validate_yaml/);
   assert.match(prompt, /revyl_create_test_from_yaml/);
+});
+
+test("shouldDeferSteering defers when collect just acked tool calls and there is no result", () => {
+  // The snapshot's status was captured before the acks went out, so "idle"
+  // is stale — the model is about to resume with the tool results. A steer
+  // sent now is delivered AFTER the model's next event, which can be its
+  // terminal outcome call; the turn reset on that message would discard it.
+  assert.equal(shouldDeferSteering({ result: null, sentToolAckCount: 1 }), true);
+  assert.equal(shouldDeferSteering({ result: null, sentToolAckCount: 3 }), true);
+});
+
+test("shouldDeferSteering does not defer settled or concluded snapshots", () => {
+  // No acks sent: the idle status is genuine, steers are safe.
+  assert.equal(shouldDeferSteering({ result: null, sentToolAckCount: 0 }), false);
+  // Runners that never report the field keep today's behaviour.
+  assert.equal(shouldDeferSteering({ result: null }), false);
+  // A result landed: the run is concluding; the completion path owns it.
+  assert.equal(
+    shouldDeferSteering({ result: { state: "complete", summary: "x" }, sentToolAckCount: 1 }),
+    false,
+  );
 });
 
 test("terminalOutcomeNudgePrompt names every terminal outcome tool", () => {

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -151,6 +151,21 @@ export function mobileRegressionRepairPrompt(): string {
   ].join("\n");
 }
 
+// A collect pass that just sent custom_tool_result acks has unblocked the
+// model: the snapshot's "idle" status predates those acks, so the agent is
+// about to resume with the tool results. A steer (human reply, context delta,
+// or the terminal nudge) sent into that window is queued behind the open turn
+// and delivered AFTER the model's next event — which can be its terminal
+// outcome call, whose turn would then be reset out from under it. Defer all
+// steering to the next tick, when the session state has settled. A result
+// means the run is concluding; the completion paths below own it.
+export function shouldDeferSteering(snapshot: {
+  result: unknown;
+  sentToolAckCount?: number;
+}): boolean {
+  return !snapshot.result && (snapshot.sentToolAckCount ?? 0) > 0;
+}
+
 // Steered into a session that went idle without calling any terminal outcome
 // tool (e.g. the model wrote a chat message instead of a tool call). Fired at
 // most once per session; the runtime/wall-clock budgets stay the hard floor.
@@ -261,6 +276,14 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
       .update(schema.agentRuns)
       .set(baseUpdate)
       .where(eq(schema.agentRuns.id, ctx.agentRun.id));
+
+    if (shouldDeferSteering(snapshot)) {
+      // This pass acked tool calls (e.g. report_findings) and the model is
+      // resuming; the idle status is stale. Steering now races the model's
+      // next event — retry every steer on the next tick instead. The budget
+      // checks above already ran, so a run can't hide here indefinitely.
+      return;
+    }
 
     // A human message that arrived mid-turn (the run was still `running`, so it
     // was recorded rather than reactivating a terminal run). Steer it into the


### PR DESCRIPTION
## Problem

Investigations were dying with `wall_clock_timeout` **after** the agent had already called a terminal outcome tool (`propose_pr`, `silence_as_noise`). Sequence:

1. The agent calls `report_findings`. Its turn stays open while it waits for the `user.custom_tool_result` ack, and the provider reports the session as **idle** during that wait.
2. `syncRunningAgentRun` collects: the pass sends the ack, but the snapshot's status was captured *before* the ack went out. Sync sees `idle` + no result and steers the one-shot terminal nudge (or a pending incident-context delta / human reply).
3. The steer is queued behind the open turn. The agent — unblocked by the ack — calls its terminal tool, and only then does the session deliver the queued `user.message`, *after* the terminal call.
4. The next collect pass hits that trailing `user.message`, and the turn-reset semantics discard the terminal outcome. The nudge is already spent, so nothing ever re-steers the session, and the run idles until the wall-clock backstop reaps it — with a completed, validated result thrown away.

Every `wall_clock_timeout` in the last day matches this shape: a terminal tool call immediately followed by a steered `user.message`, then six silent hours.

## Fix

- `AgentRunnerSnapshot` gains an optional `sentToolAckCount`: how many `custom_tool_result` acks the collect pass just sent. Runners without a collect-time ack step never set it and are unaffected.
- New pure helper `shouldDeferSteering(snapshot)`: true when acks were just sent and no result landed.
- `syncRunningAgentRun` returns early past all three steer paths (human replies, context deltas, terminal nudge) for that tick. The next tick sees the settled state — either a result (processed normally) or a genuinely idle session (steered safely).

The budget backstops (runtime + wall clock) run before the guard, so a session that acks forever still gets reaped.

## Testing

- `tsx --test src/agent-runs/sync.test.ts` — new `shouldDeferSteering` cases (defer on acks+no-result; no defer on zero/absent count or when a result landed), 15 pass.
- `tsx --test` on `agent-runs/status.test.ts`, `agent-run.test.ts`, `managed-agent-result.test.ts` — pass.
- `pnpm --filter @superlog/worker typecheck` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers steering for one tick after a collect pass sends custom tool acks to prevent discarding terminal outcomes and avoid `wall_clock_timeout`. The next tick sees the settled state and steers safely if still idle.

- **Bug Fixes**
  - Added optional `sentToolAckCount` to AgentRunnerSnapshot to mark when acks were sent; runners without collect-time acks are unaffected.
  - Introduced `shouldDeferSteering()` to defer steering when acks were just sent and no result exists.
  - Updated `syncRunningAgentRun` to skip human replies, context deltas, and the terminal nudge for that tick; runtime and wall-clock budgets still apply.

<sup>Written for commit df2f074427a740f4d5c69916224b04daae5b429a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

