### PR TITLE
Metric-name picker: hourly rollup fast path + concurrent metric-table fan-outs

### DIFF
--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -6,6 +6,7 @@ import {
   fieldColumnExpr,
   listAttributeKeys,
   listAttributeValues,
+  listMetricNames,
   metricSeries,
   queryLogs,
   queryMetrics,
@@ -457,6 +458,187 @@ test("queryTraces returns resource attributes and flattened exception fields", a
   assert.match(capture.query ?? "", /AS exception_type/);
   assert.match(capture.query ?? "", /AS exception_message/);
   assert.match(capture.query ?? "", /AS exception_stacktrace/);
+});
+
+// Tracks how many queries are in flight at once so tests can assert that a
+// fan-out across the four metric tables actually runs concurrently instead of
+// awaiting each table before starting the next.
+function fakeClickhouseConcurrent(state: { inFlight: number; maxInFlight: number }) {
+  return {
+    async query() {
+      state.inFlight += 1;
+      state.maxInFlight = Math.max(state.maxInFlight, state.inFlight);
+      await new Promise((resolve) => setImmediate(resolve));
+      state.inFlight -= 1;
+      return {
+        async json() {
+          return [];
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+}
+
+// Like fakeClickhouseWithSummary, but for the metric-names rollup: answers the
+// EXISTS probe and the coverage probe, captures the real query, and returns
+// canned rollup rows so kind mapping / ordering can be asserted.
+function fakeClickhouseMetricNamesRollup(
+  capture: { query?: string; params?: Record<string, unknown> },
+  rollupExists = true,
+  windowCovered = true,
+  rows: { kind: string; name: string; unit: string; c: number }[] = [],
+) {
+  return {
+    async query(input: { query: string; query_params?: Record<string, unknown> }) {
+      if (/^EXISTS TABLE/i.test(input.query.trim())) {
+        return {
+          async json() {
+            return [{ result: rollupExists ? 1 : 0 }];
+          },
+        };
+      }
+      if (/count\(\) AS c/i.test(input.query) && /FROM \(/.test(input.query)) {
+        return {
+          async json() {
+            return [{ c: windowCovered ? 1 : 0 }];
+          },
+        };
+      }
+      capture.query = input.query;
+      capture.params = input.query_params;
+      return {
+        async json() {
+          return rows;
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+}
+
+test("listMetricNames reads the metric_names_per_hour rollup instead of scanning the raw tables", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  const names = await listMetricNames(
+    fakeClickhouseMetricNamesRollup(capture, true, true, [
+      { kind: "sum", name: "http.requests", unit: "1", c: 500 },
+      { kind: "gauge", name: "process.memory", unit: "By", c: 100 },
+      { kind: "bogus", name: "ignored", unit: "", c: 1 },
+    ]),
+    "project-1",
+    { since: "now() - INTERVAL 24 HOUR", until: "now()" },
+  );
+
+  assert.match(capture.query ?? "", /FROM metric_names_per_hour/);
+  assert.match(capture.query ?? "", /sum\(c\)/);
+  // the partial first hour rounds down to its cell boundary so it is included
+  assert.match(capture.query ?? "", /hour >= toStartOfHour\(/);
+  assert.doesNotMatch(capture.query ?? "", /FROM otel_metrics/);
+  assert.equal(capture.params?.projectId, "project-1");
+  // rows come back in METRIC_TABLES kind order; unknown kinds are dropped
+  assert.deepEqual(names, [
+    { name: "process.memory", kind: "gauge", unit: "By" },
+    { name: "http.requests", kind: "sum", unit: "1" },
+  ]);
+});
+
+test("listMetricNames falls back to the raw tables when the rollup is absent", async () => {
+  const queries: string[] = [];
+
+  await listMetricNames(
+    {
+      async query(input: { query: string }) {
+        if (/^EXISTS TABLE/i.test(input.query.trim())) {
+          return {
+            async json() {
+              return [{ result: 0 }];
+            },
+          };
+        }
+        queries.push(input.query);
+        return {
+          async json() {
+            return [];
+          },
+        };
+      },
+    } as unknown as ClickHouseClient,
+    "project-1",
+    { since: "now() - INTERVAL 24 HOUR", until: "now()" },
+  );
+
+  assert.equal(queries.length, 4);
+  for (const q of queries) assert.match(q, /FROM otel_metrics_/);
+});
+
+test("listMetricNames falls back to the raw tables when the rollup does not cover the window", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await listMetricNames(
+    fakeClickhouseMetricNamesRollup(capture, true, false),
+    "project-1",
+    { since: "now() - INTERVAL 24 HOUR", until: "now()" },
+  );
+
+  assert.match(capture.query ?? "", /FROM otel_metrics_/);
+  assert.doesNotMatch(capture.query ?? "", /FROM metric_names_per_hour/);
+});
+
+test("listMetricNames raw fallback queries the four metric tables concurrently", async () => {
+  const state = { inFlight: 0, maxInFlight: 0 };
+
+  await listMetricNames(
+    {
+      async query(input: { query: string }) {
+        if (/^EXISTS TABLE/i.test(input.query.trim())) {
+          return {
+            async json() {
+              return [{ result: 0 }];
+            },
+          };
+        }
+        state.inFlight += 1;
+        state.maxInFlight = Math.max(state.maxInFlight, state.inFlight);
+        await new Promise((resolve) => setImmediate(resolve));
+        state.inFlight -= 1;
+        return {
+          async json() {
+            return [];
+          },
+        };
+      },
+    } as unknown as ClickHouseClient,
+    "project-1",
+    { since: "now() - INTERVAL 24 HOUR", until: "now()" },
+  );
+
+  assert.equal(state.maxInFlight, 4);
+});
+
+test("queryMetrics queries the four metric tables concurrently", async () => {
+  const state = { inFlight: 0, maxInFlight: 0 };
+
+  await queryMetrics(fakeClickhouseConcurrent(state), "project-1", {
+    range: { since: "now() - INTERVAL 1 HOUR", until: "now()" },
+    limit: 100,
+  });
+
+  assert.equal(state.maxInFlight, 4);
+});
+
+test("metricSeries queries the metric tables concurrently", async () => {
+  const state = { inFlight: 0, maxInFlight: 0 };
+
+  await metricSeries(
+    fakeClickhouseConcurrent(state),
+    "project-1",
+    "http.server.duration",
+    { range: { since: "now() - INTERVAL 1 HOUR", until: "now()" } },
+    undefined,
+    { n: 1, unit: "MINUTE" },
+    "avg",
+  );
+
+  assert.equal(state.maxInFlight, 4);
 });
 
 test("queryMetrics returns data-point attributes for every metric kind", async () => {

--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -486,7 +486,10 @@ function fakeClickhouseMetricNamesRollup(
   capture: { query?: string; params?: Record<string, unknown> },
   rollupExists = true,
   windowCovered = true,
-  rows: { kind: string; name: string; unit: string; c: number }[] = [],
+  // Mirrors the real ClickHouse response: the rollup query aliases `sum(c) AS
+  // total`, so rows come back keyed by `total`, which is what
+  // listMetricNamesFromRollup sorts on within a kind.
+  rows: { kind: string; name: string; unit: string; total: number }[] = [],
 ) {
   return {
     async query(input: { query: string; query_params?: Record<string, unknown> }) {
@@ -519,10 +522,15 @@ test("listMetricNames reads the metric_names_per_hour rollup instead of scanning
   const capture: { query?: string; params?: Record<string, unknown> } = {};
 
   const names = await listMetricNames(
+    // Two "sum" names with differing totals so the within-kind frequency sort
+    // (Number(b.total) - Number(a.total)) is actually exercised, not just the
+    // primary kind ordering. ClickHouse can return them in any order, so seed
+    // them low-then-high to prove the sort flips them.
     fakeClickhouseMetricNamesRollup(capture, true, true, [
-      { kind: "sum", name: "http.requests", unit: "1", c: 500 },
-      { kind: "gauge", name: "process.memory", unit: "By", c: 100 },
-      { kind: "bogus", name: "ignored", unit: "", c: 1 },
+      { kind: "sum", name: "http.retries", unit: "1", total: 12 },
+      { kind: "sum", name: "http.requests", unit: "1", total: 500 },
+      { kind: "gauge", name: "process.memory", unit: "By", total: 100 },
+      { kind: "bogus", name: "ignored", unit: "", total: 1 },
     ]),
     "project-1",
     { since: "now() - INTERVAL 24 HOUR", until: "now()" },
@@ -534,10 +542,12 @@ test("listMetricNames reads the metric_names_per_hour rollup instead of scanning
   assert.match(capture.query ?? "", /hour >= toStartOfHour\(/);
   assert.doesNotMatch(capture.query ?? "", /FROM otel_metrics/);
   assert.equal(capture.params?.projectId, "project-1");
-  // rows come back in METRIC_TABLES kind order; unknown kinds are dropped
+  // Rows come back in METRIC_TABLES kind order; within a kind, most frequent
+  // first (http.requests before http.retries); unknown kinds are dropped.
   assert.deepEqual(names, [
     { name: "process.memory", kind: "gauge", unit: "By" },
     { name: "http.requests", kind: "sum", unit: "1" },
+    { name: "http.retries", kind: "sum", unit: "1" },
   ]);
 });
 

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -683,29 +683,29 @@ export async function queryMetrics(
 ) {
   const { sinceSql, untilSql, sinceExpr, untilExpr } = resolveRange(params.range);
   const attr = attrConds(params.resourceAttrs);
-  const results: Record<string, unknown>[] = [];
 
-  for (const { table, kind } of METRIC_TABLES) {
-    const conds: string[] = [
-      "ResourceAttributes['superlog.project_id'] = {projectId:String}",
-      `TimeUnix >= ${sinceExpr}`,
-      `TimeUnix <= ${untilExpr}`,
-      ...attr.conds,
-    ];
-    if (params.metricName) conds.push("MetricName = {metricName:String}");
-    if (params.service) conds.push("ResourceAttributes['service.name'] = {service:String}");
+  const perTable = await Promise.all(
+    METRIC_TABLES.map(async ({ table, kind }): Promise<Record<string, unknown>[]> => {
+      const conds: string[] = [
+        "ResourceAttributes['superlog.project_id'] = {projectId:String}",
+        `TimeUnix >= ${sinceExpr}`,
+        `TimeUnix <= ${untilExpr}`,
+        ...attr.conds,
+      ];
+      if (params.metricName) conds.push("MetricName = {metricName:String}");
+      if (params.service) conds.push("ResourceAttributes['service.name'] = {service:String}");
 
-    // Histograms/summaries have no scalar Value; surface the rolled-up
-    // Count/Sum (and Min/Max for histograms) so a point conveys more than just
-    // "an observation happened". Min/Max don't exist on the summary table.
-    const valueExpr =
-      kind === "histogram"
-        ? "NULL AS value, Count AS count, Sum AS sum, Min AS min, Max AS max"
-        : kind === "summary"
-          ? "NULL AS value, Count AS count, Sum AS sum, NULL AS min, NULL AS max"
-          : "Value AS value, NULL AS count, NULL AS sum, NULL AS min, NULL AS max";
+      // Histograms/summaries have no scalar Value; surface the rolled-up
+      // Count/Sum (and Min/Max for histograms) so a point conveys more than just
+      // "an observation happened". Min/Max don't exist on the summary table.
+      const valueExpr =
+        kind === "histogram"
+          ? "NULL AS value, Count AS count, Sum AS sum, Min AS min, Max AS max"
+          : kind === "summary"
+            ? "NULL AS value, Count AS count, Sum AS sum, NULL AS min, NULL AS max"
+            : "Value AS value, NULL AS count, NULL AS sum, NULL AS min, NULL AS max";
 
-    const query = `
+      const query = `
       SELECT
         '${kind}' AS kind,
         toString(TimeUnix) AS timestamp,
@@ -721,28 +721,30 @@ export async function queryMetrics(
       LIMIT {limit:UInt32}
     `;
 
-    try {
-      const r = await ch.query({
-        query,
-        query_params: {
-          projectId,
-          since: sinceSql,
-          until: untilSql,
-          metricName: params.metricName ?? "",
-          service: params.service ?? "",
-          limit: params.limit,
-          ...attr.params,
-        },
-        format: "JSONEachRow",
-      });
-      const rows = (await r.json()) as Record<string, unknown>[];
-      results.push(...rows);
-    } catch (err) {
-      // metric tables may not exist if no metrics of this kind have been ingested yet
-      if (!(err instanceof Error && /UNKNOWN_TABLE|doesn't exist/i.test(err.message))) throw err;
-    }
-  }
+      try {
+        const r = await ch.query({
+          query,
+          query_params: {
+            projectId,
+            since: sinceSql,
+            until: untilSql,
+            metricName: params.metricName ?? "",
+            service: params.service ?? "",
+            limit: params.limit,
+            ...attr.params,
+          },
+          format: "JSONEachRow",
+        });
+        return (await r.json()) as Record<string, unknown>[];
+      } catch (err) {
+        // metric tables may not exist if no metrics of this kind have been ingested yet
+        if (!(err instanceof Error && /UNKNOWN_TABLE|doesn't exist/i.test(err.message))) throw err;
+        return [];
+      }
+    }),
+  );
 
+  const results = perTable.flat();
   results.sort((a, b) => String(b.timestamp).localeCompare(String(a.timestamp)));
   return results.slice(0, params.limit);
 }
@@ -1129,17 +1131,110 @@ function cumulativeMonotonicSumQuery(args: {
   `;
 }
 
+// Same shape as traceRollupCoversWindow: the MVs only populate the rollup from
+// their creation forward, so until the backfill reaches back past the window
+// start for this project, the fast path would silently hide names that only
+// occur earlier in the window. A brand-new project with no history before the
+// window falls back too, which is fine — it is low-volume and the raw scan is
+// fast there.
+async function metricNamesRollupCoversWindow(
+  ch: ClickHouseClient,
+  projectId: string,
+  sinceExpr: string,
+  sinceSql: string,
+): Promise<boolean> {
+  const r = await ch.query({
+    query: `
+      SELECT count() AS c
+      FROM (
+        SELECT 1
+        FROM metric_names_per_hour
+        WHERE project_id = {projectId:String} AND hour < ${sinceExpr}
+        LIMIT 1
+      )
+    `,
+    query_params: { projectId, since: sinceSql },
+    format: "JSONEachRow",
+  });
+  const rows = (await r.json()) as { c: string | number }[];
+  return Number(rows[0]?.c ?? 0) > 0;
+}
+
+const METRIC_KIND_SET = new Set<string>(METRIC_TABLES.map((t) => t.kind));
+const METRIC_KIND_ORDER = new Map<string, number>(METRIC_TABLES.map((t, i) => [t.kind, i]));
+
+// Single read over the (project, kind, name, unit, hour) summing rollup —
+// milliseconds at any range where the raw per-table GROUP BYs read millions of
+// map-column rows. The partial first hour rounds down to its cell boundary so
+// names from it are included rather than dropped.
+async function listMetricNamesFromRollup(
+  ch: ClickHouseClient,
+  projectId: string,
+  sinceExpr: string,
+  untilExpr: string,
+  sinceSql: string,
+  untilSql: string,
+): Promise<MetricName[]> {
+  const r = await ch.query({
+    query: `
+      SELECT kind, name, unit, sum(c) AS total
+      FROM metric_names_per_hour
+      WHERE project_id = {projectId:String}
+        AND hour >= toStartOfHour(${sinceExpr})
+        AND hour <= ${untilExpr}
+      GROUP BY kind, name, unit
+      ORDER BY total DESC
+      LIMIT 200 BY kind
+    `,
+    query_params: { projectId, since: sinceSql, until: untilSql },
+    format: "JSONEachRow",
+  });
+  const rows = (await r.json()) as {
+    kind: string;
+    name: string;
+    unit: string;
+    total: string | number;
+  }[];
+  // Match the raw path's output order: tables in METRIC_TABLES order, most
+  // frequent names first within each. Unknown kinds can't be routed to a
+  // series query, so drop them.
+  return rows
+    .filter((row) => METRIC_KIND_SET.has(row.kind))
+    .sort(
+      (a, b) =>
+        (METRIC_KIND_ORDER.get(a.kind) ?? 0) - (METRIC_KIND_ORDER.get(b.kind) ?? 0) ||
+        Number(b.total) - Number(a.total),
+    )
+    .map((row) => ({ name: row.name, kind: row.kind as MetricKind, unit: row.unit }));
+}
+
 export async function listMetricNames(
   ch: ClickHouseClient,
   projectId: string,
   range?: TimeRange,
 ): Promise<MetricName[]> {
   const { sinceSql, untilSql, sinceExpr, untilExpr } = resolveRange(range);
-  const results: MetricName[] = [];
-  for (const { table, kind } of METRIC_TABLES) {
-    try {
-      const r = await ch.query({
-        query: `
+
+  // Fast path: the picker only needs distinct MetricName/MetricUnit pairs, but
+  // on the raw tables the project filter is a ResourceAttributes map lookup
+  // that no primary-key or partition pruning helps with — on high-volume
+  // projects each per-table GROUP BY reads millions of rows (~0.5 GiB of map
+  // column) and the four scans added up to 10s+ picker loads. Row-capped
+  // sampling (à la ATTRIBUTE_KEY_SCAN_ROW_CAP) is not an option: the raw
+  // tables sort by (ServiceName, MetricName, ...), so a capped scan
+  // systematically drops metrics late in the sort order. The rollup answers
+  // exactly, in milliseconds; anything without it falls back to the raw scan.
+  if (await tableExists(ch, "metric_names_per_hour")) {
+    if (await metricNamesRollupCoversWindow(ch, projectId, sinceExpr, sinceSql)) {
+      return listMetricNamesFromRollup(ch, projectId, sinceExpr, untilExpr, sinceSql, untilSql);
+    }
+  }
+
+  const perTable = await Promise.all(
+    METRIC_TABLES.map(async ({ table, kind }): Promise<MetricName[]> => {
+      try {
+        const r = await ch.query({
+          query: `
           SELECT MetricName AS name, MetricUnit AS unit, count() AS c
           FROM ${table}
           WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
@@ -1149,16 +1244,18 @@ export async function listMetricNames(
           ORDER BY c DESC
           LIMIT 200
         `,
-        query_params: { projectId, since: sinceSql, until: untilSql },
-        format: "JSONEachRow",
-      });
-      const rows = (await r.json()) as { name: string; unit: string; c: string | number }[];
-      for (const row of rows) results.push({ name: row.name, kind, unit: row.unit });
-    } catch (err) {
-      if (!(err instanceof Error && /UNKNOWN_TABLE|doesn't exist/i.test(err.message))) throw err;
-    }
-  }
-  return results;
+          query_params: { projectId, since: sinceSql, until: untilSql },
+          format: "JSONEachRow",
+        });
+        const rows = (await r.json()) as { name: string; unit: string; c: string | number }[];
+        return rows.map((row) => ({ name: row.name, kind, unit: row.unit }));
+      } catch (err) {
+        if (!(err instanceof Error && /UNKNOWN_TABLE|doesn't exist/i.test(err.message))) throw err;
+        return [];
+      }
+    }),
+  );
+  return perTable.flat();
 }
 
 export type MetricSeriesFilter = {
@@ -1195,36 +1292,36 @@ export async function metricSeries(
     groupParams.groupKey = groupBy;
   }
 
-  const results: MetricSeriesRow[] = [];
-  for (const { table, kind } of METRIC_TABLES) {
-    const valueExpr = aggregation ? AGG_EXPR[aggregation][kind] : DEFAULT_AGG_EXPR[kind];
-    if (!valueExpr) continue;
-    const conds: string[] = [
-      "ResourceAttributes['superlog.project_id'] = {projectId:String}",
-      `TimeUnix >= ${sinceExpr}`,
-      `TimeUnix <= ${untilExpr}`,
-      "MetricName = {metricName:String}",
-      ...attr.conds,
-    ];
-    if (filter.service) conds.push("ServiceName = {service:String}");
-    const query =
-      kind === "histogram" && (aggregation === "p95" || aggregation === "p99")
-        ? histogramQuantileQuery({
-            table,
-            step,
-            groupExpr,
-            conds,
-            q: aggregation === "p95" ? 0.95 : 0.99,
-          })
-        : kind === "sum" && (!aggregation || aggregation === "sum")
-          ? cumulativeMonotonicSumQuery({
+  const perTable = await Promise.all(
+    METRIC_TABLES.map(async ({ table, kind }): Promise<MetricSeriesRow[]> => {
+      const valueExpr = aggregation ? AGG_EXPR[aggregation][kind] : DEFAULT_AGG_EXPR[kind];
+      if (!valueExpr) return [];
+      const conds: string[] = [
+        "ResourceAttributes['superlog.project_id'] = {projectId:String}",
+        `TimeUnix >= ${sinceExpr}`,
+        `TimeUnix <= ${untilExpr}`,
+        "MetricName = {metricName:String}",
+        ...attr.conds,
+      ];
+      if (filter.service) conds.push("ServiceName = {service:String}");
+      const query =
+        kind === "histogram" && (aggregation === "p95" || aggregation === "p99")
+          ? histogramQuantileQuery({
               table,
               step,
               groupExpr,
               conds,
-              sinceExpr,
+              q: aggregation === "p95" ? 0.95 : 0.99,
             })
-          : `
+          : kind === "sum" && (!aggregation || aggregation === "sum")
+            ? cumulativeMonotonicSumQuery({
+                table,
+                step,
+                groupExpr,
+                conds,
+                sinceExpr,
+              })
+            : `
           SELECT
             toString(toStartOfInterval(TimeUnix, INTERVAL ${step.n} ${step.unit})) AS bucket,
             ${groupExpr} AS group_key,
@@ -1235,41 +1332,46 @@ export async function metricSeries(
           ORDER BY bucket ASC
           LIMIT 10000
         `;
-    try {
-      const r = await ch.query({
-        query,
-        query_params: {
-          projectId,
-          since: sinceSql,
-          until: untilSql,
-          metricName,
-          service: filter.service ?? "",
-          ...attr.params,
-          ...groupParams,
-        },
-        format: "JSONEachRow",
-      });
-      const rows = (await r.json()) as {
-        bucket: string;
-        group_key: string;
-        v: string | number | null;
-      }[];
-      for (const row of rows) {
-        if (row.v === null) continue;
-        const value = Number(row.v);
-        if (!Number.isFinite(value)) continue;
-        results.push({ bucket: row.bucket, group: row.group_key, value });
-      }
-    } catch (err) {
-      if (
-        !(
-          err instanceof Error &&
-          /UNKNOWN_TABLE|UNKNOWN_IDENTIFIER|doesn't exist/i.test(err.message)
+      try {
+        const r = await ch.query({
+          query,
+          query_params: {
+            projectId,
+            since: sinceSql,
+            until: untilSql,
+            metricName,
+            service: filter.service ?? "",
+            ...attr.params,
+            ...groupParams,
+          },
+          format: "JSONEachRow",
+        });
+        const rows = (await r.json()) as {
+          bucket: string;
+          group_key: string;
+          v: string | number | null;
+        }[];
+        const parsed: MetricSeriesRow[] = [];
+        for (const row of rows) {
+          if (row.v === null) continue;
+          const value = Number(row.v);
+          if (!Number.isFinite(value)) continue;
+          parsed.push({ bucket: row.bucket, group: row.group_key, value });
+        }
+        return parsed;
+      } catch (err) {
+        if (
+          !(
+            err instanceof Error &&
+            /UNKNOWN_TABLE|UNKNOWN_IDENTIFIER|doesn't exist/i.test(err.message)
+          )
         )
-      )
-        throw err;
-    }
-  }
+          throw err;
+        return [];
+      }
+    }),
+  );
+  const results = perTable.flat();
   results.sort((a, b) => a.bucket.localeCompare(b.bucket));
   return results;
 }

--- a/infra/clickhouse/migrations/007_metric_names_per_hour.sql
+++ b/infra/clickhouse/migrations/007_metric_names_per_hour.sql
@@ -1,0 +1,106 @@
+-- Per-hour metric-name counts per project, feeding the metric-name picker
+-- fast path (listMetricNames in apps/api/src/mcp/clickhouse.ts).
+--
+-- Why: the picker only needs the distinct MetricName/MetricUnit pairs in the
+-- window, but the project filter on the raw otel_metrics_* tables is a
+-- ResourceAttributes map lookup that no primary-key or partition pruning
+-- helps with. On high-volume projects each per-table GROUP BY reads millions
+-- of rows (~0.5 GiB of map column) per request, and the four tables together
+-- put the picker load at 10s+. Row-capped sampling is not an option here: the
+-- raw tables sort by (ServiceName, MetricName, ...), so a capped scan
+-- systematically drops metrics late in the sort order — a picker that hides
+-- metrics is broken for discovery. A SummingMergeTree keyed
+-- (project, kind, name, unit, hour) answers the same query exactly, in
+-- milliseconds at any range.
+--
+-- The `kind` column carries which raw table the name came from
+-- (gauge | sum | histogram | summary) since the picker needs it to route
+-- subsequent series queries. Counts are only used to order the picker by
+-- frequency. otel_metrics_exp_histogram is intentionally not rolled up — the
+-- API does not read it.
+--
+-- Run ONCE per environment. Statements are IF NOT EXISTS so they are
+-- individually safe to retry. The MVs only roll up rows inserted AFTER they
+-- are created; historical windows need a one-shot backfill, chunked by day to
+-- bound memory, covering only time strictly BEFORE the MV creation hour so
+-- nothing is double-counted, e.g. (once per metric table/kind):
+--
+--   INSERT INTO superlog.metric_names_per_hour
+--   SELECT ResourceAttributes['superlog.project_id'], 'gauge', MetricName,
+--          MetricUnit, toStartOfHour(TimeUnix), count()
+--   FROM superlog.otel_metrics_gauge
+--   WHERE TimeUnix >= {day} AND TimeUnix < {day_after}
+--     AND TimeUnix < {mv_created_hour}
+--     AND ResourceAttributes['superlog.project_id'] != ''
+--   GROUP BY 1, 2, 3, 4, 5;
+--
+-- The read path gates on the rollup reaching back past the window start for
+-- the project (see metricNamesRollupCoversWindow) and falls back to the raw
+-- scan otherwise, so applying this before the backfill never under-reports.
+
+CREATE TABLE IF NOT EXISTS superlog.metric_names_per_hour ON CLUSTER superlog_ha
+(
+    `project_id` String CODEC(ZSTD(1)),
+    `kind` LowCardinality(String) CODEC(ZSTD(1)),
+    `name` String CODEC(ZSTD(1)),
+    `unit` LowCardinality(String) CODEC(ZSTD(1)),
+    `hour` DateTime CODEC(Delta(4), ZSTD(1)),
+    `c` UInt64 CODEC(Delta(8), ZSTD(1))
+)
+ENGINE = ReplicatedSummingMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
+PARTITION BY toYYYYMM(hour)
+ORDER BY (project_id, kind, name, unit, hour)
+SETTINGS index_granularity = 8192
+;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.metric_names_per_hour_from_gauge_mv ON CLUSTER superlog_ha TO superlog.metric_names_per_hour
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    'gauge' AS kind,
+    MetricName AS name,
+    MetricUnit AS unit,
+    toStartOfHour(TimeUnix) AS hour,
+    count() AS c
+FROM superlog.otel_metrics_gauge
+WHERE ResourceAttributes['superlog.project_id'] != ''
+GROUP BY project_id, kind, name, unit, hour
+;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.metric_names_per_hour_from_sum_mv ON CLUSTER superlog_ha TO superlog.metric_names_per_hour
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    'sum' AS kind,
+    MetricName AS name,
+    MetricUnit AS unit,
+    toStartOfHour(TimeUnix) AS hour,
+    count() AS c
+FROM superlog.otel_metrics_sum
+WHERE ResourceAttributes['superlog.project_id'] != ''
+GROUP BY project_id, kind, name, unit, hour
+;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.metric_names_per_hour_from_histogram_mv ON CLUSTER superlog_ha TO superlog.metric_names_per_hour
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    'histogram' AS kind,
+    MetricName AS name,
+    MetricUnit AS unit,
+    toStartOfHour(TimeUnix) AS hour,
+    count() AS c
+FROM superlog.otel_metrics_histogram
+WHERE ResourceAttributes['superlog.project_id'] != ''
+GROUP BY project_id, kind, name, unit, hour
+;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS superlog.metric_names_per_hour_from_summary_mv ON CLUSTER superlog_ha TO superlog.metric_names_per_hour
+AS SELECT
+    ResourceAttributes['superlog.project_id'] AS project_id,
+    'summary' AS kind,
+    MetricName AS name,
+    MetricUnit AS unit,
+    toStartOfHour(TimeUnix) AS hour,
+    count() AS c
+FROM superlog.otel_metrics_summary
+WHERE ResourceAttributes['superlog.project_id'] != ''
+GROUP BY project_id, kind, name, unit, hour
+;


### PR DESCRIPTION
## Problem

The explore metrics tab's name picker (`GET /explore/metric-names`) runs four sequential `GROUP BY MetricName, MetricUnit` scans over the raw `otel_metrics_{gauge,sum,histogram,summary}` tables. The project filter is a `ResourceAttributes` map lookup that neither primary-key nor partition pruning helps with, so on high-volume projects each scan reads millions of rows (~0.5 GiB of map column per table for a 24h window) and the four sequential round trips add up to **10s+ page loads**.

## Fix

**Fast path — `metric_names_per_hour` rollup (migration 007).** A SummingMergeTree keyed `(project_id, kind, name, unit, hour)`, fed by materialized views on the four metric tables, answers the picker exactly in one ~ms query at any range. Read path uses the same gating as the trace-list / `events_per_minute` rollups:
- `EXISTS TABLE` probe (positive result cached; absent re-probed) — deployments without the migration keep working on the raw scan.
- Per-project window-coverage probe — until the backfill reaches past the window start, fall back to the raw scan rather than silently hiding pre-migration names.

**Fallback + list/series paths — concurrent fan-out.** The raw-scan fallback in `listMetricNames`, and the per-table loops in `queryMetrics` / `metricSeries`, previously awaited each table before starting the next. They now run concurrently, so wall-clock is the slowest table instead of the sum of four.

## Why not row-capped sampling

`ATTRIBUTE_KEY_SCAN_ROW_CAP`-style capping was tried and rejected for the picker: the raw tables sort by `(ServiceName, MetricName, ...)`, so a capped scan systematically drops metrics late in the sort order (verified: a low-volume metric name disappeared from the capped result). A picker that hides metrics is broken for discovery, so the fallback stays exact.

## Rollout

The migration is `IF NOT EXISTS`-safe to retry and can be applied before or after deploy — the coverage gate means the fast path only activates once the rollup covers the requested window. The MVs populate from creation forward; the migration header documents the day-chunked backfill for historical windows.

## Testing

- New unit tests: rollup fast path (query shape, kind mapping/order, unknown-kind drop), absent-table fallback, uncovered-window fallback, concurrency of `listMetricNames` fallback / `queryMetrics` / `metricSeries` fan-outs.
- All migration statements and the new read queries validated with `EXPLAIN AST` against ClickHouse 26.5.
- `pnpm --filter @superlog/api test`: no new failures; typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `metric_names_per_hour` rollup for the Explore metrics name picker and makes metric-table reads concurrent. Loads drop from 10s+ to ms on large projects with an exact, gated fallback; tests now assert within-kind frequency ordering.

- **New Features**
  - `metric_names_per_hour` SummingMergeTree with MVs on gauge/sum/histogram/summary; `listMetricNames` reads it in one query using EXISTS + per-project coverage gating, falling back to exact raw scans when needed.
  - Concurrent fan-out across metric tables in `listMetricNames` fallback, `queryMetrics`, and `metricSeries`; wall-clock equals the slowest table instead of the sum of all four.

- **Migration**
  - Apply `infra/clickhouse/migrations/007_metric_names_per_hour.sql` (IF NOT EXISTS-safe).
  - Optionally backfill by day for historical windows; the fast path activates only after the coverage gate passes, otherwise the raw scan is used.

<sup>Written for commit 03f022e7abe78b3a1ffec77fa51267be4488dc85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

