### PR TITLE
Explore: deep-link "Open in Explore" from incident query cards

### DIFF
--- a/apps/web/src/Explore.tsx
+++ b/apps/web/src/Explore.tsx
@@ -42,6 +42,7 @@ import {
   useSyncCloudConnection,
 } from "./api.ts";
 import { Dropdown } from "./design/Dropdown.tsx";
+import { CUSTOM_RANGE_LABEL, parseAbsoluteRange } from "./design/range-url.ts";
 import {
   RANGE_PRESETS,
   RangePicker,
@@ -234,7 +235,18 @@ function ExploreInner({ projectId }: { projectId: string }) {
   const [metricShowLegend, setMetricShowLegend] = useState(true);
   const [limit, setLimit] = useState(100);
 
-  const range = useMemo(() => rangeFromSeconds(selection.seconds, nowTick), [selection, nowTick]);
+  // A page can be deep-linked (e.g. from an incident's telemetry query) to a
+  // fixed absolute window via `?since=…&until=…`. When present and valid it
+  // pins the range instead of the live "last N" preset; picking any preset in
+  // the RangePicker clears these params and returns to a sliding window.
+  const absoluteRange = useMemo(
+    () => parseAbsoluteRange(searchParams.get("since"), searchParams.get("until")),
+    [searchParams],
+  );
+  const range = useMemo(
+    () => absoluteRange ?? rangeFromSeconds(selection.seconds, nowTick),
+    [absoluteRange, selection, nowTick],
+  );
 
   const filter: ExploreFilter = useMemo(
     () => ({
@@ -295,7 +307,7 @@ function ExploreInner({ projectId }: { projectId: string }) {
         {/* Resources are inventory, not time-ranged telemetry — no range picker. */}
         {source !== "resources" && (
           <RangePicker
-            value={selection}
+            value={absoluteRange ? { seconds: 0, label: CUSTOM_RANGE_LABEL } : selection}
             range={range}
             onChange={(next) => {
               const span = tracer.startSpan("explore.range_change", {
@@ -308,6 +320,14 @@ function ExploreInner({ projectId }: { projectId: string }) {
               try {
                 setSelection(next);
                 setNowTick(Date.now());
+                // Leaving a pinned absolute window for a live preset — drop the
+                // deep-link params so the range slides again.
+                if (absoluteRange) {
+                  updateParams((p) => {
+                    p.delete("since");
+                    p.delete("until");
+                  });
+                }
               } finally {
                 span.end();
               }

--- a/apps/web/src/Explore.tsx
+++ b/apps/web/src/Explore.tsx
@@ -320,9 +320,10 @@ function ExploreInner({ projectId }: { projectId: string }) {
               try {
                 setSelection(next);
                 setNowTick(Date.now());
-                // Leaving a pinned absolute window for a live preset — drop the
-                // deep-link params so the range slides again.
-                if (absoluteRange) {
+                // Picking a live preset drops any pinned-window params so the
+                // range slides again — keyed on the raw params (not the parsed
+                // range) so a malformed `since`/`until` gets cleaned up too.
+                if (searchParams.has("since") || searchParams.has("until")) {
                   updateParams((p) => {
                     p.delete("since");
                     p.delete("until");

--- a/apps/web/src/design/range-url.test.ts
+++ b/apps/web/src/design/range-url.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseAbsoluteRange } from "./range-url.ts";
+
+test("parseAbsoluteRange accepts a valid absolute ISO window", () => {
+  assert.deepEqual(parseAbsoluteRange("2026-06-26T02:40:00Z", "2026-06-26T03:10:00Z"), {
+    since: "2026-06-26T02:40:00Z",
+    until: "2026-06-26T03:10:00Z",
+  });
+});
+
+test("parseAbsoluteRange rejects a missing bound", () => {
+  assert.equal(parseAbsoluteRange(null, "2026-06-26T03:10:00Z"), null);
+  assert.equal(parseAbsoluteRange("2026-06-26T02:40:00Z", null), null);
+  assert.equal(parseAbsoluteRange(null, null), null);
+});
+
+test("parseAbsoluteRange rejects non-ISO / ClickHouse expressions", () => {
+  assert.equal(parseAbsoluteRange("now() - INTERVAL 2 HOUR", "now()"), null);
+  assert.equal(parseAbsoluteRange("yesterday", "today"), null);
+  assert.equal(parseAbsoluteRange("", ""), null);
+});
+
+test("parseAbsoluteRange rejects a non-positive window (until <= since)", () => {
+  assert.equal(parseAbsoluteRange("2026-06-26T03:10:00Z", "2026-06-26T02:40:00Z"), null);
+  assert.equal(parseAbsoluteRange("2026-06-26T03:10:00Z", "2026-06-26T03:10:00Z"), null);
+});

--- a/apps/web/src/design/range-url.test.ts
+++ b/apps/web/src/design/range-url.test.ts
@@ -25,3 +25,28 @@ test("parseAbsoluteRange rejects a non-positive window (until <= since)", () => 
   assert.equal(parseAbsoluteRange("2026-06-26T03:10:00Z", "2026-06-26T02:40:00Z"), null);
   assert.equal(parseAbsoluteRange("2026-06-26T03:10:00Z", "2026-06-26T03:10:00Z"), null);
 });
+
+test("parseAbsoluteRange rejects impossible calendar dates instead of normalizing them", () => {
+  // Date.parse would silently roll these forward; a deep link must not pin them.
+  assert.equal(parseAbsoluteRange("2026-02-31T00:00:00Z", "2026-06-26T03:10:00Z"), null); // Feb 31
+  assert.equal(parseAbsoluteRange("2026-06-31T00:00:00Z", "2026-06-26T03:10:00Z"), null); // Jun 31
+  assert.equal(parseAbsoluteRange("2026-13-01T00:00:00Z", "2026-06-26T03:10:00Z"), null); // month 13
+  assert.equal(parseAbsoluteRange("2026-00-10T00:00:00Z", "2026-06-26T03:10:00Z"), null); // month 0
+  assert.equal(parseAbsoluteRange("2025-02-29T00:00:00Z", "2026-06-26T03:10:00Z"), null); // 2025 not leap
+});
+
+test("parseAbsoluteRange rejects out-of-range time components", () => {
+  assert.equal(parseAbsoluteRange("2026-06-26T24:00:00Z", "2026-06-27T00:00:00Z"), null); // hour 24
+  assert.equal(parseAbsoluteRange("2026-06-26T10:60:00Z", "2026-06-27T00:00:00Z"), null); // minute 60
+});
+
+test("parseAbsoluteRange accepts a real leap day and a space separator", () => {
+  assert.deepEqual(parseAbsoluteRange("2024-02-29T00:00:00Z", "2024-03-01T00:00:00Z"), {
+    since: "2024-02-29T00:00:00Z",
+    until: "2024-03-01T00:00:00Z",
+  });
+  assert.deepEqual(parseAbsoluteRange("2026-06-26 02:40:00", "2026-06-26 03:10:00"), {
+    since: "2026-06-26 02:40:00",
+    until: "2026-06-26 03:10:00",
+  });
+});

--- a/apps/web/src/design/range-url.ts
+++ b/apps/web/src/design/range-url.ts
@@ -10,19 +10,40 @@ import type { ExploreRange } from "../api.ts";
 // rather than a live "last N" preset.
 export const CUSTOM_RANGE_LABEL = "Custom";
 
-const ISO_RE = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/;
+const ISO_RE = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?/;
+
+/** True when `s` is an absolute ISO timestamp with a real calendar date/time.
+ *  Guards against `Date.parse` silently normalizing impossible inputs — it
+ *  rolls `2026-02-31` forward to March instead of rejecting it — by validating
+ *  the month/day (leap-aware) and time components directly. */
+function isCalendarTimestamp(s: string): boolean {
+  const m = ISO_RE.exec(s);
+  if (!m) return false;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+  const hour = Number(m[4]);
+  const minute = Number(m[5]);
+  const second = m[6] ? Number(m[6]) : 0;
+  if (month < 1 || month > 12) return false;
+  if (hour > 23 || minute > 59 || second > 59) return false;
+  const leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+  const daysInMonth = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1] ?? 31;
+  return day >= 1 && day <= daysInMonth;
+}
 
 /** Validate a pair of URL `since`/`until` values into a fixed absolute range.
- *  Requires both bounds to be absolute ISO timestamps forming a positive
- *  window; rejects missing bounds, ClickHouse time expressions (`now() - …`),
- *  and inverted/empty ranges so a malformed URL falls back to the default
- *  preset instead of pinning a nonsense window. */
+ *  Requires both bounds to be absolute ISO timestamps with real calendar
+ *  dates forming a positive window; rejects missing bounds, ClickHouse time
+ *  expressions (`now() - …`), impossible dates, and inverted/empty ranges so a
+ *  malformed URL falls back to the default preset instead of pinning a
+ *  nonsense window. */
 export function parseAbsoluteRange(
   since: string | null | undefined,
   until: string | null | undefined,
 ): ExploreRange | null {
   if (!since || !until) return null;
-  if (!ISO_RE.test(since) || !ISO_RE.test(until)) return null;
+  if (!isCalendarTimestamp(since) || !isCalendarTimestamp(until)) return null;
   const s = Date.parse(since);
   const u = Date.parse(until);
   if (!Number.isFinite(s) || !Number.isFinite(u) || s >= u) return null;

--- a/apps/web/src/design/range-url.ts
+++ b/apps/web/src/design/range-url.ts
@@ -1,0 +1,30 @@
+// Pure helpers for representing an absolute time window in the Explore URL.
+// The range picker itself works in live "last N" presets (RangePicker.tsx),
+// but a page can be deep-linked (e.g. from an incident's telemetry query) to a
+// fixed absolute window via `?since=…&until=…`. Kept in a JSX-free module so it
+// can be unit-tested with `node --test`.
+
+import type { ExploreRange } from "../api.ts";
+
+// Label shown on the picker trigger when the range is a fixed absolute window
+// rather than a live "last N" preset.
+export const CUSTOM_RANGE_LABEL = "Custom";
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/;
+
+/** Validate a pair of URL `since`/`until` values into a fixed absolute range.
+ *  Requires both bounds to be absolute ISO timestamps forming a positive
+ *  window; rejects missing bounds, ClickHouse time expressions (`now() - …`),
+ *  and inverted/empty ranges so a malformed URL falls back to the default
+ *  preset instead of pinning a nonsense window. */
+export function parseAbsoluteRange(
+  since: string | null | undefined,
+  until: string | null | undefined,
+): ExploreRange | null {
+  if (!since || !until) return null;
+  if (!ISO_RE.test(since) || !ISO_RE.test(until)) return null;
+  const s = Date.parse(since);
+  const u = Date.parse(until);
+  if (!Number.isFinite(s) || !Number.isFinite(u) || s >= u) return null;
+  return { since, until };
+}

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -6,6 +6,7 @@ import { Chip, type ChipTone } from "../design/ui.tsx";
 import { LogsTable, TracesTable } from "../Explore.tsx";
 import {
   type TelemetryKind,
+  exploreHref,
   formatRangeLabel,
   parseResultRows,
   telemetryToolKind,
@@ -439,7 +440,7 @@ export function TelemetryQueryWidget({
         )}
         {!empty && <span className="text-subtle">· {count} rows</span>}
         <a
-          href="/explore"
+          href={exploreHref(kind, input)}
           className="ml-auto inline-flex h-7 items-center rounded-md px-2.5 text-[12px] font-medium text-fg transition-colors hover:bg-surface-2"
         >
           Open in Explore

--- a/apps/web/src/incidents/telemetry-result.test.ts
+++ b/apps/web/src/incidents/telemetry-result.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  exploreHref,
   formatRangeLabel,
   normalizeBucket,
   parseResultRows,
@@ -8,6 +9,21 @@ import {
   toMetricRows,
   toTraceRows,
 } from "./telemetry-result.ts";
+
+// react-router decodes `attr` values, so compare on the decoded query the
+// Explore page actually receives rather than the percent-encoded raw string.
+function decodedParams(href: string): {
+  path: string;
+  attrs: string[];
+  rest: Record<string, string>;
+} {
+  const [path, qs = ""] = href.split("?");
+  const p = new URLSearchParams(qs);
+  const attrs = p.getAll("attr");
+  const rest: Record<string, string> = {};
+  for (const [k, v] of p) if (k !== "attr") rest[k] = v;
+  return { path: path!, attrs, rest };
+}
 
 test("telemetryToolKind maps the three query tools and nothing else", () => {
   assert.equal(telemetryToolKind("query_metrics"), "metrics");
@@ -78,6 +94,127 @@ test("toTraceRows coerces the span fields the table needs, tolerating missing on
   assert.equal(rows[1]!.service, "x");
   assert.equal(rows[1]!.span_name, "");
   assert.equal(rows[1]!.duration_ms, 0);
+});
+
+test("exploreHref points at the matching source with no filters when input is bare", () => {
+  assert.equal(exploreHref("logs", {}), "/explore/logs");
+  assert.equal(exploreHref("traces", {}), "/explore/traces");
+  assert.equal(exploreHref("metrics", {}), "/explore/metrics");
+});
+
+test("exploreHref maps service to a service.name resource-attr filter", () => {
+  const { path, attrs, rest } = decodedParams(exploreHref("logs", { service: "core-platform" }));
+  assert.equal(path, "/explore/logs");
+  assert.deepEqual(attrs, ["service.name=core-platform"]);
+  assert.deepEqual(rest, {});
+});
+
+test("exploreHref carries resource_attrs through as attr filters, after service", () => {
+  const { attrs } = decodedParams(
+    exploreHref("traces", {
+      service: "api",
+      resource_attrs: [
+        { key: "host.name", value: "prod-1" },
+        { key: "deployment.environment", value: "prod" },
+      ],
+    }),
+  );
+  assert.deepEqual(attrs, ["service.name=api", "host.name=prod-1", "deployment.environment=prod"]);
+});
+
+test("exploreHref maps severity to sev only for logs", () => {
+  assert.deepEqual(decodedParams(exploreHref("logs", { severity: "ERROR" })).rest, {
+    sev: "ERROR",
+  });
+  // severity is meaningless on traces/metrics — dropped
+  assert.deepEqual(decodedParams(exploreHref("traces", { severity: "ERROR" })).rest, {});
+});
+
+test("exploreHref maps status_code to status only for traces", () => {
+  assert.deepEqual(
+    decodedParams(exploreHref("traces", { status_code: "STATUS_CODE_ERROR" })).rest,
+    {
+      status: "STATUS_CODE_ERROR",
+    },
+  );
+  assert.deepEqual(
+    decodedParams(exploreHref("logs", { status_code: "STATUS_CODE_ERROR" })).rest,
+    {},
+  );
+});
+
+test("exploreHref maps metric_name to metric only for metrics", () => {
+  assert.deepEqual(
+    decodedParams(exploreHref("metrics", { metric_name: "auth.signin.failures" })).rest,
+    { metric: "auth.signin.failures" },
+  );
+  assert.deepEqual(
+    decodedParams(exploreHref("logs", { metric_name: "auth.signin.failures" })).rest,
+    {},
+  );
+});
+
+test("exploreHref drops filters Explore's URL can't express (span_name, search, span/log attrs)", () => {
+  const { attrs, rest } = decodedParams(
+    exploreHref("traces", {
+      span_name: "POST /api/auth/events",
+      search: "timeout",
+      span_attrs: [{ key: "http.method", value: "POST" }],
+      log_attrs: [{ key: "code", value: "500" }],
+    }),
+  );
+  assert.deepEqual(attrs, []);
+  assert.deepEqual(rest, {});
+});
+
+test("exploreHref ignores empty/blank filter values and malformed attrs", () => {
+  const { attrs, rest } = decodedParams(
+    exploreHref("logs", {
+      service: "",
+      severity: "",
+      resource_attrs: [{ key: "", value: "x" }, { value: "novalue" }, { key: "ok" }],
+    }),
+  );
+  assert.deepEqual(attrs, ["ok="]);
+  assert.deepEqual(rest, {});
+});
+
+test("exploreHref carries an absolute ISO window through as since/until", () => {
+  const { rest } = decodedParams(
+    exploreHref("logs", {
+      range: { since: "2026-06-26T02:40:00Z", until: "2026-06-26T03:10:00Z" },
+    }),
+  );
+  assert.deepEqual(rest, {
+    since: "2026-06-26T02:40:00Z",
+    until: "2026-06-26T03:10:00Z",
+  });
+});
+
+test("exploreHref drops a ClickHouse-expression range (not URL-addressable)", () => {
+  const { rest } = decodedParams(
+    exploreHref("metrics", {
+      metric_name: "auth.signin.failures",
+      range: { since: "now() - INTERVAL 2 HOUR", until: "now()" },
+    }),
+  );
+  // only the metric survives; the relative expression can't be pinned in the URL
+  assert.deepEqual(rest, { metric: "auth.signin.failures" });
+});
+
+test("exploreHref drops a half-specified or inverted range", () => {
+  assert.deepEqual(
+    decodedParams(exploreHref("traces", { range: { since: "2026-06-26T03:00:00Z" } })).rest,
+    {},
+  );
+  assert.deepEqual(
+    decodedParams(
+      exploreHref("traces", {
+        range: { since: "2026-06-26T03:10:00Z", until: "2026-06-26T02:40:00Z" },
+      }),
+    ).rest,
+    {},
+  );
 });
 
 test("formatRangeLabel renders ISO ranges as UTC HH:MM, passes ClickHouse exprs through", () => {

--- a/apps/web/src/incidents/telemetry-result.ts
+++ b/apps/web/src/incidents/telemetry-result.ts
@@ -10,6 +10,7 @@
 // filters the MCP tools accept, so a live re-run would be lossy).
 
 import type { LogRow, MetricSeriesRow } from "../api.ts";
+import { parseAbsoluteRange } from "../design/range-url.ts";
 
 export type TelemetryKind = "metrics" | "logs" | "traces";
 
@@ -113,6 +114,61 @@ export function toTraceRows(rows: Record<string, unknown>[]): TraceTableRow[] {
     duration_ms: numField(r, "duration_ms") ?? 0,
     trace_id: strField(r, "trace_id"),
   }));
+}
+
+/** Build a deep link into the Explore page that pre-fills the filters from a
+ *  recorded agent query, so the widget's "Open in Explore" lands on the same
+ *  view the agent saw instead of the bare /explore page.
+ *
+ *  Explore addresses its filters through the URL (see `Explore.tsx`): `attr`
+ *  (repeatable `key=value` resource attributes, with the service modeled as the
+ *  `service.name` attribute), `sev` (logs), `status` (traces), and `metric`
+ *  (metrics). The MCP query tools also accept span_name / free-text search /
+ *  span_attrs / log_attrs, none of which Explore can express in its URL, so
+ *  those are dropped rather than mismapped. The time range is likewise not
+ *  URL-addressable in Explore (it's a stored preset), so it isn't carried. */
+export function exploreHref(kind: TelemetryKind, input: Record<string, unknown>): string {
+  const params = new URLSearchParams();
+
+  if (typeof input.service === "string" && input.service) {
+    params.append("attr", `service.name=${input.service}`);
+  }
+  const resourceAttrs = input.resource_attrs;
+  if (Array.isArray(resourceAttrs)) {
+    for (const a of resourceAttrs as { key?: unknown; value?: unknown }[]) {
+      if (a && typeof a.key === "string" && a.key) {
+        params.append("attr", `${a.key}=${typeof a.value === "string" ? a.value : ""}`);
+      }
+    }
+  }
+
+  if (kind === "logs" && typeof input.severity === "string" && input.severity) {
+    params.set("sev", input.severity);
+  }
+  if (kind === "traces" && typeof input.status_code === "string" && input.status_code) {
+    params.set("status", input.status_code);
+  }
+  if (kind === "metrics" && typeof input.metric_name === "string" && input.metric_name) {
+    params.set("metric", input.metric_name);
+  }
+
+  // Pin the exact window the agent queried, but only when it's an absolute
+  // range — the MCP tools also accept ClickHouse expressions (`now() - …`),
+  // which Explore can't reconstruct from the URL.
+  const range = input.range as { since?: unknown; until?: unknown } | undefined;
+  const absolute = range
+    ? parseAbsoluteRange(
+        typeof range.since === "string" ? range.since : null,
+        typeof range.until === "string" ? range.until : null,
+      )
+    : null;
+  if (absolute) {
+    params.set("since", absolute.since);
+    params.set("until", absolute.until);
+  }
+
+  const qs = params.toString();
+  return qs ? `/explore/${kind}?${qs}` : `/explore/${kind}`;
 }
 
 function isoToHm(s: string): string | null {

--- a/apps/web/src/incidents/telemetry-result.ts
+++ b/apps/web/src/incidents/telemetry-result.ts
@@ -125,8 +125,10 @@ export function toTraceRows(rows: Record<string, unknown>[]): TraceTableRow[] {
  *  `service.name` attribute), `sev` (logs), `status` (traces), and `metric`
  *  (metrics). The MCP query tools also accept span_name / free-text search /
  *  span_attrs / log_attrs, none of which Explore can express in its URL, so
- *  those are dropped rather than mismapped. The time range is likewise not
- *  URL-addressable in Explore (it's a stored preset), so it isn't carried. */
+ *  those are dropped rather than mismapped. The time range is carried as
+ *  `since` / `until` when it's an absolute window; relative ClickHouse
+ *  expressions (`now() - …`) are dropped because Explore can't reconstruct
+ *  them from the URL. */
 export function exploreHref(kind: TelemetryKind, input: Record<string, unknown>): string {
   const params = new URLSearchParams();
 


### PR DESCRIPTION
## Problem

The logs / traces / metrics query cards in the incident transcript have an **Open in Explore** button, but it was hardcoded to `/explore` — it dropped you on the generic Explore page with none of the query's filters or time window.

## Fix

Build the link from the recorded query (`exploreHref(kind, input)`):

- **source** → `/explore/logs` | `/explore/traces` | `/explore/metrics`
- **service** → `service.name` resource-attr filter (`attr=service.name=…`)
- **resource_attrs** → one `attr=key=value` each
- **severity** → `sev=` (logs), **status_code** → `status=` (traces), **metric_name** → `metric=` (metrics)
- **absolute query window** → `since` / `until`

Explore reads `since`/`until` and pins the range to that fixed window (shown as `02:40 → 03:10 (Custom)` in the range picker). Picking any preset — or typing a duration — clears the params and resumes a live sliding window.

### Deliberately not mapped

- `span_name`, free-text `search`, `span_attrs`, `log_attrs` — Explore's URL only addresses resource attributes, so these are dropped rather than mismapped onto the wrong filter.
- ClickHouse time expressions (`now() - INTERVAL 2 HOUR`) aren't reconstructable from a URL, so only an absolute ISO window is pinned; anything else falls back to Explore's default preset.

`parseAbsoluteRange` lives in a JSX-free module (`design/range-url.ts`) so it's unit-testable and shared by both the link builder and the Explore reader — one definition of what counts as a valid absolute window.

## Tests

- `telemetry-result.test.ts` — `exploreHref` source/filter/range mapping, including dropped and malformed cases
- `range-url.test.ts` — `parseAbsoluteRange` accept/reject cases

22 unit tests, `@superlog/web` typecheck clean, biome-formatted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open in Explore now deep-links from incident query cards to the exact view, carrying source, filters, and a fixed time window when available. This opens Explore with the same context the agent used, not the generic page.

- **New Features**
  - Build links with `exploreHref(kind, input)`: maps source to `/explore/logs|traces|metrics`, `service`/`resource_attrs` to `attr` filters, and `severity`/`status_code`/`metric_name` to `sev`/`status`/`metric`.
  - Carry absolute ISO windows via `since`/`until`. Explore pins them as Custom and clears them when a preset is selected.
  - Drop filters not representable in the URL (span_name, free-text, span/log attrs) and ignore relative time expressions.
  - Add `parseAbsoluteRange` in a shared module, plus unit tests for range parsing and link mapping.

- **Bug Fixes**
  - `parseAbsoluteRange` now rejects impossible dates and non-positive windows (e.g., Feb 31, hour 24, until ≤ since) to prevent bogus pinned ranges.
  - On preset change, Explore clears `since`/`until` whenever those params are present, even if invalid, so bad deep links don’t linger.

<sup>Written for commit f2db06083b8a66b6af79bdb62f22cd56ff709ce1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

