### PR TITLE
Add telemetry loading skeletons

### DIFF
--- a/apps/web/src/Explore.tsx
+++ b/apps/web/src/Explore.tsx
@@ -52,6 +52,12 @@ import { ScrollArea } from "./design/scroll-area.tsx";
 import { Btn, Chip, Input, Label, ShortcutKey, Tile } from "./design/ui.tsx";
 import { addAttrFilter } from "./exploreAttrFilter.ts";
 import { tracer } from "./instrumentation.ts";
+import {
+  ExploreSignalDetailSkeleton,
+  ExploreSignalListSkeleton,
+  MetricDetailSkeleton,
+  type TelemetrySkeletonSource,
+} from "./skeletons.tsx";
 import { formatLocalHm, formatLocalTimestamp, formatLocalTimestampMs } from "./timeFormat.ts";
 
 const PRESET_STORAGE_KEY = "superlog.explore.range";
@@ -89,6 +95,7 @@ export function Explore() {
 }
 
 export type Source = "logs" | "traces" | "metrics" | "resources";
+type TelemetrySource = TelemetrySkeletonSource;
 export type TracesView = "spans" | "traces";
 
 function sourceFromPath(pathname: string): Source | null {
@@ -418,6 +425,9 @@ function ExploreInner({ projectId }: { projectId: string }) {
         }}
         onAddFilter={addFilter}
       />
+      {selectedLogKey && !selectedLog && logsForSelection.isLoading && (
+        <ExploreSignalDetailDrawerSkeleton source="logs" onClose={closeLog} />
+      )}
     </div>
   );
 }
