### PR TITLE
worker: exclude awaiting_human time from the investigation wall-clock budget

### DIFF
--- a/apps/worker/src/agent-runs/status.test.ts
+++ b/apps/worker/src/agent-runs/status.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   agentRunErrorLogMeta,
+  awaitingHumanSecondsFromEvents,
   exceededWallClockBudget,
   isTransientError,
   WALL_CLOCK_MULTIPLIER,
@@ -71,6 +72,103 @@ test("exceededWallClockBudget fires when wall-clock age exceeds maxRuntimeMinute
   assert.equal(
     exceededWallClockBudget({ startedAt, now: justOver, maxRuntimeMinutes }),
     true,
+  );
+});
+
+test("exceededWallClockBudget excludes time parked awaiting a human", () => {
+  // The prod case: agent diagnosed in ~2 min, called ask_human, parked for
+  // ~22h, then the human replied and it resumed. Without excluding the parked
+  // time the resumed run is instantly reaped even though it barely ran.
+  const startedAt = new Date("2026-07-09T00:00:00Z");
+  const maxRuntimeMinutes = 90;
+  const budgetMs = WALL_CLOCK_MULTIPLIER * maxRuntimeMinutes * 60_000; // 6h
+  // 22h later, but 21h 58m of it was spent parked awaiting the human.
+  const now = new Date(startedAt.getTime() + 22 * 60 * 60_000);
+  const awaitingHumanSeconds = 21 * 60 * 60 + 58 * 60; // active time ≈ 2 min
+
+  assert.equal(
+    exceededWallClockBudget({ startedAt, now, maxRuntimeMinutes, awaitingHumanSeconds }),
+    false,
+  );
+
+  // Same wall-clock age with no parking → over the 6h budget, still fires.
+  assert.equal(
+    exceededWallClockBudget({
+      startedAt,
+      now: new Date(startedAt.getTime() + budgetMs + 1_000),
+      maxRuntimeMinutes,
+      awaitingHumanSeconds: 0,
+    }),
+    true,
+  );
+
+  // Parked time that still leaves active time over budget → fires.
+  assert.equal(
+    exceededWallClockBudget({
+      startedAt,
+      now: new Date(startedAt.getTime() + budgetMs + 60 * 60_000), // 7h wall clock
+      maxRuntimeMinutes,
+      awaitingHumanSeconds: 30 * 60, // only 30 min parked → 6.5h active > 6h
+    }),
+    true,
+  );
+});
+
+test("awaitingHumanSecondsFromEvents sums a single park→resume gap", () => {
+  const park = new Date("2026-07-09T00:37:00Z");
+  const resume = new Date("2026-07-09T22:39:00Z"); // ~22h later
+  const events = [
+    { kind: "started", createdAt: new Date("2026-07-09T00:35:00Z") },
+    { kind: "awaiting_human", createdAt: park },
+    { kind: "resumed", createdAt: resume },
+  ];
+
+  assert.equal(
+    awaitingHumanSecondsFromEvents(events, new Date("2026-07-09T22:40:00Z")),
+    Math.round((resume.getTime() - park.getTime()) / 1_000),
+  );
+});
+
+test("awaitingHumanSecondsFromEvents adds multiple park cycles", () => {
+  const events = [
+    { kind: "awaiting_human", createdAt: new Date("2026-07-09T00:00:00Z") },
+    { kind: "resumed", createdAt: new Date("2026-07-09T01:00:00Z") }, // 1h
+    { kind: "awaiting_human", createdAt: new Date("2026-07-09T02:00:00Z") },
+    { kind: "resumed", createdAt: new Date("2026-07-09T02:30:00Z") }, // 30m
+  ];
+
+  assert.equal(
+    awaitingHumanSecondsFromEvents(events, new Date("2026-07-09T03:00:00Z")),
+    90 * 60,
+  );
+});
+
+test("awaitingHumanSecondsFromEvents counts a still-parked run up to now", () => {
+  const park = new Date("2026-07-09T00:00:00Z");
+  const now = new Date("2026-07-09T05:00:00Z"); // still parked, 5h
+  const events = [{ kind: "awaiting_human", createdAt: park }];
+
+  assert.equal(awaitingHumanSecondsFromEvents(events, now), 5 * 60 * 60);
+});
+
+test("awaitingHumanSecondsFromEvents is 0 when the run never parked", () => {
+  const events = [
+    { kind: "started", createdAt: new Date("2026-07-09T00:00:00Z") },
+    { kind: "report_findings", createdAt: new Date("2026-07-09T00:02:00Z") },
+  ];
+
+  assert.equal(awaitingHumanSecondsFromEvents(events, new Date("2026-07-09T00:03:00Z")), 0);
+});
+
+test("awaitingHumanSecondsFromEvents tolerates unordered events", () => {
+  const events = [
+    { kind: "resumed", createdAt: new Date("2026-07-09T01:00:00Z") },
+    { kind: "awaiting_human", createdAt: new Date("2026-07-09T00:00:00Z") },
+  ];
+
+  assert.equal(
+    awaitingHumanSecondsFromEvents(events, new Date("2026-07-09T02:00:00Z")),
+    60 * 60,
   );
 });
 

