### PR TITLE
Decorate memory tool calls in transcript

### DIFF
--- a/apps/web/src/incidents/IncidentTranscript.test.ts
+++ b/apps/web/src/incidents/IncidentTranscript.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { memoryActivityFromTool } from "./memory-tool-activity.ts";
+
+test("memoryActivityFromTool decorates save_memory calls as memory activity", () => {
+  assert.deepEqual(
+    memoryActivityFromTool(
+      "tool-use-1",
+      "save_memory",
+      {
+        kind: "infra",
+        title: "Deploy window",
+        body: "Deploys happen during the US morning support window.",
+      },
+      '{"ok":true,"id":"mem-1"}',
+      false,
+    ),
+    {
+      type: "memory",
+      id: "tool-use-1",
+      action: "saved",
+      kind: "infra",
+      memoryId: "mem-1",
+      status: null,
+      title: "Deploy window",
+      body: "Deploys happen during the US morning support window.",
+      result: '{"ok":true,"id":"mem-1"}',
+      isError: false,
+    },
+  );
+});

--- a/apps/web/src/incidents/IncidentTranscript.test.ts
+++ b/apps/web/src/incidents/IncidentTranscript.test.ts
@@ -29,3 +29,65 @@ test("memoryActivityFromTool decorates save_memory calls as memory activity", ()
     },
   );
 });
+
+test("memoryActivityFromTool decorates update_memory calls as memory activity", () => {
+  assert.deepEqual(
+    memoryActivityFromTool(
+      "tool-use-2",
+      "update_memory",
+      {
+        id: "mem-existing",
+        status: "archived",
+      },
+      '{"ok":true,"id":"mem-existing"}',
+      false,
+    ),
+    {
+      type: "memory",
+      id: "tool-use-2",
+      action: "updated",
+      kind: null,
+      memoryId: "mem-existing",
+      status: "archived",
+      title: null,
+      body: null,
+      result: '{"ok":true,"id":"mem-existing"}',
+      isError: false,
+    },
+  );
+});
+
+test("memoryActivityFromTool ignores non-memory tools", () => {
+  assert.equal(
+    memoryActivityFromTool("tool-use-3", "query_logs", { search: "error" }, "[]", false),
+    null,
+  );
+});
+
+test("memoryActivityFromTool preserves failed memory tool results", () => {
+  assert.deepEqual(
+    memoryActivityFromTool(
+      "tool-use-4",
+      "save_memory",
+      {
+        kind: "infra",
+        title: "Deploy window",
+        body: "Deploys happen during the US morning support window.",
+      },
+      '{"error":"memory tools unavailable"}',
+      true,
+    ),
+    {
+      type: "memory",
+      id: "tool-use-4",
+      action: "saved",
+      kind: "infra",
+      memoryId: null,
+      status: null,
+      title: "Deploy window",
+      body: "Deploys happen during the US morning support window.",
+      result: '{"error":"memory tools unavailable"}',
+      isError: true,
+    },
+  );
+});

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -5,6 +5,7 @@ import { DEFAULT_TOP_N } from "../dashboards/widgets/series-topn.ts";
 import { Chip, type ChipTone } from "../design/ui.tsx";
 import { type EvidenceLinkContext, EvidenceMarkdown } from "../EvidenceMarkdown.tsx";
 import { LogsTable, TracesTable } from "../Explore.tsx";
+import { type MemoryActivity, memoryActivityFromTool } from "./memory-tool-activity.ts";
 import {
   type TelemetryKind,
   exploreHref,
@@ -53,6 +54,7 @@ type TranscriptItem =
       result: string | null;
       isError: boolean;
     }
+  | MemoryActivity
   // The run paused on `ask_human`. The question lives in the awaiting_human
   // event's detail (or, absent that event, on the run result). Rendered as a
   // rich terminal node rather than a bare lifecycle one-liner.
