### PR TITLE
Cloudflare: Workers list, wire/unwire, auto-wire + reconcile

### DIFF
--- a/apps/api/src/cloudflare-service.test.ts
+++ b/apps/api/src/cloudflare-service.test.ts
@@ -19,6 +19,7 @@ import {
   projectDestinationToken,
   signState,
   staleDestinationSlugs,
+  unwireObservabilityDestinations,
   verifyState,
   wireObservabilityDestinations,
 } from "./cloudflare-service.js";
@@ -294,6 +295,61 @@ test("wireObservabilityDestinations is additive + idempotent and skips when alre
     enabled: true,
     logs: { enabled: true, destinations: ["superlog-logs"] },
   });
+});
+
+test("unwireObservabilityDestinations removes our slugs, keeps others, null when absent", () => {
+  // Removes our slug from each signal, leaving the Worker's other destinations
+  // and fields intact.
+  assert.deepEqual(
+    unwireObservabilityDestinations(
+      {
+        enabled: true,
+        head_sampling_rate: 1,
+        logs: { enabled: true, persist: true, destinations: ["other-dest", "superlog-logs"] },
+        traces: { enabled: true, destinations: ["superlog-traces"] },
+      },
+      { traces: "superlog-traces", logs: "superlog-logs" },
+    ),
+    {
+      enabled: true,
+      head_sampling_rate: 1,
+      logs: { enabled: true, persist: true, destinations: ["other-dest"] },
+      traces: { enabled: true, destinations: [] },
+    },
+  );
+
+  // Our slugs aren't present → null (nothing to change, skip the PATCH).
+  assert.equal(
+    unwireObservabilityDestinations(
+      {
+        enabled: true,
+        logs: { enabled: true, destinations: ["other-dest"] },
+        traces: { enabled: true, destinations: [] },
+      },
+      { traces: "superlog-traces", logs: "superlog-logs" },
+    ),
+    null,
+  );
+
+  // Null/unset observability → null.
+  assert.equal(unwireObservabilityDestinations(null, { logs: "superlog-logs" }), null);
+
+  // Only the signal whose slug is present is touched.
+  assert.deepEqual(
+    unwireObservabilityDestinations(
+      {
+        enabled: true,
+        logs: { enabled: true, destinations: ["superlog-logs"] },
+        traces: { enabled: true, destinations: ["kept"] },
+      },
+      { traces: "superlog-traces", logs: "superlog-logs" },
+    ),
+    {
+      enabled: true,
+      logs: { enabled: true, destinations: [] },
+      traces: { enabled: true, destinations: ["kept"] },
+    },
+  );
 });
 
 test("parseCreateDestinationResponse returns slug on success and message on failure", () => {

--- a/apps/api/src/cloudflare-service.ts
+++ b/apps/api/src/cloudflare-service.ts
@@ -17,7 +17,6 @@
 export const CLOUDFLARE_OAUTH_AUTHORIZE_URL = "https://dash.cloudflare.com/oauth2/auth";
 export const CLOUDFLARE_OAUTH_TOKEN_URL = "https://dash.cloudflare.com/oauth2/token";
 export const CLOUDFLARE_OAUTH_REVOKE_URL = "https://dash.cloudflare.com/oauth2/revoke";
-export const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4";
 
 // Cloudflare OAuth scope identifiers (dot-delimited, mirroring API-token
 // permission names — verified against `GET /client/v4/oauth/scopes`). The
@@ -195,15 +194,34 @@ export { signState, verifyState } from "./oauth-state.js";
 // Response parsing
 // ---------------------------------------------------------------------------
 
-// OAuth token primitives (exchange / refresh / parse) live in @superlog/cloudflare
-// so the worker's background refresh job shares exactly one implementation with
-// this connect flow. Re-exported here so existing api imports keep working.
+// OAuth token primitives (exchange / refresh / parse) and the Workers
+// Observability wiring + script client live in @superlog/cloudflare so the
+// worker's background jobs (token refresh, wiring reconcile) share exactly one
+// implementation with this connect flow. Re-exported here so existing api
+// imports keep working.
 export {
+  CLOUDFLARE_API_BASE,
   type CloudflareTokenResult,
+  type WorkerDestinationSlugs,
+  type WorkerObservability,
+  type WorkerObservabilitySignal,
   exchangeCodeForToken,
+  getScriptObservability,
+  isWorkerWired,
+  listScripts,
+  listScriptsStrict,
+  parseScriptsResponse,
   parseTokenResponse,
+  reconcileWorkerWiring,
   refreshAccessToken,
+  unwireObservabilityDestinations,
+  updateScriptObservability,
+  wireObservabilityDestinations,
 } from "@superlog/cloudflare";
+
+// Imported (not just re-exported) because the account/destination wrappers below
+// still build request URLs against it.
+import { CLOUDFLARE_API_BASE } from "@superlog/cloudflare";
 
 export type CloudflareAccount = { id: string; name: string };
 
@@ -298,111 +316,13 @@ export function staleDestinationSlugs(
 }
 
 // ---------------------------------------------------------------------------
-// Worker observability wiring
-//
-// Creating a destination is not enough: a Worker only exports to a destination
-// when its own `observability` config enables the signal and lists the
-// destination by name. So on connect we read each Worker's settings and merge our
-// destination slugs in.
-// ---------------------------------------------------------------------------
-
-export type WorkerObservabilitySignal = {
-  enabled?: boolean;
-  destinations?: string[];
-  [k: string]: unknown;
-};
-export type WorkerObservability = {
-  enabled?: boolean;
-  logs?: WorkerObservabilitySignal;
-  traces?: WorkerObservabilitySignal;
-  [k: string]: unknown;
-};
-
-/** signal → the Worker `observability` sub-key it maps to (metrics isn't a Worker signal). */
-const WORKER_OBSERVABILITY_SIGNALS = ["logs", "traces"] as const;
-
-/**
- * Merge our destination slugs into a Worker's existing observability config so it
- * exports the matching signals to our intake. Additive and idempotent: turns on
- * observability and each wired signal, and appends our slug to that signal's
- * `destinations` without dropping the Worker's existing destinations, sampling
- * rates, or any other fields. Returns the updated config, or `null` when the
- * Worker is already wired (nothing to change) so the caller can skip the PATCH.
- *
- * `slugs` maps our signal name (traces/logs) to the destination slug we created;
- * metrics is omitted because Workers Observability has no per-Worker metrics
- * signal.
- */
-export function wireObservabilityDestinations(
-  current: WorkerObservability | null | undefined,
-  slugs: { traces?: string; logs?: string },
-): WorkerObservability | null {
-  const next: WorkerObservability = current ? { ...current } : {};
-  let changed = false;
-  if (next.enabled !== true) {
-    next.enabled = true;
-    changed = true;
-  }
-  for (const signal of WORKER_OBSERVABILITY_SIGNALS) {
-    const slug = slugs[signal];
-    if (!slug) continue;
-    const sig: WorkerObservabilitySignal = { ...(next[signal] ?? {}) };
-    const destinations = Array.isArray(sig.destinations) ? [...sig.destinations] : [];
-    if (sig.enabled !== true) {
-      sig.enabled = true;
-      changed = true;
-    }
-    if (!destinations.includes(slug)) {
-      destinations.push(slug);
-      changed = true;
-    }
-    sig.destinations = destinations;
-    next[signal] = sig;
-  }
-  return changed ? next : null;
-}
-
-/**
- * Remove our destination slugs from a Worker's observability config (the inverse
- * of wireObservabilityDestinations). Only strips our slug from each signal's
- * `destinations` — it leaves the signal enabled and any other destinations the
- * Worker uses untouched, so unwiring from us never disables the Worker's own
- * observability. Returns the updated config, or `null` when none of our slugs
- * were present (nothing to change) so the caller can skip the PATCH.
- */
-export function unwireObservabilityDestinations(
-  current: WorkerObservability | null | undefined,
-  slugs: { traces?: string; logs?: string },
-): WorkerObservability | null {
-  if (!current) return null;
-  const next: WorkerObservability = { ...current };
-  let changed = false;
-  for (const signal of WORKER_OBSERVABILITY_SIGNALS) {
-    const slug = slugs[signal];
-    if (!slug) continue;
-    const existing = next[signal];
-    if (!existing || !Array.isArray(existing.destinations)) continue;
-    if (!existing.destinations.includes(slug)) continue;
-    next[signal] = { ...existing, destinations: existing.destinations.filter((d) => d !== slug) };
-    changed = true;
-  }
-  return changed ? next : null;
-}
-
-/**
- * Whether a Worker is fully wired to our destinations — i.e. wiring would be a
- * no-op. Defined in terms of wireObservabilityDestinations so "wired" and "wire"
- * can never drift: if wiring returns null there's nothing to add, so it's wired.
- */
-export function isWorkerWired(
-  current: WorkerObservability | null | undefined,
-  slugs: { traces?: string; logs?: string },
-): boolean {
-  return wireObservabilityDestinations(current, slugs) === null;
-}
-
-// ---------------------------------------------------------------------------
 // HTTP wrappers (injectable fetch)
+//
+// The Workers Observability wiring (wire/unwire/isWorkerWired) and script client
+// (listScripts/getScriptObservability/updateScriptObservability/reconcile) moved
+// to @superlog/cloudflare so the worker's reconcile job shares them; they're
+// re-exported above. Only the account + destination wrappers, which are connect-
+// only, stay here.
 // ---------------------------------------------------------------------------
 
 export type FetchImpl = typeof fetch;
@@ -487,100 +407,5 @@ export async function revokeToken(input: {
     });
   } catch {
     // best-effort
-  }
-}
-
-/** Parse `GET /workers/scripts` → list of script (Worker) ids. */
-export function parseScriptsResponse(json: unknown): string[] {
-  if (!json || typeof json !== "object") return [];
-  const result = (json as Record<string, unknown>).result;
-  if (!Array.isArray(result)) return [];
-  const ids: string[] = [];
-  for (const item of result) {
-    const id = item && typeof item === "object" ? (item as Record<string, unknown>).id : null;
-    if (typeof id === "string" && id) ids.push(id);
-  }
-  return ids;
-}
-
-/** List the Worker script ids in an account. Returns [] on any failure. */
-export async function listScripts(
-  accountId: string,
-  accessToken: string,
-  fetchImpl: FetchImpl = fetch,
-): Promise<string[]> {
-  const res = await fetchImpl(`${CLOUDFLARE_API_BASE}/accounts/${accountId}/workers/scripts`, {
-    headers: { authorization: `Bearer ${accessToken}` },
-  });
-  const json = await res.json().catch(() => null);
-  return parseScriptsResponse(json);
-}
-
-/**
- * Read one Worker's `observability` config. Returns `null` only on a *successful*
- * read where observability is unset (a genuinely fresh Worker). A failed read
- * (non-OK HTTP or `success !== true`) THROWS — the caller must not treat that as
- * "fresh" and PATCH a minimal config, which would clobber an existing
- * observability block we simply couldn't read.
- */
-export async function getScriptObservability(input: {
-  accountId: string;
-  script: string;
-  accessToken: string;
-  fetchImpl?: FetchImpl;
-}): Promise<WorkerObservability | null> {
-  const fetchImpl = input.fetchImpl ?? fetch;
-  const res = await fetchImpl(
-    `${CLOUDFLARE_API_BASE}/accounts/${input.accountId}/workers/scripts/${encodeURIComponent(
-      input.script,
-    )}/settings`,
-    { headers: { authorization: `Bearer ${input.accessToken}` } },
-  );
-  const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
-  if (!res.ok || !json || json.success !== true) {
-    throw new Error(`cloudflare: read worker settings failed (status ${res.status})`);
-  }
-  const result = json.result as Record<string, unknown> | undefined;
-  const obs = result?.observability;
-  return obs && typeof obs === "object" ? (obs as WorkerObservability) : null;
-}
-
-/**
- * PATCH a Worker's settings to set its `observability` config. The settings
- * endpoint only accepts `multipart/form-data` with a JSON `settings` part (not a
- * JSON body), so we build a FormData and let fetch set the multipart boundary.
- */
-export async function updateScriptObservability(input: {
-  accountId: string;
-  script: string;
-  observability: WorkerObservability;
-  accessToken: string;
-  fetchImpl?: FetchImpl;
-}): Promise<{ ok: boolean; error?: string }> {
-  const fetchImpl = input.fetchImpl ?? fetch;
-  const form = new FormData();
-  form.append(
-    "settings",
-    new Blob([JSON.stringify({ observability: input.observability })], {
-      type: "application/json",
-    }),
-    "settings.json",
-  );
-  try {
-    const res = await fetchImpl(
-      `${CLOUDFLARE_API_BASE}/accounts/${input.accountId}/workers/scripts/${encodeURIComponent(
-        input.script,
-      )}/settings`,
-      {
-        method: "PATCH",
-        headers: { authorization: `Bearer ${input.accessToken}` },
-        body: form,
-      },
-    );
-    const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
-    if (json?.success === true) return { ok: true };
-    return { ok: false, error: extractCreateError(json ?? {}) };
-  } catch (e) {
-    return { ok: false, error: e instanceof Error ? e.message : "request_failed" };
   }
 }

--- a/apps/api/src/cloudflare-service.ts
+++ b/apps/api/src/cloudflare-service.ts
@@ -362,6 +362,45 @@ export function wireObservabilityDestinations(
   return changed ? next : null;
 }
 
+/**
+ * Remove our destination slugs from a Worker's observability config (the inverse
+ * of wireObservabilityDestinations). Only strips our slug from each signal's
+ * `destinations` — it leaves the signal enabled and any other destinations the
+ * Worker uses untouched, so unwiring from us never disables the Worker's own
+ * observability. Returns the updated config, or `null` when none of our slugs
+ * were present (nothing to change) so the caller can skip the PATCH.
+ */
+export function unwireObservabilityDestinations(
+  current: WorkerObservability | null | undefined,
+  slugs: { traces?: string; logs?: string },
+): WorkerObservability | null {
+  if (!current) return null;
+  const next: WorkerObservability = { ...current };
+  let changed = false;
+  for (const signal of WORKER_OBSERVABILITY_SIGNALS) {
+    const slug = slugs[signal];
+    if (!slug) continue;
+    const existing = next[signal];
+    if (!existing || !Array.isArray(existing.destinations)) continue;
+    if (!existing.destinations.includes(slug)) continue;
+    next[signal] = { ...existing, destinations: existing.destinations.filter((d) => d !== slug) };
+    changed = true;
+  }
+  return changed ? next : null;
+}
+
+/**
+ * Whether a Worker is fully wired to our destinations — i.e. wiring would be a
+ * no-op. Defined in terms of wireObservabilityDestinations so "wired" and "wire"
+ * can never drift: if wiring returns null there's nothing to add, so it's wired.
+ */
+export function isWorkerWired(
+  current: WorkerObservability | null | undefined,
+  slugs: { traces?: string; logs?: string },
+): boolean {
+  return wireObservabilityDestinations(current, slugs) === null;
+}
+
 // ---------------------------------------------------------------------------
 // HTTP wrappers (injectable fetch)
 // ---------------------------------------------------------------------------

