### PR TITLE
Slack: self-join the notification channel so thread replies reach the agent

### DIFF
--- a/apps/api/src/slack.test.ts
+++ b/apps/api/src/slack.test.ts
@@ -195,3 +195,58 @@ test("chat anchors: DMs have no thread anchor (one conversation per channel)", a
     null,
   );
 });
+
+// The bot posts to public channels via chat:write.public WITHOUT joining them,
+// but Slack's Events API only delivers message events for channels the bot is
+// a member of — so thread replies in a never-joined channel vanish silently.
+// joinSlackChannel is the repair: called on install, channel-route changes,
+// and re-auth so replies always reach us.
+test("joinSlackChannel joins the channel and reports success", async () => {
+  const { joinSlackChannel } = await import("./slack.js");
+  const calls: { url: string; body: Record<string, unknown> }[] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    calls.push({ url: String(input), body: JSON.parse(String(init?.body)) });
+    return { json: async () => ({ ok: true, channel: { id: "C123" } }) } as unknown as Response;
+  };
+
+  const result = await joinSlackChannel("xoxb-token", "C123", fetchImpl);
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(calls[0]?.url, "https://slack.com/api/conversations.join");
+  assert.deepEqual(calls[0]?.body, { channel: "C123" });
+});
+
+test("joinSlackChannel treats already_in_channel as success", async () => {
+  const { joinSlackChannel } = await import("./slack.js");
+  const fetchImpl: typeof fetch = async () =>
+    ({
+      json: async () => ({ ok: true, warning: "already_in_channel", channel: { id: "C123" } }),
+    }) as unknown as Response;
+
+  assert.deepEqual(await joinSlackChannel("xoxb-token", "C123", fetchImpl), { ok: true });
+});
+
+// Legacy installations predate the channels:join scope; the caller uses this
+// error to fall back to an "invite the bot" hint instead of failing the flow.
+test("joinSlackChannel surfaces the Slack error (missing_scope, private channels)", async () => {
+  const { joinSlackChannel } = await import("./slack.js");
+  const fetchImpl: typeof fetch = async () =>
+    ({ json: async () => ({ ok: false, error: "missing_scope" }) }) as unknown as Response;
+
+  assert.deepEqual(await joinSlackChannel("xoxb-token", "C123", fetchImpl), {
+    ok: false,
+    error: "missing_scope",
+  });
+});
+
+test("joinSlackChannel never throws on network failure", async () => {
+  const { joinSlackChannel } = await import("./slack.js");
+  const fetchImpl: typeof fetch = async () => {
+    throw new Error("boom");
+  };
+
+  assert.deepEqual(await joinSlackChannel("xoxb-token", "C123", fetchImpl), {
+    ok: false,
+    error: "network_error",
+  });
+});

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -1523,6 +1523,9 @@ export async function joinSlackChannel(
         authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({ channel: channelId }),
+      // Callers sit on user-facing requests (OAuth redirect, route PUT); a
+      // Slack stall must fall through to best-effort, not hang the response.
+      signal: AbortSignal.timeout(5000),
     });
     const data = (await res.json()) as { ok: boolean; error?: string };
     if (!data.ok) return { ok: false, error: data.error ?? "unknown" };

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -33,8 +33,15 @@ const log = logger.child({ scope: "slack" });
 // DMs). Existing installations predating them keep working: channel mentions
 // also arrive as plain `message` events, which the chat router matches by
 // bot-user id. Only DMs strictly need the new scope (and thus a reinstall).
+//
+// `channels:join` lets the bot join the notification channel itself. Posting
+// only needs chat:write.public, but the Events API delivers channel messages
+// solely for channels the bot is a MEMBER of — without joining, thread
+// replies to the agent vanish silently. `users:read` (resolve author ids to
+// names in transcripts/chats) and `reactions:write` (emoji acks) ride along
+// so the next feature doesn't force yet another reinstall wave.
 const SCOPES =
-  "chat:write,chat:write.public,channels:read,groups:read,channels:history,groups:history,app_mentions:read,im:history";
+  "chat:write,chat:write.public,channels:read,groups:read,channels:history,groups:history,app_mentions:read,im:history,channels:join,users:read,reactions:write";
 
 type Vars = { userId: string; orgId: string | null };
 
@@ -154,6 +161,24 @@ export function mountSlackPublic(app: Hono<any>): void {
       },
       "slack installed",
     );
