### PR TITLE
Add toggleable facets to logs and traces

### DIFF
--- a/apps/web/src/Explore.tsx
+++ b/apps/web/src/Explore.tsx
@@ -14,6 +14,8 @@ import {
 } from "recharts";
 import { LogDrawer } from "./LogDetail.tsx";
 import { TraceDrawer } from "./TraceDetail.tsx";
+import { ExploreFacets, SEVERITY_OPTIONS, STATUS_OPTIONS } from "./ExploreFacets.tsx";
+import { facetDisplayName } from "./FacetValues.tsx";
 import {
   type CloudResourceRow,
   type ExploreFilter,
@@ -50,7 +52,7 @@ import {
   rangeFromSeconds,
 } from "./design/RangePicker.tsx";
 import { ScrollArea } from "./design/scroll-area.tsx";
-import { Btn, Chip, Input, Label, ShortcutKey, Tile } from "./design/ui.tsx";
+import { Btn, Chip, Input, ShortcutKey, Tile } from "./design/ui.tsx";
 import { addAttrFilter } from "./exploreAttrFilter.ts";
 import { tracer } from "./instrumentation.ts";
 import {
@@ -81,9 +83,7 @@ function logRowKey(log: LogRow): string {
 export function Explore() {
   const me = useMe();
   if (me.isLoading) {
-    return (
-      <div className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted">loading…</div>
-    );
+    return <div className="font-sans text-[12px] text-muted">Loading…</div>;
   }
   if (me.error || !me.data || !me.data.project) {
     return (
@@ -392,35 +392,48 @@ function ExploreInner({ projectId }: { projectId: string }) {
           </Tile>
         </>
       ) : (
-        <>
-          <ChartPanel
+        <div className="grid items-start gap-4 xl:grid-cols-[240px_minmax(0,1fr)]">
+          <ExploreFacets
             projectId={projectId}
-            filter={filter}
-            source={source}
-            groupBy={groupBy}
-            onGroupByChange={setGroupBy}
-            range={range}
-          />
-          <ListPanel
-            projectId={projectId}
-            filter={filter}
-            source={source}
-            limit={limit}
-            onLoadMore={() => setLimit((l) => Math.min(l + 100, 500))}
             attrs={attrs}
             onAttrsChange={setAttrs}
             range={range}
-            metricName={metricName}
-            tracesView={tracesView}
-            onTracesViewChange={setTracesView}
-            onSelectTrace={openTrace}
-            onSelectLog={openLog}
+            source={source}
             severity={severity}
             onSeverityChange={setSeverity}
             statusCode={statusCode}
             onStatusCodeChange={setStatusCode}
           />
-        </>
+          <div className="min-w-0 space-y-4">
+            <ChartPanel
+              projectId={projectId}
+              filter={filter}
+              source={source}
+              groupBy={groupBy}
+              onGroupByChange={setGroupBy}
+              range={range}
+            />
+            <ListPanel
+              projectId={projectId}
+              filter={filter}
+              source={source}
+              limit={limit}
+              onLoadMore={() => setLimit((l) => Math.min(l + 100, 500))}
+              attrs={attrs}
+              onAttrsChange={setAttrs}
+              range={range}
+              metricName={metricName}
+              tracesView={tracesView}
+              onTracesViewChange={setTracesView}
+              onSelectTrace={openTrace}
+              onSelectLog={openLog}
+              severity={severity}
+              onSeverityChange={setSeverity}
+              statusCode={statusCode}
+              onStatusCodeChange={setStatusCode}
+            />
+          </div>
+        </div>
       )}
       <TraceDrawer
         projectId={projectId}
@@ -675,9 +688,9 @@ function FilterPill({
       type="button"
       onClick={onRemove}
       title="remove"
-      className="inline-flex h-8 items-center gap-1.5 rounded-md bg-accent-soft px-2.5 font-mono text-[12px] tabular-nums text-accent transition-colors hover:brightness-110"
+      className="inline-flex h-8 items-center gap-1.5 rounded-md bg-accent-soft px-2.5 font-sans text-[12px] tabular-nums text-accent transition-colors hover:brightness-110"
     >
-      <span className="opacity-70">{label}</span>
+      <span className="opacity-70">{facetDisplayName(label)}</span>
       <span>=</span>
       <span>{value}</span>
       <span className="ml-1 opacity-60">×</span>
@@ -801,14 +814,6 @@ function FilterBar({
     </div>
   );
 }
-
-const SEVERITY_OPTIONS = ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"];
-
-const STATUS_OPTIONS: { value: string; label: string }[] = [
-  { value: "STATUS_CODE_OK", label: "OK" },
-  { value: "STATUS_CODE_ERROR", label: "ERROR" },
-  { value: "STATUS_CODE_UNSET", label: "UNSET" },
-];
 
 const STATUS_LABEL_BY_VALUE: Record<string, string> = Object.fromEntries(
   STATUS_OPTIONS.map((o) => [o.value, o.label]),
@@ -1685,7 +1690,7 @@ function KeyboardSelect({
             onListKey(e);
           }
         }}
-        className="inline-flex h-8 items-center gap-2 rounded-md border border-border bg-surface pl-2.5 pr-1.5 font-mono text-[12px] text-fg transition-colors hover:border-border-strong"
+        className="inline-flex h-8 items-center gap-2 rounded-md border border-border bg-surface pl-2.5 pr-1.5 font-sans text-[12px] text-fg transition-colors hover:border-border-strong"
       >
         {triggerLabel && <span className="font-sans text-fg">{triggerLabel}:</span>}
         <span className="truncate text-fg">{selectedLabel}</span>
@@ -1767,12 +1772,12 @@ export function GroupBySelect({
   );
   const options = useMemo<KeyboardSelectOption[]>(() => {
     const out: KeyboardSelectOption[] = [
-      { value: "", label: "none" },
-      { value: "service.name", label: "service.name" },
+      { value: "", label: "None" },
+      { value: "service.name", label: "Service name" },
     ];
     for (const k of keys.data ?? []) {
       if (k.key === "service.name") continue;
-      out.push({ value: k.key, label: k.key });
+      out.push({ value: k.key, label: facetDisplayName(k.key) });
     }
     return out;
   }, [keys.data]);
@@ -1783,14 +1788,14 @@ export function GroupBySelect({
         ariaLabel="group by"
         shortcut={shortcut || undefined}
         value={value}
-        placeholder="none"
+        placeholder="None"
         triggerLabel={triggerLabel}
         options={options}
         searchable
         searchPlaceholder="Search attributes…"
         onChange={onChange}
       />
-      {step && <span className="font-mono text-[10px] text-subtle">step {step.toLowerCase()}</span>}
+      {step && <span className="font-sans text-[10px] text-subtle">Step {step.toLowerCase()}</span>}
     </div>
   );
 }
@@ -1847,7 +1852,7 @@ function ChartPanel({
     <Tile>
       {showControls && (
         <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
-          <Label>chart</Label>
+          <span className="font-sans text-[12px] font-medium text-subtle">Chart</span>
           <GroupBySelect
             projectId={projectId}
             range={range}
@@ -1860,8 +1865,8 @@ function ChartPanel({
       )}
       <div className="opacity-50">
         {countSeries.isLoading ? (
-          <div className="flex h-14 items-center justify-center font-mono text-[11px] text-subtle">
-            loading…
+          <div className="flex h-14 items-center justify-center font-sans text-[11px] text-subtle">
+            Loading…
           </div>
         ) : countSeries.data && countSeries.data.rows.length > 0 ? (
           <TimeseriesChart
@@ -1871,8 +1876,8 @@ function ChartPanel({
             step={countSeries.data.step}
           />
         ) : (
-          <div className="flex h-14 items-center justify-center font-mono text-[11px] text-subtle">
-            no data
+          <div className="flex h-14 items-center justify-center font-sans text-[11px] text-subtle">
+            No data
           </div>
         )}
       </div>
@@ -2086,7 +2091,7 @@ const TOOLTIP_STYLE = {
     background: "#161618",
     border: "1px solid rgba(255,255,255,0.12)",
     borderRadius: 6,
-    fontFamily: "ui-monospace, monospace",
+    fontFamily: "ui-sans-serif, system-ui, sans-serif",
     fontSize: 11,
     padding: "6px 10px",
   },
@@ -2188,11 +2193,11 @@ function fmtBucketTime(s: string): string {
 const AXIS_TICK_STYLE = {
   fill: "#6b7280",
   fontSize: 9,
-  fontFamily: "ui-monospace, monospace",
+  fontFamily: "ui-sans-serif, system-ui, sans-serif",
 };
 const LEGEND_STYLE = {
   fontSize: 10,
-  fontFamily: "ui-monospace, monospace",
+  fontFamily: "ui-sans-serif, system-ui, sans-serif",
   paddingTop: 16,
 };
 
@@ -2500,8 +2505,8 @@ function ListPanel({
                 <SegmentedToggle
                   value={tracesView}
                   options={[
-                    { value: "traces", label: "traces" },
-                    { value: "spans", label: "spans" },
+                    { value: "traces", label: "Traces" },
+                    { value: "spans", label: "Spans" },
                   ]}
                   onChange={(v) => onTracesViewChange(v as TracesView)}
                 />
@@ -2512,9 +2517,7 @@ function ListPanel({
       )}
       {q.isFetching && !initialLoading && (
         <div className="flex items-center justify-end border-b border-border px-5 py-1.5">
-          <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-subtle">
-            loading…
-          </span>
+          <span className="font-sans text-[11px] text-subtle">Loading…</span>
         </div>
       )}
       <div className="overflow-auto">
@@ -2536,11 +2539,11 @@ function ListPanel({
         )}
       </div>
       <div className="flex items-center justify-between border-t border-border px-5 py-3">
-        <span className="font-mono text-[11px] text-subtle">
-          showing {q.data?.length ?? 0} (limit {limit})
+        <span className="font-sans text-[11px] text-subtle">
+          Showing {q.data?.length ?? 0} (Limit {limit})
         </span>
         <Btn variant="secondary" size="sm" onClick={onLoadMore} disabled={limit >= 500}>
-          load more
+          Load more
         </Btn>
       </div>
     </Tile>
@@ -2556,17 +2559,17 @@ export function LogsTable({
 }) {
   if (rows.length === 0) {
     return (
-      <div className="px-5 py-8 text-center font-mono text-[11px] text-subtle">no results</div>
+      <div className="px-5 py-8 text-center font-sans text-[11px] text-subtle">No results</div>
     );
   }
   return (
     <table className="w-full border-collapse font-mono text-[12px]">
-      <thead>
+      <thead className="font-sans">
         <tr className="text-left text-subtle">
-          <th className="px-5 py-2 font-normal">timestamp</th>
-          <th className="px-5 py-2 font-normal">service</th>
-          <th className="px-5 py-2 font-normal">sev</th>
-          <th className="px-5 py-2 font-normal">body</th>
+          <th className="px-5 py-2 font-normal">Timestamp</th>
+          <th className="px-5 py-2 font-normal">Service</th>
+          <th className="px-5 py-2 font-normal">Severity</th>
+          <th className="px-5 py-2 font-normal">Body</th>
         </tr>
       </thead>
       <tbody>
@@ -2610,9 +2613,9 @@ function SeverityCell({ severity }: { severity: string }) {
           : "bg-success/15 text-success";
   return (
     <span
-      className={`inline-flex items-center rounded-sm px-2 py-0.5 font-mono text-[11px] tabular-nums ${cls}`}
+      className={`inline-flex items-center rounded-sm px-2 py-0.5 font-sans text-[11px] tabular-nums ${cls}`}
     >
-      {s || "—"}
+      {s ? facetDisplayName(s) : "—"}
     </span>
   );
 }
@@ -2639,18 +2642,18 @@ export function TracesTable({
 }) {
   if (rows.length === 0) {
     return (
-      <div className="px-5 py-8 text-center font-mono text-[11px] text-subtle">no results</div>
+      <div className="px-5 py-8 text-center font-sans text-[11px] text-subtle">No results</div>
     );
   }
   return (
     <table className="w-full border-collapse font-mono text-[12px]">
-      <thead>
+      <thead className="font-sans">
         <tr className="text-left text-subtle">
-          <th className="px-5 py-2 font-normal">timestamp</th>
-          <th className="px-5 py-2 font-normal">service</th>
-          <th className="px-5 py-2 font-normal">span</th>
-          <th className="px-5 py-2 font-normal">status</th>
-          <th className="px-5 py-2 text-right font-normal">ms</th>
+          <th className="px-5 py-2 font-normal">Timestamp</th>
+          <th className="px-5 py-2 font-normal">Service</th>
+          <th className="px-5 py-2 font-normal">Span</th>
+          <th className="px-5 py-2 font-normal">Status</th>
+          <th className="px-5 py-2 text-right font-normal">Ms</th>
         </tr>
       </thead>
       <tbody>
@@ -2689,20 +2692,20 @@ export function TracesAggregatedTable({
 }) {
   if (rows.length === 0) {
     return (
-      <div className="px-5 py-8 text-center font-mono text-[11px] text-subtle">no results</div>
+      <div className="px-5 py-8 text-center font-sans text-[11px] text-subtle">No results</div>
     );
   }
   return (
     <table className="w-full border-collapse font-mono text-[12px]">
-      <thead>
+      <thead className="font-sans">
         <tr className="text-left text-subtle">
-          <th className="px-5 py-2 font-normal">started</th>
-          <th className="px-5 py-2 font-normal">service</th>
-          <th className="px-5 py-2 font-normal">root span</th>
-          <th className="px-5 py-2 font-normal">status</th>
-          <th className="px-5 py-2 text-right font-normal">spans</th>
-          <th className="px-5 py-2 text-right font-normal">errors</th>
-          <th className="px-5 py-2 text-right font-normal">ms</th>
+          <th className="px-5 py-2 font-normal">Started</th>
+          <th className="px-5 py-2 font-normal">Service</th>
+          <th className="px-5 py-2 font-normal">Root span</th>
+          <th className="px-5 py-2 font-normal">Status</th>
+          <th className="px-5 py-2 text-right font-normal">Spans</th>
+          <th className="px-5 py-2 text-right font-normal">Errors</th>
+          <th className="px-5 py-2 text-right font-normal">Ms</th>
         </tr>
       </thead>
       <tbody>
@@ -2814,7 +2817,7 @@ export function SegmentedToggle({
           <button
             key={o.value}
             onClick={() => onChange(o.value)}
-            className={`h-7 px-3 font-mono text-[11px] tracking-tight transition-colors ${
+            className={`h-7 px-3 font-sans text-[11px] tracking-tight transition-colors ${
               active ? "bg-accent text-accent-ink" : "text-muted hover:text-fg"
             }`}
           >

--- a/apps/web/src/ExploreFacets.test.tsx
+++ b/apps/web/src/ExploreFacets.test.tsx
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { FacetValues, facetDisplayName } from "./FacetValues.tsx";
+
+test("facetDisplayName turns scoped telemetry keys into capitalized labels", () => {
+  assert.equal(facetDisplayName("resource.service.name"), "Service name");
+  assert.equal(facetDisplayName("span.http.request.method"), "Http request method");
+  assert.equal(facetDisplayName("log.exception_type"), "Exception type");
+});
+
+test("facet values expose toggle state and event counts", () => {
+  const html = renderToStaticMarkup(
+    <FacetValues
+      facetLabel="service.name"
+      values={[
+        { value: "api", label: "api", count: 42 },
+        { value: "worker", label: "worker", count: 7 },
+      ]}
+      selectedValues={new Set(["api"])}
+      onToggle={() => {}}
+    />,
+  );
+
+  assert.match(html, /type="checkbox"/);
+  assert.match(html, /aria-label="service\.name: api"/);
+  assert.match(html, /checked=""/);
+  assert.match(html, />42</);
+  assert.equal((html.match(/type="checkbox"/g) ?? []).length, 2);
+});

--- a/apps/web/src/ExploreFacets.test.tsx
+++ b/apps/web/src/ExploreFacets.test.tsx
@@ -2,12 +2,20 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { FacetValues, facetDisplayName } from "./FacetValues.tsx";
+import { FacetValues, facetDisplayName, facetMatchesQuery } from "./FacetValues.tsx";
 
 test("facetDisplayName turns scoped telemetry keys into capitalized labels", () => {
-  assert.equal(facetDisplayName("resource.service.name"), "Service name");
-  assert.equal(facetDisplayName("span.http.request.method"), "Http request method");
-  assert.equal(facetDisplayName("log.exception_type"), "Exception type");
+  assert.equal(facetDisplayName("resource.service.name"), "Resource · Service name");
+  assert.equal(facetDisplayName("span.http.request.method"), "Span · Http request method");
+  assert.equal(facetDisplayName("log.exception_type"), "Log · Exception type");
+  assert.equal(facetDisplayName("service.name"), "Service name");
+});
+
+test("facetMatchesQuery finds the words users see in a humanized facet label", () => {
+  assert.equal(facetMatchesQuery("resource.service.name", "service name"), true);
+  assert.equal(facetMatchesQuery("resource.service.name", "resource service"), true);
+  assert.equal(facetMatchesQuery("span.http.request.method", "http request"), true);
+  assert.equal(facetMatchesQuery("span.http.request.method", "log request"), false);
 });
 
 test("facet values expose toggle state and event counts", () => {

--- a/apps/web/src/ExploreFacets.test.tsx
+++ b/apps/web/src/ExploreFacets.test.tsx
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { FacetValues, facetDisplayName, facetMatchesQuery } from "./FacetValues.tsx";
+import {
+  FacetValues,
+  facetDisplayName,
+  facetMatchesQuery,
+  normalizeFacetQuery,
+} from "./FacetValues.tsx";
 
 test("facetDisplayName turns scoped telemetry keys into capitalized labels", () => {
   assert.equal(facetDisplayName("resource.service.name"), "Resource · Service name");
@@ -16,6 +21,11 @@ test("facetMatchesQuery finds the words users see in a humanized facet label", (
   assert.equal(facetMatchesQuery("resource.service.name", "resource service"), true);
   assert.equal(facetMatchesQuery("span.http.request.method", "http request"), true);
   assert.equal(facetMatchesQuery("span.http.request.method", "log request"), false);
+});
+
+test("normalizeFacetQuery treats whitespace-only input as no search", () => {
+  assert.equal(normalizeFacetQuery("   "), "");
+  assert.equal(normalizeFacetQuery("  service name  "), "service name");
 });
 
 test("facet values expose toggle state and event counts", () => {

--- a/apps/web/src/ExploreFacets.test.tsx
+++ b/apps/web/src/ExploreFacets.test.tsx
@@ -23,9 +23,10 @@ test("facetMatchesQuery finds the words users see in a humanized facet label", (
   assert.equal(facetMatchesQuery("span.http.request.method", "log request"), false);
 });
 
-test("normalizeFacetQuery treats whitespace-only input as no search", () => {
+test("normalizeFacetQuery treats punctuation-only input as no search", () => {
   assert.equal(normalizeFacetQuery("   "), "");
-  assert.equal(normalizeFacetQuery("  service name  "), "service name");
+  assert.equal(normalizeFacetQuery("---"), "");
+  assert.equal(normalizeFacetQuery("  Service.Name  "), "service name");
 });
 
 test("facet values expose toggle state and event counts", () => {

--- a/apps/web/src/ExploreFacets.tsx
+++ b/apps/web/src/ExploreFacets.tsx
@@ -1,6 +1,11 @@
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
-import { type FacetValue, FacetValues, facetDisplayName } from "./FacetValues.tsx";
+import {
+  type FacetValue,
+  FacetValues,
+  facetDisplayName,
+  facetMatchesQuery,
+} from "./FacetValues.tsx";
 import {
   type AttributeKey,
   type ExploreRange,
@@ -56,9 +61,8 @@ export function ExploreFacets({
   }, [primaryFacet]);
 
   const visibleKeys = useMemo(() => {
-    const normalized = query.trim().toLowerCase();
-    if (!normalized) return keys.data ?? [];
-    return (keys.data ?? []).filter((key) => key.key.toLowerCase().includes(normalized));
+    if (!query.trim()) return keys.data ?? [];
+    return (keys.data ?? []).filter((key) => facetMatchesQuery(key.key, query));
   }, [keys.data, query]);
 
   const selectedAttributeValues = useMemo(() => {

--- a/apps/web/src/ExploreFacets.tsx
+++ b/apps/web/src/ExploreFacets.tsx
@@ -1,0 +1,267 @@
+import type React from "react";
+import { useEffect, useMemo, useState } from "react";
+import { type FacetValue, FacetValues, facetDisplayName } from "./FacetValues.tsx";
+import {
+  type AttributeKey,
+  type ExploreRange,
+  type ResourceAttr,
+  useExploreAttributeKeys,
+  useExploreAttributeValues,
+} from "./api.ts";
+import { toggleAttrFilter, toggleSingleFacetValue } from "./exploreAttrFilter.ts";
+
+export const SEVERITY_OPTIONS = ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"];
+
+export const STATUS_OPTIONS: { value: string; label: string }[] = [
+  { value: "STATUS_CODE_OK", label: "Ok" },
+  { value: "STATUS_CODE_ERROR", label: "Error" },
+  { value: "STATUS_CODE_UNSET", label: "Unset" },
+];
+
+type FacetSource = "logs" | "traces";
+
+export function ExploreFacets({
+  projectId,
+  range,
+  source,
+  attrs,
+  onAttrsChange,
+  severity = "",
+  onSeverityChange,
+  statusCode = "",
+  onStatusCodeChange,
+}: {
+  projectId: string;
+  range: ExploreRange;
+  source: FacetSource;
+  attrs: ResourceAttr[];
+  onAttrsChange: (attrs: ResourceAttr[]) => void;
+  severity?: string;
+  onSeverityChange: (value: string) => void;
+  statusCode?: string;
+  onStatusCodeChange: (value: string) => void;
+}) {
+  const primaryFacet = source === "logs" ? "severity" : "status";
+  const [expandedFacet, setExpandedFacet] = useState(primaryFacet);
+  const [query, setQuery] = useState("");
+  const keys = useExploreAttributeKeys(projectId, range, source);
+  const activeAttributeKey = expandedFacet.startsWith("attr:")
+    ? expandedFacet.slice("attr:".length)
+    : undefined;
+  const values = useExploreAttributeValues(projectId, activeAttributeKey, range, source);
+
+  useEffect(() => {
+    setExpandedFacet(primaryFacet);
+    setQuery("");
+  }, [primaryFacet]);
+
+  const visibleKeys = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return keys.data ?? [];
+    return (keys.data ?? []).filter((key) => key.key.toLowerCase().includes(normalized));
+  }, [keys.data, query]);
+
+  const selectedAttributeValues = useMemo(() => {
+    if (!activeAttributeKey) return new Set<string>();
+    return new Set(
+      attrs
+        .filter((attr) => attr.key === activeAttributeKey && (attr.op ?? "eq") === "eq")
+        .map((attr) => attr.value),
+    );
+  }, [activeAttributeKey, attrs]);
+
+  const attributeValues = useMemo(() => {
+    const rows: FacetValue[] = (values.data ?? []).map((value) => ({
+      value: value.value,
+      label: value.value,
+      count: value.count,
+    }));
+    const loaded = new Set(rows.map((row) => row.value));
+    for (const selected of selectedAttributeValues) {
+      if (!loaded.has(selected)) rows.unshift({ value: selected, label: selected });
+    }
+    return rows;
+  }, [selectedAttributeValues, values.data]);
+
+  const toggleExpanded = (facet: string) => {
+    setExpandedFacet((current) => (current === facet ? "" : facet));
+  };
+
+  return (
+    <aside
+      aria-label="Explore facets"
+      className="overflow-hidden rounded-lg border border-border bg-surface xl:sticky xl:top-4"
+    >
+      <div className="border-b border-border px-3 pb-3 pt-3.5">
+        <div className="mb-2.5 flex items-center justify-between gap-2">
+          <h2 className="text-[12px] font-medium text-fg">Facets</h2>
+          <span className="font-sans text-[10px] text-subtle">{keys.data?.length ?? 0} Fields</span>
+        </div>
+        <div className="relative">
+          <svg
+            aria-hidden
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            className="pointer-events-none absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-subtle"
+          >
+            <title>Search facets</title>
+            <circle cx="11" cy="11" r="7" />
+            <path d="m20 20-3.5-3.5" />
+          </svg>
+          <input
+            type="search"
+            aria-label="Search facets"
+            placeholder="Find a facet…"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            className="h-7 w-full rounded-sm border border-border bg-surface-2 pl-7 pr-2 text-[11.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none"
+          />
+        </div>
+      </div>
+
+      <div className="max-h-[min(68vh,720px)] overflow-y-auto py-1.5">
+        {!query && source === "logs" ? (
+          <FacetGroup
+            id="severity"
+            label="Severity"
+            expanded={expandedFacet === "severity"}
+            selectedCount={severity ? 1 : 0}
+            onToggle={() => toggleExpanded("severity")}
+          >
+            <FacetValues
+              facetLabel="Severity"
+              values={SEVERITY_OPTIONS.map((value) => ({
+                value,
+                label: facetDisplayName(value),
+              }))}
+              selectedValues={new Set(severity ? [severity] : [])}
+              onToggle={(value) => onSeverityChange(toggleSingleFacetValue(severity, value))}
+            />
+          </FacetGroup>
+        ) : null}
+
+        {!query && source === "traces" ? (
+          <FacetGroup
+            id="status"
+            label="Status"
+            expanded={expandedFacet === "status"}
+            selectedCount={statusCode ? 1 : 0}
+            onToggle={() => toggleExpanded("status")}
+          >
+            <FacetValues
+              facetLabel="Status"
+              values={STATUS_OPTIONS}
+              selectedValues={new Set(statusCode ? [statusCode] : [])}
+              onToggle={(value) => onStatusCodeChange(toggleSingleFacetValue(statusCode, value))}
+            />
+          </FacetGroup>
+        ) : null}
+
+        {keys.isLoading ? (
+          <div className="px-4 py-5 font-sans text-[11px] text-subtle">Loading facets…</div>
+        ) : visibleKeys.length === 0 ? (
+          <div className="px-4 py-5 text-[11px] text-subtle">
+            {query ? "No matching facets." : "No attributes in this window."}
+          </div>
+        ) : (
+          visibleKeys.map((key) => {
+            const facetId = `attr:${key.key}`;
+            const selectedCount = selectedCountFor(attrs, key.key);
+            return (
+              <FacetGroup
+                key={key.key}
+                id={facetId}
+                label={facetDisplayName(key.key)}
+                count={key.count}
+                selectedCount={selectedCount}
+                expanded={expandedFacet === facetId}
+                onToggle={() => toggleExpanded(facetId)}
+              >
+                {values.isLoading ? (
+                  <div className="px-4 pb-3 pt-1 font-sans text-[11px] text-subtle">
+                    Loading values…
+                  </div>
+                ) : attributeValues.length === 0 ? (
+                  <div className="px-4 pb-3 pt-1 text-[11px] text-subtle">
+                    No values in this window.
+                  </div>
+                ) : (
+                  <FacetValues
+                    facetLabel={facetDisplayName(key.key)}
+                    values={attributeValues}
+                    selectedValues={selectedAttributeValues}
+                    onToggle={(value) => onAttrsChange(toggleAttrFilter(attrs, key.key, value))}
+                  />
+                )}
+              </FacetGroup>
+            );
+          })
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function selectedCountFor(attrs: ResourceAttr[], key: string): number {
+  return attrs.filter((attr) => attr.key === key && (attr.op ?? "eq") === "eq").length;
+}
+
+function FacetGroup({
+  id,
+  label,
+  count,
+  selectedCount,
+  expanded,
+  onToggle,
+  children,
+}: {
+  id: string;
+  label: string;
+  count?: AttributeKey["count"];
+  selectedCount: number;
+  expanded: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  const panelId = `facet-${id.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+  return (
+    <section className="border-b border-border last:border-b-0">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-controls={panelId}
+        onClick={onToggle}
+        className="flex w-full items-center gap-2 px-3 py-2.5 text-left hover:bg-surface-2"
+      >
+        <svg
+          aria-hidden
+          viewBox="0 0 20 20"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          className={`h-3 w-3 shrink-0 text-subtle transition-transform ${
+            expanded ? "rotate-90" : ""
+          }`}
+        >
+          <title>{expanded ? `Collapse ${label}` : `Expand ${label}`}</title>
+          <path d="m7 4 6 6-6 6" />
+        </svg>
+        <span className="min-w-0 flex-1 truncate font-sans text-[11.5px] text-fg" title={label}>
+          {label}
+        </span>
+        {selectedCount > 0 ? (
+          <span className="grid min-w-4 place-items-center rounded-full bg-accent px-1 py-0.5 font-sans text-[9px] leading-none text-accent-ink">
+            {selectedCount}
+          </span>
+        ) : count !== undefined ? (
+          <span className="font-sans text-[9px] tabular-nums text-subtle">
+            {count.toLocaleString()}
+          </span>
+        ) : null}
+      </button>
+      {expanded ? <div id={panelId}>{children}</div> : null}
+    </section>
+  );
+}

--- a/apps/web/src/ExploreFacets.tsx
+++ b/apps/web/src/ExploreFacets.tsx
@@ -5,6 +5,7 @@ import {
   FacetValues,
   facetDisplayName,
   facetMatchesQuery,
+  normalizeFacetQuery,
 } from "./FacetValues.tsx";
 import {
   type AttributeKey,
@@ -54,6 +55,7 @@ export function ExploreFacets({
     ? expandedFacet.slice("attr:".length)
     : undefined;
   const values = useExploreAttributeValues(projectId, activeAttributeKey, range, source);
+  const normalizedQuery = normalizeFacetQuery(query);
 
   useEffect(() => {
     setExpandedFacet(primaryFacet);
@@ -61,9 +63,9 @@ export function ExploreFacets({
   }, [primaryFacet]);
 
   const visibleKeys = useMemo(() => {
-    if (!query.trim()) return keys.data ?? [];
-    return (keys.data ?? []).filter((key) => facetMatchesQuery(key.key, query));
-  }, [keys.data, query]);
+    if (!normalizedQuery) return keys.data ?? [];
+    return (keys.data ?? []).filter((key) => facetMatchesQuery(key.key, normalizedQuery));
+  }, [keys.data, normalizedQuery]);
 
   const selectedAttributeValues = useMemo(() => {
     if (!activeAttributeKey) return new Set<string>();
@@ -126,7 +128,7 @@ export function ExploreFacets({
       </div>
 
       <div className="max-h-[min(68vh,720px)] overflow-y-auto py-1.5">
-        {!query && source === "logs" ? (
+        {!normalizedQuery && source === "logs" ? (
           <FacetGroup
             id="severity"
             label="Severity"
@@ -146,7 +148,7 @@ export function ExploreFacets({
           </FacetGroup>
         ) : null}
 
-        {!query && source === "traces" ? (
+        {!normalizedQuery && source === "traces" ? (
           <FacetGroup
             id="status"
             label="Status"
@@ -167,7 +169,7 @@ export function ExploreFacets({
           <div className="px-4 py-5 font-sans text-[11px] text-subtle">Loading facets…</div>
         ) : visibleKeys.length === 0 ? (
           <div className="px-4 py-5 text-[11px] text-subtle">
-            {query ? "No matching facets." : "No attributes in this window."}
+            {normalizedQuery ? "No matching facets." : "No attributes in this window."}
           </div>
         ) : (
           visibleKeys.map((key) => {

--- a/apps/web/src/FacetValues.tsx
+++ b/apps/web/src/FacetValues.tsx
@@ -18,13 +18,17 @@ export function facetDisplayName(value: string): string {
   return `${scope} · ${label}`;
 }
 
+export function normalizeFacetQuery(query: string): string {
+  return query.trim();
+}
+
 export function facetMatchesQuery(key: string, query: string): boolean {
   const normalize = (value: string) =>
     value
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, " ")
       .trim();
-  const normalizedQuery = normalize(query);
+  const normalizedQuery = normalize(normalizeFacetQuery(query));
   if (!normalizedQuery) return true;
   return normalize(`${key} ${facetDisplayName(key)}`).includes(normalizedQuery);
 }

--- a/apps/web/src/FacetValues.tsx
+++ b/apps/web/src/FacetValues.tsx
@@ -7,12 +7,26 @@ export type FacetValue = {
 };
 
 export function facetDisplayName(value: string): string {
-  const words = value
-    .replace(/^(resource|span|log)\./, "")
+  const scoped = value.match(/^(resource|span|log)\.(.+)$/);
+  const words = (scoped?.[2] ?? value)
     .replace(/[._-]+/g, " ")
     .trim()
     .toLowerCase();
-  return words ? `${words[0]?.toUpperCase()}${words.slice(1)}` : value;
+  const label = words ? `${words[0]?.toUpperCase()}${words.slice(1)}` : value;
+  if (!scoped?.[1]) return label;
+  const scope = `${scoped[1][0]?.toUpperCase()}${scoped[1].slice(1)}`;
+  return `${scope} · ${label}`;
+}
+
+export function facetMatchesQuery(key: string, query: string): boolean {
+  const normalize = (value: string) =>
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, " ")
+      .trim();
+  const normalizedQuery = normalize(query);
+  if (!normalizedQuery) return true;
+  return normalize(`${key} ${facetDisplayName(key)}`).includes(normalizedQuery);
 }
 
 export function FacetValues({

--- a/apps/web/src/FacetValues.tsx
+++ b/apps/web/src/FacetValues.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+
+export type FacetValue = {
+  value: string;
+  label: string;
+  count?: number;
+};
+
+export function facetDisplayName(value: string): string {
+  const words = value
+    .replace(/^(resource|span|log)\./, "")
+    .replace(/[._-]+/g, " ")
+    .trim()
+    .toLowerCase();
+  return words ? `${words[0]?.toUpperCase()}${words.slice(1)}` : value;
+}
+
+export function FacetValues({
+  facetLabel,
+  values,
+  selectedValues,
+  onToggle,
+}: {
+  facetLabel: string;
+  values: FacetValue[];
+  selectedValues: ReadonlySet<string>;
+  onToggle: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-0.5 px-2 pb-2">
+      {values.map((item) => {
+        const selected = selectedValues.has(item.value);
+        return (
+          <label
+            key={item.value}
+            className={`flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left text-[11.5px] transition-colors ${
+              selected ? "bg-accent/10 text-fg" : "text-muted hover:bg-surface-2 hover:text-fg"
+            }`}
+          >
+            <input
+              type="checkbox"
+              aria-label={`${facetLabel}: ${item.label}`}
+              checked={selected}
+              onChange={() => onToggle(item.value)}
+              className="sr-only"
+            />
+            <span
+              aria-hidden
+              className={`grid h-3.5 w-3.5 shrink-0 place-items-center rounded-[3px] border ${
+                selected ? "border-accent bg-accent text-accent-ink" : "border-border-strong"
+              }`}
+            >
+              {selected ? "✓" : null}
+            </span>
+            <span className="min-w-0 flex-1 truncate font-sans" title={item.label}>
+              {item.label}
+            </span>
+            {item.count !== undefined ? (
+              <span className="shrink-0 font-sans text-[10px] tabular-nums text-subtle">
+                {item.count.toLocaleString()}
+              </span>
+            ) : null}
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/FacetValues.tsx
+++ b/apps/web/src/FacetValues.tsx
@@ -19,18 +19,16 @@ export function facetDisplayName(value: string): string {
 }
 
 export function normalizeFacetQuery(query: string): string {
-  return query.trim();
+  return query
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
 }
 
 export function facetMatchesQuery(key: string, query: string): boolean {
-  const normalize = (value: string) =>
-    value
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, " ")
-      .trim();
-  const normalizedQuery = normalize(normalizeFacetQuery(query));
+  const normalizedQuery = normalizeFacetQuery(query);
   if (!normalizedQuery) return true;
-  return normalize(`${key} ${facetDisplayName(key)}`).includes(normalizedQuery);
+  return normalizeFacetQuery(`${key} ${facetDisplayName(key)}`).includes(normalizedQuery);
 }
 
 export function FacetValues({

--- a/apps/web/src/exploreAttrFilter.test.ts
+++ b/apps/web/src/exploreAttrFilter.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { addAttrFilter, attrFilterKey } from "./exploreAttrFilter.ts";
+import {
+  addAttrFilter,
+  attrFilterKey,
+  toggleAttrFilter,
+  toggleSingleFacetValue,
+} from "./exploreAttrFilter.ts";
 
 test("attrFilterKey prefixes the key with its attribute scope", () => {
   assert.equal(attrFilterKey("resource", "service.name"), "resource.service.name");
@@ -43,4 +48,25 @@ test("addAttrFilter allows the same key with a different value", () => {
     { key: "resource.service.name", value: "api" },
     { key: "resource.service.name", value: "web" },
   ]);
+});
+
+test("toggleAttrFilter selects, replaces, and clears a facet value", () => {
+  const existing = [
+    { key: "resource.service.name", value: "api" },
+    { key: "resource.deployment.environment", value: "prod" },
+  ];
+
+  assert.deepEqual(toggleAttrFilter(existing, "resource.service.name", "web"), [
+    { key: "resource.deployment.environment", value: "prod" },
+    { key: "resource.service.name", value: "web" },
+  ]);
+  assert.deepEqual(toggleAttrFilter(existing, "resource.service.name", "api"), [
+    { key: "resource.deployment.environment", value: "prod" },
+  ]);
+});
+
+test("toggleSingleFacetValue selects, replaces, and clears a single-value facet", () => {
+  assert.equal(toggleSingleFacetValue("", "ERROR"), "ERROR");
+  assert.equal(toggleSingleFacetValue("WARN", "ERROR"), "ERROR");
+  assert.equal(toggleSingleFacetValue("ERROR", "ERROR"), "");
 });

--- a/apps/web/src/exploreAttrFilter.ts
+++ b/apps/web/src/exploreAttrFilter.ts
@@ -28,3 +28,25 @@ export function addAttrFilter(attrs: ResourceAttr[], key: string, value: string)
   if (alreadyPresent) return attrs;
   return [...attrs, { key, value }];
 }
+
+// Explore combines attribute filters with AND, so one facet can have only one
+// equality value without becoming contradictory (for example service=api AND
+// service=web). Selecting a different value replaces the equality selection;
+// selecting the active value clears it. Other facets and non-equality filters
+// stay untouched.
+export function toggleAttrFilter(
+  attrs: ResourceAttr[],
+  key: string,
+  value: string,
+): ResourceAttr[] {
+  const selected = attrs.some((a) => a.key === key && a.value === value && (a.op ?? "eq") === "eq");
+  const withoutFacetEquality = attrs.filter((a) => !(a.key === key && (a.op ?? "eq") === "eq"));
+  if (selected) return withoutFacetEquality;
+  return [...withoutFacetEquality, { key, value }];
+}
+
+// Severity and trace status are single-value URL facets. Clicking a different
+// value replaces the selection; clicking the active value clears it.
+export function toggleSingleFacetValue(current: string, next: string): string {
+  return current === next ? "" : next;
+}


### PR DESCRIPTION
## Summary

- add a searchable, collapsible facet sidebar to the logs and traces explorer
- support URL-backed severity, status, and attribute value toggles with lazy-loaded counts
- align explorer spacing, typography, table labels, and facet dividers

Attribute facets keep one equality value active at a time because Explore combines attribute filters with `AND`; choosing another value replaces the prior value instead of creating a contradictory query.

## Validation

- `pnpm exec tsx --test apps/web/src/exploreAttrFilter.test.ts apps/web/src/ExploreFacets.test.tsx`
- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web build`
- `pnpm worktree:verify`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a searchable, collapsible facet sidebar to Logs and Traces for faster filtering. Facet search now normalizes case and punctuation and matches humanized labels; severity/status and attribute toggles sync to the URL.

- New Features
  - Facet sidebar with search and collapse for logs and traces (`ExploreFacets`, `FacetValues`).
  - Logs: Severity facet. Traces: Status facet (Ok/Error/Unset).
  - Attribute facets with lazy value counts; selected value stays visible.
  - Single equality per attribute facet; picking a new value replaces the old, picking the same clears it.
  - Scope-aware facet labels via `facetDisplayName`; search matches these labels with normalized input.

- Refactors
  - Integrated sidebar into `Explore` two-column layout; aligned spacing and capitalization; switched to sans-serif UI text.
  - Added `toggleAttrFilter` and `toggleSingleFacetValue`; moved severity/status options into `ExploreFacets`.
  - Group By options and filter pills use humanized facet names.
  - Unified facet query normalization; punctuation-only input is treated as no search.

<sup>Written for commit 2a46740fbcf7f7937f5f8c62521c1bbc65f91280. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