--- a/apps/worker/src/agent-runs/status.test.ts
+++ b/apps/worker/src/agent-runs/status.test.ts
@@ -115,21 +115,23 @@ test("exceededWallClockBudget excludes time parked awaiting a human", () => {
 });
 
 test("awaitingHumanSecondsFromEvents sums a single park→resume gap", () => {
+  const startedAt = new Date("2026-07-09T00:35:00Z");
   const park = new Date("2026-07-09T00:37:00Z");
   const resume = new Date("2026-07-09T22:39:00Z"); // ~22h later
   const events = [
-    { kind: "started", createdAt: new Date("2026-07-09T00:35:00Z") },
+    { kind: "agent_run_started", createdAt: startedAt },
     { kind: "awaiting_human", createdAt: park },
     { kind: "resumed", createdAt: resume },
   ];
 
   assert.equal(
-    awaitingHumanSecondsFromEvents(events, new Date("2026-07-09T22:40:00Z")),
+    awaitingHumanSecondsFromEvents({ events, startedAt, now: new Date("2026-07-09T22:40:00Z") }),
     Math.round((resume.getTime() - park.getTime()) / 1_000),
   );
 });
 
 test("awaitingHumanSecondsFromEvents adds multiple park cycles", () => {
+  const startedAt = new Date("2026-07-08T23:59:00Z");
   const events = [
     { kind: "awaiting_human", createdAt: new Date("2026-07-09T00:00:00Z") },
     { kind: "resumed", createdAt: new Date("2026-07-09T01:00:00Z") }, // 1h
@@ -138,36 +140,90 @@ test("awaitingHumanSecondsFromEvents adds multiple park cycles", () => {
   ];
 
   assert.equal(
-    awaitingHumanSecondsFromEvents(events, new Date("2026-07-09T03:00:00Z")),
+    awaitingHumanSecondsFromEvents({ events, startedAt, now: new Date("2026-07-09T03:00:00Z") }),
     90 * 60,
   );
 });
 
-test("awaitingHumanSecondsFromEvents counts a still-parked run up to now", () => {
-  const park = new Date("2026-07-09T00:00:00Z");
-  const now = new Date("2026-07-09T05:00:00Z"); // still parked, 5h
-  const events = [{ kind: "awaiting_human", createdAt: park }];
+test("awaitingHumanSecondsFromEvents excludes parks before startedAt (repo-discovery)", () => {
+  // A repo_discovery pause emits `awaiting_human` before the managed session
+  // starts, and the pre-session resume path requeues WITHOUT a `resumed`
+  // event. That dangling, pre-startedAt park must not be subtracted — doing so
+  // would silently disable the wall-clock backstop once the run starts.
+  const startedAt = new Date("2026-07-09T02:00:00Z");
+  const events = [
+    { kind: "awaiting_human", createdAt: new Date("2026-07-09T00:00:00Z") }, // pre-session, no resumed
+    { kind: "agent_run_started", createdAt: startedAt },
+  ];
 
-  assert.equal(awaitingHumanSecondsFromEvents(events, now), 5 * 60 * 60);
+  assert.equal(
+    awaitingHumanSecondsFromEvents({ events, startedAt, now: new Date("2026-07-09T09:00:00Z") }),
+    0,
+  );
+});
+
+test("awaitingHumanSecondsFromEvents clamps a park that straddles startedAt", () => {
+  // Park opens before startedAt but the matching resume lands after it — only
+  // the portion inside [startedAt, now] counts.
+  const startedAt = new Date("2026-07-09T01:00:00Z");
+  const events = [
+    { kind: "awaiting_human", createdAt: new Date("2026-07-09T00:00:00Z") },
+    { kind: "resumed", createdAt: new Date("2026-07-09T01:30:00Z") }, // 30m after startedAt
+  ];
+
+  assert.equal(
+    awaitingHumanSecondsFromEvents({ events, startedAt, now: new Date("2026-07-09T02:00:00Z") }),
+    30 * 60,
+  );
+});
+
+test("awaitingHumanSecondsFromEvents does not count a dangling open park", () => {
+  // No matching `resumed` → the park's end is untracked; it must not extend to
+  // `now`. In the sync path the run is already `running`, so an unclosed
+  // `awaiting_human` here is a spent repo-discovery pause, not an active wait.
+  const startedAt = new Date("2026-07-09T00:00:00Z");
+  const events = [{ kind: "awaiting_human", createdAt: new Date("2026-07-09T00:10:00Z") }];
+
+  assert.equal(
+    awaitingHumanSecondsFromEvents({ events, startedAt, now: new Date("2026-07-09T05:00:00Z") }),
+    0,
+  );
 });
 
 test("awaitingHumanSecondsFromEvents is 0 when the run never parked", () => {
+  const startedAt = new Date("2026-07-09T00:00:00Z");
   const events = [
-    { kind: "started", createdAt: new Date("2026-07-09T00:00:00Z") },
+    { kind: "agent_run_started", createdAt: startedAt },
     { kind: "report_findings", createdAt: new Date("2026-07-09T00:02:00Z") },
   ];
 
-  assert.equal(awaitingHumanSecondsFromEvents(events, new Date("2026-07-09T00:03:00Z")), 0);
+  assert.equal(
+    awaitingHumanSecondsFromEvents({ events, startedAt, now: new Date("2026-07-09T00:03:00Z") }),
+    0,
+  );
+});
+
+test("awaitingHumanSecondsFromEvents is 0 with no startedAt", () => {
+  const events = [
+    { kind: "awaiting_human", createdAt: new Date("2026-07-09T00:00:00Z") },
+    { kind: "resumed", createdAt: new Date("2026-07-09T01:00:00Z") },
+  ];
+
+  assert.equal(
+    awaitingHumanSecondsFromEvents({ events, startedAt: null, now: new Date("2026-07-09T02:00:00Z") }),
+    0,
+  );
 });
 
 test("awaitingHumanSecondsFromEvents tolerates unordered events", () => {
+  const startedAt = new Date("2026-07-08T23:59:00Z");
   const events = [
     { kind: "resumed", createdAt: new Date("2026-07-09T01:00:00Z") },
     { kind: "awaiting_human", createdAt: new Date("2026-07-09T00:00:00Z") },
   ];
 
   assert.equal(
-    awaitingHumanSecondsFromEvents(events, new Date("2026-07-09T02:00:00Z")),
+    awaitingHumanSecondsFromEvents({ events, startedAt, now: new Date("2026-07-09T02:00:00Z") }),
     60 * 60,
   );
 });

--- a/apps/worker/src/agent-runs/status.ts
+++ b/apps/worker/src/agent-runs/status.ts
@@ -28,11 +28,47 @@ export function exceededWallClockBudget(opts: {
   startedAt: Date | null;
   now: Date;
   maxRuntimeMinutes: number;
+  // Total seconds the run has spent parked in `awaiting_human`. This time is
+  // excluded from the budget: a run waiting on a human reply isn't stuck, and
+  // a human can legitimately take hours to answer. Without this a run that
+  // parked on `ask_human` gets reaped the moment it resumes, discarding a
+  // finished investigation (prod incident 2026-07-09).
+  awaitingHumanSeconds?: number;
 }): boolean {
   if (!opts.startedAt) return false;
-  const ageMs = opts.now.getTime() - opts.startedAt.getTime();
+  const parkedMs = Math.max(0, opts.awaitingHumanSeconds ?? 0) * 1_000;
+  const ageMs = opts.now.getTime() - opts.startedAt.getTime() - parkedMs;
   const budgetMs = WALL_CLOCK_MULTIPLIER * opts.maxRuntimeMinutes * 60_000;
   return ageMs > budgetMs;
+}
+
+// Total wall-clock seconds a run has spent parked in `awaiting_human`, derived
+// from its lifecycle events. `pauseForHuman` emits an `awaiting_human` event;
+// the matching `resumeRunning` emits `resumed`. Pair each `awaiting_human` with
+// the next `resumed` and sum the gaps. A trailing `awaiting_human` with no
+// matching `resumed` means the run is still parked, so it counts up to `now`.
+// Nested/duplicate `awaiting_human` events (a re-park before a resume) collapse
+// to the earliest park start, which is the conservative choice — it can only
+// exclude more idle time, never fabricate active time.
+export function awaitingHumanSecondsFromEvents(
+  events: ReadonlyArray<{ kind: string; createdAt: Date }>,
+  now: Date,
+): number {
+  const relevant = events
+    .filter((e) => e.kind === "awaiting_human" || e.kind === "resumed")
+    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  let totalMs = 0;
+  let parkedSince: Date | null = null;
+  for (const event of relevant) {
+    if (event.kind === "awaiting_human") {
+      if (parkedSince === null) parkedSince = event.createdAt;
+    } else if (parkedSince !== null) {
+      totalMs += event.createdAt.getTime() - parkedSince.getTime();
+      parkedSince = null;
+    }
+  }
+  if (parkedSince !== null) totalMs += now.getTime() - parkedSince.getTime();
+  return Math.max(0, Math.round(totalMs / 1_000));
 }
 
 const TRANSIENT_ERROR_CODES = new Set([

--- a/apps/worker/src/agent-runs/status.ts
+++ b/apps/worker/src/agent-runs/status.ts
@@ -42,19 +42,32 @@ export function exceededWallClockBudget(opts: {
   return ageMs > budgetMs;
 }
 
-// Total wall-clock seconds a run has spent parked in `awaiting_human`, derived
-// from its lifecycle events. `pauseForHuman` emits an `awaiting_human` event;
-// the matching `resumeRunning` emits `resumed`. Pair each `awaiting_human` with
-// the next `resumed` and sum the gaps. A trailing `awaiting_human` with no
-// matching `resumed` means the run is still parked, so it counts up to `now`.
-// Nested/duplicate `awaiting_human` events (a re-park before a resume) collapse
-// to the earliest park start, which is the conservative choice — it can only
-// exclude more idle time, never fabricate active time.
-export function awaitingHumanSecondsFromEvents(
-  events: ReadonlyArray<{ kind: string; createdAt: Date }>,
-  now: Date,
-): number {
-  const relevant = events
+// Wall-clock seconds a run spent parked in `awaiting_human` *within its
+// wall-clock measurement window* `[startedAt, now]`, derived from lifecycle
+// events. A managed-session pause (`pauseForHuman` from `running`) emits an
+// `awaiting_human` event and the matching `resumeRunning` emits `resumed`; we
+// pair each such open→close and sum the gaps, clamped to the window.
+//
+// Two things are deliberately excluded, both because the exclusion must never
+// exceed the age it's subtracted from (`now - startedAt`), or the wall-clock
+// backstop silently disables itself:
+//   - Parks before `startedAt` — a `repo_discovery` pause happens before the
+//     managed session (and `startedAt`) exists, so its time was never part of
+//     the age. Clamping to the window drops it.
+//   - A dangling `awaiting_human` with no matching `resumed`. The pre-session
+//     resume path (`requeueAfterHumanReply`) requeues *without* a `resumed`
+//     event, so an unclosed park is that repo-discovery pause — already over,
+//     its end untracked — not an active wait. Only closed intervals count.
+// Nested/duplicate `awaiting_human` events collapse to the earliest park start.
+export function awaitingHumanSecondsFromEvents(opts: {
+  events: ReadonlyArray<{ kind: string; createdAt: Date }>;
+  startedAt: Date | null;
+  now: Date;
+}): number {
+  if (!opts.startedAt) return 0;
+  const windowStart = opts.startedAt.getTime();
+  const windowEnd = opts.now.getTime();
+  const relevant = opts.events
     .filter((e) => e.kind === "awaiting_human" || e.kind === "resumed")
     .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
   let totalMs = 0;
@@ -63,11 +76,12 @@ export function awaitingHumanSecondsFromEvents(
     if (event.kind === "awaiting_human") {
       if (parkedSince === null) parkedSince = event.createdAt;
     } else if (parkedSince !== null) {
-      totalMs += event.createdAt.getTime() - parkedSince.getTime();
+      const from = Math.max(parkedSince.getTime(), windowStart);
+      const to = Math.min(event.createdAt.getTime(), windowEnd);
+      if (to > from) totalMs += to - from;
       parkedSince = null;
     }
   }
-  if (parkedSince !== null) totalMs += now.getTime() - parkedSince.getTime();
   return Math.max(0, Math.round(totalMs / 1_000));
 }
 

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -28,7 +28,12 @@ const agentRunLifecycle = createAgentRunLifecycle(db);
 // reaped the moment it resumes (prod incident 2026-07-09). Derived from the
 // run's lifecycle events; defaults to 0 if the lookup fails so a telemetry
 // hiccup can never make the budget stricter than it already was.
-async function loadAwaitingHumanSeconds(agentRunId: string, now: Date): Promise<number> {
+async function loadAwaitingHumanSeconds(
+  agentRunId: string,
+  startedAt: Date | null,
+  now: Date,
+): Promise<number> {
+  if (!startedAt) return 0;
   try {
     const events = await db
       .select({
@@ -42,7 +47,7 @@ async function loadAwaitingHumanSeconds(agentRunId: string, now: Date): Promise<
           inArray(schema.incidentEvents.kind, ["awaiting_human", "resumed"]),
         ),
       );
-    return awaitingHumanSecondsFromEvents(events, now);
+    return awaitingHumanSecondsFromEvents({ events, startedAt, now });
   } catch (err) {
     logger.error(
       { err, scope: "agent_run", agent_run_id: agentRunId },
@@ -215,7 +220,11 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
 
   // Time parked awaiting a human is excluded from every wall-clock check below.
   // Computed once up front so the transient-error path in `catch` can reuse it.
-  const awaitingHumanSeconds = await loadAwaitingHumanSeconds(ctx.agentRun.id, new Date());
+  const awaitingHumanSeconds = await loadAwaitingHumanSeconds(
+    ctx.agentRun.id,
+    ctx.agentRun.startedAt,
+    new Date(),
+  );
 
   try {
     const runner = await getAgentRunnerBackend(ctx.agentRun.runtime);

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -14,6 +14,7 @@ import { tryMergeAfterAgentRun } from "./merge.js";
 import { completeWithPullRequest, resolvePullRequestBaseBranch } from "./pr-delivery.js";
 import { applyIncidentMetadataFromResult } from "./result-metadata.js";
 import {
+  awaitingHumanSecondsFromEvents,
   exceededWallClockBudget,
   failAgentRun,
   isTransientError,
@@ -21,6 +22,35 @@ import {
 } from "./status.js";
 
 const agentRunLifecycle = createAgentRunLifecycle(db);
+
+// Wall-clock seconds a run has spent parked in `awaiting_human`, excluded from
+// the wall-clock budget so a run that legitimately waits on a human reply isn't
+// reaped the moment it resumes (prod incident 2026-07-09). Derived from the
+// run's lifecycle events; defaults to 0 if the lookup fails so a telemetry
+// hiccup can never make the budget stricter than it already was.
+async function loadAwaitingHumanSeconds(agentRunId: string, now: Date): Promise<number> {
+  try {
+    const events = await db
+      .select({
+        kind: schema.incidentEvents.kind,
+        createdAt: schema.incidentEvents.createdAt,
+      })
+      .from(schema.incidentEvents)
+      .where(
+        and(
+          eq(schema.incidentEvents.agentRunId, agentRunId),
+          inArray(schema.incidentEvents.kind, ["awaiting_human", "resumed"]),
+        ),
+      );
+    return awaitingHumanSecondsFromEvents(events, now);
+  } catch (err) {
+    logger.error(
+      { err, scope: "agent_run", agent_run_id: agentRunId },
+      "failed to load awaiting_human duration for wall-clock budget; treating as 0",
+    );
+    return 0;
+  }
+}
 
 export type PendingContextEvent = {
   id: string;
@@ -183,6 +213,10 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
     return;
   }
 
+  // Time parked awaiting a human is excluded from every wall-clock check below.
+  // Computed once up front so the transient-error path in `catch` can reuse it.
+  const awaitingHumanSeconds = await loadAwaitingHumanSeconds(ctx.agentRun.id, new Date());
+
   try {
     const runner = await getAgentRunnerBackend(ctx.agentRun.runtime);
     const dispatched = await runner
@@ -233,6 +267,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         startedAt: ctx.agentRun.startedAt,
         now: new Date(),
         maxRuntimeMinutes: ctx.automation.maxRuntimeMinutes,
+        awaitingHumanSeconds,
       })
     ) {
       await failAgentRun(
@@ -368,6 +403,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
               startedAt: ctx.agentRun.startedAt,
               now: new Date(),
               maxRuntimeMinutes: ctx.automation.maxRuntimeMinutes,
+              awaitingHumanSeconds,
             })
           ) {
             await failAgentRun(
@@ -629,6 +665,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
           startedAt: ctx.agentRun.startedAt,
           now: new Date(),
           maxRuntimeMinutes: ctx.automation.maxRuntimeMinutes,
+          awaitingHumanSeconds,
         })
       ) {
         await failAgentRun(


### PR DESCRIPTION
## Problem

The wall-clock backstop (`exceededWallClockBudget`) reaps an investigation run when `now - startedAt` exceeds `4 × maxRuntimeMinutes` (6h at the default 90m). It measured raw wall-clock age and **did not exclude time the run spent parked in `awaiting_human`**.

So a run that legitimately waits on a human reply gets reaped the moment it resumes — throwing away a finished investigation even though the model barely ran.

Observed in practice:

1. Agent pulls telemetry, diagnoses the incident, and records findings — ~2 min of model time.
2. It calls `ask_human` to confirm; the run parks in `awaiting_human`.
3. ~22h of silence until a human replies.
4. The run resumes and re-emits a full summary — but the same sync tick's wall-clock check trips (22h ≫ 6h) and fails it as `wall_clock_timeout`, discarding the result.

This also contradicts the health-metrics stance that parked (`awaiting_human` / `blocked`) runs are not "stuck".

## Fix

Subtract parked time from the measured wall-clock age:

- `exceededWallClockBudget` takes an optional `awaitingHumanSeconds` and removes it from the age before comparing to the budget.
- `awaitingHumanSecondsFromEvents(events, now)` — pure function that derives parked duration from the run's lifecycle events: pair each `awaiting_human` with the next `resumed`, sum the gaps; a still-parked trailing `awaiting_human` counts up to `now`; duplicate parks collapse to the earliest start (conservative — can only exclude idle time, never fabricate active time). **No schema change** — the events already exist.
- `syncRunningAgentRun` loads it once per tick and threads it into all three wall-clock call sites (idle-no-result, mobile-regression gate, transient-unreachable). The lookup defaults to `0` on query failure, so a telemetry hiccup can only ever make the budget *looser*, never stricter.

Active runtime stays independently bounded by the provider active-seconds budget and the human-resume cap, so excluding park time doesn't uncap total runtime — it only stops human-wait from eating the budget.

## Tests

New unit tests in `status.test.ts` for `awaitingHumanSecondsFromEvents` (single gap, multiple park cycles, still-parked-to-now, never-parked, unordered events) and for `exceededWallClockBudget` excluding parked time. `test:agent-run-status` (14) and `test:agent-run-sync` (15) pass; `tsc --noEmit` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude time spent in `awaiting_human` from the wall-clock budget so runs aren’t reaped right after a human replies. The exclusion is now bounded to `[startedAt, now]` and only counts closed `awaiting_human`→`resumed` intervals to avoid disabling the backstop.

- **Bug Fixes**
  - Added `awaitingHumanSecondsFromEvents({ events, startedAt, now })` to sum parked time within the window; ignores pre-session parks and dangling opens; tolerates unordered events.
  - Updated `exceededWallClockBudget` to accept `awaitingHumanSeconds` and subtract it from age.
  - `syncRunningAgentRun` loads the parked duration once per tick and threads it into all wall-clock checks; defaults to 0 on lookup failure.
  - Added unit tests for window clamping, pre-session/dangling parks, and budget exclusion.

<sup>Written for commit d22e518e13613b60c16f5a21c51834ab803f61af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