@@ -103,6 +105,13 @@ export function buildActivityFeed(events: IncidentEvent[]): FeedItem[] {
       const result = resultByUseId.get(e.providerEventId ?? e.id) ?? null;
       const isError = result ? (readToolResult(result)?.isError ?? false) : false;
       const kind = telemetryToolKind(name);
+      const memory = memoryActivityFromTool(
+        e.id,
+        name,
+        use?.input ?? {},
+        result?.summary ?? null,
+        isError,
+      );
       if (kind) {
         items.push({
           type: "telemetry",
@@ -112,6 +121,8 @@ export function buildActivityFeed(events: IncidentEvent[]): FeedItem[] {
           rows: parseResultRows(result?.summary),
           isError,
         });
+      } else if (memory) {
+        items.push(memory);
       } else if (name !== "submit_agent_run_result") {
         items.push({
           type: "tool",
@@ -184,6 +195,7 @@ export function IncidentActivityFeed({
   const renderItem = (item: FeedItem) => {
     if (item.type === "message") return <MessageEntry key={item.id} text={item.text} />;
     if (item.type === "telemetry") return <TelemetryEntry key={item.id} item={item} />;
+    if (item.type === "memory") return <MemoryEntry key={item.id} item={item} />;
     if (item.type === "tool") return <ToolEntry key={item.id} item={item} />;
     if (item.type === "start") return <StartEntry key={item.id} prompt={item.prompt} />;
     if (item.type === "question")
@@ -198,7 +210,7 @@ export function IncidentActivityFeed({
   // the conclusion render after it — so the timeline reads
   // start → (N steps) → conclusion by default without hiding real activity.
   const isStep = (i: FeedItem) =>
-    i.type === "message" || i.type === "telemetry" || i.type === "tool";
+    i.type === "message" || i.type === "telemetry" || i.type === "memory" || i.type === "tool";
   const startIdx = feed.findIndex((i) => i.type === "start");
   let termIdx = -1;
   for (let i = feed.length - 1; i > startIdx; i--) {
@@ -758,6 +770,41 @@ function CodeEntry({ item }: { item: Extract<TranscriptItem, { type: "tool" }> }
           {result.slice(0, 240)}
         </div>
       )}
+    </div>
+  );
+}
+
+function MemoryEntry({ item }: { item: Extract<TranscriptItem, { type: "memory" }> }) {
+  const label = item.action === "updated" ? "Updated memory" : "Saved memory";
+  const fallbackTitle = item.memoryId ? `Memory ${item.memoryId}` : "Project memory";
+  const title = item.title ?? fallbackTitle;
+  const result = (item.result ?? "").trim();
+  return (
+    <div className="relative mb-6">
+      <Node tone="accent">
+        <path d="M19 21l-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+      </Node>
+      <div className="mb-1.5 flex min-h-[22px] flex-wrap items-center gap-2">
+        <span className="text-[12px] font-semibold text-fg">{label}</span>
+        {item.kind && <Chip tone="muted">{item.kind}</Chip>}
+        {item.status && (
+          <Chip tone={item.status === "archived" ? "warning" : "muted"}>{item.status}</Chip>
+        )}
+        {item.isError && <Chip tone="danger">failed</Chip>}
+      </div>
+      <div className="rounded-lg border border-border bg-surface px-3.5 py-3">
+        <div className="text-[13px] font-medium text-fg">{title}</div>
+        {item.body && (
+          <div className="mt-1.5 whitespace-pre-wrap break-words text-[13px] leading-relaxed text-muted">
+            {item.body}
+          </div>
+        )}
+        {result && item.isError && (
+          <div className="mt-2 line-clamp-2 break-all font-mono text-[11px] text-danger">
+            {result.slice(0, 240)}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -775,7 +775,13 @@ function CodeEntry({ item }: { item: Extract<TranscriptItem, { type: "tool" }> }
 }
 
 function MemoryEntry({ item }: { item: Extract<TranscriptItem, { type: "memory" }> }) {
-  const label = item.action === "updated" ? "Updated memory" : "Saved memory";
+  const label = item.isError
+    ? item.action === "updated"
+      ? "Memory update failed"
+      : "Memory save failed"
+    : item.action === "updated"
+      ? "Updated memory"
+      : "Saved memory";
   const fallbackTitle = item.memoryId ? `Memory ${item.memoryId}` : "Project memory";
   const title = item.title ?? fallbackTitle;
   const result = (item.result ?? "").trim();

--- a/apps/web/src/incidents/memory-tool-activity.ts
+++ b/apps/web/src/incidents/memory-tool-activity.ts
@@ -1,0 +1,51 @@
+export type MemoryActivity = {
+  type: "memory";
+  id: string;
+  action: "saved" | "updated";
+  kind: string | null;
+  memoryId: string | null;
+  status: string | null;
+  title: string | null;
+  body: string | null;
+  result: string | null;
+  isError: boolean;
+};
+
+const MEMORY_TOOLS = new Set(["save_memory", "update_memory"]);
+
+function textArg(input: Record<string, unknown>, key: string): string | null {
+  const value = input[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function memoryIdFromResult(result: string | null): string | null {
+  if (!result) return null;
+  try {
+    const parsed = JSON.parse(result) as { id?: unknown };
+    return typeof parsed.id === "string" && parsed.id ? parsed.id : null;
+  } catch {
+    return null;
+  }
+}
+
+export function memoryActivityFromTool(
+  id: string,
+  name: string,
+  input: Record<string, unknown>,
+  result: string | null,
+  isError: boolean,
+): MemoryActivity | null {
+  if (!MEMORY_TOOLS.has(name)) return null;
+  return {
+    type: "memory",
+    id,
+    action: name === "update_memory" ? "updated" : "saved",
+    kind: textArg(input, "kind"),
+    memoryId: textArg(input, "id") ?? memoryIdFromResult(result),
+    status: textArg(input, "status"),
+    title: textArg(input, "title"),
+    body: textArg(input, "body"),
+    result,
+    isError,
+  };
+}


### PR DESCRIPTION
## Summary

- Render `save_memory` and `update_memory` custom tool calls as memory activity in the incident transcript
- Show memory title/body, kind/status chips, and failure state instead of the generic tool-call card
- Add a dependency-light projection helper and regression test for saved-memory transcript activity

## Validation

- `pnpm --dir . --filter @superlog/web exec tsx --test src/incidents/IncidentTranscript.test.ts`
- `pnpm --dir . --filter @superlog/web typecheck`
- `pnpm --dir . exec biome check apps/web/src/incidents/memory-tool-activity.ts apps/web/src/incidents/IncidentTranscript.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render `save_memory` and `update_memory` tool calls as dedicated memory activity in the incident transcript, replacing the generic tool card. This makes memory actions clearer with labels, chips, and failure details.

- New Features
  - Convert memory tool events into `memory` feed items (saved/updated) with title/body, kind/status chips, memory ID (from input or result), fallback title, and a trimmed error result snippet.
  - Add `memoryActivityFromTool` helper and tests covering save/update, failures, and non-memory tools; integrate memory entries into the activity feed rendering.

<sup>Written for commit db298ac5786081844c4dfada7c3fc7da098acfa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