@@ -1878,11 +1888,7 @@ function MetricChartBody({
     metricAggregation,
   );
   if (q.isLoading) {
-    return (
-      <div className="flex h-48 items-center justify-center font-mono text-[11px] text-subtle">
-        loading…
-      </div>
-    );
+    return <MetricDetailSkeleton />;
   }
   if (q.data && q.data.rows.length > 0) {
     return (
@@ -2353,6 +2359,30 @@ export function MetricLineChart({
   );
 }
 
+function ExploreSignalDetailDrawerSkeleton({
+  source,
+  onClose,
+}: {
+  source: TelemetrySource;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50">
+      <button
+        type="button"
+        aria-label="close"
+        className="absolute inset-0 bg-black/60"
+        onClick={onClose}
+      />
+      <aside className="absolute inset-y-0 right-0 flex w-full max-w-[720px] flex-col border-l border-border bg-bg shadow-2xl">
+        <div className="flex-1 overflow-y-auto">
+          <ExploreSignalDetailSkeleton source={source} />
+        </div>
+      </aside>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // ListPanel
 // ---------------------------------------------------------------------------
@@ -2379,7 +2409,7 @@ function ListPanel({
 }: {
   projectId: string;
   filter: ExploreFilter;
-  source: Source;
+  source: TelemetrySource;
   limit: number;
   onLoadMore: () => void;
   attrs: ResourceAttr[];
@@ -2412,6 +2442,7 @@ function ListPanel({
   );
   const q =
     source === "logs" ? logs : source === "traces" ? (isTraceAgg ? tracesAgg : traces) : metrics;
+  const initialLoading = q.isLoading && !q.data;
 
   return (
     <Tile padded={false}>
@@ -2442,7 +2473,7 @@ function ListPanel({
           />
         </div>
       )}
-      {q.isFetching && (
+      {q.isFetching && !initialLoading && (
         <div className="flex items-center justify-end border-b border-border px-5 py-1.5">
           <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-subtle">
             loading…
@@ -2450,7 +2481,9 @@ function ListPanel({
         </div>
       )}
       <div className="overflow-auto">
-        {source === "logs" ? (
+        {initialLoading ? (
+          <ExploreSignalListSkeleton source={source} />
+        ) : source === "logs" ? (
           <LogsTable rows={(logs.data ?? []) as never} onSelect={onSelectLog} />
         ) : source === "traces" ? (
           isTraceAgg ? (

--- a/apps/web/src/Explore.tsx
+++ b/apps/web/src/Explore.tsx
@@ -2366,6 +2366,14 @@ function ExploreSignalDetailDrawerSkeleton({
   source: TelemetrySource;
   onClose: () => void;
 }) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
   return (
     <div className="fixed inset-0 z-50">
       <button
@@ -2375,6 +2383,14 @@ function ExploreSignalDetailDrawerSkeleton({
         onClick={onClose}
       />
       <aside className="absolute inset-y-0 right-0 flex w-full max-w-[720px] flex-col border-l border-border bg-bg shadow-2xl">
+        <button
+          type="button"
+          onClick={onClose}
+          title="close (esc)"
+          className="absolute right-4 top-4 z-10 rounded-sm border border-border bg-bg px-2 py-1 font-mono text-[11px] text-muted hover:text-fg"
+        >
+          ✕
+        </button>
         <div className="flex-1 overflow-y-auto">
           <ExploreSignalDetailSkeleton source={source} />
         </div>

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -62,6 +62,12 @@ import {
   buildIncidentDetailMeta,
 } from "./incidents/incident-detail-view-model.ts";
 import { getIssueIncidentLinkState } from "./issue-incident-link-state.ts";
+import {
+  IncidentDetailSkeleton,
+  IncidentListSkeleton,
+  IssueDetailSkeleton,
+  IssueListSkeleton,
+} from "./skeletons.tsx";
 
 const IncidentPrDiffView = lazy(() => import("./IncidentPrDiffView.tsx"));
 
@@ -188,6 +194,7 @@ function IssuesTab({ projectId }: { projectId: string }) {
   const fromList = selectedId ? (issues.data?.find((i) => i.id === selectedId) ?? null) : null;
   const fetched = useIssue(projectId, selectedId && !fromList ? selectedId : undefined);
   const selected = fromList ?? fetched.data ?? null;
+  const detailLoading = !!selectedId && !selected && (issues.isLoading || fetched.isLoading);
 
   function selectIssue(issueId: string | null) {
     if (issueId == null) closeItem();
@@ -233,7 +240,7 @@ function IssuesTab({ projectId }: { projectId: string }) {
         )}
       </div>
 
-      {issues.isLoading && <div className="text-[13px] text-muted">Loading…</div>}
+      {issues.isLoading && <IssueListSkeleton />}
       {issues.error && (
         <div className="text-[13px] text-danger">Failed to load: {String(issues.error)}</div>
       )}
@@ -268,6 +275,7 @@ function IssuesTab({ projectId }: { projectId: string }) {
           silenceUpdating={silence.isPending || unsilence.isPending}
         />
       )}
+      {detailLoading && <IssueDrawerSkeleton onClose={() => selectIssue(null)} />}
 
       {eventTarget?.kind === "trace" && (
         <TraceDrawer
@@ -290,6 +298,32 @@ function IssuesTab({ projectId }: { projectId: string }) {
           }
         />
       )}
+    </div>
+  );
+}
+
+function IssueDrawerSkeleton({ onClose }: { onClose: () => void }) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div className="absolute inset-0">
+      <button
+        type="button"
+        aria-label="close"
+        className="absolute inset-0 bg-black/60"
+        onClick={onClose}
+      />
+      <aside className="absolute inset-y-0 right-0 flex w-full max-w-[720px] flex-col border-l border-border bg-bg shadow-2xl">
+        <div className="flex-1 overflow-y-auto">
+          <IssueDetailSkeleton />
+        </div>
+      </aside>
     </div>
   );
 }
@@ -705,7 +739,7 @@ function IncidentsTab({ projectId }: { projectId: string }) {
         </div>
       </div>
 
-      {incidents.isLoading && <div className="text-[13px] text-muted">Loading…</div>}
+      {incidents.isLoading && <IncidentListSkeleton />}
       {incidents.error && (
         <div className="text-[13px] text-danger">Failed to load: {String(incidents.error)}</div>
       )}
@@ -940,11 +974,7 @@ function IncidentDetailBody({
   const decideProposal = useDecideResolutionProposal(projectId);
 
   if (q.isLoading) {
-    return (
-      <div className="p-4 font-mono text-[11px] uppercase tracking-[0.2em] text-muted">
-        loading…
-      </div>
-    );
+    return <IncidentDetailSkeleton />;
   }
   if (q.error || !q.data) {
     return (
@@ -1405,9 +1435,7 @@ export function IncidentDetailContent({
       <div className="flex shrink-0 items-center gap-2 border-b border-border bg-bg px-5 py-3">
         <span className="text-[13px] text-muted">Incidents</span>
         <span className="text-subtle">›</span>
-        <span className="min-w-0 flex-1 truncate text-[13px] text-fg">
-          {incident.title}
-        </span>
+        <span className="min-w-0 flex-1 truncate text-[13px] text-fg">{incident.title}</span>
         <div className="flex shrink-0 items-center gap-3">
           {notAnIssueAction && (
             <Btn
@@ -2189,7 +2217,6 @@ function AgentRunStateChip({ state }: { state: string }) {
   return <Chip tone="neutral">{state}</Chip>;
 }
 
-
 function humanizeReasonCode(code: string): string {
   return code.replace(/[._]/g, " ").trim().toLowerCase();
 }
@@ -2202,7 +2229,6 @@ function sentenceCase(text: string): string {
   if (!trimmed) return trimmed;
   return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
 }
-
 
 // ---------------------------------------------------------------------------
 // Small components

--- a/apps/web/src/TraceDetail.tsx
+++ b/apps/web/src/TraceDetail.tsx
@@ -1,10 +1,37 @@
 import { useEffect, useMemo, useState } from "react";
 import { type TraceLog, type TraceSpan, useTraceDetail } from "./api.ts";
 import { RowMenu, type RowMenuItem } from "./design/RowMenu.tsx";
+import { Chip, Label, SkeletonBlock } from "./design/ui.tsx";
 import { type AttrScope, attrFilterKey } from "./exploreAttrFilter.ts";
 import { tracer } from "./instrumentation.ts";
-import { Chip, Label } from "./design/ui.tsx";
 import { formatLocalTimestampMs } from "./timeFormat.ts";
+
+const TRACE_SPAN_SKELETON_ROWS = [
+  "root",
+  "auth",
+  "route",
+  "handler",
+  "db",
+  "cache",
+  "queue",
+  "worker",
+  "response",
+];
+const TRACE_LOG_SKELETON_ROWS = ["first", "second", "third", "fourth"];
+const TRACE_ATTR_SKELETON_ROWS = [
+  "span-name",
+  "service",
+  "kind",
+  "status",
+  "duration",
+  "span-id",
+  "parent-span-id",
+  "resource-service",
+  "resource-env",
+  "resource-region",
+  "http-route",
+  "http-method",
+];
 
 export function TraceDrawer({
   projectId,
@@ -97,7 +124,7 @@ function TraceDrawerBody({
   }, [detail.error, traceId]);
 
   if (detail.isLoading) {
-    return <div className="flex-1 px-6 py-6 font-mono text-[11px] text-subtle">loading…</div>;
+    return <TraceDetailSkeleton />;
   }
   if (detail.error) {
     return (
@@ -123,6 +150,75 @@ function TraceDrawerBody({
       focusSpanId={focusSpanId}
       onAddFilter={onAddFilter}
     />
+  );
+}
+
+function TraceDetailSkeleton() {
+  return (
+    <div
+      aria-label="Loading traces detail"
+      className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] lg:divide-x lg:divide-border"
+    >
+      <div className="flex min-h-0 min-w-0 flex-col gap-5 overflow-y-auto px-6 py-6">
+        <section>
+          <div className="mb-2 flex items-baseline gap-2">
+            <SkeletonBlock className="h-4 w-14" />
+            <SkeletonBlock className="h-3 w-64" />
+          </div>
+          <div className="border border-border">
+            <div className="grid grid-cols-[minmax(180px,1fr)_2fr_72px] gap-3 border-b border-border px-4 py-1.5">
+              <SkeletonBlock className="h-3 w-16" />
+              <span />
+              <SkeletonBlock className="h-3 w-14" />
+            </div>
+            {TRACE_SPAN_SKELETON_ROWS.map((row) => (
+              <div
+                key={`trace-span-skeleton-${row}`}
+                className="grid grid-cols-[minmax(180px,1fr)_2fr_72px] items-center gap-3 border-b border-border px-4 py-1.5 last:border-b-0"
+              >
+                <SkeletonBlock className="h-4 w-4/5" />
+                <SkeletonBlock className="h-4 w-full" />
+                <SkeletonBlock className="h-4 w-12" />
+              </div>
+            ))}
+          </div>
+        </section>
+        <section>
+          <SkeletonBlock className="mb-2 h-4 w-20" />
+          <div className="border border-border">
+            {TRACE_LOG_SKELETON_ROWS.map((row) => (
+              <div
+                key={`trace-log-skeleton-${row}`}
+                className="grid grid-cols-[120px_100px_64px_80px_minmax(0,1fr)] gap-3 border-b border-border px-4 py-2 last:border-b-0"
+              >
+                <SkeletonBlock className="h-4 w-full" />
+                <SkeletonBlock className="h-4 w-full" />
+                <SkeletonBlock className="h-4 w-full" />
+                <SkeletonBlock className="h-4 w-full" />
+                <SkeletonBlock className="h-4 w-full" />
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+      <aside className="min-h-0 min-w-0 overflow-y-auto px-6 py-6">
+        <div className="mb-2 flex items-baseline gap-2">
+          <SkeletonBlock className="h-4 w-12" />
+          <SkeletonBlock className="h-3 w-32" />
+        </div>
+        <div className="border border-border">
+          {TRACE_ATTR_SKELETON_ROWS.map((row) => (
+            <div
+              key={`trace-attr-skeleton-${row}`}
+              className="grid grid-cols-[minmax(0,1fr)_minmax(0,2fr)] gap-3 border-b border-border px-3 py-1.5 last:border-b-0"
+            >
+              <SkeletonBlock className="h-4 w-4/5" />
+              <SkeletonBlock className="h-4 w-full" />
+            </div>
+          ))}
+        </div>
+      </aside>
+    </div>
   );
 }
 

--- a/apps/web/src/design/ui.tsx
+++ b/apps/web/src/design/ui.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useState } from "react";
+import { type CSSProperties, type ReactNode, useEffect, useState } from "react";
 
 // ---------------------------------------------------------------------------
 // Canonical shared primitives — used across the app and the /design sheet.
@@ -49,6 +49,24 @@ export function Tile({
       )}
       {children}
     </div>
+  );
+}
+
+export function SkeletonBlock({
+  className = "",
+  label = "Loading",
+  style,
+}: {
+  className?: string;
+  label?: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <span
+      aria-label={label}
+      style={style}
+      className={`block animate-pulse rounded-sm bg-surface-2 ${className}`}
+    />
   );
 }
 

--- a/apps/web/src/design/ui.tsx
+++ b/apps/web/src/design/ui.tsx
@@ -54,18 +54,16 @@ export function Tile({
 
 export function SkeletonBlock({
   className = "",
-  label = "Loading",
   style,
 }: {
   className?: string;
-  label?: string;
   style?: CSSProperties;
 }) {
   return (
     <span
-      aria-label={label}
+      aria-hidden="true"
       style={style}
-      className={`block animate-pulse rounded-sm bg-surface-2 ${className}`}
+      className={`block rounded-sm bg-surface-2 motion-safe:animate-pulse ${className}`}
     />
   );
 }

--- a/apps/web/src/skeletons.test.tsx
+++ b/apps/web/src/skeletons.test.tsx
@@ -12,17 +12,20 @@ import {
   MetricDetailSkeleton,
 } from "./skeletons.tsx";
 
-test("skeleton blocks expose an accessible loading label", () => {
-  const html = renderToStaticMarkup(<SkeletonBlock label="Loading incident title" />);
+test("skeleton blocks are decorative and respect reduced motion", () => {
+  const html = renderToStaticMarkup(<SkeletonBlock />);
 
-  assert.match(html, /aria-label="Loading incident title"/);
-  assert.match(html, /animate-pulse/);
+  assert.match(html, /aria-hidden="true"/);
+  assert.doesNotMatch(html, /aria-label=/);
+  assert.match(html, /motion-safe:animate-pulse/);
 });
 
 test("issue skeletons cover list and detail loading surfaces", () => {
   const list = renderToStaticMarkup(<IssueListSkeleton />);
   const detail = renderToStaticMarkup(<IssueDetailSkeleton />);
 
+  assert.match(list, /role="status"/);
+  assert.match(detail, /role="status"/);
   assert.match(list, /aria-label="Loading issues"/);
   assert.match(detail, /aria-label="Loading issue detail"/);
 });
@@ -31,19 +34,31 @@ test("incident skeletons cover list and detail loading surfaces", () => {
   const list = renderToStaticMarkup(<IncidentListSkeleton />);
   const detail = renderToStaticMarkup(<IncidentDetailSkeleton />);
 
+  assert.match(list, /role="status"/);
+  assert.match(detail, /role="status"/);
   assert.match(list, /aria-label="Loading incidents"/);
   assert.match(detail, /aria-label="Loading incident detail"/);
 });
 
 test("explore skeletons cover logs, traces, and metrics list and detail surfaces", () => {
+  const expectedColumns = { logs: 4, traces: 5, metrics: 6 };
   for (const source of ["logs", "traces", "metrics"] as const) {
     const list = renderToStaticMarkup(<ExploreSignalListSkeleton source={source} />);
     const detail = renderToStaticMarkup(<ExploreSignalDetailSkeleton source={source} />);
 
+    assert.match(list, /role="status"/);
+    assert.match(detail, /role="status"/);
     assert.match(list, new RegExp(`aria-label="Loading ${source}"`));
     assert.match(detail, new RegExp(`aria-label="Loading ${source} detail"`));
+    assert.match(
+      list,
+      new RegExp(
+        `grid-template-columns:repeat\\(${expectedColumns[source]},\\s*minmax\\(0,\\s*1fr\\)\\)`,
+      ),
+    );
   }
 
   const metricDetail = renderToStaticMarkup(<MetricDetailSkeleton />);
+  assert.match(metricDetail, /role="status"/);
   assert.match(metricDetail, /aria-label="Loading metric detail"/);
 });

--- a/apps/web/src/skeletons.test.tsx
+++ b/apps/web/src/skeletons.test.tsx
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SkeletonBlock } from "./design/ui.tsx";
+import {
+  ExploreSignalDetailSkeleton,
+  ExploreSignalListSkeleton,
+  IncidentDetailSkeleton,
+  IncidentListSkeleton,
+  IssueDetailSkeleton,
+  IssueListSkeleton,
+  MetricDetailSkeleton,
+} from "./skeletons.tsx";
+
+test("skeleton blocks expose an accessible loading label", () => {
+  const html = renderToStaticMarkup(<SkeletonBlock label="Loading incident title" />);
+
+  assert.match(html, /aria-label="Loading incident title"/);
+  assert.match(html, /animate-pulse/);
+});
+
+test("issue skeletons cover list and detail loading surfaces", () => {
+  const list = renderToStaticMarkup(<IssueListSkeleton />);
+  const detail = renderToStaticMarkup(<IssueDetailSkeleton />);
+
+  assert.match(list, /aria-label="Loading issues"/);
+  assert.match(detail, /aria-label="Loading issue detail"/);
+});
+
+test("incident skeletons cover list and detail loading surfaces", () => {
+  const list = renderToStaticMarkup(<IncidentListSkeleton />);
+  const detail = renderToStaticMarkup(<IncidentDetailSkeleton />);
+
+  assert.match(list, /aria-label="Loading incidents"/);
+  assert.match(detail, /aria-label="Loading incident detail"/);
+});
+
+test("explore skeletons cover logs, traces, and metrics list and detail surfaces", () => {
+  for (const source of ["logs", "traces", "metrics"] as const) {
+    const list = renderToStaticMarkup(<ExploreSignalListSkeleton source={source} />);
+    const detail = renderToStaticMarkup(<ExploreSignalDetailSkeleton source={source} />);
+
+    assert.match(list, new RegExp(`aria-label="Loading ${source}"`));
+    assert.match(detail, new RegExp(`aria-label="Loading ${source} detail"`));
+  }
+
+  const metricDetail = renderToStaticMarkup(<MetricDetailSkeleton />);
+  assert.match(metricDetail, /aria-label="Loading metric detail"/);
+});

--- a/apps/web/src/skeletons.tsx
+++ b/apps/web/src/skeletons.tsx
@@ -1,0 +1,254 @@
+import { SkeletonBlock } from "./design/ui.tsx";
+
+export type TelemetrySkeletonSource = "logs" | "traces" | "metrics";
+
+const LIST_ROWS = ["one", "two", "three", "four", "five", "six", "seven"];
+const ISSUE_META_CELLS = ["service", "environment", "events", "first-seen", "last-seen"];
+const INCIDENT_META_ROWS = [
+  "priority",
+  "status",
+  "service",
+  "environment",
+  "first-detection",
+  "latest-detection",
+  "agent-run",
+];
+const INCIDENT_EVENT_ROWS = ["created", "grouped", "investigated", "updated", "resolved"];
+const DETAIL_ROWS = [
+  "timestamp",
+  "severity",
+  "service",
+  "trace",
+  "span",
+  "resource",
+  "body",
+  "attrs",
+];
+const METRIC_BARS = [35, 58, 44, 70, 52, 82, 62, 48, 76, 56, 88, 64, 42, 72, 54, 80].map(
+  (height, index) => ({ key: `bar-${index}-${height}`, height }),
+);
+
+function EntityListSkeleton({
+  label,
+  rows = 7,
+}: {
+  label: string;
+  rows?: number;
+}) {
+  return (
+    <div
+      aria-label={label}
+      className="divide-y divide-border overflow-hidden rounded-2xl border border-border bg-surface"
+    >
+      {LIST_ROWS.slice(0, rows).map((row) => (
+        <div key={`${label}-${row}`} className="px-4 py-3">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 flex-1 space-y-2">
+              <div className="flex items-center gap-2">
+                <SkeletonBlock className="h-5 w-14" />
+                <SkeletonBlock className="h-5 w-20" />
+                <SkeletonBlock className="h-3 w-28" />
+              </div>
+              <SkeletonBlock className="h-4 w-4/5" />
+              <SkeletonBlock className="h-3 w-2/3" />
+            </div>
+            <div className="w-24 shrink-0 space-y-2">
+              <SkeletonBlock className="ml-auto h-3 w-16" />
+              <SkeletonBlock className="ml-auto h-3 w-20" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function IssueListSkeleton() {
+  return <EntityListSkeleton label="Loading issues" />;
+}
+
+export function IncidentListSkeleton() {
+  return <EntityListSkeleton label="Loading incidents" />;
+}
+
+export function IssueDetailSkeleton() {
+  return (
+    <div aria-label="Loading issue detail" className="space-y-8 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <SkeletonBlock className="h-5 w-14" />
+          <SkeletonBlock className="h-5 w-2/3" />
+        </div>
+        <SkeletonBlock className="h-7 w-7" />
+      </div>
+      <div className="space-y-2">
+        <div className="flex gap-2">
+          <SkeletonBlock className="h-5 w-20" />
+          <SkeletonBlock className="h-5 w-24" />
+          <SkeletonBlock className="h-5 w-28" />
+        </div>
+        <SkeletonBlock className="h-4 w-3/5" />
+      </div>
+      <div className="space-y-3">
+        <SkeletonBlock className="h-4 w-24" />
+        <SkeletonBlock className="h-28 w-full" />
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        {ISSUE_META_CELLS.map((cell) => (
+          <div
+            key={`issue-meta-${cell}`}
+            className="space-y-2 border border-border bg-surface-2 p-3"
+          >
+            <SkeletonBlock className="h-3 w-20" />
+            <SkeletonBlock className="h-4 w-28" />
+          </div>
+        ))}
+      </div>
+      <div className="space-y-2">
+        <SkeletonBlock className="h-8 w-full" />
+        <SkeletonBlock className="h-8 w-full" />
+      </div>
+    </div>
+  );
+}
+
+export function IncidentDetailSkeleton() {
+  return (
+    <div aria-label="Loading incident detail" className="flex min-h-0 flex-1 flex-col bg-bg">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-5 py-3">
+        <SkeletonBlock className="h-4 w-20" />
+        <SkeletonBlock className="h-4 w-3/5" />
+        <SkeletonBlock className="ml-auto h-7 w-28" />
+        <SkeletonBlock className="h-7 w-7" />
+      </div>
+      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[390px_minmax(0,1fr)]">
+        <aside className="border-b border-border px-7 py-7 lg:border-b-0 lg:border-r">
+          <div className="space-y-4">
+            <SkeletonBlock className="h-3 w-28" />
+            <SkeletonBlock className="h-7 w-4/5" />
+            <SkeletonBlock className="h-4 w-full" />
+            <SkeletonBlock className="h-4 w-5/6" />
+          </div>
+          <div className="mt-7 grid gap-3.5">
+            {INCIDENT_META_ROWS.map((row) => (
+              <div
+                key={`incident-meta-${row}`}
+                className="grid grid-cols-[132px_minmax(0,1fr)] gap-3"
+              >
+                <SkeletonBlock className="h-4 w-24" />
+                <SkeletonBlock className="h-4 w-full" />
+              </div>
+            ))}
+          </div>
+          <div className="mt-7 grid gap-2">
+            <SkeletonBlock className="h-7 w-full" />
+            <SkeletonBlock className="h-7 w-full" />
+          </div>
+        </aside>
+        <main className="min-h-0 min-w-0 px-8 py-6">
+          <div className="mb-6 flex gap-2">
+            <SkeletonBlock className="h-7 w-20" />
+            <SkeletonBlock className="h-7 w-20" />
+            <SkeletonBlock className="h-7 w-14" />
+          </div>
+          <div className="space-y-4">
+            {INCIDENT_EVENT_ROWS.map((row) => (
+              <div
+                key={`incident-event-${row}`}
+                className="rounded-lg border border-border bg-surface p-4"
+              >
+                <SkeletonBlock className="h-4 w-2/3" />
+                <SkeletonBlock className="mt-3 h-3 w-full" />
+                <SkeletonBlock className="mt-2 h-3 w-5/6" />
+              </div>
+            ))}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export function ExploreSignalListSkeleton({ source }: { source: TelemetrySkeletonSource }) {
+  const columns =
+    source === "logs"
+      ? [
+          { key: "timestamp", width: "w-32" },
+          { key: "service", width: "w-24" },
+          { key: "severity", width: "w-12" },
+          { key: "body", width: "w-full" },
+        ]
+      : source === "traces"
+        ? [
+            { key: "timestamp", width: "w-32" },
+            { key: "service", width: "w-24" },
+            { key: "span", width: "w-full" },
+            { key: "status", width: "w-16" },
+            { key: "duration", width: "w-14" },
+          ]
+        : [
+            { key: "timestamp", width: "w-32" },
+            { key: "metric", width: "w-full" },
+            { key: "kind", width: "w-16" },
+            { key: "service", width: "w-24" },
+            { key: "value", width: "w-20" },
+            { key: "unit", width: "w-12" },
+          ];
+  return (
+    <div aria-label={`Loading ${source}`} className="min-w-[720px]">
+      <div className="grid grid-cols-[repeat(6,minmax(0,1fr))] gap-4 px-5 py-2">
+        {columns.map((column) => (
+          <SkeletonBlock key={`${source}-head-${column.key}`} className={`h-3 ${column.width}`} />
+        ))}
+      </div>
+      <div className="divide-y divide-border border-t border-border">
+        {LIST_ROWS.map((row) => (
+          <div
+            key={`${source}-row-${row}`}
+            className="grid grid-cols-[repeat(6,minmax(0,1fr))] gap-4 px-5 py-3"
+          >
+            {columns.map((column, col) => (
+              <SkeletonBlock
+                key={`${source}-cell-${row}-${column.key}`}
+                className={`h-4 ${col === columns.length - 1 ? "w-full" : column.width}`}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ExploreSignalDetailSkeleton({ source }: { source: TelemetrySkeletonSource }) {
+  return (
+    <div aria-label={`Loading ${source} detail`} className="flex h-full flex-col gap-6 px-6 py-6">
+      <div className="space-y-2">
+        <SkeletonBlock className="h-3 w-20" />
+        <SkeletonBlock className="h-5 w-2/3" />
+      </div>
+      <SkeletonBlock className="h-36 w-full" />
+      <div className="grid gap-2">
+        {DETAIL_ROWS.map((row) => (
+          <div
+            key={`${source}-detail-${row}`}
+            className="grid grid-cols-[160px_minmax(0,1fr)] gap-3"
+          >
+            <SkeletonBlock className="h-4 w-28" />
+            <SkeletonBlock className="h-4 w-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function MetricDetailSkeleton() {
+  return (
+    <div aria-label="Loading metric detail" className="flex h-48 items-end gap-2 px-2 pb-2">
+      {METRIC_BARS.map((bar) => (
+        <SkeletonBlock key={bar.key} className="flex-1" style={{ height: `${bar.height}%` }} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/skeletons.tsx
+++ b/apps/web/src/skeletons.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { SkeletonBlock } from "./design/ui.tsx";
 
 export type TelemetrySkeletonSource = "logs" | "traces" | "metrics";
@@ -28,6 +29,23 @@ const METRIC_BARS = [35, 58, 44, 70, 52, 82, 62, 48, 76, 56, 88, 64, 42, 72, 54,
   (height, index) => ({ key: `bar-${index}-${height}`, height }),
 );
 
+function SkeletonStatus({
+  label,
+  className,
+  children,
+}: {
+  label: string;
+  className: string;
+  children: ReactNode;
+}) {
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: this status region wraps complex loading layouts; output cannot contain this structure.
+    <div role="status" aria-label={label} className={className}>
+      {children}
+    </div>
+  );
+}
+
 function EntityListSkeleton({
   label,
   rows = 7,
@@ -36,8 +54,8 @@ function EntityListSkeleton({
   rows?: number;
 }) {
   return (
-    <div
-      aria-label={label}
+    <SkeletonStatus
+      label={label}
       className="divide-y divide-border overflow-hidden rounded-2xl border border-border bg-surface"
     >
       {LIST_ROWS.slice(0, rows).map((row) => (
@@ -59,7 +77,7 @@ function EntityListSkeleton({
           </div>
         </div>
       ))}
-    </div>
+    </SkeletonStatus>
   );
 }
 
@@ -73,7 +91,7 @@ export function IncidentListSkeleton() {
 
 export function IssueDetailSkeleton() {
   return (
-    <div aria-label="Loading issue detail" className="space-y-8 p-4">
+    <SkeletonStatus label="Loading issue detail" className="space-y-8 p-4">
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <SkeletonBlock className="h-5 w-14" />
@@ -108,13 +126,13 @@ export function IssueDetailSkeleton() {
         <SkeletonBlock className="h-8 w-full" />
         <SkeletonBlock className="h-8 w-full" />
       </div>
-    </div>
+    </SkeletonStatus>
   );
 }
 
 export function IncidentDetailSkeleton() {
   return (
-    <div aria-label="Loading incident detail" className="flex min-h-0 flex-1 flex-col bg-bg">
+    <SkeletonStatus label="Loading incident detail" className="flex min-h-0 flex-1 flex-col bg-bg">
       <div className="flex shrink-0 items-center gap-2 border-b border-border px-5 py-3">
         <SkeletonBlock className="h-4 w-20" />
         <SkeletonBlock className="h-4 w-3/5" />
@@ -165,7 +183,7 @@ export function IncidentDetailSkeleton() {
           </div>
         </main>
       </div>
-    </div>
+    </SkeletonStatus>
   );
 }
 
@@ -194,19 +212,17 @@ export function ExploreSignalListSkeleton({ source }: { source: TelemetrySkeleto
             { key: "value", width: "w-20" },
             { key: "unit", width: "w-12" },
           ];
+  const gridStyle = { gridTemplateColumns: `repeat(${columns.length}, minmax(0, 1fr))` };
   return (
-    <div aria-label={`Loading ${source}`} className="min-w-[720px]">
-      <div className="grid grid-cols-[repeat(6,minmax(0,1fr))] gap-4 px-5 py-2">
+    <SkeletonStatus label={`Loading ${source}`} className="min-w-[720px]">
+      <div className="grid gap-4 px-5 py-2" style={gridStyle}>
         {columns.map((column) => (
           <SkeletonBlock key={`${source}-head-${column.key}`} className={`h-3 ${column.width}`} />
         ))}
       </div>
       <div className="divide-y divide-border border-t border-border">
         {LIST_ROWS.map((row) => (
-          <div
-            key={`${source}-row-${row}`}
-            className="grid grid-cols-[repeat(6,minmax(0,1fr))] gap-4 px-5 py-3"
-          >
+          <div key={`${source}-row-${row}`} className="grid gap-4 px-5 py-3" style={gridStyle}>
             {columns.map((column, col) => (
               <SkeletonBlock
                 key={`${source}-cell-${row}-${column.key}`}
@@ -216,13 +232,16 @@ export function ExploreSignalListSkeleton({ source }: { source: TelemetrySkeleto
           </div>
         ))}
       </div>
-    </div>
+    </SkeletonStatus>
   );
 }
 
 export function ExploreSignalDetailSkeleton({ source }: { source: TelemetrySkeletonSource }) {
   return (
-    <div aria-label={`Loading ${source} detail`} className="flex h-full flex-col gap-6 px-6 py-6">
+    <SkeletonStatus
+      label={`Loading ${source} detail`}
+      className="flex h-full flex-col gap-6 px-6 py-6"
+    >
       <div className="space-y-2">
         <SkeletonBlock className="h-3 w-20" />
         <SkeletonBlock className="h-5 w-2/3" />
@@ -239,16 +258,16 @@ export function ExploreSignalDetailSkeleton({ source }: { source: TelemetrySkele
           </div>
         ))}
       </div>
-    </div>
+    </SkeletonStatus>
   );
 }
 
 export function MetricDetailSkeleton() {
   return (
-    <div aria-label="Loading metric detail" className="flex h-48 items-end gap-2 px-2 pb-2">
+    <SkeletonStatus label="Loading metric detail" className="flex h-48 items-end gap-2 px-2 pb-2">
       {METRIC_BARS.map((bar) => (
         <SkeletonBlock key={bar.key} className="flex-1" style={{ height: `${bar.height}%` }} />
       ))}
-    </div>
+    </SkeletonStatus>
   );
 }


### PR DESCRIPTION
## Summary

Adds reusable loading skeletons for telemetry-heavy screens so first-load states preserve layout instead of showing plain loading text.

## Changes

- Adds shared skeleton components for incident, issue, log, trace, and metric loading states.
- Uses list skeletons for incidents, issues, logs, traces, and metrics.
- Uses detail-shaped skeletons for incident detail, issue detail, selected log lookup, trace detail, and metric chart loading.
- Adds focused render tests for the skeleton components and accessible loading labels.

## Validation

- `pnpm exec tsx --tsconfig apps/web/tsconfig.json --test apps/web/src/skeletons.test.tsx`
- `pnpm --filter @superlog/web typecheck`
- `pnpm exec biome check apps/web/src/skeletons.tsx apps/web/src/skeletons.test.tsx`
- Verified local routes return 200 for `/explore/logs`, `/issues`, and `/incidents`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add accessible loading skeletons for telemetry-heavy screens to keep layouts stable and improve perceived speed. Replaces “loading…” across issues, incidents, explore (logs/traces/metrics), trace detail, and metric charts.

- **New Features**
  - Add `SkeletonBlock` primitive in `design/ui.tsx`.
  - Add reusable skeletons in `skeletons.tsx` for issues/incidents lists and detail, explore lists and detail (logs/traces/metrics), and the metric chart.
  - Integrate skeletons in `Explore.tsx`, `Issues.tsx`, and `TraceDetail.tsx`, including initial list states and detail drawers for selected log/issue.

- **Bug Fixes**
  - Improve accessibility: wrap skeleton UIs with `role="status"` and descriptive `aria-label`s; make `SkeletonBlock` decorative (`aria-hidden`) and motion-safe (`motion-safe:animate-pulse`).
  - Add tests in `skeletons.test.tsx` to verify labels, roles, reduced motion, and coverage of list/detail loading surfaces.

<sup>Written for commit de08a4e0311216876d860bf59fad0c3b4d599318. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

