### PR TITLE
Incident chat: talk to the investigation from the incident page

### DIFF
--- a/apps/api/src/incidents/chat.test.ts
+++ b/apps/api/src/incidents/chat.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { INCIDENT_CHAT_MAX_LENGTH, prepareIncidentChatMessage } from "./chat.js";
+
+const NOW = new Date("2026-07-09T12:00:00Z");
+
+test("builds a web_chat interaction from a valid message", () => {
+  const result = prepareIncidentChatMessage({
+    text: "  please rename the flag in the PR  ",
+    messageId: "0d4f9c1e-6f0f-4d34-9b56-1a2b3c4d5e6f",
+    author: "Ada Lovelace",
+    now: NOW,
+  });
+  assert.deepEqual(result, {
+    ok: true,
+    interaction: {
+      channel: "web_chat",
+      author: "Ada Lovelace",
+      text: "please rename the flag in the PR",
+      occurredAt: NOW.toISOString(),
+    },
+    dedupeKey: "web_chat:0d4f9c1e-6f0f-4d34-9b56-1a2b3c4d5e6f",
+  });
+});
+
+test("rejects empty or whitespace-only messages", () => {
+  for (const text of ["", "   ", "\n\t"]) {
+    assert.deepEqual(
+      prepareIncidentChatMessage({ text, messageId: "m1", author: null, now: NOW }),
+      {
+        ok: false,
+        error: "empty_message",
+      },
+    );
+  }
+});
+
+test("rejects messages over the length cap", () => {
+  const result = prepareIncidentChatMessage({
+    text: "x".repeat(INCIDENT_CHAT_MAX_LENGTH + 1),
+    messageId: "m1",
+    author: null,
+    now: NOW,
+  });
+  assert.deepEqual(result, { ok: false, error: "message_too_long" });
+});
+
+test("rejects a missing or malformed client message id (dedupe key must be stable)", () => {
+  for (const messageId of ["", "  ", "not/a/safe*key", "x".repeat(129)]) {
+    assert.deepEqual(
+      prepareIncidentChatMessage({ text: "hello", messageId, author: null, now: NOW }),
+      { ok: false, error: "invalid_message_id" },
+    );
+  }
+});
+
+test("null author is preserved (falls back to null, not empty string)", () => {
+  const result = prepareIncidentChatMessage({
+    text: "hi",
+    messageId: "m-1",
+    author: null,
+    now: NOW,
+  });
+  assert.ok(result.ok);
+  assert.equal(result.interaction.author, null);
+});

