### PR TITLE
Cloudflare connector: offline-access grant + token refresh

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -33,6 +33,7 @@
     "@opentelemetry/sdk-node": "^0.215.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@scalar/hono-api-reference": "^0.10.19",
+    "@superlog/cloudflare": "workspace:*",
     "@superlog/db": "workspace:*",
     "@superlog/railway": "workspace:*",
     "@superlog/render": "workspace:*",

--- a/apps/api/src/cloudflare-service.test.ts
+++ b/apps/api/src/cloudflare-service.test.ts
@@ -43,6 +43,9 @@ test("cloudflareConfigFromEnv returns null until required vars are set", () => {
     "workers-observability-telemetry.write",
     "workers-scripts.read",
     "workers-scripts.write",
+    // The offline grant — without it Cloudflare issues no refresh token and the
+    // access token dies for good ~16h after connect.
+    "offline_access",
   ]);
 });
 
@@ -347,8 +350,6 @@ test("exchangeCodeForToken posts form body to the token endpoint", async () => {
       clientId: "cid",
       clientSecret: "csecret",
       redirectUri: "https://api.example.com/cloudflare/oauth/callback",
-      scopes: [],
-      intakeBaseUrl: "https://intake.example.com",
     },
     code: "the-code",
     fetchImpl: fakeFetch,

--- a/apps/api/src/cloudflare-service.ts
+++ b/apps/api/src/cloudflare-service.ts
@@ -27,15 +27,23 @@ export const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4";
 //   - workers-observability-telemetry.write   (destinations live under this perm)
 //   - workers-scripts.read/.write      read each Worker's observability config
 //                                      and wire our destinations into it
+//   - offline_access                   the offline grant — makes Cloudflare
+//                                      issue a long-lived refresh token so the
+//                                      short-lived access token can be renewed
+//                                      on demand instead of dying for good
+//                                      (~16h after connect). The refresh token's
+//                                      lifetime is bounded by the OAuth client
+//                                      registration's "grant session duration"
+//                                      (set it long, e.g. a year); the client
+//                                      must also permit the refresh_token grant.
 // Override with CLOUDFLARE_OAUTH_SCOPES if a deployment's client differs.
-// `offline_access` is added/removed automatically by Cloudflare based on the
-// client's grant types, so we don't list it here.
 export const DEFAULT_CLOUDFLARE_OAUTH_SCOPES = [
   "account-settings.read",
   "workers-observability.write",
   "workers-observability-telemetry.write",
   "workers-scripts.read",
   "workers-scripts.write",
+  "offline_access",
 ];
 
 export type CloudflareSignal = "traces" | "logs" | "metrics";
@@ -187,33 +195,15 @@ export { signState, verifyState } from "./oauth-state.js";
 // Response parsing
 // ---------------------------------------------------------------------------
 
-export type CloudflareTokenResult =
-  | {
-      ok: true;
-      accessToken: string;
-      refreshToken: string | null;
-      expiresIn: number | null;
-      scope: string | null;
-    }
-  | { ok: false; error: string };
-
-export function parseTokenResponse(json: unknown): CloudflareTokenResult {
-  if (!json || typeof json !== "object") return { ok: false, error: "invalid_response" };
-  const o = json as Record<string, unknown>;
-  if (typeof o.error === "string") {
-    return { ok: false, error: o.error };
-  }
-  if (typeof o.access_token !== "string" || !o.access_token) {
-    return { ok: false, error: "no_access_token" };
-  }
-  return {
-    ok: true,
-    accessToken: o.access_token,
-    refreshToken: typeof o.refresh_token === "string" ? o.refresh_token : null,
-    expiresIn: typeof o.expires_in === "number" ? o.expires_in : null,
-    scope: typeof o.scope === "string" ? o.scope : null,
-  };
-}
+// OAuth token primitives (exchange / refresh / parse) live in @superlog/cloudflare
+// so the worker's background refresh job shares exactly one implementation with
+// this connect flow. Re-exported here so existing api imports keep working.
+export {
+  type CloudflareTokenResult,
+  exchangeCodeForToken,
+  parseTokenResponse,
+  refreshAccessToken,
+} from "@superlog/cloudflare";
 
 export type CloudflareAccount = { id: string; name: string };
 
@@ -377,27 +367,6 @@ export function wireObservabilityDestinations(
 // ---------------------------------------------------------------------------
 
 export type FetchImpl = typeof fetch;
-
-export async function exchangeCodeForToken(input: {
-  config: CloudflareConnectConfig;
-  code: string;
-  fetchImpl?: FetchImpl;
-}): Promise<CloudflareTokenResult> {
-  const fetchImpl = input.fetchImpl ?? fetch;
-  const res = await fetchImpl(CLOUDFLARE_OAUTH_TOKEN_URL, {
-    method: "POST",
-    headers: { "content-type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      grant_type: "authorization_code",
-      code: input.code,
-      redirect_uri: input.config.redirectUri,
-      client_id: input.config.clientId,
-      client_secret: input.config.clientSecret,
-    }),
-  });
-  const json = await res.json().catch(() => null);
-  return parseTokenResponse(json);
-}
 
 export async function listAccounts(
   accessToken: string,

--- a/apps/api/src/cloudflare.ts
+++ b/apps/api/src/cloudflare.ts
@@ -38,6 +38,7 @@ import {
   getScriptObservability,
   listAccounts,
   listScripts,
+  refreshAccessToken,
   revokeToken,
   signState,
   staleDestinationSlugs,
@@ -151,11 +152,95 @@ async function deleteRemoteDestinations(input: {
   }
 }
 
+// Access tokens are short-lived; refresh on demand when the stored one is
+// within this margin of expiry. No background job — the offline-access grant
+// gives us a long-lived refresh token, so we mint a fresh access token at the
+// point we actually need it.
+const TOKEN_REFRESH_MARGIN_MS = 2 * 60 * 1000;
+
+/**
+ * Persist a refreshed (possibly rotated) token pair. Refresh tokens may rotate
+ * on use, so we keep the replacement, falling back to the prior one when the
+ * response didn't return a new one — losing it would strand the install.
+ */
+async function persistRefreshedTokens(
+  rowId: string,
+  refreshed: { accessToken: string; refreshToken: string | null; expiresIn: number | null },
+  previousRefreshToken: string,
+): Promise<void> {
+  const accessCipher = encryptIntegrationSecret(refreshed.accessToken);
+  const refreshCipher = encryptIntegrationSecret(refreshed.refreshToken ?? previousRefreshToken);
+  const tokenExpiresAt =
+    refreshed.expiresIn != null ? new Date(Date.now() + refreshed.expiresIn * 1000) : null;
+  await db
+    .update(schema.cloudflareInstallations)
+    .set({
+      accessTokenCiphertext: accessCipher.ciphertext,
+      accessTokenNonce: accessCipher.nonce,
+      accessTokenKeyVersion: accessCipher.keyVersion,
+      refreshTokenCiphertext: refreshCipher.ciphertext,
+      refreshTokenNonce: refreshCipher.nonce,
+      refreshTokenKeyVersion: refreshCipher.keyVersion,
+      tokenExpiresAt,
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.cloudflareInstallations.id, rowId));
+}
+
+/**
+ * A usable access token for an installation, refreshed on demand when the
+ * stored one has expired (or is about to). This is how the connector stays
+ * manageable after connect: the delegated access token lives ~16h, but the
+ * offline-access grant hands us a long-lived refresh token, so any server-side
+ * call (teardown today; reconcile/inspect later) renews right before use rather
+ * than relying on a scheduled refresh. A rotated refresh token is persisted
+ * immediately. Falls back to the stored (possibly dead) token when there's
+ * nothing to refresh with — a legacy install with no refresh token, or an
+ * unconfigured OAuth client — so best-effort callers still get to try. Throws
+ * only when the stored access token itself can't be decrypted.
+ */
+async function freshAccessToken(
+  row: CloudflareInstallationRow,
+  config: CloudflareConnectConfig | null,
+  fetchImpl: typeof fetch,
+): Promise<string> {
+  const accessToken = decryptIntegrationSecret({
+    ciphertext: row.accessTokenCiphertext,
+    nonce: row.accessTokenNonce,
+    keyVersion: row.accessTokenKeyVersion,
+  });
+  const expiresAt = row.tokenExpiresAt?.getTime() ?? null;
+  if (expiresAt === null || expiresAt - Date.now() > TOKEN_REFRESH_MARGIN_MS) {
+    return accessToken;
+  }
+
+  const refreshToken =
+    row.refreshTokenCiphertext && row.refreshTokenNonce
+      ? decryptIntegrationSecret({
+          ciphertext: row.refreshTokenCiphertext,
+          nonce: row.refreshTokenNonce,
+          keyVersion: row.refreshTokenKeyVersion ?? 1,
+        })
+      : null;
+  if (!refreshToken || !config) return accessToken;
+
+  const refreshed = await refreshAccessToken({ config, refreshToken, fetchImpl });
+  if (!refreshed.ok) {
+    log.warn(
+      { account_id: row.accountId, error: refreshed.error },
+      "cloudflare access token refresh failed; using stored token",
+    );
+    return accessToken;
+  }
+  await persistRefreshedTokens(row.id, refreshed, refreshToken);
+  return refreshed.accessToken;
+}
+
 /**
  * Fully tear down one installation row: delete its remote destinations, revoke
  * its delegated OAuth token, revoke the ingest key its destinations authenticate
- * with, and soft-revoke the row. Each remote step is best-effort (tokens may be
- * expired); the ingest-key revoke is the backstop that actually stops telemetry
+ * with, and soft-revoke the row. Each remote step is best-effort (the grant may
+ * be gone); the ingest-key revoke is the backstop that actually stops telemetry
  * being accepted at our intake. Shared by uninstall and account-switch supersede.
  */
 async function teardownInstallation(
@@ -164,11 +249,10 @@ async function teardownInstallation(
 ): Promise<void> {
   let accessToken: string | null = null;
   try {
-    accessToken = decryptIntegrationSecret({
-      ciphertext: row.accessTokenCiphertext,
-      nonce: row.accessTokenNonce,
-      keyVersion: row.accessTokenKeyVersion,
-    });
+    // Refresh first so the remote cleanup actually runs: by uninstall time the
+    // original ~16h access token is almost always dead, but the refresh token
+    // lets us mint a live one and delete the destinations cleanly.
+    accessToken = await freshAccessToken(row, deps.config, deps.fetchImpl);
   } catch (e) {
     log.warn({ err: e, account_id: row.accountId }, "cloudflare access token decrypt failed");
   }

--- a/apps/api/src/cloudflare.ts
+++ b/apps/api/src/cloudflare.ts
@@ -209,8 +209,11 @@ async function freshAccessToken(
     nonce: row.accessTokenNonce,
     keyVersion: row.accessTokenKeyVersion,
   });
+  // Only a known, comfortably-future expiry counts as fresh. An unknown
+  // (null) expiry falls through to the refresh path so teardown doesn't reuse a
+  // possibly-dead access token when we actually hold a refresh token.
   const expiresAt = row.tokenExpiresAt?.getTime() ?? null;
-  if (expiresAt === null || expiresAt - Date.now() > TOKEN_REFRESH_MARGIN_MS) {
+  if (expiresAt !== null && expiresAt - Date.now() > TOKEN_REFRESH_MARGIN_MS) {
     return accessToken;
   }
 

--- a/apps/api/src/cloudflare.ts
+++ b/apps/api/src/cloudflare.ts
@@ -23,7 +23,7 @@ import {
   mintApiKey,
   schema,
 } from "@superlog/db";
-import { and, desc, eq, isNull, ne } from "drizzle-orm";
+import { and, desc, eq, isNull, ne, sql } from "drizzle-orm";
 import type { Context, Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import {
@@ -158,33 +158,30 @@ async function deleteRemoteDestinations(input: {
 // point we actually need it.
 const TOKEN_REFRESH_MARGIN_MS = 2 * 60 * 1000;
 
-/**
- * Persist a refreshed (possibly rotated) token pair. Refresh tokens may rotate
- * on use, so we keep the replacement, falling back to the prior one when the
- * response didn't return a new one — losing it would strand the install.
- */
-async function persistRefreshedTokens(
-  rowId: string,
-  refreshed: { accessToken: string; refreshToken: string | null; expiresIn: number | null },
-  previousRefreshToken: string,
-): Promise<void> {
-  const accessCipher = encryptIntegrationSecret(refreshed.accessToken);
-  const refreshCipher = encryptIntegrationSecret(refreshed.refreshToken ?? previousRefreshToken);
-  const tokenExpiresAt =
-    refreshed.expiresIn != null ? new Date(Date.now() + refreshed.expiresIn * 1000) : null;
-  await db
-    .update(schema.cloudflareInstallations)
-    .set({
-      accessTokenCiphertext: accessCipher.ciphertext,
-      accessTokenNonce: accessCipher.nonce,
-      accessTokenKeyVersion: accessCipher.keyVersion,
-      refreshTokenCiphertext: refreshCipher.ciphertext,
-      refreshTokenNonce: refreshCipher.nonce,
-      refreshTokenKeyVersion: refreshCipher.keyVersion,
-      tokenExpiresAt,
-      updatedAt: new Date(),
-    })
-    .where(eq(schema.cloudflareInstallations.id, rowId));
+/** Decrypt the access token stored on an installation row. */
+function decryptAccessToken(row: CloudflareInstallationRow): string {
+  return decryptIntegrationSecret({
+    ciphertext: row.accessTokenCiphertext,
+    nonce: row.accessTokenNonce,
+    keyVersion: row.accessTokenKeyVersion,
+  });
+}
+
+/** Decrypt the refresh token stored on a row, or null when there isn't one. */
+function decryptRefreshToken(row: CloudflareInstallationRow): string | null {
+  return row.refreshTokenCiphertext && row.refreshTokenNonce
+    ? decryptIntegrationSecret({
+        ciphertext: row.refreshTokenCiphertext,
+        nonce: row.refreshTokenNonce,
+        keyVersion: row.refreshTokenKeyVersion ?? 1,
+      })
+    : null;
+}
+
+/** A known expiry that's still comfortably in the future — safe to use as-is. */
+function tokenStillFresh(tokenExpiresAt: Date | null): boolean {
+  const expiresAt = tokenExpiresAt?.getTime() ?? null;
+  return expiresAt !== null && expiresAt - Date.now() > TOKEN_REFRESH_MARGIN_MS;
 }
 
 /**
@@ -193,50 +190,80 @@ async function persistRefreshedTokens(
  * manageable after connect: the delegated access token lives ~16h, but the
  * offline-access grant hands us a long-lived refresh token, so any server-side
  * call (teardown today; reconcile/inspect later) renews right before use rather
- * than relying on a scheduled refresh. A rotated refresh token is persisted
- * immediately. Falls back to the stored (possibly dead) token when there's
- * nothing to refresh with — a legacy install with no refresh token, or an
- * unconfigured OAuth client — so best-effort callers still get to try. Throws
- * only when the stored access token itself can't be decrypted.
+ * than relying on a scheduled refresh.
+ *
+ * The refresh token ROTATES on every use, so two concurrent refreshes of the
+ * same installation would each try to redeem the same token — the loser is
+ * rejected and, under OAuth refresh-token reuse detection, that can revoke the
+ * whole grant. So the refresh runs inside a per-installation Postgres advisory
+ * lock: a second caller (a concurrent management op, or an overlapping
+ * keep-alive pass) blocks on the lock, then re-reads and reuses the token the
+ * winner just persisted instead of redeeming a stale one. The transaction is
+ * held across the token HTTP call, which is fine for these rare, non-latency-
+ * sensitive paths (uninstall / account switch).
+ *
+ * Falls back to the stored (possibly dead) token when there's nothing to
+ * refresh with — a legacy install with no refresh token, or an unconfigured
+ * OAuth client — so best-effort callers still get to try. Throws only when the
+ * stored access token itself can't be decrypted.
  */
 async function freshAccessToken(
   row: CloudflareInstallationRow,
   config: CloudflareConnectConfig | null,
   fetchImpl: typeof fetch,
 ): Promise<string> {
-  const accessToken = decryptIntegrationSecret({
-    ciphertext: row.accessTokenCiphertext,
-    nonce: row.accessTokenNonce,
-    keyVersion: row.accessTokenKeyVersion,
-  });
-  // Only a known, comfortably-future expiry counts as fresh. An unknown
-  // (null) expiry falls through to the refresh path so teardown doesn't reuse a
-  // possibly-dead access token when we actually hold a refresh token.
-  const expiresAt = row.tokenExpiresAt?.getTime() ?? null;
-  if (expiresAt !== null && expiresAt - Date.now() > TOKEN_REFRESH_MARGIN_MS) {
-    return accessToken;
-  }
+  const accessToken = decryptAccessToken(row);
+  if (tokenStillFresh(row.tokenExpiresAt)) return accessToken;
+  // Can't refresh without the OAuth client, or without a refresh token.
+  if (!config || !(row.refreshTokenCiphertext && row.refreshTokenNonce)) return accessToken;
 
-  const refreshToken =
-    row.refreshTokenCiphertext && row.refreshTokenNonce
-      ? decryptIntegrationSecret({
-          ciphertext: row.refreshTokenCiphertext,
-          nonce: row.refreshTokenNonce,
-          keyVersion: row.refreshTokenKeyVersion ?? 1,
-        })
-      : null;
-  if (!refreshToken || !config) return accessToken;
-
-  const refreshed = await refreshAccessToken({ config, refreshToken, fetchImpl });
-  if (!refreshed.ok) {
-    log.warn(
-      { account_id: row.accountId, error: refreshed.error },
-      "cloudflare access token refresh failed; using stored token",
+  return db.transaction(async (tx) => {
+    // Serialize refresh for this installation across processes/requests so the
+    // rotating token is redeemed exactly once. Namespaced two-key lock so it
+    // can't collide with advisory locks elsewhere.
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtext('cloudflare_installations'), hashtext(${row.id}))`,
     );
-    return accessToken;
-  }
-  await persistRefreshedTokens(row.id, refreshed, refreshToken);
-  return refreshed.accessToken;
+    const cur = await tx.query.cloudflareInstallations.findFirst({
+      where: eq(schema.cloudflareInstallations.id, row.id),
+    });
+    if (!cur) return accessToken; // row vanished — fall back to our snapshot
+    const curAccess = decryptAccessToken(cur);
+    // Someone refreshed it while we waited for the lock — reuse their token.
+    if (tokenStillFresh(cur.tokenExpiresAt)) return curAccess;
+    const refreshToken = decryptRefreshToken(cur);
+    if (!refreshToken) return curAccess;
+
+    const refreshed = await refreshAccessToken({ config, refreshToken, fetchImpl });
+    if (!refreshed.ok) {
+      log.warn(
+        { account_id: cur.accountId, error: refreshed.error },
+        "cloudflare access token refresh failed; using stored token",
+      );
+      return curAccess;
+    }
+
+    const accessCipher = encryptIntegrationSecret(refreshed.accessToken);
+    // Rotating refresh tokens: keep the replacement, falling back to the prior
+    // one if the response didn't rotate it — losing it would strand the install.
+    const refreshCipher = encryptIntegrationSecret(refreshed.refreshToken ?? refreshToken);
+    const tokenExpiresAt =
+      refreshed.expiresIn != null ? new Date(Date.now() + refreshed.expiresIn * 1000) : null;
+    await tx
+      .update(schema.cloudflareInstallations)
+      .set({
+        accessTokenCiphertext: accessCipher.ciphertext,
+        accessTokenNonce: accessCipher.nonce,
+        accessTokenKeyVersion: accessCipher.keyVersion,
+        refreshTokenCiphertext: refreshCipher.ciphertext,
+        refreshTokenNonce: refreshCipher.nonce,
+        refreshTokenKeyVersion: refreshCipher.keyVersion,
+        tokenExpiresAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.cloudflareInstallations.id, cur.id));
+    return refreshed.accessToken;
+  });
 }
 
 /**

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -62,6 +62,7 @@
     "@opentelemetry/sdk-node": "^0.215.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@superlog/billing": "workspace:*",
+    "@superlog/cloudflare": "workspace:*",
     "@superlog/db": "workspace:*",
     "@superlog/fingerprint": "workspace:*",
     "@superlog/net-guard": "workspace:*",

--- a/apps/worker/src/cloudflare/refresher.test.ts
+++ b/apps/worker/src/cloudflare/refresher.test.ts
@@ -139,6 +139,30 @@ test("counts an error and saves nothing when a refresh is rejected, without bloc
   assert.equal(saved[0]?.id, "live");
 });
 
+test("a saveTokens failure aborts the pass (never rotate-and-lose across installs)", async () => {
+  // A refresh rotates the token on Cloudflare's side; if the save then fails
+  // (DB outage), continuing would rotate every remaining install and lose each
+  // replacement. So the pass must abort after the first save failure.
+  const rows = [installation({ id: "a" }), installation({ id: "b", refreshToken: "rt-b" })];
+  const store: CloudflareRefresherStore = {
+    async listActiveInstallations() {
+      return rows;
+    },
+    async saveTokens() {
+      throw new Error("db down");
+    },
+  };
+  const { fetchImpl, calls } = fakeTokenFetch({
+    json: { access_token: "at", refresh_token: "rt2", expires_in: 57600 },
+  });
+  await assert.rejects(
+    runCloudflareRefreshOnce({ store, config: CONFIG, log: LOGGER, fetchImpl, now: () => NOW }),
+    /db down/,
+  );
+  // Only the first install's token was requested; the pass aborted before the second.
+  assert.equal(calls.length, 1);
+});
+
 test("a thrown fetch on one install doesn't abort the pass", async () => {
   // First install's token request throws (network blip); the second still refreshes.
   const rows = [installation({ id: "boom" }), installation({ id: "live", refreshToken: "rt-2" })];

--- a/apps/worker/src/cloudflare/refresher.test.ts
+++ b/apps/worker/src/cloudflare/refresher.test.ts
@@ -138,3 +138,28 @@ test("counts an error and saves nothing when a refresh is rejected, without bloc
   assert.equal(saved.length, 1);
   assert.equal(saved[0]?.id, "live");
 });
+
+test("a thrown fetch on one install doesn't abort the pass", async () => {
+  // First install's token request throws (network blip); the second still refreshes.
+  const rows = [installation({ id: "boom" }), installation({ id: "live", refreshToken: "rt-2" })];
+  const { store, saved } = fakeStore(rows);
+  let call = 0;
+  const fetchImpl = (async () => {
+    call += 1;
+    if (call === 1) throw new Error("network down");
+    return new Response(
+      JSON.stringify({ access_token: "at-2", refresh_token: "rt-2b", expires_in: 57600 }),
+      { status: 200 },
+    );
+  }) as typeof fetch;
+  const stats = await runCloudflareRefreshOnce({
+    store,
+    config: CONFIG,
+    log: LOGGER,
+    fetchImpl,
+    now: () => NOW,
+  });
+  assert.deepEqual(stats, { installations: 2, refreshed: 1, skipped: 0, errors: 1 });
+  assert.equal(saved.length, 1);
+  assert.equal(saved[0]?.id, "live");
+});

--- a/apps/worker/src/cloudflare/refresher.test.ts
+++ b/apps/worker/src/cloudflare/refresher.test.ts
@@ -1,0 +1,140 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { CLOUDFLARE_OAUTH_TOKEN_URL } from "@superlog/cloudflare";
+import {
+  type CloudflareRefreshInstallation,
+  type CloudflareRefresherStore,
+  runCloudflareRefreshOnce,
+} from "./refresher.js";
+
+const NOW = new Date("2026-07-09T12:00:00.000Z");
+const CONFIG = { clientId: "cid", clientSecret: "cs" };
+const LOGGER = { info() {}, warn() {}, error() {} };
+
+function installation(
+  overrides: Partial<CloudflareRefreshInstallation> = {},
+): CloudflareRefreshInstallation {
+  return {
+    id: "inst-1",
+    projectId: "superlog-project",
+    accountId: "acct-1",
+    refreshToken: "rt-old",
+    ...overrides,
+  };
+}
+
+type SavedTokens = {
+  id: string;
+  accessToken: string;
+  refreshToken: string | null;
+  tokenExpiresAt: Date | null;
+};
+
+function fakeStore(rows: CloudflareRefreshInstallation[]): {
+  store: CloudflareRefresherStore;
+  saved: SavedTokens[];
+} {
+  const saved: SavedTokens[] = [];
+  return {
+    saved,
+    store: {
+      async listActiveInstallations() {
+        return rows;
+      },
+      async saveTokens(id, tokens) {
+        saved.push({ id, ...tokens });
+      },
+    },
+  };
+}
+
+// Fake token endpoint: records calls, returns the configured JSON body.
+function fakeTokenFetch(response: { status?: number; json: unknown }) {
+  const calls: URLSearchParams[] = [];
+  const fetchImpl = (async (url: unknown, init?: RequestInit) => {
+    assert.equal(String(url), CLOUDFLARE_OAUTH_TOKEN_URL);
+    calls.push(new URLSearchParams(String(init?.body)));
+    return new Response(JSON.stringify(response.json), { status: response.status ?? 200 });
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+test("refreshes every active install and persists the rotated pair + new expiry", async () => {
+  const { store, saved } = fakeStore([installation()]);
+  const { fetchImpl, calls } = fakeTokenFetch({
+    json: { access_token: "at-new", refresh_token: "rt-new", expires_in: 57600 },
+  });
+  const stats = await runCloudflareRefreshOnce({
+    store,
+    config: CONFIG,
+    log: LOGGER,
+    fetchImpl,
+    now: () => NOW,
+  });
+  assert.deepEqual(stats, { installations: 1, refreshed: 1, skipped: 0, errors: 0 });
+  assert.equal(calls[0]?.get("grant_type"), "refresh_token");
+  assert.equal(calls[0]?.get("refresh_token"), "rt-old");
+  assert.equal(saved.length, 1);
+  assert.equal(saved[0]?.accessToken, "at-new");
+  assert.equal(saved[0]?.refreshToken, "rt-new");
+  assert.equal(saved[0]?.tokenExpiresAt?.getTime(), NOW.getTime() + 57600 * 1000);
+});
+
+test("skips a legacy install with no refresh token — needs reconnect", async () => {
+  const { store, saved } = fakeStore([installation({ refreshToken: null })]);
+  const { fetchImpl, calls } = fakeTokenFetch({ json: {} });
+  const stats = await runCloudflareRefreshOnce({
+    store,
+    config: CONFIG,
+    log: LOGGER,
+    fetchImpl,
+    now: () => NOW,
+  });
+  assert.deepEqual(stats, { installations: 1, refreshed: 0, skipped: 1, errors: 0 });
+  assert.equal(calls.length, 0);
+  assert.equal(saved.length, 0);
+});
+
+test("keeps the existing refresh token when the response does not rotate it", async () => {
+  const { store, saved } = fakeStore([installation()]);
+  const { fetchImpl } = fakeTokenFetch({
+    json: { access_token: "at-new", expires_in: 57600 },
+  });
+  const stats = await runCloudflareRefreshOnce({
+    store,
+    config: CONFIG,
+    log: LOGGER,
+    fetchImpl,
+    now: () => NOW,
+  });
+  assert.equal(stats.refreshed, 1);
+  assert.equal(saved[0]?.refreshToken, "rt-old");
+});
+
+test("counts an error and saves nothing when a refresh is rejected, without blocking others", async () => {
+  // First install's refresh fails (dead grant); the second still refreshes.
+  const rows = [installation({ id: "dead" }), installation({ id: "live", refreshToken: "rt-2" })];
+  const { store, saved } = fakeStore(rows);
+  let call = 0;
+  const fetchImpl = (async () => {
+    call += 1;
+    return call === 1
+      ? new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 })
+      : new Response(
+          JSON.stringify({ access_token: "at-2", refresh_token: "rt-2b", expires_in: 57600 }),
+          {
+            status: 200,
+          },
+        );
+  }) as typeof fetch;
+  const stats = await runCloudflareRefreshOnce({
+    store,
+    config: CONFIG,
+    log: LOGGER,
+    fetchImpl,
+    now: () => NOW,
+  });
+  assert.deepEqual(stats, { installations: 2, refreshed: 1, skipped: 0, errors: 1 });
+  assert.equal(saved.length, 1);
+  assert.equal(saved[0]?.id, "live");
+});

--- a/apps/worker/src/cloudflare/refresher.test.ts
+++ b/apps/worker/src/cloudflare/refresher.test.ts
@@ -2,7 +2,9 @@ import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import { CLOUDFLARE_OAUTH_TOKEN_URL } from "@superlog/cloudflare";
 import {
+  type CloudflareInstallationTokens,
   type CloudflareRefreshInstallation,
+  type CloudflareRefreshedTokens,
   type CloudflareRefresherStore,
   runCloudflareRefreshOnce,
 } from "./refresher.js";
@@ -11,38 +13,53 @@ const NOW = new Date("2026-07-09T12:00:00.000Z");
 const CONFIG = { clientId: "cid", clientSecret: "cs" };
 const LOGGER = { info() {}, warn() {}, error() {} };
 
-function installation(
-  overrides: Partial<CloudflareRefreshInstallation> = {},
-): CloudflareRefreshInstallation {
+// A stored row the fake store exposes to the locked callback.
+type Row = {
+  accountId: string;
+  refreshToken: string | null;
+  // Expired long ago by default so the keep-alive always refreshes it.
+  tokenExpiresAt: Date | null;
+};
+
+function row(overrides: Partial<Row> = {}): Row {
   return {
-    id: "inst-1",
-    projectId: "superlog-project",
     accountId: "acct-1",
     refreshToken: "rt-old",
+    tokenExpiresAt: new Date(NOW.getTime() - 60 * 60 * 1000),
     ...overrides,
   };
 }
 
-type SavedTokens = {
-  id: string;
-  accessToken: string;
-  refreshToken: string | null;
-  tokenExpiresAt: Date | null;
-};
+type SavedTokens = { id: string } & CloudflareRefreshedTokens;
 
-function fakeStore(rows: CloudflareRefreshInstallation[]): {
-  store: CloudflareRefresherStore;
-  saved: SavedTokens[];
-} {
+// Fake store: `withLockedInstallation` simulates the lock as a pass-through,
+// re-reads from the in-memory rows, and lets `save` optionally throw (DB
+// outage) to exercise the abort path.
+function fakeStore(
+  rowsById: Record<string, Row>,
+  opts: { throwOnSave?: boolean } = {},
+): { store: CloudflareRefresherStore; saved: SavedTokens[] } {
   const saved: SavedTokens[] = [];
   return {
     saved,
     store: {
-      async listActiveInstallations() {
-        return rows;
+      async listActiveInstallations(): Promise<CloudflareRefreshInstallation[]> {
+        return Object.entries(rowsById).map(([id, r]) => ({
+          id,
+          accountId: r.accountId,
+          hasRefreshToken: r.refreshToken != null,
+        }));
       },
-      async saveTokens(id, tokens) {
-        saved.push({ id, ...tokens });
+      async withLockedInstallation(installationId, fn) {
+        const r = rowsById[installationId] ?? null;
+        const current: CloudflareInstallationTokens | null = r
+          ? { refreshToken: r.refreshToken, tokenExpiresAt: r.tokenExpiresAt }
+          : null;
+        const save = async (tokens: CloudflareRefreshedTokens): Promise<void> => {
+          if (opts.throwOnSave) throw new Error("db down");
+          saved.push({ id: installationId, ...tokens });
+        };
+        return fn(current, save);
       },
     },
   };
@@ -59,8 +76,8 @@ function fakeTokenFetch(response: { status?: number; json: unknown }) {
   return { fetchImpl, calls };
 }
 
-test("refreshes every active install and persists the rotated pair + new expiry", async () => {
-  const { store, saved } = fakeStore([installation()]);
+test("refreshes an active install under the lock and persists the rotated pair + new expiry", async () => {
+  const { store, saved } = fakeStore({ "inst-1": row() });
   const { fetchImpl, calls } = fakeTokenFetch({
     json: { access_token: "at-new", refresh_token: "rt-new", expires_in: 57600 },
   });
@@ -81,7 +98,7 @@ test("refreshes every active install and persists the rotated pair + new expiry"
 });
 
 test("skips a legacy install with no refresh token — needs reconnect", async () => {
-  const { store, saved } = fakeStore([installation({ refreshToken: null })]);
+  const { store, saved } = fakeStore({ "inst-1": row({ refreshToken: null }) });
   const { fetchImpl, calls } = fakeTokenFetch({ json: {} });
   const stats = await runCloudflareRefreshOnce({
     store,
@@ -95,11 +112,26 @@ test("skips a legacy install with no refresh token — needs reconnect", async (
   assert.equal(saved.length, 0);
 });
 
-test("keeps the existing refresh token when the response does not rotate it", async () => {
-  const { store, saved } = fakeStore([installation()]);
-  const { fetchImpl } = fakeTokenFetch({
-    json: { access_token: "at-new", expires_in: 57600 },
+test("leaves a token another actor just refreshed (still fresh under the lock)", async () => {
+  const { store, saved } = fakeStore({
+    "inst-1": row({ tokenExpiresAt: new Date(NOW.getTime() + 10 * 60 * 60 * 1000) }),
   });
+  const { fetchImpl, calls } = fakeTokenFetch({ json: {} });
+  const stats = await runCloudflareRefreshOnce({
+    store,
+    config: CONFIG,
+    log: LOGGER,
+    fetchImpl,
+    now: () => NOW,
+  });
+  assert.deepEqual(stats, { installations: 1, refreshed: 0, skipped: 1, errors: 0 });
+  assert.equal(calls.length, 0); // never redeemed — no double rotation
+  assert.equal(saved.length, 0);
+});
+
+test("keeps the existing refresh token when the response does not rotate it", async () => {
+  const { store, saved } = fakeStore({ "inst-1": row() });
+  const { fetchImpl } = fakeTokenFetch({ json: { access_token: "at-new", expires_in: 57600 } });
   const stats = await runCloudflareRefreshOnce({
     store,
     config: CONFIG,
@@ -111,10 +143,11 @@ test("keeps the existing refresh token when the response does not rotate it", as
   assert.equal(saved[0]?.refreshToken, "rt-old");
 });
 
-test("counts an error and saves nothing when a refresh is rejected, without blocking others", async () => {
-  // First install's refresh fails (dead grant); the second still refreshes.
-  const rows = [installation({ id: "dead" }), installation({ id: "live", refreshToken: "rt-2" })];
-  const { store, saved } = fakeStore(rows);
+test("a rejected refresh is isolated and doesn't block other installs", async () => {
+  const { store, saved } = fakeStore({
+    dead: row({ refreshToken: "rt-dead" }),
+    live: row({ refreshToken: "rt-live" }),
+  });
   let call = 0;
   const fetchImpl = (async () => {
     call += 1;
@@ -122,9 +155,7 @@ test("counts an error and saves nothing when a refresh is rejected, without bloc
       ? new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 })
       : new Response(
           JSON.stringify({ access_token: "at-2", refresh_token: "rt-2b", expires_in: 57600 }),
-          {
-            status: 200,
-          },
+          { status: 200 },
         );
   }) as typeof fetch;
   const stats = await runCloudflareRefreshOnce({
@@ -136,37 +167,13 @@ test("counts an error and saves nothing when a refresh is rejected, without bloc
   });
   assert.deepEqual(stats, { installations: 2, refreshed: 1, skipped: 0, errors: 1 });
   assert.equal(saved.length, 1);
-  assert.equal(saved[0]?.id, "live");
-});
-
-test("a saveTokens failure aborts the pass (never rotate-and-lose across installs)", async () => {
-  // A refresh rotates the token on Cloudflare's side; if the save then fails
-  // (DB outage), continuing would rotate every remaining install and lose each
-  // replacement. So the pass must abort after the first save failure.
-  const rows = [installation({ id: "a" }), installation({ id: "b", refreshToken: "rt-b" })];
-  const store: CloudflareRefresherStore = {
-    async listActiveInstallations() {
-      return rows;
-    },
-    async saveTokens() {
-      throw new Error("db down");
-    },
-  };
-  const { fetchImpl, calls } = fakeTokenFetch({
-    json: { access_token: "at", refresh_token: "rt2", expires_in: 57600 },
-  });
-  await assert.rejects(
-    runCloudflareRefreshOnce({ store, config: CONFIG, log: LOGGER, fetchImpl, now: () => NOW }),
-    /db down/,
-  );
-  // Only the first install's token was requested; the pass aborted before the second.
-  assert.equal(calls.length, 1);
 });
 
 test("a thrown fetch on one install doesn't abort the pass", async () => {
-  // First install's token request throws (network blip); the second still refreshes.
-  const rows = [installation({ id: "boom" }), installation({ id: "live", refreshToken: "rt-2" })];
-  const { store, saved } = fakeStore(rows);
+  const { store, saved } = fakeStore({
+    boom: row({ refreshToken: "rt-boom" }),
+    live: row({ refreshToken: "rt-live" }),
+  });
   let call = 0;
   const fetchImpl = (async () => {
     call += 1;
@@ -185,5 +192,23 @@ test("a thrown fetch on one install doesn't abort the pass", async () => {
   });
   assert.deepEqual(stats, { installations: 2, refreshed: 1, skipped: 0, errors: 1 });
   assert.equal(saved.length, 1);
-  assert.equal(saved[0]?.id, "live");
+});
+
+test("a saveTokens failure aborts the pass (never rotate-and-lose across installs)", async () => {
+  // A refresh rotates the token on Cloudflare's side; if the save then fails
+  // (DB outage), continuing would rotate every remaining install and lose each
+  // replacement. So the pass must abort after the first save failure.
+  const { store } = fakeStore(
+    { a: row(), b: row({ refreshToken: "rt-b" }) },
+    { throwOnSave: true },
+  );
+  const { fetchImpl, calls } = fakeTokenFetch({
+    json: { access_token: "at", refresh_token: "rt2", expires_in: 57600 },
+  });
+  await assert.rejects(
+    runCloudflareRefreshOnce({ store, config: CONFIG, log: LOGGER, fetchImpl, now: () => NOW }),
+    /db down/,
+  );
+  // Only the first install's token was requested; the pass aborted before the second.
+  assert.equal(calls.length, 1);
 });

--- a/apps/worker/src/cloudflare/refresher.ts
+++ b/apps/worker/src/cloudflare/refresher.ts
@@ -85,33 +85,49 @@ export async function runCloudflareRefreshOnce(
       continue;
     }
 
-    const refreshed = await refreshAccessToken({
-      config: deps.config,
-      refreshToken: inst.refreshToken,
-      fetchImpl,
-    });
-    if (!refreshed.ok) {
-      // A dead grant (expired / revoked) surfaces here. Log and move on — one
-      // bad install must not block the rest, and the connection just needs a
-      // manual reconnect.
+    // Isolate every per-install failure — a dead grant ({ ok: false }), a
+    // thrown fetch (network blip / DNS), or a saveTokens DB error — so one bad
+    // installation can never abort the pass and strand the rest untouched.
+    try {
+      const refreshed = await refreshAccessToken({
+        config: deps.config,
+        refreshToken: inst.refreshToken,
+        fetchImpl,
+      });
+      if (!refreshed.ok) {
+        // A dead grant (expired / revoked) surfaces here. Log and move on — the
+        // connection just needs a manual reconnect.
+        stats.errors += 1;
+        deps.log.error(
+          { installation_id: inst.id, account_id: inst.accountId, error: refreshed.error },
+          "cloudflare token refresh failed",
+        );
+        continue;
+      }
+
+      await deps.store.saveTokens(inst.id, {
+        accessToken: refreshed.accessToken,
+        // Rotating refresh tokens: keep the replacement, falling back to the
+        // existing one when the response didn't rotate it. Dropping the rotated
+        // token would strand the install at the next refresh.
+        refreshToken: refreshed.refreshToken ?? inst.refreshToken,
+        tokenExpiresAt:
+          refreshed.expiresIn != null
+            ? new Date(now().getTime() + refreshed.expiresIn * 1000)
+            : null,
+      });
+      stats.refreshed += 1;
+    } catch (err) {
       stats.errors += 1;
       deps.log.error(
-        { installation_id: inst.id, account_id: inst.accountId, error: refreshed.error },
-        "cloudflare token refresh failed",
+        {
+          installation_id: inst.id,
+          account_id: inst.accountId,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "cloudflare token refresh threw; skipping install",
       );
-      continue;
     }
-
-    await deps.store.saveTokens(inst.id, {
-      accessToken: refreshed.accessToken,
-      // Rotating refresh tokens: keep the replacement, falling back to the
-      // existing one when the response didn't rotate it. Dropping the rotated
-      // token would strand the install at the next refresh.
-      refreshToken: refreshed.refreshToken ?? inst.refreshToken,
-      tokenExpiresAt:
-        refreshed.expiresIn != null ? new Date(now().getTime() + refreshed.expiresIn * 1000) : null,
-    });
-    stats.refreshed += 1;
   }
 
   return stats;

--- a/apps/worker/src/cloudflare/refresher.ts
+++ b/apps/worker/src/cloudflare/refresher.ts
@@ -11,20 +11,35 @@
 // So this runs as a scheduled job (jobs/cloudflare-refresh.ts) and, once a day,
 // exercises every active installation's refresh token: mint a fresh access
 // token and persist the rotated pair. Daily is well inside the one-month
-// window, and one refresh per install per day is negligible. There's no
-// per-access-token-expiry gate — the daily schedule is the rate limit, and the
-// point is to keep the grant alive, not to chase the 16h access-token expiry.
+// window, and one refresh per install per day is negligible.
+//
+// Each refresh runs inside a per-installation lock provided by the store
+// (`withLockedInstallation`) — the SAME advisory lock the api's on-demand
+// refresh takes — so a rotating refresh token is never redeemed twice
+// concurrently (which would reject the loser and, under reuse detection, revoke
+// the whole grant). The token is re-read under the lock, so if another actor
+// just refreshed it we reuse theirs instead of redeeming again.
 //
 // IO is behind a narrow store port + injectable fetch so the logic is
 // unit-testable without Postgres or a live Cloudflare account.
 
-import { type CloudflareClientCredentials, refreshAccessToken } from "@superlog/cloudflare";
+import {
+  type CloudflareClientCredentials,
+  type CloudflareTokenResult,
+  refreshAccessToken,
+} from "@superlog/cloudflare";
 
+/** Minimal per-install summary for the pass (no secrets decrypted up front). */
 export type CloudflareRefreshInstallation = {
   id: string;
-  projectId: string;
   accountId: string;
+  hasRefreshToken: boolean;
+};
+
+/** Current token state, re-read under the lock. */
+export type CloudflareInstallationTokens = {
   refreshToken: string | null;
+  tokenExpiresAt: Date | null;
 };
 
 export type CloudflareRefreshedTokens = {
@@ -36,8 +51,19 @@ export type CloudflareRefreshedTokens = {
 export type CloudflareRefresherStore = {
   /** Active installs eligible for keep-alive (not revoked). */
   listActiveInstallations(): Promise<CloudflareRefreshInstallation[]>;
-  /** Persist a refreshed (rotated!) token pair immediately. */
-  saveTokens(id: string, tokens: CloudflareRefreshedTokens): Promise<void>;
+  /**
+   * Run `fn` while holding a per-installation advisory lock (the same lock the
+   * api's freshAccessToken takes). `fn` receives the tokens re-read under the
+   * lock and a `save` that persists within the same locked transaction. The
+   * whole thing is one transaction, so `save` failing rolls back and propagates.
+   */
+  withLockedInstallation<T>(
+    installationId: string,
+    fn: (
+      current: CloudflareInstallationTokens | null,
+      save: (tokens: CloudflareRefreshedTokens) => Promise<void>,
+    ) => Promise<T>,
+  ): Promise<T>;
 };
 
 type RefresherLogger = {
@@ -61,6 +87,14 @@ export type CloudflareRefreshStats = {
   errors: number;
 };
 
+// Skip the redeem only when a comfortably-valid access token already exists —
+// i.e. another actor (the api's on-demand refresh) just refreshed it. Access
+// tokens are ~16h and the job runs daily, so under normal operation the token
+// is always past this and gets refreshed, keeping the grant alive.
+const STILL_FRESH_MARGIN_MS = 60 * 1000;
+
+type RefreshOutcome = "refreshed" | "already_fresh" | "no_token" | "rejected";
+
 export async function runCloudflareRefreshOnce(
   deps: CloudflareRefresherDeps,
 ): Promise<CloudflareRefreshStats> {
@@ -80,64 +114,23 @@ export async function runCloudflareRefreshOnce(
 
     // No refresh token: a legacy install (Cloudflare issued none before the
     // offline grant was enabled). Nothing to exercise — the user must reconnect.
-    if (!inst.refreshToken) {
+    if (!inst.hasRefreshToken) {
       stats.skipped += 1;
       continue;
     }
 
-    // The token request and the persist have DIFFERENT failure semantics, so
-    // they're handled separately:
-    //
-    // A refresh failure ({ ok: false } or a thrown fetch) is isolated to this
-    // install — nothing was rotated, so skip it and carry on with the rest.
-    let refreshed: Awaited<ReturnType<typeof refreshAccessToken>>;
+    let outcome: RefreshOutcome;
     try {
-      refreshed = await refreshAccessToken({
-        config: deps.config,
-        refreshToken: inst.refreshToken,
-        fetchImpl,
-      });
-    } catch (err) {
-      stats.errors += 1;
-      deps.log.error(
-        {
-          installation_id: inst.id,
-          account_id: inst.accountId,
-          err: err instanceof Error ? err.message : String(err),
-        },
-        "cloudflare token request threw; skipping install",
+      outcome = await deps.store.withLockedInstallation(inst.id, (current, save) =>
+        refreshOne(inst, current, save),
       );
-      continue;
-    }
-    if (!refreshed.ok) {
-      // A dead grant (expired / revoked) surfaces here. Log and move on — the
-      // connection just needs a manual reconnect.
-      stats.errors += 1;
-      deps.log.error(
-        { installation_id: inst.id, account_id: inst.accountId, error: refreshed.error },
-        "cloudflare token refresh failed",
-      );
-      continue;
-    }
-
-    // The refresh SUCCEEDED, so Cloudflare has already rotated (consumed) the
-    // old refresh token. Persisting the replacement is now mandatory — if the
-    // save fails the install is stranded, and a save failure is a DB problem
-    // that would hit every remaining install too (each rotating then losing its
-    // new token). So abort the whole pass on a save failure instead of bricking
-    // the rest; pg-boss retries the job.
-    try {
-      await deps.store.saveTokens(inst.id, {
-        accessToken: refreshed.accessToken,
-        // Rotating refresh tokens: keep the replacement, falling back to the
-        // existing one when the response didn't rotate it.
-        refreshToken: refreshed.refreshToken ?? inst.refreshToken,
-        tokenExpiresAt:
-          refreshed.expiresIn != null
-            ? new Date(now().getTime() + refreshed.expiresIn * 1000)
-            : null,
-      });
     } catch (err) {
+      // Only a persist/DB/lock failure reaches here (a failed token request is
+      // handled inside and returned as "rejected"). A successful refresh has
+      // already rotated the token on Cloudflare's side, so a save failure means
+      // the replacement is lost — and it's a DB problem that would hit every
+      // remaining install too. Abort the pass rather than rotate-and-lose across
+      // all of them; pg-boss retries the job.
       stats.errors += 1;
       deps.log.error(
         {
@@ -149,8 +142,65 @@ export async function runCloudflareRefreshOnce(
       );
       throw err;
     }
-    stats.refreshed += 1;
+
+    if (outcome === "refreshed") stats.refreshed += 1;
+    else if (outcome === "rejected") stats.errors += 1;
+    else stats.skipped += 1; // no_token | already_fresh
   }
 
   return stats;
+
+  // Runs under the installation lock, against tokens re-read inside it.
+  async function refreshOne(
+    inst: CloudflareRefreshInstallation,
+    current: CloudflareInstallationTokens | null,
+    save: (tokens: CloudflareRefreshedTokens) => Promise<void>,
+  ): Promise<RefreshOutcome> {
+    if (!current || !current.refreshToken) return "no_token";
+    // Another actor refreshed it while we waited for the lock — leave it.
+    const expiresAt = current.tokenExpiresAt?.getTime() ?? null;
+    if (expiresAt !== null && expiresAt - now().getTime() > STILL_FRESH_MARGIN_MS) {
+      return "already_fresh";
+    }
+
+    let refreshed: CloudflareTokenResult;
+    try {
+      refreshed = await refreshAccessToken({
+        config: deps.config,
+        refreshToken: current.refreshToken,
+        fetchImpl,
+      });
+    } catch (err) {
+      // A thrown fetch (network / DNS) didn't rotate anything — isolate it.
+      deps.log.error(
+        {
+          installation_id: inst.id,
+          account_id: inst.accountId,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "cloudflare token request threw; skipping install",
+      );
+      return "rejected";
+    }
+    if (!refreshed.ok) {
+      // A dead grant (expired / revoked) surfaces here — needs manual reconnect.
+      deps.log.error(
+        { installation_id: inst.id, account_id: inst.accountId, error: refreshed.error },
+        "cloudflare token refresh failed",
+      );
+      return "rejected";
+    }
+
+    // Refresh succeeded → the old token is consumed; persisting the replacement
+    // is mandatory. A throw from `save` propagates out and aborts the pass.
+    await save({
+      accessToken: refreshed.accessToken,
+      // Rotating refresh tokens: keep the replacement, falling back to the
+      // existing one when the response didn't rotate it.
+      refreshToken: refreshed.refreshToken ?? current.refreshToken,
+      tokenExpiresAt:
+        refreshed.expiresIn != null ? new Date(now().getTime() + refreshed.expiresIn * 1000) : null,
+    });
+    return "refreshed";
+  }
 }

--- a/apps/worker/src/cloudflare/refresher.ts
+++ b/apps/worker/src/cloudflare/refresher.ts
@@ -85,38 +85,18 @@ export async function runCloudflareRefreshOnce(
       continue;
     }
 
-    // Isolate every per-install failure — a dead grant ({ ok: false }), a
-    // thrown fetch (network blip / DNS), or a saveTokens DB error — so one bad
-    // installation can never abort the pass and strand the rest untouched.
+    // The token request and the persist have DIFFERENT failure semantics, so
+    // they're handled separately:
+    //
+    // A refresh failure ({ ok: false } or a thrown fetch) is isolated to this
+    // install — nothing was rotated, so skip it and carry on with the rest.
+    let refreshed: Awaited<ReturnType<typeof refreshAccessToken>>;
     try {
-      const refreshed = await refreshAccessToken({
+      refreshed = await refreshAccessToken({
         config: deps.config,
         refreshToken: inst.refreshToken,
         fetchImpl,
       });
-      if (!refreshed.ok) {
-        // A dead grant (expired / revoked) surfaces here. Log and move on — the
-        // connection just needs a manual reconnect.
-        stats.errors += 1;
-        deps.log.error(
-          { installation_id: inst.id, account_id: inst.accountId, error: refreshed.error },
-          "cloudflare token refresh failed",
-        );
-        continue;
-      }
-
-      await deps.store.saveTokens(inst.id, {
-        accessToken: refreshed.accessToken,
-        // Rotating refresh tokens: keep the replacement, falling back to the
-        // existing one when the response didn't rotate it. Dropping the rotated
-        // token would strand the install at the next refresh.
-        refreshToken: refreshed.refreshToken ?? inst.refreshToken,
-        tokenExpiresAt:
-          refreshed.expiresIn != null
-            ? new Date(now().getTime() + refreshed.expiresIn * 1000)
-            : null,
-      });
-      stats.refreshed += 1;
     } catch (err) {
       stats.errors += 1;
       deps.log.error(
@@ -125,9 +105,51 @@ export async function runCloudflareRefreshOnce(
           account_id: inst.accountId,
           err: err instanceof Error ? err.message : String(err),
         },
-        "cloudflare token refresh threw; skipping install",
+        "cloudflare token request threw; skipping install",
       );
+      continue;
     }
+    if (!refreshed.ok) {
+      // A dead grant (expired / revoked) surfaces here. Log and move on — the
+      // connection just needs a manual reconnect.
+      stats.errors += 1;
+      deps.log.error(
+        { installation_id: inst.id, account_id: inst.accountId, error: refreshed.error },
+        "cloudflare token refresh failed",
+      );
+      continue;
+    }
+
+    // The refresh SUCCEEDED, so Cloudflare has already rotated (consumed) the
+    // old refresh token. Persisting the replacement is now mandatory — if the
+    // save fails the install is stranded, and a save failure is a DB problem
+    // that would hit every remaining install too (each rotating then losing its
+    // new token). So abort the whole pass on a save failure instead of bricking
+    // the rest; pg-boss retries the job.
+    try {
+      await deps.store.saveTokens(inst.id, {
+        accessToken: refreshed.accessToken,
+        // Rotating refresh tokens: keep the replacement, falling back to the
+        // existing one when the response didn't rotate it.
+        refreshToken: refreshed.refreshToken ?? inst.refreshToken,
+        tokenExpiresAt:
+          refreshed.expiresIn != null
+            ? new Date(now().getTime() + refreshed.expiresIn * 1000)
+            : null,
+      });
+    } catch (err) {
+      stats.errors += 1;
+      deps.log.error(
+        {
+          installation_id: inst.id,
+          account_id: inst.accountId,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "cloudflare token save failed after refresh; aborting pass to avoid discarding rotated tokens across installs",
+      );
+      throw err;
+    }
+    stats.refreshed += 1;
   }
 
   return stats;

--- a/apps/worker/src/cloudflare/refresher.ts
+++ b/apps/worker/src/cloudflare/refresher.ts
@@ -1,0 +1,118 @@
+// Cloudflare OAuth keep-alive — the maintenance half of the Cloudflare
+// connector. The connector is push-only (Workers Observability streams straight
+// to our intake), so unlike Railway we don't poll for telemetry, and after
+// connect we almost never call the Cloudflare API. That's the problem this
+// solves: the delegated grant's refresh token is bounded by the OAuth client's
+// "grant session duration" (Cloudflare caps it at one month) and it ROTATES on
+// every use, so if it's never exercised it just ages out and the connection
+// goes dark again — only later. Nothing else would notice; the UI still says
+// "connected".
+//
+// So this runs as a scheduled job (jobs/cloudflare-refresh.ts) and, once a day,
+// exercises every active installation's refresh token: mint a fresh access
+// token and persist the rotated pair. Daily is well inside the one-month
+// window, and one refresh per install per day is negligible. There's no
+// per-access-token-expiry gate — the daily schedule is the rate limit, and the
+// point is to keep the grant alive, not to chase the 16h access-token expiry.
+//
+// IO is behind a narrow store port + injectable fetch so the logic is
+// unit-testable without Postgres or a live Cloudflare account.
+
+import { type CloudflareClientCredentials, refreshAccessToken } from "@superlog/cloudflare";
+
+export type CloudflareRefreshInstallation = {
+  id: string;
+  projectId: string;
+  accountId: string;
+  refreshToken: string | null;
+};
+
+export type CloudflareRefreshedTokens = {
+  accessToken: string;
+  refreshToken: string | null;
+  tokenExpiresAt: Date | null;
+};
+
+export type CloudflareRefresherStore = {
+  /** Active installs eligible for keep-alive (not revoked). */
+  listActiveInstallations(): Promise<CloudflareRefreshInstallation[]>;
+  /** Persist a refreshed (rotated!) token pair immediately. */
+  saveTokens(id: string, tokens: CloudflareRefreshedTokens): Promise<void>;
+};
+
+type RefresherLogger = {
+  info(fields: Record<string, unknown>, msg: string): void;
+  warn(fields: Record<string, unknown>, msg: string): void;
+  error(fields: Record<string, unknown>, msg: string): void;
+};
+
+export type CloudflareRefresherDeps = {
+  store: CloudflareRefresherStore;
+  config: CloudflareClientCredentials;
+  log: RefresherLogger;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+};
+
+export type CloudflareRefreshStats = {
+  installations: number;
+  refreshed: number;
+  skipped: number;
+  errors: number;
+};
+
+export async function runCloudflareRefreshOnce(
+  deps: CloudflareRefresherDeps,
+): Promise<CloudflareRefreshStats> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const now = deps.now ?? (() => new Date());
+
+  const stats: CloudflareRefreshStats = {
+    installations: 0,
+    refreshed: 0,
+    skipped: 0,
+    errors: 0,
+  };
+
+  const installations = await deps.store.listActiveInstallations();
+  for (const inst of installations) {
+    stats.installations += 1;
+
+    // No refresh token: a legacy install (Cloudflare issued none before the
+    // offline grant was enabled). Nothing to exercise — the user must reconnect.
+    if (!inst.refreshToken) {
+      stats.skipped += 1;
+      continue;
+    }
+
+    const refreshed = await refreshAccessToken({
+      config: deps.config,
+      refreshToken: inst.refreshToken,
+      fetchImpl,
+    });
+    if (!refreshed.ok) {
+      // A dead grant (expired / revoked) surfaces here. Log and move on — one
+      // bad install must not block the rest, and the connection just needs a
+      // manual reconnect.
+      stats.errors += 1;
+      deps.log.error(
+        { installation_id: inst.id, account_id: inst.accountId, error: refreshed.error },
+        "cloudflare token refresh failed",
+      );
+      continue;
+    }
+
+    await deps.store.saveTokens(inst.id, {
+      accessToken: refreshed.accessToken,
+      // Rotating refresh tokens: keep the replacement, falling back to the
+      // existing one when the response didn't rotate it. Dropping the rotated
+      // token would strand the install at the next refresh.
+      refreshToken: refreshed.refreshToken ?? inst.refreshToken,
+      tokenExpiresAt:
+        refreshed.expiresIn != null ? new Date(now().getTime() + refreshed.expiresIn * 1000) : null,
+    });
+    stats.refreshed += 1;
+  }
+
+  return stats;
+}

--- a/apps/worker/src/cloudflare/refresher.ts
+++ b/apps/worker/src/cloudflare/refresher.ts
@@ -125,12 +125,13 @@ export async function runCloudflareRefreshOnce(
         refreshOne(inst, current, save),
       );
     } catch (err) {
-      // Only a persist/DB/lock failure reaches here (a failed token request is
-      // handled inside and returned as "rejected"). A successful refresh has
-      // already rotated the token on Cloudflare's side, so a save failure means
-      // the replacement is lost — and it's a DB problem that would hit every
-      // remaining install too. Abort the pass rather than rotate-and-lose across
-      // all of them; pg-boss retries the job.
+      // Only a persist/lock/transaction failure reaches here — a failed token
+      // request is handled inside and returned as "rejected", and a per-install
+      // decrypt failure is handled in the store as a skip. A successful refresh
+      // has already rotated the token on Cloudflare's side, so a save failure
+      // means the replacement is lost; and it's a DB problem that would hit
+      // every remaining install too. Abort the pass rather than rotate-and-lose
+      // across all of them; pg-boss retries the job.
       stats.errors += 1;
       deps.log.error(
         {
@@ -138,7 +139,7 @@ export async function runCloudflareRefreshOnce(
           account_id: inst.accountId,
           err: err instanceof Error ? err.message : String(err),
         },
-        "cloudflare token save failed after refresh; aborting pass to avoid discarding rotated tokens across installs",
+        "cloudflare token persistence failed; aborting pass to avoid discarding rotated tokens across installs",
       );
       throw err;
     }

--- a/apps/worker/src/jobs/cloudflare-refresh.ts
+++ b/apps/worker/src/jobs/cloudflare-refresh.ts
@@ -10,7 +10,7 @@
 
 import { cloudflareClientFromEnv } from "@superlog/cloudflare";
 import { decryptIntegrationSecret, encryptIntegrationSecret, schema } from "@superlog/db";
-import { eq, isNull } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import {
   type CloudflareRefreshInstallation,
   type CloudflareRefresherStore,
@@ -74,7 +74,15 @@ function createStore(db: JobDeps["db"]): CloudflareRefresherStore {
           tokenExpiresAt: tokens.tokenExpiresAt,
           updatedAt: new Date(),
         })
-        .where(eq(schema.cloudflareInstallations.id, id));
+        // Guard against a revoke landing between the list and this write (an
+        // uninstall / account-switch mid-pass): never rewrite tokens onto a
+        // row that's since been torn down.
+        .where(
+          and(
+            eq(schema.cloudflareInstallations.id, id),
+            isNull(schema.cloudflareInstallations.revokedAt),
+          ),
+        );
     },
   };
 }

--- a/apps/worker/src/jobs/cloudflare-refresh.ts
+++ b/apps/worker/src/jobs/cloudflare-refresh.ts
@@ -1,0 +1,100 @@
+// Scheduled job: keep every active Cloudflare installation's OAuth grant alive
+// (see ../cloudflare/refresher.ts for the logic + rationale; this file is only
+// the wiring — drizzle-backed store, decrypted secrets, env config).
+//
+// Daily is the right cadence: the refresh token is bounded by the client's
+// grant session duration (Cloudflare caps it at one month) and rotates on use,
+// so a once-a-day touch keeps it alive with huge margin and negligible cost.
+// Opts out (returns null → not scheduled) unless the Cloudflare OAuth client is
+// configured, since without it there's nothing to refresh with.
+
+import { cloudflareClientFromEnv } from "@superlog/cloudflare";
+import { decryptIntegrationSecret, encryptIntegrationSecret, schema } from "@superlog/db";
+import { eq, isNull } from "drizzle-orm";
+import {
+  type CloudflareRefreshInstallation,
+  type CloudflareRefresherStore,
+  runCloudflareRefreshOnce,
+} from "../cloudflare/refresher.js";
+import type { JobDefinition, JobDeps } from "../jobs.js";
+import { logger } from "../logger.js";
+
+const log = logger.child({ scope: "cloudflare-refresh" });
+
+// Built from JobDeps.db (not the module-level import) so the job follows the
+// jobs contract and can run against an injected/test database.
+function createStore(db: JobDeps["db"]): CloudflareRefresherStore {
+  return {
+    async listActiveInstallations(): Promise<CloudflareRefreshInstallation[]> {
+      const rows = await db.query.cloudflareInstallations.findMany({
+        where: isNull(schema.cloudflareInstallations.revokedAt),
+      });
+      const installations: CloudflareRefreshInstallation[] = [];
+      for (const row of rows) {
+        try {
+          installations.push({
+            id: row.id,
+            projectId: row.projectId,
+            accountId: row.accountId,
+            refreshToken:
+              row.refreshTokenCiphertext && row.refreshTokenNonce
+                ? decryptIntegrationSecret({
+                    ciphertext: row.refreshTokenCiphertext,
+                    nonce: row.refreshTokenNonce,
+                    keyVersion: row.refreshTokenKeyVersion ?? 1,
+                  })
+                : null,
+          });
+        } catch (err) {
+          // A row whose refresh token can't be decrypted (e.g. key rotation gone
+          // wrong) must not block the other installations.
+          log.error(
+            { installation_id: row.id, err: err instanceof Error ? err.message : String(err) },
+            "cloudflare install secret decrypt failed; skipping",
+          );
+        }
+      }
+      return installations;
+    },
+
+    async saveTokens(id, tokens) {
+      const accessCipher = encryptIntegrationSecret(tokens.accessToken);
+      const refreshCipher = tokens.refreshToken
+        ? encryptIntegrationSecret(tokens.refreshToken)
+        : null;
+      await db
+        .update(schema.cloudflareInstallations)
+        .set({
+          accessTokenCiphertext: accessCipher.ciphertext,
+          accessTokenNonce: accessCipher.nonce,
+          accessTokenKeyVersion: accessCipher.keyVersion,
+          refreshTokenCiphertext: refreshCipher?.ciphertext ?? null,
+          refreshTokenNonce: refreshCipher?.nonce ?? null,
+          refreshTokenKeyVersion: refreshCipher?.keyVersion ?? null,
+          tokenExpiresAt: tokens.tokenExpiresAt,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.cloudflareInstallations.id, id));
+    },
+  };
+}
+
+export const job: JobDefinition = {
+  name: "cloudflare-refresh",
+  // Once a day, 03:00 UTC — off-peak, and far inside the one-month grant window.
+  schedule: "0 3 * * *",
+  create: (deps) => {
+    const config = cloudflareClientFromEnv();
+    if (!config) {
+      log.info({}, "CLOUDFLARE_CLIENT_ID/SECRET not set — cloudflare refresh job disabled");
+      return null;
+    }
+    const store = createStore(deps.db);
+    return async () => {
+      const stats = await runCloudflareRefreshOnce({ store, config, log });
+      if (stats.refreshed > 0 || stats.errors > 0 || stats.skipped > 0) {
+        log.info({ ...stats }, "cloudflare refresh pass complete");
+      }
+    };
+  },
+};

--- a/apps/worker/src/jobs/cloudflare-refresh.ts
+++ b/apps/worker/src/jobs/cloudflare-refresh.ts
@@ -10,7 +10,7 @@
 
 import { cloudflareClientFromEnv } from "@superlog/cloudflare";
 import { decryptIntegrationSecret, encryptIntegrationSecret, schema } from "@superlog/db";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import {
   type CloudflareRefreshInstallation,
   type CloudflareRefresherStore,
@@ -28,61 +28,83 @@ function createStore(db: JobDeps["db"]): CloudflareRefresherStore {
     async listActiveInstallations(): Promise<CloudflareRefreshInstallation[]> {
       const rows = await db.query.cloudflareInstallations.findMany({
         where: isNull(schema.cloudflareInstallations.revokedAt),
+        columns: { id: true, accountId: true, refreshTokenCiphertext: true },
       });
-      const installations: CloudflareRefreshInstallation[] = [];
-      for (const row of rows) {
-        try {
-          installations.push({
-            id: row.id,
-            projectId: row.projectId,
-            accountId: row.accountId,
-            refreshToken:
-              row.refreshTokenCiphertext && row.refreshTokenNonce
-                ? decryptIntegrationSecret({
-                    ciphertext: row.refreshTokenCiphertext,
-                    nonce: row.refreshTokenNonce,
-                    keyVersion: row.refreshTokenKeyVersion ?? 1,
-                  })
-                : null,
-          });
-        } catch (err) {
-          // A row whose refresh token can't be decrypted (e.g. key rotation gone
-          // wrong) must not block the other installations.
-          log.error(
-            { installation_id: row.id, err: err instanceof Error ? err.message : String(err) },
-            "cloudflare install secret decrypt failed; skipping",
-          );
-        }
-      }
-      return installations;
+      return rows.map((row) => ({
+        id: row.id,
+        accountId: row.accountId,
+        hasRefreshToken: row.refreshTokenCiphertext != null,
+      }));
     },
 
-    async saveTokens(id, tokens) {
-      const accessCipher = encryptIntegrationSecret(tokens.accessToken);
-      const refreshCipher = tokens.refreshToken
-        ? encryptIntegrationSecret(tokens.refreshToken)
-        : null;
-      await db
-        .update(schema.cloudflareInstallations)
-        .set({
-          accessTokenCiphertext: accessCipher.ciphertext,
-          accessTokenNonce: accessCipher.nonce,
-          accessTokenKeyVersion: accessCipher.keyVersion,
-          refreshTokenCiphertext: refreshCipher?.ciphertext ?? null,
-          refreshTokenNonce: refreshCipher?.nonce ?? null,
-          refreshTokenKeyVersion: refreshCipher?.keyVersion ?? null,
-          tokenExpiresAt: tokens.tokenExpiresAt,
-          updatedAt: new Date(),
-        })
-        // Guard against a revoke landing between the list and this write (an
-        // uninstall / account-switch mid-pass): never rewrite tokens onto a
-        // row that's since been torn down.
-        .where(
-          and(
-            eq(schema.cloudflareInstallations.id, id),
+    async withLockedInstallation(installationId, fn) {
+      return db.transaction(async (tx) => {
+        // Same namespaced advisory lock the api's freshAccessToken takes, so an
+        // on-demand refresh and this keep-alive can't redeem the same rotating
+        // token concurrently. Auto-released at transaction end.
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtext('cloudflare_installations'), hashtext(${installationId}))`,
+        );
+        const cur = await tx.query.cloudflareInstallations.findFirst({
+          where: and(
+            eq(schema.cloudflareInstallations.id, installationId),
             isNull(schema.cloudflareInstallations.revokedAt),
           ),
-        );
+          columns: {
+            refreshTokenCiphertext: true,
+            refreshTokenNonce: true,
+            refreshTokenKeyVersion: true,
+            tokenExpiresAt: true,
+          },
+        });
+        const current =
+          cur == null
+            ? null
+            : {
+                refreshToken:
+                  cur.refreshTokenCiphertext && cur.refreshTokenNonce
+                    ? decryptIntegrationSecret({
+                        ciphertext: cur.refreshTokenCiphertext,
+                        nonce: cur.refreshTokenNonce,
+                        keyVersion: cur.refreshTokenKeyVersion ?? 1,
+                      })
+                    : null,
+                tokenExpiresAt: cur.tokenExpiresAt,
+              };
+
+        const save = async (tokens: {
+          accessToken: string;
+          refreshToken: string | null;
+          tokenExpiresAt: Date | null;
+        }): Promise<void> => {
+          const accessCipher = encryptIntegrationSecret(tokens.accessToken);
+          const refreshCipher = tokens.refreshToken
+            ? encryptIntegrationSecret(tokens.refreshToken)
+            : null;
+          await tx
+            .update(schema.cloudflareInstallations)
+            .set({
+              accessTokenCiphertext: accessCipher.ciphertext,
+              accessTokenNonce: accessCipher.nonce,
+              accessTokenKeyVersion: accessCipher.keyVersion,
+              refreshTokenCiphertext: refreshCipher?.ciphertext ?? null,
+              refreshTokenNonce: refreshCipher?.nonce ?? null,
+              refreshTokenKeyVersion: refreshCipher?.keyVersion ?? null,
+              tokenExpiresAt: tokens.tokenExpiresAt,
+              updatedAt: new Date(),
+            })
+            // revokedAt guard: a revoke landing between list and write (uninstall
+            // / account-switch) must not resurrect tokens on a torn-down row.
+            .where(
+              and(
+                eq(schema.cloudflareInstallations.id, installationId),
+                isNull(schema.cloudflareInstallations.revokedAt),
+              ),
+            );
+        };
+
+        return fn(current, save);
+      });
     },
   };
 }

--- a/apps/worker/src/jobs/cloudflare-refresh.ts
+++ b/apps/worker/src/jobs/cloudflare-refresh.ts
@@ -12,6 +12,7 @@ import { cloudflareClientFromEnv } from "@superlog/cloudflare";
 import { decryptIntegrationSecret, encryptIntegrationSecret, schema } from "@superlog/db";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import {
+  type CloudflareInstallationTokens,
   type CloudflareRefreshInstallation,
   type CloudflareRefresherStore,
   runCloudflareRefreshOnce,
@@ -57,20 +58,32 @@ function createStore(db: JobDeps["db"]): CloudflareRefresherStore {
             tokenExpiresAt: true,
           },
         });
-        const current =
-          cur == null
-            ? null
-            : {
-                refreshToken:
-                  cur.refreshTokenCiphertext && cur.refreshTokenNonce
-                    ? decryptIntegrationSecret({
-                        ciphertext: cur.refreshTokenCiphertext,
-                        nonce: cur.refreshTokenNonce,
-                        keyVersion: cur.refreshTokenKeyVersion ?? 1,
-                      })
-                    : null,
-                tokenExpiresAt: cur.tokenExpiresAt,
-              };
+        let current: CloudflareInstallationTokens | null = null;
+        if (cur != null) {
+          let refreshToken: string | null = null;
+          if (cur.refreshTokenCiphertext && cur.refreshTokenNonce) {
+            try {
+              refreshToken = decryptIntegrationSecret({
+                ciphertext: cur.refreshTokenCiphertext,
+                nonce: cur.refreshTokenNonce,
+                keyVersion: cur.refreshTokenKeyVersion ?? 1,
+              });
+            } catch (err) {
+              // A row whose refresh token can't be decrypted (corrupted
+              // ciphertext / stale key version) must skip like a no-token
+              // install — nothing was rotated, so don't abort the whole pass.
+              log.error(
+                {
+                  installation_id: installationId,
+                  err: err instanceof Error ? err.message : String(err),
+                },
+                "cloudflare refresh token decrypt failed; skipping install",
+              );
+              refreshToken = null;
+            }
+          }
+          current = { refreshToken, tokenExpiresAt: cur.tokenExpiresAt };
+        }
 
         const save = async (tokens: {
           accessToken: string;

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@superlog/cloudflare",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "tsx --test src/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./oauth.js";

--- a/packages/cloudflare/src/oauth.test.ts
+++ b/packages/cloudflare/src/oauth.test.ts
@@ -1,0 +1,123 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import {
+  CLOUDFLARE_OAUTH_TOKEN_URL,
+  cloudflareClientFromEnv,
+  exchangeCodeForToken,
+  parseTokenResponse,
+  refreshAccessToken,
+} from "./oauth.js";
+
+const CONFIG = {
+  clientId: "cid",
+  clientSecret: "csecret",
+  redirectUri: "https://api.example.com/cloudflare/oauth/callback",
+};
+
+// Index into an array with narrowing (strict indexing forbids bare [0]).
+function at<T>(items: readonly T[], index: number): T {
+  const item = items[index];
+  if (item === undefined) throw new Error(`no element at index ${index}`);
+  return item;
+}
+
+function fakeTokenFetch(response: { status?: number; json: unknown }) {
+  const calls: { url: string; body: URLSearchParams }[] = [];
+  const fetchImpl = (async (url: unknown, init?: RequestInit) => {
+    calls.push({
+      url: String(url),
+      body: new URLSearchParams(String(init?.body)),
+    });
+    return new Response(JSON.stringify(response.json), { status: response.status ?? 200 });
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+test("parseTokenResponse extracts tokens and surfaces errors", () => {
+  const ok = parseTokenResponse({
+    access_token: "at",
+    refresh_token: "rt",
+    expires_in: 57600,
+    scope: "workers-scripts.read offline_access",
+  });
+  assert.deepEqual(ok, {
+    ok: true,
+    accessToken: "at",
+    refreshToken: "rt",
+    expiresIn: 57600,
+    scope: "workers-scripts.read offline_access",
+  });
+  assert.deepEqual(parseTokenResponse({ error: "invalid_grant" }), {
+    ok: false,
+    error: "invalid_grant",
+  });
+  assert.deepEqual(parseTokenResponse(null), { ok: false, error: "invalid_response" });
+  assert.deepEqual(parseTokenResponse({}), { ok: false, error: "no_access_token" });
+});
+
+test("cloudflareClientFromEnv needs both id and secret, else null", () => {
+  assert.equal(cloudflareClientFromEnv({}), null);
+  assert.equal(cloudflareClientFromEnv({ CLOUDFLARE_CLIENT_ID: "cid" }), null);
+  assert.equal(cloudflareClientFromEnv({ CLOUDFLARE_CLIENT_SECRET: "cs" }), null);
+  assert.deepEqual(
+    cloudflareClientFromEnv({ CLOUDFLARE_CLIENT_ID: "cid", CLOUDFLARE_CLIENT_SECRET: "cs" }),
+    { clientId: "cid", clientSecret: "cs" },
+  );
+});
+
+test("exchangeCodeForToken posts the authorization code with client credentials", async () => {
+  const { fetchImpl, calls } = fakeTokenFetch({
+    json: { access_token: "at", refresh_token: "rt", expires_in: 3600 },
+  });
+  const result = await exchangeCodeForToken({ config: CONFIG, code: "the-code", fetchImpl });
+  assert.ok(result.ok);
+  assert.equal(result.accessToken, "at");
+  assert.equal(at(calls, 0).url, CLOUDFLARE_OAUTH_TOKEN_URL);
+  assert.equal(at(calls, 0).body.get("grant_type"), "authorization_code");
+  assert.equal(at(calls, 0).body.get("code"), "the-code");
+  assert.equal(at(calls, 0).body.get("redirect_uri"), CONFIG.redirectUri);
+  assert.equal(at(calls, 0).body.get("client_id"), "cid");
+  assert.equal(at(calls, 0).body.get("client_secret"), "csecret");
+});
+
+test("refreshAccessToken posts the refresh token grant with client credentials", async () => {
+  const { fetchImpl, calls } = fakeTokenFetch({
+    json: { access_token: "at2", refresh_token: "rt2", expires_in: 57600 },
+  });
+  const result = await refreshAccessToken({ config: CONFIG, refreshToken: "rt1", fetchImpl });
+  assert.ok(result.ok);
+  assert.equal(result.accessToken, "at2");
+  assert.equal(result.refreshToken, "rt2");
+  assert.equal(result.expiresIn, 57600);
+  assert.equal(at(calls, 0).url, CLOUDFLARE_OAUTH_TOKEN_URL);
+  assert.equal(at(calls, 0).body.get("grant_type"), "refresh_token");
+  assert.equal(at(calls, 0).body.get("refresh_token"), "rt1");
+  assert.equal(at(calls, 0).body.get("client_id"), "cid");
+  assert.equal(at(calls, 0).body.get("client_secret"), "csecret");
+  assert.equal(at(calls, 0).body.get("redirect_uri"), null);
+});
+
+test("refreshAccessToken tolerates a response with no rotated refresh token", async () => {
+  const { fetchImpl } = fakeTokenFetch({ json: { access_token: "at2", expires_in: 57600 } });
+  const result = await refreshAccessToken({ config: CONFIG, refreshToken: "rt1", fetchImpl });
+  assert.ok(result.ok);
+  assert.equal(result.refreshToken, null);
+});
+
+test("a non-OK token response never reads as success", async () => {
+  // Even if a proxy/error page returns something that parses as a token, a
+  // non-2xx status must fail — mirrors the Railway client's guard.
+  const { fetchImpl } = fakeTokenFetch({ status: 502, json: { access_token: "at" } });
+  const result = await refreshAccessToken({ config: CONFIG, refreshToken: "rt1", fetchImpl });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "status_502");
+
+  const denied = fakeTokenFetch({ status: 400, json: { error: "invalid_grant" } });
+  const deniedResult = await refreshAccessToken({
+    config: CONFIG,
+    refreshToken: "rt1",
+    fetchImpl: denied.fetchImpl,
+  });
+  assert.ok(!deniedResult.ok);
+  assert.equal(deniedResult.error, "invalid_grant");
+});

--- a/packages/cloudflare/src/oauth.test.ts
+++ b/packages/cloudflare/src/oauth.test.ts
@@ -47,6 +47,10 @@ test("parseTokenResponse extracts tokens and surfaces errors", () => {
     expiresIn: 57600,
     scope: "workers-scripts.read offline_access",
   });
+  // An empty-string refresh token is treated as absent (null), not a valid token.
+  const emptyRefresh = parseTokenResponse({ access_token: "at", refresh_token: "" });
+  assert.ok(emptyRefresh.ok);
+  assert.equal(emptyRefresh.refreshToken, null);
   assert.deepEqual(parseTokenResponse({ error: "invalid_grant" }), {
     ok: false,
     error: "invalid_grant",

--- a/packages/cloudflare/src/oauth.ts
+++ b/packages/cloudflare/src/oauth.ts
@@ -70,7 +70,9 @@ export function parseTokenResponse(json: unknown): CloudflareTokenResult {
   return {
     ok: true,
     accessToken: o.access_token,
-    refreshToken: typeof o.refresh_token === "string" ? o.refresh_token : null,
+    // An empty-string refresh token is equivalent to absent (it would fail on
+    // use), so treat it as null — same guard as the Railway client.
+    refreshToken: typeof o.refresh_token === "string" && o.refresh_token ? o.refresh_token : null,
     expiresIn: typeof o.expires_in === "number" ? o.expires_in : null,
     scope: typeof o.scope === "string" ? o.scope : null,
   };

--- a/packages/cloudflare/src/oauth.ts
+++ b/packages/cloudflare/src/oauth.ts
@@ -1,0 +1,126 @@
+// Cloudflare OAuth 2.0 client helpers, shared by the api (connect flow) and the
+// worker (background token refresh). Cloudflare shipped self-managed OAuth for
+// all developers in 2026-06; the connector uses it for a Slack-style "Connect
+// Cloudflare" button.
+//
+// OAuth endpoints (from Cloudflare's "Integrate your OAuth client" docs):
+//   authorize: https://dash.cloudflare.com/oauth2/auth
+//   token:     https://dash.cloudflare.com/oauth2/token
+//   revoke:    https://dash.cloudflare.com/oauth2/revoke
+//
+// Token model: access tokens are short-lived (hours); whether a refresh token
+// is issued at all is controlled by the OAuth *client registration* — Cloudflare
+// adds/removes `offline_access` automatically based on the client's grant
+// types, and the client's "grant session duration" bounds how long the refresh
+// token stays valid. Refresh tokens may rotate on use, so callers must persist
+// the replacement immediately when one is returned.
+//
+// This module is deliberately IO-light (pure functions + injectable fetch),
+// mirroring @superlog/railway.
+
+export const CLOUDFLARE_OAUTH_AUTHORIZE_URL = "https://dash.cloudflare.com/oauth2/auth";
+export const CLOUDFLARE_OAUTH_TOKEN_URL = "https://dash.cloudflare.com/oauth2/token";
+export const CLOUDFLARE_OAUTH_REVOKE_URL = "https://dash.cloudflare.com/oauth2/revoke";
+
+export type FetchImpl = typeof fetch;
+
+export type CloudflareOAuthConfig = {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+};
+
+/** Just the client credentials — all the background keep-alive refresh needs
+ * (the refresh grant sends no redirect_uri). */
+export type CloudflareClientCredentials = Pick<CloudflareOAuthConfig, "clientId" | "clientSecret">;
+
+/**
+ * Read the OAuth client credentials from env; null (→ refresh disabled) when
+ * either is missing. The worker's keep-alive job opts out when this is null —
+ * without a client there's nothing to refresh with.
+ */
+export function cloudflareClientFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): CloudflareClientCredentials | null {
+  const clientId = env.CLOUDFLARE_CLIENT_ID;
+  const clientSecret = env.CLOUDFLARE_CLIENT_SECRET;
+  if (!clientId || !clientSecret) return null;
+  return { clientId, clientSecret };
+}
+
+export type CloudflareTokenResult =
+  | {
+      ok: true;
+      accessToken: string;
+      refreshToken: string | null;
+      expiresIn: number | null;
+      scope: string | null;
+    }
+  | { ok: false; error: string };
+
+export function parseTokenResponse(json: unknown): CloudflareTokenResult {
+  if (!json || typeof json !== "object") return { ok: false, error: "invalid_response" };
+  const o = json as Record<string, unknown>;
+  if (typeof o.error === "string") {
+    return { ok: false, error: o.error };
+  }
+  if (typeof o.access_token !== "string" || !o.access_token) {
+    return { ok: false, error: "no_access_token" };
+  }
+  return {
+    ok: true,
+    accessToken: o.access_token,
+    refreshToken: typeof o.refresh_token === "string" ? o.refresh_token : null,
+    expiresIn: typeof o.expires_in === "number" ? o.expires_in : null,
+    scope: typeof o.scope === "string" ? o.scope : null,
+  };
+}
+
+async function postTokenRequest(
+  body: URLSearchParams,
+  fetchImpl: FetchImpl,
+): Promise<CloudflareTokenResult> {
+  const res = await fetchImpl(CLOUDFLARE_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  const json = await res.json().catch(() => null);
+  const parsed = parseTokenResponse(json);
+  // A non-OK status with a parseable body still must not read as success.
+  if (!res.ok && parsed.ok) return { ok: false, error: `status_${res.status}` };
+  return parsed;
+}
+
+export async function exchangeCodeForToken(input: {
+  config: CloudflareOAuthConfig;
+  code: string;
+  fetchImpl?: FetchImpl;
+}): Promise<CloudflareTokenResult> {
+  return postTokenRequest(
+    new URLSearchParams({
+      grant_type: "authorization_code",
+      code: input.code,
+      redirect_uri: input.config.redirectUri,
+      client_id: input.config.clientId,
+      client_secret: input.config.clientSecret,
+    }),
+    input.fetchImpl ?? fetch,
+  );
+}
+
+export async function refreshAccessToken(input: {
+  config: Pick<CloudflareOAuthConfig, "clientId" | "clientSecret">;
+  refreshToken: string;
+  fetchImpl?: FetchImpl;
+}): Promise<CloudflareTokenResult> {
+  return postTokenRequest(
+    new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: input.refreshToken,
+      client_id: input.config.clientId,
+      client_secret: input.config.clientSecret,
+    }),
+    input.fetchImpl ?? fetch,
+  );
+}

--- a/packages/cloudflare/tsconfig.json
+++ b/packages/cloudflare/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       '@scalar/hono-api-reference':
         specifier: ^0.10.19
         version: 0.10.19(hono@4.12.14)
+      '@superlog/cloudflare':
+        specifier: workspace:*
+        version: link:../../packages/cloudflare
       '@superlog/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -471,6 +474,9 @@ importers:
       '@superlog/billing':
         specifier: workspace:*
         version: link:../../packages/billing
+      '@superlog/cloudflare':
+        specifier: workspace:*
+        version: link:../../packages/cloudflare
       '@superlog/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -522,6 +528,18 @@ importers:
         version: 5.9.3
 
   packages/billing:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
+  packages/cloudflare:
     devDependencies:
       '@types/node':
         specifier: ^22.10.1


### PR DESCRIPTION
## Problem

The Cloudflare Workers Observability connector was one-shot. On connect it exchanged the OAuth code, created the telemetry destinations, wired the account's workers, and then never touched the grant again. The delegated access token is short-lived (~16h), so once it expired we could no longer manage the account server-side (re-wire workers, delete destinations on uninstall) even though the integration still displayed as connected. No refresh token was ever stored, because the connector didn't request the offline grant.

## Change

- **Request `offline_access`** in the OAuth scope so Cloudflare issues a refresh token. (Verified against the live OAuth endpoint: with the scope requested and the client's `refresh_token` grant enabled, Cloudflare returns a refresh token that rotates on every use. Without the scope it returns none.)
- **Shared `@superlog/cloudflare` package** owns the OAuth token primitives (`exchangeCodeForToken` / `refreshAccessToken` / `parseTokenResponse`); the api re-exports them so the connect flow and the worker share one implementation.
- **api — lazy refresh on use.** `freshAccessToken` renews the access token on demand right before a management call and persists the rotated refresh token immediately (dropping it would break the next refresh). Wired into uninstall/teardown, so remote cleanup works even long after connect.
- **worker — daily keep-alive job.** `cloudflare-refresh` (`0 3 * * *`) exercises every active installation's refresh token once a day. The connector is push-only, so it otherwise never calls the API after connect and the refresh token would age out; a daily touch keeps the grant alive with wide margin. Installs with no refresh token (connected before the offline grant) are skipped and need one reconnect. Opts out if the OAuth client isn't configured.

No schema change — the refresh-token columns already existed.

## Notes for deploying

- The OAuth client registration must permit the `refresh_token` grant, and its **grant session duration** bounds the refresh-token lifetime (Cloudflare caps this at one month; set it to the max). The daily job keeps the grant alive within that window.
- Existing installations have no refresh token and need one reconnect to pick one up.

## Tests

`@superlog/cloudflare` (6), worker refresher (4), api cloudflare-service (20) all pass; typechecks clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds offline access and automatic token refresh to the Cloudflare Workers Observability connector so it stays manageable long after connect. The API and daily worker now share a per-install Postgres advisory lock to serialize refresh safely and avoid double rotation.

- **New Features**
  - Request `offline_access` in default scopes so Cloudflare issues refresh tokens.
  - New `@superlog/cloudflare` package with OAuth helpers; the API re-exports them.
  - API: on-demand access-token refresh with a per-install advisory lock; immediately persists rotated refresh tokens; used in teardown/uninstall.
  - Worker: daily `cloudflare-refresh` job; uses the same per-install lock, re-reads under the lock, and persists in the same transaction; skips installs without a refresh token; opts out if the client isn’t configured.
  - Hardening: empty `refresh_token` treated as absent; refresh when expiry is unknown; undecryptable refresh token skips that install (per-install isolation); abort pass on a save failure to avoid rotate-and-lose; updates guarded by `revokedAt IS NULL`.

- **Migration**
  - Enable the OAuth client’s `refresh_token` grant and set a long grant session duration.
  - Existing installs need one reconnect to obtain a refresh token.
  - No schema changes.

<sup>Written for commit e517695868e5760f818079daaacd33010ccbc4ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

