### PR TITLE
web: show live GitHub star count in the landing nav

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --test src/content/*.test.ts",
+    "test": "tsx --test src/content/*.test.ts src/githubStars.test.ts src/Landing.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --test src/content/*.test.ts src/githubStars.test.ts src/Landing.test.ts",
+    "test": "tsx --test src/*.test.ts src/content/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/src/Landing.test.ts
+++ b/apps/web/src/Landing.test.ts
@@ -23,10 +23,20 @@ test("landing top nav renders a Docs link wired to the docs URL", async () => {
 test("landing top nav renders a GitHub link wired to the repository URL", async () => {
   const source = await readFile(new URL("./Landing.tsx", import.meta.url), "utf8");
 
+  // The link still opens the repo in a new tab and shows the octocat, but the
+  // label is now the live star count (with a static "GitHub" fallback until the
+  // count loads or if the API is unreachable).
   assert.match(
     source,
-    /href=\{LANDING_GITHUB_REPO_URL\}[\s\S]*?target="_blank"[\s\S]*?rel="noreferrer"[\s\S]*?<GitHubIcon \/>[\s\S]*?GitHub\s*<\/a>/,
+    /href=\{LANDING_GITHUB_REPO_URL\}[\s\S]*?target="_blank"[\s\S]*?rel="noreferrer"[\s\S]*?<GitHubIcon \/>[\s\S]*?formatStarCount\(stars\)[\s\S]*?"GitHub"[\s\S]*?<\/a>/,
   );
+});
+
+test("landing top nav feeds the live star count from the repo URL", async () => {
+  const source = await readFile(new URL("./Landing.tsx", import.meta.url), "utf8");
+  // The count is derived from the same repo URL the link points at, so the
+  // badge and the destination can never drift apart.
+  assert.match(source, /useGithubStarCount\(LANDING_GITHUB_REPO_URL\)/);
 });
 
 test("landing footer links to the terms of service page", async () => {

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -2,8 +2,10 @@ import { usePostHog } from "posthog-js/react";
 import { useEffect, useRef, useState } from "react";
 import { AuthForm } from "./AuthForm.tsx";
 import { Btn, Chip, Label, Tile, Wordmark } from "./design/ui.tsx";
+import { formatStarCount } from "./githubStars.ts";
 import { INSTALL_PROMPT } from "./installPrompt.ts";
 import { LANDING_DOCS_URL, LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
+import { useGithubStarCount } from "./useGithubStars.ts";
 
 // ---------------------------------------------------------------------------
 // Landing — /
@@ -109,6 +111,7 @@ function TopNav({
   onSignIn: () => void;
   onSignUp: () => void;
 }) {
+  const stars = useGithubStarCount(LANDING_GITHUB_REPO_URL);
   return (
     <header className="sticky top-0 z-40 bg-bg">
       <div className="mx-auto w-full max-w-[1400px] px-4 md:px-8 xl:px-12">
@@ -119,10 +122,17 @@ function TopNav({
               href={LANDING_GITHUB_REPO_URL}
               target="_blank"
               rel="noreferrer"
+              aria-label={
+                stars != null
+                  ? `Superlog on GitHub, ${stars.toLocaleString()} stars`
+                  : "Superlog on GitHub"
+              }
               className="hidden items-center gap-1.5 text-[12px] font-medium text-muted transition-colors hover:text-fg sm:inline-flex"
             >
               <GitHubIcon />
-              GitHub
+              <span className="tabular-nums">
+                {stars != null ? formatStarCount(stars) : "GitHub"}
+              </span>
             </a>
             <a
               href={LANDING_DOCS_URL}

--- a/apps/web/src/githubStars.test.ts
+++ b/apps/web/src/githubStars.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatStarCount, githubApiUrlFromRepoUrl } from "./githubStars.ts";
+
+test("githubApiUrlFromRepoUrl maps a repo URL to the REST stars endpoint", () => {
+  assert.equal(
+    githubApiUrlFromRepoUrl("https://github.com/superloglabs/superlog"),
+    "https://api.github.com/repos/superloglabs/superlog",
+  );
+});
+
+test("githubApiUrlFromRepoUrl tolerates a trailing slash and .git suffix", () => {
+  assert.equal(
+    githubApiUrlFromRepoUrl("https://github.com/superloglabs/superlog/"),
+    "https://api.github.com/repos/superloglabs/superlog",
+  );
+  assert.equal(
+    githubApiUrlFromRepoUrl("https://github.com/superloglabs/superlog.git"),
+    "https://api.github.com/repos/superloglabs/superlog",
+  );
+});
+
+test("githubApiUrlFromRepoUrl returns null for non-repo GitHub URLs", () => {
+  assert.equal(githubApiUrlFromRepoUrl("https://github.com/superloglabs"), null);
+  assert.equal(githubApiUrlFromRepoUrl("https://example.com/a/b"), null);
+  assert.equal(githubApiUrlFromRepoUrl("not a url"), null);
+});
+
+test("formatStarCount shows exact values below 1,000", () => {
+  assert.equal(formatStarCount(0), "0");
+  assert.equal(formatStarCount(1), "1");
+  assert.equal(formatStarCount(947), "947");
+  assert.equal(formatStarCount(999), "999");
+});
+
+test("formatStarCount abbreviates thousands with one decimal, trimming '.0'", () => {
+  assert.equal(formatStarCount(1000), "1k");
+  assert.equal(formatStarCount(1500), "1.5k");
+  assert.equal(formatStarCount(10300), "10.3k");
+  // Two-decimal inputs round to a single decimal.
+  assert.equal(formatStarCount(12040), "12k");
+  assert.equal(formatStarCount(12060), "12.1k");
+});
+
+test("formatStarCount abbreviates millions and never emits '1000k'", () => {
+  assert.equal(formatStarCount(999_999), "1M");
+  assert.equal(formatStarCount(1_000_000), "1M");
+  assert.equal(formatStarCount(1_200_000), "1.2M");
+});
+
+test("formatStarCount is defensive about junk input", () => {
+  assert.equal(formatStarCount(Number.NaN), "0");
+  assert.equal(formatStarCount(-5), "0");
+  assert.equal(formatStarCount(3.7), "3");
+});

--- a/apps/web/src/githubStars.ts
+++ b/apps/web/src/githubStars.ts
@@ -1,0 +1,51 @@
+// ---------------------------------------------------------------------------
+// GitHub star helpers — pure logic for the landing nav's live star badge.
+// The React hook that fetches + caches lives in useGithubStars.ts; everything
+// here is DOM-free so it can be unit-tested under `tsx --test`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Turn a public repo URL (`https://github.com/owner/repo`) into the REST API
+ * endpoint that returns `{ stargazers_count }`. Tolerates a trailing slash and
+ * a `.git` suffix. Returns null for anything that isn't an `owner/repo` URL on
+ * github.com so callers can degrade gracefully instead of fetching garbage.
+ */
+export function githubApiUrlFromRepoUrl(repoUrl: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(repoUrl);
+  } catch {
+    return null;
+  }
+  if (url.hostname !== "github.com" && url.hostname !== "www.github.com") {
+    return null;
+  }
+  const [owner, repoRaw] = url.pathname.split("/").filter(Boolean);
+  if (!owner || !repoRaw) return null;
+  const repo = repoRaw.replace(/\.git$/, "");
+  if (!repo) return null;
+  return `https://api.github.com/repos/${owner}/${repo}`;
+}
+
+/**
+ * Compact, GitHub-style star count: exact below 1,000, then one-decimal `k`
+ * and `M` with trailing `.0` trimmed (10_300 → "10.3k", 1_000 → "1k",
+ * 1_200_000 → "1.2M"). Rounding-aware so 999_999 renders "1M", never "1000k".
+ */
+export function formatStarCount(count: number): string {
+  if (!Number.isFinite(count) || count < 0) return "0";
+  const n = Math.floor(count);
+  if (n < 1000) return String(n);
+
+  const format = (value: number, suffix: string) => {
+    const rounded = Math.round(value * 10) / 10;
+    const text = rounded % 1 === 0 ? String(rounded) : rounded.toFixed(1);
+    return `${text}${suffix}`;
+  };
+
+  // Pick the tier from the rounded magnitude so a value that rounds up across a
+  // boundary (999_999 → 1,000.0k) promotes to the next suffix.
+  const thousands = Math.round((n / 1000) * 10) / 10;
+  if (thousands < 1000) return format(n / 1000, "k");
+  return format(n / 1_000_000, "M");
+}

