### PR TITLE
Retire the complete_investigation and report_failure outcome tools

### DIFF
--- a/apps/worker/src/agent-outcome-tools.test.ts
+++ b/apps/worker/src/agent-outcome-tools.test.ts
@@ -22,9 +22,9 @@ const FINDINGS: AgentRunFindings = {
   handoffNotes: "Checked the vendor API timeout config; it is not the cause.",
 };
 
-test("exposes all eight tools with API-safe schemas", () => {
-  assert.equal(OUTCOME_TOOL_NAMES.length, 8);
-  assert.equal(OUTCOME_TOOL_DEFINITIONS.length, 8);
+test("exposes all six tools with API-safe schemas", () => {
+  assert.equal(OUTCOME_TOOL_NAMES.length, 6);
+  assert.equal(OUTCOME_TOOL_DEFINITIONS.length, 6);
   for (const def of OUTCOME_TOOL_DEFINITIONS) {
     // Some runner APIs reject any top-level composition keyword
     // (allOf/oneOf/if...), which would block every run at agent-create time.
@@ -78,17 +78,25 @@ test("noise-outcome descriptions carry the per-reason evidentiary bars", () => {
   assert.ok(silence?.description.includes("Do NOT propose code changes"));
 });
 
-test("report_failure description reserves no_findings and redirects external causes", () => {
-  const def = OUTCOME_TOOL_DEFINITIONS.find((d) => d.name === "report_failure");
-  const text = def?.description ?? "";
-  assert.ok(text.includes("RESERVED"));
-  assert.ok(text.includes("complete_investigation"));
-  assert.ok(text.includes("ask_human"));
+test("marks exactly five tools terminal", () => {
+  assert.equal(TERMINAL_OUTCOME_TOOL_NAMES.length, 5);
+  assert.ok(!(TERMINAL_OUTCOME_TOOL_NAMES as readonly string[]).includes(REPORT_FINDINGS_TOOL_NAME));
 });
 
-test("marks exactly seven tools terminal", () => {
-  assert.equal(TERMINAL_OUTCOME_TOOL_NAMES.length, 7);
-  assert.ok(!(TERMINAL_OUTCOME_TOOL_NAMES as readonly string[]).includes(REPORT_FINDINGS_TOOL_NAME));
+// Sessions created against the old toolset can resume days later (e.g. from
+// awaiting_human) and still call a retired tool. The validator must reject
+// the call with redirect guidance so the model re-lands on a live outcome —
+// falling through to the unknown-tool path would hard-fail the run instead.
+test("rejects retired terminal tools with redirect guidance", () => {
+  for (const name of ["complete_investigation", "report_failure"]) {
+    const v = validateOutcomeToolInput(name, { disposition: "informational" }, { hasFindings: true });
+    assert.equal(v.ok, false, name);
+    if (!v.ok) {
+      const text = v.errors.join(" ");
+      assert.ok(text.includes("ask_human"), name);
+      assert.ok(text.includes("propose_pr"), name);
+    }
+  }
 });
 
 test("accepts a full report_findings payload", () => {
@@ -140,7 +148,6 @@ test("requires findings before complete-family terminals", () => {
   const cases: Array<[string, Record<string, unknown>]> = [
     ["silence_as_noise", { reason: "cosmetic_log_only", evidence: "e" }],
     ["mark_already_resolved", { reason: "upstream_recovered", evidence: "e" }],
-    ["complete_investigation", { disposition: "informational" }],
     [
       "place_under_observation",
       { reason: "cosmetic_log_only", evidence: "e", escalateOn: "additional_events", threshold: 10 },
@@ -166,17 +173,9 @@ test("requires findings before complete-family terminals", () => {
   }
 });
 
-test("allows ask_human and report_failure without findings", () => {
+test("allows ask_human without findings", () => {
   assert.equal(
     validateOutcomeToolInput("ask_human", { question: "which repo owns api-gw?" }, { hasFindings: false }).ok,
-    true,
-  );
-  assert.equal(
-    validateOutcomeToolInput(
-      "report_failure",
-      { reason: "no_findings", detail: "Insufficient evidence: searched services/*" },
-      { hasFindings: false },
-    ).ok,
     true,
   );
 });
@@ -364,15 +363,17 @@ test("assembles propose_pr into an AgentRunPr with pending openStatus", () => {
 test("derives the legacy rootCauseConfidence bucket from the numeric confidence", () => {
   const result = assembleAgentRunResult({
     findings: FINDINGS,
-    terminal: { name: "complete_investigation", payload: { disposition: "diagnosed_external_cause" } },
+    terminal: {
+      name: "mark_already_resolved",
+      payload: { reason: "transient_condition_cleared", evidence: "e" },
+    },
   });
   assert.deepEqual(result.rootCause, { text: FINDINGS.rootCause, confidence: 9 });
   assert.equal(result.rootCauseConfidence, "high");
   assert.deepEqual(result.estimatedImpact, { text: FINDINGS.estimatedImpact, confidence: 7 });
-  assert.equal(result.disposition, "diagnosed_external_cause");
 });
 
-test("falls back to the question/detail as summary when findings are absent", () => {
+test("falls back to the question as summary when findings are absent", () => {
   const ask = assembleAgentRunResult({
     findings: null,
     terminal: { name: "ask_human", payload: { question: "Which repo owns api-gw?" } },
@@ -380,27 +381,4 @@ test("falls back to the question/detail as summary when findings are absent", ()
   assert.equal(ask.state, "awaiting_human");
   assert.equal(ask.question, "Which repo owns api-gw?");
   assert.equal(ask.summary, "Which repo owns api-gw?");
-
-  const fail = assembleAgentRunResult({
-    findings: null,
-    terminal: {
-      name: "report_failure",
-      payload: { reason: "no_findings", detail: "Insufficient evidence: searched services/*" },
-    },
-  });
-  assert.equal(fail.state, "failed");
-  assert.equal(fail.failureReason, "agent_no_findings");
-  assert.ok(fail.summary.includes("Insufficient evidence"));
-});
-
-test("maps patch_validation_failed reason through verbatim", () => {
-  const fail = assembleAgentRunResult({
-    findings: FINDINGS,
-    terminal: {
-      name: "report_failure",
-      payload: { reason: "patch_validation_failed", detail: "repro still fails after patch" },
-    },
-  });
-  assert.equal(fail.failureReason, "patch_validation_failed");
-  assert.equal(fail.summary, FINDINGS.summary);
 });

--- a/apps/worker/src/agent-outcome-tools.ts
+++ b/apps/worker/src/agent-outcome-tools.ts
@@ -17,7 +17,6 @@
 // split.
 
 import type {
-  AgentRunFailureReason,
   AgentRunMobileRegressionTest,
   AgentRunPr,
   AgentRunResult,
@@ -46,12 +45,16 @@ export const TERMINAL_OUTCOME_TOOL_NAMES = [
   "silence_as_noise",
   "place_under_observation",
   "mark_already_resolved",
-  "complete_investigation",
   "ask_human",
-  "report_failure",
 ] as const;
 
 export type TerminalOutcomeToolName = (typeof TERMINAL_OUTCOME_TOOL_NAMES)[number];
+
+// Terminal tools retired from the contract. Sessions created against the old
+// toolset can outlive a deploy (awaiting_human resumes days later), so a call
+// to one of these must be error-acked with redirect guidance — not routed to
+// the unknown-tool path, which hard-fails the run.
+export const RETIRED_OUTCOME_TOOL_NAMES = ["complete_investigation", "report_failure"] as const;
 
 export const OUTCOME_TOOL_NAMES = [
   REPORT_FINDINGS_TOOL_NAME,
@@ -74,15 +77,7 @@ const RESOLUTION_REASONS: IncidentResolutionReason[] = [
 
 const SEVERITIES: IncidentSeverity[] = ["SEV-1", "SEV-2", "SEV-3"];
 
-const DISPOSITIONS = [
-  "diagnosed_needs_code_change",
-  "diagnosed_external_cause",
-  "informational",
-] as const;
-
 const ESCALATE_ON = ["events_per_minute", "additional_events"] as const;
-
-const FAILURE_REASONS = ["no_findings", "patch_validation_failed"] as const;
 
 const MOBILE_TEST_STATUSES = ["created", "skipped", "not_applicable"] as const;
 
@@ -130,7 +125,7 @@ const REPORT_FINDINGS_DEFINITION: OutcomeToolDefinition = {
         minimum: 0,
         maximum: 10,
         description:
-          "0-10. 10 = every claim backed by a verbatim quote from a file read this session AND you observed/reproduced the failure; 7-9 = quote-backed, reproduction inferred; 4-6 = code path identified, mechanism is hypothesis; 1-3 = speculative; 0 = no evidence (prefer report_failure then).",
+          "0-10. 10 = every claim backed by a verbatim quote from a file read this session AND you observed/reproduced the failure; 7-9 = quote-backed, reproduction inferred; 4-6 = code path identified, mechanism is hypothesis; 1-3 = speculative; 0 = no evidence (prefer ask_human then).",
       },
       estimatedImpact: {
         type: "string",
@@ -322,39 +317,12 @@ const MARK_ALREADY_RESOLVED_DEFINITION: OutcomeToolDefinition = {
   },
 };
 
-export type CompleteInvestigationPayload = {
-  disposition: (typeof DISPOSITIONS)[number];
-  recommendedAction?: string;
-};
-
-const COMPLETE_INVESTIGATION_DEFINITION: OutcomeToolDefinition = {
-  name: "complete_investigation",
-  description:
-    "Terminal: you diagnosed the problem but the remediation is not yours to make — no patch, no noise verdict, no resolution claim. The incident stays open with your findings recorded for the humans who must act. Use this when the failing code lives outside the mounted repos (third-party library defect, external API contract), when the customer must act (raise a provider quota, change a region, update env/config), or when a human decision is needed between remediation paths. NEVER use report_failure for a diagnosis you actually made — that throws the diagnosis away.",
-  input_schema: {
-    type: "object",
-    properties: {
-      disposition: {
-        type: "string",
-        enum: DISPOSITIONS,
-        description:
-          "diagnosed_needs_code_change = a code fix is warranted but was not produced this run (policy or missing access). diagnosed_external_cause = the cause is outside the mounted repos and the customer/provider must act. informational = findings recorded, no action required.",
-      },
-      recommendedAction: {
-        type: "string",
-        description: "One sentence: the concrete next step a human should take.",
-      },
-    },
-    required: ["disposition"],
-  },
-};
-
 export type AskHumanPayload = { question: string };
 
 const ASK_HUMAN_DEFINITION: OutcomeToolDefinition = {
   name: "ask_human",
   description:
-    "Terminal: you need specific missing context to continue; the run pauses until a human replies, then resumes with your session intact. Ask for the specific thing you need (expected behavior, a suspected owner, a recent deploy, a repro hint) and include the best leads you checked. Wrong-repo escape hatch: if telemetry names a concrete code artifact (file path, function, exception class, endpoint) that is genuinely absent from every mounted repo at HEAD and across remote branches, use this tool — quote the missing artifact, name the repos you searched, and ask which repo owns the code. Do not use report_failure for that case: more repos exist than were mounted into this session.",
+    "Terminal: a human must act or answer before this investigation can conclude; the run pauses until they reply, then resumes with your session intact. This is the outcome whenever you cannot land on a patch, a noise verdict, or a resolution claim — an investigation never ends with findings merely filed away. Use it when: (1) you need specific missing context (expected behavior, a suspected owner, a recent deploy, a repro hint) — ask for the specific thing and include the best leads you checked; (2) you diagnosed the problem but the remediation is not yours to make (third-party library defect, provider quota, config the customer owns, or a decision needed between remediation paths) — state the diagnosis, then ask the concrete question whose answer unblocks action, naming the options if there are several; (3) you genuinely could not locate the failing code path — say what you searched and ask for the pointer you are missing; (4) telemetry names a concrete code artifact (file path, function, exception class, endpoint) absent from every mounted repo at HEAD and across remote branches — quote the missing artifact, name the repos you searched, and ask which repo owns the code (more repos exist than were mounted into this session). Never fabricate a question to avoid a harder outcome you have the evidence for.",
   input_schema: {
     type: "object",
     properties: {
@@ -367,35 +335,13 @@ const ASK_HUMAN_DEFINITION: OutcomeToolDefinition = {
   },
 };
 
-export type ReportFailurePayload = { reason: (typeof FAILURE_REASONS)[number]; detail: string };
-
-const REPORT_FAILURE_DEFINITION: OutcomeToolDefinition = {
-  name: "report_failure",
-  description:
-    "Terminal: the run itself failed. no_findings is RESERVED for 'I searched the application and genuinely cannot locate the failing code path' — NOT for 'I found the path but it lives in a third-party library or external system' (that is complete_investigation or silence_as_noise) and NOT for 'the artifact is missing from every mounted repo' (that is ask_human). Do not infer code structure from memory of similar codebases — an honest no_findings beats guessing. patch_validation_failed = you produced a patch but your own validation of it failed.",
-  input_schema: {
-    type: "object",
-    properties: {
-      reason: { type: "string", enum: FAILURE_REASONS, description: "Why the run failed." },
-      detail: {
-        type: "string",
-        description:
-          "For no_findings, start with 'Insufficient evidence:' and list the specific files/regions you searched and could not locate or read. For patch_validation_failed, what validation ran and how it failed.",
-      },
-    },
-    required: ["reason", "detail"],
-  },
-};
-
 export const OUTCOME_TOOL_DEFINITIONS: OutcomeToolDefinition[] = [
   REPORT_FINDINGS_DEFINITION,
   PROPOSE_PR_DEFINITION,
   SILENCE_AS_NOISE_DEFINITION,
   PLACE_UNDER_OBSERVATION_DEFINITION,
   MARK_ALREADY_RESOLVED_DEFINITION,
-  COMPLETE_INVESTIGATION_DEFINITION,
   ASK_HUMAN_DEFINITION,
-  REPORT_FAILURE_DEFINITION,
 ];
 
 // ---------------------------------------------------------------------------
@@ -407,9 +353,7 @@ export type TerminalOutcome =
   | { name: "silence_as_noise"; payload: SilenceAsNoisePayload }
   | { name: "place_under_observation"; payload: PlaceUnderObservationPayload }
   | { name: "mark_already_resolved"; payload: MarkAlreadyResolvedPayload }
-  | { name: "complete_investigation"; payload: CompleteInvestigationPayload }
-  | { name: "ask_human"; payload: AskHumanPayload }
-  | { name: "report_failure"; payload: ReportFailurePayload };
+  | { name: "ask_human"; payload: AskHumanPayload };
 
 export type ValidateOutcome =
   | { ok: true; tool: "report_findings"; payload: AgentRunFindings }
@@ -423,7 +367,6 @@ const FINDINGS_REQUIRED = new Set<string>([
   "silence_as_noise",
   "place_under_observation",
   "mark_already_resolved",
-  "complete_investigation",
 ]);
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -499,6 +442,14 @@ export function validateOutcomeToolInput(
   rawInput: unknown,
   ctx: { hasFindings: boolean },
 ): ValidateOutcome {
+  if ((RETIRED_OUTCOME_TOOL_NAMES as readonly string[]).includes(name)) {
+    return {
+      ok: false,
+      errors: [
+        `\`${name}\` is no longer available. End the run with exactly one of: \`propose_pr\`, \`silence_as_noise\`, \`place_under_observation\`, \`mark_already_resolved\`, or \`ask_human\`. If the remediation is not yours to make, or you cannot locate the failing code path, call \`ask_human\` with your findings and the specific question that unblocks action.`,
+      ],
+    };
+  }
   if (!(OUTCOME_TOOL_NAMES as readonly string[]).includes(name)) {
     return { ok: false, errors: [`Unknown outcome tool \`${name}\`.`] };
   }
@@ -639,35 +590,10 @@ export function validateOutcomeToolInput(
       };
     }
 
-    case "complete_investigation": {
-      const disposition = requiredEnum(errors, input, "disposition", DISPOSITIONS);
-      const recommendedAction = optionalString(errors, input, "recommendedAction");
-      if (errors.length > 0) return { ok: false, errors };
-      const payload: CompleteInvestigationPayload = {
-        disposition: disposition as CompleteInvestigationPayload["disposition"],
-      };
-      if (recommendedAction) payload.recommendedAction = recommendedAction;
-      return { ok: true, tool: "complete_investigation", payload };
-    }
-
     case "ask_human": {
       const question = pushRequiredString(errors, input, "question");
       if (errors.length > 0) return { ok: false, errors };
       return { ok: true, tool: "ask_human", payload: { question: question as string } };
-    }
-
-    case "report_failure": {
-      const reason = requiredEnum(errors, input, "reason", FAILURE_REASONS);
-      const detail = pushRequiredString(errors, input, "detail");
-      if (errors.length > 0) return { ok: false, errors };
-      return {
-        ok: true,
-        tool: "report_failure",
-        payload: {
-          reason: reason as ReportFailurePayload["reason"],
-          detail: detail as string,
-        },
-      };
     }
 
     default:
@@ -738,19 +664,9 @@ export function assembleAgentRunResult(args: {
 }): AgentRunResult {
   const { findings, terminal } = args;
 
-  const fallbackSummary =
-    terminal.name === "ask_human"
-      ? terminal.payload.question
-      : terminal.name === "report_failure"
-        ? terminal.payload.detail
-        : "";
+  const fallbackSummary = terminal.name === "ask_human" ? terminal.payload.question : "";
   const result: AgentRunResult = {
-    state:
-      terminal.name === "ask_human"
-        ? "awaiting_human"
-        : terminal.name === "report_failure"
-          ? "failed"
-          : "complete",
+    state: terminal.name === "ask_human" ? "awaiting_human" : "complete",
     summary: findings?.summary ?? fallbackSummary,
   };
   if (findings) applyFindings(result, findings);
@@ -796,20 +712,8 @@ export function assembleAgentRunResult(args: {
         evidence: terminal.payload.evidence,
       };
       break;
-    case "complete_investigation":
-      result.disposition = terminal.payload.disposition;
-      if (terminal.payload.recommendedAction) {
-        result.recommendedAction = terminal.payload.recommendedAction;
-      }
-      break;
     case "ask_human":
       result.question = terminal.payload.question;
-      break;
-    case "report_failure":
-      result.failureReason =
-        terminal.payload.reason === "no_findings"
-          ? ("agent_no_findings" as AgentRunFailureReason)
-          : ("patch_validation_failed" as AgentRunFailureReason);
       break;
   }
 

--- a/apps/worker/src/agent-runs/linear-delivery.test.ts
+++ b/apps/worker/src/agent-runs/linear-delivery.test.ts
@@ -197,14 +197,13 @@ test("skips delivery when the workspace has no teams", async () => {
   assert.equal(deps.calls.createIssue.length, 0);
 });
 
-test("ticket description includes PR link and recommended action when present", () => {
+test("ticket description includes PR link when present", () => {
   const desc = ticketDescription(
     { incidentId: "inc-1", incidentTitle: "t" },
-    { ...RESULT, recommendedAction: "Raise the provider quota." },
+    RESULT,
     "https://github.com/acme/shop/pull/12",
   );
   assert.ok(desc.includes("Proposed fix: https://github.com/acme/shop/pull/12"));
-  assert.ok(desc.includes("## Recommended action"));
   assert.ok(desc.includes(incidentMarker("inc-1")));
 });
 

--- a/apps/worker/src/agent-runs/linear-delivery.ts
+++ b/apps/worker/src/agent-runs/linear-delivery.ts
@@ -54,9 +54,6 @@ export function ticketDescription(
     lines.push("", "## Impact", result.estimatedImpact.text);
   }
   if (result.severity) lines.push("", `Severity: ${result.severity}`);
-  if (result.recommendedAction) {
-    lines.push("", "## Recommended action", result.recommendedAction);
-  }
   if (prUrl) lines.push("", `Proposed fix: ${prUrl}`);
   lines.push("", `[Incident on Superlog](${WEB_ORIGIN}/incidents/${args.incidentId})`);
   lines.push("", incidentMarker(args.incidentId));

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -331,9 +331,7 @@ test("terminalOutcomeNudgePrompt names every terminal outcome tool", () => {
     "silence_as_noise",
     "place_under_observation",
     "mark_already_resolved",
-    "complete_investigation",
     "ask_human",
-    "report_failure",
   ]) {
     assert.ok(prompt.includes(name), `missing ${name}`);
   }

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -172,7 +172,7 @@ export function shouldDeferSteering(snapshot: {
 export function terminalOutcomeNudgePrompt(): string {
   return [
     "You ended your turn without calling a terminal outcome tool, so your investigation has no recorded result.",
-    "Call `report_findings` now if you have findings to record, then end your turn by calling exactly ONE terminal outcome tool: `propose_pr`, `silence_as_noise`, `place_under_observation`, `mark_already_resolved`, `complete_investigation`, `ask_human`, or `report_failure`.",
+    "Call `report_findings` now if you have findings to record, then end your turn by calling exactly ONE terminal outcome tool: `propose_pr`, `silence_as_noise`, `place_under_observation`, `mark_already_resolved`, or `ask_human`.",
   ].join("\n");
 }
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -258,12 +258,6 @@ export type AgentRunResult = {
   mobileRegressionTest?: AgentRunMobileRegressionTest | null;
   noiseClassification?: IncidentNoiseClassification | null;
   resolutionClassification?: IncidentResolutionClassification | null;
-  // How a findings-only completion left the incident: a code change is still
-  // warranted, the cause is external to the mounted repos, or purely
-  // informational. Set by runs that conclude without a PR or classification.
-  disposition?: "diagnosed_needs_code_change" | "diagnosed_external_cause" | "informational" | null;
-  // One-sentence next step for a human, paired with `disposition`.
-  recommendedAction?: string | null;
 };
 
 export const orgs = pgTable("orgs", {


### PR DESCRIPTION
# Summary

An investigation could previously end with nothing happening: `complete_investigation` filed findings on an incident that stayed open with nobody asked to act, and `report_failure` threw the run away. Both are gone. Every run now ends on an actionable outcome — `propose_pr`, `silence_as_noise`, `place_under_observation`, `mark_already_resolved` — or paused on a human via `ask_human`.

`ask_human` absorbs the retired cases. Its description now covers: a diagnosis whose remediation is not the agent's to make (third-party defect, provider quota, customer-owned config, a decision between fix paths) — state the diagnosis, ask the concrete question that unblocks action; and a failing code path the agent genuinely could not locate — say what was searched. The session pauses on the question and resumes with context intact, so the diagnosis stays live instead of rotting on an open incident.

## Compatibility

Sessions created against the old toolset can outlive a deploy (an `awaiting_human` session resumes days later) and may still call a retired tool. `validateOutcomeToolInput` now rejects `complete_investigation` / `report_failure` with redirect guidance listing the live outcomes, so the model re-lands on a real outcome in-session instead of the call falling through to the unknown-tool path and hard-failing the run (`RETIRED_OUTCOME_TOOL_NAMES` is exported for runner integrations that route tool calls by name).

`AgentRunResult` loses the `disposition` / `recommendedAction` fields (nothing rendered them; the Linear ticket body drops its optional "Recommended action" section). Platform-side failure reasons (`agent_no_findings`, `patch_validation_failed`, etc.) are unchanged — they're still produced by the worker for legacy results and failed patch validation.

## Validation

- `pnpm --filter @superlog/worker test:agent-outcome-tools` (23 pass, includes new retired-tool redirect test)
- `test:agent-run-sync`, `test:linear-delivery`, `test:agent-run`, `test:agent-run-start`, `test:agent-run-status`, `test:agent-run-merge`, `test:managed-agent-result`, `test:merge-agent-run`, `test:incident-state` — all pass
- `typecheck` clean on `@superlog/db`, `@superlog/worker`, `@superlog/web`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retired the `complete_investigation` and `report_failure` outcome tools so every run ends with an actionable outcome or pauses on `ask_human`. This prevents silent completions and keeps diagnoses live until a human unblocks.

- **Refactors**
  - Terminal outcomes are now: `propose_pr`, `silence_as_noise`, `place_under_observation`, `mark_already_resolved`, `ask_human`.
  - `ask_human` expanded to cover external remediation, missing code path, and wrong-repo cases; ask a concrete question and resume with context.
  - Validator rejects retired tools with redirect guidance; exported `RETIRED_OUTCOME_TOOL_NAMES` for runner integrations.
  - Removed `disposition` and `recommendedAction` from `AgentRunResult`; Linear ticket no longer shows "Recommended action".
  - `report_findings` 0-evidence guidance now prefers `ask_human`; nudge prompt updated; tests adjusted.

- **Migration**
  - Stop calling `complete_investigation` and `report_failure`; use `ask_human` or a live terminal outcome.
  - Update runners to route using `RETIRED_OUTCOME_TOOL_NAMES` and handle validator errors by re-landing on a live outcome.
  - Remove any reads/writes of `AgentRunResult.disposition` and `.recommendedAction`; do not expect a "Recommended action" section in tickets.
  - Update prompts and tooling to list only the five supported terminal tools.

<sup>Written for commit 9fd798085d5e289b621ac33761c2d63c55b95416. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

