### PR TITLE
Render connector: API-key connect + worker-side log/metrics puller

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -76,3 +76,7 @@ AWS_LOGS_TEMPLATE_URL=
 RAILWAY_CLIENT_ID=
 RAILWAY_CLIENT_SECRET=
 RAILWAY_OAUTH_REDIRECT_URL=
+
+# The Render connector needs no client credentials here — users paste their own
+# Render API key. It only requires AGENT_SECRETS_KEY (above) so the key can be
+# stored encrypted.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -79,4 +79,7 @@ RAILWAY_OAUTH_REDIRECT_URL=
 
 # The Render connector needs no client credentials here — users paste their own
 # Render API key. It only requires AGENT_SECRETS_KEY (above) so the key can be
-# stored encrypted.
+# stored encrypted. RENDER_STREAM_INTAKE_URL is the public intake origin the
+# connector registers as the workspace's log + metrics stream destination
+# (prod: the intake origin); unset, the connector falls back to API polling.
+RENDER_STREAM_INTAKE_URL=

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -35,6 +35,7 @@
     "@scalar/hono-api-reference": "^0.10.19",
     "@superlog/db": "workspace:*",
     "@superlog/railway": "workspace:*",
+    "@superlog/render": "workspace:*",
     "@superlog/fingerprint": "workspace:*",
     "@superlog/net-guard": "workspace:*",
     "autumn-js": "^1.2.27",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -105,6 +105,7 @@ import {
   mergeAgentPullRequestAndResolveIncident,
 } from "./pr-merge-service.js";
 import { mountRailwayAuthed, mountRailwayPublic } from "./railway.js";
+import { mountRenderAuthed } from "./render.js";
 import { mountSettingsAuthed } from "./settings.js";
 import { normalizeSignupIntentKeyHash, normalizeSignupIntentKeyPrefix } from "./signup-intents.js";
 import { mountSlackAuthed, mountSlackPublic } from "./slack.js";
@@ -329,6 +330,7 @@ mountSlackAuthed(app);
 mountCloudflareAuthed(app);
 mountVercelAuthed(app);
 mountRailwayAuthed(app);
+mountRenderAuthed(app);
 mountSettingsAuthed(app);
 mountOrgKeyManagementAuthed(app);
 mountDashboards(app);

--- a/apps/api/src/ingest-filters-service.test.ts
+++ b/apps/api/src/ingest-filters-service.test.ts
@@ -8,7 +8,7 @@ import {
   ingestFilterStateSchema,
 } from "./ingest-filters-service.js";
 
-test("allIngestFilterPairs covers otlp×3 + aws×2 + vercel×2 + railway×2", () => {
+test("allIngestFilterPairs covers otlp×3 + aws×2 + vercel×2 + railway×2 + render×2", () => {
   const pairs = allIngestFilterPairs()
     .map((p) => ingestFilterKey(p.source, p.signal))
     .sort();
@@ -20,6 +20,8 @@ test("allIngestFilterPairs covers otlp×3 + aws×2 + vercel×2 + railway×2", ()
     "otlp:traces",
     "railway:logs",
     "railway:metrics",
+    "render:logs",
+    "render:metrics",
     "vercel:logs",
     "vercel:traces",
   ]);
@@ -31,6 +33,7 @@ test("empty disabled set → everything enabled", () => {
     aws: { logs: true, metrics: true },
     vercel: { traces: true, logs: true },
     railway: { logs: true, metrics: true },
+    render: { logs: true, metrics: true },
   });
 });
 
@@ -60,6 +63,7 @@ test("state schema rejects unknown source/signal keys", () => {
       aws: { logs: true, metrics: true },
       vercel: { traces: true, logs: true },
       railway: { logs: true, metrics: true },
+      render: { logs: true, metrics: true },
     }).success,
     true,
   );
@@ -70,6 +74,7 @@ test("state schema rejects unknown source/signal keys", () => {
       aws: { logs: true, metrics: true, traces: true },
       vercel: { traces: true, logs: true },
       railway: { logs: true, metrics: true },
+      render: { logs: true, metrics: true },
     }).success,
     false,
   );
@@ -80,6 +85,7 @@ test("state schema rejects unknown source/signal keys", () => {
       aws: { logs: true, metrics: true },
       vercel: { traces: true, logs: true },
       railway: { logs: true, metrics: true },
+      render: { logs: true, metrics: true },
     }).success,
     false,
   );

--- a/apps/api/src/ingest-filters-service.ts
+++ b/apps/api/src/ingest-filters-service.ts
@@ -2,12 +2,14 @@ import { z } from "zod";
 
 // The telemetry signals each ingest source can carry. OTLP (the SDK/exporter
 // path) carries all three; AWS (CloudWatch → Firehose) carries logs+metrics;
-// Vercel Drains carry traces+logs; the Railway API puller carries logs+metrics.
+// Vercel Drains carry traces+logs; the Railway and Render API pullers carry
+// logs+metrics.
 export const INGEST_SOURCE_SIGNALS = {
   otlp: ["traces", "logs", "metrics"],
   aws: ["logs", "metrics"],
   vercel: ["traces", "logs"],
   railway: ["logs", "metrics"],
+  render: ["logs", "metrics"],
 } as const;
 
 export type IngestSource = keyof typeof INGEST_SOURCE_SIGNALS;
@@ -18,6 +20,7 @@ export type IngestFilterState = {
   aws: { logs: boolean; metrics: boolean };
   vercel: { traces: boolean; logs: boolean };
   railway: { logs: boolean; metrics: boolean };
+  render: { logs: boolean; metrics: boolean };
 };
 
 /** Stable key for a (source, signal) pair — matches the proxy's filter key. */
@@ -46,6 +49,7 @@ export function deriveIngestFilterState(disabled: Set<string>): IngestFilterStat
     aws: { logs: on("aws", "logs"), metrics: on("aws", "metrics") },
     vercel: { traces: on("vercel", "traces"), logs: on("vercel", "logs") },
     railway: { logs: on("railway", "logs"), metrics: on("railway", "metrics") },
+    render: { logs: on("render", "logs"), metrics: on("render", "metrics") },
   };
 }
 
@@ -57,6 +61,7 @@ export const ingestFilterStateSchema = z
     aws: z.object({ logs: z.boolean(), metrics: z.boolean() }).strict(),
     vercel: z.object({ traces: z.boolean(), logs: z.boolean() }).strict(),
     railway: z.object({ logs: z.boolean(), metrics: z.boolean() }).strict(),
+    render: z.object({ logs: z.boolean(), metrics: z.boolean() }).strict(),
   })
   .strict();
 

--- a/apps/api/src/ingest-filters.test.ts
+++ b/apps/api/src/ingest-filters.test.ts
@@ -66,6 +66,7 @@ test("defaults to everything enabled (no rows)", async () => {
     aws: { logs: true, metrics: true },
     vercel: { traces: true, logs: true },
     railway: { logs: true, metrics: true },
+    render: { logs: true, metrics: true },
   });
 });
 
