### PR TITLE
Live-update the incident detail view while an investigation is running

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePostHog } from "posthog-js/react";
+import { incidentPollIntervalMs } from "./incidents/agent-run-polling.ts";
 import { buildSignupEventProperties, readFirstTouchAttribution } from "./signupAttribution.ts";
 
 const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:4100";
@@ -2219,6 +2220,10 @@ export function useIncident(projectId: string | undefined, incidentId: string | 
     queryKey: ["incident", projectId, incidentId],
     queryFn: () => fetcher<IncidentDetail>(`/api/projects/${projectId}/incidents/${incidentId}`),
     enabled: !!projectId && !!incidentId,
+    // Poll while the investigation is live so the transcript updates on its own.
+    // Re-evaluated each tick against the freshest data, so it stops the moment
+    // the run reaches a terminal state.
+    refetchInterval: (query) => incidentPollIntervalMs(query.state.data?.agentRun?.state),
   });
 }
 

--- a/apps/web/src/incidents/agent-run-polling.test.ts
+++ b/apps/web/src/incidents/agent-run-polling.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { INCIDENT_POLL_INTERVAL_MS, incidentPollIntervalMs } from "./agent-run-polling.ts";
+
+// Poll only while the latest agent run is still doing (or about to do) work.
+// The worker flushes new transcript events to Postgres every few seconds while
+// a run is in an active state; once the run reaches a terminal state no more
+// events will ever appear, so polling must stop.
+
+test("polls while the run is running", () => {
+  assert.equal(incidentPollIntervalMs("running"), INCIDENT_POLL_INTERVAL_MS);
+});
+
+test("polls in the pre-work active states (queued, repo_discovery, resuming, pr_retry_queued)", () => {
+  for (const state of ["queued", "repo_discovery", "resuming", "pr_retry_queued"]) {
+    assert.equal(
+      incidentPollIntervalMs(state),
+      INCIDENT_POLL_INTERVAL_MS,
+      `expected to poll while ${state}`,
+    );
+  }
+});
+
+test("keeps polling while awaiting a human — a Slack reply elsewhere can resume the run", () => {
+  assert.equal(incidentPollIntervalMs("awaiting_human"), INCIDENT_POLL_INTERVAL_MS);
+});
+
+test("stops polling in terminal states", () => {
+  assert.equal(incidentPollIntervalMs("complete"), false);
+  assert.equal(incidentPollIntervalMs("failed"), false);
+});
+
+test("stops polling for a dormant run that won't progress without an external webhook", () => {
+  assert.equal(incidentPollIntervalMs("blocked_no_github"), false);
+});
+
+test("does not poll when there is no run yet", () => {
+  assert.equal(incidentPollIntervalMs(undefined), false);
+  assert.equal(incidentPollIntervalMs(null), false);
+});
+
+test("does not poll on an unknown/unexpected state (fail closed)", () => {
+  assert.equal(incidentPollIntervalMs("something_new"), false);
+});

--- a/apps/web/src/incidents/agent-run-polling.ts
+++ b/apps/web/src/incidents/agent-run-polling.ts
@@ -1,0 +1,33 @@
+// How often the incident detail view re-fetches while an investigation is live.
+//
+// The worker flushes new transcript events to Postgres every few seconds while a
+// run is active, so a short poll makes the page feel live without any realtime
+// transport. Polling is gated on the run's state: we only refetch while the run
+// is in an active state and stop entirely once it's terminal or dormant, so an
+// idle incident page costs nothing.
+export const INCIDENT_POLL_INTERVAL_MS = 3000;
+
+// Mirror of the worker's ACTIVE_STATES (apps/worker/src/agent-runs/domain.ts).
+// These are the states where the worker is still ticking the run, so new events
+// can still land. `awaiting_human` is included on purpose: a reply arriving on
+// another channel (e.g. Slack) flips it back to `resuming`, and we want the page
+// to catch that without a manual refresh. Terminal (`complete`/`failed`) and
+// dormant (`blocked_no_github`) states are omitted — they won't produce more
+// events until an external event requeues them, so we let the poll stop.
+const ACTIVE_AGENT_RUN_STATES: ReadonlySet<string> = new Set([
+  "queued",
+  "repo_discovery",
+  "running",
+  "awaiting_human",
+  "resuming",
+  "pr_retry_queued",
+]);
+
+// Returns the poll interval for react-query's `refetchInterval`, or `false` to
+// stop polling. Fails closed: an unknown or missing state does not poll.
+export function incidentPollIntervalMs(agentRunState: string | null | undefined): number | false {
+  if (agentRunState && ACTIVE_AGENT_RUN_STATES.has(agentRunState)) {
+    return INCIDENT_POLL_INTERVAL_MS;
+  }
+  return false;
+}


### PR DESCRIPTION
## What

The incident detail view fetched its data once on mount, so the agent
investigation transcript only advanced when the user manually refreshed.
This makes the view update on its own while a run is in progress.

## How

Adds a small pure helper, `incidentPollIntervalMs(state)`, and wires it
into the `useIncident` query as a `refetchInterval`:

- Polls every 3s while the latest agent run is in an **active** state
  (`queued`, `repo_discovery`, `running`, `awaiting_human`, `resuming`,
  `pr_retry_queued`).
- Returns `false` (no polling) for terminal (`complete`/`failed`) and
  dormant states, and fails closed on any unknown state.

React Query re-evaluates the interval against the freshest data after
each fetch, so polling stops the moment the run terminates and an idle or
closed incident page does no polling at all. The transcript already
renders off this query, so no component change is needed.

The 3s interval is deliberately conservative — the backend flushes new
transcript events every few seconds, so a faster poll would mostly return
unchanged data. The interval is a single exported constant.

## Testing

- New unit test covers every state → interval mapping (active states,
  terminal, dormant, null/undefined, unknown).
- `tsc --noEmit` and `biome check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the incident detail view live-update while an investigation is running. Polls every 3s via `@tanstack/react-query` and stops automatically when the run ends, so the transcript updates without manual refresh.

- New Features
  - Added `incidentPollIntervalMs` with a 3s interval that polls only in active run states.
  - Wired into `useIncident` as `refetchInterval`; stops on terminal, dormant, or unknown states.
  - Added unit tests covering all state-to-interval mappings.

<sup>Written for commit 3eda045c0165c6bb97fe5d80f0ba1f421975f837. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

