### PR TITLE
Agent runs: detect repo agent-instruction files for the investigator

### DIFF
--- a/apps/worker/src/agent-chats/tick.ts
+++ b/apps/worker/src/agent-chats/tick.ts
@@ -13,7 +13,10 @@ import { listAccessibleGithubRepositories } from "../agent-run-context.js";
 import type { AgentRunnerRepoCandidate } from "../agent-runner-backend.js";
 import { recordTokenUsage } from "../ai-usage.js";
 import { getAgentRunnerBackend } from "../infra/agent-runner/backend.js";
-import { createRepositoryReadToken } from "../infra/github/repositories.js";
+import {
+  createRepositoryReadToken,
+  listRepositoryInstructionFiles,
+} from "../infra/github/repositories.js";
 import { postAgentChatMessage } from "../infra/slack/chat-messages.js";
 import { logger } from "../logger.js";
 import {
@@ -27,6 +30,7 @@ const tracer = trace.getTracer("@superlog/worker");
 const log = logger.child({ scope: "agent_chat" });
 
 const AGENT_CHAT_BATCH_SIZE = parsePositiveInt(process.env.AGENT_CHAT_BATCH_SIZE, 10, 100);
+const CHAT_INSTRUCTION_FILE_PROBE_LIMIT = 10;
 
 function parsePositiveInt(value: string | undefined, fallback: number, max: number): number {
   if (value === undefined) return fallback;
@@ -67,16 +71,25 @@ const deps: AgentChatWorkflowDeps = {
     // Questions can reference any repo, and the agent picks its own path.
     const repos = (await listAccessibleGithubRepositories({ githubInstalls })).slice(0, maxRepos);
     const candidates = await Promise.all(
-      repos.map(async (repo): Promise<AgentRunnerRepoCandidate | null> => {
+      repos.map(async (repo, index): Promise<AgentRunnerRepoCandidate | null> => {
         try {
+          const installationToken = await createRepositoryReadToken(
+            repo.installation.installationId,
+            repo.id,
+          );
           return {
             fullName: repo.fullName,
             cloneUrl: `https://github.com/${repo.fullName}`,
-            installationToken: await createRepositoryReadToken(
-              repo.installation.installationId,
-              repo.id,
-            ),
+            installationToken,
             score: 0,
+            // Same cap rationale as agent runs: the probe costs GitHub API
+            // requests per repo, so only the first few mounted repos get one.
+            instructionFiles:
+              index < CHAT_INSTRUCTION_FILE_PROBE_LIMIT
+                ? await listRepositoryInstructionFiles(installationToken, repo.fullName).catch(
+                    () => [],
+                  )
+                : [],
           };
         } catch (err) {
           log.warn({ err, repo: repo.fullName }, "skipping inaccessible repo for agent chat");

--- a/apps/worker/src/agent-chats/workflow.test.ts
+++ b/apps/worker/src/agent-chats/workflow.test.ts
@@ -147,6 +147,7 @@ function makeHarness(opts: {
           cloneUrl: "https://github.com/acme/app",
           installationToken: "t",
           score: 0,
+          instructionFiles: [],
         },
       ];
     },

--- a/apps/worker/src/agent-runner-backend.ts
+++ b/apps/worker/src/agent-runner-backend.ts
@@ -11,6 +11,12 @@ export type AgentRunnerRepoCandidate = {
   cloneUrl: string;
   installationToken: string;
   score: number;
+  // Agent-instruction files (CLAUDE.md, AGENTS.md, .cursorrules,
+  // .cursor/rules/*, .github/copilot-instructions.md) detected on the repo's
+  // default branch at start time. Best-effort — empty when probing failed or
+  // was skipped for a low-scored candidate. Runners surface these so the
+  // agent reads them after cloning and follows the repo's conventions.
+  instructionFiles: string[];
 };
 
 export type AgentRunnerIssueSummary = {

--- a/apps/worker/src/agent-runs/start-run.ts
+++ b/apps/worker/src/agent-runs/start-run.ts
@@ -3,7 +3,10 @@ import type { AgentRunContext } from "../agent-run-context.js";
 import { listAccessibleGithubRepositories, scoreRepos } from "../agent-run-context.js";
 import { createAgentRunLifecycle } from "../agent-run.js";
 import { getAgentRunnerBackend } from "../infra/agent-runner/backend.js";
-import { createRepositoryReadToken } from "../infra/github/repositories.js";
+import {
+  createRepositoryReadToken,
+  listRepositoryInstructionFiles,
+} from "../infra/github/repositories.js";
 import {
   incidentBlocks,
   postIncidentThreadMessage,
@@ -28,6 +31,7 @@ export async function startQueuedAgentRun(ctx: AgentRunContext): Promise<void> {
     listRepositories: listAccessibleGithubRepositories,
     scoreRepositories: scoreRepos,
     createRepositoryReadToken,
+    listRepositoryInstructionFiles,
     buildIssueSummaries: (ctx) =>
       Promise.all(ctx.issueRows.map((issue) => buildIssueSummaryWithTrace(ctx.project.id, issue))),
     fail: failAgentRun,

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -102,6 +102,55 @@ test("startQueuedAgentRunWorkflow passes agent memories to the runner", async ()
   ]);
 });
 
+test("startQueuedAgentRunWorkflow passes probed instruction files to the runner", async () => {
+  const calls: string[] = [];
+  const ctx = makeContext();
+
+  let received: string[][] = [];
+  await startQueuedAgentRunWorkflow(
+    ctx,
+    makeDeps(
+      calls,
+      {
+        async listRepositoryInstructionFiles(_token, repoFullName) {
+          calls.push(`listRepositoryInstructionFiles:${repoFullName}`);
+          return ["CLAUDE.md", ".cursor/rules/logging.mdc"];
+        },
+      },
+      (input) => {
+        received = input.repoCandidates.map((repo) => repo.instructionFiles);
+      },
+    ),
+  );
+
+  assert.ok(calls.includes("listRepositoryInstructionFiles:org/repo-1"));
+  assert.deepEqual(received, [["CLAUDE.md", ".cursor/rules/logging.mdc"]]);
+});
+
+test("startQueuedAgentRunWorkflow starts with empty instruction files when probing fails", async () => {
+  const calls: string[] = [];
+  const ctx = makeContext();
+
+  let received: string[][] = [];
+  await startQueuedAgentRunWorkflow(
+    ctx,
+    makeDeps(
+      calls,
+      {
+        async listRepositoryInstructionFiles() {
+          throw new Error("github contents listing failed");
+        },
+      },
+      (input) => {
+        received = input.repoCandidates.map((repo) => repo.instructionFiles);
+      },
+    ),
+  );
+
+  assert.ok(calls.includes("runner.start:1"));
+  assert.deepEqual(received, [[]]);
+});
+
 test("startQueuedAgentRunWorkflow fails cleanly when async backend selection rejects", async () => {
   const calls: string[] = [];
   const ctx = makeContext();
@@ -188,6 +237,9 @@ function makeDeps(
     async createRepositoryReadToken(_installationId, repoId) {
       calls.push(`createRepositoryReadToken:repo-${repoId}`);
       return `token-${repoId}`;
+    },
+    async listRepositoryInstructionFiles() {
+      return [];
     },
     async buildIssueSummaries() {
       calls.push("buildIssueSummaries");

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -151,6 +151,32 @@ test("startQueuedAgentRunWorkflow starts with empty instruction files when probi
   assert.deepEqual(received, [[]]);
 });
 
+test("startQueuedAgentRunWorkflow keeps the repo candidate when the probe throws synchronously", async () => {
+  const calls: string[] = [];
+  const ctx = makeContext();
+
+  let received: string[][] = [];
+  await startQueuedAgentRunWorkflow(
+    ctx,
+    makeDeps(
+      calls,
+      {
+        // Not async: a synchronous throw never yields a rejected promise, so
+        // a .catch() on the return value alone would not cover it.
+        listRepositoryInstructionFiles() {
+          throw new Error("synchronous probe failure");
+        },
+      },
+      (input) => {
+        received = input.repoCandidates.map((repo) => repo.instructionFiles);
+      },
+    ),
+  );
+
+  assert.ok(calls.includes("runner.start:1"));
+  assert.deepEqual(received, [[]]);
+});
+
 test("startQueuedAgentRunWorkflow fails cleanly when async backend selection rejects", async () => {
   const calls: string[] = [];
   const ctx = makeContext();

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -23,6 +23,10 @@ export type StartQueuedAgentRunDeps = {
   listRepositories(ctx: AgentRunContext): Promise<InstalledGithubRepo[]>;
   scoreRepositories(repos: InstalledGithubRepo[], ctx: AgentRunContext): ScoredGithubRepo[];
   createRepositoryReadToken(installationId: number, repoId: number): Promise<string>;
+  listRepositoryInstructionFiles(
+    installationToken: string,
+    repoFullName: string,
+  ): Promise<string[]>;
   buildIssueSummaries(ctx: AgentRunContext): Promise<AgentRunnerIssueSummary[]>;
   fail(
     ctx: AgentRunContext,
@@ -172,24 +176,44 @@ async function createRunnerRepoCandidates(
   }
 
   const candidates = await Promise.all(
-    topScored.map(async (repo) => createRunnerRepoCandidate(repo, deps)),
+    topScored.map(async (repo, index) =>
+      createRunnerRepoCandidate(repo, index < INSTRUCTION_FILE_PROBE_LIMIT, deps),
+    ),
   );
   return candidates.filter((repo): repo is AgentRunnerRepoCandidate => repo !== null);
 }
 
+// Each probe costs up to three GitHub contents-API requests, so only the
+// strongest candidates get one; the rest start with an empty list and the
+// agent falls back to looking for instruction files itself after cloning.
+const INSTRUCTION_FILE_PROBE_LIMIT = 10;
+
 async function createRunnerRepoCandidate(
   repo: ScoredGithubRepo,
+  probeInstructionFiles: boolean,
   deps: StartQueuedAgentRunDeps,
 ): Promise<AgentRunnerRepoCandidate | null> {
   try {
+    const installationToken = await deps.createRepositoryReadToken(
+      repo.installation.installationId,
+      repo.id,
+    );
     return {
       fullName: repo.fullName,
       cloneUrl: `https://github.com/${repo.fullName}`,
-      installationToken: await deps.createRepositoryReadToken(
-        repo.installation.installationId,
-        repo.id,
-      ),
+      installationToken,
       score: repo.score,
+      instructionFiles: probeInstructionFiles
+        ? await deps
+            .listRepositoryInstructionFiles(installationToken, repo.fullName)
+            .catch((err) => {
+              logger.warn(
+                { err, repo: repo.fullName },
+                "instruction-file probe failed; starting without repo instruction files",
+              );
+              return [];
+            })
+        : [],
     };
   } catch (err) {
     logger.warn(

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -188,6 +188,24 @@ async function createRunnerRepoCandidates(
 // agent falls back to looking for instruction files itself after cloning.
 const INSTRUCTION_FILE_PROBE_LIMIT = 10;
 
+// Best-effort: the probe must never cost us a repo candidate, so both
+// rejected promises and synchronous throws from the dep degrade to [].
+async function probeRepoInstructionFiles(
+  repo: ScoredGithubRepo,
+  installationToken: string,
+  deps: StartQueuedAgentRunDeps,
+): Promise<string[]> {
+  try {
+    return await deps.listRepositoryInstructionFiles(installationToken, repo.fullName);
+  } catch (err) {
+    logger.warn(
+      { err, repo: repo.fullName },
+      "instruction-file probe failed; starting without repo instruction files",
+    );
+    return [];
+  }
+}
+
 async function createRunnerRepoCandidate(
   repo: ScoredGithubRepo,
   probeInstructionFiles: boolean,
@@ -204,15 +222,7 @@ async function createRunnerRepoCandidate(
       installationToken,
       score: repo.score,
       instructionFiles: probeInstructionFiles
-        ? await deps
-            .listRepositoryInstructionFiles(installationToken, repo.fullName)
-            .catch((err) => {
-              logger.warn(
-                { err, repo: repo.fullName },
-                "instruction-file probe failed; starting without repo instruction files",
-              );
-              return [];
-            })
+        ? await probeRepoInstructionFiles(repo, installationToken, deps)
         : [],
     };
   } catch (err) {

--- a/apps/worker/src/github-app.test.ts
+++ b/apps/worker/src/github-app.test.ts
@@ -5,13 +5,94 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import {
+  type GithubDirEntry,
+  MAX_REPO_INSTRUCTION_FILES,
   applyAgentPatch,
+  collectRepoInstructionFiles,
   formatRetryBranchName,
   isGitPushBranchCollision,
   isMissingRemoteBranchFailure,
   isRetryableGitPushFailure,
   redactGitSecrets,
 } from "./github-app.js";
+
+function makeDirLister(
+  dirs: Record<string, GithubDirEntry[]>,
+): (dirPath: string) => Promise<GithubDirEntry[] | null> {
+  return async (dirPath: string) => dirs[dirPath] ?? null;
+}
+
+function file(path: string): GithubDirEntry {
+  return { name: path.split("/").at(-1) ?? path, path, type: "file" };
+}
+
+function dir(path: string): GithubDirEntry {
+  return { name: path.split("/").at(-1) ?? path, path, type: "dir" };
+}
+
+test("collectRepoInstructionFiles finds root-level instruction files", async () => {
+  const found = await collectRepoInstructionFiles(
+    makeDirLister({
+      "": [file("CLAUDE.md"), file("AGENTS.md"), file(".cursorrules"), file("README.md")],
+    }),
+  );
+  assert.deepEqual(found, ["CLAUDE.md", "AGENTS.md", ".cursorrules"]);
+});
+
+test("collectRepoInstructionFiles matches instruction file names case-insensitively", async () => {
+  const found = await collectRepoInstructionFiles(
+    makeDirLister({ "": [file("claude.md"), file("Agents.md")] }),
+  );
+  assert.deepEqual(found, ["claude.md", "Agents.md"]);
+});
+
+test("collectRepoInstructionFiles lists .cursor/rules contents when .cursor exists", async () => {
+  const found = await collectRepoInstructionFiles(
+    makeDirLister({
+      "": [dir(".cursor"), file("README.md")],
+      ".cursor/rules": [file(".cursor/rules/logging.mdc"), dir(".cursor/rules/backend")],
+    }),
+  );
+  assert.deepEqual(found, [".cursor/rules/logging.mdc", ".cursor/rules/backend/"]);
+});
+
+test("collectRepoInstructionFiles finds .github/copilot-instructions.md", async () => {
+  const found = await collectRepoInstructionFiles(
+    makeDirLister({
+      "": [dir(".github")],
+      ".github": [file(".github/copilot-instructions.md"), file(".github/CODEOWNERS")],
+    }),
+  );
+  assert.deepEqual(found, [".github/copilot-instructions.md"]);
+});
+
+test("collectRepoInstructionFiles skips directory probes when the root lacks them", async () => {
+  const probed: string[] = [];
+  const found = await collectRepoInstructionFiles(async (dirPath) => {
+    probed.push(dirPath);
+    return dirPath === "" ? [file("README.md"), dir("src")] : [];
+  });
+  assert.deepEqual(found, []);
+  assert.deepEqual(probed, [""]);
+});
+
+test("collectRepoInstructionFiles returns empty when the root listing fails", async () => {
+  const found = await collectRepoInstructionFiles(async () => null);
+  assert.deepEqual(found, []);
+});
+
+test("collectRepoInstructionFiles ignores directories named like instruction files", async () => {
+  const found = await collectRepoInstructionFiles(makeDirLister({ "": [dir("CLAUDE.md")] }));
+  assert.deepEqual(found, []);
+});
+
+test("collectRepoInstructionFiles caps the result list", async () => {
+  const rules = Array.from({ length: 40 }, (_, i) => file(`.cursor/rules/rule-${i}.mdc`));
+  const found = await collectRepoInstructionFiles(
+    makeDirLister({ "": [dir(".cursor")], ".cursor/rules": rules }),
+  );
+  assert.equal(found.length, MAX_REPO_INSTRUCTION_FILES);
+});
 
 test("redactGitSecrets scrubs GitHub installation/app tokens", () => {
   const token = ["ghs", "AbCdEf0123456789AbCdEf0123456789"].join("_");

--- a/apps/worker/src/github-app.ts
+++ b/apps/worker/src/github-app.ts
@@ -274,6 +274,83 @@ export async function listGithubInstallationRepositories(
   return repos;
 }
 
+export type GithubDirEntry = {
+  name: string;
+  path: string;
+  type: string;
+};
+
+// Instruction files aimed at coding agents (Claude Code, Cursor, Copilot).
+// Investigation agents should read these after cloning so patches follow the
+// repository's own conventions.
+const ROOT_INSTRUCTION_FILE_NAMES = new Set(["claude.md", "agents.md", ".cursorrules"]);
+export const MAX_REPO_INSTRUCTION_FILES = 20;
+
+// Detect agent-instruction files on a repository's default branch from
+// directory listings: the root (CLAUDE.md / AGENTS.md / .cursorrules), the
+// .cursor/rules directory, and .github/copilot-instructions.md. Directory
+// entries under .cursor/rules are reported with a trailing slash so the
+// reader knows to look inside. The lister returns null when a listing is
+// unavailable (missing directory, API error) — absence is never an error.
+export async function collectRepoInstructionFiles(
+  listDir: (dirPath: string) => Promise<GithubDirEntry[] | null>,
+): Promise<string[]> {
+  const root = await listDir("");
+  if (!root) return [];
+
+  const files: string[] = [];
+  for (const entry of root) {
+    if (entry.type === "file" && ROOT_INSTRUCTION_FILE_NAMES.has(entry.name.toLowerCase())) {
+      files.push(entry.path);
+    }
+  }
+
+  const hasRootDir = (name: string) =>
+    root.some((entry) => entry.type === "dir" && entry.name === name);
+
+  if (hasRootDir(".cursor")) {
+    for (const entry of (await listDir(".cursor/rules")) ?? []) {
+      if (entry.type === "file") files.push(entry.path);
+      else if (entry.type === "dir") files.push(`${entry.path}/`);
+    }
+  }
+
+  if (hasRootDir(".github")) {
+    for (const entry of (await listDir(".github")) ?? []) {
+      if (entry.type === "file" && entry.name.toLowerCase() === "copilot-instructions.md") {
+        files.push(entry.path);
+      }
+    }
+  }
+
+  return files.slice(0, MAX_REPO_INSTRUCTION_FILES);
+}
+
+// Best-effort: returns [] on any API failure rather than blocking a run
+// start on a metadata probe. Costs 1-3 contents-API requests per repo.
+export async function listGithubRepoInstructionFiles(
+  installationToken: string,
+  repoFullName: string,
+): Promise<string[]> {
+  return collectRepoInstructionFiles(async (dirPath) => {
+    try {
+      const data = await githubRequest<GithubDirEntry[] | { type: string }>(
+        dirPath === ""
+          ? `/repos/${repoFullName}/contents`
+          : `/repos/${repoFullName}/contents/${dirPath}`,
+        { bearerToken: installationToken },
+      );
+      return Array.isArray(data) ? data : null;
+    } catch (err) {
+      logger.debug(
+        { err, repo: repoFullName, dir: dirPath },
+        "instruction-file probe listing failed",
+      );
+      return null;
+    }
+  });
+}
+
 function runGit(
   args: string[],
   opts: { cwd?: string; env?: NodeJS.ProcessEnv; input?: string } = {},

--- a/apps/worker/src/infra/github/repositories.ts
+++ b/apps/worker/src/infra/github/repositories.ts
@@ -1,4 +1,5 @@
 export {
   createGithubReadToken as createRepositoryReadToken,
   listGithubInstallationRepositories as listInstallationRepositories,
+  listGithubRepoInstructionFiles as listRepositoryInstructionFiles,
 } from "../../github-app.js";


### PR DESCRIPTION
## What

At investigation start, probe each mounted repo's default branch for coding-agent instruction files — `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.cursor/rules/*`, `.github/copilot-instructions.md` — via the GitHub contents API, and pass the detected paths through `AgentRunnerRepoCandidate.instructionFiles` so runner backends can tell the agent which convention files exist before it clones.

## Why

Repos increasingly carry conventions written for coding agents (test commands, style, PR target branch). The investigation agent gets the repo mounted but nothing tells it those files exist, so patches can ignore the repo's own rules. Telling the runner which files were detected lets its prompt direct the agent to read them.

## How

- `github-app.ts`: `listGithubRepoInstructionFiles()` — 1-3 contents-API directory listings (root, `.cursor/rules`, `.github`), pure collector split out as `collectRepoInstructionFiles()` for tests. Best-effort: any API failure yields `[]`, never a failed run.
- `agent-runs/start.ts`: probe is dependency-injected and limited to the 10 strongest candidates; a probe failure degrades to an empty list.
- `agent-chats/tick.ts`: chat repo candidates get the same field, same cap.

## Tests

- `test:github-app`: 8 new cases for the collector (root files, case-insensitivity, `.cursor/rules` listing incl. subdirs, copilot file, no-probe-when-absent, root-listing failure, dir-named-like-file, result cap).
- `test:agent-run-start`: instruction files flow into `runner.start`; probe failure still starts the run with `[]`.
- `pnpm --filter @superlog/worker typecheck` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect agent-instruction files on each repo’s default branch and pass them to the runner so the agent follows repo conventions; also surface “Out of credits” incidents in the UI and fix Slack Q&A chats closing too early.

- New Features
  - Detect instruction files via the GitHub contents API: CLAUDE.md, AGENTS.md, .cursorrules, .cursor/rules/*, .github/copilot-instructions.md.
  - Add `instructionFiles` to `AgentRunnerRepoCandidate`; probe only the first 10 candidates for runs and chats; best-effort with [] on failure.
  - Implement `listGithubRepoInstructionFiles()` using `collectRepoInstructionFiles()`; caps results; tests cover root, .cursor/rules, .github, case-insensitivity, and caps.
  - Persist and show “Out of credits” when auto-investigation is skipped (DB column, workflow hooks, list-row badge, detail banner, sidebar update).

- Bug Fixes
  - Keep Slack Q&A turns running until truly terminal; only close on idle with a concrete, non-requires_action stopReason.
  - Instruction-file probe failures never drop a repo candidate; sync and async errors degrade to instructionFiles: [].
  - Add per-tick decision logging and scope `AgentRunnerSnapshot.stopReason` to the current turn.

<sup>Written for commit 69f5a063ed75071aa209ca29235264999326e335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

