### PR TITLE
Route Vercel drain failures to prompt onboarding

### DIFF
--- a/apps/web/src/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/onboarding/OnboardingWizard.tsx
@@ -22,6 +22,11 @@ import { VercelConnectFlow } from "./VercelConnectFlow.tsx";
 import type { ConnectAction } from "./connectChoices.ts";
 import { CheckIcon, GithubIcon, SlackIcon, SpinnerIcon } from "./icons.tsx";
 import {
+  type WebView,
+  initialWebViewFromSearch,
+  stripHandledOnboardingParams,
+} from "./onboardingWebView.ts";
+import {
   ExploreDemoLink,
   InstallPromptCard,
   SOFT_LINE,
@@ -44,30 +49,17 @@ import {
 // Completion calls onComplete; the gate only allows it after telemetry arrives.
 
 type Mode = "web" | "agent";
-// Web-mode landing fork: choose a source, then either a no-code integration
-// flow (AWS / Cloudflare / Vercel) or the coding-agent install → deploy flow.
-type WebView =
-  | "chooser"
-  | "aws"
-  | "cloudflare"
-  | "vercel"
-  | "railway"
-  | "render"
-  | "code"
-  | "deploy";
 
 // The Cloudflare / Vercel OAuth callbacks redirect back to the app with
 // `?cloudflare=...` / `?vercel=...`. When that lands we want to drop straight
 // into the matching flow (which reads the outcome + install status), not the
 // chooser — otherwise the user is bounced back to "Connect your data" and has
-// to click the integration again to see progress.
+// to click the integration again to see progress. A Vercel `drains_unavailable`
+// outcome is different: the API already learned the team can't use Drains, so
+// route into the coding-agent prompt instead.
 function initialWebView(): WebView {
   if (typeof window === "undefined") return "chooser";
-  const params = new URLSearchParams(window.location.search);
-  if (params.has("cloudflare")) return "cloudflare";
-  if (params.has("vercel")) return "vercel";
-  if (params.has("railway")) return "railway";
-  return "chooser";
+  return initialWebViewFromSearch(window.location.search);
 }
 
 export function OnboardingWizard({
@@ -100,6 +92,17 @@ export function OnboardingWizard({
   const createKey = useCreateKey(projectId ?? "");
   const github = useGithubInstallation();
   const slack = useSlackInstallation();
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const nextSearch = stripHandledOnboardingParams(window.location.search);
+    if (nextSearch === window.location.search) return;
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${nextSearch}${window.location.hash}`,
+    );
+  }, []);
 
   // Route a chooser selection to the matching view. AWS / Cloudflare / Vercel
   // get their no-code integration flows; "I'm hosted elsewhere" (action "code")
@@ -194,6 +197,7 @@ export function OnboardingWizard({
               onBack={() => setWebView("chooser")}
               onDone={onComplete}
               onExploreDemo={onExploreDemo}
+              onDrainsUnavailable={() => setWebView("code")}
             />
           ) : webView === "railway" ? (
             <RailwayConnectFlow

--- a/apps/web/src/onboarding/VercelConnectFlow.tsx
+++ b/apps/web/src/onboarding/VercelConnectFlow.tsx
@@ -40,6 +40,7 @@ export function VercelConnectFlow({
   onBack,
   onDone,
   onExploreDemo,
+  onDrainsUnavailable,
 }: {
   projectId: string;
   // Whether the real project has ingested telemetry yet (from the parent's
@@ -49,6 +50,7 @@ export function VercelConnectFlow({
   onBack: () => void;
   onDone: () => void;
   onExploreDemo?: () => void;
+  onDrainsUnavailable?: () => void;
 }) {
   // Whether we've opened the install screen this session. Drives the transition
   // from the "start" call-to-action to the "connecting" waiting state while the
@@ -68,14 +70,16 @@ export function VercelConnectFlow({
   useEffect(() => {
     const outcome = parseVercelOutcome(searchParams.get("vercel"));
     if (!outcome) return;
-    if (outcome === "denied" || outcome === "error" || outcome === "drains_unavailable") {
+    if (outcome === "drains_unavailable") {
+      onDrainsUnavailable?.();
+    } else if (outcome === "denied" || outcome === "error") {
       setLaunched(false);
       setOutcomeError(vercelOutcomeMessage(outcome));
     }
     const next = new URLSearchParams(searchParams);
     next.delete("vercel");
     setSearchParams(next, { replace: true });
-  }, [searchParams, setSearchParams]);
+  }, [searchParams, setSearchParams, onDrainsUnavailable]);
 
   const installed = install.data?.installed === true;
   const phase = vercelPhase({ installed, launched });

--- a/apps/web/src/onboarding/connectChoices.ts
+++ b/apps/web/src/onboarding/connectChoices.ts
@@ -93,10 +93,11 @@ export const CONNECT_SECTIONS: ConnectSection[] = [
 ];
 
 // Runtime availability for connectors that depend on server-side config. The
-// backend self-disables the Cloudflare / Vercel connectors when their OAuth
-// client / OTLP intake env isn't set (see system-capabilities), so the chooser
-// must not offer a click that would 503 — it renders the tile as "coming soon"
-// until the API reports the connector is configured.
+// backend self-disables connectors when their OAuth client / OTLP intake env
+// isn't set (see system-capabilities), so the chooser must not offer a click
+// that would 503. Vercel plan eligibility is detected after OAuth by attempting
+// drain provisioning; if Vercel says drains are unavailable, the callback routes
+// into the coding-agent prompt.
 export type ConnectAvailability = {
   cloudflare: boolean;
   vercel: boolean;

--- a/apps/web/src/onboarding/onboardingWebView.test.ts
+++ b/apps/web/src/onboarding/onboardingWebView.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { initialWebViewFromSearch, stripHandledOnboardingParams } from "./onboardingWebView.ts";
+
+test("Vercel drains-unavailable callback opens prompt onboarding", () => {
+  assert.equal(initialWebViewFromSearch("?vercel=drains_unavailable"), "code");
+});
+
+test("other Vercel callback outcomes resume the Vercel flow", () => {
+  assert.equal(initialWebViewFromSearch("?vercel=installed"), "vercel");
+  assert.equal(initialWebViewFromSearch("?vercel=denied"), "vercel");
+  assert.equal(initialWebViewFromSearch("?vercel=error"), "vercel");
+});
+
+test("drains-unavailable is stripped after routing to prompt onboarding", () => {
+  assert.equal(stripHandledOnboardingParams("?vercel=drains_unavailable"), "");
+  assert.equal(stripHandledOnboardingParams("?vercel=drains_unavailable&x=1"), "?x=1");
+  assert.equal(stripHandledOnboardingParams("?vercel=installed"), "?vercel=installed");
+});

--- a/apps/web/src/onboarding/onboardingWebView.ts
+++ b/apps/web/src/onboarding/onboardingWebView.ts
@@ -1,0 +1,26 @@
+export type WebView =
+  | "chooser"
+  | "aws"
+  | "cloudflare"
+  | "vercel"
+  | "railway"
+  | "render"
+  | "code"
+  | "deploy";
+
+export function initialWebViewFromSearch(search: string): WebView {
+  const params = new URLSearchParams(search);
+  if (params.get("vercel") === "drains_unavailable") return "code";
+  if (params.has("cloudflare")) return "cloudflare";
+  if (params.has("vercel")) return "vercel";
+  if (params.has("railway")) return "railway";
+  return "chooser";
+}
+
+export function stripHandledOnboardingParams(search: string): string {
+  const params = new URLSearchParams(search);
+  if (params.get("vercel") !== "drains_unavailable") return search;
+  params.delete("vercel");
+  const next = params.toString();
+  return next ? `?${next}` : "";
+}

--- a/apps/web/src/vercelCallbackModel.test.ts
+++ b/apps/web/src/vercelCallbackModel.test.ts
@@ -12,14 +12,15 @@ test("installed carries the outcome back so the wizard resumes the Vercel flow",
   assert.equal(view.backHref, "/?vercel=installed");
 });
 
-test("drains_unavailable spells out the Pro/Enterprise plan requirement", () => {
+test("drains_unavailable explains the prompt fallback", () => {
   const view = vercelCallbackView("drains_unavailable");
   assert.equal(view.tone, "error");
   assert.match(view.title, /drains aren't available/i);
   assert.match(view.body, /Pro or Enterprise/);
   assert.match(view.body, /Hobby|free/i);
+  assert.match(view.body, /prompt/i);
   // Failure back-links carry the outcome so the onboarding wizard (which reads
-  // `?vercel=` on `/`) resets out of its waiting state when the user returns.
+  // `?vercel=` on `/`) can open the coding-agent prompt when the user returns.
   assert.equal(view.backHref, "/?vercel=drains_unavailable");
 });
 

--- a/apps/web/src/vercelCallbackModel.ts
+++ b/apps/web/src/vercelCallbackModel.ts
@@ -39,7 +39,7 @@ export function vercelCallbackView(raw: string | null | undefined): VercelCallba
       return {
         tone: "error",
         title: "Vercel Drains aren't available on your plan",
-        body: "Your Vercel team is on the Hobby (free) plan, and Vercel only offers Drains — the mechanism we use to stream your telemetry — on Pro or Enterprise teams. Nothing was connected. To finish, upgrade the team in Vercel or reinstall on a Pro or Enterprise team, then connect again.",
+        body: "Vercel only offers Drains — the mechanism we use to stream telemetry automatically — on Pro or Enterprise teams. If this team is on Hobby or Pro Trial, Superlog can still help you finish setup with the prompt-based install path.",
         backHref: "/?vercel=drains_unavailable",
         backLabel: "Back to Superlog",
       };


### PR DESCRIPTION
## Summary
- route Vercel `drains_unavailable` callbacks into the prompt onboarding path
- keep normal Vercel install callbacks on the Vercel flow
- update the Vercel callback result copy to explain the prompt fallback

## Validation
- `pnpm exec tsx --test apps/web/src/onboarding/onboardingWebView.test.ts apps/web/src/onboarding/connectChoices.test.ts apps/web/src/vercelCallbackModel.test.ts apps/api/src/vercel-service.test.ts`
- `pnpm exec biome check apps/web/src/onboarding/OnboardingWizard.tsx apps/web/src/onboarding/VercelConnectFlow.tsx apps/web/src/onboarding/connectChoices.ts apps/web/src/onboarding/connectChoices.test.ts apps/web/src/onboarding/onboardingWebView.ts apps/web/src/onboarding/onboardingWebView.test.ts apps/web/src/vercelCallbackModel.ts apps/web/src/vercelCallbackModel.test.ts`
- `pnpm --filter @superlog/web typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Vercel drain failures (`drains_unavailable`) to the prompt-based onboarding and updates the callback copy to explain the fallback. Other outcomes stay in the Vercel flow, and handled params are cleaned from the URL.

- **New Features**
  - `?vercel=drains_unavailable` opens the prompt install; denied/error keep showing the Vercel flow.
  - Strips `vercel=drains_unavailable` from the URL after routing; other outcomes are cleared inside the Vercel flow.
  - Adds `onboardingWebView` helpers (`initialWebViewFromSearch`, `stripHandledOnboardingParams`) with tests, and tweaks callback copy to mention the prompt fallback.

<sup>Written for commit f891213989d19b66c842da6df57acb5860d47d82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

