### PR TITLE
Incidents: add "resolve all recovery detected" button

### DIFF
--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -44,6 +44,7 @@ import {
   useIssues,
   useMe,
   useMergeIncidentPullRequest,
+  useResolveAllRecoveryDetected,
   useRestartAgentRun,
   useRetryPrDelivery,
   useSendIncidentChatMessage,
@@ -669,6 +670,7 @@ function IncidentsTab({ projectId }: { projectId: string }) {
   const [newInvestigationOpen, setNewInvestigationOpen] = useState(false);
   const { id: selectedId, openItem, closeItem } = useNav();
   const incidents = useIncidents(projectId, status);
+  const resolveAllRecovery = useResolveAllRecoveryDetected(projectId);
 
   // Group incidents by severity (most severe first), newest-seen first within
   // each group. Incidents where the autorecovery agent has detected recovery
@@ -756,9 +758,29 @@ function IncidentsTab({ projectId }: { projectId: string }) {
         <div className="space-y-6">
           {groups.map((group) => (
             <section key={group.key}>
-              <h3 className="mb-2 px-1 text-[11px] font-medium uppercase tracking-wide text-muted">
-                {group.label}
-              </h3>
+              <div className="mb-2 flex items-center justify-between px-1">
+                <h3 className="text-[11px] font-medium uppercase tracking-wide text-muted">
+                  {group.label}
+                </h3>
+                {group.key === "recovery" && (
+                  <Btn
+                    variant="secondary"
+                    size="sm"
+                    loading={resolveAllRecovery.isPending}
+                    onClick={() => {
+                      const targets = group.items
+                        .filter((r) => r.pendingResolutionProposal != null)
+                        .map((r) => ({
+                          incidentId: r.incident.id,
+                          proposalId: r.pendingResolutionProposal!.id,
+                        }));
+                      if (targets.length > 0) resolveAllRecovery.mutate(targets);
+                    }}
+                  >
+                    Resolve all {group.items.length}
+                  </Btn>
+                )}
+              </div>
               <div className="divide-y divide-border overflow-hidden rounded-2xl border border-border bg-surface">
                 {group.items.map((row) => (
                   <IncidentRow

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -781,6 +781,13 @@ function IncidentsTab({ projectId }: { projectId: string }) {
                   </Btn>
                 )}
               </div>
+              {group.key === "recovery" && resolveAllRecovery.isError && (
+                <div className="mb-2 px-1 text-[12px] text-danger">
+                  Couldn't resolve all incidents:{" "}
+                  {String(resolveAllRecovery.error).replace(/^Error:\s*/, "")}. Some may have
+                  resolved — refresh to see the current state.
+                </div>
+              )}
               <div className="divide-y divide-border overflow-hidden rounded-2xl border border-border bg-surface">
                 {group.items.map((row) => (
                   <IncidentRow

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -2476,7 +2476,12 @@ export function useResolveAllRecoveryDetected(projectId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (targets: { incidentId: string; proposalId: string }[]) => {
-      const results = await Promise.all(
+      // allSettled (not Promise.all) so every confirm finishes before we react
+      // — Promise.all would reject on the first failure while the remaining
+      // requests keep running in the background, letting a retry overlap the
+      // still-in-flight batch. Wait for the whole batch to quiesce, then rethrow
+      // the first unexpected failure so the mutation lands in its error state.
+      const results = await Promise.allSettled(
         targets.map(async (t) => {
           try {
             await fetcher<{ ok: true }>(
@@ -2492,7 +2497,11 @@ export function useResolveAllRecoveryDetected(projectId: string) {
           }
         }),
       );
-      const resolved = results.filter((r) => r === "resolved").length;
+      const failed = results.find((r) => r.status === "rejected");
+      if (failed) throw failed.reason;
+      const resolved = results.filter(
+        (r) => r.status === "fulfilled" && r.value === "resolved",
+      ).length;
       return { resolved, alreadyResolved: results.length - resolved };
     },
     onSuccess: (_data, targets) => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -2465,24 +2465,35 @@ export function useDecideResolutionProposal(projectId: string) {
 // incident's pending resolution proposal. There's no server-side bulk route —
 // we fan out to the same confirm endpoint the single-incident banner uses, so
 // each confirm still runs the full resolve + PR-close side effects and stays
-// race-safe (a proposal a teammate already decided comes back 409, which we
-// swallow via allSettled rather than failing the whole batch). Returns how
-// many confirms succeeded vs failed so the caller can surface a partial result.
+// race-safe. A proposal a teammate already decided comes back 409; that's the
+// one expected, benign outcome, so we count it as "already resolved" and keep
+// going. Any other failure (auth, 5xx, network) is unexpected — we rethrow so
+// the mutation lands in its error state instead of silently reporting success.
+// Returns how many confirms went through vs. were already resolved so the
+// caller can surface a partial result.
 export function useResolveAllRecoveryDetected(projectId: string) {
   const fetcher = useFetcher();
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (targets: { incidentId: string; proposalId: string }[]) => {
-      const results = await Promise.allSettled(
-        targets.map((t) =>
-          fetcher<{ ok: true }>(
-            `/api/projects/${projectId}/incidents/${t.incidentId}/resolution-proposals/${t.proposalId}/confirm`,
-            { method: "POST" },
-          ),
-        ),
+      const results = await Promise.all(
+        targets.map(async (t) => {
+          try {
+            await fetcher<{ ok: true }>(
+              `/api/projects/${projectId}/incidents/${t.incidentId}/resolution-proposals/${t.proposalId}/confirm`,
+              { method: "POST" },
+            );
+            return "resolved" as const;
+          } catch (err) {
+            if (err instanceof Error && err.message.startsWith("409:")) {
+              return "already" as const;
+            }
+            throw err;
+          }
+        }),
       );
-      const succeeded = results.filter((r) => r.status === "fulfilled").length;
-      return { succeeded, failed: results.length - succeeded };
+      const resolved = results.filter((r) => r === "resolved").length;
+      return { resolved, alreadyResolved: results.length - resolved };
     },
     onSuccess: (_data, targets) => {
       qc.invalidateQueries({ queryKey: ["incidents", projectId] });

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -2461,6 +2461,39 @@ export function useDecideResolutionProposal(projectId: string) {
   });
 }
 
+// Resolve every "recovery detected" incident in one click by confirming each
+// incident's pending resolution proposal. There's no server-side bulk route —
+// we fan out to the same confirm endpoint the single-incident banner uses, so
+// each confirm still runs the full resolve + PR-close side effects and stays
+// race-safe (a proposal a teammate already decided comes back 409, which we
+// swallow via allSettled rather than failing the whole batch). Returns how
+// many confirms succeeded vs failed so the caller can surface a partial result.
+export function useResolveAllRecoveryDetected(projectId: string) {
+  const fetcher = useFetcher();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (targets: { incidentId: string; proposalId: string }[]) => {
+      const results = await Promise.allSettled(
+        targets.map((t) =>
+          fetcher<{ ok: true }>(
+            `/api/projects/${projectId}/incidents/${t.incidentId}/resolution-proposals/${t.proposalId}/confirm`,
+            { method: "POST" },
+          ),
+        ),
+      );
+      const succeeded = results.filter((r) => r.status === "fulfilled").length;
+      return { succeeded, failed: results.length - succeeded };
+    },
+    onSuccess: (_data, targets) => {
+      qc.invalidateQueries({ queryKey: ["incidents", projectId] });
+      for (const t of targets) {
+        qc.invalidateQueries({ queryKey: ["incident", projectId, t.incidentId] });
+        qc.invalidateQueries({ queryKey: ["incident-investigation", projectId, t.incidentId] });
+      }
+    },
+  });
+}
+
 export function useUpdateIncident(projectId: string) {
   const fetcher = useFetcher();
   const qc = useQueryClient();


### PR DESCRIPTION
## What

The incidents list splits incidents that have a pending autorecovery resolution proposal into a trailing **"Recovery detected"** group. Confirming each proposal one at a time via the per-incident banner is tedious when several incidents recover at once, so this adds a **"Resolve all N"** button to that group's section header.

## How

- New `useResolveAllRecoveryDetected(projectId)` mutation in `apps/web/src/api.ts`. It fans out to the existing per-incident confirm endpoint (`POST /api/projects/:projectId/incidents/:incidentId/resolution-proposals/:proposalId/confirm`) — one call per incident — rather than adding a new bulk route. So each confirm still runs the full resolve + PR-close side effects and stays race-safe: a proposal a teammate already decided comes back 409 and is swallowed via `Promise.allSettled` instead of failing the whole batch. Returns `{ succeeded, failed }` and invalidates the incident list + each incident's queries.
- `apps/web/src/Issues.tsx`: the "Recovery detected" group header now renders a secondary `sm` **"Resolve all N"** button (only for `group.key === "recovery"`). It builds the `{incidentId, proposalId}` targets from the group's items and calls the mutation.

"Recovery detected" is a derived UI label, not a stored status — it's an `open` incident with an undecided resolution proposal. Confirming the proposal is what flips it to `resolved`, so bulk-confirming is the correct semantics for "resolve all recovery detected."

## Notes

- No confirmation dialog before the bulk resolve — matches the single-incident banner, which confirms on one click.
- No new backend code; reuses the race-safe `confirmResolutionProposal` transaction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Resolve all N" button to the Incidents list’s Recovery detected group to bulk-confirm autorecovery proposals and resolve multiple incidents with one click. Uses the existing confirm endpoint to keep side effects and race safety, waits for all confirms to finish, and surfaces unexpected failures with an inline error.

- **New Features**
  - Added `useResolveAllRecoveryDetected(projectId)` that fans out to the per-incident confirm endpoint, waits for all requests to settle, treats `409` as "already resolved," rethrows other errors, returns `{ resolved, alreadyResolved }`, and invalidates incidents and per-incident queries.
  - The Recovery detected group header shows a "Resolve all N" button and, on error, an inline message so partial/total failures are visible.
  - No confirmation dialog; matches the single-incident flow.

<sup>Written for commit 88f78516b4ba68c949bb191c8d44a2e93458c782. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