@@ -78,6 +79,7 @@ test("PUT disables a pair, persists one sparse row, and reflects in GET", async 
     aws: { logs: false, metrics: true },
     vercel: { traces: true, logs: true },
     railway: { logs: true, metrics: true },
+    render: { logs: true, metrics: true },
   };
   const res = await app.request(`/api/projects/${project.id}/ingest-filters`, {
     method: "PUT",
@@ -117,12 +119,14 @@ test("PUT is a full replace — re-enabling clears the row", async () => {
     aws: { logs: false, metrics: true },
     vercel: { traces: true, logs: true },
     railway: { logs: true, metrics: true },
+    render: { logs: true, metrics: true },
   });
   await put({
     otlp: { traces: true, logs: true, metrics: true },
     aws: { logs: true, metrics: true },
     vercel: { traces: true, logs: true },
     railway: { logs: true, metrics: true },
+    render: { logs: true, metrics: true },
   });
   const rows = await db.query.projectIngestFilters.findMany({
     where: eq(schema.projectIngestFilters.projectId, project.id),

--- a/apps/api/src/render.ts
+++ b/apps/api/src/render.ts
@@ -1,0 +1,325 @@
+// Render integration routes: a "Connect Render" flow built on a user-created
+// API key. Render has no third-party OAuth, so unlike the Railway connector
+// there is no consent redirect and no public callback — the user pastes an API
+// key (Render dashboard → Account settings → API Keys), we list the workspaces
+// the key can see, the user picks one, and the key is stored encrypted. Like
+// Railway there is nothing to provision on Render's side: a worker-side puller
+// (apps/worker) reads logs and metrics from the chosen workspace via Render's
+// REST API and forwards them to our intake with the ingest key minted here.
+//
+// Flow (all authed; no public routes):
+//   1. POST /api/projects/:projectId/render/owners   { apiKey }
+//      → validates the key, returns the workspaces it can see
+//   2. POST /api/projects/:projectId/render/connect  { apiKey, ownerId }
+//      → snapshots the workspace's services, mints the ingest key, persists
+//   3. GET  /api/projects/:projectId/render/installation → status
+//      POST /api/projects/:projectId/render/uninstall    → remove
+//
+// A Render API key grants access to every workspace its creator belongs to —
+// there are no read-only or scoped keys — so the key is treated like any other
+// integration secret: encrypted at rest, never logged, only ever used for
+// reads scoped to the workspace the user picked.
+
+import {
+  db,
+  decryptIntegrationSecret,
+  encryptIntegrationSecret,
+  mintApiKey,
+  schema,
+} from "@superlog/db";
+import { fetchOwners, fetchServices } from "@superlog/render";
+import { and, desc, eq, isNull, ne } from "drizzle-orm";
+import type { Context, Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { logger } from "./logger.js";
+import { resolveActiveOrgContext } from "./org-context.js";
+
+const log = logger.child({ scope: "render" });
+
+type Vars = { userId: string; orgId: string | null };
+
+type RenderInstallationRow = typeof schema.renderInstallations.$inferSelect;
+
+/** Public shape — never leaks the API key ciphertext. */
+function toPublic(row: RenderInstallationRow) {
+  return {
+    installed: true,
+    ownerId: row.renderOwnerId,
+    ownerName: row.renderOwnerName,
+    services: row.services ?? [],
+    installedAt: row.createdAt,
+  };
+}
+
+// Resolve the project the request targets from the path param and confirm the
+// caller's active org owns it (same discipline as the other connectors —
+// installs are per-project, so the project must be explicit).
+async function requireProjectAccess(
+  c: Context<{ Variables: Vars }>,
+  projectId: string,
+): Promise<{ userId: string; orgId: string; projectId: string }> {
+  const userId = c.var.userId;
+  if (!userId) throw new HTTPException(401, { message: "unauthenticated" });
+  const project = await db.query.projects.findFirst({
+    where: eq(schema.projects.id, projectId),
+  });
+  if (!project) throw new HTTPException(404, { message: "project not found" });
+  const ctx = await resolveActiveOrgContext({ userId, preferredOrgId: c.var.orgId });
+  if (project.orgId !== ctx.org.id) throw new HTTPException(403, { message: "forbidden" });
+  return { userId: ctx.user.id, orgId: ctx.org.id, projectId };
+}
+
+// The single active install for a project (enforced at provision time by the
+// supersede step; `orderBy` is belt-and-suspenders).
+async function findInstallation(projectId: string) {
+  return db.query.renderInstallations.findFirst({
+    where: and(
+      eq(schema.renderInstallations.projectId, projectId),
+      isNull(schema.renderInstallations.revokedAt),
+    ),
+    orderBy: desc(schema.renderInstallations.createdAt),
+  });
+}
+
+/**
+ * Get (or mint) the ingest key the puller forwards telemetry with. Reuses the
+ * installation's stored key when it's still live so a re-connect doesn't
+ * orphan a working key; mints a fresh one otherwise.
+ */
+async function ensureIngestKey(
+  projectId: string,
+  existing: RenderInstallationRow | null,
+): Promise<{ ingestKey: string; apiKeyId: string; minted: boolean }> {
+  if (existing?.apiKeyId && existing.ingestKeyCiphertext && existing.ingestKeyNonce) {
+    const keyRow = await db.query.apiKeys.findFirst({
+      where: eq(schema.apiKeys.id, existing.apiKeyId),
+    });
+    if (keyRow && keyRow.revokedAt == null) {
+      const ingestKey = decryptIntegrationSecret({
+        ciphertext: existing.ingestKeyCiphertext,
+        nonce: existing.ingestKeyNonce,
+        keyVersion: existing.ingestKeyKeyVersion ?? 1,
+      });
+      return { ingestKey, apiKeyId: existing.apiKeyId, minted: false };
+    }
+  }
+  const minted = await mintApiKey({ projectId, name: "Render puller" });
+  return { ingestKey: minted.plaintext, apiKeyId: minted.id, minted: true };
+}
+
+/**
+ * Tear down one installation row. There is nothing to delete on Render's side
+ * (the user's API key stays theirs — they can revoke it from Render's
+ * dashboard); revoking the ingest key stops our intake accepting anything the
+ * puller would forward, and the soft-revoke stops the puller reading Render at
+ * all. The stored Render key ciphertext stays on the revoked row, unreadable
+ * without AGENT_SECRETS_KEY and unused once revoked.
+ */
+type DbExecutor = Pick<typeof db, "update">;
+
+async function teardownInstallation(
+  row: RenderInstallationRow,
+  executor: DbExecutor = db,
+): Promise<void> {
+  if (row.apiKeyId) {
+    await executor
+      .update(schema.apiKeys)
+      .set({ revokedAt: new Date() })
+      .where(eq(schema.apiKeys.id, row.apiKeyId));
+  }
+  await executor
+    .update(schema.renderInstallations)
+    .set({ revokedAt: new Date(), updatedAt: new Date() })
+    .where(eq(schema.renderInstallations.id, row.id));
+}
+
+// The connect/owners request body: the key the user pasted. Never logged.
+function readApiKey(body: unknown): string | null {
+  if (!body || typeof body !== "object") return null;
+  const key = (body as { apiKey?: unknown }).apiKey;
+  return typeof key === "string" && key.trim() ? key.trim() : null;
+}
+
+export function mountRenderAuthed(
+  app: Hono<{ Variables: Vars }>,
+  deps: { fetchImpl?: typeof fetch } = {},
+): void {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  // Storing the pasted key requires the at-rest encryption key; without it the
+  // connect flow could never complete, so the routes self-disable (and
+  // system-capabilities hides the connector tile).
+  const secretsConfigured = () => !!process.env.AGENT_SECRETS_KEY;
+
+  app.get("/api/projects/:projectId/render/installation", async (c) => {
+    const ctx = await requireProjectAccess(c, c.req.param("projectId"));
+    const row = await findInstallation(ctx.projectId);
+    if (!row) return c.json({ installed: false });
+    return c.json(toPublic(row));
+  });
+
+  // Validate a pasted key and list the workspaces it can see — the connect
+  // dialog's picker. The key is used for one listing call and discarded.
+  app.post("/api/projects/:projectId/render/owners", async (c) => {
+    if (!secretsConfigured()) return c.json({ error: "render not configured" }, 503);
+    await requireProjectAccess(c, c.req.param("projectId"));
+    const apiKey = readApiKey(await c.req.json().catch(() => null));
+    if (!apiKey) return c.json({ error: "missing apiKey" }, 400);
+
+    const owners = await fetchOwners({ apiKey, fetchImpl });
+    if (!owners.ok) {
+      if (owners.unauthorized) return c.json({ error: "invalid_key" }, 400);
+      log.warn({ error: owners.error }, "render owners lookup failed");
+      return c.json({ error: "render_unavailable" }, 502);
+    }
+    return c.json({
+      owners: owners.owners.map((o) => ({
+        id: o.id,
+        name: o.name,
+        email: o.email,
+        type: o.type,
+      })),
+    });
+  });
+
+  app.post("/api/projects/:projectId/render/connect", async (c) => {
+    if (!secretsConfigured()) return c.json({ error: "render not configured" }, 503);
+    const ctx = await requireProjectAccess(c, c.req.param("projectId"));
+    const body = (await c.req.json().catch(() => null)) as { ownerId?: unknown } | null;
+    const apiKey = readApiKey(body);
+    const ownerId = typeof body?.ownerId === "string" && body.ownerId ? body.ownerId : null;
+    if (!apiKey || !ownerId) return c.json({ error: "missing apiKey or ownerId" }, 400);
+
+    // Re-validate the key server-side and confirm it can actually see the
+    // chosen workspace — the picker response is client input by the time it
+    // comes back here.
+    const owners = await fetchOwners({ apiKey, fetchImpl });
+    if (!owners.ok) {
+      if (owners.unauthorized) return c.json({ error: "invalid_key" }, 400);
+      log.warn({ error: owners.error }, "render owners lookup failed");
+      return c.json({ error: "render_unavailable" }, 502);
+    }
+    const owner = owners.owners.find((o) => o.id === ownerId);
+    if (!owner) return c.json({ error: "unknown_owner" }, 400);
+
+    // Snapshot the workspace's services so the UI can show what the pull
+    // covers. An empty workspace still connects — services may come later; the
+    // puller refreshes the snapshot every pass.
+    const services = await fetchServices({ apiKey, ownerId, fetchImpl });
+    if (!services.ok) {
+      log.warn({ error: services.error }, "render services lookup failed");
+      return c.json({ error: "render_unavailable" }, 502);
+    }
+
+    const existing = await db.query.renderInstallations.findFirst({
+      where: and(
+        eq(schema.renderInstallations.projectId, ctx.projectId),
+        eq(schema.renderInstallations.renderOwnerId, ownerId),
+        isNull(schema.renderInstallations.revokedAt),
+      ),
+    });
+    const { ingestKey, apiKeyId, minted } = await ensureIngestKey(ctx.projectId, existing ?? null);
+
+    try {
+      const keyCipher = encryptIntegrationSecret(apiKey);
+      const ingestCipher = encryptIntegrationSecret(ingestKey);
+      const now = new Date();
+      const servicesSnapshot = services.services.map((s) => ({
+        id: s.id,
+        name: s.name,
+        type: s.type,
+        region: s.region,
+        suspended: s.suspended,
+      }));
+
+      // One transaction for the upsert AND the supersede of other active rows,
+      // so "a project has exactly one active install" holds even across a
+      // crash between the two writes or two concurrent connects — the
+      // superseded install can't keep pulling with a live ingest key.
+      await db.transaction(async (tx) => {
+        await tx
+          .insert(schema.renderInstallations)
+          .values({
+            projectId: ctx.projectId,
+            renderOwnerId: owner.id,
+            renderOwnerName: owner.name,
+            services: servicesSnapshot,
+            renderApiKeyCiphertext: keyCipher.ciphertext,
+            renderApiKeyNonce: keyCipher.nonce,
+            renderApiKeyKeyVersion: keyCipher.keyVersion,
+            apiKeyId,
+            ingestKeyCiphertext: ingestCipher.ciphertext,
+            ingestKeyNonce: ingestCipher.nonce,
+            ingestKeyKeyVersion: ingestCipher.keyVersion,
+            installedByUserId: ctx.userId,
+          })
+          .onConflictDoUpdate({
+            target: [
+              schema.renderInstallations.projectId,
+              schema.renderInstallations.renderOwnerId,
+            ],
+            set: {
+              renderOwnerName: owner.name,
+              services: servicesSnapshot,
+              renderApiKeyCiphertext: keyCipher.ciphertext,
+              renderApiKeyNonce: keyCipher.nonce,
+              renderApiKeyKeyVersion: keyCipher.keyVersion,
+              apiKeyId,
+              ingestKeyCiphertext: ingestCipher.ciphertext,
+              ingestKeyNonce: ingestCipher.nonce,
+              ingestKeyKeyVersion: ingestCipher.keyVersion,
+              installedByUserId: ctx.userId,
+              // A re-connect resurrects a previously revoked install and
+              // resets the puller's checkpoints (the old cursor may be far in
+              // the past).
+              logCursor: null,
+              metricsCursor: null,
+              revokedAt: null,
+              updatedAt: now,
+            },
+          });
+
+        // Enforce a single active install per project inside the same
+        // transaction: soft-revoke rows keyed to a different workspace and
+        // revoke their ingest keys.
+        const superseded = await tx
+          .select()
+          .from(schema.renderInstallations)
+          .where(
+            and(
+              eq(schema.renderInstallations.projectId, ctx.projectId),
+              ne(schema.renderInstallations.renderOwnerId, owner.id),
+              isNull(schema.renderInstallations.revokedAt),
+            ),
+          );
+        for (const row of superseded) {
+          await teardownInstallation(row, tx);
+        }
+      });
+    } catch (e) {
+      // Roll back a key we minted for this connect; a reused key predates the
+      // failure and stays.
+      if (minted) {
+        await db
+          .update(schema.apiKeys)
+          .set({ revokedAt: new Date() })
+          .where(eq(schema.apiKeys.id, apiKeyId));
+      }
+      throw e;
+    }
+
+    log.info(
+      { project_id: ctx.projectId, owner_id: owner.id, services: services.services.length },
+      "render connected",
+    );
+    const row = await findInstallation(ctx.projectId);
+    return row ? c.json(toPublic(row)) : c.json({ installed: false });
+  });
+
+  app.post("/api/projects/:projectId/render/uninstall", async (c) => {
+    const ctx = await requireProjectAccess(c, c.req.param("projectId"));
+    const row = await findInstallation(ctx.projectId);
+    if (!row) return c.json({ ok: true });
+    await teardownInstallation(row);
+    return c.json({ ok: true });
+  });
+}

--- a/apps/api/src/render.ts
+++ b/apps/api/src/render.ts
@@ -28,7 +28,7 @@ import {
   schema,
 } from "@superlog/db";
 import { fetchOwners, fetchServices } from "@superlog/render";
-import { and, desc, eq, isNull, ne } from "drizzle-orm";
+import { and, desc, eq, isNull, ne, sql } from "drizzle-orm";
 import type { Context, Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { logger } from "./logger.js";
@@ -233,9 +233,15 @@ export function mountRenderAuthed(
 
       // One transaction for the upsert AND the supersede of other active rows,
       // so "a project has exactly one active install" holds even across a
-      // crash between the two writes or two concurrent connects — the
-      // superseded install can't keep pulling with a live ingest key.
+      // crash between the two writes. The project-scoped advisory lock
+      // serializes concurrent connects for *different* workspaces — without
+      // it, two simultaneous transactions can each miss the other's
+      // uncommitted row in the supersede SELECT and both installs stay
+      // active. Released automatically at commit/rollback.
       await db.transaction(async (tx) => {
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtext(${`render_install:${ctx.projectId}`}))`,
+        );
         await tx
           .insert(schema.renderInstallations)
           .values({

--- a/apps/api/src/render.ts
+++ b/apps/api/src/render.ts
@@ -27,7 +27,16 @@ import {
   mintApiKey,
   schema,
 } from "@superlog/db";
-import { fetchOwners, fetchServices } from "@superlog/render";
+import {
+  deleteOwnerLogStream,
+  deleteOwnerMetricsStream,
+  fetchOwnerLogStream,
+  fetchOwnerMetricsStream,
+  fetchOwners,
+  fetchServices,
+  updateOwnerLogStream,
+  upsertOwnerMetricsStream,
+} from "@superlog/render";
 import { and, desc, eq, isNull, ne, sql } from "drizzle-orm";
 import type { Context, Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -40,6 +49,22 @@ type Vars = { userId: string; orgId: string | null };
 
 type RenderInstallationRow = typeof schema.renderInstallations.$inferSelect;
 
+type StreamState = {
+  status: "provisioned" | "conflict" | "unavailable";
+  endpoint: string | null;
+  detail: string | null;
+};
+
+/**
+ * Public intake origin Render's streams push to (prod:
+ * https://intake.superlog.sh). Unset → streams can't be provisioned and the
+ * connector runs on API polling alone.
+ */
+function streamIntakeBaseUrl(env: NodeJS.ProcessEnv = process.env): string | null {
+  const base = env.RENDER_STREAM_INTAKE_URL;
+  return base ? base.replace(/\/+$/, "") : null;
+}
+
 /** Public shape — never leaks the API key ciphertext. */
 function toPublic(row: RenderInstallationRow) {
   return {
@@ -47,6 +72,8 @@ function toPublic(row: RenderInstallationRow) {
     ownerId: row.renderOwnerId,
     ownerName: row.renderOwnerName,
     services: row.services ?? [],
+    logStream: row.logStream ?? null,
+    metricsStream: row.metricsStream ?? null,
     installedAt: row.createdAt,
   };
 }
@@ -108,12 +135,135 @@ async function ensureIngestKey(
 }
 
 /**
- * Tear down one installation row. There is nothing to delete on Render's side
- * (the user's API key stays theirs — they can revoke it from Render's
- * dashboard); revoking the ingest key stops our intake accepting anything the
- * puller would forward, and the soft-revoke stops the puller reading Render at
- * all. The stored Render key ciphertext stays on the revoked row, unreadable
- * without AGENT_SECRETS_KEY and unused once revoked.
+ * Provision the workspace's push streams to our intake. A workspace has
+ * exactly ONE log stream and ONE metrics stream destination, so each slot is
+ * read first and a foreign destination is never overwritten — that signal
+ * falls back to API polling instead ("conflict"). Metrics streams are also
+ * plan-gated by Render (Pro+), which surfaces here as "unavailable". Both
+ * outcomes are non-fatal: the install works either way, just via polling.
+ */
+async function provisionStreams(input: {
+  apiKey: string;
+  ownerId: string;
+  ingestKey: string;
+  fetchImpl: typeof fetch;
+}): Promise<{ logStream: StreamState; metricsStream: StreamState }> {
+  const base = streamIntakeBaseUrl();
+  if (!base) {
+    const detail = "stream intake url not configured";
+    return {
+      logStream: { status: "unavailable", endpoint: null, detail },
+      metricsStream: { status: "unavailable", endpoint: null, detail },
+    };
+  }
+
+  let logStream: StreamState;
+  const logsEndpoint = `${base}/render/stream/logs`;
+  const currentLogs = await fetchOwnerLogStream({
+    apiKey: input.apiKey,
+    ownerId: input.ownerId,
+    fetchImpl: input.fetchImpl,
+  });
+  if (!currentLogs.ok) {
+    logStream = { status: "unavailable", endpoint: null, detail: currentLogs.error };
+  } else if (currentLogs.stream?.endpoint && !currentLogs.stream.endpoint.startsWith(base)) {
+    logStream = {
+      status: "conflict",
+      endpoint: currentLogs.stream.endpoint,
+      detail: "workspace already streams logs to another destination",
+    };
+  } else {
+    const updated = await updateOwnerLogStream({
+      apiKey: input.apiKey,
+      ownerId: input.ownerId,
+      endpoint: logsEndpoint,
+      token: input.ingestKey,
+      fetchImpl: input.fetchImpl,
+    });
+    logStream = updated.ok
+      ? { status: "provisioned", endpoint: logsEndpoint, detail: null }
+      : { status: "unavailable", endpoint: null, detail: updated.error };
+  }
+
+  let metricsStream: StreamState;
+  const metricsEndpoint = `${base}/render/stream/metrics`;
+  const currentMetrics = await fetchOwnerMetricsStream({
+    apiKey: input.apiKey,
+    ownerId: input.ownerId,
+    fetchImpl: input.fetchImpl,
+  });
+  if (!currentMetrics.ok) {
+    metricsStream = { status: "unavailable", endpoint: null, detail: currentMetrics.error };
+  } else if (currentMetrics.stream?.url && !currentMetrics.stream.url.startsWith(base)) {
+    metricsStream = {
+      status: "conflict",
+      endpoint: currentMetrics.stream.url,
+      detail: "workspace already streams metrics to another destination",
+    };
+  } else {
+    const updated = await upsertOwnerMetricsStream({
+      apiKey: input.apiKey,
+      ownerId: input.ownerId,
+      url: metricsEndpoint,
+      token: input.ingestKey,
+      fetchImpl: input.fetchImpl,
+    });
+    metricsStream = updated.ok
+      ? { status: "provisioned", endpoint: metricsEndpoint, detail: null }
+      : { status: "unavailable", endpoint: null, detail: updated.error };
+  }
+
+  return { logStream, metricsStream };
+}
+
+/**
+ * Best-effort removal of streams we provisioned. Reads each slot first and
+ * only deletes a destination that still points at our intake — a customer who
+ * re-pointed the stream at another provider keeps their setting.
+ */
+async function teardownStreams(row: RenderInstallationRow, fetchImpl: typeof fetch): Promise<void> {
+  const base = streamIntakeBaseUrl();
+  if (!base) return;
+  let apiKey: string;
+  try {
+    apiKey = decryptIntegrationSecret({
+      ciphertext: row.renderApiKeyCiphertext,
+      nonce: row.renderApiKeyNonce,
+      keyVersion: row.renderApiKeyKeyVersion,
+    });
+  } catch {
+    return;
+  }
+  const ownerId = row.renderOwnerId;
+  try {
+    if (row.logStream?.status === "provisioned") {
+      const current = await fetchOwnerLogStream({ apiKey, ownerId, fetchImpl });
+      if (current.ok && current.stream?.endpoint?.startsWith(base)) {
+        await deleteOwnerLogStream({ apiKey, ownerId, fetchImpl });
+      }
+    }
+    if (row.metricsStream?.status === "provisioned") {
+      const current = await fetchOwnerMetricsStream({ apiKey, ownerId, fetchImpl });
+      if (current.ok && current.stream?.url?.startsWith(base)) {
+        await deleteOwnerMetricsStream({ apiKey, ownerId, fetchImpl });
+      }
+    }
+  } catch (e) {
+    log.warn(
+      { installation_id: row.id, err: e instanceof Error ? e.message : String(e) },
+      "render stream teardown failed (best-effort)",
+    );
+  }
+}
+
+/**
+ * Tear down one installation row. Revoking the ingest key stops our intake
+ * accepting anything Render (or the puller) would forward, and the
+ * soft-revoke stops the puller reading Render at all. Stream removal on
+ * Render's side is separate and best-effort (teardownStreams) — the user can
+ * also revoke the API key from Render's dashboard. The stored Render key
+ * ciphertext stays on the revoked row, unreadable without AGENT_SECRETS_KEY
+ * and unused once revoked.
  */
 type DbExecutor = Pick<typeof db, "update">;
 
@@ -219,6 +369,7 @@ export function mountRenderAuthed(
     });
     const { ingestKey, apiKeyId, minted } = await ensureIngestKey(ctx.projectId, existing ?? null);
 
+    let superseded: RenderInstallationRow[] = [];
     try {
       const keyCipher = encryptIntegrationSecret(apiKey);
       const ingestCipher = encryptIntegrationSecret(ingestKey);
@@ -287,7 +438,7 @@ export function mountRenderAuthed(
         // Enforce a single active install per project inside the same
         // transaction: soft-revoke rows keyed to a different workspace and
         // revoke their ingest keys.
-        const superseded = await tx
+        const rows = await tx
           .select()
           .from(schema.renderInstallations)
           .where(
@@ -297,9 +448,10 @@ export function mountRenderAuthed(
               isNull(schema.renderInstallations.revokedAt),
             ),
           );
-        for (const row of superseded) {
+        for (const row of rows) {
           await teardownInstallation(row, tx);
         }
+        superseded = rows;
       });
     } catch (e) {
       // Roll back a key we minted for this connect; a reused key predates the
@@ -313,8 +465,38 @@ export function mountRenderAuthed(
       throw e;
     }
 
+    // Remote IO stays out of the transaction: point the workspace's push
+    // streams at our intake now that the install is durable, and best-effort
+    // remove streams the superseded installs had provisioned (different
+    // workspaces, so no overlap with the streams just created).
+    for (const row of superseded) {
+      await teardownStreams(row, fetchImpl);
+    }
+    const streams = await provisionStreams({
+      apiKey,
+      ownerId: owner.id,
+      ingestKey,
+      fetchImpl,
+    });
+    await db
+      .update(schema.renderInstallations)
+      .set({ logStream: streams.logStream, metricsStream: streams.metricsStream })
+      .where(
+        and(
+          eq(schema.renderInstallations.projectId, ctx.projectId),
+          eq(schema.renderInstallations.renderOwnerId, owner.id),
+          isNull(schema.renderInstallations.revokedAt),
+        ),
+      );
+
     log.info(
-      { project_id: ctx.projectId, owner_id: owner.id, services: services.services.length },
+      {
+        project_id: ctx.projectId,
+        owner_id: owner.id,
+        services: services.services.length,
+        log_stream: streams.logStream.status,
+        metrics_stream: streams.metricsStream.status,
+      },
       "render connected",
     );
     const row = await findInstallation(ctx.projectId);
@@ -325,6 +507,9 @@ export function mountRenderAuthed(
     const ctx = await requireProjectAccess(c, c.req.param("projectId"));
     const row = await findInstallation(ctx.projectId);
     if (!row) return c.json({ ok: true });
+    // Deprovision on Render's side while the stored key is still ours to use,
+    // then revoke locally.
+    await teardownStreams(row, fetchImpl);
     await teardownInstallation(row);
     return c.json({ ok: true });
   });

--- a/apps/api/src/system-capabilities.test.ts
+++ b/apps/api/src/system-capabilities.test.ts
@@ -12,7 +12,13 @@ test("system capabilities default to the open-core community edition", () => {
     cloudflareConnect: false,
     vercelConnect: false,
     railwayConnect: false,
+    renderConnect: false,
   });
+});
+
+test("renderConnect only needs AGENT_SECRETS_KEY (API-key connect, no OAuth client)", () => {
+  assert.equal(buildSystemCapabilities({}).renderConnect, false);
+  assert.equal(buildSystemCapabilities({ AGENT_SECRETS_KEY: "k" }).renderConnect, true);
 });
 
 test("railwayConnect flips on only when client creds + both platform secrets are set", () => {
@@ -86,6 +92,7 @@ test("system capabilities expose cloud billing and managed agents when explicitl
       cloudflareConnect: false,
       vercelConnect: false,
       railwayConnect: false,
+      renderConnect: false,
     },
   );
 });

--- a/apps/api/src/system-capabilities.ts
+++ b/apps/api/src/system-capabilities.ts
@@ -17,6 +17,9 @@ export type SystemCapabilities = {
   // Same gate for the Railway connector (OAuth client only — telemetry is
   // pulled by the worker, so there's no intake URL to configure here).
   railwayConnect: boolean;
+  // The Render connector has no OAuth client at all (the user pastes an API
+  // key), so it only needs the at-rest encryption key.
+  renderConnect: boolean;
 };
 
 type CapabilityEnv = Partial<
@@ -74,6 +77,10 @@ export function buildSystemCapabilities(env: CapabilityEnv = process.env): Syste
     env.STATE_SIGNING_SECRET &&
     env.AGENT_SECRETS_KEY
   );
+  // Render connect is an API-key paste, not OAuth — no client id/secret and no
+  // signed state. Storing the pasted key still needs the at-rest encryption
+  // key, so that's the whole gate.
+  const renderConnect = !!env.AGENT_SECRETS_KEY;
 
   return {
     edition,
@@ -84,6 +91,7 @@ export function buildSystemCapabilities(env: CapabilityEnv = process.env): Syste
     cloudflareConnect,
     vercelConnect,
     railwayConnect,
+    renderConnect,
   };
 }
 

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -295,6 +295,7 @@ async function validateIngestKey(c: Context<{ Variables: Variables }>, next: () 
 app.use("/v1/*", validateIngestKey);
 app.use("/vercel/drains/*", validateIngestKey);
 app.use("/railway/pull/*", validateIngestKey);
+app.use("/render/pull/*", validateIngestKey);
 
 app.post("/v1/traces", (c) => forward(c, "/v1/traces", "resourceSpans"));
 app.post("/v1/logs", (c) => forward(c, "/v1/logs", "resourceLogs"));
@@ -323,6 +324,14 @@ app.post("/vercel/drains/logs", (c) =>
 app.post("/railway/pull/logs", (c) => forward(c, "/v1/logs", "resourceLogs", { source: "railway" }));
 app.post("/railway/pull/metrics", (c) =>
   forward(c, "/v1/metrics", "resourceMetrics", { source: "railway" }),
+);
+
+// Render puller ingest: identical discipline to the Railway routes — the
+// worker-side puller reads logs/metrics from Render's REST API, transforms to
+// OTLP JSON, and forwards here with the installation's ingest key.
+app.post("/render/pull/logs", (c) => forward(c, "/v1/logs", "resourceLogs", { source: "render" }));
+app.post("/render/pull/metrics", (c) =>
+  forward(c, "/v1/metrics", "resourceMetrics", { source: "render" }),
 );
 
 // AWS Data Firehose HTTP-endpoint ingest (CloudWatch Metric Streams + Logs).

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -36,6 +36,9 @@ import {
 } from "./ingest-source-filter.js";
 import { logger } from "./logger.js";
 import { proxyOperationalRecorder } from "./operational-metrics.js";
+import { decodeOtlpMetricsPayload } from "./otlp-decode.js";
+import { parseRenderLogStreamBody, renderStreamLogsToOtlp } from "./render-log-stream.js";
+import { stampRenderStreamMetrics } from "./render-metrics-stream.js";
 import { Semaphore } from "./semaphore.js";
 import { lookupOrgForProject, recordIngestRequest } from "./tenant-metrics.js";
 import { parseVercelLogDrainBody, vercelLogsToOtlp } from "./vercel-log-drain.js";
@@ -296,6 +299,7 @@ app.use("/v1/*", validateIngestKey);
 app.use("/vercel/drains/*", validateIngestKey);
 app.use("/railway/pull/*", validateIngestKey);
 app.use("/render/pull/*", validateIngestKey);
+app.use("/render/stream/*", validateIngestKey);
 
 app.post("/v1/traces", (c) => forward(c, "/v1/traces", "resourceSpans"));
 app.post("/v1/logs", (c) => forward(c, "/v1/logs", "resourceLogs"));
@@ -333,6 +337,44 @@ app.post("/render/pull/logs", (c) => forward(c, "/v1/logs", "resourceLogs", { so
 app.post("/render/pull/metrics", (c) =>
   forward(c, "/v1/metrics", "resourceMetrics", { source: "render" }),
 );
+
+// Render stream ingest: Render pushes directly here (no puller in the path).
+// The connector registers these URLs as the workspace's Log Stream (HTTPS
+// JSON payloads, transformed below) and Metrics Stream (standard OTLP —
+// provider CUSTOM sends the token as a bearer header). Authenticated by the
+// installation's ingest key like every other ingest route.
+app.post("/render/stream/logs", (c) =>
+  forward(c, "/v1/logs", "resourceLogs", {
+    source: "render",
+    bodyTransform: (body, contentType) => ({
+      body: Buffer.from(
+        JSON.stringify(renderStreamLogsToOtlp(parseRenderLogStreamBody(body, contentType))),
+      ),
+      contentType: "application/json",
+    }),
+  }),
+);
+// Metrics arrive as standard OTLP/HTTP (JSON or protobuf, possibly gzipped)
+// produced by Render itself, so telemetry.source has to be stamped here —
+// decode, stamp, re-emit as JSON for the collector.
+const forwardRenderStreamMetrics = (c: Context<{ Variables: Variables }>) =>
+  forward(c, "/v1/metrics", "resourceMetrics", {
+    source: "render",
+    bodyTransform: (body, contentType, contentEncoding) => ({
+      body: Buffer.from(
+        JSON.stringify(
+          stampRenderStreamMetrics(
+            decodeOtlpMetricsPayload({ body, contentType, contentEncoding }),
+          ),
+        ),
+      ),
+      contentType: "application/json",
+    }),
+  });
+app.post("/render/stream/metrics", forwardRenderStreamMetrics);
+// Standard OTLP exporters append the signal path to a configured base
+// endpoint; accept that form too so the registered URL works either way.
+app.post("/render/stream/metrics/v1/metrics", forwardRenderStreamMetrics);
 
 // AWS Data Firehose HTTP-endpoint ingest (CloudWatch Metric Streams + Logs).
 // Firehose authenticates with X-Amz-Firehose-Access-Key (the project's ingest
@@ -419,6 +461,14 @@ function extractApiKey(c: Context): string | null {
   if (header) return header;
   const auth = c.req.header("authorization");
   if (auth?.toLowerCase().startsWith("bearer ")) return auth.slice(7).trim();
+  // Render stream destinations take a single "token" whose delivery header
+  // isn't under our control — the stream routes also accept it as a query
+  // param so the registered URL can carry it if the header form ever changes.
+  const path = new URL(c.req.url).pathname;
+  if (path.startsWith("/render/stream/")) {
+    const token = c.req.query("token");
+    if (token) return token;
+  }
   return null;
 }
 
@@ -434,6 +484,7 @@ type ForwardOptions = {
   bodyTransform?: (
     body: Buffer,
     contentType: string,
+    contentEncoding?: string,
   ) => { body: Buffer; contentType: string; contentEncoding?: string };
 };
 
@@ -532,7 +583,7 @@ async function forward(
       if (opts.bodyTransform) {
         try {
           const original = await collectStreamWithCap(bodyStream, MAX_BODY_BYTES);
-          const transformed = opts.bodyTransform(original, contentType);
+          const transformed = opts.bodyTransform(original, contentType, contentEncoding);
           prebufferedBody = transformed.body;
           contentType = transformed.contentType;
           contentEncoding = transformed.contentEncoding;

--- a/apps/proxy/src/ingest-source-filter.ts
+++ b/apps/proxy/src/ingest-source-filter.ts
@@ -9,7 +9,7 @@
 // a few seconds to apply is fine; a DB hiccup silently dropping telemetry is not.
 import { logger } from "./logger.js";
 
-export type IngestSource = "otlp" | "aws" | "vercel" | "railway";
+export type IngestSource = "otlp" | "aws" | "vercel" | "railway" | "render";
 export type TelemetrySignal = "traces" | "logs" | "metrics";
 
 export const ingestFilterKey = (source: IngestSource, signal: TelemetrySignal): string =>

--- a/apps/proxy/src/otlp-decode.ts
+++ b/apps/proxy/src/otlp-decode.ts
@@ -16,6 +16,8 @@ const require = createRequire(import.meta.url);
 const otlpRoot = require("@opentelemetry/otlp-transformer/build/esm/generated/root.js");
 const ExportTraceServiceRequest =
   otlpRoot.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+const ExportMetricsServiceRequest =
+  otlpRoot.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 
 // Logs protobuf: the transformer's bundled root only includes trace + metrics, so we
 // decode logs with a minimal inline descriptor. Field numbers follow the OTLP logs.proto
@@ -101,6 +103,23 @@ export function decodeOtlpToRows(input: DecodeInput): DecodedRows | null {
     ? JSON.parse(body.toString("utf8"))
     : decodeProto(ExportTraceServiceRequest, body);
   return { table: "otel_traces", rows: otlpTracesToRows(payload, input.projectId) };
+}
+
+// Decode an OTLP metrics export request (JSON or protobuf, possibly
+// compressed) into its OTLP-JSON object shape. Used by ingest routes that
+// must rewrite a metrics payload before forwarding (e.g. the Render
+// metrics-stream route stamps telemetry.source). Unknown content types are
+// treated as protobuf — that's OTLP/HTTP's default encoding.
+export function decodeOtlpMetricsPayload(input: {
+  contentType: string;
+  contentEncoding?: string;
+  body: Buffer;
+}): unknown {
+  const body = decompress(input.body, input.contentEncoding);
+  if (input.contentType.toLowerCase().includes("json")) {
+    return JSON.parse(body.toString("utf8"));
+  }
+  return decodeProto(ExportMetricsServiceRequest, body);
 }
 
 // The proto reflection types (protobufjs Type / the otlp-transformer root) are

--- a/apps/proxy/src/render-log-stream.test.ts
+++ b/apps/proxy/src/render-log-stream.test.ts
@@ -1,0 +1,102 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { parseRenderLogStreamBody, renderStreamLogsToOtlp } from "./render-log-stream.js";
+
+// Index into an array with narrowing (strict indexing forbids bare [0]).
+function at<T>(items: readonly T[] | undefined, index: number): T {
+  const item = items?.[index];
+  assert.ok(item !== undefined, `expected item at index ${index}`);
+  return item;
+}
+
+test("parses a JSON array, an envelope, and NDJSON", () => {
+  const record = { message: "hi", timestamp: "2026-07-08T10:00:00Z" };
+  assert.equal(
+    parseRenderLogStreamBody(Buffer.from(JSON.stringify([record, record])), "application/json")
+      .length,
+    2,
+  );
+  assert.equal(
+    parseRenderLogStreamBody(
+      Buffer.from(JSON.stringify({ logs: [record] })),
+      "application/json",
+    ).length,
+    1,
+  );
+  const ndjson = `${JSON.stringify(record)}\n${JSON.stringify(record)}\n`;
+  assert.equal(parseRenderLogStreamBody(Buffer.from(ndjson), "application/x-ndjson").length, 2);
+  // NDJSON mislabeled as application/json still parses.
+  assert.equal(parseRenderLogStreamBody(Buffer.from(ndjson), "application/json").length, 2);
+  assert.equal(parseRenderLogStreamBody(Buffer.from(""), "application/json").length, 0);
+});
+
+test("maps Render's labels shape to an OTLP record", () => {
+  const out = renderStreamLogsToOtlp([
+    {
+      id: "log-1",
+      timestamp: "2026-07-08T10:00:00.123456789Z",
+      message: "GET /health 200",
+      labels: [
+        { name: "resource", value: "srv-abc" },
+        { name: "app", value: "acme-api" },
+        { name: "instance", value: "srv-abc-xyz" },
+        { name: "level", value: "info" },
+        { name: "type", value: "app" },
+      ],
+    },
+  ]);
+  const rl = at(out.resourceLogs, 0);
+  const resourceAttrs = Object.fromEntries(
+    rl.resource.attributes.map((a) => [a.key, a.value.stringValue]),
+  );
+  assert.equal(resourceAttrs["service.name"], "acme-api");
+  assert.equal(resourceAttrs["telemetry.source"], "render");
+  assert.equal(resourceAttrs["render.service_id"], "srv-abc");
+  assert.equal(resourceAttrs["render.service_type"], "app");
+
+  const record = at(at(rl.scopeLogs, 0).logRecords, 0);
+  assert.equal(record.severityText, "INFO");
+  assert.equal(record.body.stringValue, "GET /health 200");
+  assert.equal(record.timeUnixNano, `${BigInt(Date.parse("2026-07-08T10:00:00Z")) * 1_000_000n + 123456789n}`);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["render.log_id"], "log-1");
+  assert.equal(attrs["render.instance"], "srv-abc-xyz");
+});
+
+test("maps flat syslog-annotation-style fields and epoch timestamps", () => {
+  const out = renderStreamLogsToOtlp([
+    {
+      message: "worker started",
+      time: 1783936800123, // epoch ms
+      level: "warning",
+      service: "acme-worker",
+      instance: "srv-def-1",
+      deploy: "dep-42",
+    },
+  ]);
+  const rl = at(out.resourceLogs, 0);
+  const resourceAttrs = Object.fromEntries(
+    rl.resource.attributes.map((a) => [a.key, a.value.stringValue]),
+  );
+  assert.equal(resourceAttrs["service.name"], "acme-worker");
+  const record = at(at(rl.scopeLogs, 0).logRecords, 0);
+  assert.equal(record.severityText, "WARN");
+  assert.equal(record.timeUnixNano, `${1783936800123n * 1_000_000n}`);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["render.instance"], "srv-def-1");
+  // Unknown scalar fields ride along instead of being dropped.
+  assert.equal(attrs["render.attr.deploy"], "dep-42");
+});
+
+test("an unrecognized record still produces a usable log line", () => {
+  const out = renderStreamLogsToOtlp([{ weird: true, nested: { a: 1 } }]);
+  const rl = at(out.resourceLogs, 0);
+  const resourceAttrs = Object.fromEntries(
+    rl.resource.attributes.map((a) => [a.key, a.value.stringValue]),
+  );
+  assert.equal(resourceAttrs["service.name"], "render");
+  const record = at(at(rl.scopeLogs, 0).logRecords, 0);
+  // Whole record serialized as the body so nothing is lost.
+  assert.match(record.body.stringValue ?? "", /weird/);
+  assert.equal(record.timeUnixNano, "0");
+});

--- a/apps/proxy/src/render-log-stream.ts
+++ b/apps/proxy/src/render-log-stream.ts
@@ -1,0 +1,265 @@
+// Render Log Stream (HTTPS destination) → OTLP JSON. Render pushes each
+// workspace's logs to the endpoint the connector registered
+// (/render/stream/logs) as JSON over HTTPS. The payload schema for custom
+// HTTPS destinations is not formally documented, so the parser is permissive:
+// it accepts an array, a single object, an enveloped `{logs: [...]}`, or
+// NDJSON, and maps the field names Render uses elsewhere (its /v1/logs API
+// shape with a `labels` name/value array, and flat syslog-annotation-style
+// fields like appname/service/instance). Unknown scalar fields ride along as
+// render.attr.* so nothing is silently dropped.
+
+type OtlpAnyValue = {
+  stringValue?: string;
+  intValue?: string;
+  doubleValue?: number;
+  boolValue?: boolean;
+};
+
+type OtlpKeyValue = { key: string; value: OtlpAnyValue };
+
+export type RenderStreamLogRecord = Record<string, unknown>;
+
+export type RenderStreamOtlpLogsExport = {
+  resourceLogs: Array<{
+    resource: { attributes: OtlpKeyValue[] };
+    scopeLogs: Array<{
+      scope: { name: string };
+      logRecords: Array<{
+        timeUnixNano: string;
+        observedTimeUnixNano: string;
+        severityText: string;
+        severityNumber: number;
+        body: OtlpAnyValue;
+        attributes: OtlpKeyValue[];
+      }>;
+    }>;
+  }>;
+};
+
+const LEVEL_TO_SEVERITY: Record<string, { text: string; number: number }> = {
+  trace: { text: "TRACE", number: 1 },
+  debug: { text: "DEBUG", number: 5 },
+  info: { text: "INFO", number: 9 },
+  notice: { text: "INFO", number: 10 },
+  warning: { text: "WARN", number: 13 },
+  warn: { text: "WARN", number: 13 },
+  error: { text: "ERROR", number: 17 },
+  err: { text: "ERROR", number: 17 },
+  crit: { text: "FATAL", number: 21 },
+  fatal: { text: "FATAL", number: 21 },
+};
+
+export function parseRenderLogStreamBody(
+  body: Buffer,
+  contentType: string,
+): RenderStreamLogRecord[] {
+  const text = body.toString("utf8").trim();
+  if (!text) return [];
+  const lower = contentType.toLowerCase();
+  if (lower.includes("ndjson") || lower.includes("x-ndjson")) {
+    return text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => coerceRecord(JSON.parse(line)));
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // Some senders use content-type application/json for newline-delimited
+    // payloads anyway — retry as NDJSON before giving up.
+    return text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => coerceRecord(JSON.parse(line)));
+  }
+  if (Array.isArray(parsed)) return parsed.map(coerceRecord);
+  if (parsed && typeof parsed === "object") {
+    const envelope = parsed as { logs?: unknown };
+    if (Array.isArray(envelope.logs)) return envelope.logs.map(coerceRecord);
+    return [coerceRecord(parsed)];
+  }
+  throw new Error("invalid Render log stream payload");
+}
+
+export function renderStreamLogsToOtlp(
+  logs: RenderStreamLogRecord[],
+): RenderStreamOtlpLogsExport {
+  return {
+    resourceLogs: logs.map((log) => {
+      const labels = labelMap(log);
+      const nanos = timestampToNanos(log.timestamp ?? log.time ?? log.ts ?? labels.timestamp);
+      return {
+        resource: { attributes: resourceAttributes(log, labels) },
+        scopeLogs: [
+          {
+            scope: { name: "render.stream.logs" },
+            logRecords: [
+              {
+                timeUnixNano: nanos,
+                observedTimeUnixNano: nanos,
+                ...severity(labels.level ?? log.level ?? log.severity ?? log.status),
+                body: { stringValue: messageBody(log) },
+                attributes: logAttributes(log, labels),
+              },
+            ],
+          },
+        ],
+      };
+    }),
+  };
+}
+
+function coerceRecord(value: unknown): RenderStreamLogRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("invalid Render log stream record");
+  }
+  return value as RenderStreamLogRecord;
+}
+
+// Render's own log objects carry metadata as labels: [{name, value}]
+// (resource, instance, level, type, …). Flatten to a dict when present.
+function labelMap(log: RenderStreamLogRecord): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (Array.isArray(log.labels)) {
+    for (const label of log.labels) {
+      if (
+        label &&
+        typeof label === "object" &&
+        typeof (label as { name?: unknown }).name === "string" &&
+        typeof (label as { value?: unknown }).value === "string"
+      ) {
+        out[(label as { name: string }).name] = (label as { value: string }).value;
+      }
+    }
+  }
+  return out;
+}
+
+function resourceAttributes(
+  log: RenderStreamLogRecord,
+  labels: Record<string, string>,
+): OtlpKeyValue[] {
+  // Prefer human-readable slugs (syslog annotations use the service slug as
+  // APP-NAME) over srv- ids for service.name; keep the id as an attribute.
+  const serviceName =
+    stringOf(log.service) ??
+    stringOf(log.serviceName) ??
+    stringOf(log.app) ??
+    stringOf(log.appname) ??
+    labels.service ??
+    labels.app ??
+    labels.resource ??
+    stringOf(log.resource) ??
+    "render";
+  const serviceId =
+    labels.resource ?? stringOf(log.resource) ?? stringOf(log.serviceId) ?? undefined;
+  return [
+    kv("service.name", serviceName),
+    kv("telemetry.source", "render"),
+    kv("render.service_id", serviceId),
+    kv("render.service_type", labels.type ?? stringOf(log.type)),
+  ].filter(isKv);
+}
+
+function logAttributes(
+  log: RenderStreamLogRecord,
+  labels: Record<string, string>,
+): OtlpKeyValue[] {
+  const attrs: Array<OtlpKeyValue | null> = [
+    kv("render.log_id", stringOf(log.id)),
+    kv("render.instance", labels.instance ?? stringOf(log.instance) ?? stringOf(log.hostname)),
+  ];
+  const claimed = new Set(["resource", "instance", "level", "type", "service", "app"]);
+  for (const [name, value] of Object.entries(labels)) {
+    if (!claimed.has(name)) attrs.push(kv(`render.attr.${name}`, value));
+  }
+  const claimedFields = new Set([
+    "id",
+    "message",
+    "msg",
+    "log",
+    "text",
+    "timestamp",
+    "time",
+    "ts",
+    "level",
+    "severity",
+    "status",
+    "labels",
+    "service",
+    "serviceName",
+    "app",
+    "appname",
+    "resource",
+    "serviceId",
+    "instance",
+    "hostname",
+    "type",
+  ]);
+  for (const [name, value] of Object.entries(log)) {
+    if (claimedFields.has(name)) continue;
+    if (value === null || typeof value === "object") continue;
+    attrs.push(kv(`render.attr.${name}`, value));
+  }
+  return attrs.filter(isKv);
+}
+
+function messageBody(log: RenderStreamLogRecord): string {
+  for (const field of ["message", "msg", "log", "text"]) {
+    const value = log[field];
+    if (typeof value === "string") return value;
+  }
+  return JSON.stringify(log);
+}
+
+function severity(value: unknown): { severityText: string; severityNumber: number } {
+  const mapped = typeof value === "string" ? LEVEL_TO_SEVERITY[value.toLowerCase()] : undefined;
+  return { severityText: mapped?.text ?? "", severityNumber: mapped?.number ?? 0 };
+}
+
+// Timestamps arrive as RFC3339 strings or epoch numbers of unknown unit —
+// disambiguate by magnitude (s ~1e9, ms ~1e12, µs ~1e15, ns ~1e18).
+function timestampToNanos(value: unknown): string {
+  if (typeof value === "string" && value) {
+    if (/^\d+$/.test(value)) return timestampToNanos(Number(value));
+    const ms = Date.parse(value);
+    if (Number.isFinite(ms)) {
+      // Preserve sub-millisecond fraction when present.
+      const match = value.match(/\.(\d{4,9})(?:Z|[+-])/);
+      const base = BigInt(ms) * 1_000_000n - BigInt(ms % 1000) * 1_000_000n;
+      if (match?.[1]) return `${base + BigInt(match[1].padEnd(9, "0"))}`;
+      return `${BigInt(ms) * 1_000_000n}`;
+    }
+    return "0";
+  }
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    if (value > 1e17) return `${BigInt(Math.trunc(value))}`;
+    if (value > 1e14) return `${BigInt(Math.trunc(value)) * 1_000n}`;
+    if (value > 1e11) return `${BigInt(Math.trunc(value)) * 1_000_000n}`;
+    return `${BigInt(Math.trunc(value)) * 1_000_000_000n}`;
+  }
+  return "0";
+}
+
+function kv(key: string, value: unknown): OtlpKeyValue | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "string") return value ? { key, value: { stringValue: value } } : null;
+  if (typeof value === "number") {
+    return Number.isInteger(value)
+      ? { key, value: { intValue: String(value) } }
+      : { key, value: { doubleValue: value } };
+  }
+  if (typeof value === "boolean") return { key, value: { boolValue: value } };
+  return { key, value: { stringValue: String(value) } };
+}
+
+function isKv(value: OtlpKeyValue | null): value is OtlpKeyValue {
+  return value !== null;
+}
+
+function stringOf(value: unknown): string | undefined {
+  return typeof value === "string" && value ? value : undefined;
+}

--- a/apps/proxy/src/render-metrics-stream.test.ts
+++ b/apps/proxy/src/render-metrics-stream.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+import { gzipSync } from "node:zlib";
+
+import { decodeOtlpMetricsPayload } from "./otlp-decode.js";
+import { stampRenderStreamMetrics } from "./render-metrics-stream.js";
+
+const require = createRequire(import.meta.url);
+const otlpRoot = require("@opentelemetry/otlp-transformer/build/esm/generated/root.js");
+const ExportMetricsServiceRequest =
+  otlpRoot.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+
+function samplePayload() {
+  return {
+    resourceMetrics: [
+      {
+        resource: {
+          attributes: [{ key: "service.name", value: { stringValue: "fakeco-api" } }],
+        },
+        scopeMetrics: [
+          {
+            scope: { name: "render" },
+            metrics: [
+              {
+                name: "render.cpu_usage",
+                unit: "cpu",
+                gauge: {
+                  dataPoints: [{ timeUnixNano: "1750000000000000000", asDouble: 0.25 }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+test("stamps telemetry.source=render onto every resource", () => {
+  const stamped = stampRenderStreamMetrics(samplePayload()) as ReturnType<typeof samplePayload>;
+  const attrs = stamped.resourceMetrics[0]?.resource.attributes ?? [];
+  assert.deepEqual(attrs, [
+    { key: "service.name", value: { stringValue: "fakeco-api" } },
+    { key: "telemetry.source", value: { stringValue: "render" } },
+  ]);
+});
+
+test("replaces a spoofed telemetry.source instead of duplicating it", () => {
+  const payload = samplePayload();
+  payload.resourceMetrics[0]?.resource.attributes.push({
+    key: "telemetry.source",
+    value: { stringValue: "otlp" },
+  });
+  const stamped = stampRenderStreamMetrics(payload) as ReturnType<typeof samplePayload>;
+  const sources = (stamped.resourceMetrics[0]?.resource.attributes ?? []).filter(
+    (a) => a.key === "telemetry.source",
+  );
+  assert.deepEqual(sources, [{ key: "telemetry.source", value: { stringValue: "render" } }]);
+});
+
+test("stamps a resource-less entry rather than dropping it", () => {
+  const payload = {
+    resourceMetrics: [{ scopeMetrics: [] }],
+  };
+  const stamped = stampRenderStreamMetrics(payload) as {
+    resourceMetrics: Array<{ resource?: { attributes?: unknown[] } }>;
+  };
+  assert.deepEqual(stamped.resourceMetrics[0]?.resource?.attributes, [
+    { key: "telemetry.source", value: { stringValue: "render" } },
+  ]);
+});
+
+test("strips exemplars so protobuf byte fields never reach the JSON forward", () => {
+  const payload = samplePayload();
+  const dp = payload.resourceMetrics[0]?.scopeMetrics[0]?.metrics[0]?.gauge.dataPoints[0] as
+    | (Record<string, unknown> & { exemplars?: unknown })
+    | undefined;
+  if (dp) dp.exemplars = [{ spanId: Buffer.from("abc"), asDouble: 1 }];
+  const stamped = stampRenderStreamMetrics(payload);
+  assert.ok(!JSON.stringify(stamped).includes("exemplars"));
+});
+
+test("rejects a payload without resourceMetrics", () => {
+  assert.throws(() => stampRenderStreamMetrics({ resourceLogs: [] }));
+  assert.throws(() => stampRenderStreamMetrics("nope"));
+});
+
+test("decodes a gzipped protobuf OTLP export and stamps it", () => {
+  const message = ExportMetricsServiceRequest.fromObject(samplePayload());
+  const body = gzipSync(Buffer.from(ExportMetricsServiceRequest.encode(message).finish()));
+  const decoded = decodeOtlpMetricsPayload({
+    contentType: "application/x-protobuf",
+    contentEncoding: "gzip",
+    body,
+  });
+  const stamped = stampRenderStreamMetrics(decoded) as {
+    resourceMetrics: Array<{
+      resource: { attributes: Array<{ key: string; value: { stringValue?: string } }> };
+      scopeMetrics: Array<{
+        metrics: Array<{
+          gauge: { dataPoints: Array<{ timeUnixNano: string; asDouble: number }> };
+        }>;
+      }>;
+    }>;
+  };
+  const attrs = stamped.resourceMetrics[0]?.resource.attributes ?? [];
+  assert.ok(attrs.some((a) => a.key === "telemetry.source" && a.value.stringValue === "render"));
+  assert.ok(attrs.some((a) => a.key === "service.name" && a.value.stringValue === "fakeco-api"));
+  const point = stamped.resourceMetrics[0]?.scopeMetrics[0]?.metrics[0]?.gauge.dataPoints[0];
+  assert.equal(point?.timeUnixNano, "1750000000000000000");
+  assert.equal(point?.asDouble, 0.25);
+});
+
+test("decodes a plain JSON export", () => {
+  const decoded = decodeOtlpMetricsPayload({
+    contentType: "application/json",
+    body: Buffer.from(JSON.stringify(samplePayload())),
+  });
+  assert.deepEqual(decoded, samplePayload());
+});

--- a/apps/proxy/src/render-metrics-stream.ts
+++ b/apps/proxy/src/render-metrics-stream.ts
@@ -1,0 +1,60 @@
+// Render Metrics Stream (provider CUSTOM) → OTLP JSON stamped with
+// telemetry.source=render. Render pushes standard OTLP/HTTP metrics to the
+// endpoint the connector registered (/render/stream/metrics). Unlike our own
+// transforms, the payload is produced by Render and carries no
+// telemetry.source resource attribute — without stamping, streamed metrics
+// would be indistinguishable from plain OTLP ingest on the read path.
+
+type KeyValue = { key?: unknown; value?: unknown };
+
+export function stampRenderStreamMetrics(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("invalid Render metrics stream payload");
+  }
+  const root = payload as { resourceMetrics?: unknown };
+  if (!Array.isArray(root.resourceMetrics)) {
+    throw new Error("invalid Render metrics stream payload: missing resourceMetrics");
+  }
+  for (const rm of root.resourceMetrics) {
+    if (!rm || typeof rm !== "object") continue;
+    const entry = rm as {
+      resource?: { attributes?: KeyValue[] };
+      scopeMetrics?: unknown;
+    };
+    entry.resource ??= {};
+    const attrs = Array.isArray(entry.resource.attributes) ? entry.resource.attributes : [];
+    entry.resource.attributes = [
+      ...attrs.filter((a) => !(a && typeof a === "object" && a.key === "telemetry.source")),
+      { key: "telemetry.source", value: { stringValue: "render" } },
+    ];
+    stripExemplars(entry.scopeMetrics);
+  }
+  return payload;
+}
+
+// Protobuf-decoded exemplars carry trace/span ids as raw Buffers, which don't
+// survive JSON re-encoding in the hex form OTLP JSON expects. They're
+// irrelevant for infra metrics, so drop them rather than risk the collector
+// rejecting the whole batch.
+function stripExemplars(scopeMetrics: unknown): void {
+  if (!Array.isArray(scopeMetrics)) return;
+  for (const sm of scopeMetrics) {
+    const metrics = (sm as { metrics?: unknown } | null)?.metrics;
+    if (!Array.isArray(metrics)) continue;
+    for (const metric of metrics) {
+      if (!metric || typeof metric !== "object") continue;
+      for (const family of ["gauge", "sum", "histogram", "exponentialHistogram", "summary"]) {
+        const dataPoints = (metric as Record<string, { dataPoints?: unknown } | undefined>)[family]
+          ?.dataPoints;
+        if (!Array.isArray(dataPoints)) continue;
+        for (const dp of dataPoints) {
+          if (dp && typeof dp === "object" && "exemplars" in dp) {
+            // undefined is omitted by JSON.stringify, which is all the
+            // re-encode needs; assignment avoids the delete deopt.
+            (dp as { exemplars?: unknown }).exemplars = undefined;
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -85,6 +85,7 @@ import {
   useStartRailwayInstall,
   useStartSlackInstall,
   useStartVercelInstall,
+  useSystemCapabilities,
   useTestWebhook,
   useUninstallCloudflare,
   useUninstallLinear,
@@ -1393,6 +1394,10 @@ function RenderCard({ projectId }: { projectId: string | undefined }) {
   const validate = useRenderOwners(projectId);
   const connect = useConnectRender(projectId);
   const uninstall = useUninstallRender(projectId);
+  // Self-hosted deployments without AGENT_SECRETS_KEY can't store the pasted
+  // key — don't offer a connect that would only ever 503.
+  const capabilities = useSystemCapabilities();
+  const unavailable = capabilities.data ? !capabilities.data.renderConnect : false;
 
   const [apiKey, setApiKey] = useState("");
   const [owners, setOwners] = useState<RenderOwner[] | null>(null);
@@ -1510,12 +1515,18 @@ function RenderCard({ projectId }: { projectId: string | undefined }) {
           </div>
         )}
         {error && <p className="m-0 text-[12.5px] text-danger">{error}</p>}
+        {unavailable && (
+          <p className="m-0 text-[12.5px] text-muted">
+            Render connect isn't configured in this environment — the server needs an integration
+            secrets key (AGENT_SECRETS_KEY) to store pasted API keys encrypted.
+          </p>
+        )}
         {!connecting && (
           <div className="flex items-center gap-2">
             <Btn
               size="sm"
               variant={installed ? "secondary" : "primary"}
-              disabled={!projectId}
+              disabled={!projectId || unavailable}
               onClick={() => setConnecting(true)}
             >
               {installed ? "Reconnect" : "Connect Render"}

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -14,6 +14,7 @@ import {
   type LinearTicketInstruction,
   type LinearTicketPolicy,
   type PrPolicy,
+  type RenderOwner,
   type RepoBranch,
   type StackComponent,
   type WebhookDelivery,
@@ -22,6 +23,7 @@ import {
   useCloudConnections,
   useCloudStackHealth,
   useCloudflareInstallation,
+  useConnectRender,
   useCreateCloudConnection,
   useCreateKey,
   useCreateMcpToken,
@@ -55,6 +57,8 @@ import {
   useRailwayInstallation,
   useRedeliverWebhook,
   useRemoveIntegration,
+  useRenderInstallation,
+  useRenderOwners,
   useResetGithubCommitAuthor,
   useRevokeKey,
   useRevokeMcpToken,
@@ -85,6 +89,7 @@ import {
   useUninstallCloudflare,
   useUninstallLinear,
   useUninstallRailway,
+  useUninstallRender,
   useUninstallSlack,
   useUninstallVercel,
   useUpdateGithubRepoAccess,
@@ -100,6 +105,7 @@ import { Dropdown, type DropdownOption } from "./design/Dropdown.tsx";
 import { Btn, Chip, FieldLabel, Input, Label, Tile } from "./design/ui";
 import { McpInstallPanel } from "./onboarding/McpInstallDialog.tsx";
 import { InfoIcon } from "./onboarding/icons.tsx";
+import { renderErrorMessage } from "./onboarding/renderConnectModel.ts";
 import { VERCEL_PLAN_REQUIREMENT } from "./onboarding/vercelConnectModel.ts";
 import { AgentMemoriesCard } from "./settings/AgentMemoriesCard.tsx";
 import { BillingCard } from "./settings/BillingCard.tsx";
@@ -626,6 +632,7 @@ function ProjectSectionView({
             <CloudflareCard projectId={projectId} />
             <VercelCard projectId={projectId} />
             <RailwayCard projectId={projectId} />
+            <RenderCard projectId={projectId} />
             <AwsCard projectId={projectId} />
             <IngestSourcesCard projectId={projectId} />
           </div>
@@ -1378,6 +1385,159 @@ function RailwayCard({ projectId }: { projectId: string | undefined }) {
   );
 }
 
+// Render connect is an API-key paste (no OAuth redirect), so the card embeds
+// the same two-step form as the onboarding flow in a compact shape: validate
+// the key → pick a workspace → connect.
+function RenderCard({ projectId }: { projectId: string | undefined }) {
+  const install = useRenderInstallation(projectId);
+  const validate = useRenderOwners(projectId);
+  const connect = useConnectRender(projectId);
+  const uninstall = useUninstallRender(projectId);
+
+  const [apiKey, setApiKey] = useState("");
+  const [owners, setOwners] = useState<RenderOwner[] | null>(null);
+  const [ownerId, setOwnerId] = useState<string | null>(null);
+  const [connecting, setConnecting] = useState(false);
+
+  const installed = install.data?.installed === true;
+  const serviceCount = install.data?.installed
+    ? install.data.services.filter((s) => !s.suspended).length
+    : 0;
+
+  const reset = () => {
+    setApiKey("");
+    setOwners(null);
+    setOwnerId(null);
+    setConnecting(false);
+    validate.reset();
+    connect.reset();
+  };
+
+  const error = connect.error
+    ? renderErrorMessage(connect.error)
+    : validate.error
+      ? renderErrorMessage(validate.error)
+      : null;
+
+  return (
+    <Tile label="Render">
+      <div className="space-y-3">
+        <p className="text-[13px] text-muted">
+          Paste a Render API key and pick the workspace to share — we pull your services' logs and
+          infra metrics from Render's API into this project automatically. The key is stored
+          encrypted; revoke it in Render at any time.
+        </p>
+        <div>
+          {installed ? (
+            <Chip tone="success" dot>
+              {install.data?.installed && install.data.ownerName
+                ? `${install.data.ownerName} — ${serviceCount === 1 ? "1 service" : `${serviceCount} services`}`
+                : `${serviceCount} services`}
+            </Chip>
+          ) : (
+            <Chip tone="muted" dot>
+              Not connected
+            </Chip>
+          )}
+        </div>
+        {connecting && !owners && (
+          <form
+            className="flex items-center gap-2"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (validate.isPending || !apiKey.trim()) return;
+              validate.mutate(apiKey.trim(), {
+                onSuccess: ({ owners }) => {
+                  setOwners(owners);
+                  setOwnerId(owners.length === 1 ? (owners[0]?.id ?? null) : null);
+                },
+              });
+            }}
+          >
+            <input
+              type="password"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder="rnd_…"
+              autoComplete="off"
+              spellCheck={false}
+              className="h-[32px] min-w-0 flex-1 rounded-[8px] border border-border bg-surface-2 px-2.5 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:outline-none"
+            />
+            <Btn
+              size="sm"
+              variant="primary"
+              type="submit"
+              loading={validate.isPending}
+              disabled={!apiKey.trim()}
+            >
+              Validate
+            </Btn>
+            <Btn size="sm" variant="secondary" onClick={reset}>
+              Cancel
+            </Btn>
+          </form>
+        )}
+        {connecting && owners && (
+          <div className="flex items-center gap-2">
+            <select
+              value={ownerId ?? ""}
+              onChange={(e) => setOwnerId(e.target.value || null)}
+              className="h-[32px] min-w-0 flex-1 rounded-[8px] border border-border bg-surface-2 px-2 text-[12.5px] text-fg focus:outline-none"
+            >
+              <option value="">Pick a workspace…</option>
+              {owners.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.name}
+                  {o.type === "team" ? " (team)" : ""}
+                </option>
+              ))}
+            </select>
+            <Btn
+              size="sm"
+              variant="primary"
+              loading={connect.isPending}
+              disabled={!ownerId}
+              onClick={() => {
+                if (!ownerId) return;
+                connect.mutate({ apiKey: apiKey.trim(), ownerId }, { onSuccess: () => reset() });
+              }}
+            >
+              Connect
+            </Btn>
+            <Btn size="sm" variant="secondary" onClick={reset}>
+              Cancel
+            </Btn>
+          </div>
+        )}
+        {error && <p className="m-0 text-[12.5px] text-danger">{error}</p>}
+        {!connecting && (
+          <div className="flex items-center gap-2">
+            <Btn
+              size="sm"
+              variant={installed ? "secondary" : "primary"}
+              disabled={!projectId}
+              onClick={() => setConnecting(true)}
+            >
+              {installed ? "Reconnect" : "Connect Render"}
+            </Btn>
+            {installed && (
+              <Btn
+                size="sm"
+                variant="danger"
+                loading={uninstall.isPending}
+                disabled={!projectId || uninstall.isPending}
+                onClick={() => uninstall.mutate()}
+              >
+                Disconnect
+              </Btn>
+            )}
+          </div>
+        )}
+      </div>
+    </Tile>
+  );
+}
+
 function SlackRoutingCard({ projectId }: { projectId: string | undefined }) {
   const install = useSlackInstallation();
   const installed = install.data?.installed === true;
@@ -1748,7 +1908,7 @@ function IngestSourcesCard({ projectId }: { projectId: string | undefined }) {
   const state = filters.data;
 
   const setSignal = (
-    source: "otlp" | "aws" | "vercel" | "railway",
+    source: "otlp" | "aws" | "vercel" | "railway" | "render",
     signal: string,
     next: boolean,
   ) => {
@@ -1815,6 +1975,17 @@ function IngestSourcesCard({ projectId }: { projectId: string | undefined }) {
               state={state.railway}
               disabled={setFilters.isPending}
               onToggle={(signal, next) => setSignal("railway", signal, next)}
+            />
+            <IngestSourceRow
+              title="Render"
+              hint="Logs and infra metrics pulled from the connected Render workspace."
+              signals={[
+                { key: "logs", label: "Logs" },
+                { key: "metrics", label: "Metrics" },
+              ]}
+              state={state.render}
+              disabled={setFilters.isPending}
+              onToggle={(signal, next) => setSignal("render", signal, next)}
             />
           </div>
         )}

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -1428,9 +1428,9 @@ function RenderCard({ projectId }: { projectId: string | undefined }) {
     <Tile label="Render">
       <div className="space-y-3">
         <p className="text-[13px] text-muted">
-          Paste a Render API key and pick the workspace to share — we pull your services' logs and
-          infra metrics from Render's API into this project automatically. The key is stored
-          encrypted; revoke it in Render at any time.
+          Paste a Render API key and pick the workspace to share — we set up Render's log and
+          metrics streams to push your services' telemetry into this project (with API polling as
+          fallback). The key is stored encrypted; revoke it in Render at any time.
         </p>
         <div>
           {installed ? (

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -80,6 +80,7 @@ export type SystemCapabilities = {
   cloudflareConnect: boolean;
   vercelConnect: boolean;
   railwayConnect: boolean;
+  renderConnect: boolean;
 };
 
 const SIGNUP_SOURCE_STORAGE_KEY = "superlog.signup_source";
@@ -974,6 +975,82 @@ export function useUninstallRailway(projectId: string | undefined) {
   });
 }
 
+export type RenderServiceSummary = {
+  id: string;
+  name: string;
+  type: string;
+  region: string | null;
+  suspended: boolean;
+};
+
+export type RenderInstallation =
+  | { installed: false }
+  | {
+      installed: true;
+      ownerId: string;
+      ownerName: string | null;
+      services: RenderServiceSummary[];
+      installedAt: string;
+    };
+
+export type RenderOwner = {
+  id: string;
+  name: string;
+  email: string | null;
+  type: string;
+};
+
+// Render installs are per-project, same scoping discipline as Railway.
+export function useRenderInstallation(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  return useQuery({
+    queryKey: ["render-installation", projectId],
+    queryFn: () => fetcher<RenderInstallation>(`/api/projects/${projectId}/render/installation`),
+    enabled: !!projectId,
+    refetchInterval: 15000,
+  });
+}
+
+// Validate a pasted Render API key and list the workspaces it can see — the
+// connect dialog's picker step. The key is only held in memory client-side.
+export function useRenderOwners(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  return useMutation({
+    mutationFn: (apiKey: string) =>
+      fetcher<{ owners: RenderOwner[] }>(`/api/projects/${projectId}/render/owners`, {
+        method: "POST",
+        body: JSON.stringify({ apiKey }),
+      }),
+  });
+}
+
+export function useConnectRender(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { apiKey: string; ownerId: string }) =>
+      fetcher<RenderInstallation>(`/api/projects/${projectId}/render/connect`, {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["render-installation", projectId] });
+    },
+  });
+}
+
+export function useUninstallRender(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      fetcher<{ ok: true }>(`/api/projects/${projectId}/render/uninstall`, { method: "POST" }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["render-installation", projectId] });
+    },
+  });
+}
+
 export function useSlackChannels(enabled: boolean) {
   const fetcher = useFetcher();
   return useQuery({
@@ -1173,13 +1250,14 @@ export function useDeleteCloudConnection(projectId: string) {
 }
 
 // Per-project ingest source filters: turn a telemetry source (SDK/OTLP, AWS
-// CloudWatch, Vercel Drains, or the Railway puller) on/off per signal. The
-// proxy ack-drops disabled telemetry.
+// CloudWatch, Vercel Drains, or the Railway/Render pullers) on/off per signal.
+// The proxy ack-drops disabled telemetry.
 export type IngestFilterState = {
   otlp: { traces: boolean; logs: boolean; metrics: boolean };
   aws: { logs: boolean; metrics: boolean };
   vercel: { traces: boolean; logs: boolean };
   railway: { logs: boolean; metrics: boolean };
+  render: { logs: boolean; metrics: boolean };
 };
 
 export function useIngestFilters(projectId: string | undefined) {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -983,6 +983,12 @@ export type RenderServiceSummary = {
   suspended: boolean;
 };
 
+export type RenderStreamState = {
+  status: "provisioned" | "conflict" | "unavailable";
+  endpoint: string | null;
+  detail: string | null;
+} | null;
+
 export type RenderInstallation =
   | { installed: false }
   | {
@@ -990,6 +996,11 @@ export type RenderInstallation =
       ownerId: string;
       ownerName: string | null;
       services: RenderServiceSummary[];
+      // How each signal arrives: "provisioned" = Render pushes it to our
+      // intake (log/metrics stream); anything else = the worker polls
+      // Render's API as a fallback.
+      logStream: RenderStreamState;
+      metricsStream: RenderStreamState;
       installedAt: string;
     };
 

--- a/apps/web/src/onboarding/ConnectDataChooser.tsx
+++ b/apps/web/src/onboarding/ConnectDataChooser.tsx
@@ -11,6 +11,7 @@ import {
   ChevronRightIcon,
   CloudflareIcon,
   RailwayIcon,
+  RenderIcon,
   TerminalIcon,
   VercelIcon,
 } from "./icons.tsx";
@@ -27,6 +28,7 @@ function ConnectGlyph({ icon }: { icon: ConnectIcon }) {
     cloudflare: CloudflareIcon,
     vercel: VercelIcon,
     railway: RailwayIcon,
+    render: RenderIcon,
     terminal: TerminalIcon,
   };
   const Glyph = map[icon];
@@ -113,6 +115,7 @@ export function ConnectDataChooser({
     cloudflare: capabilities.data?.cloudflareConnect ?? false,
     vercel: capabilities.data?.vercelConnect ?? false,
     railway: capabilities.data?.railwayConnect ?? false,
+    render: capabilities.data?.renderConnect ?? false,
   });
   return (
     <>

--- a/apps/web/src/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/onboarding/OnboardingWizard.tsx
@@ -17,6 +17,7 @@ import { AwsConnectFlow } from "./AwsConnectFlow.tsx";
 import { CloudflareConnectFlow } from "./CloudflareConnectFlow.tsx";
 import { ConnectDataChooser } from "./ConnectDataChooser.tsx";
 import { RailwayConnectFlow } from "./RailwayConnectFlow.tsx";
+import { RenderConnectFlow } from "./RenderConnectFlow.tsx";
 import { VercelConnectFlow } from "./VercelConnectFlow.tsx";
 import type { ConnectAction } from "./connectChoices.ts";
 import { CheckIcon, GithubIcon, SlackIcon, SpinnerIcon } from "./icons.tsx";
@@ -45,7 +46,15 @@ import {
 type Mode = "web" | "agent";
 // Web-mode landing fork: choose a source, then either a no-code integration
 // flow (AWS / Cloudflare / Vercel) or the coding-agent install → deploy flow.
-type WebView = "chooser" | "aws" | "cloudflare" | "vercel" | "railway" | "code" | "deploy";
+type WebView =
+  | "chooser"
+  | "aws"
+  | "cloudflare"
+  | "vercel"
+  | "railway"
+  | "render"
+  | "code"
+  | "deploy";
 
 // The Cloudflare / Vercel OAuth callbacks redirect back to the app with
 // `?cloudflare=...` / `?vercel=...`. When that lands we want to drop straight
@@ -104,6 +113,8 @@ export function OnboardingWizard({
       setWebView("vercel");
     } else if (action === "railway") {
       setWebView("railway");
+    } else if (action === "render") {
+      setWebView("render");
     } else {
       setWebView("code");
     }
@@ -186,6 +197,14 @@ export function OnboardingWizard({
             />
           ) : webView === "railway" ? (
             <RailwayConnectFlow
+              projectId={projectId}
+              eventsArrived={eventsArrived}
+              onBack={() => setWebView("chooser")}
+              onDone={onComplete}
+              onExploreDemo={onExploreDemo}
+            />
+          ) : webView === "render" ? (
+            <RenderConnectFlow
               projectId={projectId}
               eventsArrived={eventsArrived}
               onBack={() => setWebView("chooser")}

--- a/apps/web/src/onboarding/RenderConnectFlow.tsx
+++ b/apps/web/src/onboarding/RenderConnectFlow.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import {
   type RenderOwner,
+  type RenderStreamState,
   useConnectRender,
   useRenderInstallation,
   useRenderOwners,
@@ -131,6 +132,8 @@ export function RenderConnectFlow({
         <ConnectedPanel
           ownerName={installedData.ownerName}
           services={installedData.services}
+          logStream={installedData.logStream}
+          metricsStream={installedData.metricsStream}
           statusText={renderStatusText(phase, eventsArrived)}
           eventsArrived={eventsArrived}
         />
@@ -152,7 +155,7 @@ function headerForPhase(phase: "start" | "pick" | "connected"): { title: string;
     case "start":
       return {
         title: "Connect Render",
-        sub: "Paste a Render API key and pick the workspace to share. We pull your services' logs and infra metrics from Render's API — no agent, no code changes.",
+        sub: "Paste a Render API key and pick the workspace to share. We set up Render's log and metrics streams to push your services' telemetry straight to Superlog — no agent, no code changes.",
       };
     case "pick":
       return {
@@ -162,7 +165,7 @@ function headerForPhase(phase: "start" | "pick" | "connected"): { title: string;
     default:
       return {
         title: "You're connected",
-        sub: "We're pulling logs and metrics from your Render services. First events typically appear within a minute.",
+        sub: "Render is sending logs and metrics from your services. First events typically appear within a minute.",
       };
   }
 }
@@ -297,14 +300,27 @@ function PickPanel({
   );
 }
 
+// One line per signal: streamed (Render pushes) vs polled (our fallback).
+function deliveryText(signal: "Logs" | "Metrics", stream: RenderStreamState): string {
+  if (stream?.status === "provisioned") return `${signal}: streamed by Render in real time.`;
+  if (stream?.status === "conflict") {
+    return `${signal}: polled — your workspace already streams to another destination.`;
+  }
+  return `${signal}: polled from Render's API.`;
+}
+
 function ConnectedPanel({
   ownerName,
   services,
+  logStream,
+  metricsStream,
   statusText,
   eventsArrived,
 }: {
   ownerName: string | null;
   services: Array<{ id: string; name: string; type: string; suspended: boolean }>;
+  logStream: RenderStreamState;
+  metricsStream: RenderStreamState;
   statusText: string;
   eventsArrived: boolean;
 }) {
@@ -317,6 +333,9 @@ function ConnectedPanel({
             {ownerName ? `${ownerName} — ` : ""}
             {active.length === 1 ? "1 Render service" : `${active.length} Render services`}
           </span>
+        </div>
+        <div className={`border-b px-[18px] py-[10px] text-[12px] text-muted ${SOFT_LINE}`}>
+          {deliveryText("Logs", logStream)} {deliveryText("Metrics", metricsStream)}
         </div>
         <div className="divide-y divide-[rgba(255,255,255,0.07)]">
           {active.length === 0 ? (

--- a/apps/web/src/onboarding/RenderConnectFlow.tsx
+++ b/apps/web/src/onboarding/RenderConnectFlow.tsx
@@ -49,7 +49,15 @@ export function RenderConnectFlow({
   const validate = useRenderOwners(projectId);
   const connect = useConnectRender(projectId);
 
-  const installed = install.data?.installed === true;
+  // The connect mutation's response doubles as the installed view until the
+  // installation poll catches up, so clearing the local form state below
+  // can't bounce the flow back to the key panel.
+  const installedData = install.data?.installed
+    ? install.data
+    : connect.data?.installed
+      ? connect.data
+      : null;
+  const installed = installedData !== null;
   const phase = renderPhase({ installed, ownersLoaded: owners !== null });
 
   const submitKey = () => {
@@ -65,7 +73,18 @@ export function RenderConnectFlow({
 
   const submitConnect = () => {
     if (connect.isPending || !ownerId) return;
-    connect.mutate({ apiKey: apiKey.trim(), ownerId });
+    connect.mutate(
+      { apiKey: apiKey.trim(), ownerId },
+      {
+        onSuccess: () => {
+          // The account-wide key has done its job — drop it from memory
+          // instead of keeping it in component state until unmount.
+          setApiKey("");
+          setOwners(null);
+          setOwnerId(null);
+        },
+      },
+    );
   };
 
   const resetKey = () => {
@@ -108,10 +127,10 @@ export function RenderConnectFlow({
         />
       )}
 
-      {phase === "connected" && install.data?.installed && (
+      {phase === "connected" && installedData && (
         <ConnectedPanel
-          ownerName={install.data.ownerName}
-          services={install.data.services}
+          ownerName={installedData.ownerName}
+          services={installedData.services}
           statusText={renderStatusText(phase, eventsArrived)}
           eventsArrived={eventsArrived}
         />

--- a/apps/web/src/onboarding/RenderConnectFlow.tsx
+++ b/apps/web/src/onboarding/RenderConnectFlow.tsx
@@ -1,0 +1,346 @@
+import { useState } from "react";
+import {
+  type RenderOwner,
+  useConnectRender,
+  useRenderInstallation,
+  useRenderOwners,
+} from "../api.ts";
+import { Btn } from "../design/ui.tsx";
+import { CheckIcon, SpinnerIcon } from "./icons.tsx";
+import {
+  canContinueRender,
+  renderErrorMessage,
+  renderPhase,
+  renderStatusText,
+} from "./renderConnectModel.ts";
+import {
+  ExploreDemoLink,
+  SOFT_LINE,
+  STRONG_LINE,
+  StepFooter,
+  StepHeader,
+} from "./wizardChrome.tsx";
+
+// Render has no third-party OAuth, so this flow is a two-step form instead of
+// a consent popup: paste an API key (validated server-side by listing the
+// workspaces it can see), pick the workspace to share, connect. The key only
+// lives in component state between the two calls.
+export function RenderConnectFlow({
+  projectId,
+  eventsArrived,
+  onBack,
+  onDone,
+  onExploreDemo,
+}: {
+  projectId: string;
+  // Whether the real project has ingested telemetry yet (from the parent's
+  // `me.project.hasIngested`). NOT derived from the stats endpoint, which is
+  // demo-overlaid for un-ingested projects and would falsely report events.
+  eventsArrived: boolean;
+  onBack: () => void;
+  onDone: () => void;
+  onExploreDemo?: () => void;
+}) {
+  const [apiKey, setApiKey] = useState("");
+  const [owners, setOwners] = useState<RenderOwner[] | null>(null);
+  const [ownerId, setOwnerId] = useState<string | null>(null);
+
+  const install = useRenderInstallation(projectId);
+  const validate = useRenderOwners(projectId);
+  const connect = useConnectRender(projectId);
+
+  const installed = install.data?.installed === true;
+  const phase = renderPhase({ installed, ownersLoaded: owners !== null });
+
+  const submitKey = () => {
+    if (validate.isPending || !apiKey.trim()) return;
+    validate.mutate(apiKey.trim(), {
+      onSuccess: ({ owners }) => {
+        setOwners(owners);
+        // A single workspace needs no choice.
+        setOwnerId(owners.length === 1 ? (owners[0]?.id ?? null) : null);
+      },
+    });
+  };
+
+  const submitConnect = () => {
+    if (connect.isPending || !ownerId) return;
+    connect.mutate({ apiKey: apiKey.trim(), ownerId });
+  };
+
+  const resetKey = () => {
+    setOwners(null);
+    setOwnerId(null);
+    validate.reset();
+    connect.reset();
+  };
+
+  const header = headerForPhase(phase);
+  const error = connect.error
+    ? renderErrorMessage(connect.error)
+    : validate.error
+      ? renderErrorMessage(validate.error)
+      : null;
+
+  return (
+    <>
+      <StepHeader title={header.title} sub={header.sub} />
+
+      {phase === "start" && (
+        <KeyPanel
+          apiKey={apiKey}
+          onChange={setApiKey}
+          onSubmit={submitKey}
+          pending={validate.isPending}
+          error={error}
+        />
+      )}
+
+      {phase === "pick" && owners && (
+        <PickPanel
+          owners={owners}
+          ownerId={ownerId}
+          onPick={setOwnerId}
+          onConnect={submitConnect}
+          onChangeKey={resetKey}
+          pending={connect.isPending}
+          error={error}
+        />
+      )}
+
+      {phase === "connected" && install.data?.installed && (
+        <ConnectedPanel
+          ownerName={install.data.ownerName}
+          services={install.data.services}
+          statusText={renderStatusText(phase, eventsArrived)}
+          eventsArrived={eventsArrived}
+        />
+      )}
+
+      <StepFooter
+        onBack={onBack}
+        onNext={onDone}
+        nextLabel={canContinueRender(phase) ? "Continue" : "Waiting for Render…"}
+        nextDisabled={!canContinueRender(phase)}
+      />
+      {!canContinueRender(phase) && <ExploreDemoLink onExploreDemo={onExploreDemo} />}
+    </>
+  );
+}
+
+function headerForPhase(phase: "start" | "pick" | "connected"): { title: string; sub: string } {
+  switch (phase) {
+    case "start":
+      return {
+        title: "Connect Render",
+        sub: "Paste a Render API key and pick the workspace to share. We pull your services' logs and infra metrics from Render's API — no agent, no code changes.",
+      };
+    case "pick":
+      return {
+        title: "Pick a workspace",
+        sub: "The key checks out. Choose the Render workspace whose services should flow into this project.",
+      };
+    default:
+      return {
+        title: "You're connected",
+        sub: "We're pulling logs and metrics from your Render services. First events typically appear within a minute.",
+      };
+  }
+}
+
+function KeyPanel({
+  apiKey,
+  onChange,
+  onSubmit,
+  pending,
+  error,
+}: {
+  apiKey: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  pending: boolean;
+  error: string | null;
+}) {
+  return (
+    <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+      <div className={`border-b px-[22px] py-[18px] ${SOFT_LINE}`}>
+        <p className="m-0 text-[13px] leading-[1.55] text-muted">
+          Create a key in Render under <span className="text-fg">Account settings → API Keys</span>.
+          Render keys are account-wide (Render doesn't offer scoped keys), so we store yours
+          encrypted and only ever read logs and metrics from the workspace you pick — revoke it in
+          Render at any time to cut access.
+        </p>
+      </div>
+      <form
+        className="flex items-center gap-3 px-[22px] py-[16px]"
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSubmit();
+        }}
+      >
+        <input
+          type="password"
+          value={apiKey}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="rnd_…"
+          autoComplete="off"
+          spellCheck={false}
+          className={`h-[36px] min-w-0 flex-1 rounded-[8px] border bg-surface-2 px-3 font-mono text-[13px] text-fg placeholder:text-subtle focus:outline-none ${STRONG_LINE}`}
+        />
+        <Btn
+          variant="primary"
+          size="md"
+          type="submit"
+          loading={pending}
+          disabled={!apiKey.trim()}
+          className="!h-[36px] !rounded-[8px] !px-[14px] !text-[13px]"
+        >
+          {pending ? "Checking…" : "Validate key"}
+        </Btn>
+      </form>
+      {error && (
+        <div className={`border-t px-[22px] py-[12px] ${SOFT_LINE}`}>
+          <p className="m-0 text-[12.5px] text-danger">{error}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PickPanel({
+  owners,
+  ownerId,
+  onPick,
+  onConnect,
+  onChangeKey,
+  pending,
+  error,
+}: {
+  owners: RenderOwner[];
+  ownerId: string | null;
+  onPick: (id: string) => void;
+  onConnect: () => void;
+  onChangeKey: () => void;
+  pending: boolean;
+  error: string | null;
+}) {
+  return (
+    <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+      <div className="divide-y divide-[rgba(255,255,255,0.07)]">
+        {owners.map((owner) => (
+          <label
+            key={owner.id}
+            className="flex cursor-pointer items-center gap-3 px-[18px] py-[13px] transition-colors hover:bg-surface-2"
+          >
+            <input
+              type="radio"
+              name="render-owner"
+              checked={ownerId === owner.id}
+              onChange={() => onPick(owner.id)}
+            />
+            <span className="min-w-0 flex-1">
+              <span className="block text-[13px] font-medium text-fg">{owner.name}</span>
+              <span className="block text-[12px] text-muted">
+                {owner.type === "team" ? "Team workspace" : "Personal workspace"}
+                {owner.email ? ` — ${owner.email}` : ""}
+              </span>
+            </span>
+          </label>
+        ))}
+      </div>
+      <div
+        className={`flex items-center justify-between gap-3 border-t px-[22px] py-[14px] ${SOFT_LINE}`}
+      >
+        <button
+          type="button"
+          onClick={onChangeKey}
+          className="text-[12.5px] font-medium text-muted transition-colors hover:text-fg"
+        >
+          Use a different key
+        </button>
+        <Btn
+          variant="primary"
+          size="md"
+          onClick={onConnect}
+          loading={pending}
+          disabled={!ownerId}
+          className="!h-[36px] !rounded-[8px] !px-[14px] !text-[13px]"
+        >
+          {pending ? "Connecting…" : "Connect workspace"}
+        </Btn>
+      </div>
+      {error && (
+        <div className={`border-t px-[22px] py-[12px] ${SOFT_LINE}`}>
+          <p className="m-0 text-[12.5px] text-danger">{error}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConnectedPanel({
+  ownerName,
+  services,
+  statusText,
+  eventsArrived,
+}: {
+  ownerName: string | null;
+  services: Array<{ id: string; name: string; type: string; suspended: boolean }>;
+  statusText: string;
+  eventsArrived: boolean;
+}) {
+  const active = services.filter((s) => !s.suspended);
+  return (
+    <div className="flex flex-col gap-4">
+      <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+        <div className={`border-b px-[18px] py-[10px] ${SOFT_LINE}`}>
+          <span className="font-mono text-[12px] text-muted">
+            {ownerName ? `${ownerName} — ` : ""}
+            {active.length === 1 ? "1 Render service" : `${active.length} Render services`}
+          </span>
+        </div>
+        <div className="divide-y divide-[rgba(255,255,255,0.07)]">
+          {active.length === 0 ? (
+            <div className="px-[18px] py-[14px] text-[12.5px] text-muted">
+              No running services in this workspace yet — telemetry starts flowing when one deploys.
+            </div>
+          ) : (
+            active.map((service) => (
+              <div key={service.id} className="flex items-center gap-3 px-[18px] py-[13px]">
+                <span className="text-success">
+                  <CheckIcon size={14} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-[13px] font-medium text-fg">{service.name}</span>
+                  <span className="block text-[12px] text-muted">
+                    {service.type.replaceAll("_", " ")} — logs + metrics
+                  </span>
+                </span>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {eventsArrived ? (
+        <div className="flex items-center gap-2.5 rounded-[10px] border border-[rgba(65,209,149,0.35)] bg-[rgba(65,209,149,0.06)] px-4 py-3">
+          <span className="text-success">
+            <CheckIcon size={14} />
+          </span>
+          <div className="flex-1 text-[12.5px] text-fg">
+            First events received. <span className="text-muted">You're flowing.</span>
+          </div>
+        </div>
+      ) : (
+        <div
+          className={`flex items-center gap-2.5 rounded-[10px] border border-dashed px-4 py-3 ${STRONG_LINE}`}
+        >
+          <span className="text-[#8C98F0]">
+            <SpinnerIcon size={14} />
+          </span>
+          <div className="flex-1 text-[12.5px] text-muted">{statusText}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/onboarding/connectChoices.test.ts
+++ b/apps/web/src/onboarding/connectChoices.test.ts
@@ -16,9 +16,9 @@ function findOption(sections: ReturnType<typeof connectSectionsFor>, id: string)
   return undefined;
 }
 
-test("the chooser offers exactly five lanes: AWS, Cloudflare, Vercel, Railway, and 'I'm hosted elsewhere'", () => {
+test("the chooser offers exactly six lanes: AWS, Cloudflare, Vercel, Railway, Render, and 'I'm hosted elsewhere'", () => {
   const ids = CONNECT_SECTIONS.flatMap((s) => s.options.map((o) => o.id));
-  assert.deepEqual(ids, ["aws", "cloudflare", "vercel", "railway", "elsewhere"]);
+  assert.deepEqual(ids, ["aws", "cloudflare", "vercel", "railway", "render", "elsewhere"]);
 });
 
 test("there is no coming-soon grid", () => {
@@ -42,7 +42,12 @@ test("integration-first: the primary option is a no-code integration (AWS)", () 
 });
 
 test("every lane is actionable when its connectors are configured", () => {
-  const sections = connectSectionsFor({ cloudflare: true, vercel: true, railway: true });
+  const sections = connectSectionsFor({
+    cloudflare: true,
+    vercel: true,
+    railway: true,
+    render: true,
+  });
   for (const section of sections) {
     for (const option of section.options) {
       assert.notEqual(option.action, null, `${option.id} should be actionable`);
@@ -56,12 +61,18 @@ test("connectActionFor resolves known ids and returns null for unknown", () => {
   assert.equal(connectActionFor("cloudflare"), "cloudflare");
   assert.equal(connectActionFor("vercel"), "vercel");
   assert.equal(connectActionFor("railway"), "railway");
+  assert.equal(connectActionFor("render"), "render");
   assert.equal(connectActionFor("elsewhere"), "code");
   assert.equal(connectActionFor("does-not-exist"), null);
 });
 
 test("connectSectionsFor disables Cloudflare when the connector isn't configured", () => {
-  const gated = connectSectionsFor({ cloudflare: false, vercel: true, railway: true });
+  const gated = connectSectionsFor({
+    cloudflare: false,
+    vercel: true,
+    railway: true,
+    render: true,
+  });
   const cloudflare = findOption(gated, "cloudflare");
   assert.ok(cloudflare);
   assert.equal(cloudflare.action, null, "cloudflare should not be actionable when unavailable");
@@ -73,7 +84,12 @@ test("connectSectionsFor disables Cloudflare when the connector isn't configured
 });
 
 test("connectSectionsFor disables Vercel when the connector isn't configured", () => {
-  const gated = connectSectionsFor({ cloudflare: true, vercel: false, railway: true });
+  const gated = connectSectionsFor({
+    cloudflare: true,
+    vercel: false,
+    railway: true,
+    render: true,
+  });
   const vercel = findOption(gated, "vercel");
   assert.ok(vercel);
   assert.equal(vercel.action, null, "vercel should not be actionable when unavailable");
@@ -85,7 +101,12 @@ test("connectSectionsFor disables Vercel when the connector isn't configured", (
 });
 
 test("connectSectionsFor disables Railway when the connector isn't configured", () => {
-  const gated = connectSectionsFor({ cloudflare: true, vercel: true, railway: false });
+  const gated = connectSectionsFor({
+    cloudflare: true,
+    vercel: true,
+    railway: false,
+    render: true,
+  });
   const railway = findOption(gated, "railway");
   assert.ok(railway);
   assert.equal(railway.action, null, "railway should not be actionable when unavailable");
@@ -96,11 +117,34 @@ test("connectSectionsFor disables Railway when the connector isn't configured", 
   assert.equal(findOption(gated, "elsewhere")?.action, "code");
 });
 
+test("connectSectionsFor disables Render when the connector isn't configured", () => {
+  const gated = connectSectionsFor({
+    cloudflare: true,
+    vercel: true,
+    railway: true,
+    render: false,
+  });
+  const render = findOption(gated, "render");
+  assert.ok(render);
+  assert.equal(render.action, null, "render should not be actionable when unavailable");
+  assert.equal(isComingSoon(render), true);
+  // Other lanes are untouched.
+  assert.equal(findOption(gated, "aws")?.action, "aws");
+  assert.equal(findOption(gated, "railway")?.action, "railway");
+  assert.equal(findOption(gated, "elsewhere")?.action, "code");
+});
+
 test("connectSectionsFor leaves configured connectors actionable", () => {
-  const enabled = connectSectionsFor({ cloudflare: true, vercel: true, railway: true });
+  const enabled = connectSectionsFor({
+    cloudflare: true,
+    vercel: true,
+    railway: true,
+    render: true,
+  });
   assert.equal(findOption(enabled, "cloudflare")?.action, "cloudflare");
   assert.equal(findOption(enabled, "vercel")?.action, "vercel");
   assert.equal(findOption(enabled, "railway")?.action, "railway");
+  assert.equal(findOption(enabled, "render")?.action, "render");
 });
 
 test("every option id is unique", () => {

--- a/apps/web/src/onboarding/connectChoices.ts
+++ b/apps/web/src/onboarding/connectChoices.ts
@@ -10,11 +10,11 @@
 // What activating a row does. `null` => not yet available (coming soon), so the
 // row renders disabled and is not actionable. "code" opens the coding-agent
 // prompt (paste into Cursor / Claude Code / Codex).
-export type ConnectAction = "aws" | "cloudflare" | "vercel" | "railway" | "code";
+export type ConnectAction = "aws" | "cloudflare" | "vercel" | "railway" | "render" | "code";
 
 // Glyph key resolved to a neutral monochrome icon by the component. Kept as a
 // string union (not a component) so this module stays free of JSX/React.
-export type ConnectIcon = "aws" | "cloudflare" | "vercel" | "railway" | "terminal";
+export type ConnectIcon = "aws" | "cloudflare" | "vercel" | "railway" | "render" | "terminal";
 
 export type ConnectOption = {
   id: string;
@@ -73,10 +73,18 @@ export const CONNECT_SECTIONS: ConnectSection[] = [
         action: "railway",
       },
       {
+        id: "render",
+        title: "Render",
+        description:
+          "Paste a Render API key once and pick the workspace to share — we pull your services' logs and infra metrics from Render's API. No agent, no code.",
+        icon: "render",
+        action: "render",
+      },
+      {
         id: "elsewhere",
         title: "I'm hosted elsewhere",
         description:
-          "Fly, Render, a VM, your laptop — anywhere. Paste a prompt into Cursor, Claude Code, or Codex and it installs the SDK, instruments your app, and opens a PR.",
+          "Fly, a VM, your laptop — anywhere. Paste a prompt into Cursor, Claude Code, or Codex and it installs the SDK, instruments your app, and opens a PR.",
         icon: "terminal",
         action: "code",
       },
@@ -93,6 +101,7 @@ export type ConnectAvailability = {
   cloudflare: boolean;
   vercel: boolean;
   railway: boolean;
+  render: boolean;
 };
 
 export function connectSectionsFor(availability: ConnectAvailability): ConnectSection[] {
@@ -100,6 +109,7 @@ export function connectSectionsFor(availability: ConnectAvailability): ConnectSe
   if (!availability.cloudflare) unavailable.add("cloudflare");
   if (!availability.vercel) unavailable.add("vercel");
   if (!availability.railway) unavailable.add("railway");
+  if (!availability.render) unavailable.add("render");
   if (unavailable.size === 0) return CONNECT_SECTIONS;
   return CONNECT_SECTIONS.map((section) => ({
     ...section,

--- a/apps/web/src/onboarding/connectChoices.ts
+++ b/apps/web/src/onboarding/connectChoices.ts
@@ -76,7 +76,7 @@ export const CONNECT_SECTIONS: ConnectSection[] = [
         id: "render",
         title: "Render",
         description:
-          "Paste a Render API key once and pick the workspace to share — we pull your services' logs and infra metrics from Render's API. No agent, no code.",
+          "Paste a Render API key once and pick the workspace to share — Render streams your services' logs and infra metrics straight in. No agent, no code.",
         icon: "render",
         action: "render",
       },

--- a/apps/web/src/onboarding/icons.tsx
+++ b/apps/web/src/onboarding/icons.tsx
@@ -337,6 +337,22 @@ export function RailwayIcon({ size = 18, className }: IconProps) {
   );
 }
 
+// Render — the official mark (Simple Icons, CC0), monochrome via currentColor.
+export function RenderIcon({ size = 18, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M18.263.007c-3.121-.147-5.744 2.109-6.192 5.082-.018.138-.045.272-.067.405-.696 3.703-3.936 6.507-7.827 6.507-1.388 0-2.691-.356-3.825-.979a.2024.2024 0 0 0-.302.178V24H12v-8.999c0-1.656 1.338-3 2.987-3h2.988c3.382 0 6.103-2.817 5.97-6.244-.12-3.084-2.61-5.603-5.682-5.75" />
+    </svg>
+  );
+}
+
 export function KubernetesIcon({ size = 18, className }: IconProps) {
   return (
     <svg

--- a/apps/web/src/onboarding/renderConnectModel.test.ts
+++ b/apps/web/src/onboarding/renderConnectModel.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  canContinueRender,
+  renderErrorMessage,
+  renderPhase,
+  renderStatusText,
+} from "./renderConnectModel.ts";
+
+test("phase progression: start → pick → connected", () => {
+  assert.equal(renderPhase({ installed: false, ownersLoaded: false }), "start");
+  assert.equal(renderPhase({ installed: false, ownersLoaded: true }), "pick");
+  // Installed wins regardless of the picker state.
+  assert.equal(renderPhase({ installed: true, ownersLoaded: false }), "connected");
+  assert.equal(renderPhase({ installed: true, ownersLoaded: true }), "connected");
+});
+
+test("continue unlocks only when connected", () => {
+  assert.equal(canContinueRender("start"), false);
+  assert.equal(canContinueRender("pick"), false);
+  assert.equal(canContinueRender("connected"), true);
+});
+
+test("API error codes map to actionable messages", () => {
+  assert.match(
+    renderErrorMessage(new Error('400: {"error":"invalid_key"}')),
+    /rejected that API key/i,
+  );
+  assert.match(renderErrorMessage(new Error('400: {"error":"unknown_owner"}')), /isn't visible/i);
+  assert.match(
+    renderErrorMessage(new Error('502: {"error":"render_unavailable"}')),
+    /reach Render/i,
+  );
+  assert.match(renderErrorMessage(new Error("boom")), /couldn't finish/i);
+});
+
+test("status text reflects the telemetry wait", () => {
+  assert.match(renderStatusText("connected", false), /within a minute/i);
+  assert.match(renderStatusText("connected", true), /arriving/i);
+  assert.match(renderStatusText("pick", false), /pick the workspace/i);
+});

--- a/apps/web/src/onboarding/renderConnectModel.test.ts
+++ b/apps/web/src/onboarding/renderConnectModel.test.ts
@@ -35,6 +35,7 @@ test("API error codes map to actionable messages", () => {
 });
 
 test("status text reflects the telemetry wait", () => {
+  assert.match(renderStatusText("start", false), /not connected/i);
   assert.match(renderStatusText("connected", false), /within a minute/i);
   assert.match(renderStatusText("connected", true), /arriving/i);
   assert.match(renderStatusText("pick", false), /pick the workspace/i);

--- a/apps/web/src/onboarding/renderConnectModel.ts
+++ b/apps/web/src/onboarding/renderConnectModel.ts
@@ -1,0 +1,61 @@
+// Pure phase model for the onboarding Render connect flow, split out of the
+// component so the transitions are unit-testable (the `.tsx` can't be imported
+// by the node:test runner). Mirrors railwayConnectModel.ts.
+//
+// Render connect has no OAuth round-trip: the user pastes an API key (Render
+// dashboard → Account settings → API Keys), we list the workspaces the key can
+// see, they pick one, and the connect call stores the key encrypted. The
+// milestone that unlocks "Continue" is that the workspace is connected
+// (`installed`); telemetry arrival is surfaced as a bonus but never blocks.
+
+export type RenderPhase = "start" | "pick" | "connected";
+
+/**
+ * Resolve the flow phase:
+ *  - `installed`     → the connect call finished and the key is stored.
+ *  - `ownersLoaded`  → the pasted key validated; the user is picking the
+ *                      workspace to share.
+ *  - otherwise       → the initial API-key form.
+ */
+export function renderPhase(input: { installed: boolean; ownersLoaded: boolean }): RenderPhase {
+  if (input.installed) return "connected";
+  if (input.ownersLoaded) return "pick";
+  return "start";
+}
+
+/** Continue unlocks once the workspace is connected. */
+export function canContinueRender(phase: RenderPhase): boolean {
+  return phase === "connected";
+}
+
+/**
+ * User-facing message for a failed owners/connect call. The fetcher throws
+ * `Error("<status>: <body>")`, so match on the API's stable error codes.
+ */
+export function renderErrorMessage(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  if (raw.includes("invalid_key")) {
+    return "Render rejected that API key. Paste a key from Render's Account settings → API Keys.";
+  }
+  if (raw.includes("unknown_owner")) {
+    return "That workspace isn't visible to this API key anymore. Validate the key again and re-pick.";
+  }
+  if (raw.includes("render_unavailable")) {
+    return "We couldn't reach Render's API. Try again in a moment.";
+  }
+  return "We couldn't finish connecting Render. Try again.";
+}
+
+/** Status text for the small banner in the "connected" state. */
+export function renderStatusText(phase: RenderPhase, eventsArrived: boolean): string {
+  switch (phase) {
+    case "start":
+      return "Not connected yet.";
+    case "pick":
+      return "Key validated — pick the workspace to share.";
+    default:
+      return eventsArrived
+        ? "Connected — telemetry from Render is arriving."
+        : "Connected — we're pulling logs and metrics from your Render services. First events typically appear within a minute.";
+  }
+}

--- a/apps/web/src/onboarding/renderConnectModel.ts
+++ b/apps/web/src/onboarding/renderConnectModel.ts
@@ -56,6 +56,6 @@ export function renderStatusText(phase: RenderPhase, eventsArrived: boolean): st
     default:
       return eventsArrived
         ? "Connected — telemetry from Render is arriving."
-        : "Connected — we're pulling logs and metrics from your Render services. First events typically appear within a minute.";
+        : "Connected — Render is sending logs and metrics from your services. First events typically appear within a minute.";
   }
 }

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -24,3 +24,9 @@ LINEAR_CLIENT_SECRET=
 RAILWAY_CLIENT_ID=
 RAILWAY_CLIENT_SECRET=
 RAILWAY_INTAKE_URL=
+
+# Render connector: the puller job reads each installation's stored API key
+# (decrypted with AGENT_SECRETS_KEY, which must match the api's) and forwards
+# pulled telemetry to the proxy intake. RENDER_INTAKE_URL defaults to the
+# local proxy (http://localhost:$PROXY_APP_PORT or :4000).
+RENDER_INTAKE_URL=

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -66,6 +66,7 @@
     "@superlog/fingerprint": "workspace:*",
     "@superlog/net-guard": "workspace:*",
     "@superlog/railway": "workspace:*",
+    "@superlog/render": "workspace:*",
     "@superlog/topology": "workspace:*",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",

--- a/apps/worker/src/jobs/render-pull.ts
+++ b/apps/worker/src/jobs/render-pull.ts
@@ -60,6 +60,8 @@ function createStore(db: JobDeps["db"]): RenderPullerStore {
             services: row.services ?? [],
             logCursor: row.logCursor ?? {},
             metricsCursor: row.metricsCursor ?? {},
+            logStreamActive: row.logStream?.status === "provisioned",
+            metricsStreamActive: row.metricsStream?.status === "provisioned",
           });
         } catch (err) {
           // A row whose secrets can't be decrypted (e.g. key rotation gone

--- a/apps/worker/src/jobs/render-pull.ts
+++ b/apps/worker/src/jobs/render-pull.ts
@@ -90,6 +90,25 @@ function createStore(db: JobDeps["db"]): RenderPullerStore {
         })
         .where(eq(schema.renderInstallations.id, id));
     },
+
+    // Persistently-rejected key → soft-revoke, mirroring the api's
+    // teardownInstallation: the ingest key is revoked too so nothing minted
+    // for this install can keep writing.
+    async markRevoked(id) {
+      const row = await db.query.renderInstallations.findFirst({
+        where: eq(schema.renderInstallations.id, id),
+      });
+      if (row?.apiKeyId) {
+        await db
+          .update(schema.apiKeys)
+          .set({ revokedAt: new Date() })
+          .where(eq(schema.apiKeys.id, row.apiKeyId));
+      }
+      await db
+        .update(schema.renderInstallations)
+        .set({ revokedAt: new Date(), updatedAt: new Date() })
+        .where(eq(schema.renderInstallations.id, id));
+    },
   };
 }
 

--- a/apps/worker/src/jobs/render-pull.ts
+++ b/apps/worker/src/jobs/render-pull.ts
@@ -1,0 +1,113 @@
+// Scheduled job: pull logs + infra metrics from Render for every active
+// installation and forward them to our intake (see ../render/puller.ts for
+// the pull logic; this file is only the wiring — drizzle-backed store,
+// decrypted secrets, env config).
+//
+// Every minute is the latency floor for Render logs (pg-boss cron is
+// minute-granular); metrics are gated inside the puller to one poll per
+// installation per ~5 minutes. Opts out (returns null → not scheduled) unless
+// AGENT_SECRETS_KEY is set — without it the stored Render API keys can't be
+// decrypted, so there is nothing the puller could do.
+
+import { decryptIntegrationSecret, schema } from "@superlog/db";
+import { eq, isNull } from "drizzle-orm";
+import type { JobDefinition, JobDeps } from "../jobs.js";
+import { logger } from "../logger.js";
+import {
+  type RenderPullerInstallation,
+  type RenderPullerStore,
+  runRenderPullOnce,
+} from "../render/puller.js";
+
+const log = logger.child({ scope: "render-pull" });
+
+function intakeBaseUrlFromEnv(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.RENDER_INTAKE_URL) return env.RENDER_INTAKE_URL;
+  // Local default: the proxy on this machine (portless injects its app port).
+  const proxyPort = env.PROXY_APP_PORT ?? "4000";
+  return `http://localhost:${proxyPort}`;
+}
+
+// Built from JobDeps.db (not the module-level import) so the job follows the
+// jobs contract and can run against an injected/test database.
+function createStore(db: JobDeps["db"]): RenderPullerStore {
+  return {
+    async listActiveInstallations(): Promise<RenderPullerInstallation[]> {
+      const rows = await db.query.renderInstallations.findMany({
+        where: isNull(schema.renderInstallations.revokedAt),
+      });
+      const installations: RenderPullerInstallation[] = [];
+      for (const row of rows) {
+        try {
+          installations.push({
+            id: row.id,
+            projectId: row.projectId,
+            renderApiKey: decryptIntegrationSecret({
+              ciphertext: row.renderApiKeyCiphertext,
+              nonce: row.renderApiKeyNonce,
+              keyVersion: row.renderApiKeyKeyVersion,
+            }),
+            ownerId: row.renderOwnerId,
+            ownerName: row.renderOwnerName ?? row.renderOwnerId,
+            ingestKey:
+              row.ingestKeyCiphertext && row.ingestKeyNonce
+                ? decryptIntegrationSecret({
+                    ciphertext: row.ingestKeyCiphertext,
+                    nonce: row.ingestKeyNonce,
+                    keyVersion: row.ingestKeyKeyVersion ?? 1,
+                  })
+                : null,
+            services: row.services ?? [],
+            logCursor: row.logCursor ?? {},
+            metricsCursor: row.metricsCursor ?? {},
+          });
+        } catch (err) {
+          // A row whose secrets can't be decrypted (e.g. key rotation gone
+          // wrong) must not block the other installations.
+          log.error(
+            { installation_id: row.id, err: err instanceof Error ? err.message : String(err) },
+            "render install secrets decrypt failed; skipping",
+          );
+        }
+      }
+      return installations;
+    },
+
+    async saveServices(id, services) {
+      await db
+        .update(schema.renderInstallations)
+        .set({ services, updatedAt: new Date() })
+        .where(eq(schema.renderInstallations.id, id));
+    },
+
+    async saveCursors(id, cursors) {
+      await db
+        .update(schema.renderInstallations)
+        .set({
+          logCursor: cursors.logCursor,
+          metricsCursor: cursors.metricsCursor,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.renderInstallations.id, id));
+    },
+  };
+}
+
+export const job: JobDefinition = {
+  name: "render-pull",
+  schedule: "* * * * *",
+  create: (deps) => {
+    if (!process.env.AGENT_SECRETS_KEY) {
+      log.info({}, "AGENT_SECRETS_KEY not set — render pull job disabled");
+      return null;
+    }
+    const store = createStore(deps.db);
+    const intakeBaseUrl = intakeBaseUrlFromEnv();
+    return async () => {
+      const stats = await runRenderPullOnce({ store, intakeBaseUrl, log });
+      if (stats.installations > 0) {
+        log.info({ ...stats }, "render pull pass complete");
+      }
+    };
+  },
+};

--- a/apps/worker/src/render/puller.test.ts
+++ b/apps/worker/src/render/puller.test.ts
@@ -161,7 +161,7 @@ test("first pass seeds logs backward, forwards fresh telemetry, persists cursors
   assert.ok(!logCall?.url.includes("resource=srv-2"));
 
   // Log + metric exports hit the intake with the ingest key.
-  const intakeCalls = calls.filter((c) => c.url.startsWith("http://intake.test"));
+  const intakeCalls = calls.filter((c) => new URL(c.url).origin === "http://intake.test");
   assert.deepEqual(
     intakeCalls.map((c) => c.url),
     ["http://intake.test/render/pull/logs", "http://intake.test/render/pull/metrics"],
@@ -210,7 +210,7 @@ test("cursor pass reads forward with pagination and dedupes already-seen lines",
   // the cursor was fully deduped so no metrics export happened.
   assert.equal(stats.logsForwarded, 1);
   assert.equal(stats.metricPointsForwarded, 0);
-  const intakeCalls = calls.filter((c) => c.url.startsWith("http://intake.test"));
+  const intakeCalls = calls.filter((c) => new URL(c.url).origin === "http://intake.test");
   assert.equal(intakeCalls.length, 1);
 
   const cursors = state.savedCursors[0];

--- a/apps/worker/src/render/puller.test.ts
+++ b/apps/worker/src/render/puller.test.ts
@@ -1,0 +1,293 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import {
+  type RenderPullerInstallation,
+  type RenderPullerStore,
+  runRenderPullOnce,
+} from "./puller.js";
+
+const silentLog = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const NOW = new Date("2026-07-07T14:20:00Z");
+
+function installation(overrides: Partial<RenderPullerInstallation> = {}): RenderPullerInstallation {
+  return {
+    id: "inst-1",
+    projectId: "proj-1",
+    renderApiKey: "rnd_key",
+    ownerId: "tea-1",
+    ownerName: "Acme",
+    ingestKey: "sl_public_abc",
+    services: [],
+    logCursor: {},
+    metricsCursor: {},
+    ...overrides,
+  };
+}
+
+type StoreState = {
+  installations: RenderPullerInstallation[];
+  savedServices: Array<{ id: string; services: unknown }>;
+  savedCursors: Array<{
+    id: string;
+    logCursor: Record<string, string>;
+    metricsCursor: Record<string, number>;
+  }>;
+};
+
+function makeStore(installations: RenderPullerInstallation[]): {
+  store: RenderPullerStore;
+  state: StoreState;
+} {
+  const state: StoreState = { installations, savedServices: [], savedCursors: [] };
+  return {
+    store: {
+      listActiveInstallations: async () => state.installations,
+      saveServices: async (id, services) => {
+        state.savedServices.push({ id, services });
+      },
+      saveCursors: async (id, cursors) => {
+        state.savedCursors.push({ id, ...cursors });
+      },
+    },
+    state,
+  };
+}
+
+const SERVICES_PAGE = [
+  {
+    service: {
+      id: "srv-1",
+      name: "acme-api",
+      type: "web_service",
+      suspended: "not_suspended",
+      serviceDetails: { region: "oregon" },
+    },
+    cursor: "c1",
+  },
+  {
+    service: {
+      id: "srv-2",
+      name: "acme-worker",
+      type: "background_worker",
+      suspended: "suspended",
+      serviceDetails: { region: "oregon" },
+    },
+    cursor: "c2",
+  },
+];
+
+const LOG_LINE = {
+  id: "log-1",
+  timestamp: "2026-07-07T14:19:30Z",
+  message: "hello",
+  labels: [
+    { name: "resource", value: "srv-1" },
+    { name: "level", value: "info" },
+  ],
+};
+
+const CPU_SERIES = {
+  labels: [{ field: "resource", value: "srv-1" }],
+  unit: "cpu",
+  values: [{ timestamp: "2026-07-07T14:19:00Z", value: 0.12 }],
+};
+
+// Routing fetch mock: answers Render API + intake calls, records requests.
+function makeFetch(
+  opts: {
+    logsResponses?: Array<Record<string, unknown>>;
+    intakeStatus?: number;
+  } = {},
+) {
+  const calls: Array<{ url: string; method: string; body: unknown }> = [];
+  const logsResponses = [...(opts.logsResponses ?? [])];
+  const impl: typeof fetch = async (input, init) => {
+    const url = String(input);
+    const call = {
+      url,
+      method: init?.method ?? "GET",
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    };
+    calls.push(call);
+    const respond = (body: unknown, status = 200) =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      });
+    if (url.includes("/v1/services")) return respond(SERVICES_PAGE);
+    if (url.includes("/v1/logs")) {
+      const next = logsResponses.shift() ?? { logs: [], hasMore: false };
+      return respond(next);
+    }
+    if (url.includes("/v1/metrics/cpu")) return respond([CPU_SERIES]);
+    if (url.includes("/v1/metrics/")) return respond([]);
+    if (url.includes("/render/pull/")) return respond({}, opts.intakeStatus ?? 200);
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  return { impl, calls };
+}
+
+test("first pass seeds logs backward, forwards fresh telemetry, persists cursors", async () => {
+  const { store, state } = makeStore([installation()]);
+  const { impl, calls } = makeFetch({ logsResponses: [{ logs: [LOG_LINE], hasMore: false }] });
+
+  const stats = await runRenderPullOnce({
+    store,
+    intakeBaseUrl: "http://intake.test",
+    log: silentLog,
+    fetchImpl: impl,
+    now: () => NOW,
+    metricsPollState: new Map(),
+  });
+
+  assert.equal(stats.installations, 1);
+  assert.equal(stats.logsForwarded, 1);
+  assert.equal(stats.metricPointsForwarded, 1);
+  assert.equal(stats.errors, 0);
+
+  // Inventory snapshot refreshed (both services, incl. the suspended one).
+  assert.equal(state.savedServices.length, 1);
+
+  // The backward seed read has no `direction=forward` and no startTime.
+  const logCall = calls.find((c) => c.url.includes("/v1/logs"));
+  assert.ok(logCall && !logCall.url.includes("direction=forward"));
+  // Suspended services are excluded from the pull.
+  assert.ok(logCall?.url.includes("resource=srv-1"));
+  assert.ok(!logCall?.url.includes("resource=srv-2"));
+
+  // Log + metric exports hit the intake with the ingest key.
+  const intakeCalls = calls.filter((c) => c.url.startsWith("http://intake.test"));
+  assert.deepEqual(
+    intakeCalls.map((c) => c.url),
+    ["http://intake.test/render/pull/logs", "http://intake.test/render/pull/metrics"],
+  );
+
+  // Cursors persisted: log cursor at the seed line, metrics cursor per key.
+  assert.equal(state.savedCursors.length, 1);
+  const cursors = state.savedCursors[0];
+  assert.equal(cursors?.logCursor.oregon, "2026-07-07T14:19:30Z");
+  assert.equal(cursors?.metricsCursor["srv-1:cpu"], Date.parse("2026-07-07T14:19:00Z") / 1000);
+});
+
+test("cursor pass reads forward with pagination and dedupes already-seen lines", async () => {
+  const older = { ...LOG_LINE, timestamp: "2026-07-07T14:18:00Z" };
+  const fresh = { ...LOG_LINE, id: "log-2", timestamp: "2026-07-07T14:19:45Z" };
+  const { store, state } = makeStore([
+    installation({
+      logCursor: { oregon: "2026-07-07T14:19:00Z" },
+      metricsCursor: { "srv-1:cpu": Date.parse("2026-07-07T14:19:00Z") / 1000 },
+    }),
+  ]);
+  const { impl, calls } = makeFetch({
+    logsResponses: [
+      { logs: [older], hasMore: true, nextStartTime: "2026-07-07T14:19:10Z" },
+      { logs: [fresh], hasMore: false },
+    ],
+  });
+
+  const stats = await runRenderPullOnce({
+    store,
+    intakeBaseUrl: "http://intake.test",
+    log: silentLog,
+    fetchImpl: impl,
+    now: () => NOW,
+    metricsPollState: new Map(),
+  });
+
+  // Two log pages were read forward from the cursor.
+  const logCalls = calls.filter((c) => c.url.includes("/v1/logs"));
+  assert.equal(logCalls.length, 2);
+  assert.ok(logCalls[0]?.url.includes("direction=forward"));
+  assert.ok(logCalls[0]?.url.includes(encodeURIComponent("2026-07-07T14:19:00Z")));
+  assert.ok(logCalls[1]?.url.includes(encodeURIComponent("2026-07-07T14:19:10Z")));
+
+  // Only the line newer than the cursor was forwarded; the metric sample at
+  // the cursor was fully deduped so no metrics export happened.
+  assert.equal(stats.logsForwarded, 1);
+  assert.equal(stats.metricPointsForwarded, 0);
+  const intakeCalls = calls.filter((c) => c.url.startsWith("http://intake.test"));
+  assert.equal(intakeCalls.length, 1);
+
+  const cursors = state.savedCursors[0];
+  assert.equal(cursors?.logCursor.oregon, "2026-07-07T14:19:45Z");
+});
+
+test("metrics polls are gated by the interval clock", async () => {
+  const pollState = new Map<string, number>();
+  const { store } = makeStore([installation({ logCursor: { oregon: "2026-07-07T14:19:50Z" } })]);
+  const first = makeFetch();
+  await runRenderPullOnce({
+    store,
+    intakeBaseUrl: "http://intake.test",
+    log: silentLog,
+    fetchImpl: first.impl,
+    now: () => NOW,
+    metricsPollState: pollState,
+  });
+  assert.ok(first.calls.some((c) => c.url.includes("/v1/metrics/cpu")));
+
+  // A pass one minute later skips metrics entirely (interval is 5 min).
+  const second = makeFetch();
+  await runRenderPullOnce({
+    store,
+    intakeBaseUrl: "http://intake.test",
+    log: silentLog,
+    fetchImpl: second.impl,
+    now: () => new Date(NOW.getTime() + 60_000),
+    metricsPollState: pollState,
+  });
+  assert.ok(!second.calls.some((c) => c.url.includes("/v1/metrics/")));
+});
+
+test("a rejected key skips the installation without throwing", async () => {
+  const { store, state } = makeStore([installation()]);
+  const impl: typeof fetch = async (input) => {
+    const url = String(input);
+    if (url.includes("/v1/services")) {
+      return new Response(JSON.stringify({ message: "unauthorized" }), { status: 401 });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+
+  const stats = await runRenderPullOnce({
+    store,
+    intakeBaseUrl: "http://intake.test",
+    log: silentLog,
+    fetchImpl: impl,
+    now: () => NOW,
+    metricsPollState: new Map(),
+  });
+  assert.equal(stats.installations, 1);
+  assert.equal(stats.logsForwarded, 0);
+  assert.equal(state.savedCursors.length, 0);
+});
+
+test("an intake rejection keeps the cursor so nothing is lost", async () => {
+  const { store, state } = makeStore([
+    installation({ logCursor: { oregon: "2026-07-07T14:19:00Z" } }),
+  ]);
+  const { impl } = makeFetch({
+    logsResponses: [{ logs: [{ ...LOG_LINE, timestamp: "2026-07-07T14:19:45Z" }], hasMore: false }],
+    intakeStatus: 503,
+  });
+
+  const stats = await runRenderPullOnce({
+    store,
+    intakeBaseUrl: "http://intake.test",
+    log: silentLog,
+    fetchImpl: impl,
+    now: () => NOW,
+    metricsPollState: new Map(),
+  });
+  assert.ok(stats.errors >= 1);
+  assert.equal(stats.logsForwarded, 0);
+  // The log cursor must not advance past unforwarded lines. (Metrics may have
+  // failed too; either way nothing recorded a log-cursor move.)
+  const moved = state.savedCursors.some((c) => c.logCursor.oregon !== "2026-07-07T14:19:00Z");
+  assert.equal(moved, false);
+});

--- a/apps/worker/src/render/puller.test.ts
+++ b/apps/worker/src/render/puller.test.ts
@@ -26,6 +26,8 @@ function installation(overrides: Partial<RenderPullerInstallation> = {}): Render
     services: [],
     logCursor: {},
     metricsCursor: {},
+    logStreamActive: false,
+    metricsStreamActive: false,
     ...overrides,
   };
 }
@@ -247,6 +249,31 @@ test("metrics polls are gated by the interval clock", async () => {
     metricsPollState: pollState,
   });
   assert.ok(!second.calls.some((c) => c.url.includes("/v1/metrics/")));
+});
+
+test("provisioned streams suppress polling for their signal", async () => {
+  const { store, state } = makeStore([
+    installation({ logStreamActive: true, metricsStreamActive: true }),
+  ]);
+  const { impl, calls } = makeFetch();
+
+  const stats = await runRenderPullOnce({
+    store,
+    intakeBaseUrl: "http://intake.test",
+    log: silentLog,
+    fetchImpl: impl,
+    now: () => NOW,
+    metricsPollState: new Map(),
+  });
+
+  // Inventory still refreshes (cheap, keeps the snapshot + revocation checks
+  // alive), but no log or metric reads and nothing forwarded.
+  assert.ok(calls.some((c) => c.url.includes("/v1/services")));
+  assert.ok(!calls.some((c) => c.url.includes("/v1/logs")));
+  assert.ok(!calls.some((c) => c.url.includes("/v1/metrics/")));
+  assert.equal(stats.logsForwarded, 0);
+  assert.equal(stats.metricPointsForwarded, 0);
+  assert.equal(state.savedCursors.length, 0);
 });
 
 test("a persistently rejected key is soft-revoked after three passes", async () => {

--- a/apps/worker/src/render/puller.test.ts
+++ b/apps/worker/src/render/puller.test.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
+import type { RenderLogCursor } from "@superlog/render";
 import {
   type RenderPullerInstallation,
   type RenderPullerStore,
@@ -34,16 +35,17 @@ type StoreState = {
   savedServices: Array<{ id: string; services: unknown }>;
   savedCursors: Array<{
     id: string;
-    logCursor: Record<string, string>;
+    logCursor: RenderLogCursor;
     metricsCursor: Record<string, number>;
   }>;
+  revoked: string[];
 };
 
 function makeStore(installations: RenderPullerInstallation[]): {
   store: RenderPullerStore;
   state: StoreState;
 } {
-  const state: StoreState = { installations, savedServices: [], savedCursors: [] };
+  const state: StoreState = { installations, savedServices: [], savedCursors: [], revoked: [] };
   return {
     store: {
       listActiveInstallations: async () => state.installations,
@@ -52,6 +54,9 @@ function makeStore(installations: RenderPullerInstallation[]): {
       },
       saveCursors: async (id, cursors) => {
         state.savedCursors.push({ id, ...cursors });
+      },
+      markRevoked: async (id) => {
+        state.revoked.push(id);
       },
     },
     state,
@@ -170,7 +175,7 @@ test("first pass seeds logs backward, forwards fresh telemetry, persists cursors
   // Cursors persisted: log cursor at the seed line, metrics cursor per key.
   assert.equal(state.savedCursors.length, 1);
   const cursors = state.savedCursors[0];
-  assert.equal(cursors?.logCursor.oregon, "2026-07-07T14:19:30Z");
+  assert.deepEqual(cursors?.logCursor.oregon, { ts: "2026-07-07T14:19:30Z", ids: ["log-1"] });
   assert.equal(cursors?.metricsCursor["srv-1:cpu"], Date.parse("2026-07-07T14:19:00Z") / 1000);
 });
 
@@ -214,7 +219,7 @@ test("cursor pass reads forward with pagination and dedupes already-seen lines",
   assert.equal(intakeCalls.length, 1);
 
   const cursors = state.savedCursors[0];
-  assert.equal(cursors?.logCursor.oregon, "2026-07-07T14:19:45Z");
+  assert.deepEqual(cursors?.logCursor.oregon, { ts: "2026-07-07T14:19:45Z", ids: ["log-2"] });
 });
 
 test("metrics polls are gated by the interval clock", async () => {
@@ -244,7 +249,7 @@ test("metrics polls are gated by the interval clock", async () => {
   assert.ok(!second.calls.some((c) => c.url.includes("/v1/metrics/")));
 });
 
-test("a rejected key skips the installation without throwing", async () => {
+test("a persistently rejected key is soft-revoked after three passes", async () => {
   const { store, state } = makeStore([installation()]);
   const impl: typeof fetch = async (input) => {
     const url = String(input);
@@ -253,18 +258,29 @@ test("a rejected key skips the installation without throwing", async () => {
     }
     throw new Error(`unexpected fetch: ${url}`);
   };
+  const unauthorizedState = new Map<string, number>();
+  const run = () =>
+    runRenderPullOnce({
+      store,
+      intakeBaseUrl: "http://intake.test",
+      log: silentLog,
+      fetchImpl: impl,
+      now: () => NOW,
+      metricsPollState: new Map(),
+      unauthorizedState,
+    });
 
-  const stats = await runRenderPullOnce({
-    store,
-    intakeBaseUrl: "http://intake.test",
-    log: silentLog,
-    fetchImpl: impl,
-    now: () => NOW,
-    metricsPollState: new Map(),
-  });
+  const stats = await run();
   assert.equal(stats.installations, 1);
   assert.equal(stats.logsForwarded, 0);
   assert.equal(state.savedCursors.length, 0);
+  // Two rejected passes: still just skipping.
+  assert.deepEqual(state.revoked, []);
+  await run();
+  assert.deepEqual(state.revoked, []);
+  // Third consecutive rejection revokes the install.
+  await run();
+  assert.deepEqual(state.revoked, ["inst-1"]);
 });
 
 test("an intake rejection keeps the cursor so nothing is lost", async () => {

--- a/apps/worker/src/render/puller.ts
+++ b/apps/worker/src/render/puller.ts
@@ -44,6 +44,13 @@ export type RenderPullerInstallation = {
   services: RenderService[];
   logCursor: RenderLogCursor;
   metricsCursor: Record<string, number>;
+  // True when the workspace's push stream for the signal points at our intake
+  // (see the api's provisionStreams) — Render delivers it directly and the
+  // puller must not double-ingest. Polling remains the fallback for conflict
+  // (slot taken by another destination) and unavailable (e.g. metrics streams
+  // are plan-gated) signals.
+  logStreamActive: boolean;
+  metricsStreamActive: boolean;
 };
 
 export type RenderPullerStore = {
@@ -207,15 +214,18 @@ export async function runRenderPullOnce(deps: RenderPullerDeps): Promise<RenderP
     let cursorsDirty = false;
 
     // --- Logs ---------------------------------------------------------------
-    // One query covers every resource in a region (Render requires the batch
-    // to share owner + region), so the request count stays flat as services
-    // grow: pages consumed ≤ regions × logPageBudget per pass.
+    // Only when the workspace's log stream isn't pushing to us. One query
+    // covers every resource in a region (Render requires the batch to share
+    // owner + region), so the request count stays flat as services grow:
+    // pages consumed ≤ regions × logPageBudget per pass.
     const byRegion = new Map<string, RenderService[]>();
-    for (const service of active) {
-      const region = service.region ?? "unknown";
-      const group = byRegion.get(region);
-      if (group) group.push(service);
-      else byRegion.set(region, [service]);
+    if (!installation.logStreamActive) {
+      for (const service of active) {
+        const region = service.region ?? "unknown";
+        const group = byRegion.get(region);
+        if (group) group.push(service);
+        else byRegion.set(region, [service]);
+      }
     }
 
     for (const [region, group] of byRegion) {
@@ -312,7 +322,7 @@ export async function runRenderPullOnce(deps: RenderPullerDeps): Promise<RenderP
     // let a fast instance advance past a lagging one and drop its points.
     const nowSec = Math.floor(now().getTime() / 1000);
     const lastPoll = pollState.get(installation.id) ?? 0;
-    if (nowSec - lastPoll >= metricsInterval) {
+    if (!installation.metricsStreamActive && nowSec - lastPoll >= metricsInterval) {
       pollState.set(installation.id, nowSec);
       const startTime = new Date((nowSec - METRICS_LOOKBACK_S) * 1000).toISOString();
       const endTime = now().toISOString();

--- a/apps/worker/src/render/puller.ts
+++ b/apps/worker/src/render/puller.ts
@@ -1,0 +1,365 @@
+// Render telemetry puller — the ingest half of the Render connector. Render
+// has no drains, so instead of the vendor pushing to our intake, this module
+// reads logs and infra metrics from Render's REST API for every active
+// installation and forwards them (as OTLP JSON) to our own intake,
+// authenticated with the installation's project ingest key. Runs as a
+// scheduled job (jobs/render-pull.ts): one bounded pass per fire, cursors in
+// the installation row make restarts gap- and duplicate-free.
+//
+// Render rate limits are per user API key: the logs endpoints allow 30
+// requests/minute, so logs are read in one batched query per region (all
+// resources of a region share a query) with a small page budget per pass;
+// metrics GETs (400/minute) are batched per kind across all resources.
+//
+// IO is behind narrow ports (store + fetch) so the pull logic is unit-testable
+// without Postgres or a live Render account.
+
+import {
+  RENDER_METRIC_KINDS,
+  type RenderLog,
+  type RenderMetricSeries,
+  type RenderService,
+  advanceLogCursor,
+  advanceSeriesCursor,
+  fetchLogs,
+  fetchMetrics,
+  fetchServices,
+  filterLogsAfterCursor,
+  filterSeriesAfterCursor,
+  renderLogsToOtlp,
+  renderMetricsToOtlp,
+  seriesResourceId,
+} from "@superlog/render";
+
+export type RenderPullerInstallation = {
+  id: string;
+  projectId: string;
+  renderApiKey: string;
+  ownerId: string;
+  ownerName: string;
+  ingestKey: string | null;
+  services: RenderService[];
+  logCursor: Record<string, string>;
+  metricsCursor: Record<string, number>;
+};
+
+export type RenderPullerStore = {
+  listActiveInstallations(): Promise<RenderPullerInstallation[]>;
+  saveServices(id: string, services: RenderService[]): Promise<void>;
+  saveCursors(
+    id: string,
+    cursors: { logCursor: Record<string, string>; metricsCursor: Record<string, number> },
+  ): Promise<void>;
+};
+
+type PullerLogger = {
+  info(fields: Record<string, unknown>, msg: string): void;
+  warn(fields: Record<string, unknown>, msg: string): void;
+  error(fields: Record<string, unknown>, msg: string): void;
+};
+
+export type RenderPullerDeps = {
+  store: RenderPullerStore;
+  /** Base URL of our proxy intake, e.g. https://intake.superlog.sh */
+  intakeBaseUrl: string;
+  log: PullerLogger;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+  /** Max log pages (of `logPageLimit` lines) per region group per pass. */
+  logPageBudget?: number;
+  /** Log lines per page (Render caps at 100). */
+  logPageLimit?: number;
+  /** Minimum seconds between metrics polls per installation. */
+  metricsIntervalSeconds?: number;
+  metricsResolutionSeconds?: number;
+  /**
+   * Per-installation last-poll clock (epoch seconds), process-lived. Keeps
+   * metrics from being polled every pass; on worker restart the worst case is
+   * one early poll, deduped by the sample cursor anyway.
+   */
+  metricsPollState?: Map<string, number>;
+};
+
+export type RenderPullStats = {
+  installations: number;
+  logsForwarded: number;
+  metricPointsForwarded: number;
+  errors: number;
+};
+
+// Metrics polls read a fixed recent window; the per-resource sample cursor
+// dedupes overlap between polls.
+const METRICS_LOOKBACK_S = 15 * 60;
+// Metric resource batching: keep request URLs bounded.
+const METRICS_RESOURCE_CHUNK = 25;
+
+export async function runRenderPullOnce(deps: RenderPullerDeps): Promise<RenderPullStats> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const now = deps.now ?? (() => new Date());
+  const logPageBudget = deps.logPageBudget ?? 5;
+  const logPageLimit = deps.logPageLimit ?? 100;
+  const metricsInterval = deps.metricsIntervalSeconds ?? 300;
+  const resolution = deps.metricsResolutionSeconds ?? 60;
+  const pollState = deps.metricsPollState ?? sharedMetricsPollState;
+  const intake = deps.intakeBaseUrl.replace(/\/+$/, "");
+
+  const stats: RenderPullStats = {
+    installations: 0,
+    logsForwarded: 0,
+    metricPointsForwarded: 0,
+    errors: 0,
+  };
+
+  const installations = await deps.store.listActiveInstallations();
+  for (const installation of installations) {
+    stats.installations += 1;
+    try {
+      await pullInstallation(installation);
+    } catch (err) {
+      stats.errors += 1;
+      deps.log.error(
+        { installation_id: installation.id, err: err instanceof Error ? err.message : String(err) },
+        "render pull failed for installation",
+      );
+    }
+  }
+  return stats;
+
+  async function pullInstallation(installation: RenderPullerInstallation): Promise<void> {
+    if (!installation.ingestKey) {
+      deps.log.warn({ installation_id: installation.id }, "render install has no ingest key");
+      return;
+    }
+
+    // --- Service inventory --------------------------------------------------
+    // Refresh the snapshot every pass so new services start flowing without a
+    // reconnect. A revoked key is terminal (Render keys don't refresh): skip
+    // and let the user reconnect.
+    let services = installation.services;
+    const inventory = await fetchServices({
+      apiKey: installation.renderApiKey,
+      ownerId: installation.ownerId,
+      fetchImpl,
+    });
+    if (inventory.ok) {
+      services = inventory.services;
+      await deps.store.saveServices(installation.id, inventory.services);
+    } else if (inventory.unauthorized) {
+      deps.log.warn(
+        { installation_id: installation.id },
+        "render api key rejected — skipping (user must reconnect)",
+      );
+      return;
+    } else {
+      deps.log.warn(
+        { installation_id: installation.id, error: inventory.error },
+        "render inventory read failed; using stored snapshot",
+      );
+    }
+
+    const active = services.filter((s) => !s.suspended);
+    if (active.length === 0) return;
+    const serviceNamesById = Object.fromEntries(active.map((s) => [s.id, s.name]));
+    const ctx = {
+      serviceNamesById,
+      ownerId: installation.ownerId,
+      ownerName: installation.ownerName,
+    };
+
+    let logCursor = installation.logCursor;
+    let metricsCursor = installation.metricsCursor;
+    let cursorsDirty = false;
+
+    // --- Logs ---------------------------------------------------------------
+    // One query covers every resource in a region (Render requires the batch
+    // to share owner + region), so the request count stays flat as services
+    // grow: pages consumed ≤ regions × logPageBudget per pass.
+    const byRegion = new Map<string, RenderService[]>();
+    for (const service of active) {
+      const region = service.region ?? "unknown";
+      const group = byRegion.get(region);
+      if (group) group.push(service);
+      else byRegion.set(region, [service]);
+    }
+
+    for (const [region, group] of byRegion) {
+      const resources = group.map((s) => s.id);
+      const cursorTs = logCursor[region];
+      const collected: RenderLog[] = [];
+      let readOk = true;
+
+      if (!cursorTs) {
+        // First pull: one backward read seeds from the most recent lines
+        // rather than the beginning of time.
+        const read = await fetchLogs({
+          apiKey: installation.renderApiKey,
+          ownerId: installation.ownerId,
+          resources,
+          endTime: now().toISOString(),
+          limit: logPageLimit,
+          fetchImpl,
+        });
+        if (read.ok) {
+          collected.push(...read.page.logs);
+        } else {
+          readOk = false;
+          stats.errors += 1;
+          deps.log.warn(
+            { installation_id: installation.id, region, error: read.error },
+            "render log read failed",
+          );
+        }
+      } else {
+        // Forward from the cursor, following Render's timestamp pagination up
+        // to the page budget; anything left over is picked up next pass.
+        let startTime: string = cursorTs;
+        let endTime: string = now().toISOString();
+        for (let page = 0; page < logPageBudget; page++) {
+          const read = await fetchLogs({
+            apiKey: installation.renderApiKey,
+            ownerId: installation.ownerId,
+            resources,
+            startTime,
+            endTime,
+            direction: "forward",
+            limit: logPageLimit,
+            fetchImpl,
+          });
+          if (!read.ok) {
+            readOk = false;
+            stats.errors += 1;
+            deps.log.warn(
+              { installation_id: installation.id, region, error: read.error },
+              "render log read failed",
+            );
+            break;
+          }
+          collected.push(...read.page.logs);
+          if (!read.page.hasMore || !read.page.nextStartTime) break;
+          startTime = read.page.nextStartTime;
+          endTime = read.page.nextEndTime ?? endTime;
+        }
+      }
+
+      if (readOk) {
+        const fresh = filterLogsAfterCursor(logCursor, region, collected);
+        const forwarded =
+          fresh.length === 0
+            ? true
+            : await forwardOtlp(
+                `${intake}/render/pull/logs`,
+                renderLogsToOtlp(fresh, ctx),
+                installation.ingestKey,
+              );
+        if (forwarded) {
+          // Seed the cursor even when the first batch is empty so the next
+          // pass reads forward instead of re-anchoring.
+          const next = advanceLogCursor(logCursor, region, collected);
+          const seeded =
+            next[region] === undefined ? { ...next, [region]: now().toISOString() } : next;
+          if (seeded !== logCursor) {
+            logCursor = seeded;
+            cursorsDirty = true;
+          }
+          stats.logsForwarded += fresh.length;
+        } else {
+          stats.errors += 1;
+        }
+      }
+    }
+
+    // --- Metrics ------------------------------------------------------------
+    // One request per kind per resource chunk, gated to one poll per
+    // installation per ~5 minutes. Series come back labeled per resource, so
+    // the sample cursor is keyed `${resourceId}:${kind}`.
+    const nowSec = Math.floor(now().getTime() / 1000);
+    const lastPoll = pollState.get(installation.id) ?? 0;
+    if (nowSec - lastPoll >= metricsInterval) {
+      pollState.set(installation.id, nowSec);
+      const startTime = new Date((nowSec - METRICS_LOOKBACK_S) * 1000).toISOString();
+      const endTime = now().toISOString();
+      const allResources = active.map((s) => s.id);
+
+      for (const kind of RENDER_METRIC_KINDS) {
+        for (let i = 0; i < allResources.length; i += METRICS_RESOURCE_CHUNK) {
+          const chunk = allResources.slice(i, i + METRICS_RESOURCE_CHUNK);
+          const read = await fetchMetrics({
+            apiKey: installation.renderApiKey,
+            kind,
+            resources: chunk,
+            startTime,
+            endTime,
+            resolutionSeconds: resolution,
+            fetchImpl,
+          });
+          if (!read.ok) {
+            stats.errors += 1;
+            deps.log.warn(
+              { installation_id: installation.id, kind, error: read.error },
+              "render metrics read failed",
+            );
+            continue;
+          }
+
+          // Dedupe each series against its own resource's cursor, then
+          // forward whatever is fresh in one export.
+          const freshByKey = new Map<string, RenderMetricSeries[]>();
+          for (const series of read.series) {
+            const resourceId = seriesResourceId(series);
+            if (!resourceId) continue;
+            const key = `${resourceId}:${kind}`;
+            const fresh = filterSeriesAfterCursor(metricsCursor, key, [series]);
+            if (fresh.length === 0) continue;
+            const group = freshByKey.get(key);
+            if (group) group.push(...fresh);
+            else freshByKey.set(key, fresh);
+          }
+          const freshSeries = [...freshByKey.values()].flat();
+          const points = freshSeries.reduce((n, s) => n + s.values.length, 0);
+          if (points === 0) continue;
+
+          const forwarded = await forwardOtlp(
+            `${intake}/render/pull/metrics`,
+            renderMetricsToOtlp(kind, freshSeries, ctx),
+            installation.ingestKey,
+          );
+          if (!forwarded) {
+            stats.errors += 1;
+            continue;
+          }
+          for (const [key, group] of freshByKey) {
+            metricsCursor = advanceSeriesCursor(metricsCursor, key, group);
+          }
+          cursorsDirty = true;
+          stats.metricPointsForwarded += points;
+        }
+      }
+    }
+
+    if (cursorsDirty) {
+      await deps.store.saveCursors(installation.id, { logCursor, metricsCursor });
+    }
+  }
+
+  async function forwardOtlp(url: string, payload: unknown, ingestKey: string): Promise<boolean> {
+    try {
+      const res = await fetchImpl(url, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-api-key": ingestKey },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        deps.log.warn({ url, status: res.status }, "render intake forward rejected");
+      }
+      return res.ok;
+    } catch (err) {
+      deps.log.warn(
+        { url, err: err instanceof Error ? err.message : String(err) },
+        "render intake forward failed",
+      );
+      return false;
+    }
+  }
+}
+
+const sharedMetricsPollState = new Map<string, number>();

--- a/apps/worker/src/render/puller.ts
+++ b/apps/worker/src/render/puller.ts
@@ -17,6 +17,7 @@
 import {
   RENDER_METRIC_KINDS,
   type RenderLog,
+  type RenderLogCursor,
   type RenderMetricSeries,
   type RenderService,
   advanceLogCursor,
@@ -26,8 +27,10 @@ import {
   fetchServices,
   filterLogsAfterCursor,
   filterSeriesAfterCursor,
+  logCursorTs,
   renderLogsToOtlp,
   renderMetricsToOtlp,
+  seriesCursorKey,
   seriesResourceId,
 } from "@superlog/render";
 
@@ -39,7 +42,7 @@ export type RenderPullerInstallation = {
   ownerName: string;
   ingestKey: string | null;
   services: RenderService[];
-  logCursor: Record<string, string>;
+  logCursor: RenderLogCursor;
   metricsCursor: Record<string, number>;
 };
 
@@ -48,8 +51,14 @@ export type RenderPullerStore = {
   saveServices(id: string, services: RenderService[]): Promise<void>;
   saveCursors(
     id: string,
-    cursors: { logCursor: Record<string, string>; metricsCursor: Record<string, number> },
+    cursors: { logCursor: RenderLogCursor; metricsCursor: Record<string, number> },
   ): Promise<void>;
+  /**
+   * Soft-revoke an installation whose Render key has been persistently
+   * rejected — Render keys don't expire or refresh, so a rejected key stays
+   * rejected until the user reconnects with a new one.
+   */
+  markRevoked(id: string): Promise<void>;
 };
 
 type PullerLogger = {
@@ -78,6 +87,13 @@ export type RenderPullerDeps = {
    * one early poll, deduped by the sample cursor anyway.
    */
   metricsPollState?: Map<string, number>;
+  /**
+   * Per-installation consecutive-unauthorized counter, process-lived. A key
+   * that stays rejected for several passes is treated as revoked on Render's
+   * side and the install is soft-revoked; a worker restart just restarts the
+   * count (worst case a few extra probe calls).
+   */
+  unauthorizedState?: Map<string, number>;
 };
 
 export type RenderPullStats = {
@@ -87,11 +103,17 @@ export type RenderPullStats = {
   errors: number;
 };
 
-// Metrics polls read a fixed recent window; the per-resource sample cursor
+// Metrics polls read a fixed recent window; the per-series sample cursor
 // dedupes overlap between polls.
 const METRICS_LOOKBACK_S = 15 * 60;
 // Metric resource batching: keep request URLs bounded.
 const METRICS_RESOURCE_CHUNK = 25;
+// Series cursor entries untouched for this long are dropped at save time so
+// instance churn (every deploy mints new instance labels) can't grow the
+// cursor blob without bound.
+const METRICS_CURSOR_MAX_AGE_S = 7 * 24 * 60 * 60;
+// Consecutive passes with a rejected key before the install is soft-revoked.
+const UNAUTHORIZED_REVOKE_THRESHOLD = 3;
 
 export async function runRenderPullOnce(deps: RenderPullerDeps): Promise<RenderPullStats> {
   const fetchImpl = deps.fetchImpl ?? fetch;
@@ -101,6 +123,7 @@ export async function runRenderPullOnce(deps: RenderPullerDeps): Promise<RenderP
   const metricsInterval = deps.metricsIntervalSeconds ?? 300;
   const resolution = deps.metricsResolutionSeconds ?? 60;
   const pollState = deps.metricsPollState ?? sharedMetricsPollState;
+  const unauthorizedState = deps.unauthorizedState ?? sharedUnauthorizedState;
   const intake = deps.intakeBaseUrl.replace(/\/+$/, "");
 
   const stats: RenderPullStats = {
@@ -133,8 +156,9 @@ export async function runRenderPullOnce(deps: RenderPullerDeps): Promise<RenderP
 
     // --- Service inventory --------------------------------------------------
     // Refresh the snapshot every pass so new services start flowing without a
-    // reconnect. A revoked key is terminal (Render keys don't refresh): skip
-    // and let the user reconnect.
+    // reconnect. A revoked key is terminal (Render keys don't refresh): after
+    // a few consecutive rejections the install is soft-revoked so the UI
+    // reads "not connected" and the puller stops probing until reconnect.
     let services = installation.services;
     const inventory = await fetchServices({
       apiKey: installation.renderApiKey,
@@ -142,13 +166,25 @@ export async function runRenderPullOnce(deps: RenderPullerDeps): Promise<RenderP
       fetchImpl,
     });
     if (inventory.ok) {
+      unauthorizedState.delete(installation.id);
       services = inventory.services;
       await deps.store.saveServices(installation.id, inventory.services);
     } else if (inventory.unauthorized) {
-      deps.log.warn(
-        { installation_id: installation.id },
-        "render api key rejected — skipping (user must reconnect)",
-      );
+      const strikes = (unauthorizedState.get(installation.id) ?? 0) + 1;
+      unauthorizedState.set(installation.id, strikes);
+      if (strikes >= UNAUTHORIZED_REVOKE_THRESHOLD) {
+        unauthorizedState.delete(installation.id);
+        await deps.store.markRevoked(installation.id);
+        deps.log.warn(
+          { installation_id: installation.id, strikes },
+          "render api key rejected repeatedly — install revoked (user must reconnect)",
+        );
+      } else {
+        deps.log.warn(
+          { installation_id: installation.id, strikes },
+          "render api key rejected — skipping this pass",
+        );
+      }
       return;
     } else {
       deps.log.warn(
@@ -184,7 +220,7 @@ export async function runRenderPullOnce(deps: RenderPullerDeps): Promise<RenderP
 
     for (const [region, group] of byRegion) {
       const resources = group.map((s) => s.id);
-      const cursorTs = logCursor[region];
+      const cursorTs = logCursorTs(logCursor[region]);
       const collected: RenderLog[] = [];
       let readOk = true;
 
@@ -270,8 +306,10 @@ export async function runRenderPullOnce(deps: RenderPullerDeps): Promise<RenderP
 
     // --- Metrics ------------------------------------------------------------
     // One request per kind per resource chunk, gated to one poll per
-    // installation per ~5 minutes. Series come back labeled per resource, so
-    // the sample cursor is keyed `${resourceId}:${kind}`.
+    // installation per ~5 minutes. Series come back labeled per resource (and
+    // per instance for multi-instance services), so the sample cursor is
+    // keyed by the full series identity — a shared per-resource cursor would
+    // let a fast instance advance past a lagging one and drop its points.
     const nowSec = Math.floor(now().getTime() / 1000);
     const lastPoll = pollState.get(installation.id) ?? 0;
     if (nowSec - lastPoll >= metricsInterval) {
@@ -301,13 +339,13 @@ export async function runRenderPullOnce(deps: RenderPullerDeps): Promise<RenderP
             continue;
           }
 
-          // Dedupe each series against its own resource's cursor, then
-          // forward whatever is fresh in one export.
+          // Dedupe each series against its own cursor, then forward whatever
+          // is fresh in one export.
           const freshByKey = new Map<string, RenderMetricSeries[]>();
           for (const series of read.series) {
             const resourceId = seriesResourceId(series);
             if (!resourceId) continue;
-            const key = `${resourceId}:${kind}`;
+            const key = seriesCursorKey(resourceId, kind, series);
             const fresh = filterSeriesAfterCursor(metricsCursor, key, [series]);
             if (fresh.length === 0) continue;
             const group = freshByKey.get(key);
@@ -337,7 +375,13 @@ export async function runRenderPullOnce(deps: RenderPullerDeps): Promise<RenderP
     }
 
     if (cursorsDirty) {
-      await deps.store.saveCursors(installation.id, { logCursor, metricsCursor });
+      // Instance churn mints new series keys on every deploy; drop entries
+      // whose last sample is old enough that re-reading them is impossible
+      // anyway (the poll window only looks back METRICS_LOOKBACK_S).
+      const pruned = Object.fromEntries(
+        Object.entries(metricsCursor).filter(([, sec]) => sec >= nowSec - METRICS_CURSOR_MAX_AGE_S),
+      );
+      await deps.store.saveCursors(installation.id, { logCursor, metricsCursor: pruned });
     }
   }
 
@@ -363,3 +407,4 @@ export async function runRenderPullOnce(deps: RenderPullerDeps): Promise<RenderP
 }
 
 const sharedMetricsPollState = new Map<string, number>();
+const sharedUnauthorizedState = new Map<string, number>();

--- a/packages/db/migrations/0088_heavy_vision.sql
+++ b/packages/db/migrations/0088_heavy_vision.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "render_installations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"project_id" uuid NOT NULL,
+	"render_owner_id" text NOT NULL,
+	"render_owner_name" text,
+	"services" jsonb,
+	"render_api_key_ciphertext" "bytea" NOT NULL,
+	"render_api_key_nonce" "bytea" NOT NULL,
+	"render_api_key_key_version" integer DEFAULT 1 NOT NULL,
+	"api_key_id" uuid,
+	"ingest_key_ciphertext" "bytea",
+	"ingest_key_nonce" "bytea",
+	"ingest_key_key_version" integer,
+	"log_cursor" jsonb,
+	"metrics_cursor" jsonb,
+	"installed_by_user_id" uuid,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "render_installations" ADD CONSTRAINT "render_installations_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "render_installations" ADD CONSTRAINT "render_installations_api_key_id_api_keys_id_fk" FOREIGN KEY ("api_key_id") REFERENCES "public"."api_keys"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "render_installations" ADD CONSTRAINT "render_installations_installed_by_user_id_users_id_fk" FOREIGN KEY ("installed_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "render_installations_project_owner_idx" ON "render_installations" USING btree ("project_id","render_owner_id");

--- a/packages/db/migrations/0089_remarkable_darwin.sql
+++ b/packages/db/migrations/0089_remarkable_darwin.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "render_installations" ADD COLUMN "log_stream_state" jsonb;--> statement-breakpoint
+ALTER TABLE "render_installations" ADD COLUMN "metrics_stream_state" jsonb;

--- a/packages/db/migrations/meta/0088_snapshot.json
+++ b/packages/db/migrations/meta/0088_snapshot.json
@@ -1,0 +1,8897 @@
+{
+  "id": "adf85c74-946a-47b7-b9d3-cb63e007ad0d",
+  "prevId": "61f62c41-9dbc-44f2-be05-9810b44e24f3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_provider_account_idx": {
+          "name": "accounts_provider_account_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_idx": {
+          "name": "accounts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_chat_messages": {
+      "name": "agent_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_slack_user_id": {
+          "name": "author_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_chat_messages_dedupe_idx": {
+          "name": "agent_chat_messages_dedupe_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chat_messages_pending_idx": {
+          "name": "agent_chat_messages_pending_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "processed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_chat_messages_chat_id_agent_chats_id_fk": {
+          "name": "agent_chat_messages_chat_id_agent_chats_id_fk",
+          "tableFrom": "agent_chat_messages",
+          "tableTo": "agent_chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_chats": {
+      "name": "agent_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_slack_user_id": {
+          "name": "created_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_status": {
+          "name": "provider_session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cumulative_active_seconds": {
+          "name": "cumulative_active_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "session_base_active_seconds": {
+          "name": "session_base_active_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_chats_thread_idx": {
+          "name": "agent_chats_thread_idx",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_thread_ts IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_dm_channel_idx": {
+          "name": "agent_chats_dm_channel_idx",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_thread_ts IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_provider_session_idx": {
+          "name": "agent_chats_provider_session_idx",
+          "columns": [
+            {
+              "expression": "provider_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_state_idx": {
+          "name": "agent_chats_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_chats_project_id_projects_id_fk": {
+          "name": "agent_chats_project_id_projects_id_fk",
+          "tableFrom": "agent_chats",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_chats_slack_installation_id_slack_installations_id_fk": {
+          "name": "agent_chats_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "agent_chats",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_ticket_events": {
+      "name": "agent_linear_ticket_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_linear_ticket_id": {
+          "name": "agent_linear_ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_linear_id": {
+          "name": "actor_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_ticket_events_ticket_idx": {
+          "name": "agent_linear_ticket_events_ticket_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_ticket_events_provider_event_idx": {
+          "name": "agent_linear_ticket_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk": {
+          "name": "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk",
+          "tableFrom": "agent_linear_ticket_events",
+          "tableTo": "agent_linear_tickets",
+          "columnsFrom": [
+            "agent_linear_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_tickets": {
+      "name": "agent_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_identifier": {
+          "name": "ticket_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_name": {
+          "name": "assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_linear_id": {
+          "name": "assignee_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_tickets_incident_idx": {
+          "name": "agent_linear_tickets_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_agent_run_idx": {
+          "name": "agent_linear_tickets_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_workspace_ticket_idx": {
+          "name": "agent_linear_tickets_workspace_ticket_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_tickets_incident_id_incidents_id_fk": {
+          "name": "agent_linear_tickets_incident_id_incidents_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_linear_tickets_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_installation_id_linear_installations_id_fk": {
+          "name": "agent_linear_tickets_installation_id_linear_installations_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "linear_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memories": {
+      "name": "agent_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source_agent_run_id": {
+          "name": "source_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memories_org_status_idx": {
+          "name": "agent_memories_org_status_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_memories_org_id_orgs_id_fk": {
+          "name": "agent_memories_org_id_orgs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_id_projects_id_fk": {
+          "name": "agent_memories_project_id_projects_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_memories_source_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "source_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_user_id_users_id_fk": {
+          "name": "agent_memories_source_user_id_users_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "source_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_org_fk": {
+          "name": "agent_memories_project_org_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_memories_single_source_check": {
+          "name": "agent_memories_single_source_check",
+          "value": "NOT (source_agent_run_id IS NOT NULL AND source_user_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_pr_events": {
+      "name": "agent_pr_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_pr_id": {
+          "name": "agent_pr_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_login": {
+          "name": "actor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_github_id": {
+          "name": "actor_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pr_events_pr_idx": {
+          "name": "agent_pr_events_pr_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pr_events_provider_event_idx": {
+          "name": "agent_pr_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk": {
+          "name": "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk",
+          "tableFrom": "agent_pr_events",
+          "tableTo": "agent_pull_requests",
+          "columnsFrom": [
+            "agent_pr_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_pull_requests": {
+      "name": "agent_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_node_id": {
+          "name": "pr_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_login": {
+          "name": "merged_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_github_id": {
+          "name": "merged_by_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pull_requests_incident_idx": {
+          "name": "agent_pull_requests_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_agent_run_idx": {
+          "name": "agent_pull_requests_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_repo_pr_idx": {
+          "name": "agent_pull_requests_repo_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pull_requests_incident_id_incidents_id_fk": {
+          "name": "agent_pull_requests_incident_id_incidents_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_pull_requests_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_installation_id_github_installations_id_fk": {
+          "name": "agent_pull_requests_installation_id_github_installations_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'incident'"
+        },
+        "trigger_detail": {
+          "name": "trigger_detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_status": {
+          "name": "provider_session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_full_name": {
+          "name": "selected_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_url": {
+          "name": "selected_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_base_branch": {
+          "name": "selected_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_score": {
+          "name": "selected_repo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cumulative_runtime_minutes": {
+          "name": "cumulative_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resume_count": {
+          "name": "resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_runs_incident_idx": {
+          "name": "agent_runs_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_provider_session_idx": {
+          "name": "agent_runs_provider_session_idx",
+          "columns": [
+            {
+              "expression": "provider_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_incident_id_incidents_id_fk": {
+          "name": "agent_runs_incident_id_incidents_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_episodes": {
+      "name": "alert_episodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'firing'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_observed_value": {
+          "name": "open_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_observed_value": {
+          "name": "peak_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_value": {
+          "name": "last_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_firing_at": {
+          "name": "last_firing_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alert_episodes_alert_started_idx": {
+          "name": "alert_episodes_alert_started_idx",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_episodes_incident_idx": {
+          "name": "alert_episodes_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_episodes_open_uniq": {
+          "name": "alert_episodes_open_uniq",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "state = 'firing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_episodes_alert_id_alerts_id_fk": {
+          "name": "alert_episodes_alert_id_alerts_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_project_id_projects_id_fk": {
+          "name": "alert_episodes_project_id_projects_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_issue_id_issues_id_fk": {
+          "name": "alert_episodes_issue_id_issues_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_incident_id_incidents_id_fk": {
+          "name": "alert_episodes_incident_id_incidents_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_firings": {
+      "name": "alert_firings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_value": {
+          "name": "observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluated_at": {
+          "name": "evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_firings_alert_group_idx": {
+          "name": "alert_firings_alert_group_idx",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_firings_alert_id_alerts_id_fk": {
+          "name": "alert_firings_alert_id_alerts_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_firings_issue_id_issues_id_fk": {
+          "name": "alert_firings_issue_id_issues_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_name": {
+          "name": "metric_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "group_by": {
+          "name": "group_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mode": {
+          "name": "group_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single'"
+        },
+        "aggregation": {
+          "name": "aggregation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparator": {
+          "name": "comparator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "evaluation_interval_seconds": {
+          "name": "evaluation_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alerts_project_idx": {
+          "name": "alerts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alerts_enabled_idx": {
+          "name": "alerts_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alerts_project_id_projects_id_fk": {
+          "name": "alerts_project_id_projects_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alerts_created_by_users_id_fk": {
+          "name": "alerts_created_by_users_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions": {
+      "name": "cli_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cli_sessions_user_id_users_id_fk": {
+          "name": "cli_sessions_user_id_users_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_org_id_orgs_id_fk": {
+          "name": "cli_sessions_org_id_orgs_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_sessions_token_hash_unique": {
+          "name": "cli_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_connections": {
+      "name": "cloud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scrape_role_arn": {
+          "name": "scrape_role_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id_ciphertext": {
+          "name": "external_id_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_nonce": {
+          "name": "external_id_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_key_version": {
+          "name": "external_id_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloud_connections_project_idx": {
+          "name": "cloud_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_connections_active_role_idx": {
+          "name": "cloud_connections_active_role_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scrape_role_arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_connections_project_id_projects_id_fk": {
+          "name": "cloud_connections_project_id_projects_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_connections_created_by_users_id_fk": {
+          "name": "cloud_connections_created_by_users_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_resources": {
+      "name": "cloud_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arn": {
+          "name": "arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_fetched_at": {
+          "name": "config_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_resources_project_arn_idx": {
+          "name": "cloud_resources_project_arn_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_project_idx": {
+          "name": "cloud_resources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_connection_idx": {
+          "name": "cloud_resources_connection_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_resources_project_id_projects_id_fk": {
+          "name": "cloud_resources_project_id_projects_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_resources_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_resources_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_stream_keys": {
+      "name": "cloud_stream_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_ciphertext": {
+          "name": "key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_nonce": {
+          "name": "key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_key_version": {
+          "name": "key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_stream_keys_connection_kind_idx": {
+          "name": "cloud_stream_keys_connection_kind_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_stream_keys_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_stream_keys_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_stream_keys",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_stream_keys_api_key_id_api_keys_id_fk": {
+          "name": "cloud_stream_keys_api_key_id_api_keys_id_fk",
+          "tableFrom": "cloud_stream_keys",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_installations": {
+      "name": "cloudflare_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_token_ciphertext": {
+          "name": "refresh_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_nonce": {
+          "name": "refresh_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_key_version": {
+          "name": "refresh_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destinations": {
+          "name": "destinations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloudflare_installations_project_account_idx": {
+          "name": "cloudflare_installations_project_account_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_installations_project_id_projects_id_fk": {
+          "name": "cloudflare_installations_project_id_projects_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloudflare_installations_api_key_id_api_keys_id_fk": {
+          "name": "cloudflare_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cloudflare_installations_installed_by_user_id_users_id_fk": {
+          "name": "cloudflare_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_widgets": {
+      "name": "dashboard_widgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboard_widgets_dashboard_idx": {
+          "name": "dashboard_widgets_dashboard_idx",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_widgets_dashboard_id_dashboards_id_fk": {
+          "name": "dashboard_widgets_dashboard_id_dashboards_id_fk",
+          "tableFrom": "dashboard_widgets",
+          "tableTo": "dashboards",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboards": {
+      "name": "dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboards_project_slug_idx": {
+          "name": "dashboards_project_slug_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboards_project_idx": {
+          "name": "dashboards_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboards_project_id_projects_id_fk": {
+          "name": "dashboards_project_id_projects_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboards_created_by_users_id_fk": {
+          "name": "dashboards_created_by_users_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_repo": {
+          "name": "ref_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_external": {
+          "name": "author_external",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "triaged_by_user_id": {
+          "name": "triaged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_status_created_idx": {
+          "name": "feedback_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_kind_ref_idx": {
+          "name": "feedback_kind_ref_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_user_id_users_id_fk": {
+          "name": "feedback_author_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_org_id_orgs_id_fk": {
+          "name": "feedback_org_id_orgs_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_project_id_projects_id_fk": {
+          "name": "feedback_project_id_projects_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_triaged_by_user_id_users_id_fk": {
+          "name": "feedback_triaged_by_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triaged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repos": {
+          "name": "repos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_enabled": {
+          "name": "agent_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "repo_access": {
+          "name": "repo_access",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_name": {
+          "name": "commit_author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_email": {
+          "name": "commit_author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_login": {
+          "name": "commit_author_github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_id": {
+          "name": "commit_author_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_avatar_url": {
+          "name": "commit_author_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_by_user_id": {
+          "name": "commit_author_set_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_at": {
+          "name": "commit_author_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_project_installation_idx": {
+          "name": "github_installations_project_installation_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NOT NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_installation_idx": {
+          "name": "github_installations_org_installation_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_idx": {
+          "name": "github_installations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_org_id_orgs_id_fk": {
+          "name": "github_installations_org_id_orgs_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_project_id_projects_id_fk": {
+          "name": "github_installations_project_id_projects_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_commit_author_set_by_user_id_users_id_fk": {
+          "name": "github_installations_commit_author_set_by_user_id_users_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "commit_author_set_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_events": {
+      "name": "incident_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_posted_at": {
+          "name": "slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_events_agent_run_idx": {
+          "name": "incident_events_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_idx": {
+          "name": "incident_events_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_provider_event_idx": {
+          "name": "incident_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_provider_event_idx": {
+          "name": "incident_events_incident_provider_event_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_dedupe_idx": {
+          "name": "incident_events_dedupe_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_dedupe_idx": {
+          "name": "incident_events_incident_dedupe_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_events_agent_run_id_agent_runs_id_fk": {
+          "name": "incident_events_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_events_incident_id_incidents_id_fk": {
+          "name": "incident_events_incident_id_incidents_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "incident_events_parentage_check": {
+          "name": "incident_events_parentage_check",
+          "value": "agent_run_id IS NOT NULL OR incident_id IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.incident_issues": {
+      "name": "incident_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_issues_pair_idx": {
+          "name": "incident_issues_pair_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_issues_incident_idx": {
+          "name": "incident_issues_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_issues_issue_lookup_idx": {
+          "name": "incident_issues_issue_lookup_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_issues_incident_id_incidents_id_fk": {
+          "name": "incident_issues_incident_id_incidents_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_issues_issue_id_issues_id_fk": {
+          "name": "incident_issues_issue_id_issues_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_resolution_proposals": {
+      "name": "incident_resolution_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sweep'"
+        },
+        "proposed_reason_code": {
+          "name": "proposed_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_reason_text": {
+          "name": "proposed_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_at": {
+          "name": "proposed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_slack_user_id": {
+          "name": "decided_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_resolution_proposals_incident_idx": {
+          "name": "incident_resolution_proposals_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proposed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_resolution_proposals_slack_msg_idx": {
+          "name": "incident_resolution_proposals_slack_msg_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_message_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_channel_id IS NOT NULL AND slack_message_ts IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_resolution_proposals_incident_id_incidents_id_fk": {
+          "name": "incident_resolution_proposals_incident_id_incidents_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk": {
+          "name": "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_decided_by_user_id_users_id_fk": {
+          "name": "incident_resolution_proposals_decided_by_user_id_users_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "noise_reason": {
+          "name": "noise_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_resolved_at": {
+          "name": "noise_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_into_id": {
+          "name": "merged_into_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_incident_id": {
+          "name": "previous_incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_investigate_suppressed_until": {
+          "name": "auto_investigate_suppressed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autorecovery_last_evaluated_at": {
+          "name": "autorecovery_last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_summary": {
+          "name": "agent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_text": {
+          "name": "root_cause_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_confidence": {
+          "name": "root_cause_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_text": {
+          "name": "estimated_impact_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_confidence": {
+          "name": "estimated_impact_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_severity": {
+          "name": "suggested_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_classification": {
+          "name": "noise_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_classification": {
+          "name": "resolution_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_agent_run_id": {
+          "name": "findings_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_kind": {
+          "name": "resolved_by_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_slack_user_id": {
+          "name": "resolved_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_code": {
+          "name": "resolved_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_text": {
+          "name": "resolved_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incidents_project_status_seen_idx": {
+          "name": "incidents_project_status_seen_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_autorecovery_eval_idx": {
+          "name": "incidents_autorecovery_eval_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "autorecovery_last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_slack_thread_idx": {
+          "name": "incidents_slack_thread_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_project_codename_idx": {
+          "name": "incidents_project_codename_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "codename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "codename <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_project_id_projects_id_fk": {
+          "name": "incidents_project_id_projects_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incidents_merged_into_id_incidents_id_fk": {
+          "name": "incidents_merged_into_id_incidents_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "merged_into_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_previous_incident_id_incidents_id_fk": {
+          "name": "incidents_previous_incident_id_incidents_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "previous_incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_slack_installation_id_slack_installations_id_fk": {
+          "name": "incidents_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_findings_agent_run_id_agent_runs_id_fk": {
+          "name": "incidents_findings_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "findings_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_resolved_by_user_id_users_id_fk": {
+          "name": "incidents_resolved_by_user_id_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_org_idx": {
+          "name": "invitations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_org_id_orgs_id_fk": {
+          "name": "invitations_org_id_orgs_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'span'"
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_type": {
+          "name": "exception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_frame": {
+          "name": "top_frame",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_frames": {
+          "name": "normalized_frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_sample": {
+          "name": "last_sample",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "silenced_at": {
+          "name": "silenced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_trigger": {
+          "name": "escalation_trigger",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_started_at": {
+          "name": "observation_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_baseline_event_count": {
+          "name": "observation_baseline_event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_last_evaluated_at": {
+          "name": "observation_last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_last_event_count": {
+          "name": "observation_last_event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_alerted_at": {
+          "name": "last_alerted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "grouping_state": {
+          "name": "grouping_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'grouped'"
+        },
+        "grouping_source": {
+          "name": "grouping_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_reason": {
+          "name": "grouping_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempted_at": {
+          "name": "grouping_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempt_count": {
+          "name": "grouping_attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_project_fingerprint_idx": {
+          "name": "issues_project_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_grouping_state_idx": {
+          "name": "issues_grouping_state_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grouping_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grouping_state IN ('pending', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_observation_idx": {
+          "name": "issues_observation_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observation_started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'under_observation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_project_status_idx": {
+          "name": "issues_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_installations": {
+      "name": "linear_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_url_key": {
+          "name": "workspace_url_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_vault_id": {
+          "name": "anthropic_vault_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_credential_id": {
+          "name": "anthropic_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_required_at": {
+          "name": "reauth_required_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_reason": {
+          "name": "reauth_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linear_installations_project_active_idx": {
+          "name": "linear_installations_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_installations_project_id_projects_id_fk": {
+          "name": "linear_installations_project_id_projects_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_installations_actor_user_id_users_id_fk": {
+          "name": "linear_installations_actor_user_id_users_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_codes": {
+      "name": "mcp_oauth_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_codes_client_idx": {
+          "name": "mcp_oauth_codes_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_user_id_users_id_fk": {
+          "name": "mcp_oauth_codes_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_project_id_projects_id_fk": {
+          "name": "mcp_oauth_codes_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_tokens": {
+      "name": "mcp_oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "access_hash": {
+          "name": "access_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_hash": {
+          "name": "refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_tokens_client_idx": {
+          "name": "mcp_oauth_tokens_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_tokens_user_idx": {
+          "name": "mcp_oauth_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_user_id_users_id_fk": {
+          "name": "mcp_oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_project_id_projects_id_fk": {
+          "name": "mcp_oauth_tokens_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_tokens_access_hash_unique": {
+          "name": "mcp_oauth_tokens_access_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_hash"
+          ]
+        },
+        "mcp_oauth_tokens_refresh_hash_unique": {
+          "name": "mcp_oauth_tokens_refresh_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_agent_settings": {
+      "name": "org_agent_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "digest_enabled": {
+          "name": "digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "digest_slack_installation_id": {
+          "name": "digest_slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_id": {
+          "name": "digest_slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_name": {
+          "name": "digest_slack_channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_last_run_at": {
+          "name": "digest_last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_agent_settings_org_idx": {
+          "name": "org_agent_settings_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_agent_settings_org_id_orgs_id_fk": {
+          "name": "org_agent_settings_org_id_orgs_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk": {
+          "name": "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "digest_slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_api_keys": {
+      "name": "org_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_api_keys_org_idx": {
+          "name": "org_api_keys_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_api_keys_org_id_orgs_id_fk": {
+          "name": "org_api_keys_org_id_orgs_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_api_keys_created_by_user_id_users_id_fk": {
+          "name": "org_api_keys_created_by_user_id_users_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_api_keys_key_hash_unique": {
+          "name": "org_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integration_secrets": {
+      "name": "org_integration_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_integration_id": {
+          "name": "org_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_name": {
+          "name": "secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integration_secrets_unique_idx": {
+          "name": "org_integration_secrets_unique_idx",
+          "columns": [
+            {
+              "expression": "org_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integration_secrets_org_integration_id_org_integrations_id_fk": {
+          "name": "org_integration_secrets_org_integration_id_org_integrations_id_fk",
+          "tableFrom": "org_integration_secrets",
+          "tableTo": "org_integrations",
+          "columnsFrom": [
+            "org_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integrations": {
+      "name": "org_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integrations_org_slug_idx": {
+          "name": "org_integrations_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_integrations_org_enabled_idx": {
+          "name": "org_integrations_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integrations_org_id_orgs_id_fk": {
+          "name": "org_integrations_org_id_orgs_id_fk",
+          "tableFrom": "org_integrations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_members_org_user_idx": {
+          "name": "org_members_org_user_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_org_id_orgs_id_fk": {
+          "name": "org_members_org_id_orgs_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_members_user_id_users_id_fk": {
+          "name": "org_members_user_id_users_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_setup_skipped_at": {
+          "name": "github_setup_skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_source": {
+          "name": "signup_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_return_url_hosts": {
+          "name": "allowed_return_url_hosts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_slug_unique": {
+          "name": "orgs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "orgs_clerk_org_id_unique": {
+          "name": "orgs_clerk_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personal_access_tokens_user_idx": {
+          "name": "personal_access_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personal_access_tokens_project_idx": {
+          "name": "personal_access_tokens_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_users_id_fk": {
+          "name": "personal_access_tokens_user_id_users_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personal_access_tokens_project_id_projects_id_fk": {
+          "name": "personal_access_tokens_project_id_projects_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_automation_settings": {
+      "name": "project_automation_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_investigate_issues_enabled": {
+          "name": "auto_investigate_issues_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "agent_run_provider": {
+          "name": "agent_run_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "max_runtime_minutes": {
+          "name": "max_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "max_human_resume_count": {
+          "name": "max_human_resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_follow_up_enabled": {
+          "name": "auto_follow_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "chat_enabled": {
+          "name": "chat_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "linear_ticket_instructions": {
+          "name": "linear_ticket_instructions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "linear_default_team_id": {
+          "name": "linear_default_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_base_branch": {
+          "name": "pr_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_merge_fix_prs": {
+          "name": "auto_merge_fix_prs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'never'"
+        },
+        "auto_merge_method": {
+          "name": "auto_merge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'squash'"
+        },
+        "issue_filter": {
+          "name": "issue_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "issue_filter_config": {
+          "name": "issue_filter_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"includeLogs\":[],\"includeSpans\":[],\"excludeLogs\":[],\"excludeSpans\":[]}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_automation_settings_project_idx": {
+          "name": "project_automation_settings_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_automation_settings_project_id_projects_id_fk": {
+          "name": "project_automation_settings_project_id_projects_id_fk",
+          "tableFrom": "project_automation_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_github_repos": {
+      "name": "project_github_repos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_full_name": {
+          "name": "github_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_github_repos_project_repo_idx": {
+          "name": "project_github_repos_project_repo_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_github_repos_installation_idx": {
+          "name": "project_github_repos_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_github_repos_project_id_projects_id_fk": {
+          "name": "project_github_repos_project_id_projects_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_github_repos_installation_id_github_installations_id_fk": {
+          "name": "project_github_repos_installation_id_github_installations_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_ingest_filters": {
+      "name": "project_ingest_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal": {
+          "name": "signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_ingest_filters_project_source_signal_idx": {
+          "name": "project_ingest_filters_project_source_signal_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_ingest_filters_project_id_projects_id_fk": {
+          "name": "project_ingest_filters_project_id_projects_id_fk",
+          "tableFrom": "project_ingest_filters",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_topologies": {
+      "name": "project_topologies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment": {
+          "name": "enrichment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_requested_at": {
+          "name": "refresh_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_topologies_project_idx": {
+          "name": "project_topologies_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_topologies_project_id_projects_id_fk": {
+          "name": "project_topologies_project_id_projects_id_fk",
+          "tableFrom": "project_topologies",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_context": {
+          "name": "project_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_idx": {
+          "name": "projects_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_org_id_orgs_id_fk": {
+          "name": "projects_org_id_orgs_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_id_org_uniq": {
+          "name": "projects_id_org_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.railway_installations": {
+      "name": "railway_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "railway_user_id": {
+          "name": "railway_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_projects": {
+          "name": "granted_projects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_token_ciphertext": {
+          "name": "refresh_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_nonce": {
+          "name": "refresh_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_key_version": {
+          "name": "refresh_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_cursor": {
+          "name": "log_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_cursor": {
+          "name": "metrics_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "railway_installations_project_user_idx": {
+          "name": "railway_installations_project_user_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "railway_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "railway_installations_project_id_projects_id_fk": {
+          "name": "railway_installations_project_id_projects_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "railway_installations_api_key_id_api_keys_id_fk": {
+          "name": "railway_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "railway_installations_installed_by_user_id_users_id_fk": {
+          "name": "railway_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.render_installations": {
+      "name": "render_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_owner_id": {
+          "name": "render_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_owner_name": {
+          "name": "render_owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "render_api_key_ciphertext": {
+          "name": "render_api_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_api_key_nonce": {
+          "name": "render_api_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_api_key_key_version": {
+          "name": "render_api_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_cursor": {
+          "name": "log_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_cursor": {
+          "name": "metrics_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "render_installations_project_owner_idx": {
+          "name": "render_installations_project_owner_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "render_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "render_installations_project_id_projects_id_fk": {
+          "name": "render_installations_project_id_projects_id_fk",
+          "tableFrom": "render_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "render_installations_api_key_id_api_keys_id_fk": {
+          "name": "render_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "render_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "render_installations_installed_by_user_id_users_id_fk": {
+          "name": "render_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "render_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_orgs_id_fk": {
+          "name": "sessions_active_organization_id_orgs_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signup_intents": {
+      "name": "signup_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_project_id": {
+          "name": "claimed_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signup_intents_claimed_project_id_projects_id_fk": {
+          "name": "signup_intents_claimed_project_id_projects_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "claimed_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "signup_intents_claimed_by_user_id_users_id_fk": {
+          "name": "signup_intents_claimed_by_user_id_users_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signup_intents_key_hash_unique": {
+          "name": "signup_intents_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default_chat_project": {
+          "name": "is_default_chat_project",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "slack_installations_project_team_idx": {
+          "name": "slack_installations_project_team_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_default_chat_idx": {
+          "name": "slack_installations_default_chat_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default_chat_project",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_project_id_projects_id_fk": {
+          "name": "slack_installations_project_id_projects_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_installations_installed_by_user_id_users_id_fk": {
+          "name": "slack_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_map_artifacts": {
+      "name": "source_map_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dist": {
+          "name": "dist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug_id": {
+          "name": "debug_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_file": {
+          "name": "bundle_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_file": {
+          "name": "map_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_hash": {
+          "name": "source_map_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_bytes": {
+          "name": "source_map_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_bucket": {
+          "name": "storage_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_encoding": {
+          "name": "content_encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gzip'"
+        },
+        "uploaded_by_org_api_key_id": {
+          "name": "uploaded_by_org_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_map_artifacts_project_debug_id_idx": {
+          "name": "source_map_artifacts_project_debug_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "debug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "debug_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_map_artifacts_project_release_idx": {
+          "name": "source_map_artifacts_project_release_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "release",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_map_artifacts_project_id_projects_id_fk": {
+          "name": "source_map_artifacts_project_id_projects_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk": {
+          "name": "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "org_api_keys",
+          "columnsFrom": [
+            "uploaded_by_org_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_notifications": {
+      "name": "usage_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_notifications_org_period_threshold_idx": {
+          "name": "usage_notifications_org_period_threshold_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "threshold",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_notifications_org_id_orgs_id_fk": {
+          "name": "usage_notifications_org_id_orgs_id_fk",
+          "tableFrom": "usage_notifications",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_project_id": {
+          "name": "active_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_org_id": {
+          "name": "active_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_org_id": {
+          "name": "favorite_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_project_id": {
+          "name": "favorite_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_active_project_id_projects_id_fk": {
+          "name": "users_active_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "active_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_active_org_id_orgs_id_fk": {
+          "name": "users_active_org_id_orgs_id_fk",
+          "tableFrom": "users",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_favorite_org_id_orgs_id_fk": {
+          "name": "users_favorite_org_id_orgs_id_fk",
+          "tableFrom": "users",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "favorite_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_favorite_project_id_projects_id_fk": {
+          "name": "users_favorite_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "favorite_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_installations": {
+      "name": "vercel_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_id": {
+          "name": "configuration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drains": {
+          "name": "drains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vercel_installations_project_configuration_idx": {
+          "name": "vercel_installations_project_configuration_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configuration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_installations_project_id_projects_id_fk": {
+          "name": "vercel_installations_project_id_projects_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vercel_installations_api_key_id_api_keys_id_fk": {
+          "name": "vercel_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vercel_installations_installed_by_user_id_users_id_fk": {
+          "name": "vercel_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_status": {
+          "name": "last_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_endpoint_idx": {
+          "name": "webhook_deliveries_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_events": {
+          "name": "enabled_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"incident.created\",\"incident.updated\"]'::jsonb"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_endpoints_project_idx": {
+          "name": "webhook_endpoints_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_endpoints_project_id_projects_id_fk": {
+          "name": "webhook_endpoints_project_id_projects_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_state": {
+      "name": "worker_state",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0089_snapshot.json
+++ b/packages/db/migrations/meta/0089_snapshot.json
@@ -1,0 +1,8909 @@
+{
+  "id": "bf206f74-99df-49e5-a846-db4cbeb6bca6",
+  "prevId": "adf85c74-946a-47b7-b9d3-cb63e007ad0d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_provider_account_idx": {
+          "name": "accounts_provider_account_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_idx": {
+          "name": "accounts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_chat_messages": {
+      "name": "agent_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_slack_user_id": {
+          "name": "author_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_chat_messages_dedupe_idx": {
+          "name": "agent_chat_messages_dedupe_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chat_messages_pending_idx": {
+          "name": "agent_chat_messages_pending_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "processed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_chat_messages_chat_id_agent_chats_id_fk": {
+          "name": "agent_chat_messages_chat_id_agent_chats_id_fk",
+          "tableFrom": "agent_chat_messages",
+          "tableTo": "agent_chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_chats": {
+      "name": "agent_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_slack_user_id": {
+          "name": "created_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_status": {
+          "name": "provider_session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cumulative_active_seconds": {
+          "name": "cumulative_active_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "session_base_active_seconds": {
+          "name": "session_base_active_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_chats_thread_idx": {
+          "name": "agent_chats_thread_idx",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_thread_ts IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_dm_channel_idx": {
+          "name": "agent_chats_dm_channel_idx",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_thread_ts IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_provider_session_idx": {
+          "name": "agent_chats_provider_session_idx",
+          "columns": [
+            {
+              "expression": "provider_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_state_idx": {
+          "name": "agent_chats_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_chats_project_id_projects_id_fk": {
+          "name": "agent_chats_project_id_projects_id_fk",
+          "tableFrom": "agent_chats",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_chats_slack_installation_id_slack_installations_id_fk": {
+          "name": "agent_chats_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "agent_chats",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_ticket_events": {
+      "name": "agent_linear_ticket_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_linear_ticket_id": {
+          "name": "agent_linear_ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_linear_id": {
+          "name": "actor_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_ticket_events_ticket_idx": {
+          "name": "agent_linear_ticket_events_ticket_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_ticket_events_provider_event_idx": {
+          "name": "agent_linear_ticket_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk": {
+          "name": "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk",
+          "tableFrom": "agent_linear_ticket_events",
+          "tableTo": "agent_linear_tickets",
+          "columnsFrom": [
+            "agent_linear_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_tickets": {
+      "name": "agent_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_identifier": {
+          "name": "ticket_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_name": {
+          "name": "assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_linear_id": {
+          "name": "assignee_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_tickets_incident_idx": {
+          "name": "agent_linear_tickets_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_agent_run_idx": {
+          "name": "agent_linear_tickets_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_workspace_ticket_idx": {
+          "name": "agent_linear_tickets_workspace_ticket_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_tickets_incident_id_incidents_id_fk": {
+          "name": "agent_linear_tickets_incident_id_incidents_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_linear_tickets_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_installation_id_linear_installations_id_fk": {
+          "name": "agent_linear_tickets_installation_id_linear_installations_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "linear_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memories": {
+      "name": "agent_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source_agent_run_id": {
+          "name": "source_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memories_org_status_idx": {
+          "name": "agent_memories_org_status_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_memories_org_id_orgs_id_fk": {
+          "name": "agent_memories_org_id_orgs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_id_projects_id_fk": {
+          "name": "agent_memories_project_id_projects_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_memories_source_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "source_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_user_id_users_id_fk": {
+          "name": "agent_memories_source_user_id_users_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "source_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_org_fk": {
+          "name": "agent_memories_project_org_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_memories_single_source_check": {
+          "name": "agent_memories_single_source_check",
+          "value": "NOT (source_agent_run_id IS NOT NULL AND source_user_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_pr_events": {
+      "name": "agent_pr_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_pr_id": {
+          "name": "agent_pr_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_login": {
+          "name": "actor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_github_id": {
+          "name": "actor_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pr_events_pr_idx": {
+          "name": "agent_pr_events_pr_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pr_events_provider_event_idx": {
+          "name": "agent_pr_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk": {
+          "name": "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk",
+          "tableFrom": "agent_pr_events",
+          "tableTo": "agent_pull_requests",
+          "columnsFrom": [
+            "agent_pr_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_pull_requests": {
+      "name": "agent_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_node_id": {
+          "name": "pr_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_login": {
+          "name": "merged_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_github_id": {
+          "name": "merged_by_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pull_requests_incident_idx": {
+          "name": "agent_pull_requests_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_agent_run_idx": {
+          "name": "agent_pull_requests_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_repo_pr_idx": {
+          "name": "agent_pull_requests_repo_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pull_requests_incident_id_incidents_id_fk": {
+          "name": "agent_pull_requests_incident_id_incidents_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_pull_requests_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_installation_id_github_installations_id_fk": {
+          "name": "agent_pull_requests_installation_id_github_installations_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'incident'"
+        },
+        "trigger_detail": {
+          "name": "trigger_detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_status": {
+          "name": "provider_session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_full_name": {
+          "name": "selected_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_url": {
+          "name": "selected_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_base_branch": {
+          "name": "selected_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_score": {
+          "name": "selected_repo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cumulative_runtime_minutes": {
+          "name": "cumulative_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resume_count": {
+          "name": "resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_runs_incident_idx": {
+          "name": "agent_runs_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_provider_session_idx": {
+          "name": "agent_runs_provider_session_idx",
+          "columns": [
+            {
+              "expression": "provider_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_incident_id_incidents_id_fk": {
+          "name": "agent_runs_incident_id_incidents_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_episodes": {
+      "name": "alert_episodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'firing'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_observed_value": {
+          "name": "open_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_observed_value": {
+          "name": "peak_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_value": {
+          "name": "last_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_firing_at": {
+          "name": "last_firing_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alert_episodes_alert_started_idx": {
+          "name": "alert_episodes_alert_started_idx",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_episodes_incident_idx": {
+          "name": "alert_episodes_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_episodes_open_uniq": {
+          "name": "alert_episodes_open_uniq",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "state = 'firing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_episodes_alert_id_alerts_id_fk": {
+          "name": "alert_episodes_alert_id_alerts_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_project_id_projects_id_fk": {
+          "name": "alert_episodes_project_id_projects_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_issue_id_issues_id_fk": {
+          "name": "alert_episodes_issue_id_issues_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_incident_id_incidents_id_fk": {
+          "name": "alert_episodes_incident_id_incidents_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_firings": {
+      "name": "alert_firings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_value": {
+          "name": "observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluated_at": {
+          "name": "evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_firings_alert_group_idx": {
+          "name": "alert_firings_alert_group_idx",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_firings_alert_id_alerts_id_fk": {
+          "name": "alert_firings_alert_id_alerts_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_firings_issue_id_issues_id_fk": {
+          "name": "alert_firings_issue_id_issues_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_name": {
+          "name": "metric_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "group_by": {
+          "name": "group_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mode": {
+          "name": "group_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single'"
+        },
+        "aggregation": {
+          "name": "aggregation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparator": {
+          "name": "comparator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "evaluation_interval_seconds": {
+          "name": "evaluation_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alerts_project_idx": {
+          "name": "alerts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alerts_enabled_idx": {
+          "name": "alerts_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alerts_project_id_projects_id_fk": {
+          "name": "alerts_project_id_projects_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alerts_created_by_users_id_fk": {
+          "name": "alerts_created_by_users_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions": {
+      "name": "cli_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cli_sessions_user_id_users_id_fk": {
+          "name": "cli_sessions_user_id_users_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_org_id_orgs_id_fk": {
+          "name": "cli_sessions_org_id_orgs_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_sessions_token_hash_unique": {
+          "name": "cli_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_connections": {
+      "name": "cloud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scrape_role_arn": {
+          "name": "scrape_role_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id_ciphertext": {
+          "name": "external_id_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_nonce": {
+          "name": "external_id_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_key_version": {
+          "name": "external_id_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloud_connections_project_idx": {
+          "name": "cloud_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_connections_active_role_idx": {
+          "name": "cloud_connections_active_role_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scrape_role_arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_connections_project_id_projects_id_fk": {
+          "name": "cloud_connections_project_id_projects_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_connections_created_by_users_id_fk": {
+          "name": "cloud_connections_created_by_users_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_resources": {
+      "name": "cloud_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arn": {
+          "name": "arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_fetched_at": {
+          "name": "config_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_resources_project_arn_idx": {
+          "name": "cloud_resources_project_arn_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_project_idx": {
+          "name": "cloud_resources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_connection_idx": {
+          "name": "cloud_resources_connection_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_resources_project_id_projects_id_fk": {
+          "name": "cloud_resources_project_id_projects_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_resources_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_resources_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_stream_keys": {
+      "name": "cloud_stream_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_ciphertext": {
+          "name": "key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_nonce": {
+          "name": "key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_key_version": {
+          "name": "key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_stream_keys_connection_kind_idx": {
+          "name": "cloud_stream_keys_connection_kind_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_stream_keys_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_stream_keys_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_stream_keys",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_stream_keys_api_key_id_api_keys_id_fk": {
+          "name": "cloud_stream_keys_api_key_id_api_keys_id_fk",
+          "tableFrom": "cloud_stream_keys",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_installations": {
+      "name": "cloudflare_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_token_ciphertext": {
+          "name": "refresh_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_nonce": {
+          "name": "refresh_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_key_version": {
+          "name": "refresh_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destinations": {
+          "name": "destinations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloudflare_installations_project_account_idx": {
+          "name": "cloudflare_installations_project_account_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_installations_project_id_projects_id_fk": {
+          "name": "cloudflare_installations_project_id_projects_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloudflare_installations_api_key_id_api_keys_id_fk": {
+          "name": "cloudflare_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cloudflare_installations_installed_by_user_id_users_id_fk": {
+          "name": "cloudflare_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_widgets": {
+      "name": "dashboard_widgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboard_widgets_dashboard_idx": {
+          "name": "dashboard_widgets_dashboard_idx",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_widgets_dashboard_id_dashboards_id_fk": {
+          "name": "dashboard_widgets_dashboard_id_dashboards_id_fk",
+          "tableFrom": "dashboard_widgets",
+          "tableTo": "dashboards",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboards": {
+      "name": "dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboards_project_slug_idx": {
+          "name": "dashboards_project_slug_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboards_project_idx": {
+          "name": "dashboards_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboards_project_id_projects_id_fk": {
+          "name": "dashboards_project_id_projects_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboards_created_by_users_id_fk": {
+          "name": "dashboards_created_by_users_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_repo": {
+          "name": "ref_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_external": {
+          "name": "author_external",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "triaged_by_user_id": {
+          "name": "triaged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_status_created_idx": {
+          "name": "feedback_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_kind_ref_idx": {
+          "name": "feedback_kind_ref_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_user_id_users_id_fk": {
+          "name": "feedback_author_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_org_id_orgs_id_fk": {
+          "name": "feedback_org_id_orgs_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_project_id_projects_id_fk": {
+          "name": "feedback_project_id_projects_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_triaged_by_user_id_users_id_fk": {
+          "name": "feedback_triaged_by_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triaged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repos": {
+          "name": "repos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_enabled": {
+          "name": "agent_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "repo_access": {
+          "name": "repo_access",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_name": {
+          "name": "commit_author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_email": {
+          "name": "commit_author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_login": {
+          "name": "commit_author_github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_id": {
+          "name": "commit_author_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_avatar_url": {
+          "name": "commit_author_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_by_user_id": {
+          "name": "commit_author_set_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_at": {
+          "name": "commit_author_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_project_installation_idx": {
+          "name": "github_installations_project_installation_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NOT NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_installation_idx": {
+          "name": "github_installations_org_installation_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_idx": {
+          "name": "github_installations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_org_id_orgs_id_fk": {
+          "name": "github_installations_org_id_orgs_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_project_id_projects_id_fk": {
+          "name": "github_installations_project_id_projects_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_commit_author_set_by_user_id_users_id_fk": {
+          "name": "github_installations_commit_author_set_by_user_id_users_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "commit_author_set_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_events": {
+      "name": "incident_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_posted_at": {
+          "name": "slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_events_agent_run_idx": {
+          "name": "incident_events_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_idx": {
+          "name": "incident_events_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_provider_event_idx": {
+          "name": "incident_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_provider_event_idx": {
+          "name": "incident_events_incident_provider_event_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_dedupe_idx": {
+          "name": "incident_events_dedupe_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_dedupe_idx": {
+          "name": "incident_events_incident_dedupe_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_events_agent_run_id_agent_runs_id_fk": {
+          "name": "incident_events_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_events_incident_id_incidents_id_fk": {
+          "name": "incident_events_incident_id_incidents_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "incident_events_parentage_check": {
+          "name": "incident_events_parentage_check",
+          "value": "agent_run_id IS NOT NULL OR incident_id IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.incident_issues": {
+      "name": "incident_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_issues_pair_idx": {
+          "name": "incident_issues_pair_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_issues_incident_idx": {
+          "name": "incident_issues_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_issues_issue_lookup_idx": {
+          "name": "incident_issues_issue_lookup_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_issues_incident_id_incidents_id_fk": {
+          "name": "incident_issues_incident_id_incidents_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_issues_issue_id_issues_id_fk": {
+          "name": "incident_issues_issue_id_issues_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_resolution_proposals": {
+      "name": "incident_resolution_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sweep'"
+        },
+        "proposed_reason_code": {
+          "name": "proposed_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_reason_text": {
+          "name": "proposed_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_at": {
+          "name": "proposed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_slack_user_id": {
+          "name": "decided_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_resolution_proposals_incident_idx": {
+          "name": "incident_resolution_proposals_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proposed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_resolution_proposals_slack_msg_idx": {
+          "name": "incident_resolution_proposals_slack_msg_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_message_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_channel_id IS NOT NULL AND slack_message_ts IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_resolution_proposals_incident_id_incidents_id_fk": {
+          "name": "incident_resolution_proposals_incident_id_incidents_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk": {
+          "name": "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_decided_by_user_id_users_id_fk": {
+          "name": "incident_resolution_proposals_decided_by_user_id_users_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "noise_reason": {
+          "name": "noise_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_resolved_at": {
+          "name": "noise_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_into_id": {
+          "name": "merged_into_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_incident_id": {
+          "name": "previous_incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_investigate_suppressed_until": {
+          "name": "auto_investigate_suppressed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autorecovery_last_evaluated_at": {
+          "name": "autorecovery_last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_summary": {
+          "name": "agent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_text": {
+          "name": "root_cause_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_confidence": {
+          "name": "root_cause_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_text": {
+          "name": "estimated_impact_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_confidence": {
+          "name": "estimated_impact_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_severity": {
+          "name": "suggested_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_classification": {
+          "name": "noise_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_classification": {
+          "name": "resolution_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_agent_run_id": {
+          "name": "findings_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_kind": {
+          "name": "resolved_by_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_slack_user_id": {
+          "name": "resolved_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_code": {
+          "name": "resolved_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_text": {
+          "name": "resolved_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incidents_project_status_seen_idx": {
+          "name": "incidents_project_status_seen_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_autorecovery_eval_idx": {
+          "name": "incidents_autorecovery_eval_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "autorecovery_last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_slack_thread_idx": {
+          "name": "incidents_slack_thread_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_project_codename_idx": {
+          "name": "incidents_project_codename_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "codename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "codename <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_project_id_projects_id_fk": {
+          "name": "incidents_project_id_projects_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incidents_merged_into_id_incidents_id_fk": {
+          "name": "incidents_merged_into_id_incidents_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "merged_into_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_previous_incident_id_incidents_id_fk": {
+          "name": "incidents_previous_incident_id_incidents_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "previous_incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_slack_installation_id_slack_installations_id_fk": {
+          "name": "incidents_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_findings_agent_run_id_agent_runs_id_fk": {
+          "name": "incidents_findings_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "findings_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_resolved_by_user_id_users_id_fk": {
+          "name": "incidents_resolved_by_user_id_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_org_idx": {
+          "name": "invitations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_org_id_orgs_id_fk": {
+          "name": "invitations_org_id_orgs_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'span'"
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_type": {
+          "name": "exception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_frame": {
+          "name": "top_frame",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_frames": {
+          "name": "normalized_frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_sample": {
+          "name": "last_sample",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "silenced_at": {
+          "name": "silenced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_trigger": {
+          "name": "escalation_trigger",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_started_at": {
+          "name": "observation_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_baseline_event_count": {
+          "name": "observation_baseline_event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_last_evaluated_at": {
+          "name": "observation_last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_last_event_count": {
+          "name": "observation_last_event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_alerted_at": {
+          "name": "last_alerted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "grouping_state": {
+          "name": "grouping_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'grouped'"
+        },
+        "grouping_source": {
+          "name": "grouping_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_reason": {
+          "name": "grouping_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempted_at": {
+          "name": "grouping_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempt_count": {
+          "name": "grouping_attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_project_fingerprint_idx": {
+          "name": "issues_project_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_grouping_state_idx": {
+          "name": "issues_grouping_state_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grouping_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grouping_state IN ('pending', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_observation_idx": {
+          "name": "issues_observation_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observation_started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'under_observation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_project_status_idx": {
+          "name": "issues_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_installations": {
+      "name": "linear_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_url_key": {
+          "name": "workspace_url_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_vault_id": {
+          "name": "anthropic_vault_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_credential_id": {
+          "name": "anthropic_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_required_at": {
+          "name": "reauth_required_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_reason": {
+          "name": "reauth_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linear_installations_project_active_idx": {
+          "name": "linear_installations_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_installations_project_id_projects_id_fk": {
+          "name": "linear_installations_project_id_projects_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_installations_actor_user_id_users_id_fk": {
+          "name": "linear_installations_actor_user_id_users_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_codes": {
+      "name": "mcp_oauth_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_codes_client_idx": {
+          "name": "mcp_oauth_codes_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_user_id_users_id_fk": {
+          "name": "mcp_oauth_codes_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_project_id_projects_id_fk": {
+          "name": "mcp_oauth_codes_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_tokens": {
+      "name": "mcp_oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "access_hash": {
+          "name": "access_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_hash": {
+          "name": "refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_tokens_client_idx": {
+          "name": "mcp_oauth_tokens_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_tokens_user_idx": {
+          "name": "mcp_oauth_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_user_id_users_id_fk": {
+          "name": "mcp_oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_project_id_projects_id_fk": {
+          "name": "mcp_oauth_tokens_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_tokens_access_hash_unique": {
+          "name": "mcp_oauth_tokens_access_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_hash"
+          ]
+        },
+        "mcp_oauth_tokens_refresh_hash_unique": {
+          "name": "mcp_oauth_tokens_refresh_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_agent_settings": {
+      "name": "org_agent_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "digest_enabled": {
+          "name": "digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "digest_slack_installation_id": {
+          "name": "digest_slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_id": {
+          "name": "digest_slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_name": {
+          "name": "digest_slack_channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_last_run_at": {
+          "name": "digest_last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_agent_settings_org_idx": {
+          "name": "org_agent_settings_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_agent_settings_org_id_orgs_id_fk": {
+          "name": "org_agent_settings_org_id_orgs_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk": {
+          "name": "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "digest_slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_api_keys": {
+      "name": "org_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_api_keys_org_idx": {
+          "name": "org_api_keys_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_api_keys_org_id_orgs_id_fk": {
+          "name": "org_api_keys_org_id_orgs_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_api_keys_created_by_user_id_users_id_fk": {
+          "name": "org_api_keys_created_by_user_id_users_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_api_keys_key_hash_unique": {
+          "name": "org_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integration_secrets": {
+      "name": "org_integration_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_integration_id": {
+          "name": "org_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_name": {
+          "name": "secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integration_secrets_unique_idx": {
+          "name": "org_integration_secrets_unique_idx",
+          "columns": [
+            {
+              "expression": "org_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integration_secrets_org_integration_id_org_integrations_id_fk": {
+          "name": "org_integration_secrets_org_integration_id_org_integrations_id_fk",
+          "tableFrom": "org_integration_secrets",
+          "tableTo": "org_integrations",
+          "columnsFrom": [
+            "org_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integrations": {
+      "name": "org_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integrations_org_slug_idx": {
+          "name": "org_integrations_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_integrations_org_enabled_idx": {
+          "name": "org_integrations_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integrations_org_id_orgs_id_fk": {
+          "name": "org_integrations_org_id_orgs_id_fk",
+          "tableFrom": "org_integrations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_members_org_user_idx": {
+          "name": "org_members_org_user_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_org_id_orgs_id_fk": {
+          "name": "org_members_org_id_orgs_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_members_user_id_users_id_fk": {
+          "name": "org_members_user_id_users_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_setup_skipped_at": {
+          "name": "github_setup_skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_source": {
+          "name": "signup_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_return_url_hosts": {
+          "name": "allowed_return_url_hosts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_slug_unique": {
+          "name": "orgs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "orgs_clerk_org_id_unique": {
+          "name": "orgs_clerk_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personal_access_tokens_user_idx": {
+          "name": "personal_access_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personal_access_tokens_project_idx": {
+          "name": "personal_access_tokens_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_users_id_fk": {
+          "name": "personal_access_tokens_user_id_users_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personal_access_tokens_project_id_projects_id_fk": {
+          "name": "personal_access_tokens_project_id_projects_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_automation_settings": {
+      "name": "project_automation_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_investigate_issues_enabled": {
+          "name": "auto_investigate_issues_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "agent_run_provider": {
+          "name": "agent_run_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "max_runtime_minutes": {
+          "name": "max_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "max_human_resume_count": {
+          "name": "max_human_resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_follow_up_enabled": {
+          "name": "auto_follow_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "chat_enabled": {
+          "name": "chat_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "linear_ticket_instructions": {
+          "name": "linear_ticket_instructions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "linear_default_team_id": {
+          "name": "linear_default_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_base_branch": {
+          "name": "pr_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_merge_fix_prs": {
+          "name": "auto_merge_fix_prs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'never'"
+        },
+        "auto_merge_method": {
+          "name": "auto_merge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'squash'"
+        },
+        "issue_filter": {
+          "name": "issue_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "issue_filter_config": {
+          "name": "issue_filter_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"includeLogs\":[],\"includeSpans\":[],\"excludeLogs\":[],\"excludeSpans\":[]}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_automation_settings_project_idx": {
+          "name": "project_automation_settings_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_automation_settings_project_id_projects_id_fk": {
+          "name": "project_automation_settings_project_id_projects_id_fk",
+          "tableFrom": "project_automation_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_github_repos": {
+      "name": "project_github_repos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_full_name": {
+          "name": "github_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_github_repos_project_repo_idx": {
+          "name": "project_github_repos_project_repo_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_github_repos_installation_idx": {
+          "name": "project_github_repos_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_github_repos_project_id_projects_id_fk": {
+          "name": "project_github_repos_project_id_projects_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_github_repos_installation_id_github_installations_id_fk": {
+          "name": "project_github_repos_installation_id_github_installations_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_ingest_filters": {
+      "name": "project_ingest_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal": {
+          "name": "signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_ingest_filters_project_source_signal_idx": {
+          "name": "project_ingest_filters_project_source_signal_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_ingest_filters_project_id_projects_id_fk": {
+          "name": "project_ingest_filters_project_id_projects_id_fk",
+          "tableFrom": "project_ingest_filters",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_topologies": {
+      "name": "project_topologies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment": {
+          "name": "enrichment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_requested_at": {
+          "name": "refresh_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_topologies_project_idx": {
+          "name": "project_topologies_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_topologies_project_id_projects_id_fk": {
+          "name": "project_topologies_project_id_projects_id_fk",
+          "tableFrom": "project_topologies",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_context": {
+          "name": "project_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_idx": {
+          "name": "projects_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_org_id_orgs_id_fk": {
+          "name": "projects_org_id_orgs_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_id_org_uniq": {
+          "name": "projects_id_org_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.railway_installations": {
+      "name": "railway_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "railway_user_id": {
+          "name": "railway_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_projects": {
+          "name": "granted_projects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_token_ciphertext": {
+          "name": "refresh_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_nonce": {
+          "name": "refresh_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_key_version": {
+          "name": "refresh_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_cursor": {
+          "name": "log_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_cursor": {
+          "name": "metrics_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "railway_installations_project_user_idx": {
+          "name": "railway_installations_project_user_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "railway_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "railway_installations_project_id_projects_id_fk": {
+          "name": "railway_installations_project_id_projects_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "railway_installations_api_key_id_api_keys_id_fk": {
+          "name": "railway_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "railway_installations_installed_by_user_id_users_id_fk": {
+          "name": "railway_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.render_installations": {
+      "name": "render_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_owner_id": {
+          "name": "render_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_owner_name": {
+          "name": "render_owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "render_api_key_ciphertext": {
+          "name": "render_api_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_api_key_nonce": {
+          "name": "render_api_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_api_key_key_version": {
+          "name": "render_api_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_cursor": {
+          "name": "log_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_cursor": {
+          "name": "metrics_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_stream_state": {
+          "name": "log_stream_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_stream_state": {
+          "name": "metrics_stream_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "render_installations_project_owner_idx": {
+          "name": "render_installations_project_owner_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "render_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "render_installations_project_id_projects_id_fk": {
+          "name": "render_installations_project_id_projects_id_fk",
+          "tableFrom": "render_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "render_installations_api_key_id_api_keys_id_fk": {
+          "name": "render_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "render_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "render_installations_installed_by_user_id_users_id_fk": {
+          "name": "render_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "render_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_orgs_id_fk": {
+          "name": "sessions_active_organization_id_orgs_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signup_intents": {
+      "name": "signup_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_project_id": {
+          "name": "claimed_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signup_intents_claimed_project_id_projects_id_fk": {
+          "name": "signup_intents_claimed_project_id_projects_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "claimed_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "signup_intents_claimed_by_user_id_users_id_fk": {
+          "name": "signup_intents_claimed_by_user_id_users_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signup_intents_key_hash_unique": {
+          "name": "signup_intents_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default_chat_project": {
+          "name": "is_default_chat_project",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "slack_installations_project_team_idx": {
+          "name": "slack_installations_project_team_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_default_chat_idx": {
+          "name": "slack_installations_default_chat_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default_chat_project",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_project_id_projects_id_fk": {
+          "name": "slack_installations_project_id_projects_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_installations_installed_by_user_id_users_id_fk": {
+          "name": "slack_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_map_artifacts": {
+      "name": "source_map_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dist": {
+          "name": "dist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug_id": {
+          "name": "debug_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_file": {
+          "name": "bundle_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_file": {
+          "name": "map_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_hash": {
+          "name": "source_map_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_bytes": {
+          "name": "source_map_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_bucket": {
+          "name": "storage_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_encoding": {
+          "name": "content_encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gzip'"
+        },
+        "uploaded_by_org_api_key_id": {
+          "name": "uploaded_by_org_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_map_artifacts_project_debug_id_idx": {
+          "name": "source_map_artifacts_project_debug_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "debug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "debug_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_map_artifacts_project_release_idx": {
+          "name": "source_map_artifacts_project_release_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "release",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_map_artifacts_project_id_projects_id_fk": {
+          "name": "source_map_artifacts_project_id_projects_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk": {
+          "name": "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "org_api_keys",
+          "columnsFrom": [
+            "uploaded_by_org_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_notifications": {
+      "name": "usage_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_notifications_org_period_threshold_idx": {
+          "name": "usage_notifications_org_period_threshold_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "threshold",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_notifications_org_id_orgs_id_fk": {
+          "name": "usage_notifications_org_id_orgs_id_fk",
+          "tableFrom": "usage_notifications",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_project_id": {
+          "name": "active_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_org_id": {
+          "name": "active_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_org_id": {
+          "name": "favorite_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_project_id": {
+          "name": "favorite_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_active_project_id_projects_id_fk": {
+          "name": "users_active_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "active_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_active_org_id_orgs_id_fk": {
+          "name": "users_active_org_id_orgs_id_fk",
+          "tableFrom": "users",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_favorite_org_id_orgs_id_fk": {
+          "name": "users_favorite_org_id_orgs_id_fk",
+          "tableFrom": "users",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "favorite_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_favorite_project_id_projects_id_fk": {
+          "name": "users_favorite_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "favorite_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_installations": {
+      "name": "vercel_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_id": {
+          "name": "configuration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drains": {
+          "name": "drains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vercel_installations_project_configuration_idx": {
+          "name": "vercel_installations_project_configuration_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configuration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_installations_project_id_projects_id_fk": {
+          "name": "vercel_installations_project_id_projects_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vercel_installations_api_key_id_api_keys_id_fk": {
+          "name": "vercel_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vercel_installations_installed_by_user_id_users_id_fk": {
+          "name": "vercel_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_status": {
+          "name": "last_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_endpoint_idx": {
+          "name": "webhook_deliveries_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_events": {
+          "name": "enabled_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"incident.created\",\"incident.updated\"]'::jsonb"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_endpoints_project_idx": {
+          "name": "webhook_endpoints_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_endpoints_project_id_projects_id_fk": {
+          "name": "webhook_endpoints_project_id_projects_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_state": {
+      "name": "worker_state",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -607,8 +607,22 @@
     {
       "idx": 86,
       "version": "7",
-      "when": 1783498983347,
-      "tag": "0086_concerned_pretty_boy",
+      "when": 1783497473032,
+      "tag": "0086_shocking_owl",
+      "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1783500683525,
+      "tag": "0087_special_stryfe",
+      "breakpoints": true
+    },
+    {
+      "idx": 88,
+      "version": "7",
+      "when": 1783524363029,
+      "tag": "0088_heavy_vision",
       "breakpoints": true
     }
   ]

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -607,15 +607,8 @@
     {
       "idx": 86,
       "version": "7",
-      "when": 1783497473032,
-      "tag": "0086_shocking_owl",
-      "breakpoints": true
-    },
-    {
-      "idx": 87,
-      "version": "7",
-      "when": 1783500683525,
-      "tag": "0087_special_stryfe",
+      "when": 1783498983347,
+      "tag": "0086_concerned_pretty_boy",
       "breakpoints": true
     }
   ]

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -624,6 +624,13 @@
       "when": 1783524363029,
       "tag": "0088_heavy_vision",
       "breakpoints": true
+    },
+    {
+      "idx": 89,
+      "version": "7",
+      "when": 1783525492513,
+      "tag": "0089_remarkable_darwin",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2404,11 +2404,83 @@ export const railwayInstallations = pgTable(
 
 export type RailwayInstallation = typeof railwayInstallations.$inferSelect;
 
+// A connected Render workspace. Render has no third-party OAuth: the user
+// pastes an API key they created in Render's account settings and picks one
+// workspace (`ownerId`) to share. One row per (project, Render workspace); a
+// re-connect for the same workspace refreshes the row. Like Railway there is
+// nothing to provision on Render's side — a worker-side puller reads logs and
+// infra metrics from Render's REST API scoped to the chosen workspace and
+// forwards them to our intake authenticated by the project ingest key. Render
+// API keys don't expire and don't refresh, but they grant access to every
+// workspace the creating user belongs to, so the key is encrypted at rest
+// (same AES-256-GCM scheme as the other connectors) and only ever used for
+// reads within the chosen workspace.
+export const renderInstallations = pgTable(
+  "render_installations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    projectId: uuid("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    // The Render workspace ("owner") the user picked at connect — the stable
+    // install key alongside the project.
+    renderOwnerId: text("render_owner_id").notNull(),
+    renderOwnerName: text("render_owner_name"),
+    // Snapshot of the workspace's services, refreshed by the puller. Display +
+    // pull-planning only, never authorization.
+    services: jsonb("services").$type<
+      Array<{
+        id: string;
+        name: string;
+        type: string;
+        region: string | null;
+        suspended: boolean;
+      }>
+    >(),
+    // The user's Render API key, encrypted at rest. No expiry, no refresh; the
+    // user revokes it from Render's dashboard (which strands the install until
+    // reconnect).
+    renderApiKeyCiphertext: bytea("render_api_key_ciphertext").notNull(),
+    renderApiKeyNonce: bytea("render_api_key_nonce").notNull(),
+    renderApiKeyKeyVersion: integer("render_api_key_key_version").notNull().default(1),
+    // The ingest key the puller forwards telemetry with, stored encrypted so a
+    // re-connect reuses the same key instead of minting a new one.
+    apiKeyId: uuid("api_key_id").references(() => apiKeys.id, { onDelete: "set null" }),
+    ingestKeyCiphertext: bytea("ingest_key_ciphertext"),
+    ingestKeyNonce: bytea("ingest_key_nonce"),
+    ingestKeyKeyVersion: integer("ingest_key_key_version"),
+    // Puller checkpoint: log pull group (region) → RFC3339 timestamp of the
+    // last forwarded log line, so restarts resume without gaps or duplicates.
+    logCursor: jsonb("log_cursor").$type<Record<string, string>>(),
+    // Puller checkpoint for metrics: `${serviceId}:${kind}` → epoch seconds of
+    // the last forwarded sample.
+    metricsCursor: jsonb("metrics_cursor").$type<Record<string, number>>(),
+    installedByUserId: uuid("installed_by_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    // One live install per (project, Render workspace); a re-connect refreshes
+    // the row (see the upsert in apps/api/src/render.ts). Also serves
+    // project-scoped lookups via its left-most `project_id` prefix.
+    projectOwnerUniq: uniqueIndex("render_installations_project_owner_idx").on(
+      t.projectId,
+      t.renderOwnerId,
+    ),
+  }),
+);
+
+export type RenderInstallation = typeof renderInstallations.$inferSelect;
+
 // Per-project ingest source filters. A row means the given (source, signal) is
 // DISABLED for the project — the proxy ack-drops that telemetry at the edge.
 // Sparse by design: no row = enabled, so a new project ingests everything.
 //   source: "otlp" (SDK/OTLP exporters) | "aws" (CloudWatch → Firehose) |
-//           "vercel" (Vercel Drains) | "railway" (Railway API puller)
+//           "vercel" (Vercel Drains) | "railway" (Railway API puller) |
+//           "render" (Render API puller)
 //   signal: "traces" | "logs" | "metrics"
 export const projectIngestFilters = pgTable(
   "project_ingest_filters",
@@ -2417,7 +2489,7 @@ export const projectIngestFilters = pgTable(
     projectId: uuid("project_id")
       .notNull()
       .references(() => projects.id, { onDelete: "cascade" }),
-    source: text("source").$type<"otlp" | "aws" | "vercel" | "railway">().notNull(),
+    source: text("source").$type<"otlp" | "aws" | "vercel" | "railway" | "render">().notNull(),
     signal: text("signal").$type<"traces" | "logs" | "metrics">().notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   },

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2449,11 +2449,14 @@ export const renderInstallations = pgTable(
     ingestKeyCiphertext: bytea("ingest_key_ciphertext"),
     ingestKeyNonce: bytea("ingest_key_nonce"),
     ingestKeyKeyVersion: integer("ingest_key_key_version"),
-    // Puller checkpoint: log pull group (region) → RFC3339 timestamp of the
-    // last forwarded log line, so restarts resume without gaps or duplicates.
-    logCursor: jsonb("log_cursor").$type<Record<string, string>>(),
-    // Puller checkpoint for metrics: `${serviceId}:${kind}` → epoch seconds of
-    // the last forwarded sample.
+    // Puller checkpoint: log pull group (region) → the RFC3339 timestamp of
+    // the last forwarded log line plus the ids of the lines at that timestamp
+    // (equal-timestamp lines at a page boundary are re-read and deduped by
+    // id), so restarts resume without gaps or duplicates. Plain-string values
+    // are the earlier timestamp-only shape, still accepted on read.
+    logCursor: jsonb("log_cursor").$type<Record<string, { ts: string; ids: string[] } | string>>(),
+    // Puller checkpoint for metrics: series identity (resource + kind +
+    // distinguishing labels) → epoch seconds of the last forwarded sample.
     metricsCursor: jsonb("metrics_cursor").$type<Record<string, number>>(),
     installedByUserId: uuid("installed_by_user_id").references(() => users.id, {
       onDelete: "set null",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2458,6 +2458,23 @@ export const renderInstallations = pgTable(
     // Puller checkpoint for metrics: series identity (resource + kind +
     // distinguishing labels) → epoch seconds of the last forwarded sample.
     metricsCursor: jsonb("metrics_cursor").$type<Record<string, number>>(),
+    // Push-stream provisioning state, one per signal. A Render workspace has
+    // exactly ONE log stream and ONE metrics stream destination, so connect
+    // provisions them to our intake only when the slot is free (or already
+    // ours): "provisioned" = Render pushes this signal and the puller skips
+    // it; "conflict" = a foreign destination occupies the slot (we never
+    // steal it — polling fallback); "unavailable" = plan-gated or rejected
+    // (polling fallback). Null = pre-streams install (polling).
+    logStream: jsonb("log_stream_state").$type<{
+      status: "provisioned" | "conflict" | "unavailable";
+      endpoint: string | null;
+      detail: string | null;
+    }>(),
+    metricsStream: jsonb("metrics_stream_state").$type<{
+      status: "provisioned" | "conflict" | "unavailable";
+      endpoint: string | null;
+      detail: string | null;
+    }>(),
     installedByUserId: uuid("installed_by_user_id").references(() => users.id, {
       onDelete: "set null",
     }),

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@superlog/render",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "tsx --test src/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/render/src/client.test.ts
+++ b/packages/render/src/client.test.ts
@@ -4,9 +4,13 @@ import {
   type FetchImpl,
   fetchLogs,
   fetchMetrics,
+  fetchOwnerLogStream,
+  fetchOwnerMetricsStream,
   fetchOwners,
   fetchServices,
   seriesResourceId,
+  updateOwnerLogStream,
+  upsertOwnerMetricsStream,
 } from "./client.js";
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -172,4 +176,68 @@ test("network failure surfaces as an error, not a throw", async () => {
   });
   assert.ok(!result.ok);
   assert.equal(result.error, "ECONNRESET");
+});
+
+test("fetchOwnerLogStream treats 404 as no stream configured", async () => {
+  const { impl } = fetchStub([jsonResponse({ message: "not found" }, 404)]);
+  const result = await fetchOwnerLogStream({ apiKey: "k", ownerId: "tea-1", fetchImpl: impl });
+  assert.ok(result.ok);
+  assert.equal(result.stream, null);
+});
+
+test("updateOwnerLogStream PUTs a send-mode stream with the token", async () => {
+  const captured: Array<{ url: string; init: RequestInit }> = [];
+  const impl: FetchImpl = async (input, init) => {
+    captured.push({ url: String(input), init: init ?? {} });
+    return jsonResponse({ endpoint: "https://intake.test/render/stream/logs", preview: "send" });
+  };
+  const result = await updateOwnerLogStream({
+    apiKey: "k",
+    ownerId: "tea-1",
+    endpoint: "https://intake.test/render/stream/logs",
+    token: "sl_public_x",
+    fetchImpl: impl,
+  });
+  assert.ok(result.ok);
+  const call = captured[0];
+  assert.ok(call?.url.endsWith("/v1/logs/streams/owner/tea-1"));
+  assert.equal(call?.init.method, "PUT");
+  assert.deepEqual(JSON.parse(String(call?.init.body)), {
+    preview: "send",
+    endpoint: "https://intake.test/render/stream/logs",
+    token: "sl_public_x",
+  });
+});
+
+test("upsertOwnerMetricsStream PUTs a CUSTOM provider destination", async () => {
+  const captured: Array<{ url: string; init: RequestInit }> = [];
+  const impl: FetchImpl = async (input, init) => {
+    captured.push({ url: String(input), init: init ?? {} });
+    return jsonResponse({ ownerId: "tea-1", provider: "CUSTOM", url: "https://intake.test/render/stream/metrics" });
+  };
+  const result = await upsertOwnerMetricsStream({
+    apiKey: "k",
+    ownerId: "tea-1",
+    url: "https://intake.test/render/stream/metrics",
+    token: "sl_public_x",
+    fetchImpl: impl,
+  });
+  assert.ok(result.ok);
+  const call = captured[0];
+  assert.ok(call?.url.endsWith("/v1/metrics-stream/tea-1"));
+  assert.equal(call?.init.method, "PUT");
+  assert.deepEqual(JSON.parse(String(call?.init.body)), {
+    provider: "CUSTOM",
+    url: "https://intake.test/render/stream/metrics",
+    token: "sl_public_x",
+  });
+});
+
+test("fetchOwnerMetricsStream returns the configured destination", async () => {
+  const { impl } = fetchStub([
+    jsonResponse({ ownerId: "tea-1", provider: "DATADOG", url: "https://dd.example.com" }),
+  ]);
+  const result = await fetchOwnerMetricsStream({ apiKey: "k", ownerId: "tea-1", fetchImpl: impl });
+  assert.ok(result.ok);
+  assert.deepEqual(result.stream, { provider: "DATADOG", url: "https://dd.example.com" });
 });

--- a/packages/render/src/client.test.ts
+++ b/packages/render/src/client.test.ts
@@ -1,0 +1,175 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import {
+  type FetchImpl,
+  fetchLogs,
+  fetchMetrics,
+  fetchOwners,
+  fetchServices,
+  seriesResourceId,
+} from "./client.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// Recording fetch stub: replies from a queue and captures each request URL.
+function fetchStub(responses: Response[]): { impl: FetchImpl; urls: string[] } {
+  const urls: string[] = [];
+  const queue = [...responses];
+  const impl: FetchImpl = async (input) => {
+    urls.push(String(input));
+    const next = queue.shift();
+    if (!next) throw new Error("fetch stub exhausted");
+    return next;
+  };
+  return { impl, urls };
+}
+
+test("fetchOwners lists workspaces and sends the bearer key", async () => {
+  const captured: RequestInit[] = [];
+  const impl: FetchImpl = async (_input, init) => {
+    captured.push(init ?? {});
+    return jsonResponse([
+      { owner: { id: "tea-1", name: "Acme", email: "ops@acme.dev", type: "team" }, cursor: "c1" },
+      { owner: { id: "usr-1", name: "Jane", email: null, type: "user" }, cursor: "c2" },
+      { owner: null, cursor: "c3" },
+    ]);
+  };
+  const result = await fetchOwners({ apiKey: "rnd_key", fetchImpl: impl });
+  assert.ok(result.ok);
+  assert.deepEqual(
+    result.owners.map((o) => o.id),
+    ["tea-1", "usr-1"],
+  );
+  const headers = captured[0]?.headers as Record<string, string>;
+  assert.equal(headers.authorization, "Bearer rnd_key");
+});
+
+test("fetchOwners reports an invalid key as unauthorized", async () => {
+  const { impl } = fetchStub([jsonResponse({ message: "unauthorized" }, 401)]);
+  const result = await fetchOwners({ apiKey: "bad", fetchImpl: impl });
+  assert.ok(!result.ok);
+  assert.equal(result.unauthorized, true);
+});
+
+test("fetchServices paginates with cursors and normalizes services", async () => {
+  const pageOne = Array.from({ length: 100 }, (_, i) => ({
+    service: {
+      id: `srv-${i}`,
+      name: `svc-${i}`,
+      type: "web_service",
+      suspended: "not_suspended",
+      serviceDetails: { region: "oregon" },
+    },
+    cursor: `cur-${i}`,
+  }));
+  const pageTwo = [
+    {
+      service: { id: "srv-x", name: "worker", type: "background_worker", suspended: "suspended" },
+      cursor: "cur-x",
+    },
+  ];
+  const { impl, urls } = fetchStub([jsonResponse(pageOne), jsonResponse(pageTwo)]);
+  const result = await fetchServices({ apiKey: "k", ownerId: "tea-1", fetchImpl: impl });
+  assert.ok(result.ok);
+  assert.equal(result.services.length, 101);
+  assert.equal(result.services[0]?.region, "oregon");
+  assert.equal(result.services[100]?.suspended, true);
+  assert.equal(result.services[100]?.region, null);
+  assert.equal(urls.length, 2);
+  assert.ok(urls[0]?.includes("ownerId=tea-1"));
+  assert.ok(urls[1]?.includes("cursor=cur-99"));
+});
+
+test("fetchLogs builds the query and normalizes the page", async () => {
+  const { impl, urls } = fetchStub([
+    jsonResponse({
+      hasMore: true,
+      nextStartTime: "2026-07-07T14:11:00Z",
+      nextEndTime: "2026-07-07T14:12:00Z",
+      logs: [
+        {
+          id: "log-1",
+          timestamp: "2026-07-07T14:10:31Z",
+          message: "hello",
+          labels: [{ name: "resource", value: "srv-1" }],
+        },
+        { message: "no timestamp → dropped" },
+      ],
+    }),
+  ]);
+  const result = await fetchLogs({
+    apiKey: "k",
+    ownerId: "tea-1",
+    resources: ["srv-1", "srv-2"],
+    startTime: "2026-07-07T14:00:00Z",
+    direction: "forward",
+    limit: 100,
+    fetchImpl: impl,
+  });
+  assert.ok(result.ok);
+  assert.equal(result.page.logs.length, 1);
+  assert.equal(result.page.logs[0]?.id, "log-1");
+  assert.equal(result.page.hasMore, true);
+  assert.equal(result.page.nextStartTime, "2026-07-07T14:11:00Z");
+  const url = new URL(urls[0] ?? "");
+  assert.equal(url.pathname, "/v1/logs");
+  assert.deepEqual(url.searchParams.getAll("resource"), ["srv-1", "srv-2"]);
+  assert.equal(url.searchParams.get("direction"), "forward");
+  assert.equal(url.searchParams.get("limit"), "100");
+});
+
+test("fetchMetrics normalizes series defensively", async () => {
+  const { impl, urls } = fetchStub([
+    jsonResponse([
+      {
+        labels: [{ field: "resource", value: "srv-1" }],
+        unit: "GB",
+        values: [
+          { timestamp: "2026-07-07T14:10:00Z", value: 0.5 },
+          { timestamp: "2026-07-07T14:11:00Z", value: "garbage" },
+        ],
+      },
+      "not a series",
+    ]),
+  ]);
+  const result = await fetchMetrics({
+    apiKey: "k",
+    kind: "memory",
+    resources: ["srv-1"],
+    startTime: "2026-07-07T14:00:00Z",
+    endTime: "2026-07-07T14:15:00Z",
+    resolutionSeconds: 60,
+    fetchImpl: impl,
+  });
+  assert.ok(result.ok);
+  // The malformed entry is dropped; the garbage value inside the good series too.
+  assert.equal(result.series.length, 1);
+  assert.equal(result.series[0]?.values.length, 1);
+  assert.equal(
+    seriesResourceId(result.series[0] ?? { labels: [], unit: null, values: [] }),
+    "srv-1",
+  );
+  const url = new URL(urls[0] ?? "");
+  assert.equal(url.pathname, "/v1/metrics/memory");
+  assert.equal(url.searchParams.get("resolutionSeconds"), "60");
+});
+
+test("network failure surfaces as an error, not a throw", async () => {
+  const impl: FetchImpl = async () => {
+    throw new Error("ECONNRESET");
+  };
+  const result = await fetchLogs({
+    apiKey: "k",
+    ownerId: "tea-1",
+    resources: ["srv-1"],
+    limit: 20,
+    fetchImpl: impl,
+  });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "ECONNRESET");
+});

--- a/packages/render/src/client.ts
+++ b/packages/render/src/client.ts
@@ -1,0 +1,373 @@
+// Thin injectable-fetch wrappers over Render's public REST API
+// (api.render.com/v1) — the documented API that powers Render's dashboard.
+// Unlike Railway there is no third-party OAuth: Render integrations
+// authenticate with a user-created API key (Account settings → API Keys),
+// sent as a Bearer token. A key grants access to every workspace the creating
+// user belongs to, so the connect flow asks the user to pick one workspace
+// (`ownerId`) and the connector only ever reads within it.
+//
+// Only the endpoints the connector needs:
+//  - GET /owners      — workspaces visible to the key (connect-time picker)
+//  - GET /services    — service inventory for the chosen workspace
+//  - GET /logs        — pull logs across resources (timestamp-paginated)
+//  - GET /metrics/*   — infra series (cpu, memory, instance count, …)
+//
+// Rate limits are per user key: logs endpoints 30 req/min, other GETs
+// 400 req/min — the puller batches resources per request to stay well under.
+
+export const RENDER_API_URL = "https://api.render.com/v1";
+
+// Overridable for integration tests / local fakes; every caller of this
+// package runs in node (api + worker), so process.env is always there.
+function apiBaseUrl(): string {
+  return process.env.RENDER_API_URL || RENDER_API_URL;
+}
+
+export type FetchImpl = typeof fetch;
+
+export type RenderResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string; status: number | null; unauthorized: boolean };
+
+async function renderGet<T = unknown>(input: {
+  apiKey: string;
+  path: string;
+  query?: URLSearchParams;
+  fetchImpl?: FetchImpl;
+}): Promise<RenderResult<T>> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const qs = input.query?.toString();
+  const url = `${apiBaseUrl()}${input.path}${qs ? `?${qs}` : ""}`;
+  let res: Response;
+  try {
+    res = await fetchImpl(url, {
+      headers: { accept: "application/json", authorization: `Bearer ${input.apiKey}` },
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : "fetch_failed",
+      status: null,
+      unauthorized: false,
+    };
+  }
+  const json = (await res.json().catch(() => null)) as unknown;
+  if (!res.ok) {
+    const message =
+      json &&
+      typeof json === "object" &&
+      typeof (json as { message?: unknown }).message === "string"
+        ? (json as { message: string }).message
+        : `status_${res.status}`;
+    return {
+      ok: false,
+      error: message,
+      status: res.status,
+      unauthorized: res.status === 401 || res.status === 403,
+    };
+  }
+  if (json === null) {
+    return { ok: false, error: `status_${res.status}`, status: res.status, unauthorized: false };
+  }
+  return { ok: true, data: json as T };
+}
+
+// ---------------------------------------------------------------------------
+// Workspace + service inventory
+// ---------------------------------------------------------------------------
+
+export type RenderOwner = {
+  id: string;
+  name: string;
+  email: string | null;
+  type: "user" | "team" | string;
+};
+
+/**
+ * Workspaces the API key can see — the connect-time picker. Also doubles as
+ * key validation: an invalid key comes back `unauthorized`.
+ */
+export async function fetchOwners(input: {
+  apiKey: string;
+  fetchImpl?: FetchImpl;
+}): Promise<
+  { ok: true; owners: RenderOwner[] } | { ok: false; error: string; unauthorized: boolean }
+> {
+  const owners: RenderOwner[] = [];
+  let cursor: string | null = null;
+  // Render lists are cursor-paginated with items wrapped as { owner, cursor }.
+  for (let page = 0; page < 10; page++) {
+    const query = new URLSearchParams({ limit: "100" });
+    if (cursor) query.set("cursor", cursor);
+    const result = await renderGet<Array<{ owner?: unknown; cursor?: unknown }>>({
+      apiKey: input.apiKey,
+      path: "/owners",
+      query,
+      fetchImpl: input.fetchImpl,
+    });
+    if (!result.ok) return { ok: false, error: result.error, unauthorized: result.unauthorized };
+    const items = Array.isArray(result.data) ? result.data : [];
+    for (const item of items) {
+      const owner = normalizeOwner(item?.owner);
+      if (owner) owners.push(owner);
+    }
+    if (items.length < 100) break;
+    const last = items[items.length - 1];
+    cursor = typeof last?.cursor === "string" && last.cursor ? last.cursor : null;
+    if (!cursor) break;
+  }
+  return { ok: true, owners };
+}
+
+function normalizeOwner(value: unknown): RenderOwner | null {
+  if (!value || typeof value !== "object") return null;
+  const o = value as Record<string, unknown>;
+  if (typeof o.id !== "string" || !o.id) return null;
+  return {
+    id: o.id,
+    name: typeof o.name === "string" && o.name ? o.name : o.id,
+    email: typeof o.email === "string" && o.email ? o.email : null,
+    type: typeof o.type === "string" && o.type ? o.type : "user",
+  };
+}
+
+export type RenderService = {
+  id: string;
+  name: string;
+  type: string;
+  /** Deploy region (e.g. "oregon"); null when the API omits it (static sites). */
+  region: string | null;
+  suspended: boolean;
+};
+
+/** Service inventory for one workspace, cursor-paginated. */
+export async function fetchServices(input: {
+  apiKey: string;
+  ownerId: string;
+  fetchImpl?: FetchImpl;
+}): Promise<
+  { ok: true; services: RenderService[] } | { ok: false; error: string; unauthorized: boolean }
+> {
+  const services: RenderService[] = [];
+  let cursor: string | null = null;
+  for (let page = 0; page < 20; page++) {
+    const query = new URLSearchParams({ ownerId: input.ownerId, limit: "100" });
+    if (cursor) query.set("cursor", cursor);
+    const result = await renderGet<Array<{ service?: unknown; cursor?: unknown }>>({
+      apiKey: input.apiKey,
+      path: "/services",
+      query,
+      fetchImpl: input.fetchImpl,
+    });
+    if (!result.ok) return { ok: false, error: result.error, unauthorized: result.unauthorized };
+    const items = Array.isArray(result.data) ? result.data : [];
+    for (const item of items) {
+      const service = normalizeService(item?.service);
+      if (service) services.push(service);
+    }
+    if (items.length < 100) break;
+    const last = items[items.length - 1];
+    cursor = typeof last?.cursor === "string" && last.cursor ? last.cursor : null;
+    if (!cursor) break;
+  }
+  return { ok: true, services };
+}
+
+function normalizeService(value: unknown): RenderService | null {
+  if (!value || typeof value !== "object") return null;
+  const o = value as Record<string, unknown>;
+  if (typeof o.id !== "string" || !o.id) return null;
+  const details =
+    o.serviceDetails && typeof o.serviceDetails === "object"
+      ? (o.serviceDetails as Record<string, unknown>)
+      : null;
+  const region =
+    typeof details?.region === "string" && details.region
+      ? details.region
+      : typeof o.region === "string" && o.region
+        ? o.region
+        : null;
+  return {
+    id: o.id,
+    name: typeof o.name === "string" && o.name ? o.name : o.id,
+    type: typeof o.type === "string" && o.type ? o.type : "unknown",
+    region,
+    suspended: o.suspended === "suspended",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry reads
+// ---------------------------------------------------------------------------
+
+export type RenderLog = {
+  id: string | null;
+  timestamp: string;
+  message: string;
+  /** Render's log metadata: resource, instance, level, type, host, … */
+  labels: Array<{ name: string; value: string }>;
+};
+
+export type RenderLogsPage = {
+  logs: RenderLog[];
+  hasMore: boolean;
+  nextStartTime: string | null;
+  nextEndTime: string | null;
+};
+
+/**
+ * One page of logs across resources (must share the workspace and region).
+ * Timestamp-paginated: pass the returned nextStartTime/nextEndTime back to
+ * fetch the following page while `hasMore`.
+ */
+export async function fetchLogs(input: {
+  apiKey: string;
+  ownerId: string;
+  resources: string[];
+  startTime?: string;
+  endTime?: string;
+  direction?: "forward" | "backward";
+  limit: number;
+  fetchImpl?: FetchImpl;
+}): Promise<
+  { ok: true; page: RenderLogsPage } | { ok: false; error: string; unauthorized: boolean }
+> {
+  const query = new URLSearchParams({ ownerId: input.ownerId, limit: String(input.limit) });
+  for (const resource of input.resources) query.append("resource", resource);
+  if (input.startTime) query.set("startTime", input.startTime);
+  if (input.endTime) query.set("endTime", input.endTime);
+  if (input.direction) query.set("direction", input.direction);
+  const result = await renderGet<{
+    logs?: unknown;
+    hasMore?: unknown;
+    nextStartTime?: unknown;
+    nextEndTime?: unknown;
+  }>({ apiKey: input.apiKey, path: "/logs", query, fetchImpl: input.fetchImpl });
+  if (!result.ok) return { ok: false, error: result.error, unauthorized: result.unauthorized };
+  const raw = Array.isArray(result.data.logs) ? result.data.logs : [];
+  return {
+    ok: true,
+    page: {
+      logs: raw.map(normalizeLog).filter((log): log is RenderLog => log !== null),
+      hasMore: result.data.hasMore === true,
+      nextStartTime:
+        typeof result.data.nextStartTime === "string" && result.data.nextStartTime
+          ? result.data.nextStartTime
+          : null,
+      nextEndTime:
+        typeof result.data.nextEndTime === "string" && result.data.nextEndTime
+          ? result.data.nextEndTime
+          : null,
+    },
+  };
+}
+
+// Normalize each item instead of trusting the cast, so one malformed record
+// can't abort the pull for a whole installation downstream.
+function normalizeLog(value: unknown): RenderLog | null {
+  if (!value || typeof value !== "object") return null;
+  const o = value as Record<string, unknown>;
+  if (typeof o.timestamp !== "string" || !o.timestamp) return null;
+  const labels = Array.isArray(o.labels)
+    ? o.labels.filter(
+        (l): l is { name: string; value: string } =>
+          !!l &&
+          typeof l === "object" &&
+          typeof (l as { name?: unknown }).name === "string" &&
+          typeof (l as { value?: unknown }).value === "string",
+      )
+    : [];
+  return {
+    id: typeof o.id === "string" && o.id ? o.id : null,
+    timestamp: o.timestamp,
+    message: typeof o.message === "string" ? o.message : "",
+    labels,
+  };
+}
+
+/** The infra series the connector forwards, one GET /metrics/<kind> each. */
+export const RENDER_METRIC_KINDS = [
+  "cpu",
+  "memory",
+  "instance-count",
+  "bandwidth",
+  "disk-usage",
+] as const;
+
+export type RenderMetricKind = (typeof RENDER_METRIC_KINDS)[number];
+
+export type RenderMetricSeries = {
+  labels: Array<{ field: string; value: string }>;
+  unit: string | null;
+  values: Array<{ timestamp: string; value: number }>;
+};
+
+/** One metrics kind for a batch of resources; series come back labeled. */
+export async function fetchMetrics(input: {
+  apiKey: string;
+  kind: RenderMetricKind;
+  resources: string[];
+  startTime: string;
+  endTime: string;
+  resolutionSeconds: number;
+  fetchImpl?: FetchImpl;
+}): Promise<
+  { ok: true; series: RenderMetricSeries[] } | { ok: false; error: string; unauthorized: boolean }
+> {
+  const query = new URLSearchParams({
+    startTime: input.startTime,
+    endTime: input.endTime,
+    resolutionSeconds: String(input.resolutionSeconds),
+  });
+  for (const resource of input.resources) query.append("resource", resource);
+  const result = await renderGet<unknown[]>({
+    apiKey: input.apiKey,
+    path: `/metrics/${input.kind}`,
+    query,
+    fetchImpl: input.fetchImpl,
+  });
+  if (!result.ok) return { ok: false, error: result.error, unauthorized: result.unauthorized };
+  const raw = Array.isArray(result.data) ? result.data : [];
+  return {
+    ok: true,
+    series: raw.map(normalizeSeries).filter((s): s is RenderMetricSeries => s !== null),
+  };
+}
+
+function normalizeSeries(value: unknown): RenderMetricSeries | null {
+  if (!value || typeof value !== "object") return null;
+  const o = value as Record<string, unknown>;
+  const labels = Array.isArray(o.labels)
+    ? o.labels.filter(
+        (l): l is { field: string; value: string } =>
+          !!l &&
+          typeof l === "object" &&
+          typeof (l as { field?: unknown }).field === "string" &&
+          typeof (l as { value?: unknown }).value === "string",
+      )
+    : [];
+  const values = Array.isArray(o.values)
+    ? o.values.filter(
+        (v): v is { timestamp: string; value: number } =>
+          !!v &&
+          typeof v === "object" &&
+          typeof (v as { timestamp?: unknown }).timestamp === "string" &&
+          typeof (v as { value?: unknown }).value === "number" &&
+          Number.isFinite((v as { value: number }).value),
+      )
+    : [];
+  return {
+    labels,
+    unit: typeof o.unit === "string" && o.unit ? o.unit : null,
+    values,
+  };
+}
+
+/** The resource a series describes, from its labels (field varies by kind). */
+export function seriesResourceId(series: RenderMetricSeries): string | null {
+  for (const field of ["resource", "service", "server"]) {
+    const label = series.labels.find((l) => l.field === field);
+    if (label?.value) return label.value;
+  }
+  return null;
+}

--- a/packages/render/src/client.ts
+++ b/packages/render/src/client.ts
@@ -29,9 +29,11 @@ export type RenderResult<T> =
   | { ok: true; data: T }
   | { ok: false; error: string; status: number | null; unauthorized: boolean };
 
-async function renderGet<T = unknown>(input: {
+async function renderRequest<T = unknown>(input: {
   apiKey: string;
   path: string;
+  method?: string;
+  body?: unknown;
   query?: URLSearchParams;
   fetchImpl?: FetchImpl;
 }): Promise<RenderResult<T>> {
@@ -41,7 +43,13 @@ async function renderGet<T = unknown>(input: {
   let res: Response;
   try {
     res = await fetchImpl(url, {
-      headers: { accept: "application/json", authorization: `Bearer ${input.apiKey}` },
+      method: input.method ?? "GET",
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${input.apiKey}`,
+        ...(input.body !== undefined ? { "content-type": "application/json" } : {}),
+      },
+      ...(input.body !== undefined ? { body: JSON.stringify(input.body) } : {}),
     });
   } catch (e) {
     return {
@@ -66,9 +74,8 @@ async function renderGet<T = unknown>(input: {
       unauthorized: res.status === 401 || res.status === 403,
     };
   }
-  if (json === null) {
-    return { ok: false, error: `status_${res.status}`, status: res.status, unauthorized: false };
-  }
+  // Some write endpoints answer with an empty body (e.g. DELETE → 204);
+  // an OK status with no JSON is still a success.
   return { ok: true, data: json as T };
 }
 
@@ -99,7 +106,7 @@ export async function fetchOwners(input: {
   for (let page = 0; page < 10; page++) {
     const query = new URLSearchParams({ limit: "100" });
     if (cursor) query.set("cursor", cursor);
-    const result = await renderGet<Array<{ owner?: unknown; cursor?: unknown }>>({
+    const result = await renderRequest<Array<{ owner?: unknown; cursor?: unknown }>>({
       apiKey: input.apiKey,
       path: "/owners",
       query,
@@ -153,7 +160,7 @@ export async function fetchServices(input: {
   for (let page = 0; page < 20; page++) {
     const query = new URLSearchParams({ ownerId: input.ownerId, limit: "100" });
     if (cursor) query.set("cursor", cursor);
-    const result = await renderGet<Array<{ service?: unknown; cursor?: unknown }>>({
+    const result = await renderRequest<Array<{ service?: unknown; cursor?: unknown }>>({
       apiKey: input.apiKey,
       path: "/services",
       query,
@@ -237,7 +244,7 @@ export async function fetchLogs(input: {
   if (input.startTime) query.set("startTime", input.startTime);
   if (input.endTime) query.set("endTime", input.endTime);
   if (input.direction) query.set("direction", input.direction);
-  const result = await renderGet<{
+  const result = await renderRequest<{
     logs?: unknown;
     hasMore?: unknown;
     nextStartTime?: unknown;
@@ -320,7 +327,7 @@ export async function fetchMetrics(input: {
     resolutionSeconds: String(input.resolutionSeconds),
   });
   for (const resource of input.resources) query.append("resource", resource);
-  const result = await renderGet<unknown[]>({
+  const result = await renderRequest<unknown[]>({
     apiKey: input.apiKey,
     path: `/metrics/${input.kind}`,
     query,
@@ -370,4 +377,160 @@ export function seriesResourceId(series: RenderMetricSeries): string | null {
     if (label?.value) return label.value;
   }
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry streams (push). A workspace has ONE log stream and ONE metrics
+// stream destination — the connector must never silently overwrite a
+// destination it doesn't own, so provisioning reads the current setting first
+// (see apps/api's provisioning flow).
+//  - Log streams push JSON over HTTPS (or RFC5424 syslog; we register HTTPS).
+//  - Metrics streams push OTLP JSON with the token as a bearer header
+//    (provider CUSTOM). Pro-plan workspaces and up only.
+// ---------------------------------------------------------------------------
+
+export type RenderLogStreamSetting = {
+  endpoint: string | null;
+  /** "send" streams logs; "drop" disables the stream without deleting it. */
+  preview: string | null;
+};
+
+export async function fetchOwnerLogStream(input: {
+  apiKey: string;
+  ownerId: string;
+  fetchImpl?: FetchImpl;
+}): Promise<
+  | { ok: true; stream: RenderLogStreamSetting | null }
+  | { ok: false; error: string; unauthorized: boolean }
+> {
+  const result = await renderRequest<{ endpoint?: unknown; preview?: unknown }>({
+    apiKey: input.apiKey,
+    path: `/logs/streams/owner/${encodeURIComponent(input.ownerId)}`,
+    fetchImpl: input.fetchImpl,
+  });
+  if (!result.ok) {
+    // No stream configured yet reads as absent, not as an error.
+    if (result.status === 404) return { ok: true, stream: null };
+    return { ok: false, error: result.error, unauthorized: result.unauthorized };
+  }
+  const o = result.data;
+  if (!o || typeof o !== "object") return { ok: true, stream: null };
+  return {
+    ok: true,
+    stream: {
+      endpoint: typeof o.endpoint === "string" && o.endpoint ? o.endpoint : null,
+      preview: typeof o.preview === "string" && o.preview ? o.preview : null,
+    },
+  };
+}
+
+export async function updateOwnerLogStream(input: {
+  apiKey: string;
+  ownerId: string;
+  endpoint: string;
+  token: string;
+  fetchImpl?: FetchImpl;
+}): Promise<{ ok: true } | { ok: false; error: string; unauthorized: boolean }> {
+  const result = await renderRequest({
+    apiKey: input.apiKey,
+    path: `/logs/streams/owner/${encodeURIComponent(input.ownerId)}`,
+    method: "PUT",
+    body: { preview: "send", endpoint: input.endpoint, token: input.token },
+    fetchImpl: input.fetchImpl,
+  });
+  if (!result.ok) return { ok: false, error: result.error, unauthorized: result.unauthorized };
+  return { ok: true };
+}
+
+export async function deleteOwnerLogStream(input: {
+  apiKey: string;
+  ownerId: string;
+  fetchImpl?: FetchImpl;
+}): Promise<{ ok: true } | { ok: false; error: string; unauthorized: boolean }> {
+  const result = await renderRequest({
+    apiKey: input.apiKey,
+    path: `/logs/streams/owner/${encodeURIComponent(input.ownerId)}`,
+    method: "DELETE",
+    fetchImpl: input.fetchImpl,
+  });
+  if (!result.ok && result.status !== 404) {
+    return { ok: false, error: result.error, unauthorized: result.unauthorized };
+  }
+  return { ok: true };
+}
+
+export type RenderMetricsStreamSetting = {
+  provider: string | null;
+  url: string | null;
+};
+
+export async function fetchOwnerMetricsStream(input: {
+  apiKey: string;
+  ownerId: string;
+  fetchImpl?: FetchImpl;
+}): Promise<
+  | { ok: true; stream: RenderMetricsStreamSetting | null }
+  | { ok: false; error: string; unauthorized: boolean }
+> {
+  const result = await renderRequest<{ provider?: unknown; url?: unknown }>({
+    apiKey: input.apiKey,
+    path: `/metrics-stream/${encodeURIComponent(input.ownerId)}`,
+    fetchImpl: input.fetchImpl,
+  });
+  if (!result.ok) {
+    if (result.status === 404) return { ok: true, stream: null };
+    return { ok: false, error: result.error, unauthorized: result.unauthorized };
+  }
+  const o = result.data;
+  if (!o || typeof o !== "object") return { ok: true, stream: null };
+  const url = typeof o.url === "string" && o.url ? o.url : null;
+  if (!url) return { ok: true, stream: null };
+  return {
+    ok: true,
+    stream: { provider: typeof o.provider === "string" ? o.provider : null, url },
+  };
+}
+
+export async function upsertOwnerMetricsStream(input: {
+  apiKey: string;
+  ownerId: string;
+  url: string;
+  token: string;
+  fetchImpl?: FetchImpl;
+}): Promise<
+  { ok: true } | { ok: false; error: string; unauthorized: boolean; status: number | null }
+> {
+  const result = await renderRequest({
+    apiKey: input.apiKey,
+    path: `/metrics-stream/${encodeURIComponent(input.ownerId)}`,
+    method: "PUT",
+    body: { provider: "CUSTOM", url: input.url, token: input.token },
+    fetchImpl: input.fetchImpl,
+  });
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: result.error,
+      unauthorized: result.unauthorized,
+      status: result.status,
+    };
+  }
+  return { ok: true };
+}
+
+export async function deleteOwnerMetricsStream(input: {
+  apiKey: string;
+  ownerId: string;
+  fetchImpl?: FetchImpl;
+}): Promise<{ ok: true } | { ok: false; error: string; unauthorized: boolean }> {
+  const result = await renderRequest({
+    apiKey: input.apiKey,
+    path: `/metrics-stream/${encodeURIComponent(input.ownerId)}`,
+    method: "DELETE",
+    fetchImpl: input.fetchImpl,
+  });
+  if (!result.ok && result.status !== 404) {
+    return { ok: false, error: result.error, unauthorized: result.unauthorized };
+  }
+  return { ok: true };
 }

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./client.js";
+export * from "./transform.js";

--- a/packages/render/src/transform.test.ts
+++ b/packages/render/src/transform.test.ts
@@ -9,6 +9,7 @@ import {
   renderLogsToOtlp,
   renderMetricsToOtlp,
   rfc3339ToNanos,
+  seriesCursorKey,
   stripAnsi,
 } from "./transform.js";
 
@@ -135,7 +136,8 @@ test("renderMetricsToOtlp uses the fallback unit and drops empty series", () => 
 
 test("log cursor filters already-forwarded lines and advances to the max", () => {
   const older = { ...LOG, timestamp: "2026-07-07T14:10:30Z" };
-  const newer = { ...LOG, timestamp: "2026-07-07T14:10:32Z" };
+  const newer = { ...LOG, id: "log-9", timestamp: "2026-07-07T14:10:32Z" };
+  // Legacy timestamp-only cursors are still accepted on read.
   const cursor = { oregon: "2026-07-07T14:10:31Z" };
 
   const fresh = filterLogsAfterCursor(cursor, "oregon", [older, LOG, newer]);
@@ -147,10 +149,38 @@ test("log cursor filters already-forwarded lines and advances to the max", () =>
   assert.equal(filterLogsAfterCursor(cursor, "frankfurt", [older]).length, 1);
 
   const advanced = advanceLogCursor(cursor, "oregon", [older, LOG, newer]);
-  assert.equal(advanced.oregon, "2026-07-07T14:10:32Z");
+  assert.deepEqual(advanced.oregon, { ts: "2026-07-07T14:10:32Z", ids: ["log-9"] });
   // Never moves backwards.
   const unchanged = advanceLogCursor(advanced, "oregon", [older]);
-  assert.equal(unchanged.oregon, "2026-07-07T14:10:32Z");
+  assert.deepEqual(unchanged.oregon, { ts: "2026-07-07T14:10:32Z", ids: ["log-9"] });
+});
+
+test("boundary-timestamp lines are re-read and deduped by id, not dropped", () => {
+  // A pass can end mid-group: two lines share the boundary timestamp but only
+  // the first was fetched. The cursor carries the forwarded ids so the second
+  // line survives the next pass's filter.
+  const ts = "2026-07-07T14:10:32Z";
+  const seen = { ...LOG, id: "log-a", timestamp: ts };
+  const unseen = { ...LOG, id: "log-b", timestamp: ts };
+
+  const cursor = advanceLogCursor({}, "oregon", [seen]);
+  assert.deepEqual(cursor.oregon, { ts, ids: ["log-a"] });
+
+  const fresh = filterLogsAfterCursor(cursor, "oregon", [seen, unseen]);
+  assert.deepEqual(
+    fresh.map((l) => l.id),
+    ["log-b"],
+  );
+  // A boundary line without an id can't be deduped — treated as seen rather
+  // than re-forwarded forever.
+  assert.equal(
+    filterLogsAfterCursor(cursor, "oregon", [{ ...LOG, id: null, timestamp: ts }]).length,
+    0,
+  );
+
+  // Advancing on the same boundary accumulates ids instead of resetting.
+  const merged = advanceLogCursor(cursor, "oregon", [unseen]);
+  assert.deepEqual(merged.oregon, { ts, ids: ["log-a", "log-b"] });
 });
 
 test("series cursor filters old samples per key and advances in epoch seconds", () => {
@@ -174,4 +204,33 @@ test("series cursor filters old samples per key and advances in epoch seconds", 
   // Untouched cursor object is returned when there's nothing to advance.
   const same = advanceSeriesCursor(advanced, key, []);
   assert.equal(same[key], advanced[key]);
+});
+
+test("seriesCursorKey distinguishes instances so a fast one can't advance past a laggard", () => {
+  const instanceA: RenderMetricSeries = { ...SERIES };
+  const instanceB: RenderMetricSeries = {
+    ...SERIES,
+    labels: [
+      { field: "resource", value: "srv-1" },
+      { field: "instance", value: "srv-1-zzzzz" },
+    ],
+  };
+  const keyA = seriesCursorKey("srv-1", "memory", instanceA);
+  const keyB = seriesCursorKey("srv-1", "memory", instanceB);
+  assert.notEqual(keyA, keyB);
+  // Advancing A's cursor leaves B's series untouched.
+  const cursor = advanceSeriesCursor({}, keyA, [instanceA]);
+  assert.equal(filterSeriesAfterCursor(cursor, keyB, [instanceB]).length, 1);
+  // Label order doesn't change the key; a label-less series still keys cleanly.
+  assert.equal(
+    seriesCursorKey("srv-1", "memory", {
+      ...instanceA,
+      labels: [...instanceA.labels].reverse(),
+    }),
+    keyA,
+  );
+  assert.equal(
+    seriesCursorKey("srv-1", "cpu", { labels: [], unit: null, values: [] }),
+    "srv-1:cpu",
+  );
 });

--- a/packages/render/src/transform.test.ts
+++ b/packages/render/src/transform.test.ts
@@ -1,0 +1,177 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import type { RenderMetricSeries } from "./client.js";
+import {
+  advanceLogCursor,
+  advanceSeriesCursor,
+  filterLogsAfterCursor,
+  filterSeriesAfterCursor,
+  renderLogsToOtlp,
+  renderMetricsToOtlp,
+  rfc3339ToNanos,
+  stripAnsi,
+} from "./transform.js";
+
+// Index into an array with narrowing (strict indexing forbids bare [0]).
+function at<T>(items: readonly T[] | undefined, index: number): T {
+  const item = items?.[index];
+  assert.ok(item !== undefined, `expected item at index ${index}`);
+  return item;
+}
+
+const NAMES = {
+  serviceNamesById: { "srv-1": "acme-api" },
+  ownerId: "tea-1",
+  ownerName: "Acme",
+};
+
+const LOG = {
+  id: "log-1",
+  timestamp: "2026-07-07T14:10:31.058154105Z",
+  message: "--> GET / \u001b[32m200\u001b[0m 1ms",
+  labels: [
+    { name: "resource", value: "srv-1" },
+    { name: "level", value: "info" },
+    { name: "instance", value: "srv-1-abcde" },
+    { name: "type", value: "app" },
+  ],
+};
+
+test("rfc3339ToNanos keeps sub-millisecond precision", () => {
+  assert.equal(rfc3339ToNanos("2026-07-07T14:10:31.058154105Z"), 1783433431058154105n);
+  assert.equal(rfc3339ToNanos("2026-07-07T14:10:31Z"), 1783433431000000000n);
+  // Render emits offset timestamps too (e.g. -07:00).
+  assert.equal(rfc3339ToNanos("2026-07-07T07:10:31.058154105-07:00"), 1783433431058154105n);
+  assert.equal(rfc3339ToNanos("garbage"), null);
+});
+
+test("stripAnsi removes color sequences", () => {
+  assert.equal(stripAnsi("--> GET / \u001b[32m200\u001b[0m 1ms"), "--> GET / 200 1ms");
+});
+
+test("renderLogsToOtlp maps a Render log line to an OTLP log record", () => {
+  const out = renderLogsToOtlp([LOG], NAMES);
+  assert.equal(out.resourceLogs.length, 1);
+  const rl = at(out.resourceLogs, 0);
+  const resourceAttrs = Object.fromEntries(
+    rl.resource.attributes.map((a) => [a.key, a.value.stringValue]),
+  );
+  assert.equal(resourceAttrs["service.name"], "acme-api");
+  assert.equal(resourceAttrs["telemetry.source"], "render");
+  assert.equal(resourceAttrs["render.owner_id"], "tea-1");
+  assert.equal(resourceAttrs["render.owner_name"], "Acme");
+  assert.equal(resourceAttrs["render.service_id"], "srv-1");
+
+  const record = at(at(rl.scopeLogs, 0).logRecords, 0);
+  assert.equal(record.timeUnixNano, "1783433431058154105");
+  assert.equal(record.severityText, "INFO");
+  assert.equal(record.severityNumber, 9);
+  assert.equal(record.body.stringValue, "--> GET / 200 1ms");
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["render.log_id"], "log-1");
+  assert.equal(attrs["render.attr.instance"], "srv-1-abcde");
+  assert.equal(attrs["render.attr.type"], "app");
+  // resource/level shape the record itself; they don't repeat as attributes.
+  assert.equal(attrs["render.attr.resource"], undefined);
+  assert.equal(attrs["render.attr.level"], undefined);
+});
+
+test("renderLogsToOtlp falls back to 'render' when the resource is unknown", () => {
+  const out = renderLogsToOtlp([{ ...LOG, labels: [] }], NAMES);
+  const rl = at(out.resourceLogs, 0);
+  const resourceAttrs = Object.fromEntries(
+    rl.resource.attributes.map((a) => [a.key, a.value.stringValue]),
+  );
+  assert.equal(resourceAttrs["service.name"], "render");
+  assert.equal(resourceAttrs["render.service_id"], undefined);
+});
+
+const SERIES: RenderMetricSeries = {
+  labels: [
+    { field: "resource", value: "srv-1" },
+    { field: "instance", value: "srv-1-abcde" },
+  ],
+  unit: "GB",
+  values: [
+    { timestamp: "2026-07-07T14:10:00Z", value: 0.5 },
+    { timestamp: "2026-07-07T14:11:00Z", value: 0.75 },
+  ],
+};
+
+test("renderMetricsToOtlp maps series to gauges grouped by resource", () => {
+  const out = renderMetricsToOtlp("memory", [SERIES], NAMES);
+  assert.equal(out.resourceMetrics.length, 1);
+  const rm = at(out.resourceMetrics, 0);
+  const resourceAttrs = Object.fromEntries(
+    rm.resource.attributes.map((a) => [a.key, a.value.stringValue]),
+  );
+  assert.equal(resourceAttrs["service.name"], "acme-api");
+  assert.equal(resourceAttrs["telemetry.source"], "render");
+  assert.equal(resourceAttrs["render.service_id"], "srv-1");
+
+  const metric = at(at(rm.scopeMetrics, 0).metrics, 0);
+  assert.equal(metric.name, "render.memory.usage");
+  // The API-reported unit wins over the fallback.
+  assert.equal(metric.unit, "GB");
+  assert.equal(metric.gauge.dataPoints.length, 2);
+  const point = at(metric.gauge.dataPoints, 0);
+  assert.equal(point.asDouble, 0.5);
+  assert.equal(point.timeUnixNano, `${BigInt(Date.parse("2026-07-07T14:10:00Z")) * 1_000_000n}`);
+  const pointAttrs = Object.fromEntries(
+    (point.attributes ?? []).map((a) => [a.key, a.value.stringValue]),
+  );
+  assert.equal(pointAttrs["render.instance"], "srv-1-abcde");
+});
+
+test("renderMetricsToOtlp uses the fallback unit and drops empty series", () => {
+  const noUnit: RenderMetricSeries = { ...SERIES, unit: null };
+  const empty: RenderMetricSeries = { ...SERIES, values: [] };
+  const out = renderMetricsToOtlp("cpu", [noUnit, empty], NAMES);
+  assert.equal(out.resourceMetrics.length, 1);
+  const metric = at(at(at(out.resourceMetrics, 0).scopeMetrics, 0).metrics, 0);
+  assert.equal(metric.name, "render.cpu.usage");
+  assert.equal(metric.unit, "{cpu}");
+});
+
+test("log cursor filters already-forwarded lines and advances to the max", () => {
+  const older = { ...LOG, timestamp: "2026-07-07T14:10:30Z" };
+  const newer = { ...LOG, timestamp: "2026-07-07T14:10:32Z" };
+  const cursor = { oregon: "2026-07-07T14:10:31Z" };
+
+  const fresh = filterLogsAfterCursor(cursor, "oregon", [older, LOG, newer]);
+  assert.deepEqual(
+    fresh.map((l) => l.timestamp),
+    ["2026-07-07T14:10:31.058154105Z", "2026-07-07T14:10:32Z"],
+  );
+  // A different group is unaffected by this group's cursor.
+  assert.equal(filterLogsAfterCursor(cursor, "frankfurt", [older]).length, 1);
+
+  const advanced = advanceLogCursor(cursor, "oregon", [older, LOG, newer]);
+  assert.equal(advanced.oregon, "2026-07-07T14:10:32Z");
+  // Never moves backwards.
+  const unchanged = advanceLogCursor(advanced, "oregon", [older]);
+  assert.equal(unchanged.oregon, "2026-07-07T14:10:32Z");
+});
+
+test("series cursor filters old samples per key and advances in epoch seconds", () => {
+  const key = "srv-1:memory";
+  const cursor = { [key]: Date.parse("2026-07-07T14:10:00Z") / 1000 };
+
+  const fresh = filterSeriesAfterCursor(cursor, key, [SERIES]);
+  assert.equal(fresh.length, 1);
+  assert.deepEqual(
+    at(fresh, 0).values.map((v) => v.timestamp),
+    ["2026-07-07T14:11:00Z"],
+  );
+  // Fully-deduped series disappear.
+  const none = filterSeriesAfterCursor({ [key]: Date.parse("2026-07-07T14:11:00Z") / 1000 }, key, [
+    SERIES,
+  ]);
+  assert.equal(none.length, 0);
+
+  const advanced = advanceSeriesCursor(cursor, key, [SERIES]);
+  assert.equal(advanced[key], Date.parse("2026-07-07T14:11:00Z") / 1000);
+  // Untouched cursor object is returned when there's nothing to advance.
+  const same = advanceSeriesCursor(advanced, key, []);
+  assert.equal(same[key], advanced[key]);
+});

--- a/packages/render/src/transform.ts
+++ b/packages/render/src/transform.ts
@@ -210,30 +210,58 @@ export function renderMetricsToOtlp(
 // ---------------------------------------------------------------------------
 // Cursors — dedupe on re-delivery (start bounds are not trusted to be
 // exclusive) and never move backwards. Log cursors are keyed by the puller's
-// region group; metrics cursors by `${resourceId}:${kind}` in epoch seconds.
+// region group; metrics cursors by series identity in epoch seconds.
 // ---------------------------------------------------------------------------
 
+/**
+ * A log cursor entry: the newest forwarded timestamp plus the ids of the
+ * lines AT that timestamp. A pass can end (page budget, page boundary) in the
+ * middle of a group of lines sharing one timestamp — a timestamp-only cursor
+ * with a strict `>` filter would drop the unseen remainder of that group on
+ * the next pass, so equal-timestamp lines are re-read and deduped by id
+ * instead. Plain strings are the pre-ids shape, still accepted on read.
+ */
+export type RenderLogCursorEntry = { ts: string; ids: string[] };
+export type RenderLogCursor = Record<string, RenderLogCursorEntry | string>;
+
+export function logCursorTs(entry: RenderLogCursorEntry | string | undefined): string | null {
+  if (!entry) return null;
+  return typeof entry === "string" ? entry : entry.ts;
+}
+
+function logCursorIds(entry: RenderLogCursorEntry | string | undefined): string[] {
+  return typeof entry === "object" && entry !== null ? entry.ids : [];
+}
+
 export function filterLogsAfterCursor(
-  cursor: Record<string, string>,
+  cursor: RenderLogCursor,
   groupKey: string,
   logs: RenderLog[],
 ): RenderLog[] {
-  const last = cursor[groupKey];
+  const entry = cursor[groupKey];
+  const last = logCursorTs(entry);
   if (!last) return logs;
   const lastNanos = rfc3339ToNanos(last);
   if (lastNanos === null) return logs;
+  const seenIds = new Set(logCursorIds(entry));
   return logs.filter((log) => {
     const nanos = rfc3339ToNanos(log.timestamp);
-    return nanos !== null && nanos > lastNanos;
+    if (nanos === null) return false;
+    if (nanos > lastNanos) return true;
+    // Lines sharing the boundary timestamp are fresh unless their id was
+    // already forwarded. A boundary line without an id can't be deduped, so
+    // treat it as seen rather than re-forwarding it every pass.
+    return nanos === lastNanos && log.id !== null && !seenIds.has(log.id);
   });
 }
 
 export function advanceLogCursor(
-  cursor: Record<string, string>,
+  cursor: RenderLogCursor,
   groupKey: string,
   logs: RenderLog[],
-): Record<string, string> {
-  let maxTimestamp = cursor[groupKey] ?? null;
+): RenderLogCursor {
+  const previous = cursor[groupKey];
+  let maxTimestamp = logCursorTs(previous);
   let maxNanos = maxTimestamp ? rfc3339ToNanos(maxTimestamp) : null;
   for (const log of logs) {
     const nanos = rfc3339ToNanos(log.timestamp);
@@ -243,13 +271,42 @@ export function advanceLogCursor(
       maxTimestamp = log.timestamp;
     }
   }
-  if (maxTimestamp == null) return cursor;
-  return { ...cursor, [groupKey]: maxTimestamp };
+  if (maxTimestamp == null || maxNanos == null) return cursor;
+  // Collect ids at the boundary timestamp; keep the previous entry's ids when
+  // the boundary didn't move so successive partial reads accumulate.
+  const ids = new Set(
+    logCursorTs(previous) !== null && rfc3339ToNanos(logCursorTs(previous) ?? "") === maxNanos
+      ? logCursorIds(previous)
+      : [],
+  );
+  for (const log of logs) {
+    if (log.id !== null && rfc3339ToNanos(log.timestamp) === maxNanos) ids.add(log.id);
+  }
+  return { ...cursor, [groupKey]: { ts: maxTimestamp, ids: [...ids] } };
 }
 
 function timestampToEpochSeconds(timestamp: string): number | null {
   const ms = Date.parse(timestamp);
   return Number.isFinite(ms) ? ms / 1000 : null;
+}
+
+/**
+ * Stable cursor key for one metric series: resource + kind + every
+ * distinguishing label (e.g. instance). Keying by resource alone would let a
+ * fast instance's samples advance the cursor past a lagging instance's — the
+ * laggard's points would then be dropped as already-seen.
+ */
+export function seriesCursorKey(
+  resourceId: string,
+  kind: RenderMetricKind,
+  series: RenderMetricSeries,
+): string {
+  const extras = series.labels
+    .filter((l) => l.field !== "resource" && l.field !== "service")
+    .map((l) => `${l.field}=${l.value}`)
+    .sort()
+    .join(",");
+  return extras ? `${resourceId}:${kind}:${extras}` : `${resourceId}:${kind}`;
 }
 
 export function filterSeriesAfterCursor(

--- a/packages/render/src/transform.ts
+++ b/packages/render/src/transform.ts
@@ -1,0 +1,311 @@
+// Render → OTLP transforms plus the puller's cursor arithmetic. Pure
+// functions only; the worker-side puller wires them to IO. The OTLP JSON
+// shapes mirror the Railway connector's.
+
+import {
+  type RenderLog,
+  type RenderMetricKind,
+  type RenderMetricSeries,
+  seriesResourceId,
+} from "./client.js";
+
+type OtlpAnyValue = {
+  stringValue?: string;
+  intValue?: string;
+  doubleValue?: number;
+  boolValue?: boolean;
+};
+
+type OtlpKeyValue = { key: string; value: OtlpAnyValue };
+
+export type RenderOtlpLogsExport = {
+  resourceLogs: Array<{
+    resource: { attributes: OtlpKeyValue[] };
+    scopeLogs: Array<{
+      scope: { name: string };
+      logRecords: Array<{
+        timeUnixNano: string;
+        observedTimeUnixNano: string;
+        severityText: string;
+        severityNumber: number;
+        body: OtlpAnyValue;
+        attributes: OtlpKeyValue[];
+      }>;
+    }>;
+  }>;
+};
+
+export type RenderOtlpMetricsExport = {
+  resourceMetrics: Array<{
+    resource: { attributes: OtlpKeyValue[] };
+    scopeMetrics: Array<{
+      scope: { name: string };
+      metrics: Array<{
+        name: string;
+        unit: string;
+        gauge: {
+          dataPoints: Array<{
+            timeUnixNano: string;
+            asDouble: number;
+            attributes?: OtlpKeyValue[];
+          }>;
+        };
+      }>;
+    }>;
+  }>;
+};
+
+/** Names resolved from inventory so telemetry is labeled, not just id-tagged. */
+export type RenderNameContext = {
+  serviceNamesById: Record<string, string>;
+  ownerId: string;
+  ownerName: string;
+};
+
+const SEVERITY: Record<string, { text: string; number: number }> = {
+  trace: { text: "TRACE", number: 1 },
+  debug: { text: "DEBUG", number: 5 },
+  info: { text: "INFO", number: 9 },
+  warning: { text: "WARN", number: 13 },
+  warn: { text: "WARN", number: 13 },
+  error: { text: "ERROR", number: 17 },
+  fatal: { text: "FATAL", number: 21 },
+};
+
+/**
+ * RFC3339 → epoch nanos as bigint, preserving Render's sub-millisecond
+ * precision (Date.parse alone truncates to ms). Null on unparseable input.
+ */
+export function rfc3339ToNanos(timestamp: string): bigint | null {
+  const match = timestamp.match(/^(.*?)(?:\.(\d{1,9}))?(Z|[+-]\d\d:\d\d)$/);
+  if (!match) return null;
+  const [, base, fraction, zone] = match;
+  const ms = Date.parse(`${base}${zone}`);
+  if (!Number.isFinite(ms)) return null;
+  const nanosFraction = BigInt((fraction ?? "").padEnd(9, "0") || "0");
+  return BigInt(ms) * 1_000_000n - BigInt(ms % 1000) * 1_000_000n + nanosFraction;
+}
+
+// Strip ANSI color/control sequences Render passes through from app stdout.
+// Control-char regex is intentional here.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes start with ESC (\u001b)
+const ANSI_PATTERN = /\u001b\[[0-9;]*[A-Za-z]/g;
+
+export function stripAnsi(value: string): string {
+  return value.replace(ANSI_PATTERN, "");
+}
+
+// Render's log labels: `resource` and `level` shape the OTLP record; the rest
+// ride along as attributes under render.attr.*.
+function logLabel(log: RenderLog, name: string): string | null {
+  return log.labels.find((l) => l.name === name)?.value ?? null;
+}
+
+export function renderLogsToOtlp(logs: RenderLog[], ctx: RenderNameContext): RenderOtlpLogsExport {
+  return {
+    resourceLogs: logs.map((log) => {
+      const resourceId = logLabel(log, "resource");
+      const serviceName = (resourceId && ctx.serviceNamesById[resourceId]) || "render";
+      const nanos = rfc3339ToNanos(log.timestamp) ?? 0n;
+      return {
+        resource: {
+          attributes: [
+            kv("service.name", serviceName),
+            kv("telemetry.source", "render"),
+            kv("render.owner_id", ctx.ownerId),
+            kv("render.owner_name", ctx.ownerName),
+            kv("render.service_id", resourceId),
+          ].filter(isKv),
+        },
+        scopeLogs: [
+          {
+            scope: { name: "render.pull.logs" },
+            logRecords: [
+              {
+                timeUnixNano: nanos.toString(),
+                observedTimeUnixNano: nanos.toString(),
+                ...severity(logLabel(log, "level")),
+                body: { stringValue: stripAnsi(log.message) },
+                attributes: [
+                  kv("render.log_id", log.id),
+                  ...log.labels
+                    .filter((l) => l.name !== "resource" && l.name !== "level")
+                    .map((l) => kv(`render.attr.${l.name}`, l.value)),
+                ].filter(isKv),
+              },
+            ],
+          },
+        ],
+      };
+    }),
+  };
+}
+
+// kind → OTLP gauge name + fallback unit (the API reports a unit per series;
+// it wins when present). Values are forwarded as-is in Render's units.
+const KIND_METRICS: Record<RenderMetricKind, { name: string; unit: string }> = {
+  cpu: { name: "render.cpu.usage", unit: "{cpu}" },
+  memory: { name: "render.memory.usage", unit: "By" },
+  "instance-count": { name: "render.instance.count", unit: "{instance}" },
+  bandwidth: { name: "render.bandwidth.usage", unit: "By" },
+  "disk-usage": { name: "render.disk.usage", unit: "By" },
+};
+
+export function renderMetricsToOtlp(
+  kind: RenderMetricKind,
+  series: RenderMetricSeries[],
+  ctx: RenderNameContext,
+): RenderOtlpMetricsExport {
+  const mapped = KIND_METRICS[kind];
+  const byResource = new Map<string, RenderMetricSeries[]>();
+  for (const s of series) {
+    if (s.values.length === 0) continue;
+    const resourceId = seriesResourceId(s) ?? "unknown";
+    const group = byResource.get(resourceId);
+    if (group) group.push(s);
+    else byResource.set(resourceId, [s]);
+  }
+  const resourceMetrics = [...byResource.entries()].map(([resourceId, group]) => {
+    const serviceName = (resourceId !== "unknown" && ctx.serviceNamesById[resourceId]) || "render";
+    return {
+      resource: {
+        attributes: [
+          kv("service.name", serviceName),
+          kv("telemetry.source", "render"),
+          kv("render.owner_id", ctx.ownerId),
+          kv("render.owner_name", ctx.ownerName),
+          kv("render.service_id", resourceId === "unknown" ? null : resourceId),
+        ].filter(isKv),
+      },
+      scopeMetrics: [
+        {
+          scope: { name: "render.pull.metrics" },
+          metrics: group.map((s) => ({
+            name: mapped.name,
+            unit: s.unit ?? mapped.unit,
+            gauge: {
+              dataPoints: s.values.map((v) => {
+                const nanos = rfc3339ToNanos(v.timestamp) ?? 0n;
+                // Series-distinguishing labels (e.g. instance) ride on the
+                // data points so per-instance series don't collapse.
+                const extra = s.labels
+                  .filter((l) => l.field !== "resource" && l.field !== "service")
+                  .map((l) => kv(`render.${l.field}`, l.value))
+                  .filter(isKv);
+                return {
+                  timeUnixNano: nanos.toString(),
+                  asDouble: v.value,
+                  ...(extra.length > 0 ? { attributes: extra } : {}),
+                };
+              }),
+            },
+          })),
+        },
+      ],
+    };
+  });
+  return { resourceMetrics };
+}
+
+// ---------------------------------------------------------------------------
+// Cursors — dedupe on re-delivery (start bounds are not trusted to be
+// exclusive) and never move backwards. Log cursors are keyed by the puller's
+// region group; metrics cursors by `${resourceId}:${kind}` in epoch seconds.
+// ---------------------------------------------------------------------------
+
+export function filterLogsAfterCursor(
+  cursor: Record<string, string>,
+  groupKey: string,
+  logs: RenderLog[],
+): RenderLog[] {
+  const last = cursor[groupKey];
+  if (!last) return logs;
+  const lastNanos = rfc3339ToNanos(last);
+  if (lastNanos === null) return logs;
+  return logs.filter((log) => {
+    const nanos = rfc3339ToNanos(log.timestamp);
+    return nanos !== null && nanos > lastNanos;
+  });
+}
+
+export function advanceLogCursor(
+  cursor: Record<string, string>,
+  groupKey: string,
+  logs: RenderLog[],
+): Record<string, string> {
+  let maxTimestamp = cursor[groupKey] ?? null;
+  let maxNanos = maxTimestamp ? rfc3339ToNanos(maxTimestamp) : null;
+  for (const log of logs) {
+    const nanos = rfc3339ToNanos(log.timestamp);
+    if (nanos === null) continue;
+    if (maxNanos === null || nanos > maxNanos) {
+      maxNanos = nanos;
+      maxTimestamp = log.timestamp;
+    }
+  }
+  if (maxTimestamp == null) return cursor;
+  return { ...cursor, [groupKey]: maxTimestamp };
+}
+
+function timestampToEpochSeconds(timestamp: string): number | null {
+  const ms = Date.parse(timestamp);
+  return Number.isFinite(ms) ? ms / 1000 : null;
+}
+
+export function filterSeriesAfterCursor(
+  cursor: Record<string, number>,
+  key: string,
+  series: RenderMetricSeries[],
+): RenderMetricSeries[] {
+  const last = cursor[key];
+  if (last === undefined) return series;
+  return series
+    .map((s) => ({
+      ...s,
+      values: s.values.filter((v) => {
+        const sec = timestampToEpochSeconds(v.timestamp);
+        return sec !== null && sec > last;
+      }),
+    }))
+    .filter((s) => s.values.length > 0);
+}
+
+export function advanceSeriesCursor(
+  cursor: Record<string, number>,
+  key: string,
+  series: RenderMetricSeries[],
+): Record<string, number> {
+  let max = cursor[key] ?? null;
+  for (const s of series) {
+    for (const v of s.values) {
+      const sec = timestampToEpochSeconds(v.timestamp);
+      if (sec === null) continue;
+      if (max === null || sec > max) max = sec;
+    }
+  }
+  if (max == null) return cursor;
+  return { ...cursor, [key]: max };
+}
+
+// ---------------------------------------------------------------------------
+
+function kv(key: string, value: unknown): OtlpKeyValue | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "string") return value ? { key, value: { stringValue: value } } : null;
+  if (typeof value === "number") {
+    return Number.isInteger(value)
+      ? { key, value: { intValue: String(value) } }
+      : { key, value: { doubleValue: value } };
+  }
+  if (typeof value === "boolean") return { key, value: { boolValue: value } };
+  return { key, value: { stringValue: String(value) } };
+}
+
+function isKv(value: OtlpKeyValue | null): value is OtlpKeyValue {
+  return value !== null;
+}
+
+function severity(value: string | null): { severityText: string; severityNumber: number } {
+  const mapped = value ? SEVERITY[value.toLowerCase()] : undefined;
+  return { severityText: mapped?.text ?? "", severityNumber: mapped?.number ?? 0 };
+}

--- a/packages/render/tsconfig.json
+++ b/packages/render/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@superlog/railway':
         specifier: workspace:*
         version: link:../../packages/railway
+      '@superlog/render':
+        specifier: workspace:*
+        version: link:../../packages/render
       autumn-js:
         specifier: ^1.2.27
         version: 1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
@@ -474,6 +477,9 @@ importers:
       '@superlog/railway':
         specifier: workspace:*
         version: link:../../packages/railway
+      '@superlog/render':
+        specifier: workspace:*
+        version: link:../../packages/render
       '@superlog/topology':
         specifier: workspace:*
         version: link:../../packages/topology
@@ -581,6 +587,18 @@ importers:
         version: 5.9.3
 
   packages/railway:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
+  packages/render:
     devDependencies:
       '@types/node':
         specifier: ^22.10.1


### PR DESCRIPTION
Adds a **Render** connector alongside the existing Railway one: connect a Render workspace once and Superlog pulls your services' logs and infra metrics from Render's REST API — no agent, no code changes.

## Why the flow differs from Railway

Render has no third-party OAuth, so there is no consent redirect. The connect flow is an **API-key paste + workspace picker**:

1. `POST /api/projects/:id/render/owners { apiKey }` — validates the key against `GET /v1/owners` and returns the workspaces it can see.
2. `POST /api/projects/:id/render/connect { apiKey, ownerId }` — re-validates, snapshots the workspace's services, mints a project ingest key, and persists the install (transactional upsert + supersede so a project has exactly one active install).

Render API keys are account-wide (Render offers no scoped/read-only keys), so the key is treated like any other integration secret: AES-256-GCM encrypted at rest with `AGENT_SECRETS_KEY`, never logged, and only used for reads scoped to the picked workspace. The UI copy says exactly that. Keys don't expire, so there is no token-refresh loop.

## Pull path

`render-pull` worker job (every minute), mirroring `railway-pull`:

- **Inventory** — refreshes the workspace's service snapshot each pass (`GET /v1/services`); a 401 means the key was revoked → skip until reconnect.
- **Logs** — `GET /v1/logs` with all of a region's resources batched into one query (Render requires same-owner/same-region batches, and logs endpoints are limited to 30 req/min per key), timestamp pagination with a bounded page budget per pass, first pull seeds backward from "now". Cursor = last log timestamp per region.
- **Metrics** — `GET /v1/metrics/{cpu,memory,instance-count,bandwidth,disk-usage}`, one call per kind with resources batched, gated to one poll per installation per ~5 min. Cursor = last sample epoch-seconds per `resource:kind`.
- Forwards OTLP JSON to the proxy's new `/render/pull/{logs,metrics}` routes with the installation's ingest key — same tenant resolution and per-source filter discipline as the other connectors; telemetry is stamped `telemetry.source=render` and rides the existing per-project ingest source toggles (new `render` source).

## Pieces

- `@superlog/render` — injectable-fetch REST client, OTLP transforms, cursor arithmetic (unit-tested; `RENDER_API_URL` env override for integration tests against a local fake).
- `render_installations` (migration 0086) — encrypted key + ingest key, services snapshot, log/metrics cursors, soft-revoke.
- api — the four routes above + `renderConnect` capability (gates on `AGENT_SECRETS_KEY` only; no client credentials exist for this connector).
- web — onboarding lane (key → workspace picker → connected panel), settings card with an inline connect form, ingest-source toggles, official Render mark (Simple Icons, CC0).
- worker — `render-pull` job + puller with narrow store/fetch ports.

## Testing

- Unit: client normalization/pagination, transforms + cursor filters, puller (seed pass, incremental pagination pass, interval gating, revoked key, intake rejection keeps cursor), capability + ingest-filter wiring.
- E2E against a local fake of Render's API (`RENDER_API_URL` override): connect via the real routes → puller forwarded 100 seeded log lines + 150 metric points through the proxy into ClickHouse with `telemetry.source=render`; a second pass forwarded only the fresh 54 lines (no duplicates: `count() == uniqExact(render.log_id)`); metrics poll correctly skipped inside the 5-min interval. UI verified in a browser: settings card shows the connected workspace + service count, ingest toggles present, pulled logs visible in the explorer with severities mapped and ANSI stripped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Render connector with API‑key connect and a worker puller. Connect now auto‑provisions Render Log Stream and Metrics Stream to push to our intake (falls back to polling), with proxy routes for pull (`/render/pull/*`) and stream (`/render/stream/*`), onboarding + settings UI, ingest filters for the `render` source, a new `@superlog/render` package, and an install record with cursors and stream state.

- **Bug Fixes**
  - Cursor correctness: log cursor now stores `{ ts, ids }` to dedupe equal‑timestamp page boundaries (legacy cursors auto‑upgrade); metrics cursor is keyed by full series identity and prunes stale keys after 7 days.
  - Connect serialization and key hygiene: project‑scoped advisory lock for connect upsert+supersede; worker soft‑revokes the install (and ingest key) after three consecutive 401s; onboarding drops the pasted key after connect; settings card disables connect when `renderConnect` is off.
  - Tests: added coverage for the above and tightened intake URL origin assertions.

- **Migration**
  - Run DB migrations 0088 and 0089 to create `render_installations` and add `log_stream_state`/`metrics_stream_state`.
  - Set `AGENT_SECRETS_KEY` in both api and worker.
  - api: optionally set `RENDER_STREAM_INTAKE_URL` to register Render’s Log/Metric Streams (unset → polling fallback).
  - worker: optionally set `RENDER_INTAKE_URL` (defaults to the local proxy).

<sup>Written for commit 8f0c3f0b08d5ca3690203cb5d01c4504ca871742. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