--- a/apps/api/src/cloudflare.ts
+++ b/apps/api/src/cloudflare.ts
@@ -38,7 +38,8 @@ import {
   getScriptObservability,
   isWorkerWired,
   listAccounts,
-  listScripts,
+  listScriptsStrict,
+  reconcileWorkerWiring,
   refreshAccessToken,
   revokeToken,
   signState,
@@ -65,6 +66,7 @@ function toPublic(row: CloudflareInstallationRow) {
     accountName: row.accountName,
     scope: row.scope,
     destinations: row.destinations ?? {},
+    autoWire: row.autoWire,
     installedAt: row.createdAt,
   };
 }
@@ -322,52 +324,24 @@ async function teardownInstallation(
 }
 
 /**
- * Wire the account's Workers to our destinations. Creating a destination only
- * makes telemetry flow once each Worker's own `observability` config enables the
- * signal and lists the destination, so we read every Worker's settings and merge
- * our slugs in (additive + idempotent). Best-effort and per-Worker isolated: a
- * Worker we can't update is logged and skipped, never failing the connect. Only
- * traces/logs are wired — Workers Observability has no per-Worker metrics signal.
+ * Wire the account's Workers to our destinations — the idempotent pass run at
+ * connect and by the "Wire all" button. Delegates to the shared
+ * reconcileWorkerWiring (same code the worker's periodic reconcile uses), mapping
+ * our stored destination slugs into the traces/logs shape it expects.
  */
 async function wireAccountWorkers(input: {
   accountId: string;
   accessToken: string;
   destinations: Record<string, string>;
   fetchImpl: typeof fetch;
-}): Promise<{ scripts: number; wired: number }> {
-  const slugs = { traces: input.destinations.traces, logs: input.destinations.logs };
-  if (!slugs.traces && !slugs.logs) return { scripts: 0, wired: 0 };
-  const scripts = await listScripts(input.accountId, input.accessToken, input.fetchImpl);
-  let wired = 0;
-  for (const script of scripts) {
-    try {
-      const current = await getScriptObservability({
-        accountId: input.accountId,
-        script,
-        accessToken: input.accessToken,
-        fetchImpl: input.fetchImpl,
-      });
-      const next = wireObservabilityDestinations(current, slugs);
-      if (!next) continue; // already wired
-      const res = await updateScriptObservability({
-        accountId: input.accountId,
-        script,
-        observability: next,
-        accessToken: input.accessToken,
-        fetchImpl: input.fetchImpl,
-      });
-      if (res.ok) wired += 1;
-      else
-        log.warn({ script, error: res.error }, "cloudflare: failed to wire worker observability");
-    } catch (e) {
-      log.warn({ err: e, script }, "cloudflare: failed to wire worker observability");
-    }
-  }
-  log.info(
-    { account_id: input.accountId, scripts: scripts.length, wired },
-    "cloudflare: wired worker observability to destinations",
-  );
-  return { scripts: scripts.length, wired };
+}): Promise<{ scripts: number; wired: number; listOk: boolean }> {
+  return reconcileWorkerWiring({
+    accountId: input.accountId,
+    accessToken: input.accessToken,
+    slugs: { traces: input.destinations.traces, logs: input.destinations.logs },
+    fetchImpl: input.fetchImpl,
+    log,
+  });
 }
 
 /** Our destination slugs for a row, in the shape the wire/unwire helpers take. */