--- a/apps/api/src/incidents/chat.ts
+++ b/apps/api/src/incidents/chat.ts
@@ -1,0 +1,39 @@
+import type { AgentRunFollowUpInteraction } from "@superlog/db";
+
+// Message cap matches the other human channels' practical sizes (a Slack
+// message tops out at 4k characters); it exists to keep a pasted log dump from
+// blowing up the follow-up prompt.
+export const INCIDENT_CHAT_MAX_LENGTH = 4000;
+
+// The client generates the message id (a uuid) so retries of the same send are
+// idempotent end-to-end — the id becomes the dedupe key recordInboundInteraction
+// guards on, mirroring Slack's event_id and GitHub's comment id.
+const MESSAGE_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+
+export type PreparedIncidentChatMessage =
+  | { ok: true; interaction: AgentRunFollowUpInteraction; dedupeKey: string }
+  | { ok: false; error: "empty_message" | "message_too_long" | "invalid_message_id" };
+
+// Validate a web chat message and shape it into the shared follow-up
+// interaction. Pure — the route feeds the result to recordInboundInteraction.
+export function prepareIncidentChatMessage(args: {
+  text: string;
+  messageId: string;
+  author: string | null;
+  now: Date;
+}): PreparedIncidentChatMessage {
+  const text = args.text.trim();
+  if (!text) return { ok: false, error: "empty_message" };
+  if (text.length > INCIDENT_CHAT_MAX_LENGTH) return { ok: false, error: "message_too_long" };
+  if (!MESSAGE_ID_RE.test(args.messageId)) return { ok: false, error: "invalid_message_id" };
+  return {
+    ok: true,
+    interaction: {
+      channel: "web_chat",
+      author: args.author,
+      text,
+      occurredAt: args.now.toISOString(),
+    },
+    dedupeKey: `web_chat:${args.messageId}`,
+  };
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,6 +15,7 @@ import {
   isAgentRunProvider,
   listAccessibleGithubInstallsForProject,
   mintApiKey,
+  recordInboundInteraction,
   resolveDefaultAgentRunProvider,
   resolveIncident,
   runMigrations,
@@ -55,6 +56,7 @@ import {
 } from "./github.js";
 import { createApiHttpObservabilityMiddleware } from "./http-observability.js";
 import { mountImpersonation } from "./impersonation.js";
+import { prepareIncidentChatMessage } from "./incidents/chat.js";
 import { buildIncidentListItem, shouldInlineIncidentListStats } from "./incidents/list.js";
 import { getPrDeliveryRetryEligibility } from "./incidents/pr-retry.js";
 import { buildIncidentPullRequestViews } from "./incidents/pr-view.js";
@@ -1500,6 +1502,62 @@ app.post(
   "/api/projects/:projectId/incidents/:incidentId/resolution-proposals/:proposalId/dismiss",
   (c) => decideResolutionProposal(c, "dismiss"),
 );
+
+// Chat with the investigation from the incident page — the web sibling of a
+// Slack thread reply or a PR comment. The message flows through the same
+// shared inbound path (resume the durable session, steer it mid-turn, or
+// cold-start a follow-up run), and the agent's reply lands in the incident
+// timeline the page already renders.
+app.post("/api/projects/:projectId/incidents/:incidentId/chat", async (c) => {
+  const projectId = c.req.param("projectId");
+  const incidentId = c.req.param("incidentId");
+  await requireProjectAccess(c, projectId);
+
+  const incident = await db.query.incidents.findFirst({
+    where: and(eq(schema.incidents.id, incidentId), eq(schema.incidents.projectId, projectId)),
+    columns: { id: true },
+  });
+  if (!incident) throw new HTTPException(404, { message: "incident not found" });
+
+  // Any parse failure or valid-but-non-object body (JSON `null`, a bare string /
+  // number / array) collapses to `{}` so the field reads below can't throw —
+  // prepareIncidentChatMessage then returns a clean 400 for the empty text.
+  const rawBody = await c.req.json().catch(() => null);
+  const body: { text?: unknown; messageId?: unknown } =
+    rawBody && typeof rawBody === "object" ? (rawBody as Record<string, unknown>) : {};
+  const user = await db.query.users.findFirst({
+    where: eq(schema.users.id, c.var.userId),
+    columns: { name: true, email: true },
+  });
+  const prepared = prepareIncidentChatMessage({
+    text: typeof body.text === "string" ? body.text : "",
+    messageId: typeof body.messageId === "string" ? body.messageId : "",
+    author: user?.name?.trim() || user?.email || null,
+    now: new Date(),
+  });
+  if (!prepared.ok) throw new HTTPException(400, { message: prepared.error });
+
+  const result = await recordInboundInteraction(db, {
+    incidentId,
+    interaction: prepared.interaction,
+    dedupeKey: prepared.dedupeKey,
+    detail: { userId: c.var.userId },
+    // Typing into the incident page is an explicit human request, like the
+    // feedback button — it bypasses the auto-follow-up project gate.
+    confirmed: true,
+  });
+
+  if (result.outcome === "skipped") {
+    // Surfaced (not swallowed) so the composer can tell the user why the
+    // message won't reach the agent, e.g. agent runs disabled or no prior run.
+    return c.json({ ok: false as const, reason: result.reason }, 409);
+  }
+  return c.json({
+    ok: true as const,
+    duplicate: result.outcome === "duplicate",
+    action: result.outcome === "accepted" ? result.action : null,
+  });
+});
 
 app.post("/api/projects/:projectId/issues/:issueId/silence", async (c) => {
   const projectId = c.req.param("projectId");

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -33,6 +33,7 @@ import {
   type IssueSample,
   type LogRow,
   type PendingResolutionProposal,
+  incidentChatErrorMessage,
   useDecideResolutionProposal,
   useIncident,
   useIncidentPullRequests,
@@ -45,6 +46,7 @@ import {
   useMergeIncidentPullRequest,
   useRestartAgentRun,
   useRetryPrDelivery,
+  useSendIncidentChatMessage,
   useSilenceIssue,
   useStartInvestigation,
   useUnsilenceIssue,
@@ -1610,8 +1612,107 @@ export function IncidentDetailContent({
               <IncidentPullRequestPanel projectId={incident.projectId} incidentId={incident.id} />
             )}
           </div>
+
+          {detailTab === "activity" && (
+            <IncidentChatComposer
+              projectId={incident.projectId}
+              incidentId={incident.id}
+              hasAgentRun={!!agentRun}
+            />
+          )}
         </div>
       </div>
+    </div>
+  );
+}
+
+// Talk to the investigation from the incident page — the web equivalent of
+// replying in the incident's Slack thread or commenting on its PR. Messages
+// flow into the same durable agent session (ask for PR changes, explain how to
+// address the issue, correct course); the agent's reply lands in the activity
+// feed above.
+function IncidentChatComposer({
+  projectId,
+  incidentId,
+  hasAgentRun,
+}: {
+  projectId: string;
+  incidentId: string;
+  hasAgentRun: boolean;
+}) {
+  const send = useSendIncidentChatMessage(projectId, incidentId);
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [justSent, setJustSent] = useState(false);
+  // The dedupe id for the current draft. Minted once and reused across retries
+  // of the *same* unsent message, so a resend after a failed response (the
+  // first request may have reached the server) dedupes instead of enqueuing
+  // twice. Cleared on success and whenever the draft is edited (a new message).
+  const pendingIdRef = useRef<string | null>(null);
+  const disabled = !hasAgentRun;
+
+  function onDraftChange(value: string) {
+    setText(value);
+    pendingIdRef.current = null;
+    if (justSent) setJustSent(false);
+    if (error) setError(null);
+  }
+
+  function submit() {
+    const trimmed = text.trim();
+    if (!trimmed || send.isPending || disabled) return;
+    setError(null);
+    if (!pendingIdRef.current) pendingIdRef.current = crypto.randomUUID();
+    send.mutate(
+      { text: trimmed, messageId: pendingIdRef.current },
+      {
+        onSuccess: () => {
+          setText("");
+          pendingIdRef.current = null;
+          setJustSent(true);
+        },
+        onError: (err) => setError(incidentChatErrorMessage(err)),
+      },
+    );
+  }
+
+  return (
+    <div className="shrink-0 border-t border-border bg-bg px-6 py-4 lg:px-8">
+      <div className="flex items-end gap-2">
+        <textarea
+          value={text}
+          onChange={(e) => onDraftChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              submit();
+            }
+          }}
+          rows={2}
+          disabled={disabled}
+          placeholder={
+            disabled
+              ? "No investigation to talk to yet — start one from the Findings tab."
+              : "Reply to the investigation — request PR changes, explain the issue, add context…"
+          }
+          className="min-h-[58px] flex-1 resize-none rounded-lg border border-border bg-surface-2 px-3 py-2 text-[14px] leading-relaxed text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+        />
+        <Btn
+          variant="primary"
+          size="lg"
+          onClick={submit}
+          loading={send.isPending}
+          disabled={disabled || !text.trim()}
+        >
+          Send
+        </Btn>
+      </div>
+      {error && <p className="mt-2 text-[12px] text-danger">{error}</p>}
+      {!error && justSent && (
+        <p className="mt-2 text-[12px] text-muted">
+          Delivered to the investigation — the reply will appear in the feed above.
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -2227,6 +2227,51 @@ export function useIncident(projectId: string | undefined, incidentId: string | 
   });
 }
 
+export type IncidentChatSendResult = {
+  ok: true;
+  duplicate: boolean;
+  action: "resume" | "steer" | "cold_start" | null;
+};
+
+// Reasons recordInboundInteraction can decline a chat message (HTTP 409).
+const INCIDENT_CHAT_SKIP_MESSAGES: Record<string, string> = {
+  agent_runs_disabled: "Agent investigations are disabled for this project.",
+  no_prior_run: "There's no investigation to talk to yet — start one first.",
+  follow_up_cap_reached: "This incident has reached its follow-up limit.",
+  prior_run_too_old: "The last investigation is too old to continue.",
+  run_active: "The investigation is busy right now — try again in a moment.",
+};
+
+export function incidentChatErrorMessage(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const jsonStart = raw.indexOf("{");
+  if (jsonStart >= 0) {
+    try {
+      const body = JSON.parse(raw.slice(jsonStart)) as { reason?: string; message?: string };
+      const key = body.reason ?? body.message;
+      if (key && INCIDENT_CHAT_SKIP_MESSAGES[key]) return INCIDENT_CHAT_SKIP_MESSAGES[key];
+    } catch {
+      // fall through to the raw message
+    }
+  }
+  return `Message failed to send: ${raw}`;
+}
+
+export function useSendIncidentChatMessage(projectId: string, incidentId: string) {
+  const fetcher = useFetcher();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { text: string; messageId: string }) =>
+      fetcher<IncidentChatSendResult>(`/api/projects/${projectId}/incidents/${incidentId}/chat`, {
+        method: "POST",
+        body: JSON.stringify(vars),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["incident", projectId, incidentId] });
+    },
+  });
+}
+
 export function useIncidentPullRequests(
   projectId: string | undefined,
   incidentId: string | undefined,

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -61,7 +61,12 @@ type TranscriptItem =
   // "Started investigation" node with the raw prompt tucked behind a toggle.
   | { type: "start"; id: string; prompt: string };
 
-type FeedItem = TranscriptItem | { type: "lifecycle"; id: string; event: IncidentEvent };
+type FeedItem =
+  | TranscriptItem
+  // A human talking to the investigation (incident chat, Slack thread reply, PR
+  // comment), mirrored into the timeline as a chat message from whoever sent it.
+  | { type: "human"; id: string; author: string | null; text: string; createdAt: string }
+  | { type: "lifecycle"; id: string; event: IncidentEvent };
 
 const TOOL_USE_KINDS = new Set(["agent.tool_use", "agent.mcp_tool_use", "agent.custom_tool_use"]);
 const TOOL_RESULT_KINDS = new Set([
@@ -92,6 +97,22 @@ export function buildActivityFeed(events: IncidentEvent[]): FeedItem[] {
 
   const items: FeedItem[] = [];
   for (const e of events) {
+    // A human talking to the investigation (incident chat, Slack thread reply,
+    // PR comment) — rendered as a chat message, not a one-line lifecycle note.
+    if (e.kind === "human_reply") {
+      const origin = (e.detail as { origin?: { author?: string | null } } | null)?.origin;
+      const text = (e.summary ?? "").trim();
+      if (text) {
+        items.push({
+          type: "human",
+          id: e.id,
+          author: origin?.author ?? null,
+          text,
+          createdAt: e.createdAt,
+        });
+      }
+      continue;
+    }
     if (e.kind === "agent.message") {
       const text = (e.summary ?? "").trim();
       if (text) items.push({ type: "message", id: e.id, text });
@@ -145,7 +166,7 @@ export function buildActivityFeed(events: IncidentEvent[]): FeedItem[] {
 // (the drawer's separate timeline, summary-cited telemetry).
 export function buildTranscript(events: IncidentEvent[]): TranscriptItem[] {
   return buildActivityFeed(events).filter(
-    (item): item is TranscriptItem => item.type !== "lifecycle",
+    (item): item is TranscriptItem => item.type !== "lifecycle" && item.type !== "human",
   );
 }
 
@@ -183,6 +204,7 @@ export function IncidentActivityFeed({
 
   const renderItem = (item: FeedItem) => {
     if (item.type === "message") return <MessageEntry key={item.id} text={item.text} />;
+    if (item.type === "human") return <HumanEntry key={item.id} item={item} />;
     if (item.type === "telemetry") return <TelemetryEntry key={item.id} item={item} />;
     if (item.type === "tool") return <ToolEntry key={item.id} item={item} />;
     if (item.type === "start") return <StartEntry key={item.id} prompt={item.prompt} />;
@@ -414,6 +436,24 @@ function MessageEntry({ text }: { text: string }) {
       </Node>
       <div className="mb-1.5 text-[12px] font-semibold text-fg">Investigation agent</div>
       <div className="whitespace-pre-wrap text-[14px] leading-relaxed text-fg/85">{text}</div>
+    </div>
+  );
+}
+
+// A human message to the investigation, mirrored from whichever channel it
+// arrived on (incident chat, Slack thread, PR comment).
+function HumanEntry({ item }: { item: Extract<FeedItem, { type: "human" }> }) {
+  return (
+    <div className="relative mb-6">
+      <Node>
+        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+        <circle cx="12" cy="7" r="4" />
+      </Node>
+      <div className="mb-1.5 flex items-baseline gap-2">
+        <span className="text-[12px] font-semibold text-fg">{item.author ?? "Teammate"}</span>
+        <span className="text-[11px] text-subtle">{fmtRelative(item.createdAt)}</span>
+      </div>
+      <div className="whitespace-pre-wrap text-[14px] leading-relaxed text-fg/85">{item.text}</div>
     </div>
   );
 }

--- a/apps/worker/src/agent-runs/resume.ts
+++ b/apps/worker/src/agent-runs/resume.ts
@@ -173,7 +173,7 @@ async function coldStartFallback(
 
   const result = await requestFollowUpAgentRun(db, {
     incidentId: ctx.incident.id,
-    trigger: origin?.channel === "pr_comment" ? "pr_comment" : "slack_reply",
+    trigger: origin?.channel ?? "slack_reply",
     interaction: origin ?? {
       channel: "slack_reply",
       author: null,

--- a/packages/db/src/agent-follow-up.ts
+++ b/packages/db/src/agent-follow-up.ts
@@ -430,6 +430,8 @@ function followUpQueuedSummary(trigger: AgentRunFollowUpTrigger): string {
       return "Follow-up investigation queued from user feedback.";
     case "slack_reply":
       return "Follow-up investigation queued from a Slack reply.";
+    case "web_chat":
+      return "Follow-up investigation queued from an incident chat message.";
     case "issue_joined":
       return "Follow-up investigation queued: a new error signature joined this incident.";
   }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -208,6 +208,7 @@ export type AgentRunTrigger =
   | "pr_comment"
   | "feedback"
   | "slack_reply"
+  | "web_chat"
   | "issue_joined";
 
 // Triggers that start an *initial* investigation (vs. a follow-up revived by a


### PR DESCRIPTION
## What

Adds a chat composer at the bottom of the incident detail Activity tab — the web equivalent of replying in the incident's Slack thread or commenting on the investigation's PR. You can ask the agent to change the PR, explain how to address the issue, or add context; since follow-up turns already carry the memory tools, corrections given here can be saved as agent memories too.


## How

Messages flow through the existing shared inbound path (`recordInboundInteraction`) as a new `web_chat` channel — resume the durable session, steer it mid-turn, or cold-start a follow-up run. The agent's reply already lands in the incident timeline the page renders, so no new outbound routing is needed.

- **db**: add `web_chat` to the `AgentRunTrigger` union (text column — no migration) plus its follow-up-queued summary line.
- **api**: `POST /api/projects/:projectId/incidents/:incidentId/chat`. The client generates a `messageId` that becomes the dedupe key (mirrors Slack's `event_id` / GitHub's comment id), so retries are idempotent end-to-end. Typing into the incident page is an explicit human request, so it bypasses the auto-follow-up project gate the same way the feedback button does. Skips (agent runs disabled, no prior run, cap reached, …) surface as 409 + reason instead of being swallowed.
- **worker**: the cold-start fallback in `resume.ts` now preserves the origin channel instead of collapsing everything non-PR to `slack_reply`.
- **web**: composer (Enter to send, Shift+Enter for newline), `human_reply` events rendered as proper chat entries (author + full text) instead of truncated lifecycle one-liners, and the incident detail query polls every 4s while a run is active so the agent's replies stream in without a manual refresh.

## Testing

- New unit tests for the message validation/shaping helper (`apps/api/src/incidents/chat.test.ts`).
- Full `@superlog/api` suite passes (327 tests); db/api/web/worker typecheck clean.
- Verified end-to-end in a dev worktree: seeded an incident with a completed run, sent a message from the composer — the message renders as a chat entry, a follow-up run is enqueued with `trigger=web_chat` carrying the interaction, and the queued state appears via polling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add incident chat to the Activity tab so you can talk to the investigation from the incident page. Messages use a new `web_chat` channel on the shared inbound path, and replies show live in the timeline.

- New Features
  - Web: chat composer (Enter to send; Shift+Enter for newline), disables when no investigation, renders `human_reply` as chat (author + full text), friendly errors on skipped sends, and auto-polls every 4s while a run is active.
  - API: `POST /api/projects/:projectId/incidents/:incidentId/chat` accepts `{ text, messageId }`, trims and caps at 4000 chars, validates a stable `messageId` for idempotency; explicit human action bypasses the auto-follow-up gate; skips return 409 with a user-facing reason; success includes `duplicate` and `action`.
  - DB/Worker: add `web_chat` to `AgentRunTrigger` and follow-up queued summary; cold-start fallback preserves the origin channel.
  - Tests: unit tests for message validation/shaping; full `@superlog/api` suite passes.

<sup>Written for commit b09752ea6f2638323e708e4e2f4d5fa8a0864331. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