+
+    // Re-auth of an installation that already routes to a channel: join it
+    // now, so a bare reinstall (done to grant channels:join) repairs thread-
+    // reply delivery without the user re-picking the channel. Best-effort —
+    // a failure here must not derail the OAuth redirect.
+    const installed = await findInstallation(projectId);
+    if (installed?.channelId) {
+      const joined = await joinSlackChannel(data.access_token, installed.channelId);
+      log.info(
+        {
+          project_id: projectId,
+          channel_id: installed.channelId,
+          joined: joined.ok,
+          ...(joined.ok ? {} : { join_error: joined.error }),
+        },
+        "slack channel join after install",
+      );
+    }
     void syncLoopsContactsForOrg({ orgId, appUrl: webOrigin }).catch((err) => {
       log.warn({ err, org_id: orgId }, "loops contact sync failed after slack connect");
     });
@@ -930,7 +955,19 @@ export function mountSlackAuthed(app: Hono<any>): void {
       .update(schema.slackInstallations)
       .set({ channelId, channelName })
       .where(eq(schema.slackInstallations.id, install.id));
-    return c.json({ ok: true, channelId, channelName });
+
+    // Join the routed channel so thread replies flow back through the Events
+    // API (posting alone works unjoined via chat:write.public, receiving does
+    // not). Best-effort: private channels and pre-channels:join installs
+    // can't self-join — surface that so the UI can suggest an /invite.
+    const joined = await joinSlackChannel(install.botAccessToken, channelId);
+    if (!joined.ok) {
+      log.info(
+        { project_id: projectId, channel_id: channelId, join_error: joined.error },
+        "slack channel join on route change failed",
+      );
+    }
+    return c.json({ ok: true, channelId, channelName, botJoined: joined.ok });
   });
 
   app.delete("/api/projects/:projectId/slack-route", async (c) => {
@@ -1460,6 +1497,39 @@ export async function listSlackChannels(
   }
   if (cursor) return { ok: false, error: "pagination_limit_exceeded" };
   return { ok: true, channels };
+}
+
+export type JoinSlackChannelResult = { ok: true } | { ok: false; error: string };
+
+// Membership repair for the notification channel: chat:write.public lets the
+// bot post to public channels it never joined, but Slack only delivers
+// `message.channels` events for channels the bot is a member of — so thread
+// replies in a never-joined channel reach nobody. Join is idempotent
+// (`already_in_channel` comes back as ok:true with a warning). Private
+// channels can't be self-joined, but they don't have this gap: posting there
+// already requires an invite. Callers treat failure as best-effort —
+// `missing_scope` means a pre-channels:join installation that needs a
+// re-auth (or a manual invite).
+export async function joinSlackChannel(
+  token: string,
+  channelId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<JoinSlackChannelResult> {
+  try {
+    const res = await fetchImpl("https://slack.com/api/conversations.join", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ channel: channelId }),
+    });
+    const data = (await res.json()) as { ok: boolean; error?: string };
+    if (!data.ok) return { ok: false, error: data.error ?? "unknown" };
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "network_error" };
+  }
 }
 
 // Slack interactivity envelope. `view.state.values` is keyed by block_id

--- a/apps/worker/src/infra/slack/api.ts
+++ b/apps/worker/src/infra/slack/api.ts
@@ -83,6 +83,9 @@ export async function joinSlackChannel(target: SlackTarget): Promise<SlackJoinRe
         authorization: `Bearer ${target.botToken}`,
       },
       body: JSON.stringify({ channel: target.channelId }),