@@ -751,7 +725,15 @@ export function mountCloudflareAuthed(
     if (!row) return c.json({ error: "not connected" }, 404);
     const slugs = slugsForRow(row);
     const accessToken = await accessTokenFor(row);
-    const scripts = await listScripts(row.accountId, accessToken, fetchImpl);
+    // Strict list: a failed scripts read surfaces as an error the card shows as
+    // "reconnect", not an empty account (the tolerant listScripts would hide it).
+    let scripts: string[];
+    try {
+      scripts = await listScriptsStrict(row.accountId, accessToken, fetchImpl);
+    } catch (e) {
+      log.warn({ err: e }, "cloudflare: list workers failed");
+      return c.json({ error: "could not list workers" }, 502);
+    }
     const workers = await Promise.all(
       scripts.map(async (script) => {
         try {
@@ -790,7 +772,48 @@ export function mountCloudflareAuthed(
       destinations: row.destinations ?? {},
       fetchImpl,
     });
-    return c.json({ ok: true, ...result });
+    // A failed scripts list here means we wired nothing because we couldn't see
+    // the account — surface it instead of reporting a misleading success.
+    if (!result.listOk) {
+      return c.json({ error: "could not list workers" }, 502);
+    }
+    const { listOk: _listOk, ...counts } = result;
+    return c.json({ ok: true, ...counts });
+  });
+
+  // Toggle auto-wire. When on, the worker's periodic reconcile keeps every
+  // Worker in the account wired (including ones created/recreated after connect);
+  // when off, wiring is manual via the list. Enabling also runs one wire pass
+  // immediately so the effect is visible without waiting for the next reconcile.
+  app.post("/api/projects/:projectId/cloudflare/auto-wire", async (c) => {
+    const ctx = await requireProjectAccess(c, c.req.param("projectId"));
+    const row = await findInstallation(ctx.projectId);
+    if (!row) return c.json({ error: "not connected" }, 404);
+    const body = await c.req.json().catch(() => ({}));
+    const autoWire = (body as { autoWire?: unknown }).autoWire;
+    if (typeof autoWire !== "boolean") {
+      return c.json({ error: "autoWire must be a boolean" }, 400);
+    }
+    await db
+      .update(schema.cloudflareInstallations)
+      .set({ autoWire, updatedAt: new Date() })
+      .where(eq(schema.cloudflareInstallations.id, row.id));
+    if (autoWire) {
+      // Best-effort immediate wire so turning it on takes effect now; the
+      // scheduled reconcile is what keeps it wired going forward.
+      try {
+        const accessToken = await accessTokenFor(row);
+        await wireAccountWorkers({
+          accountId: row.accountId,
+          accessToken,
+          destinations: row.destinations ?? {},
+          fetchImpl,
+        });
+      } catch (e) {
+        log.warn({ err: e }, "cloudflare: immediate wire on auto-wire enable failed");
+      }
+    }
+    return c.json({ ok: true, autoWire });
   });
 
   // Wire / unwire one worker. Both read the worker's current observability,

--- a/apps/api/src/cloudflare.ts
+++ b/apps/api/src/cloudflare.ts
@@ -36,12 +36,14 @@ import {
   deleteDestination,
   exchangeCodeForToken,
   getScriptObservability,
+  isWorkerWired,
   listAccounts,
   listScripts,
   refreshAccessToken,
   revokeToken,
   signState,
   staleDestinationSlugs,
+  unwireObservabilityDestinations,
   updateScriptObservability,
   verifyState,
   wireObservabilityDestinations,
@@ -332,9 +334,9 @@ async function wireAccountWorkers(input: {
   accessToken: string;
   destinations: Record<string, string>;
   fetchImpl: typeof fetch;
-}): Promise<void> {
+}): Promise<{ scripts: number; wired: number }> {
   const slugs = { traces: input.destinations.traces, logs: input.destinations.logs };
-  if (!slugs.traces && !slugs.logs) return;
+  if (!slugs.traces && !slugs.logs) return { scripts: 0, wired: 0 };
   const scripts = await listScripts(input.accountId, input.accessToken, input.fetchImpl);
   let wired = 0;
   for (const script of scripts) {
@@ -365,6 +367,12 @@ async function wireAccountWorkers(input: {
     { account_id: input.accountId, scripts: scripts.length, wired },
     "cloudflare: wired worker observability to destinations",
   );
+  return { scripts: scripts.length, wired };
+}
+
+/** Our destination slugs for a row, in the shape the wire/unwire helpers take. */
+function slugsForRow(row: CloudflareInstallationRow): { traces?: string; logs?: string } {
+  return { traces: row.destinations?.traces, logs: row.destinations?.logs };
 }
 
 export function mountCloudflarePublic(
@@ -722,5 +730,136 @@ export function mountCloudflareAuthed(
     // soft-revoke the row so nothing keeps streaming after "Disconnect".
     await teardownInstallation(row, { config, fetchImpl });
     return c.json({ ok: true });
+  });
+
+  // Obtain a live access token for a management call, or throw an HTTPException
+  // the routes surface as "reconnect needed" — the shared refresh-on-use path.
+  async function accessTokenFor(row: CloudflareInstallationRow): Promise<string> {
+    try {
+      return await freshAccessToken(row, config, fetchImpl);
+    } catch (e) {
+      log.warn({ err: e, account_id: row.accountId }, "cloudflare: could not obtain access token");
+      throw new HTTPException(502, { message: "cloudflare token unavailable; reconnect" });
+    }
+  }
+
+  // List the account's Worker scripts with whether each currently exports to our
+  // destinations. This is the surface that makes a dark/unwired worker visible.
+  app.get("/api/projects/:projectId/cloudflare/workers", async (c) => {
+    const ctx = await requireProjectAccess(c, c.req.param("projectId"));
+    const row = await findInstallation(ctx.projectId);
+    if (!row) return c.json({ error: "not connected" }, 404);
+    const slugs = slugsForRow(row);
+    const accessToken = await accessTokenFor(row);
+    const scripts = await listScripts(row.accountId, accessToken, fetchImpl);
+    const workers = await Promise.all(
+      scripts.map(async (script) => {
+        try {
+          const obs = await getScriptObservability({
+            accountId: row.accountId,
+            script,
+            accessToken,
+            fetchImpl,
+          });
+          return {
+            name: script,
+            wired: isWorkerWired(obs, slugs),
+            observabilityEnabled: obs?.enabled === true,
+          };
+        } catch (e) {
+          // A single unreadable worker shouldn't blank the list — show it as
+          // unwired so the user can still try to wire it.
+          log.warn({ err: e, script }, "cloudflare: worker observability read failed");
+          return { name: script, wired: false, observabilityEnabled: false };
+        }
+      }),
+    );
+    workers.sort((a, b) => a.name.localeCompare(b.name));
+    return c.json({ workers });
+  });
+
+  // Wire every current worker in the account to our destinations (one-shot).
+  app.post("/api/projects/:projectId/cloudflare/workers/wire-all", async (c) => {
+    const ctx = await requireProjectAccess(c, c.req.param("projectId"));
+    const row = await findInstallation(ctx.projectId);
+    if (!row) return c.json({ error: "not connected" }, 404);
+    const accessToken = await accessTokenFor(row);
+    const result = await wireAccountWorkers({
+      accountId: row.accountId,
+      accessToken,
+      destinations: row.destinations ?? {},
+      fetchImpl,
+    });
+    return c.json({ ok: true, ...result });
+  });
+
+  // Wire / unwire one worker. Both read the worker's current observability,
+  // apply the additive (wire) or subtractive (unwire) transform, and PATCH only
+  // when it actually changes.
+  app.post("/api/projects/:projectId/cloudflare/workers/:script/wire", async (c) => {
+    const ctx = await requireProjectAccess(c, c.req.param("projectId"));
+    const script = c.req.param("script");
+    const row = await findInstallation(ctx.projectId);
+    if (!row) return c.json({ error: "not connected" }, 404);
+    const slugs = slugsForRow(row);
+    if (!slugs.traces && !slugs.logs) {
+      return c.json({ error: "no destinations provisioned" }, 400);
+    }
+    const accessToken = await accessTokenFor(row);
+    try {
+      const obs = await getScriptObservability({
+        accountId: row.accountId,
+        script,
+        accessToken,
+        fetchImpl,
+      });
+      const next = wireObservabilityDestinations(obs, slugs);
+      if (next) {
+        const res = await updateScriptObservability({
+          accountId: row.accountId,
+          script,
+          observability: next,
+          accessToken,
+          fetchImpl,
+        });
+        if (!res.ok) return c.json({ error: res.error ?? "wire failed" }, 502);
+      }
+      return c.json({ ok: true, wired: true });
+    } catch (e) {
+      log.warn({ err: e, script }, "cloudflare: wire worker failed");
+      return c.json({ error: "wire failed" }, 502);
+    }
+  });
+
+  app.post("/api/projects/:projectId/cloudflare/workers/:script/unwire", async (c) => {
+    const ctx = await requireProjectAccess(c, c.req.param("projectId"));
+    const script = c.req.param("script");
+    const row = await findInstallation(ctx.projectId);
+    if (!row) return c.json({ error: "not connected" }, 404);
+    const slugs = slugsForRow(row);
+    const accessToken = await accessTokenFor(row);
+    try {
+      const obs = await getScriptObservability({
+        accountId: row.accountId,
+        script,
+        accessToken,
+        fetchImpl,
+      });
+      const next = unwireObservabilityDestinations(obs, slugs);
+      if (next) {
+        const res = await updateScriptObservability({
+          accountId: row.accountId,
+          script,
+          observability: next,
+          accessToken,
+          fetchImpl,
+        });
+        if (!res.ok) return c.json({ error: res.error ?? "unwire failed" }, 502);
+      }
+      return c.json({ ok: true, wired: false });
+    } catch (e) {
+      log.warn({ err: e, script }, "cloudflare: unwire worker failed");
+      return c.json({ error: "unwire failed" }, 502);
+    }
   });
 }

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -23,6 +23,7 @@ import {
   useCloudConnections,
   useCloudStackHealth,
   useCloudflareInstallation,
+  useCloudflareWorkers,
   useConnectRender,
   useCreateCloudConnection,
   useCreateKey,
@@ -44,10 +45,10 @@ import {
   useKeys,
   useLinearInstallation,
   useMcpTokens,
-  useNotionInstallation,
   useMe,
   useMintOrgApiKey,
   useMintOrgGithubInstallUrl,
+  useNotionInstallation,
   useOrgAgentSettings,
   useOrgApiKeys,
   useOrgDigest,
@@ -96,6 +97,7 @@ import {
   useUninstallRender,
   useUninstallSlack,
   useUninstallVercel,
+  useUnwireCloudflareWorker,
   useUpdateGithubRepoAccess,
   useUpdateOrgProject,
   useUpdateWebhook,
@@ -103,6 +105,8 @@ import {
   useVerifyCloudConnection,
   useWebhookDeliveries,
   useWebhooks,
+  useWireAllCloudflareWorkers,
+  useWireCloudflareWorker,
 } from "./api";
 import { AWS_REGIONS } from "./awsRegions.ts";
 import { Dropdown, type DropdownOption } from "./design/Dropdown.tsx";
@@ -1288,8 +1292,81 @@ function CloudflareCard({ projectId }: { projectId: string | undefined }) {
             </Btn>
           )}
         </div>
+        {installed && <CloudflareWorkers projectId={projectId} />}
       </div>
     </Tile>
+  );
+}
+
+// The account's Workers, each with its current wiring state. A worker only
+// streams to us when its observability config lists our destination — so a
+// worker that was recreated/renamed shows up here as "Not wired" and can be
+// re-wired with one click (or all at once).
+function CloudflareWorkers({ projectId }: { projectId: string | undefined }) {
+  const workers = useCloudflareWorkers(projectId, true);
+  const wire = useWireCloudflareWorker(projectId);
+  const unwire = useUnwireCloudflareWorker(projectId);
+  const wireAll = useWireAllCloudflareWorkers(projectId);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  if (workers.isLoading) {
+    return <p className="text-[13px] text-muted">Loading workers…</p>;
+  }
+  if (workers.isError) {
+    return (
+      <p className="text-[13px] text-danger">
+        Couldn't load workers — the Cloudflare connection may need reconnecting.
+      </p>
+    );
+  }
+  const list = workers.data?.workers ?? [];
+  if (list.length === 0) {
+    return <p className="text-[13px] text-muted">No Workers found in this account.</p>;
+  }
+  const anyUnwired = list.some((w) => !w.wired);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-[13px] font-medium">Workers</span>
+        <Btn
+          size="sm"
+          variant="secondary"
+          loading={wireAll.isPending}
+          disabled={!anyUnwired || wireAll.isPending}
+          onClick={() => wireAll.mutate()}
+        >
+          Wire all
+        </Btn>
+      </div>
+      <ul className="divide-y divide-border overflow-hidden rounded-md border border-border">
+        {list.map((w) => {
+          const pending = busy === w.name && (wire.isPending || unwire.isPending);
+          return (
+            <li key={w.name} className="flex items-center justify-between gap-3 px-3 py-2">
+              <span className="min-w-0 truncate text-[13px]">{w.name}</span>
+              <div className="flex flex-shrink-0 items-center gap-2">
+                <Chip tone={w.wired ? "success" : "muted"} dot>
+                  {w.wired ? "Streaming" : "Not wired"}
+                </Chip>
+                <Btn
+                  size="sm"
+                  variant={w.wired ? "secondary" : "primary"}
+                  loading={pending}
+                  disabled={pending}
+                  onClick={() => {
+                    setBusy(w.name);
+                    (w.wired ? unwire : wire).mutate(w.name, { onSettled: () => setBusy(null) });
+                  }}
+                >
+                  {w.wired ? "Unwire" : "Wire"}
+                </Btn>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
   );
 }
 

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -73,6 +73,7 @@ import {
   useSaveIntegration,
   useSaveOrgAgentSettings,
   useSaveOrgDigest,
+  useSetCloudflareAutoWire,
   useSetIngestFilters,
   useSetSlackRoute,
   useSetupCloudStream,
@@ -1292,7 +1293,13 @@ function CloudflareCard({ projectId }: { projectId: string | undefined }) {
             </Btn>
           )}
         </div>
-        {installed && <CloudflareWorkers projectId={projectId} />}
+        {installed && install.data?.installed && (
+          <CloudflareWorkers
+            projectId={projectId}
+            accountId={install.data.accountId}
+            autoWire={install.data.autoWire}
+          />
+        )}
       </div>
     </Tile>
   );
@@ -1302,70 +1309,107 @@ function CloudflareCard({ projectId }: { projectId: string | undefined }) {
 // streams to us when its observability config lists our destination — so a
 // worker that was recreated/renamed shows up here as "Not wired" and can be
 // re-wired with one click (or all at once).
-function CloudflareWorkers({ projectId }: { projectId: string | undefined }) {
-  const workers = useCloudflareWorkers(projectId, true);
+function CloudflareWorkers({
+  projectId,
+  accountId,
+  autoWire,
+}: {
+  projectId: string | undefined;
+  accountId: string;
+  autoWire: boolean;
+}) {
+  const workers = useCloudflareWorkers(projectId, accountId, true);
   const wire = useWireCloudflareWorker(projectId);
   const unwire = useUnwireCloudflareWorker(projectId);
   const wireAll = useWireAllCloudflareWorkers(projectId);
+  const setAutoWire = useSetCloudflareAutoWire(projectId);
   const [busy, setBusy] = useState<string | null>(null);
 
-  if (workers.isLoading) {
-    return <p className="text-[13px] text-muted">Loading workers…</p>;
-  }
-  if (workers.isError) {
-    return (
-      <p className="text-[13px] text-danger">
-        Couldn't load workers — the Cloudflare connection may need reconnecting.
-      </p>
-    );
-  }
   const list = workers.data?.workers ?? [];
-  if (list.length === 0) {
-    return <p className="text-[13px] text-muted">No Workers found in this account.</p>;
-  }
   const anyUnwired = list.some((w) => !w.wired);
+  // Any in-flight wiring change. Disable every wiring control while one is
+  // pending so overlapping PATCHes (a row click during "Wire all", or vice
+  // versa) can't race to a nondeterministic final state.
+  const anyWiringPending =
+    wire.isPending || unwire.isPending || wireAll.isPending || setAutoWire.isPending;
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <span className="text-[13px] font-medium">Workers</span>
-        <Btn
-          size="sm"
-          variant="secondary"
-          loading={wireAll.isPending}
-          disabled={!anyUnwired || wireAll.isPending}
-          onClick={() => wireAll.mutate()}
-        >
-          Wire all
-        </Btn>
+    <div className="space-y-3">
+      {/* Auto-wire: when on, a periodic reconcile keeps every Worker wired —
+          including ones created/recreated after connect — so the list is
+          status-only. When off, wiring is manual via the per-row buttons. */}
+      <div className="flex items-start justify-between gap-3 rounded-md border border-border bg-surface-2 px-3 py-2.5">
+        <div className="min-w-0">
+          <div className="text-[13px] font-medium">Auto-wire all Workers</div>
+          <p className="mt-0.5 text-[12px] leading-relaxed text-muted">
+            Keep every Worker connected automatically, including new or recreated ones. Turn off to
+            wire Workers manually.
+          </p>
+        </div>
+        <Toggle
+          checked={autoWire}
+          disabled={anyWiringPending}
+          onChange={(v) => setAutoWire.mutate(v)}
+        />
       </div>
-      <ul className="divide-y divide-border overflow-hidden rounded-md border border-border">
-        {list.map((w) => {
-          const pending = busy === w.name && (wire.isPending || unwire.isPending);
-          return (
-            <li key={w.name} className="flex items-center justify-between gap-3 px-3 py-2">
-              <span className="min-w-0 truncate text-[13px]">{w.name}</span>
-              <div className="flex flex-shrink-0 items-center gap-2">
-                <Chip tone={w.wired ? "success" : "muted"} dot>
-                  {w.wired ? "Streaming" : "Not wired"}
-                </Chip>
-                <Btn
-                  size="sm"
-                  variant={w.wired ? "secondary" : "primary"}
-                  loading={pending}
-                  disabled={pending}
-                  onClick={() => {
-                    setBusy(w.name);
-                    (w.wired ? unwire : wire).mutate(w.name, { onSettled: () => setBusy(null) });
-                  }}
-                >
-                  {w.wired ? "Unwire" : "Wire"}
-                </Btn>
-              </div>
-            </li>
-          );
-        })}
-      </ul>
+
+      {workers.isLoading ? (
+        <p className="text-[13px] text-muted">Loading workers…</p>
+      ) : workers.isError ? (
+        <p className="text-[13px] text-danger">
+          Couldn't load workers — the Cloudflare connection may need reconnecting.
+        </p>
+      ) : list.length === 0 ? (
+        <p className="text-[13px] text-muted">No Workers found in this account.</p>
+      ) : (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-[13px] font-medium">Workers</span>
+            {!autoWire && (
+              <Btn
+                size="sm"
+                variant="secondary"
+                loading={wireAll.isPending}
+                disabled={!anyUnwired || anyWiringPending}
+                onClick={() => wireAll.mutate()}
+              >
+                Wire all
+              </Btn>
+            )}
+          </div>
+          <ul className="divide-y divide-border overflow-hidden rounded-md border border-border">
+            {list.map((w) => {
+              const pending = busy === w.name && (wire.isPending || unwire.isPending);
+              return (
+                <li key={w.name} className="flex items-center justify-between gap-3 px-3 py-2">
+                  <span className="min-w-0 truncate text-[13px]">{w.name}</span>
+                  <div className="flex flex-shrink-0 items-center gap-2">
+                    <Chip tone={w.wired ? "success" : "muted"} dot>
+                      {w.wired ? "Streaming" : "Not wired"}
+                    </Chip>
+                    {!autoWire && (
+                      <Btn
+                        size="sm"
+                        variant={w.wired ? "secondary" : "primary"}
+                        loading={pending}
+                        disabled={anyWiringPending}
+                        onClick={() => {
+                          setBusy(w.name);
+                          (w.wired ? unwire : wire).mutate(w.name, {
+                            onSettled: () => setBusy(null),
+                          });
+                        }}
+                      >
+                        {w.wired ? "Unwire" : "Wire"}
+                      </Btn>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -837,6 +837,7 @@ export type CloudflareInstallation =
       accountName: string | null;
       scope: string | null;
       destinations: Record<string, string>;
+      autoWire: boolean;
       installedAt: string;
     };
 
@@ -882,13 +883,21 @@ export type CloudflareWorker = { name: string; wired: boolean; observabilityEnab
 
 // The account's Worker scripts and whether each currently exports to us. Only
 // fetched when connected (pass `enabled`), since it hits the Cloudflare API.
-export function useCloudflareWorkers(projectId: string | undefined, enabled: boolean) {
+// Keyed by accountId as well as projectId so a same-project reconnect to a
+// different Cloudflare account can't momentarily show the previous account's
+// workers from cache. Mutations invalidate by the ["cloudflare-workers",
+// projectId] prefix, which still matches this longer key.
+export function useCloudflareWorkers(
+  projectId: string | undefined,
+  accountId: string | undefined,
+  enabled: boolean,
+) {
   const fetcher = useFetcher();
   return useQuery({
-    queryKey: ["cloudflare-workers", projectId],
+    queryKey: ["cloudflare-workers", projectId, accountId],
     queryFn: () =>
       fetcher<{ workers: CloudflareWorker[] }>(`/api/projects/${projectId}/cloudflare/workers`),
-    enabled: !!projectId && enabled,
+    enabled: !!projectId && !!accountId && enabled,
   });
 }
 
@@ -925,6 +934,24 @@ export function useWireAllCloudflareWorkers(projectId: string | undefined) {
         { method: "POST" },
       ),
     onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["cloudflare-workers", projectId] });
+    },
+  });
+}
+
+// Toggle auto-wire. Enabling also runs an immediate wire pass server-side, so
+// refresh both the installation (autoWire flag) and the workers list on success.
+export function useSetCloudflareAutoWire(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (autoWire: boolean) =>
+      fetcher<{ ok: true; autoWire: boolean }>(`/api/projects/${projectId}/cloudflare/auto-wire`, {
+        method: "POST",
+        body: JSON.stringify({ autoWire }),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["cloudflare-installation", projectId] });
       qc.invalidateQueries({ queryKey: ["cloudflare-workers", projectId] });
     },
   });

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -878,6 +878,58 @@ export function useUninstallCloudflare(projectId: string | undefined) {
   });
 }
 
+export type CloudflareWorker = { name: string; wired: boolean; observabilityEnabled: boolean };
+
+// The account's Worker scripts and whether each currently exports to us. Only
+// fetched when connected (pass `enabled`), since it hits the Cloudflare API.
+export function useCloudflareWorkers(projectId: string | undefined, enabled: boolean) {
+  const fetcher = useFetcher();
+  return useQuery({
+    queryKey: ["cloudflare-workers", projectId],
+    queryFn: () =>
+      fetcher<{ workers: CloudflareWorker[] }>(`/api/projects/${projectId}/cloudflare/workers`),
+    enabled: !!projectId && enabled,
+  });
+}
+
+function useCloudflareWorkerAction(projectId: string | undefined, action: "wire" | "unwire") {
+  const fetcher = useFetcher();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (script: string) =>
+      fetcher<{ ok: true; wired: boolean }>(
+        `/api/projects/${projectId}/cloudflare/workers/${encodeURIComponent(script)}/${action}`,
+        { method: "POST" },
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["cloudflare-workers", projectId] });
+    },
+  });
+}
+
+export function useWireCloudflareWorker(projectId: string | undefined) {
+  return useCloudflareWorkerAction(projectId, "wire");
+}
+
+export function useUnwireCloudflareWorker(projectId: string | undefined) {
+  return useCloudflareWorkerAction(projectId, "unwire");
+}
+
+export function useWireAllCloudflareWorkers(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      fetcher<{ ok: true; scripts: number; wired: number }>(
+        `/api/projects/${projectId}/cloudflare/workers/wire-all`,
+        { method: "POST" },
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["cloudflare-workers", projectId] });
+    },
+  });
+}
+
 export type VercelInstallation =
   | { installed: false }
   | {

--- a/apps/worker/src/cloudflare/lock.ts
+++ b/apps/worker/src/cloudflare/lock.ts
@@ -1,0 +1,19 @@
+import { sql } from "drizzle-orm";
+
+// The per-installation advisory lock the Cloudflare jobs and the api's on-demand
+// refresh all take before redeeming a refresh token. Cloudflare rotates the
+// refresh token on every use and, under reuse detection, revokes the whole grant
+// if the same token is redeemed twice — so every actor that might refresh a given
+// installation must serialize on the SAME key. This is that single source of
+// truth; it MUST stay identical to apps/api/src/cloudflare.ts freshAccessToken.
+//
+// `pg_advisory_xact_lock` auto-releases at transaction end, so callers must run
+// inside a transaction and hold it only across the token redemption.
+export function lockInstallation(
+  tx: { execute: (query: ReturnType<typeof sql>) => Promise<unknown> },
+  installationId: string,
+): Promise<unknown> {
+  return tx.execute(
+    sql`select pg_advisory_xact_lock(hashtext('cloudflare_installations'), hashtext(${installationId}))`,
+  );
+}

--- a/apps/worker/src/cloudflare/reconciler.test.ts
+++ b/apps/worker/src/cloudflare/reconciler.test.ts
@@ -1,0 +1,116 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import {
+  type CloudflareReconcileInstallation,
+  type CloudflareReconcilerStore,
+  type WorkerWiringFn,
+  runCloudflareReconcileOnce,
+} from "./reconciler.js";
+
+const noopLog = {
+  info() {},
+  warn() {},
+  error() {},
+};
+
+function installation(id: string): CloudflareReconcileInstallation {
+  return { id, accountId: `acc-${id}`, slugs: { traces: "t", logs: "l" } };
+}
+
+// A store whose freshAccessToken is driven by a per-id map: a string token, null
+// (no usable grant → skip), or an Error to throw (DB failure → abort).
+function makeStore(
+  installs: CloudflareReconcileInstallation[],
+  tokens: Record<string, string | null | Error>,
+): CloudflareReconcilerStore {
+  return {
+    async listAutoWireInstallations() {
+      return installs;
+    },
+    async freshAccessToken(id) {
+      const t = tokens[id];
+      if (t instanceof Error) throw t;
+      return t ?? null;
+    },
+  };
+}
+
+test("reconcile wires every auto-wire install and tallies workers", async () => {
+  const installs = [installation("a"), installation("b")];
+  const wiredCalls: string[] = [];
+  const reconcile: WorkerWiringFn = async ({ accountId }) => {
+    wiredCalls.push(accountId);
+    return { scripts: 3, wired: accountId === "acc-a" ? 2 : 1, listOk: true };
+  };
+
+  const stats = await runCloudflareReconcileOnce({
+    store: makeStore(installs, { a: "tok-a", b: "tok-b" }),
+    reconcile,
+    log: noopLog,
+  });
+
+  assert.deepEqual(wiredCalls.sort(), ["acc-a", "acc-b"]);
+  assert.equal(stats.installations, 2);
+  assert.equal(stats.reconciled, 2);
+  assert.equal(stats.workersWired, 3);
+  assert.equal(stats.skipped, 0);
+  assert.equal(stats.errors, 0);
+});
+
+test("reconcile skips installs with no usable grant, without touching Cloudflare", async () => {
+  const installs = [installation("live"), installation("dead")];
+  let reconciled = 0;
+  const reconcile: WorkerWiringFn = async () => {
+    reconciled += 1;
+    return { scripts: 1, wired: 1, listOk: true };
+  };
+
+  const stats = await runCloudflareReconcileOnce({
+    store: makeStore(installs, { live: "tok", dead: null }),
+    reconcile,
+    log: noopLog,
+  });
+
+  assert.equal(reconciled, 1); // only the live install reached the wiring pass
+  assert.equal(stats.reconciled, 1);
+  assert.equal(stats.skipped, 1);
+  assert.equal(stats.errors, 0);
+});
+
+test("a wiring failure for one install is isolated, not fatal", async () => {
+  const installs = [installation("bad"), installation("good")];
+  const reconcile: WorkerWiringFn = async ({ accountId }) => {
+    if (accountId === "acc-bad") throw new Error("cf blew up");
+    return { scripts: 2, wired: 2, listOk: true };
+  };
+
+  const stats = await runCloudflareReconcileOnce({
+    store: makeStore(installs, { bad: "tok", good: "tok" }),
+    reconcile,
+    log: noopLog,
+  });
+
+  assert.equal(stats.installations, 2);
+  assert.equal(stats.reconciled, 1); // good still ran
+  assert.equal(stats.workersWired, 2);
+  assert.equal(stats.errors, 1);
+});
+
+test("a token/DB failure aborts the whole pass (rethrows)", async () => {
+  const installs = [installation("db-error"), installation("never-reached")];
+  let reconciled = 0;
+  const reconcile: WorkerWiringFn = async () => {
+    reconciled += 1;
+    return { scripts: 1, wired: 1, listOk: true };
+  };
+
+  await assert.rejects(
+    runCloudflareReconcileOnce({
+      store: makeStore(installs, { "db-error": new Error("pg down"), "never-reached": "tok" }),
+      reconcile,
+      log: noopLog,
+    }),
+    /pg down/,
+  );
+  assert.equal(reconciled, 0); // aborted before wiring anything
+});

--- a/apps/worker/src/cloudflare/reconciler.ts
+++ b/apps/worker/src/cloudflare/reconciler.ts
@@ -1,0 +1,147 @@
+// Cloudflare wiring reconcile — the "keep every Worker connected" half of the
+// connector, the counterpart to the token keep-alive (refresher.ts).
+//
+// A Worker only streams to us when its own `observability` config lists our
+// destination, and that per-Worker link is set once at connect. So a Worker
+// created, recreated, or renamed after connect comes up UNWIRED and goes dark —
+// nothing notices; the account still shows "connected". This job closes that
+// gap: for every installation with auto-wire on, it re-runs the idempotent wire
+// pass (ensure our slugs are merged into each Worker's observability), picking up
+// any drifted / new / recreated Worker automatically.
+//
+// The reconcile cadence is the max data-loss window for a newly-unwired Worker —
+// Cloudflare doesn't backfill telemetry for the dark period — so it runs hourly
+// (see jobs/cloudflare-reconcile.ts), much tighter than the daily token refresh.
+//
+// IO is behind a narrow store port + injectable fetch/reconcile so the logic is
+// unit-testable without Postgres or a live Cloudflare account.
+
+import type { WorkerDestinationSlugs } from "@superlog/cloudflare";
+
+/** One installation to reconcile: the account + the destination slugs to wire. */
+export type CloudflareReconcileInstallation = {
+  id: string;
+  accountId: string;
+  slugs: WorkerDestinationSlugs;
+};
+
+export type CloudflareReconcilerStore = {
+  /** Active installs with auto-wire on (revoked and manual-wiring installs excluded). */
+  listAutoWireInstallations(): Promise<CloudflareReconcileInstallation[]>;
+  /**
+   * A usable access token for the install, refreshing under the per-install
+   * advisory lock when the stored one is near expiry (the SAME lock the api and
+   * the keep-alive take, so a rotating refresh token is never redeemed twice).
+   * Returns null when there's no usable grant (legacy install with no refresh
+   * token and an expired access token, or a dead grant) — that install needs a
+   * manual reconnect and is skipped. Throws ONLY on a DB/persist/lock failure,
+   * which aborts the pass (a refresh that rotated the token but couldn't be saved
+   * must not be silently continued past, and the DB issue would hit every
+   * remaining install too).
+   */
+  freshAccessToken(installationId: string): Promise<string | null>;
+};
+
+/** The wiring pass — injected so tests don't hit Cloudflare (prod: reconcileWorkerWiring). */
+export type WorkerWiringFn = (input: {
+  accountId: string;
+  accessToken: string;
+  slugs: WorkerDestinationSlugs;
+  fetchImpl?: typeof fetch;
+  log?: {
+    info(f: Record<string, unknown>, m: string): void;
+    warn(f: Record<string, unknown>, m: string): void;
+  };
+}) => Promise<{ scripts: number; wired: number; listOk: boolean }>;
+
+type ReconcilerLogger = {
+  info(fields: Record<string, unknown>, msg: string): void;
+  warn(fields: Record<string, unknown>, msg: string): void;
+  error(fields: Record<string, unknown>, msg: string): void;
+};
+
+export type CloudflareReconcilerDeps = {
+  store: CloudflareReconcilerStore;
+  reconcile: WorkerWiringFn;
+  log: ReconcilerLogger;
+  fetchImpl?: typeof fetch;
+};
+
+export type CloudflareReconcileStats = {
+  installations: number;
+  reconciled: number;
+  workersWired: number;
+  skipped: number;
+  errors: number;
+};
+
+export async function runCloudflareReconcileOnce(
+  deps: CloudflareReconcilerDeps,
+): Promise<CloudflareReconcileStats> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const stats: CloudflareReconcileStats = {
+    installations: 0,
+    reconciled: 0,
+    workersWired: 0,
+    skipped: 0,
+    errors: 0,
+  };
+
+  const installations = await deps.store.listAutoWireInstallations();
+  for (const inst of installations) {
+    stats.installations += 1;
+
+    let accessToken: string | null;
+    try {
+      accessToken = await deps.store.freshAccessToken(inst.id);
+    } catch (err) {
+      // DB/persist/lock failure (see freshAccessToken doc): abort the pass rather
+      // than risk rotating-and-losing tokens across the remaining installs.
+      // pg-boss retries the job.
+      stats.errors += 1;
+      deps.log.error(
+        {
+          installation_id: inst.id,
+          account_id: inst.accountId,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "cloudflare reconcile: token access failed; aborting pass",
+      );
+      throw err;
+    }
+
+    // No usable grant → the install needs a manual reconnect; skip it (counted so
+    // we can see how many are stuck).
+    if (!accessToken) {
+      stats.skipped += 1;
+      continue;
+    }
+
+    try {
+      const { wired } = await deps.reconcile({
+        accountId: inst.accountId,
+        accessToken,
+        slugs: inst.slugs,
+        fetchImpl,
+        log: deps.log,
+      });
+      stats.reconciled += 1;
+      stats.workersWired += wired;
+    } catch (err) {
+      // reconcileWorkerWiring is per-Worker isolated and shouldn't throw, but a
+      // stray failure for one install must not sink the whole pass — the CF-side
+      // wiring rotated nothing, so isolating it is safe.
+      stats.errors += 1;
+      deps.log.error(
+        {
+          installation_id: inst.id,
+          account_id: inst.accountId,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "cloudflare reconcile: wiring pass failed for install; skipping",
+      );
+    }
+  }
+
+  return stats;
+}

--- a/apps/worker/src/jobs/cloudflare-reconcile.ts
+++ b/apps/worker/src/jobs/cloudflare-reconcile.ts
@@ -1,0 +1,204 @@
+// Scheduled job: keep every auto-wire Cloudflare installation's Workers wired to
+// our telemetry destinations (see ../cloudflare/reconciler.ts for the logic +
+// rationale; this file is only the wiring — drizzle-backed store, decrypted
+// secrets, on-demand token refresh under the shared advisory lock).
+//
+// Hourly: the cadence is the max data-loss window for a Worker that was created,
+// recreated, or renamed after connect (it comes up unwired and Cloudflare doesn't
+// backfill the dark period), so this runs much tighter than the daily token
+// keep-alive. Opts out (returns null → not scheduled) unless the Cloudflare OAuth
+// client is configured — without it there's nothing to refresh a token with.
+
+import {
+  type CloudflareClientCredentials,
+  cloudflareClientFromEnv,
+  reconcileWorkerWiring,
+  refreshAccessToken,
+} from "@superlog/cloudflare";
+import { decryptIntegrationSecret, encryptIntegrationSecret, schema } from "@superlog/db";
+import { and, eq, isNull } from "drizzle-orm";
+import { lockInstallation } from "../cloudflare/lock.js";
+import {
+  type CloudflareReconcileInstallation,
+  type CloudflareReconcilerStore,
+  runCloudflareReconcileOnce,
+} from "../cloudflare/reconciler.js";
+import type { JobDefinition, JobDeps } from "../jobs.js";
+import { logger } from "../logger.js";
+
+const log = logger.child({ scope: "cloudflare-reconcile" });
+
+// Refresh the access token when it's within this margin of expiry. Wider than
+// the keep-alive's 60s because a reconcile then makes a burst of Cloudflare calls
+// with the token, so it must stay valid for the whole pass.
+const ACCESS_TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
+function createStore(
+  db: JobDeps["db"],
+  config: CloudflareClientCredentials,
+  fetchImpl: typeof fetch,
+): CloudflareReconcilerStore {
+  return {
+    async listAutoWireInstallations(): Promise<CloudflareReconcileInstallation[]> {
+      const rows = await db.query.cloudflareInstallations.findMany({
+        where: and(
+          isNull(schema.cloudflareInstallations.revokedAt),
+          eq(schema.cloudflareInstallations.autoWire, true),
+        ),
+        columns: { id: true, accountId: true, destinations: true },
+      });
+      return rows.map((row) => ({
+        id: row.id,
+        accountId: row.accountId,
+        slugs: { traces: row.destinations?.traces, logs: row.destinations?.logs },
+      }));
+    },
+
+    async freshAccessToken(installationId): Promise<string | null> {
+      return db.transaction(async (tx) => {
+        // Same lock the api's freshAccessToken and the keep-alive take, so a
+        // rotating refresh token is never redeemed twice concurrently. Held only
+        // across the redemption; the wiring calls run after the lock releases.
+        await lockInstallation(tx, installationId);
+        const cur = await tx.query.cloudflareInstallations.findFirst({
+          where: and(
+            eq(schema.cloudflareInstallations.id, installationId),
+            isNull(schema.cloudflareInstallations.revokedAt),
+          ),
+          columns: {
+            accessTokenCiphertext: true,
+            accessTokenNonce: true,
+            accessTokenKeyVersion: true,
+            refreshTokenCiphertext: true,
+            refreshTokenNonce: true,
+            refreshTokenKeyVersion: true,
+            tokenExpiresAt: true,
+          },
+        });
+        if (!cur) return null; // revoked between list and lock
+
+        let accessToken: string;
+        try {
+          accessToken = decryptIntegrationSecret({
+            ciphertext: cur.accessTokenCiphertext,
+            nonce: cur.accessTokenNonce,
+            keyVersion: cur.accessTokenKeyVersion,
+          });
+        } catch (err) {
+          // Undecryptable access token (corrupt ciphertext / stale key) → skip
+          // this install like a dead grant; nothing was rotated.
+          log.error(
+            {
+              installation_id: installationId,
+              err: err instanceof Error ? err.message : String(err),
+            },
+            "cloudflare reconcile: access token decrypt failed; skipping install",
+          );
+          return null;
+        }
+
+        // Still comfortably valid → use it as-is (no redemption).
+        const expiresAt = cur.tokenExpiresAt?.getTime() ?? null;
+        if (expiresAt !== null && expiresAt - Date.now() > ACCESS_TOKEN_REFRESH_MARGIN_MS) {
+          return accessToken;
+        }
+
+        // Near/at expiry → need the refresh token to mint a new one.
+        let refreshToken: string | null = null;
+        if (cur.refreshTokenCiphertext && cur.refreshTokenNonce) {
+          try {
+            refreshToken = decryptIntegrationSecret({
+              ciphertext: cur.refreshTokenCiphertext,
+              nonce: cur.refreshTokenNonce,
+              keyVersion: cur.refreshTokenKeyVersion ?? 1,
+            });
+          } catch {
+            refreshToken = null;
+          }
+        }
+        // No refresh token (legacy install) and the access token is stale → this
+        // install can't be kept alive; it needs a manual reconnect. Skip.
+        if (!refreshToken) return null;
+
+        let refreshed: Awaited<ReturnType<typeof refreshAccessToken>>;
+        try {
+          refreshed = await refreshAccessToken({ config, refreshToken, fetchImpl });
+        } catch (err) {
+          // A thrown fetch (network/DNS) didn't persist a rotation — isolate the
+          // install (skip) rather than aborting the whole pass.
+          log.error(
+            {
+              installation_id: installationId,
+              err: err instanceof Error ? err.message : String(err),
+            },
+            "cloudflare reconcile: token request threw; skipping install",
+          );
+          return null;
+        }
+        if (!refreshed.ok) {
+          // Dead grant (expired / revoked) → needs manual reconnect. Skip.
+          log.error(
+            { installation_id: installationId, error: refreshed.error },
+            "cloudflare reconcile: token refresh failed; skipping install",
+          );
+          return null;
+        }
+
+        // Refresh succeeded → the old token is consumed; persisting the
+        // replacement is mandatory. A throw here propagates out of the
+        // transaction and aborts the pass (reconciler treats it as fatal).
+        const accessCipher = encryptIntegrationSecret(refreshed.accessToken);
+        const refreshCipher = encryptIntegrationSecret(refreshed.refreshToken ?? refreshToken);
+        await tx
+          .update(schema.cloudflareInstallations)
+          .set({
+            accessTokenCiphertext: accessCipher.ciphertext,
+            accessTokenNonce: accessCipher.nonce,
+            accessTokenKeyVersion: accessCipher.keyVersion,
+            refreshTokenCiphertext: refreshCipher.ciphertext,
+            refreshTokenNonce: refreshCipher.nonce,
+            refreshTokenKeyVersion: refreshCipher.keyVersion,
+            tokenExpiresAt:
+              refreshed.expiresIn != null
+                ? new Date(Date.now() + refreshed.expiresIn * 1000)
+                : null,
+            updatedAt: new Date(),
+          })
+          // revokedAt guard: an uninstall/account-switch landing between read and
+          // write must not resurrect tokens on a torn-down row.
+          .where(
+            and(
+              eq(schema.cloudflareInstallations.id, installationId),
+              isNull(schema.cloudflareInstallations.revokedAt),
+            ),
+          );
+        return refreshed.accessToken;
+      });
+    },
+  };
+}
+
+export const job: JobDefinition = {
+  name: "cloudflare-reconcile",
+  // Hourly on the hour — tight enough that a newly-unwired Worker is dark for at
+  // most ~an hour, cheap enough (mostly reads; PATCH only the drifted Workers).
+  schedule: "0 * * * *",
+  create: (deps) => {
+    const config = cloudflareClientFromEnv();
+    if (!config) {
+      log.info({}, "CLOUDFLARE_CLIENT_ID/SECRET not set — cloudflare reconcile job disabled");
+      return null;
+    }
+    const store = createStore(deps.db, config, fetch);
+    return async () => {
+      const stats = await runCloudflareReconcileOnce({
+        store,
+        reconcile: reconcileWorkerWiring,
+        log,
+      });
+      if (stats.reconciled > 0 || stats.errors > 0 || stats.skipped > 0) {
+        log.info({ ...stats }, "cloudflare reconcile pass complete");
+      }
+    };
+  },
+};

--- a/apps/worker/src/jobs/cloudflare-refresh.ts
+++ b/apps/worker/src/jobs/cloudflare-refresh.ts
@@ -10,7 +10,8 @@
 
 import { cloudflareClientFromEnv } from "@superlog/cloudflare";
 import { decryptIntegrationSecret, encryptIntegrationSecret, schema } from "@superlog/db";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
+import { lockInstallation } from "../cloudflare/lock.js";
 import {
   type CloudflareInstallationTokens,
   type CloudflareRefreshInstallation,
@@ -40,12 +41,10 @@ function createStore(db: JobDeps["db"]): CloudflareRefresherStore {
 
     async withLockedInstallation(installationId, fn) {
       return db.transaction(async (tx) => {
-        // Same namespaced advisory lock the api's freshAccessToken takes, so an
-        // on-demand refresh and this keep-alive can't redeem the same rotating
-        // token concurrently. Auto-released at transaction end.
-        await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtext('cloudflare_installations'), hashtext(${installationId}))`,
-        );
+        // Same namespaced advisory lock the api's freshAccessToken and the
+        // reconcile job take, so no two actors redeem the same rotating token
+        // concurrently. Auto-released at transaction end.
+        await lockInstallation(tx, installationId);
         const cur = await tx.query.cloudflareInstallations.findFirst({
           where: and(
             eq(schema.cloudflareInstallations.id, installationId),

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./oauth.js";
+export * from "./observability.js";

--- a/packages/cloudflare/src/observability.test.ts
+++ b/packages/cloudflare/src/observability.test.ts
@@ -1,11 +1,11 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
-import { reconcileWorkerWiring } from "./observability.js";
+import { listScripts, listScriptsStrict, reconcileWorkerWiring } from "./observability.js";
 
 // A fetch stub that answers the three Workers endpoints reconcile touches:
-//   GET  …/workers/scripts                       → the script list
-//   GET  …/workers/scripts/:s/settings           → that script's observability
-//   PATCH …/workers/scripts/:s/settings          → apply new observability
+//   GET  …/workers/scripts?per_page&page       → the (paginated) script list
+//   GET  …/workers/scripts/:s/settings         → that script's observability
+//   PATCH …/workers/scripts/:s/settings        → apply new observability
 // `settings` maps script id → its current observability block (or undefined).
 function fakeCloudflare(input: {
   scripts: string[];
@@ -17,7 +17,8 @@ function fakeCloudflare(input: {
   const fetchImpl = (async (url: unknown, init?: RequestInit) => {
     const u = String(url);
     const method = init?.method ?? "GET";
-    if (u.endsWith("/workers/scripts")) {
+    if (new URL(u).pathname.endsWith("/workers/scripts")) {
+      // Single page (no result_info → the pager stops after one request).
       return json({ success: true, result: input.scripts.map((id) => ({ id })) });
     }
     const m = u.match(/\/workers\/scripts\/([^/]+)\/settings$/);
@@ -109,7 +110,7 @@ test("reconcileWorkerWiring is a no-op when no destination slugs exist", async (
 test("reconcileWorkerWiring reports listOk:false when the scripts list fails", async () => {
   // GET /workers/scripts returns a non-OK / unsuccessful envelope.
   const fetchImpl = (async (url: unknown) => {
-    if (String(url).endsWith("/workers/scripts")) {
+    if (new URL(String(url)).pathname.endsWith("/workers/scripts")) {
       return json({ success: false, errors: [{ message: "unauthorized" }] }, 403);
     }
     throw new Error("should not reach per-script reads");
@@ -123,4 +124,41 @@ test("reconcileWorkerWiring reports listOk:false when the scripts list fails", a
   });
 
   assert.deepEqual(res, { scripts: 0, wired: 0, listOk: false });
+});
+
+// A paged /workers/scripts fake: `pages` is the list of id-arrays per page,
+// each carrying result_info.total_pages so the lister keeps following pages.
+function pagedScriptsFetch(pages: string[][], failPage?: number) {
+  const requested: number[] = [];
+  const fetchImpl = (async (url: unknown) => {
+    const parsed = new URL(String(url));
+    const page = Number(parsed.searchParams.get("page") ?? "1");
+    requested.push(page);
+    if (failPage != null && page === failPage) return json({ success: false }, 500);
+    const result = (pages[page - 1] ?? []).map((id) => ({ id }));
+    return json({
+      success: true,
+      result,
+      result_info: { page, per_page: result.length, total_pages: pages.length },
+    });
+  }) as typeof fetch;
+  return { fetchImpl, requested };
+}
+
+test("listScripts follows pagination across all pages", async () => {
+  const { fetchImpl, requested } = pagedScriptsFetch([["a", "b"], ["c", "d"], ["e"]]);
+  const ids = await listScripts("acc", "tok", fetchImpl);
+  assert.deepEqual(ids, ["a", "b", "c", "d", "e"]);
+  assert.deepEqual(requested, [1, 2, 3]); // fetched every page
+});
+
+test("listScriptsStrict throws when a later page fails", async () => {
+  const { fetchImpl } = pagedScriptsFetch([["a"], ["b"], ["c"]], 2);
+  await assert.rejects(listScriptsStrict("acc", "tok", fetchImpl), /list worker scripts failed/);
+});
+
+test("listScripts returns the pages it got before a later page fails (tolerant)", async () => {
+  const { fetchImpl } = pagedScriptsFetch([["a", "b"], ["c"]], 2);
+  const ids = await listScripts("acc", "tok", fetchImpl);
+  assert.deepEqual(ids, ["a", "b"]); // page 1 kept, failed page 2 stops the loop
 });

--- a/packages/cloudflare/src/observability.test.ts
+++ b/packages/cloudflare/src/observability.test.ts
@@ -1,0 +1,126 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { reconcileWorkerWiring } from "./observability.js";
+
+// A fetch stub that answers the three Workers endpoints reconcile touches:
+//   GET  …/workers/scripts                       → the script list
+//   GET  …/workers/scripts/:s/settings           → that script's observability
+//   PATCH …/workers/scripts/:s/settings          → apply new observability
+// `settings` maps script id → its current observability block (or undefined).
+function fakeCloudflare(input: {
+  scripts: string[];
+  settings: Record<string, unknown>;
+  patchFails?: Set<string>;
+  readFails?: Set<string>;
+}) {
+  const patched: { script: string }[] = [];
+  const fetchImpl = (async (url: unknown, init?: RequestInit) => {
+    const u = String(url);
+    const method = init?.method ?? "GET";
+    if (u.endsWith("/workers/scripts")) {
+      return json({ success: true, result: input.scripts.map((id) => ({ id })) });
+    }
+    const m = u.match(/\/workers\/scripts\/([^/]+)\/settings$/);
+    if (m) {
+      const script = decodeURIComponent(m[1] ?? "");
+      if (method === "PATCH") {
+        patched.push({ script });
+        if (input.patchFails?.has(script)) {
+          return json({ success: false, errors: [{ message: "nope" }] }, 400);
+        }
+        return json({ success: true });
+      }
+      if (input.readFails?.has(script)) return json({ success: false }, 500);
+      return json({ success: true, result: { observability: input.settings[script] } });
+    }
+    throw new Error(`unexpected url ${u}`);
+  }) as typeof fetch;
+  return { fetchImpl, patched };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+const SLUGS = { traces: "trc-slug", logs: "log-slug" };
+
+test("reconcileWorkerWiring wires only the drifted workers", async () => {
+  // one already fully wired, one unwired, one brand-new (no observability).
+  const wired = {
+    enabled: true,
+    traces: { enabled: true, destinations: ["trc-slug"] },
+    logs: { enabled: true, destinations: ["log-slug"] },
+  };
+  const { fetchImpl, patched } = fakeCloudflare({
+    scripts: ["already-wired", "drifted", "fresh"],
+    settings: { "already-wired": wired, drifted: { enabled: true }, fresh: undefined },
+  });
+
+  const res = await reconcileWorkerWiring({
+    accountId: "acc",
+    accessToken: "tok",
+    slugs: SLUGS,
+    fetchImpl,
+  });
+
+  assert.equal(res.scripts, 3);
+  assert.equal(res.wired, 2); // drifted + fresh; already-wired skipped (no PATCH)
+  assert.deepEqual(patched.map((p) => p.script).sort(), ["drifted", "fresh"]);
+});
+
+test("reconcileWorkerWiring is per-worker isolated and never throws on failures", async () => {
+  const { fetchImpl, patched } = fakeCloudflare({
+    scripts: ["ok", "read-fails", "patch-fails"],
+    settings: { ok: { enabled: false }, "patch-fails": { enabled: false } },
+    readFails: new Set(["read-fails"]),
+    patchFails: new Set(["patch-fails"]),
+  });
+
+  const res = await reconcileWorkerWiring({
+    accountId: "acc",
+    accessToken: "tok",
+    slugs: SLUGS,
+    fetchImpl,
+  });
+
+  assert.equal(res.scripts, 3);
+  assert.equal(res.wired, 1); // only "ok" succeeded; the other two failed but didn't throw
+  assert.ok(patched.some((p) => p.script === "ok"));
+});
+
+test("reconcileWorkerWiring is a no-op when no destination slugs exist", async () => {
+  let called = false;
+  const fetchImpl = (async () => {
+    called = true;
+    return json({ success: true, result: [] });
+  }) as typeof fetch;
+
+  const res = await reconcileWorkerWiring({
+    accountId: "acc",
+    accessToken: "tok",
+    slugs: {},
+    fetchImpl,
+  });
+
+  assert.deepEqual(res, { scripts: 0, wired: 0, listOk: true });
+  assert.equal(called, false); // short-circuits before hitting Cloudflare
+});
+
+test("reconcileWorkerWiring reports listOk:false when the scripts list fails", async () => {
+  // GET /workers/scripts returns a non-OK / unsuccessful envelope.
+  const fetchImpl = (async (url: unknown) => {
+    if (String(url).endsWith("/workers/scripts")) {
+      return json({ success: false, errors: [{ message: "unauthorized" }] }, 403);
+    }
+    throw new Error("should not reach per-script reads");
+  }) as typeof fetch;
+
+  const res = await reconcileWorkerWiring({
+    accountId: "acc",
+    accessToken: "tok",
+    slugs: SLUGS,
+    fetchImpl,
+  });
+
+  assert.deepEqual(res, { scripts: 0, wired: 0, listOk: false });
+});

--- a/packages/cloudflare/src/observability.ts
+++ b/packages/cloudflare/src/observability.ts
@@ -1,0 +1,343 @@
+// Cloudflare Workers Observability wiring — shared by the api (connect flow +
+// per-Worker wire/unwire routes) and the worker (periodic reconcile job).
+//
+// Creating an account-level telemetry destination is not enough: a Worker only
+// exports to a destination when its OWN `observability` config enables the
+// signal and lists the destination by name. So wiring reads each Worker's
+// settings and merges our destination slugs in. That per-Worker link is set once
+// at connect, so a Worker created/recreated/renamed later comes up unwired —
+// which is what the reconcile job re-applies on a schedule.
+//
+// This lived in apps/api/src/cloudflare-service.ts until the worker needed it
+// too; it's here (mirroring @superlog/railway owning its client) so both share
+// exactly one implementation and "wired" can never drift from "wire". The api
+// re-exports these so its existing imports are unchanged.
+//
+// IO-light: pure merge functions + thin wrappers over an injectable `fetch`.
+
+import type { FetchImpl } from "./oauth.js";
+
+export const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4";
+
+/** Our destination slugs for a Worker, per signal (metrics isn't a Worker signal). */
+export type WorkerDestinationSlugs = { traces?: string; logs?: string };
+
+export type WorkerObservabilitySignal = {
+  enabled?: boolean;
+  destinations?: string[];
+  [k: string]: unknown;
+};
+export type WorkerObservability = {
+  enabled?: boolean;
+  logs?: WorkerObservabilitySignal;
+  traces?: WorkerObservabilitySignal;
+  [k: string]: unknown;
+};
+
+/** signal → the Worker `observability` sub-key it maps to (metrics isn't a Worker signal). */
+const WORKER_OBSERVABILITY_SIGNALS = ["logs", "traces"] as const;
+
+/**
+ * Pull a human-readable error out of a failed Cloudflare API response. Cloudflare
+ * uses two shapes: the standard envelope `{errors:[{message}]}`, and — for
+ * request-body validation — a Zod error `{error:{name, issues:[{message,path}]}}`
+ * (mirrored as `_error`). Surfacing both keeps a validation failure from being
+ * flattened to a generic "request_failed".
+ */
+export function extractCloudflareApiError(o: Record<string, unknown>): string {
+  const errors = Array.isArray(o.errors) ? o.errors : [];
+  const first = errors[0] as Record<string, unknown> | undefined;
+  if (first && typeof first.message === "string") return first.message;
+
+  const zod = (o.error ?? o._error) as Record<string, unknown> | undefined;
+  if (zod && typeof zod === "object") {
+    const issues = Array.isArray(zod.issues) ? zod.issues : [];
+    const msgs = issues
+      .map((i) => (i as Record<string, unknown>)?.message)
+      .filter((m): m is string => typeof m === "string");
+    if (msgs.length > 0) return msgs.join("; ");
+    if (typeof zod.name === "string") return zod.name;
+  }
+  return "request_failed";
+}
+
+/**
+ * Merge our destination slugs into a Worker's existing observability config so it
+ * exports the matching signals to our intake. Additive and idempotent: turns on
+ * observability and each wired signal, and appends our slug to that signal's
+ * `destinations` without dropping the Worker's existing destinations, sampling
+ * rates, or any other fields. Returns the updated config, or `null` when the
+ * Worker is already wired (nothing to change) so the caller can skip the PATCH.
+ */
+export function wireObservabilityDestinations(
+  current: WorkerObservability | null | undefined,
+  slugs: WorkerDestinationSlugs,
+): WorkerObservability | null {
+  const next: WorkerObservability = current ? { ...current } : {};
+  let changed = false;
+  if (next.enabled !== true) {
+    next.enabled = true;
+    changed = true;
+  }
+  for (const signal of WORKER_OBSERVABILITY_SIGNALS) {
+    const slug = slugs[signal];
+    if (!slug) continue;
+    const sig: WorkerObservabilitySignal = { ...(next[signal] ?? {}) };
+    const destinations = Array.isArray(sig.destinations) ? [...sig.destinations] : [];
+    if (sig.enabled !== true) {
+      sig.enabled = true;
+      changed = true;
+    }
+    if (!destinations.includes(slug)) {
+      destinations.push(slug);
+      changed = true;
+    }
+    sig.destinations = destinations;
+    next[signal] = sig;
+  }
+  return changed ? next : null;
+}
+
+/**
+ * Remove our destination slugs from a Worker's observability config (the inverse
+ * of wireObservabilityDestinations). Only strips our slug from each signal's
+ * `destinations` — it leaves the signal enabled and any other destinations the
+ * Worker uses untouched, so unwiring from us never disables the Worker's own
+ * observability. Returns the updated config, or `null` when none of our slugs
+ * were present (nothing to change) so the caller can skip the PATCH.
+ */
+export function unwireObservabilityDestinations(
+  current: WorkerObservability | null | undefined,
+  slugs: WorkerDestinationSlugs,
+): WorkerObservability | null {
+  if (!current) return null;
+  const next: WorkerObservability = { ...current };
+  let changed = false;
+  for (const signal of WORKER_OBSERVABILITY_SIGNALS) {
+    const slug = slugs[signal];
+    if (!slug) continue;
+    const existing = next[signal];
+    if (!existing || !Array.isArray(existing.destinations)) continue;
+    if (!existing.destinations.includes(slug)) continue;
+    next[signal] = { ...existing, destinations: existing.destinations.filter((d) => d !== slug) };
+    changed = true;
+  }
+  return changed ? next : null;
+}
+
+/**
+ * Whether a Worker is fully wired to our destinations — i.e. wiring would be a
+ * no-op. Defined in terms of wireObservabilityDestinations so "wired" and "wire"
+ * can never drift: if wiring returns null there's nothing to add, so it's wired.
+ */
+export function isWorkerWired(
+  current: WorkerObservability | null | undefined,
+  slugs: WorkerDestinationSlugs,
+): boolean {
+  return wireObservabilityDestinations(current, slugs) === null;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP wrappers (injectable fetch)
+// ---------------------------------------------------------------------------
+
+/** Parse `GET /workers/scripts` → list of script (Worker) ids. */
+export function parseScriptsResponse(json: unknown): string[] {
+  if (!json || typeof json !== "object") return [];
+  const result = (json as Record<string, unknown>).result;
+  if (!Array.isArray(result)) return [];
+  const ids: string[] = [];
+  for (const item of result) {
+    const id = item && typeof item === "object" ? (item as Record<string, unknown>).id : null;
+    if (typeof id === "string" && id) ids.push(id);
+  }
+  return ids;
+}
+
+/** List the Worker script ids in an account. Returns [] on any failure. */
+export async function listScripts(
+  accountId: string,
+  accessToken: string,
+  fetchImpl: FetchImpl = fetch,
+): Promise<string[]> {
+  const res = await fetchImpl(`${CLOUDFLARE_API_BASE}/accounts/${accountId}/workers/scripts`, {
+    headers: { authorization: `Bearer ${accessToken}` },
+  });
+  const json = await res.json().catch(() => null);
+  return parseScriptsResponse(json);
+}
+
+/**
+ * Strict variant of listScripts for interactive management routes: THROWS on a
+ * failed read (non-OK HTTP or `success !== true`) instead of collapsing it to an
+ * empty list. The tolerant listScripts hides an account-level failure as "no
+ * Workers" — fine for a best-effort background pass, wrong for a user staring at
+ * the settings card, who should see a reconnect/upstream error instead of an
+ * account that looks empty. Mirrors getScriptObservability's throw-on-failure.
+ */
+export async function listScriptsStrict(
+  accountId: string,
+  accessToken: string,
+  fetchImpl: FetchImpl = fetch,
+): Promise<string[]> {
+  const res = await fetchImpl(`${CLOUDFLARE_API_BASE}/accounts/${accountId}/workers/scripts`, {
+    headers: { authorization: `Bearer ${accessToken}` },
+  });
+  const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!res.ok || !json || json.success !== true) {
+    throw new Error(`cloudflare: list worker scripts failed (status ${res.status})`);
+  }
+  return parseScriptsResponse(json);
+}
+
+/**
+ * Read one Worker's `observability` config. Returns `null` only on a *successful*
+ * read where observability is unset (a genuinely fresh Worker). A failed read
+ * (non-OK HTTP or `success !== true`) THROWS — the caller must not treat that as
+ * "fresh" and PATCH a minimal config, which would clobber an existing
+ * observability block we simply couldn't read.
+ */
+export async function getScriptObservability(input: {
+  accountId: string;
+  script: string;
+  accessToken: string;
+  fetchImpl?: FetchImpl;
+}): Promise<WorkerObservability | null> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const res = await fetchImpl(
+    `${CLOUDFLARE_API_BASE}/accounts/${input.accountId}/workers/scripts/${encodeURIComponent(
+      input.script,
+    )}/settings`,
+    { headers: { authorization: `Bearer ${input.accessToken}` } },
+  );
+  const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!res.ok || !json || json.success !== true) {
+    throw new Error(`cloudflare: read worker settings failed (status ${res.status})`);
+  }
+  const result = json.result as Record<string, unknown> | undefined;
+  const obs = result?.observability;
+  return obs && typeof obs === "object" ? (obs as WorkerObservability) : null;
+}
+
+/**
+ * PATCH a Worker's settings to set its `observability` config. The settings
+ * endpoint only accepts `multipart/form-data` with a JSON `settings` part (not a
+ * JSON body), so we build a FormData and let fetch set the multipart boundary.
+ */
+export async function updateScriptObservability(input: {
+  accountId: string;
+  script: string;
+  observability: WorkerObservability;
+  accessToken: string;
+  fetchImpl?: FetchImpl;
+}): Promise<{ ok: boolean; error?: string }> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const form = new FormData();
+  form.append(
+    "settings",
+    new Blob([JSON.stringify({ observability: input.observability })], {
+      type: "application/json",
+    }),
+    "settings.json",
+  );
+  try {
+    const res = await fetchImpl(
+      `${CLOUDFLARE_API_BASE}/accounts/${input.accountId}/workers/scripts/${encodeURIComponent(
+        input.script,
+      )}/settings`,
+      {
+        method: "PATCH",
+        headers: { authorization: `Bearer ${input.accessToken}` },
+        body: form,
+      },
+    );
+    const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    if (json?.success === true) return { ok: true };
+    return { ok: false, error: extractCloudflareApiError(json ?? {}) };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "request_failed" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reconcile — the idempotent "wire every Worker in the account" pass, shared by
+// connect / wire-all (api) and the periodic reconcile (worker).
+// ---------------------------------------------------------------------------
+
+export type WiringLogger = {
+  info(fields: Record<string, unknown>, msg: string): void;
+  warn(fields: Record<string, unknown>, msg: string): void;
+};
+
+/**
+ * Wire every Worker in an account to our destinations. Reads each Worker's
+ * observability and merges our slugs in (additive + idempotent), PATCHing only
+ * the ones that actually drifted. Best-effort and per-Worker isolated: a Worker
+ * we can't read/update is logged and skipped, never failing the pass — so this
+ * never throws for a wiring failure. Only traces/logs are wired (Workers
+ * Observability has no per-Worker metrics signal).
+ *
+ * `listOk` reports whether the account-level scripts list actually succeeded:
+ * the background reconcile can ignore a transient list failure (retry next
+ * hour), but the interactive "Wire all" route uses it to surface a reconnect /
+ * upstream error instead of silently reporting "0 workers".
+ */
+export async function reconcileWorkerWiring(input: {
+  accountId: string;
+  accessToken: string;
+  slugs: WorkerDestinationSlugs;
+  fetchImpl?: FetchImpl;
+  log?: WiringLogger;
+}): Promise<{ scripts: number; wired: number; listOk: boolean }> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const slugs = { traces: input.slugs.traces, logs: input.slugs.logs };
+  if (!slugs.traces && !slugs.logs) return { scripts: 0, wired: 0, listOk: true };
+  let scripts: string[];
+  try {
+    scripts = await listScriptsStrict(input.accountId, input.accessToken, fetchImpl);
+  } catch (e) {
+    // Account-level list failure: don't throw (a background pass just retries),
+    // but report listOk:false so an interactive caller can surface the error.
+    input.log?.warn(
+      { err: e instanceof Error ? e.message : String(e), account_id: input.accountId },
+      "cloudflare: list worker scripts failed",
+    );
+    return { scripts: 0, wired: 0, listOk: false };
+  }
+  let wired = 0;
+  for (const script of scripts) {
+    try {
+      const current = await getScriptObservability({
+        accountId: input.accountId,
+        script,
+        accessToken: input.accessToken,
+        fetchImpl,
+      });
+      const next = wireObservabilityDestinations(current, slugs);
+      if (!next) continue; // already wired
+      const res = await updateScriptObservability({
+        accountId: input.accountId,
+        script,
+        observability: next,
+        accessToken: input.accessToken,
+        fetchImpl,
+      });
+      if (res.ok) wired += 1;
+      else
+        input.log?.warn(
+          { script, error: res.error },
+          "cloudflare: failed to wire worker observability",
+        );
+    } catch (e) {
+      input.log?.warn(
+        { err: e instanceof Error ? e.message : String(e), script },
+        "cloudflare: failed to wire worker observability",
+      );
+    }
+  }
+  input.log?.info(
+    { account_id: input.accountId, scripts: scripts.length, wired },
+    "cloudflare: wired worker observability to destinations",
+  );
+  return { scripts: scripts.length, wired, listOk: true };
+}

--- a/packages/cloudflare/src/observability.ts
+++ b/packages/cloudflare/src/observability.ts
@@ -154,17 +154,62 @@ export function parseScriptsResponse(json: unknown): string[] {
   return ids;
 }
 
-/** List the Worker script ids in an account. Returns [] on any failure. */
+// Cloudflare's list endpoints paginate (default `per_page` 20). A single request
+// would silently drop every Worker past the first page — those workers vanish
+// from the settings list AND never get wired by reconcile. We request a large
+// page and follow `result_info.total_pages` so all workers are covered.
+const SCRIPTS_PER_PAGE = 100;
+const SCRIPTS_MAX_PAGES = 1000; // hard stop against a misbehaving result_info
+
+/** `result_info.total_pages` when the response carries pagination metadata, else null. */
+function totalPagesOf(json: unknown): number | null {
+  const ri = (json as Record<string, unknown> | null)?.result_info as
+    | Record<string, unknown>
+    | undefined;
+  return typeof ri?.total_pages === "number" ? ri.total_pages : null;
+}
+
+/**
+ * Fetch every Worker script id in an account, following pagination. `strict`
+ * controls the failure mode: strict THROWS on a failed page (for interactive
+ * routes, so the user sees a reconnect/upstream error rather than a
+ * falsely-empty account), tolerant returns whatever it has so far (for the
+ * best-effort background reconcile, which just retries next pass).
+ */
+async function fetchAllScripts(
+  accountId: string,
+  accessToken: string,
+  fetchImpl: FetchImpl,
+  strict: boolean,
+): Promise<string[]> {
+  const all: string[] = [];
+  for (let page = 1; page <= SCRIPTS_MAX_PAGES; page += 1) {
+    const res = await fetchImpl(
+      `${CLOUDFLARE_API_BASE}/accounts/${accountId}/workers/scripts?per_page=${SCRIPTS_PER_PAGE}&page=${page}`,
+      { headers: { authorization: `Bearer ${accessToken}` } },
+    );
+    const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    if (!res.ok || !json || json.success !== true) {
+      if (strict) throw new Error(`cloudflare: list worker scripts failed (status ${res.status})`);
+      break; // tolerant: stop and return what we have
+    }
+    const ids = parseScriptsResponse(json);
+    all.push(...ids);
+    // Stop when there's no pagination metadata (endpoint returned everything at
+    // once), we've reached the last page, or a page came back empty (safety).
+    const totalPages = totalPagesOf(json);
+    if (totalPages === null || page >= totalPages || ids.length === 0) break;
+  }
+  return all;
+}
+
+/** List all Worker script ids in an account (paginated). Returns [] on any failure. */
 export async function listScripts(
   accountId: string,
   accessToken: string,
   fetchImpl: FetchImpl = fetch,
 ): Promise<string[]> {
-  const res = await fetchImpl(`${CLOUDFLARE_API_BASE}/accounts/${accountId}/workers/scripts`, {
-    headers: { authorization: `Bearer ${accessToken}` },
-  });
-  const json = await res.json().catch(() => null);
-  return parseScriptsResponse(json);
+  return fetchAllScripts(accountId, accessToken, fetchImpl, false);
 }
 
 /**
@@ -180,14 +225,7 @@ export async function listScriptsStrict(
   accessToken: string,
   fetchImpl: FetchImpl = fetch,
 ): Promise<string[]> {
-  const res = await fetchImpl(`${CLOUDFLARE_API_BASE}/accounts/${accountId}/workers/scripts`, {
-    headers: { authorization: `Bearer ${accessToken}` },
-  });
-  const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
-  if (!res.ok || !json || json.success !== true) {
-    throw new Error(`cloudflare: list worker scripts failed (status ${res.status})`);
-  }
-  return parseScriptsResponse(json);
+  return fetchAllScripts(accountId, accessToken, fetchImpl, true);
 }
 
 /**

--- a/packages/db/migrations/0095_blushing_nighthawk.sql
+++ b/packages/db/migrations/0095_blushing_nighthawk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "cloudflare_installations" ADD COLUMN "auto_wire" boolean DEFAULT true NOT NULL;

--- a/packages/db/migrations/meta/0095_snapshot.json
+++ b/packages/db/migrations/meta/0095_snapshot.json
@@ -1,0 +1,9088 @@
+{
+  "id": "2799cac7-7643-4811-8768-66889c42c475",
+  "prevId": "d69aaa5f-dc99-48c9-a834-175c98d8a989",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_provider_account_idx": {
+          "name": "accounts_provider_account_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_idx": {
+          "name": "accounts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_chat_messages": {
+      "name": "agent_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_slack_user_id": {
+          "name": "author_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_chat_messages_dedupe_idx": {
+          "name": "agent_chat_messages_dedupe_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chat_messages_pending_idx": {
+          "name": "agent_chat_messages_pending_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "processed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_chat_messages_chat_id_agent_chats_id_fk": {
+          "name": "agent_chat_messages_chat_id_agent_chats_id_fk",
+          "tableFrom": "agent_chat_messages",
+          "tableTo": "agent_chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_chats": {
+      "name": "agent_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_slack_user_id": {
+          "name": "created_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_status": {
+          "name": "provider_session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cumulative_active_seconds": {
+          "name": "cumulative_active_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "session_base_active_seconds": {
+          "name": "session_base_active_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_chats_thread_idx": {
+          "name": "agent_chats_thread_idx",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_thread_ts IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_dm_channel_idx": {
+          "name": "agent_chats_dm_channel_idx",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_thread_ts IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_provider_session_idx": {
+          "name": "agent_chats_provider_session_idx",
+          "columns": [
+            {
+              "expression": "provider_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_state_idx": {
+          "name": "agent_chats_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_chats_project_id_projects_id_fk": {
+          "name": "agent_chats_project_id_projects_id_fk",
+          "tableFrom": "agent_chats",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_chats_slack_installation_id_slack_installations_id_fk": {
+          "name": "agent_chats_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "agent_chats",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_ticket_events": {
+      "name": "agent_linear_ticket_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_linear_ticket_id": {
+          "name": "agent_linear_ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_linear_id": {
+          "name": "actor_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_ticket_events_ticket_idx": {
+          "name": "agent_linear_ticket_events_ticket_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_ticket_events_provider_event_idx": {
+          "name": "agent_linear_ticket_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk": {
+          "name": "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk",
+          "tableFrom": "agent_linear_ticket_events",
+          "tableTo": "agent_linear_tickets",
+          "columnsFrom": [
+            "agent_linear_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_tickets": {
+      "name": "agent_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_identifier": {
+          "name": "ticket_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_name": {
+          "name": "assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_linear_id": {
+          "name": "assignee_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_tickets_incident_idx": {
+          "name": "agent_linear_tickets_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_agent_run_idx": {
+          "name": "agent_linear_tickets_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_workspace_ticket_idx": {
+          "name": "agent_linear_tickets_workspace_ticket_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_tickets_incident_id_incidents_id_fk": {
+          "name": "agent_linear_tickets_incident_id_incidents_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_linear_tickets_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_installation_id_linear_installations_id_fk": {
+          "name": "agent_linear_tickets_installation_id_linear_installations_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "linear_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memories": {
+      "name": "agent_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source_agent_run_id": {
+          "name": "source_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memories_org_status_idx": {
+          "name": "agent_memories_org_status_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_memories_org_id_orgs_id_fk": {
+          "name": "agent_memories_org_id_orgs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_id_projects_id_fk": {
+          "name": "agent_memories_project_id_projects_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_memories_source_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "source_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_user_id_users_id_fk": {
+          "name": "agent_memories_source_user_id_users_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "source_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_org_fk": {
+          "name": "agent_memories_project_org_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_memories_single_source_check": {
+          "name": "agent_memories_single_source_check",
+          "value": "NOT (source_agent_run_id IS NOT NULL AND source_user_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_pr_events": {
+      "name": "agent_pr_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_pr_id": {
+          "name": "agent_pr_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_login": {
+          "name": "actor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_github_id": {
+          "name": "actor_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pr_events_pr_idx": {
+          "name": "agent_pr_events_pr_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pr_events_provider_event_idx": {
+          "name": "agent_pr_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk": {
+          "name": "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk",
+          "tableFrom": "agent_pr_events",
+          "tableTo": "agent_pull_requests",
+          "columnsFrom": [
+            "agent_pr_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_pull_requests": {
+      "name": "agent_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_node_id": {
+          "name": "pr_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_login": {
+          "name": "merged_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_github_id": {
+          "name": "merged_by_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pull_requests_incident_idx": {
+          "name": "agent_pull_requests_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_agent_run_idx": {
+          "name": "agent_pull_requests_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_repo_pr_idx": {
+          "name": "agent_pull_requests_repo_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pull_requests_incident_id_incidents_id_fk": {
+          "name": "agent_pull_requests_incident_id_incidents_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_pull_requests_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_installation_id_github_installations_id_fk": {
+          "name": "agent_pull_requests_installation_id_github_installations_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'incident'"
+        },
+        "trigger_detail": {
+          "name": "trigger_detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_status": {
+          "name": "provider_session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_full_name": {
+          "name": "selected_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_url": {
+          "name": "selected_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_base_branch": {
+          "name": "selected_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_score": {
+          "name": "selected_repo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cumulative_runtime_minutes": {
+          "name": "cumulative_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resume_count": {
+          "name": "resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_runs_incident_idx": {
+          "name": "agent_runs_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_provider_session_idx": {
+          "name": "agent_runs_provider_session_idx",
+          "columns": [
+            {
+              "expression": "provider_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_incident_id_incidents_id_fk": {
+          "name": "agent_runs_incident_id_incidents_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_episodes": {
+      "name": "alert_episodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'firing'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_observed_value": {
+          "name": "open_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_observed_value": {
+          "name": "peak_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_value": {
+          "name": "last_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_firing_at": {
+          "name": "last_firing_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alert_episodes_alert_started_idx": {
+          "name": "alert_episodes_alert_started_idx",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_episodes_incident_idx": {
+          "name": "alert_episodes_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_episodes_open_uniq": {
+          "name": "alert_episodes_open_uniq",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "state = 'firing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_episodes_issue_uniq": {
+          "name": "alert_episodes_issue_uniq",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "issue_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_episodes_alert_id_alerts_id_fk": {
+          "name": "alert_episodes_alert_id_alerts_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_project_id_projects_id_fk": {
+          "name": "alert_episodes_project_id_projects_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_issue_id_issues_id_fk": {
+          "name": "alert_episodes_issue_id_issues_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_incident_id_incidents_id_fk": {
+          "name": "alert_episodes_incident_id_incidents_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_firings": {
+      "name": "alert_firings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_value": {
+          "name": "observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluated_at": {
+          "name": "evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_firings_alert_group_idx": {
+          "name": "alert_firings_alert_group_idx",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_firings_alert_id_alerts_id_fk": {
+          "name": "alert_firings_alert_id_alerts_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_firings_issue_id_issues_id_fk": {
+          "name": "alert_firings_issue_id_issues_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_name": {
+          "name": "metric_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "group_by": {
+          "name": "group_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mode": {
+          "name": "group_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single'"
+        },
+        "aggregation": {
+          "name": "aggregation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparator": {
+          "name": "comparator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "evaluation_interval_seconds": {
+          "name": "evaluation_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alerts_project_idx": {
+          "name": "alerts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alerts_enabled_idx": {
+          "name": "alerts_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alerts_project_id_projects_id_fk": {
+          "name": "alerts_project_id_projects_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alerts_created_by_users_id_fk": {
+          "name": "alerts_created_by_users_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions": {
+      "name": "cli_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cli_sessions_user_id_users_id_fk": {
+          "name": "cli_sessions_user_id_users_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_org_id_orgs_id_fk": {
+          "name": "cli_sessions_org_id_orgs_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_sessions_token_hash_unique": {
+          "name": "cli_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_connections": {
+      "name": "cloud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scrape_role_arn": {
+          "name": "scrape_role_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id_ciphertext": {
+          "name": "external_id_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_nonce": {
+          "name": "external_id_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_key_version": {
+          "name": "external_id_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloud_connections_project_idx": {
+          "name": "cloud_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_connections_active_role_idx": {
+          "name": "cloud_connections_active_role_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scrape_role_arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_connections_project_id_projects_id_fk": {
+          "name": "cloud_connections_project_id_projects_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_connections_created_by_users_id_fk": {
+          "name": "cloud_connections_created_by_users_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_resources": {
+      "name": "cloud_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arn": {
+          "name": "arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_fetched_at": {
+          "name": "config_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_resources_project_arn_idx": {
+          "name": "cloud_resources_project_arn_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_project_idx": {
+          "name": "cloud_resources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_connection_idx": {
+          "name": "cloud_resources_connection_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_resources_project_id_projects_id_fk": {
+          "name": "cloud_resources_project_id_projects_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_resources_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_resources_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_stream_keys": {
+      "name": "cloud_stream_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_ciphertext": {
+          "name": "key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_nonce": {
+          "name": "key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_key_version": {
+          "name": "key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_stream_keys_connection_kind_idx": {
+          "name": "cloud_stream_keys_connection_kind_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_stream_keys_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_stream_keys_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_stream_keys",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_stream_keys_api_key_id_api_keys_id_fk": {
+          "name": "cloud_stream_keys_api_key_id_api_keys_id_fk",
+          "tableFrom": "cloud_stream_keys",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_installations": {
+      "name": "cloudflare_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_token_ciphertext": {
+          "name": "refresh_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_nonce": {
+          "name": "refresh_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_key_version": {
+          "name": "refresh_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destinations": {
+          "name": "destinations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_wire": {
+          "name": "auto_wire",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloudflare_installations_project_account_idx": {
+          "name": "cloudflare_installations_project_account_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_installations_project_id_projects_id_fk": {
+          "name": "cloudflare_installations_project_id_projects_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloudflare_installations_api_key_id_api_keys_id_fk": {
+          "name": "cloudflare_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cloudflare_installations_installed_by_user_id_users_id_fk": {
+          "name": "cloudflare_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_widgets": {
+      "name": "dashboard_widgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboard_widgets_dashboard_idx": {
+          "name": "dashboard_widgets_dashboard_idx",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_widgets_dashboard_id_dashboards_id_fk": {
+          "name": "dashboard_widgets_dashboard_id_dashboards_id_fk",
+          "tableFrom": "dashboard_widgets",
+          "tableTo": "dashboards",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboards": {
+      "name": "dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboards_project_slug_idx": {
+          "name": "dashboards_project_slug_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboards_project_idx": {
+          "name": "dashboards_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboards_project_id_projects_id_fk": {
+          "name": "dashboards_project_id_projects_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboards_created_by_users_id_fk": {
+          "name": "dashboards_created_by_users_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_repo": {
+          "name": "ref_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_external": {
+          "name": "author_external",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "triaged_by_user_id": {
+          "name": "triaged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_status_created_idx": {
+          "name": "feedback_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_kind_ref_idx": {
+          "name": "feedback_kind_ref_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_user_id_users_id_fk": {
+          "name": "feedback_author_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_org_id_orgs_id_fk": {
+          "name": "feedback_org_id_orgs_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_project_id_projects_id_fk": {
+          "name": "feedback_project_id_projects_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_triaged_by_user_id_users_id_fk": {
+          "name": "feedback_triaged_by_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triaged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repos": {
+          "name": "repos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_enabled": {
+          "name": "agent_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "repo_access": {
+          "name": "repo_access",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_name": {
+          "name": "commit_author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_email": {
+          "name": "commit_author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_login": {
+          "name": "commit_author_github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_id": {
+          "name": "commit_author_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_avatar_url": {
+          "name": "commit_author_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_by_user_id": {
+          "name": "commit_author_set_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_at": {
+          "name": "commit_author_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_project_installation_idx": {
+          "name": "github_installations_project_installation_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NOT NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_installation_idx": {
+          "name": "github_installations_org_installation_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_idx": {
+          "name": "github_installations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_org_id_orgs_id_fk": {
+          "name": "github_installations_org_id_orgs_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_project_id_projects_id_fk": {
+          "name": "github_installations_project_id_projects_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_commit_author_set_by_user_id_users_id_fk": {
+          "name": "github_installations_commit_author_set_by_user_id_users_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "commit_author_set_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_events": {
+      "name": "incident_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_posted_at": {
+          "name": "slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_events_agent_run_idx": {
+          "name": "incident_events_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_idx": {
+          "name": "incident_events_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_provider_event_idx": {
+          "name": "incident_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_provider_event_idx": {
+          "name": "incident_events_incident_provider_event_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_dedupe_idx": {
+          "name": "incident_events_dedupe_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_dedupe_idx": {
+          "name": "incident_events_incident_dedupe_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_events_agent_run_id_agent_runs_id_fk": {
+          "name": "incident_events_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_events_incident_id_incidents_id_fk": {
+          "name": "incident_events_incident_id_incidents_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "incident_events_parentage_check": {
+          "name": "incident_events_parentage_check",
+          "value": "agent_run_id IS NOT NULL OR incident_id IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.incident_issues": {
+      "name": "incident_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_issues_pair_idx": {
+          "name": "incident_issues_pair_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_issues_incident_idx": {
+          "name": "incident_issues_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_issues_issue_lookup_idx": {
+          "name": "incident_issues_issue_lookup_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_issues_incident_id_incidents_id_fk": {
+          "name": "incident_issues_incident_id_incidents_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_issues_issue_id_issues_id_fk": {
+          "name": "incident_issues_issue_id_issues_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_resolution_proposals": {
+      "name": "incident_resolution_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sweep'"
+        },
+        "proposed_reason_code": {
+          "name": "proposed_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_reason_text": {
+          "name": "proposed_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_at": {
+          "name": "proposed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_slack_user_id": {
+          "name": "decided_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_resolution_proposals_incident_idx": {
+          "name": "incident_resolution_proposals_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proposed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_resolution_proposals_slack_msg_idx": {
+          "name": "incident_resolution_proposals_slack_msg_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_message_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_channel_id IS NOT NULL AND slack_message_ts IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_resolution_proposals_incident_id_incidents_id_fk": {
+          "name": "incident_resolution_proposals_incident_id_incidents_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk": {
+          "name": "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_decided_by_user_id_users_id_fk": {
+          "name": "incident_resolution_proposals_decided_by_user_id_users_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "noise_reason": {
+          "name": "noise_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_resolved_at": {
+          "name": "noise_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_into_id": {
+          "name": "merged_into_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_incident_id": {
+          "name": "previous_incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_investigate_suppressed_until": {
+          "name": "auto_investigate_suppressed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_investigate_blocked_reason": {
+          "name": "auto_investigate_blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autorecovery_last_evaluated_at": {
+          "name": "autorecovery_last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_summary": {
+          "name": "agent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_text": {
+          "name": "root_cause_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_confidence": {
+          "name": "root_cause_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_text": {
+          "name": "estimated_impact_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_confidence": {
+          "name": "estimated_impact_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_severity": {
+          "name": "suggested_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_classification": {
+          "name": "noise_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_classification": {
+          "name": "resolution_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_agent_run_id": {
+          "name": "findings_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_kind": {
+          "name": "resolved_by_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_slack_user_id": {
+          "name": "resolved_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_code": {
+          "name": "resolved_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_text": {
+          "name": "resolved_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incidents_project_status_seen_idx": {
+          "name": "incidents_project_status_seen_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_autorecovery_eval_idx": {
+          "name": "incidents_autorecovery_eval_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "autorecovery_last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_slack_thread_idx": {
+          "name": "incidents_slack_thread_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_project_codename_idx": {
+          "name": "incidents_project_codename_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "codename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "codename <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_project_id_projects_id_fk": {
+          "name": "incidents_project_id_projects_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incidents_merged_into_id_incidents_id_fk": {
+          "name": "incidents_merged_into_id_incidents_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "merged_into_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_previous_incident_id_incidents_id_fk": {
+          "name": "incidents_previous_incident_id_incidents_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "previous_incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_slack_installation_id_slack_installations_id_fk": {
+          "name": "incidents_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_findings_agent_run_id_agent_runs_id_fk": {
+          "name": "incidents_findings_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "findings_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_resolved_by_user_id_users_id_fk": {
+          "name": "incidents_resolved_by_user_id_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_org_idx": {
+          "name": "invitations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_org_id_orgs_id_fk": {
+          "name": "invitations_org_id_orgs_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'span'"
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_type": {
+          "name": "exception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_frame": {
+          "name": "top_frame",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_frames": {
+          "name": "normalized_frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_sample": {
+          "name": "last_sample",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "silenced_at": {
+          "name": "silenced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_trigger": {
+          "name": "escalation_trigger",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_started_at": {
+          "name": "observation_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_baseline_event_count": {
+          "name": "observation_baseline_event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_last_evaluated_at": {
+          "name": "observation_last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_last_event_count": {
+          "name": "observation_last_event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_alerted_at": {
+          "name": "last_alerted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "grouping_state": {
+          "name": "grouping_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'grouped'"
+        },
+        "grouping_source": {
+          "name": "grouping_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_reason": {
+          "name": "grouping_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempted_at": {
+          "name": "grouping_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempt_count": {
+          "name": "grouping_attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_project_fingerprint_idx": {
+          "name": "issues_project_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_grouping_state_idx": {
+          "name": "issues_grouping_state_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grouping_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grouping_state IN ('pending', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_observation_idx": {
+          "name": "issues_observation_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observation_started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'under_observation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_project_status_idx": {
+          "name": "issues_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_installations": {
+      "name": "linear_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_url_key": {
+          "name": "workspace_url_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_vault_id": {
+          "name": "anthropic_vault_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_credential_id": {
+          "name": "anthropic_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_required_at": {
+          "name": "reauth_required_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_reason": {
+          "name": "reauth_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linear_installations_project_active_idx": {
+          "name": "linear_installations_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_installations_project_id_projects_id_fk": {
+          "name": "linear_installations_project_id_projects_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_installations_actor_user_id_users_id_fk": {
+          "name": "linear_installations_actor_user_id_users_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_codes": {
+      "name": "mcp_oauth_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_codes_client_idx": {
+          "name": "mcp_oauth_codes_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_user_id_users_id_fk": {
+          "name": "mcp_oauth_codes_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_project_id_projects_id_fk": {
+          "name": "mcp_oauth_codes_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_tokens": {
+      "name": "mcp_oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "access_hash": {
+          "name": "access_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_hash": {
+          "name": "refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_tokens_client_idx": {
+          "name": "mcp_oauth_tokens_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_tokens_user_idx": {
+          "name": "mcp_oauth_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_user_id_users_id_fk": {
+          "name": "mcp_oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_project_id_projects_id_fk": {
+          "name": "mcp_oauth_tokens_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_tokens_access_hash_unique": {
+          "name": "mcp_oauth_tokens_access_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_hash"
+          ]
+        },
+        "mcp_oauth_tokens_refresh_hash_unique": {
+          "name": "mcp_oauth_tokens_refresh_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notion_installations": {
+      "name": "notion_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_icon": {
+          "name": "workspace_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_required_at": {
+          "name": "reauth_required_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_reason": {
+          "name": "reauth_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notion_installations_project_active_idx": {
+          "name": "notion_installations_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notion_installations_project_id_projects_id_fk": {
+          "name": "notion_installations_project_id_projects_id_fk",
+          "tableFrom": "notion_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notion_installations_actor_user_id_users_id_fk": {
+          "name": "notion_installations_actor_user_id_users_id_fk",
+          "tableFrom": "notion_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_agent_settings": {
+      "name": "org_agent_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "digest_enabled": {
+          "name": "digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "digest_slack_installation_id": {
+          "name": "digest_slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_id": {
+          "name": "digest_slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_name": {
+          "name": "digest_slack_channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_last_run_at": {
+          "name": "digest_last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_agent_settings_org_idx": {
+          "name": "org_agent_settings_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_agent_settings_org_id_orgs_id_fk": {
+          "name": "org_agent_settings_org_id_orgs_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk": {
+          "name": "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "digest_slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_api_keys": {
+      "name": "org_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_api_keys_org_idx": {
+          "name": "org_api_keys_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_api_keys_org_id_orgs_id_fk": {
+          "name": "org_api_keys_org_id_orgs_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_api_keys_created_by_user_id_users_id_fk": {
+          "name": "org_api_keys_created_by_user_id_users_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_api_keys_key_hash_unique": {
+          "name": "org_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integration_secrets": {
+      "name": "org_integration_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_integration_id": {
+          "name": "org_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_name": {
+          "name": "secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integration_secrets_unique_idx": {
+          "name": "org_integration_secrets_unique_idx",
+          "columns": [
+            {
+              "expression": "org_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integration_secrets_org_integration_id_org_integrations_id_fk": {
+          "name": "org_integration_secrets_org_integration_id_org_integrations_id_fk",
+          "tableFrom": "org_integration_secrets",
+          "tableTo": "org_integrations",
+          "columnsFrom": [
+            "org_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integrations": {
+      "name": "org_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integrations_org_slug_idx": {
+          "name": "org_integrations_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_integrations_org_enabled_idx": {
+          "name": "org_integrations_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integrations_org_id_orgs_id_fk": {
+          "name": "org_integrations_org_id_orgs_id_fk",
+          "tableFrom": "org_integrations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_members_org_user_idx": {
+          "name": "org_members_org_user_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_org_id_orgs_id_fk": {
+          "name": "org_members_org_id_orgs_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_members_user_id_users_id_fk": {
+          "name": "org_members_user_id_users_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_setup_skipped_at": {
+          "name": "github_setup_skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_source": {
+          "name": "signup_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_return_url_hosts": {
+          "name": "allowed_return_url_hosts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_slug_unique": {
+          "name": "orgs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "orgs_clerk_org_id_unique": {
+          "name": "orgs_clerk_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personal_access_tokens_user_idx": {
+          "name": "personal_access_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personal_access_tokens_project_idx": {
+          "name": "personal_access_tokens_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_users_id_fk": {
+          "name": "personal_access_tokens_user_id_users_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personal_access_tokens_project_id_projects_id_fk": {
+          "name": "personal_access_tokens_project_id_projects_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_automation_settings": {
+      "name": "project_automation_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_investigate_issues_enabled": {
+          "name": "auto_investigate_issues_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "agent_run_provider": {
+          "name": "agent_run_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "max_runtime_minutes": {
+          "name": "max_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "max_human_resume_count": {
+          "name": "max_human_resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_follow_up_enabled": {
+          "name": "auto_follow_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "chat_enabled": {
+          "name": "chat_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "linear_ticket_instructions": {
+          "name": "linear_ticket_instructions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "linear_default_team_id": {
+          "name": "linear_default_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_base_branch": {
+          "name": "pr_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_merge_fix_prs": {
+          "name": "auto_merge_fix_prs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'never'"
+        },
+        "auto_merge_method": {
+          "name": "auto_merge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'squash'"
+        },
+        "issue_filter": {
+          "name": "issue_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "issue_filter_config": {
+          "name": "issue_filter_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"includeLogs\":[],\"includeSpans\":[],\"excludeLogs\":[],\"excludeSpans\":[]}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_automation_settings_project_idx": {
+          "name": "project_automation_settings_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_automation_settings_project_id_projects_id_fk": {
+          "name": "project_automation_settings_project_id_projects_id_fk",
+          "tableFrom": "project_automation_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_github_repos": {
+      "name": "project_github_repos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_full_name": {
+          "name": "github_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_github_repos_project_repo_idx": {
+          "name": "project_github_repos_project_repo_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_github_repos_installation_idx": {
+          "name": "project_github_repos_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_github_repos_project_id_projects_id_fk": {
+          "name": "project_github_repos_project_id_projects_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_github_repos_installation_id_github_installations_id_fk": {
+          "name": "project_github_repos_installation_id_github_installations_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_ingest_filters": {
+      "name": "project_ingest_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal": {
+          "name": "signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_ingest_filters_project_source_signal_idx": {
+          "name": "project_ingest_filters_project_source_signal_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_ingest_filters_project_id_projects_id_fk": {
+          "name": "project_ingest_filters_project_id_projects_id_fk",
+          "tableFrom": "project_ingest_filters",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_topologies": {
+      "name": "project_topologies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment": {
+          "name": "enrichment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_requested_at": {
+          "name": "refresh_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_topologies_project_idx": {
+          "name": "project_topologies_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_topologies_project_id_projects_id_fk": {
+          "name": "project_topologies_project_id_projects_id_fk",
+          "tableFrom": "project_topologies",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_context": {
+          "name": "project_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_idx": {
+          "name": "projects_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_org_id_orgs_id_fk": {
+          "name": "projects_org_id_orgs_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_id_org_uniq": {
+          "name": "projects_id_org_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.railway_installations": {
+      "name": "railway_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "railway_user_id": {
+          "name": "railway_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_projects": {
+          "name": "granted_projects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_token_ciphertext": {
+          "name": "refresh_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_nonce": {
+          "name": "refresh_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_key_version": {
+          "name": "refresh_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_cursor": {
+          "name": "log_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_cursor": {
+          "name": "metrics_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "railway_installations_project_user_idx": {
+          "name": "railway_installations_project_user_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "railway_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "railway_installations_project_id_projects_id_fk": {
+          "name": "railway_installations_project_id_projects_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "railway_installations_api_key_id_api_keys_id_fk": {
+          "name": "railway_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "railway_installations_installed_by_user_id_users_id_fk": {
+          "name": "railway_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.render_installations": {
+      "name": "render_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_owner_id": {
+          "name": "render_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_owner_name": {
+          "name": "render_owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "render_api_key_ciphertext": {
+          "name": "render_api_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_api_key_nonce": {
+          "name": "render_api_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_api_key_key_version": {
+          "name": "render_api_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_cursor": {
+          "name": "log_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_cursor": {
+          "name": "metrics_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_stream_state": {
+          "name": "log_stream_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_stream_state": {
+          "name": "metrics_stream_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "render_installations_project_owner_idx": {
+          "name": "render_installations_project_owner_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "render_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "render_installations_project_id_projects_id_fk": {
+          "name": "render_installations_project_id_projects_id_fk",
+          "tableFrom": "render_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "render_installations_api_key_id_api_keys_id_fk": {
+          "name": "render_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "render_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "render_installations_installed_by_user_id_users_id_fk": {
+          "name": "render_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "render_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_orgs_id_fk": {
+          "name": "sessions_active_organization_id_orgs_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signup_intents": {
+      "name": "signup_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_project_id": {
+          "name": "claimed_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signup_intents_claimed_project_id_projects_id_fk": {
+          "name": "signup_intents_claimed_project_id_projects_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "claimed_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "signup_intents_claimed_by_user_id_users_id_fk": {
+          "name": "signup_intents_claimed_by_user_id_users_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signup_intents_key_hash_unique": {
+          "name": "signup_intents_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default_chat_project": {
+          "name": "is_default_chat_project",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "slack_installations_project_team_idx": {
+          "name": "slack_installations_project_team_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_default_chat_idx": {
+          "name": "slack_installations_default_chat_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default_chat_project",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_project_id_projects_id_fk": {
+          "name": "slack_installations_project_id_projects_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_installations_installed_by_user_id_users_id_fk": {
+          "name": "slack_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_map_artifacts": {
+      "name": "source_map_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dist": {
+          "name": "dist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug_id": {
+          "name": "debug_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_file": {
+          "name": "bundle_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_file": {
+          "name": "map_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_hash": {
+          "name": "source_map_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_bytes": {
+          "name": "source_map_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_bucket": {
+          "name": "storage_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_encoding": {
+          "name": "content_encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gzip'"
+        },
+        "uploaded_by_org_api_key_id": {
+          "name": "uploaded_by_org_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_map_artifacts_project_debug_id_idx": {
+          "name": "source_map_artifacts_project_debug_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "debug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "debug_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_map_artifacts_project_release_idx": {
+          "name": "source_map_artifacts_project_release_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "release",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_map_artifacts_project_id_projects_id_fk": {
+          "name": "source_map_artifacts_project_id_projects_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk": {
+          "name": "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "org_api_keys",
+          "columnsFrom": [
+            "uploaded_by_org_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_notifications": {
+      "name": "usage_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_notifications_org_period_threshold_idx": {
+          "name": "usage_notifications_org_period_threshold_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "threshold",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_notifications_org_id_orgs_id_fk": {
+          "name": "usage_notifications_org_id_orgs_id_fk",
+          "tableFrom": "usage_notifications",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_project_id": {
+          "name": "active_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_org_id": {
+          "name": "active_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_org_id": {
+          "name": "favorite_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_project_id": {
+          "name": "favorite_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_active_project_id_projects_id_fk": {
+          "name": "users_active_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "active_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_active_org_id_orgs_id_fk": {
+          "name": "users_active_org_id_orgs_id_fk",
+          "tableFrom": "users",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_favorite_org_id_orgs_id_fk": {
+          "name": "users_favorite_org_id_orgs_id_fk",
+          "tableFrom": "users",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "favorite_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_favorite_project_id_projects_id_fk": {
+          "name": "users_favorite_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "favorite_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_installations": {
+      "name": "vercel_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_id": {
+          "name": "configuration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drains": {
+          "name": "drains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vercel_installations_project_configuration_idx": {
+          "name": "vercel_installations_project_configuration_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configuration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_installations_project_id_projects_id_fk": {
+          "name": "vercel_installations_project_id_projects_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vercel_installations_api_key_id_api_keys_id_fk": {
+          "name": "vercel_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vercel_installations_installed_by_user_id_users_id_fk": {
+          "name": "vercel_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_status": {
+          "name": "last_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_endpoint_idx": {
+          "name": "webhook_deliveries_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_events": {
+          "name": "enabled_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"incident.created\",\"incident.updated\"]'::jsonb"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_endpoints_project_idx": {
+          "name": "webhook_endpoints_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_endpoints_project_id_projects_id_fk": {
+          "name": "webhook_endpoints_project_id_projects_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_state": {
+      "name": "worker_state",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -666,6 +666,13 @@
       "when": 1783618861214,
       "tag": "0094_nasty_blue_blade",
       "breakpoints": true
+    },
+    {
+      "idx": 95,
+      "version": "7",
+      "when": 1783683432246,
+      "tag": "0095_blushing_nighthawk",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2303,6 +2303,13 @@ export const cloudflareInstallations = pgTable(
     // The Workers Observability destinations we created, keyed by signal:
     // { traces, logs, metrics } → Cloudflare destination slug.
     destinations: jsonb("destinations").$type<Record<string, string>>(),
+    // When true, a periodic reconcile keeps every Worker in the account wired to
+    // our destinations — including workers created, recreated, or renamed after
+    // connect (which come up unwired and would otherwise go dark). Default on:
+    // connect already wires everything once, so "on" preserves that intent and
+    // makes it durable. Off = the account owner manages wiring manually via the
+    // Workers list.
+    autoWire: boolean("auto_wire").notNull().default(true),
     installedByUserId: uuid("installed_by_user_id").references(() => users.id, {
       onDelete: "set null",
     }),


### PR DESCRIPTION
Makes the Cloudflare connector self-healing: surface the account's Workers in settings, let the user wire/unwire them, and keep them wired automatically.

## Workers list + manual wiring
A Workers section in the Cloudflare settings card lists every Worker in the connected account with a **Streaming / Not wired** state, plus per-Worker **Wire / Unwire** and a **Wire all** button. This is where a Worker that went dark (created/recreated/renamed after connect, so unwired) becomes visible and gets fixed in one click.

## Auto-wire + reconcile (keeps it wired)
- A persisted per-installation **`auto_wire`** flag (default on; migration `0095` backfills existing installs). The card shows a toggle; enabling runs one immediate wire pass. When on, the manual controls hide and the list is status-only — a periodic reconcile manages wiring; when off, wiring is manual.
- An **hourly reconcile job** in the worker: for each auto-wire install it refreshes the access token under the shared per-installation advisory lock when near expiry, then re-runs the idempotent wire pass — picking up new/recreated/renamed/drifted Workers. Hourly because the cadence is the max data-loss window for a newly-unwired Worker (no backfill for the dark period). Installs with no usable grant are skipped (need reconnect); a persist failure aborts the pass, a per-install upstream failure is isolated.
- The Workers-Observability wiring + script client moved into `@superlog/cloudflare` so the worker and api share one implementation (new `reconcileWorkerWiring`); the api re-exports the rest. The per-installation advisory-lock key is centralized in one helper shared by both worker jobs and matching the api's on-demand refresh.

## Review fixes
- Disable all Worker wiring controls while any wiring mutation is in flight, so overlapping PATCHes can't race to a nondeterministic final state.
- Strict scripts-list path for the interactive routes: a failed list surfaces as a reconnect/upstream error instead of an empty-looking account (the background reconcile stays tolerant and just retries next hour).
- Key the workers query by `accountId` as well as `projectId`, so a same-project reconnect to a different account can't briefly show the previous account's Workers.

## Tests
`@superlog/cloudflare` 10 (wiring/reconcile incl. list-failure), api cloudflare-service 21, worker cloudflare 11 (reconciler + refresher). Typechecks clean across api/worker/web/cloudflare.

## Operator note
Auto-wire and reconcile only exercise a live grant, so this depends on the token-refresh work already landed: the OAuth client must permit the refresh_token grant with a long grant-session duration, and existing installs need one reconnect to mint a refresh token.