### PR TITLE
Show demo data banner in setup slot

### DIFF
--- a/apps/web/src/onboarding/InstallNudge.tsx
+++ b/apps/web/src/onboarding/InstallNudge.tsx
@@ -1,15 +1,19 @@
 import { Btn } from "../design/ui.tsx";
 import { ArrowIcon } from "./icons.tsx";
 
-// Persistent, always-on nudge shown over the app while the user is exploring
-// demo (sample) data. It is deliberately prominent and NOT dismissable — the
-// whole point of demo mode is to keep pushing the user toward instrumenting
-// their own app. Clicking "Connect your app" drops the demo-exploring opt-in,
-// which sends them back to the install wizard. It disappears on its own the
-// moment real telemetry lands (the gate stops rendering it).
-export function InstallNudge({ onConnect }: { onConnect: () => void }) {
+export function DemoExploringBanner({
+  onConnect,
+  floating = false,
+}: {
+  onConnect: () => void;
+  floating?: boolean;
+}) {
   return (
-    <div className="fixed bottom-5 right-5 z-50 w-[320px] overflow-hidden rounded-[14px] border border-[rgba(140,152,240,0.35)] bg-[#0f1014] shadow-[0_12px_40px_rgba(0,0,0,0.5)]">
+    <div
+      className={`overflow-hidden rounded-[14px] border border-[rgba(140,152,240,0.35)] bg-[#0f1014] shadow-[0_12px_40px_rgba(0,0,0,0.35)] ${
+        floating ? "fixed bottom-5 right-5 z-50 w-[320px]" : "w-full"
+      }`}
+    >
       <div className="flex items-start gap-2.5 border-b border-[rgba(255,255,255,0.07)] px-[18px] py-[14px]">
         <span className="mt-1 h-2 w-2 flex-shrink-0 animate-pulse rounded-full bg-[#8C98F0]" />
         <div className="flex-1">
@@ -33,4 +37,12 @@ export function InstallNudge({ onConnect }: { onConnect: () => void }) {
       </div>
     </div>
   );
+}
+
+// Persistent, always-on nudge shown over the app while the user is exploring
+// demo (sample) data. It is deliberately prominent and NOT dismissable. Clicking
+// "Connect your app" drops the demo-exploring opt-in, which sends them back to
+// the install wizard. It disappears on its own the moment real telemetry lands.
+export function InstallNudge({ onConnect }: { onConnect: () => void }) {
+  return <DemoExploringBanner onConnect={onConnect} floating />;
 }

--- a/apps/web/src/onboarding/OnboardingGate.tsx
+++ b/apps/web/src/onboarding/OnboardingGate.tsx
@@ -2,8 +2,12 @@ import { type ReactNode, useEffect, useState } from "react";
 import { useMe } from "../api.ts";
 import { CenteredShell } from "../design/ui.tsx";
 import { finishSkillOnboarding, isSkillOnboardingPending } from "../skillOnboarding.ts";
-import { InstallNudge } from "./InstallNudge.tsx";
 import { OnboardingWizard } from "./OnboardingWizard.tsx";
+import {
+  DemoExplorationProvider,
+  readDemoExploring,
+  writeDemoExploring,
+} from "./demoExploration.tsx";
 
 // Pre-empts the dashboard for new users until they've finished the install +
 // deploy wizard and telemetry has arrived.
@@ -15,29 +19,9 @@ import { OnboardingWizard } from "./OnboardingWizard.tsx";
 // Demo overlay: when the server is serving sample data (`me.demoMode`), the
 // install wizard stays the default landing, but the user can opt to "Explore
 // with sample data" — which renders the populated app (reading the shared demo
-// project, read-only) with a persistent InstallNudge. The opt-in is local-only
-// and is dropped the instant real telemetry lands (demoMode flips false).
-
-const DEMO_EXPLORING_KEY = "superlog.demo_exploring";
-
-function readDemoExploring(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.localStorage.getItem(DEMO_EXPLORING_KEY) === "1";
-  } catch {
-    return false;
-  }
-}
-
-function writeDemoExploring(on: boolean) {
-  if (typeof window === "undefined") return;
-  try {
-    if (on) window.localStorage.setItem(DEMO_EXPLORING_KEY, "1");
-    else window.localStorage.removeItem(DEMO_EXPLORING_KEY);
-  } catch {
-    /* ignore */
-  }
-}
+// project, read-only) with a persistent connect banner in the overview setup
+// slot. The opt-in is local-only and is dropped the instant real telemetry lands
+// (demoMode flips false).
 
 export function OnboardingGate({ children }: { children: ReactNode }) {
   const me = useMe();
@@ -71,6 +55,11 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
   const stopExploring = () => {
     setExploring(false);
     writeDemoExploring(false);
+  };
+  const demoExploration = {
+    demoMode,
+    exploring: demoMode && exploring,
+    stopExploring,
   };
 
   if (me.isLoading || !me.data) {
@@ -120,14 +109,9 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
   }
 
   // Opted into the demo: render the populated app (server serves demo data,
-  // read-only) with a persistent nudge to connect their own app.
+  // read-only). The overview setup slot renders the persistent connect nudge.
   if (demoMode && exploring) {
-    return (
-      <>
-        {children}
-        <InstallNudge onConnect={stopExploring} />
-      </>
-    );
+    return <DemoExplorationProvider value={demoExploration}>{children}</DemoExplorationProvider>;
   }
 
   return (

--- a/apps/web/src/onboarding/SetupTodos.test.tsx
+++ b/apps/web/src/onboarding/SetupTodos.test.tsx
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SetupTodosView } from "./SetupTodosView.tsx";
+
+test("demo exploration replaces the setup carousel with the demo banner", () => {
+  (globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+  const html = renderToStaticMarkup(
+    <SetupTodosView showDemoExploringBanner stopExploring={() => {}} />,
+  );
+
+  assert.match(html, /You(?:'|&#x27;)re exploring sample data/);
+  assert.match(html, /Connect your app/);
+  assert.doesNotMatch(html, /Finish setting up Superlog/);
+});

--- a/apps/web/src/onboarding/SetupTodos.tsx
+++ b/apps/web/src/onboarding/SetupTodos.tsx
@@ -10,7 +10,8 @@ import {
 } from "../api.ts";
 import { DeployDialog } from "./DeployDialog.tsx";
 import { McpInstallDialog } from "./McpInstallDialog.tsx";
-import { TodoCarousel } from "./TodoCarousel.tsx";
+import { SetupTodosView } from "./SetupTodosView.tsx";
+import { useDemoExploration } from "./demoExploration.tsx";
 import { BoltIcon, GithubIcon, SlackIcon, TerminalIcon } from "./icons.tsx";
 import type { Todo, TodoId } from "./types.ts";
 
@@ -75,15 +76,21 @@ function isStatsZero(stats: Stats | undefined): boolean {
 }
 
 export function SetupTodos({ projectId }: { projectId: string }) {
+  const { exploring, stopExploring } = useDemoExploration();
   const github = useGithubInstallation();
   const slack = useSlackInstallation();
   const stats = useStats(projectId);
   const mcp = useMcpStatus(projectId);
   const startGithub = useStartGithubInstall();
   const startSlack = useStartSlackInstall();
+  const showDemoExploringBanner = exploring;
 
   const [mcpOpen, setMcpOpen] = useState(false);
   const [deployOpen, setDeployOpen] = useState(false);
+
+  if (showDemoExploringBanner) {
+    return <SetupTodosView showDemoExploringBanner stopExploring={stopExploring} />;
+  }
 
   // Hold off the first paint until every signal has resolved once — otherwise
   // a fully-onboarded user briefly sees all four todos (every `…Connected`
@@ -136,7 +143,8 @@ export function SetupTodos({ projectId }: { projectId: string }) {
 
   return (
     <>
-      <TodoCarousel
+      <SetupTodosView
+        showDemoExploringBanner={false}
         todos={todos}
         busyId={busyId}
         total={total}

--- a/apps/web/src/onboarding/SetupTodosView.tsx
+++ b/apps/web/src/onboarding/SetupTodosView.tsx
@@ -1,0 +1,33 @@
+import { DemoExploringBanner } from "./InstallNudge.tsx";
+import { TodoCarousel } from "./TodoCarousel.tsx";
+import type { Todo, TodoId } from "./types.ts";
+
+type SetupTodosViewProps =
+  | {
+      showDemoExploringBanner: true;
+      stopExploring: () => void;
+    }
+  | {
+      showDemoExploringBanner: false;
+      todos: Todo[];
+      busyId: TodoId | null;
+      total: number;
+      completed: number;
+      onAction: (todo: Todo) => void;
+    };
+
+export function SetupTodosView(props: SetupTodosViewProps) {
+  if (props.showDemoExploringBanner) {
+    return <DemoExploringBanner onConnect={props.stopExploring} />;
+  }
+
+  return (
+    <TodoCarousel
+      todos={props.todos}
+      busyId={props.busyId}
+      total={props.total}
+      completed={props.completed}
+      onAction={props.onAction}
+    />
+  );
+}

--- a/apps/web/src/onboarding/demoExploration.tsx
+++ b/apps/web/src/onboarding/demoExploration.tsx
@@ -1,0 +1,52 @@
+import { type ReactNode, createContext, useContext } from "react";
+
+const DEMO_EXPLORING_KEY = "superlog.demo_exploring";
+
+type DemoExplorationState = {
+  demoMode: boolean;
+  exploring: boolean;
+  stopExploring: () => void;
+};
+
+const defaultDemoExploration: DemoExplorationState = {
+  demoMode: false,
+  exploring: false,
+  stopExploring: () => {},
+};
+
+const DemoExplorationContext = createContext<DemoExplorationState>(defaultDemoExploration);
+
+export function readDemoExploring(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(DEMO_EXPLORING_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function writeDemoExploring(on: boolean) {
+  if (typeof window === "undefined") return;
+  try {
+    if (on) window.localStorage.setItem(DEMO_EXPLORING_KEY, "1");
+    else window.localStorage.removeItem(DEMO_EXPLORING_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function DemoExplorationProvider({
+  value,
+  children,
+}: {
+  value: DemoExplorationState;
+  children: ReactNode;
+}) {
+  return (
+    <DemoExplorationContext.Provider value={value}>{children}</DemoExplorationContext.Provider>
+  );
+}
+
+export function useDemoExploration(): DemoExplorationState {
+  return useContext(DemoExplorationContext);
+}


### PR DESCRIPTION
## Summary
- Move demo exploration state into a shared onboarding context.
- Reuse the sample-data connect card as an in-flow banner.
- Replace the setup carousel with that banner while a user is exploring demo data.

## Validation
- `pnpm exec tsx --test apps/web/src/onboarding/SetupTodos.test.tsx`
- `pnpm --filter @superlog/web typecheck`
- `pnpm exec biome check apps/web/src/onboarding/OnboardingGate.tsx apps/web/src/onboarding/SetupTodos.tsx apps/web/src/onboarding/SetupTodosView.tsx apps/web/src/onboarding/InstallNudge.tsx apps/web/src/onboarding/demoExploration.tsx apps/web/src/onboarding/SetupTodos.test.tsx`