+      // Pre-post path: a Slack stall must degrade to the soft-failure branch,
+      // not hold up the notification (fetch has no default timeout).
+      signal: AbortSignal.timeout(5000),
     });
     const data = (await res.json()) as { ok: boolean; error?: string };
     if (!data.ok) {
@@ -107,6 +110,9 @@ export async function fetchChannelMembership(target: SlackTarget): Promise<boole
     url.searchParams.set("channel", target.channelId);
     const res = await fetch(url, {
       headers: { authorization: `Bearer ${target.botToken}` },
+      // Pre-post path, same as the join above: bounded so a stall degrades to
+      // "membership unknown" instead of delaying the notification.
+      signal: AbortSignal.timeout(5000),
     });
     const data = (await res.json()) as {
       ok: boolean;

--- a/apps/worker/src/infra/slack/api.ts
+++ b/apps/worker/src/infra/slack/api.ts
@@ -66,6 +66,61 @@ export async function postSlackMessage(opts: {
   }
 }
 
+export type SlackJoinResult = { ok: true } | { ok: false; error: string };
+
+// Best-effort membership repair before posting a notification root: Slack only
+// delivers `message.channels` events for channels the bot is a member of, so
+// a never-joined channel silently swallows every thread reply to the agent.
+// Idempotent — `already_in_channel` comes back as ok:true with a warning.
+// Fails softly (`missing_scope` on pre-channels:join installs, private
+// channels) and the caller decides whether to hint the user instead.
+export async function joinSlackChannel(target: SlackTarget): Promise<SlackJoinResult> {
+  try {
+    const res = await fetch("https://slack.com/api/conversations.join", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        authorization: `Bearer ${target.botToken}`,
+      },
+      body: JSON.stringify({ channel: target.channelId }),
+    });
+    const data = (await res.json()) as { ok: boolean; error?: string };
+    if (!data.ok) {
+      if (data.error && REVOKE_ERRORS.has(data.error)) {
+        await markInstallationRevoked(target.installationId);
+      }
+      return { ok: false, error: data.error ?? "unknown" };
+    }
+    return { ok: true };
+  } catch (err) {
+    logger.warn({ scope: "slack", err }, "conversations.join failed");
+    return { ok: false, error: "network_error" };
+  }
+}
+
+// Whether the bot is a member of the channel, or null when Slack didn't say
+// (API error, network failure) — callers must treat null as "unknown", not
+// "not a member".
+export async function fetchChannelMembership(target: SlackTarget): Promise<boolean | null> {
+  try {
+    const url = new URL("https://slack.com/api/conversations.info");
+    url.searchParams.set("channel", target.channelId);
+    const res = await fetch(url, {
+      headers: { authorization: `Bearer ${target.botToken}` },
+    });
+    const data = (await res.json()) as {
+      ok: boolean;
+      error?: string;
+      channel?: { is_member?: boolean };
+    };
+    if (!data.ok || typeof data.channel?.is_member !== "boolean") return null;
+    return data.channel.is_member;
+  } catch (err) {
+    logger.warn({ scope: "slack", err }, "conversations.info failed");
+    return null;
+  }
+}
+
 export async function updateSlackMessage(opts: {
   target: SlackTarget;
   ts: string;

--- a/apps/worker/src/infra/slack/incident-messages.test.ts
+++ b/apps/worker/src/infra/slack/incident-messages.test.ts
@@ -38,3 +38,38 @@ test("incidentBlocks omits environment when absent", () => {
   );
   assert.equal(line, "`Acme` · `api`");
 });
+
+// Thread replies only reach us from channels the bot is a MEMBER of (posting
+// works unjoined via chat:write.public — receiving does not). When the bot
+// can't self-join (legacy install without channels:join, private channel) and
+// isn't a member, the root notification must carry an invite hint so users
+// learn replies are dead BEFORE they talk into the void.
+test("needsInviteHint: join succeeded → no hint", async () => {
+  const { needsInviteHint } = await import("./incident-messages.js");
+  assert.equal(needsInviteHint({ ok: true }, null), false);
+});
+
+test("needsInviteHint: join failed but bot already a member → no hint", async () => {
+  const { needsInviteHint } = await import("./incident-messages.js");
+  assert.equal(needsInviteHint({ ok: false, error: "missing_scope" }, true), false);
+});
+
+test("needsInviteHint: join failed and bot not a member → hint", async () => {
+  const { needsInviteHint } = await import("./incident-messages.js");
+  assert.equal(needsInviteHint({ ok: false, error: "missing_scope" }, false), true);
+});
+
+test("needsInviteHint: membership unknown → no hint (never nag on flaky lookups)", async () => {
+  const { needsInviteHint } = await import("./incident-messages.js");
+  assert.equal(needsInviteHint({ ok: false, error: "missing_scope" }, null), false);
+});
+
+test("inviteHintBlock is a context block that tells the user to invite the bot", async () => {
+  const { inviteHintBlock } = await import("./incident-messages.js");
+  const block = inviteHintBlock() as {
+    type: string;
+    elements: Array<{ type: string; text: string }>;
+  };
+  assert.equal(block.type, "context");
+  assert.ok(block.elements[0]?.text.includes("/invite"));
+});

--- a/apps/worker/src/infra/slack/incident-messages.ts
+++ b/apps/worker/src/infra/slack/incident-messages.ts
@@ -2,7 +2,14 @@ import { db, environmentFromResourceAttrs, schema } from "@superlog/db";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { logger } from "../../logger.js";
 import { isStaleSlackAnchorError } from "../../slack-pinning.js";
-import { type SlackTarget, postSlackMessage, updateSlackMessage } from "./api.js";
+import {
+  type SlackJoinResult,
+  type SlackTarget,
+  fetchChannelMembership,
+  joinSlackChannel,
+  postSlackMessage,
+  updateSlackMessage,
+} from "./api.js";
 
 const WEB_ORIGIN = process.env.WEB_ORIGIN ?? "http://localhost:5173";
 
@@ -222,16 +229,59 @@ export async function updateIncidentMainMessage(
   }
 }
 
