### PR TITLE
proxy: don't mark ingest.queue_send spans ERROR for expected 4xx body rejections

### DIFF
--- a/apps/proxy/src/body-capture.test.ts
+++ b/apps/proxy/src/body-capture.test.ts
@@ -5,6 +5,7 @@ import {
   PayloadTooLargeError,
   type SpillSink,
   captureBody,
+  isExpectedBodyError,
 } from "./body-capture.js";
 
 function source(...chunks: Array<Uint8Array | string>): AsyncIterable<Uint8Array> {
@@ -131,4 +132,14 @@ test("treats a zero-byte body as an EmptyBodyError", async () => {
     }),
     EmptyBodyError,
   );
+});
+
+test("isExpectedBodyError matches only the handled 4xx rejections", () => {
+  // These two are mapped to 413/400 by handleIngestBodyError — the request
+  // lifecycle handles them, so spans must not be marked ERROR for them
+  // (ERROR status on an expected rejection creates false-positive incidents).
+  assert.equal(isExpectedBodyError(new PayloadTooLargeError(64, 65)), true);
+  assert.equal(isExpectedBodyError(new EmptyBodyError()), true);
+  assert.equal(isExpectedBodyError(new Error("boom")), false);
+  assert.equal(isExpectedBodyError(undefined), false);
 });

--- a/apps/proxy/src/body-capture.ts
+++ b/apps/proxy/src/body-capture.ts
@@ -58,6 +58,14 @@ export class EmptyBodyError extends Error {
   }
 }
 
+// The two rejections above are expected client errors: handleIngestBodyError
+// maps them to 413/400 and the request lifecycle completes normally. Spans
+// that see them must not record an exception or set ERROR status — an ERROR
+// span for an operation working as designed creates false-positive incidents.
+export function isExpectedBodyError(err: unknown): boolean {
+  return err instanceof PayloadTooLargeError || err instanceof EmptyBodyError;
+}
+
 export async function captureBody(
   source: AsyncIterable<Uint8Array>,
   opts: CaptureOptions,

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -12,7 +12,7 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { cors } from "hono/cors";
 import { createIngestEntitlementGate, signalForPath } from "./billing/ingest-entitlement.js";
-import { EmptyBodyError, PayloadTooLargeError } from "./body-capture.js";
+import { EmptyBodyError, PayloadTooLargeError, isExpectedBodyError } from "./body-capture.js";
 import { EMPTY_BODY_ERROR_MESSAGE, isDeclaredEmptyBody } from "./empty-body-guard.js";
 import {
   FIREHOSE_ACCESS_KEY_HEADER,
@@ -567,8 +567,17 @@ async function forward(
               queueSpan.setAttribute("ingest.queue.storage", r.storage);
               return r;
             } catch (err) {
-              queueSpan.recordException(err as Error);
-              queueSpan.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+              // Expected 4xx rejections (empty / oversized body) are handled
+              // by handleIngestBodyError below; marking this span ERROR for
+              // them creates false-positive incidents for requests the proxy
+              // rejected as designed.
+              if (!isExpectedBodyError(err)) {
+                queueSpan.recordException(err as Error);
+                queueSpan.setStatus({
+                  code: SpanStatusCode.ERROR,
+                  message: (err as Error).message,
+                });
+              }
               throw err;
             } finally {
               queueSpan.end();


### PR DESCRIPTION
## Problem

When a client sends an empty or oversized OTLP body, `enqueueStream` throws `EmptyBodyError` / `PayloadTooLargeError`. These are **handled** client errors: the outer catch maps them to 400/413 via `handleIngestBodyError`, the S3 multipart upload is aborted for the oversized case, and the request lifecycle completes normally. But the inner catch inside the `ingest.queue_send` span unconditionally called `recordException` + `setStatus(ERROR)`, so every such request produced an ERROR span — and a false-positive incident — for an operation working exactly as designed. The surrounding spans (`ingest.forward`, `auth.validate`, the server span) all stay Unset, confirming nothing actually failed.

## Fix

- `body-capture.ts`: new `isExpectedBodyError(err)` predicate next to the two error classes.
- `index.ts`: the `ingest.queue_send` catch skips `recordException`/`setStatus(ERROR)` for expected rejections and still rethrows so the outer handler produces the 4xx. Genuine enqueue failures (SQS/S3 errors) are unchanged and still mark the span ERROR.

## Testing

- New `isExpectedBodyError` unit test in `body-capture.test.ts` (matches both rejections, rejects generic errors/undefined) — written first, red, then green.
- Full proxy suite: `tsx --test src/*.test.ts` — 89 pass, 0 fail.
- `tsc --noEmit` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop marking `ingest.queue_send` spans as ERROR for expected 4xx body rejections (empty or oversized OTLP payloads). This removes false-positive incidents while keeping real SQS/S3 enqueue failures marked as ERROR.

- **Bug Fixes**
  - Added `isExpectedBodyError` alongside `EmptyBodyError` and `PayloadTooLargeError`.
  - Updated `index.ts` to skip `recordException` and `setStatus(ERROR)` for expected rejections; still rethrows so the outer handler returns 400/413.
  - Added unit test for `isExpectedBodyError`; full proxy test suite passes.

<sup>Written for commit 3025064895e2b6dbd9cd36e9f8f9f49bfad5f376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

