### PR TITLE
Make the log/trace detail drawer a full-screen overlay

### DIFF
--- a/apps/web/src/LogDetail.tsx
+++ b/apps/web/src/LogDetail.tsx
@@ -34,7 +34,7 @@ export function LogDrawer({
   if (!log) return null;
 
   return (
-    <div className="absolute inset-0">
+    <div className="fixed inset-0 z-50">
       <button
         type="button"
         aria-label="close"

--- a/apps/web/src/TraceDetail.tsx
+++ b/apps/web/src/TraceDetail.tsx
@@ -35,7 +35,7 @@ export function TraceDrawer({
   if (!traceId) return null;
 
   return (
-    <div className="absolute inset-0">
+    <div className="fixed inset-0 z-50">
       <button
         type="button"
         aria-label="close"


### PR DESCRIPTION
## Problem

The log and trace detail drawers on the Explore page appeared clipped to a corner of the screen instead of covering the full viewport.

## Cause

Both drawer wrappers used `absolute inset-0`. `absolute` positions relative to the nearest positioned ancestor, which is the Explore page's padded, scrolled content container that sits below the app chrome. So the backdrop and panel were confined to that box rather than the viewport.

## Fix

Change the wrapper to `fixed inset-0 z-50` in `LogDetail.tsx` and `TraceDetail.tsx`. `fixed` makes the overlay viewport-relative so it covers the whole screen regardless of scroll position, and `z-50` keeps it above the explore-page dropdowns. Panel widths (720px logs / 1800px traces) and the inner layout are unchanged.

## Verification

- `@superlog/web` typecheck passes.
- Verified in a browser: the drawer wrapper computes to `position: fixed`, `z-index: 50`, rect `{0,0 → full viewport}`; the panel is right-aligned, full height. Screenshot confirms full-screen coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Explore page log and trace drawers so they cover the full viewport instead of being clipped. Switched the wrapper to `fixed inset-0 z-50` so the overlay is viewport-relative and above dropdowns; panel widths and layout stay the same.

<sup>Written for commit 3f9018ff382bf68e9ee97fe347c4d29c2e9418cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