--- a/apps/web/src/useGithubStars.ts
+++ b/apps/web/src/useGithubStars.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import { githubApiUrlFromRepoUrl } from "./githubStars.ts";
+
+// ---------------------------------------------------------------------------
+// useGithubStarCount — live star count for the landing nav badge.
+// Fetches the public GitHub REST API straight from the visitor's browser and
+// caches the result in localStorage so repeat visits render instantly and we
+// stay well under the unauthenticated rate limit (60 req/hr per IP).
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL_MS = 60 * 60 * 1000; // refresh at most once per hour per visitor
+const cacheKey = (apiUrl: string) => `superlog:gh-stars:${apiUrl}`;
+
+type CachedStars = { count: number; at: number };
+
+function readCache(apiUrl: string): CachedStars | null {
+  try {
+    const raw = localStorage.getItem(cacheKey(apiUrl));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<CachedStars>;
+    if (typeof parsed?.count !== "number" || typeof parsed?.at !== "number") {
+      return null;
+    }
+    return { count: parsed.count, at: parsed.at };
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(apiUrl: string, count: number) {
+  try {
+    localStorage.setItem(cacheKey(apiUrl), JSON.stringify({ count, at: Date.now() }));
+  } catch {
+    // Storage can be unavailable (private mode / quota) — the badge still works,
+    // it just refetches next load.
+  }
+}
+
+/**
+ * Returns the repo's star count, or null until it's known. A cached value shows
+ * immediately; a stale or missing cache triggers a background refresh. Every
+ * failure mode (bad URL, offline, rate-limited, malformed body) resolves to the
+ * cached value or null, so the caller can fall back to a static label and the
+ * page never blocks on GitHub.
+ */
+export function useGithubStarCount(repoUrl: string): number | null {
+  const [count, setCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    const apiUrl = githubApiUrlFromRepoUrl(repoUrl);
+    if (!apiUrl) return;
+
+    const cached = readCache(apiUrl);
+    if (cached) setCount(cached.count);
+    if (cached && Date.now() - cached.at < CACHE_TTL_MS) return;
+
+    const controller = new AbortController();
+    fetch(apiUrl, {
+      headers: { Accept: "application/vnd.github+json" },
+      signal: controller.signal,
+    })
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then((data: { stargazers_count?: unknown }) => {
+        const stars = data?.stargazers_count;
+        if (typeof stars === "number" && Number.isFinite(stars)) {
+          setCount(stars);
+          writeCache(apiUrl, stars);
+        }
+      })
+      .catch(() => {
+        // Keep whatever we already have (cached value or null).
+      });
+
+    return () => controller.abort();
+  }, [repoUrl]);
+
+  return count;
+}


### PR DESCRIPTION
## What

The top-nav GitHub link on the landing page now shows the repository's **live star count** instead of a static "GitHub" label (e.g. `⧉ 1k`), styled to match the other nav links (Docs, Changelog, Roadmap, Team, Pricing).

## How

- The count is fetched **client-side** from the GitHub REST API (`/repos/superloglabs/superlog`) straight from the visitor's browser — no backend involved.
- It's cached in `localStorage` with a 1-hour TTL, so repeat visits render instantly and we stay well under the unauthenticated rate limit (60 req/hr per IP).
- If the count isn't loaded yet, or the API is unreachable/rate-limited, the link **falls back to the "GitHub" label**, so the nav always degrades gracefully.
- The number is formatted GitHub-style: `1005 → "1k"`, `10300 → "10.3k"`, `1_200_000 → "1.2M"`.

## Structure

- `githubStars.ts` — pure, unit-tested helpers (`githubApiUrlFromRepoUrl`, `formatStarCount`).
- `useGithubStars.ts` — the small `useGithubStarCount` hook that does the fetch + cache.
- `Landing.tsx` — renders the badge in `TopNav`.

## Tests

- New `githubStars.test.ts` covers URL derivation and number formatting (including edge cases like `999_999 → "1M"`, never `"1000k"`).
- Updated `Landing.test.ts` for the new nav structure.
- Wired the root-level `src/*.test.ts` (this + `Landing.test.ts`) into the package `test` script, which previously only ran `src/content/*.test.ts` — so these are now enforced in CI.

Verified in the browser: the API call returns 200 and the badge renders the real count; graceful fallback confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)