### PR TITLE
Keep Slack Q&A chat turns open until the session is terminal

### DIFF
--- a/apps/worker/src/agent-chats/tick.ts
+++ b/apps/worker/src/agent-chats/tick.ts
@@ -108,6 +108,9 @@ const deps: AgentChatWorkflowDeps = {
     }
     await postReplyExactlyOnce(chat, text, dedupeId, 0);
   },
+  log(event) {
+    log.info(event, "agent chat tick decision");
+  },
   async meterTurn(chat, snapshot) {
     const project = await db.query.projects.findFirst({
       where: eq(schema.projects.id, chat.projectId),

--- a/apps/worker/src/agent-chats/workflow.test.ts
+++ b/apps/worker/src/agent-chats/workflow.test.ts
@@ -59,6 +59,9 @@ function snapshot(overrides: Partial<AgentRunnerSnapshot> = {}): AgentRunnerSnap
   return {
     sessionId: "session-1",
     status: "idle",
+    // Default represents a genuinely finished turn so the idle-close tests
+    // stay meaningful; non-terminal idles are exercised explicitly below.
+    stopReason: { type: "end_turn", eventIds: [] },
     activeSeconds: 30,
     events: [],
     result: null,
@@ -250,6 +253,41 @@ test("idle turn with no reply and no last message posts the no-answer text", asy
   await syncRunningAgentChat(chat({ state: "running", providerSessionId: "session-1" }), h.deps);
 
   assert.deepEqual(h.replies, [CHAT_NO_ANSWER_TEXT]);
+});
+
+test("idle awaiting a pending reply keeps running instead of posting the fallback", async () => {
+  // The agent emitted send_slack_reply this tick; the session sits idle with
+  // requires_action until the next dispatch acks it. Closing here would strand
+  // the reply and post the no-answer text. Keep the chat running.
+  const h = makeHarness({
+    pending: [],
+    repliesThisTurn: 0,
+    snapshot: snapshot({
+      status: "idle",
+      stopReason: { type: "requires_action", eventIds: ["sevt_reply"] },
+    }),
+  });
+  await syncRunningAgentChat(chat({ state: "running", providerSessionId: "session-1" }), h.deps);
+
+  assert.deepEqual(h.replies, []);
+  assert.ok(!h.updates.some((u) => u.patch.state === "idle"));
+  assert.ok(!h.calls.includes("meterTurn"));
+  const kept = h.updates.find((u) => u.whenState?.[0] === "running");
+  assert.ok(kept);
+});
+
+test("a freshly-started session that has not idled yet keeps running", async () => {
+  // First sync can fire before session.status_running; the session reads idle
+  // with no stop_reason. Treating that as a finished turn was the original bug.
+  const h = makeHarness({
+    pending: [],
+    repliesThisTurn: 0,
+    snapshot: snapshot({ status: "idle", stopReason: null, latestMessage: null }),
+  });
+  await syncRunningAgentChat(chat({ state: "running", providerSessionId: "session-1" }), h.deps);
+
+  assert.deepEqual(h.replies, []);
+  assert.ok(!h.updates.some((u) => u.patch.state === "idle"));
 });
 
 test("messages arriving mid-turn steer the live session and stay running", async () => {

--- a/apps/worker/src/agent-chats/workflow.ts
+++ b/apps/worker/src/agent-chats/workflow.ts
@@ -83,6 +83,17 @@ export type AgentChatWorkflowDeps = {
   postReply(chat: AgentChat, text: string, dedupeId?: string): Promise<void>;
   // Called once per finished turn, after the state transition commits.
   meterTurn(chat: AgentChat, snapshot: AgentRunnerSnapshot): Promise<void>;
+  // Structured, per-tick decision log. The chat path is otherwise silent, so
+  // this is the only way to reconstruct why a turn closed (or kept running)
+  // from production logs. Optional — omitted in tests.
+  log?(event: {
+    chatId: string;
+    sessionId: string;
+    status: string;
+    stopReason: string | null;
+    repliesThisTurn: number;
+    decision: "await-session" | "turn-finished";
+  }): void;
 };
 
 // Deliver the queued human messages: into the existing durable session when
@@ -286,14 +297,35 @@ export async function syncRunningAgentChat(
     return;
   }
 
-  if (snapshot.status === "running" || snapshot.status === "rescheduling") {
+  // `idle` does NOT imply the turn is over. Keep driving the session — leave
+  // the chat `running` so the next tick dispatches again — unless it has
+  // reached a genuinely terminal state. Two non-terminal idles used to close
+  // the turn prematurely and strand the session:
+  //   - a freshly-created session reads `idle` with no stop_reason before its
+  //     first run (the worker could sync before `session.status_running`), and
+  //   - a session that just emitted the reply tool sits idle with
+  //     `requires_action` until the next dispatch acks it.
+  // In both cases closing here posts the no-answer fallback and abandons a
+  // reply the agent is about to (or already did) produce. Only a concrete,
+  // non-`requires_action` stop_reason means the turn actually finished.
+  const stop = snapshot.stopReason?.type ?? null;
+  const turnFinished = snapshot.status === "idle" && stop !== null && stop !== "requires_action";
+  if (!turnFinished) {
     await deps.updateChat(chat.id, progressPatch, ["running"]);
+    deps.log?.({
+      chatId: chat.id,
+      sessionId,
+      status: snapshot.status,
+      stopReason: stop,
+      repliesThisTurn: dispatch.repliesThisTurn,
+      decision: "await-session",
+    });
     return;
   }
 
-  // idle: the turn finished. Win the transition first so concurrent workers
-  // can't both send the no-reply fallback; the loser leaves delivery (and
-  // metering) to the winner.
+  // The turn finished. Win the transition first so concurrent workers can't
+  // both send the no-reply fallback; the loser leaves delivery (and metering)
+  // to the winner.
   const moved = await deps.updateChat(chat.id, { ...progressPatch, state: "idle" }, ["running"]);
   if (moved) {
     // The reply tool is the delivery path; a turn that went idle without a
@@ -302,6 +334,14 @@ export async function syncRunningAgentChat(
       await deps.postReply(chat, snapshot.latestMessage?.trim() || CHAT_NO_ANSWER_TEXT);
     }
     await deps.meterTurn(chat, snapshot);
+    deps.log?.({
+      chatId: chat.id,
+      sessionId,
+      status: snapshot.status,
+      stopReason: stop,
+      repliesThisTurn: dispatch.repliesThisTurn,
+      decision: "turn-finished",
+    });
   }
   // A message that landed between collect() and the transition would
   // otherwise sit unprocessed until the next inbound wakes the chat.

--- a/apps/worker/src/agent-runner-backend.ts
+++ b/apps/worker/src/agent-runner-backend.ts
@@ -99,12 +99,17 @@ export type AgentRunnerStartInput = {
 export type AgentRunnerSnapshot = {
   sessionId: string;
   status: "running" | "idle" | "terminated" | "rescheduling";
-  // The stop_reason of the session's most recent idle, or null if it has not
-  // idled yet. `status: "idle"` is ambiguous on its own: a session idles both
-  // when a turn truly ends (`end_turn`) and when it is blocked awaiting a
-  // client-side tool result (`requires_action` — e.g. the chat reply tool the
-  // worker dispatches). The chat workflow keys off this to avoid closing a
-  // turn that is really still waiting on a reply it must deliver.
+  // The current turn's idle stop_reason, or null if the turn hasn't idled yet.
+  // Backends MUST scope this to the current turn: it is null while the turn is
+  // still in flight (fresh session before its first run, or a resumed session
+  // whose new message the provider hasn't picked up), and non-null only for an
+  // idle that followed the latest inbound message — a prior turn's `end_turn`
+  // must never leak through. `status: "idle"` is ambiguous on its own: a
+  // session idles both when a turn truly ends (`end_turn`) and when it is
+  // blocked awaiting a client-side tool result (`requires_action` — e.g. the
+  // chat reply tool the worker dispatches). The chat workflow keys off this to
+  // avoid closing a turn that is really still waiting on a reply it must
+  // deliver, or a resumed turn the provider hasn't started yet.
   stopReason: { type: string; eventIds: string[] } | null;
   activeSeconds: number;
   events: Array<{

--- a/apps/worker/src/agent-runner-backend.ts
+++ b/apps/worker/src/agent-runner-backend.ts
@@ -99,6 +99,13 @@ export type AgentRunnerStartInput = {
 export type AgentRunnerSnapshot = {
   sessionId: string;
   status: "running" | "idle" | "terminated" | "rescheduling";
+  // The stop_reason of the session's most recent idle, or null if it has not
+  // idled yet. `status: "idle"` is ambiguous on its own: a session idles both
+  // when a turn truly ends (`end_turn`) and when it is blocked awaiting a
+  // client-side tool result (`requires_action` — e.g. the chat reply tool the
+  // worker dispatches). The chat workflow keys off this to avoid closing a
+  // turn that is really still waiting on a reply it must deliver.
+  stopReason: { type: string; eventIds: string[] } | null;
   activeSeconds: number;
   events: Array<{
     id: string;

--- a/apps/worker/src/infra/agent-runner/community.ts
+++ b/apps/worker/src/infra/agent-runner/community.ts
@@ -13,6 +13,7 @@ export const communityRunnerBackend: AgentRunnerBackend = {
     const snapshot: AgentRunnerSnapshot = {
       sessionId,
       status: "terminated",
+      stopReason: null,
       activeSeconds: 0,
       events: [
         {


### PR DESCRIPTION
## Problem

The Slack Q&A chat worker sometimes replied with the *"I finished without a concrete answer. Try rephrasing or narrowing the question."* fallback while the underlying agent session had actually produced a full answer — and the reply tool call was left stuck, unacked, forever.

`syncRunningAgentChat` closed a turn whenever the runner reported `status: "idle"`. But `idle` is ambiguous:

- A **freshly-created session** reads `idle` (no `stop_reason`) for a short window before its first run. The first sync tick could fire before the session started running and immediately conclude the turn was over — with zero active seconds.
- After the agent calls the **reply tool**, the session sits `idle` with `stop_reason: "requires_action"` until the worker acks the tool result.

In both cases the worker posted the no-answer fallback and moved the chat to `idle`, so it never synced again. The reply the agent was about to produce (or already had) was never dispatched, and the session hung with an unacked custom tool call.

## Fix

- Carry the latest idle `stop_reason` on the runner snapshot (`stopReason: { type, eventIds } | null`).
- Treat the turn as finished **only** on `idle` with a concrete, non-`requires_action` stop_reason. Every other state (running, rescheduling, startup idle, `requires_action`) keeps the chat `running`, so the next tick dispatches again and drives the session to completion — delivering the reply instead of the fallback.
- Add a per-tick decision log to the chat workflow, which was otherwise silent and left runs undiagnosable from logs.

## Tests

`apps/worker/src/agent-chats/workflow.test.ts` — 19/19, including two new cases:
- `idle` + `requires_action` keeps the chat running and posts no fallback.
- a freshly-started session that has not idled yet keeps running (the original startup race).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep Slack Q&A chat turns open until the agent session is truly finished, preventing premature fallbacks and stranded reply tool calls.

- **Bug Fixes**
  - Close a turn only when `status: "idle"` with a non-`requires_action` `stopReason`; otherwise keep the chat `running` (covers startup idle and pending reply).
  - Tighten `AgentRunnerSnapshot.stopReason`: scope it to the current turn and keep it `null` until this turn idles after the latest inbound message; set `null` for community sessions.
  - Add structured per-tick decision logging to show why a turn was kept open or closed.
  - Tests: new cases for `idle + requires_action` and startup idle; default snapshot now represents a truly finished turn.

<sup>Written for commit 26fbdfd9154a13579235be1ed0cd6f2c00941580. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