+// Thread replies to the agent only arrive from channels the bot is a member
+// of; posting alone works unjoined (chat:write.public). When the bot can't
+// self-join AND is provably not a member, the root notification carries an
+// invite hint — otherwise users reply into the void with no error anywhere.
+// Membership `null` means Slack didn't say; stay silent rather than nag on a
+// flaky lookup.
+export function needsInviteHint(join: SlackJoinResult, isMember: boolean | null): boolean {
+  return !join.ok && isMember === false;
+}
+
+export function inviteHintBlock(): unknown {
+  return {
+    type: "context",
+    elements: [
+      {
+        type: "mrkdwn",
+        text: "⚠️ The Superlog bot isn't a member of this channel, so thread replies won't reach the agent. `/invite` the bot here (or reconnect Slack in project settings) to enable replies.",
+      },
+    ],
+  };
+}
+
+// Join the channel (idempotent) so replies in the new thread reach the Events
+// API; when joining is impossible, return the invite hint to append to the
+// root blocks. One extra Slack call per NEW incident root — thread replies and
+// updates skip this entirely.
+async function ensureJoinedOrHint(target: SlackTarget): Promise<unknown[]> {
+  const join = await joinSlackChannel(target);
+  if (join.ok) return [];
+  const isMember = await fetchChannelMembership(target);
+  logger.info(
+    {
+      scope: "slack",
+      channel: target.channelId,
+      join_error: join.error,
+      is_member: isMember,
+    },
+    "slack channel self-join failed before incident root post",
+  );
+  return needsInviteHint(join, isMember) ? [inviteHintBlock()] : [];
+}
+
 async function postAndRememberIncidentRoot(opts: {
   incidentId: string;
   target: SlackTarget;
   text: string;
   blocks?: unknown[];
 }): Promise<string | null> {
+  const hintBlocks = await ensureJoinedOrHint(opts.target);
   const data = await postSlackMessage({
     target: opts.target,
     text: opts.text,
-    blocks: opts.blocks,
+    blocks: opts.blocks ? [...opts.blocks, ...hintBlocks] : undefined,
   });
   if (!data?.ok || !data.ts) return null;
   await db


### PR DESCRIPTION
## Problem

Replying to the agent in an incident's Slack thread can silently do nothing — no acknowledgement, no follow-up, no error anywhere.

The bot posts incident notifications to public channels via `chat:write.public`, which does **not** join the channel. Slack's Events API, however, only delivers `message.channels` events for channels the bot is a **member** of. So unless someone happened to `/invite` the bot, every thread reply vanished before reaching `/slack/events`. Because posting works fine, nothing ever surfaces the broken reply path — users reasonably assume the bot can hear them.

## Fix

**Self-join the channel** (new `channels:join` scope):
- on OAuth install/re-auth, when the installation already routes to a channel — so a bare reinstall repairs reply delivery without re-picking the channel
- on channel-route changes (`PUT /api/projects/:id/slack-route`, response now includes `botJoined`)
- idempotently before each new incident root post in the worker (`already_in_channel` is ok), as a safety net for kicked/changed channels

**Invite hint fallback** for installations that can't self-join (pre-`channels:join` installs, private channels): when the bot is provably not a member (`conversations.info` → `is_member: false`), the incident root notification carries a context block telling the user to `/invite` the bot or reconnect Slack. Membership *unknown* stays silent — never nag on a flaky lookup.

**Scope batching:** also requests `users:read` and `reactions:write` now, so near-term features (author-name resolution in transcripts, emoji acks) don't force workspaces through yet another reinstall.

Private channels don't have the receive gap: posting there already requires membership.

## Tests

- `joinSlackChannel`: join success, `already_in_channel`, Slack error surfacing (`missing_scope`), network failure never throws
- `needsInviteHint`: joined → no hint; failed-but-member → no hint; failed-and-not-member → hint; membership unknown → no hint
- `inviteHintBlock` shape
- Full api (Slack suites) + worker test runs green; both apps typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically join the Slack notification channel so thread replies reach the agent. If joining isn’t possible, the incident root message shows a small invite hint to prevent silent failures.

- **Bug Fixes**
  - Self-join the routed channel via `conversations.join` on install/re-auth, on route changes, and before posting a new incident root; calls use a 5s timeout so OAuth and notifications never stall. This ensures we receive `message.channels` events; posting via `chat:write.public` alone wasn’t enough.
  - If join fails and the bot isn’t a member, append a context hint telling users to `/invite` the bot (membership is checked via `conversations.info`; no hint on unknown results).
  - OAuth now requests `channels:join`, plus `users:read` and `reactions:write` for upcoming features.

- **Migration**
  - Existing workspaces should reconnect Slack to grant `channels:join`. A simple reinstall auto-joins the already routed channel; no need to re-pick it.

<sup>Written for commit ca35721a99e14ee8800da8a4120dd65737ee8483. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

