### PR TITLE
Agent loop rework: mid-run action tools, multi-PR, resolve_incident

### DIFF
--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -1,13 +1,14 @@
 import crypto from "node:crypto";
 import {
   db,
+  decideInboundContinuation,
   listAccessibleGithubInstallsForProject,
   recordInboundInteraction,
   resolveIncident,
   schema,
   syncLoopsContactsForOrg,
 } from "@superlog/db";
-import { and, eq, inArray, isNull, ne, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, ne, sql } from "drizzle-orm";
 import type { Hono } from "hono";
 import type { Context } from "hono";
 import {
@@ -681,10 +682,16 @@ async function handleAgentPrWebhook(
       await recordPrClosedMetric(agentPrRow.incidentId);
     }
     if (mergedResolution) {
-      await resolveIncidentForMergedAgentPr({
+      await resumeOrResolveIncidentForMergedAgentPr({
         agentPr: agentPrRow,
         mergedAt: mergedResolution.mergedAt,
         mergedByLogin: mergedResolution.mergedByLogin,
+      });
+    } else if (updates.state === "closed" && wonTransition) {
+      await maybeResumeIncidentForClosedAgentPr({
+        agentPr: agentPrRow,
+        closedByLogin: payload.sender?.login ?? null,
+        closedAt: updates.closedAt ?? now,
       });
     }
   } else if (event === "push") {
@@ -713,6 +720,119 @@ async function handleAgentPrWebhook(
       occurredAt: now,
     })
     .onConflictDoNothing();
+}
+
+// Route a PR lifecycle event (merge/close) into the incident's durable
+// investigation session when one can be resumed: the agent — not the webhook —
+// decides whether the incident is done. Returns true when the event reached a
+// session (or already had, on redelivery).
+async function resumeIncidentSessionForPrEvent(opts: {
+  agentPr: schema.AgentPullRequest;
+  channel: "pr_merged" | "pr_closed";
+  author: string | null;
+  text: string;
+  dedupeKey: string;
+}): Promise<boolean> {
+  const incident = await db.query.incidents.findFirst({
+    where: eq(schema.incidents.id, opts.agentPr.incidentId),
+    columns: { id: true, status: true, projectId: true },
+  });
+  // Only open incidents have a decision left to make. Also guards the
+  // self-inflicted case: resolving an incident closes its remaining open PRs,
+  // and those `closed` webhooks must not re-ping the session.
+  if (!incident || incident.status !== "open") return false;
+
+  const automation = await db.query.projectAutomationSettings.findFirst({
+    where: eq(schema.projectAutomationSettings.projectId, incident.projectId),
+    columns: { agentRunEnabled: true, autoFollowUpEnabled: true },
+  });
+  const latestRun = await db.query.agentRuns.findFirst({
+    where: eq(schema.agentRuns.incidentId, incident.id),
+    orderBy: [desc(schema.agentRuns.createdAt)],
+    columns: { id: true, state: true, providerSessionId: true },
+  });
+  // Pre-route so a merge/close never cold-starts a fresh investigation: with
+  // no resumable session the caller falls back to its deterministic behavior
+  // (auto-resolve for merges, nothing for closes).
+  const verdict = decideInboundContinuation({
+    agentRunEnabled: automation?.agentRunEnabled ?? true,
+    autoFollowUpEnabled: automation?.autoFollowUpEnabled ?? true,
+    confirmed: true,
+    latestRun: latestRun ?? null,
+  });
+  if (verdict.action !== "resume" && verdict.action !== "steer") return false;
+
+  const result = await recordInboundInteraction(db, {
+    incidentId: incident.id,
+    interaction: {
+      channel: opts.channel,
+      author: opts.author,
+      text: opts.text,
+      url: opts.agentPr.url,
+      occurredAt: new Date().toISOString(),
+    },
+    dedupeKey: opts.dedupeKey,
+    confirmed: true,
+  });
+  if (result.outcome === "duplicate") return true;
+  return result.outcome === "accepted" && result.action !== "cold_start";
+}
+
+// An agent PR merged. Resume the durable session so the agent decides whether
+// the incident is complete (per the spec, the agent is the judge of done);
+// when no session can be resumed, fall back to resolving the incident
+// directly — an incident must never stay open forever because its session
+// expired.
+async function resumeOrResolveIncidentForMergedAgentPr(opts: {
+  agentPr: schema.AgentPullRequest;
+  mergedAt: Date;
+  mergedByLogin: string | null;
+}): Promise<void> {
+  const { agentPr, mergedByLogin } = opts;
+  const resumed = await resumeIncidentSessionForPrEvent({
+    agentPr,
+    channel: "pr_merged",
+    author: mergedByLogin,
+    text: `Your PR #${agentPr.prNumber} (${agentPr.repoFullName}, branch \`${agentPr.branchName}\`) was merged${
+      mergedByLogin ? ` by @${mergedByLogin}` : ""
+    }. If this completes the remediation, make sure every linked issue is classified and call resolve_incident; if more work remains (other PRs still open, issues unclassified), continue it.`,
+    dedupeKey: `agent_pr_merged:${agentPr.id}`,
+  }).catch((err) => {
+    log.warn(
+      { err, agent_pr_id: agentPr.id, incident_id: agentPr.incidentId },
+      "failed to resume session for merged agent PR; falling back to auto-resolve",
+    );
+    return false;
+  });
+  if (resumed) return;
+  await resolveIncidentForMergedAgentPr(opts);
+}
+
+// An agent PR was closed without merging. Resume the session so the agent can
+// react (per the spec: if the close context shows the issue is noise, silence
+// it and resolve; otherwise decide the next step). No fallback action — the
+// incident simply stays open for a human or a later run.
+async function maybeResumeIncidentForClosedAgentPr(opts: {
+  agentPr: schema.AgentPullRequest;
+  closedByLogin: string | null;
+  closedAt: Date;
+}): Promise<void> {
+  const { agentPr, closedByLogin } = opts;
+  await resumeIncidentSessionForPrEvent({
+    agentPr,
+    channel: "pr_closed",
+    author: closedByLogin,
+    text: `Your PR #${agentPr.prNumber} (${agentPr.repoFullName}, branch \`${agentPr.branchName}\`) was closed without being merged${
+      closedByLogin ? ` by @${closedByLogin}` : ""
+    }. Read the PR conversation for the close context: if it shows the incident is actually noise, classify the issues accordingly and call resolve_incident; if the fix is still needed, decide the next step (an adjusted PR, or ask_human).`,
+    dedupeKey: `agent_pr_closed:${agentPr.id}:${opts.closedAt.getTime()}`,
+  }).catch((err) => {
+    log.warn(
+      { err, agent_pr_id: agentPr.id, incident_id: agentPr.incidentId },
+      "failed to resume session for closed agent PR",
+    );
+    return false;
+  });
 }
 
 async function resolveIncidentForMergedAgentPr(opts: {
@@ -839,7 +959,10 @@ async function maybeRequestPrCommentFollowUp(opts: {
     interaction: {
       channel: "pr_comment",
       author: comment.actor?.login ?? null,
-      text: comment.body,
+      // Prefix with which PR the feedback is on — an incident can have
+      // several agent PRs, and the resumed session must know which one to
+      // update and reply to.
+      text: `[on PR #${opts.agentPrRow.prNumber} ${opts.agentPrRow.repoFullName}, branch \`${opts.agentPrRow.branchName}\`] ${comment.body}`,
       url: comment.commentUrl,
       path: comment.path,
       line: comment.line,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2711,6 +2711,8 @@ app.post("/api/projects/:projectId/incidents/:incidentId/agent-run/restart", asy
     "repo_discovery",
     "running",
     "awaiting_human",
+    "awaiting_events",
+    "resuming",
     "pr_retry_queued",
     "blocked_no_github",
   ];

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -5,6 +5,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
+  Fragment,
   type ReactNode,
   Suspense,
   lazy,
@@ -1114,8 +1115,11 @@ function buildAgentRunPrompt({
         result.estimatedImpact.text,
       );
     }
-    if (result?.pr?.url) {
-      lines.push("", `### Existing PR`, result.pr.url);
+    const prUrls = (result?.prs ?? (result?.pr ? [result.pr] : []))
+      .map((pr) => pr.url)
+      .filter((url): url is string => Boolean(url));
+    if (prUrls.length > 0) {
+      lines.push("", prUrls.length === 1 ? `### Existing PR` : `### Existing PRs`, ...prUrls);
     }
   }
 
@@ -2269,30 +2273,35 @@ function AgentRunMeta({ agentRun }: { agentRun: AgentRun }) {
 function AgentRunDeliverables({ agentRun }: { agentRun: AgentRun }) {
   const result = agentRun.result;
   if (!result) return null;
-  const pr = result.pr ?? null;
+  // Multi-PR runs list every PR in `prs`; older runs only have the single `pr`.
+  const prs = result.prs ?? (result.pr ? [result.pr] : []);
   const ticket = result.linearTicket ?? null;
-  if (!pr && !ticket) return null;
+  if (prs.length === 0 && !ticket) return null;
   return (
     <div className="space-y-3">
       <SectionHeading>Deliverables</SectionHeading>
       <div className="flex flex-wrap gap-2">
-        {pr && pr.openStatus === "opened" && pr.url && (
-          <a href={pr.url} target="_blank" rel="noreferrer" className="text-[12px]">
-            <Chip tone="success" dot>
-              PR opened · {pr.selectedRepoFullName}
-            </Chip>
-          </a>
-        )}
-        {pr && pr.openStatus === "pending" && (
-          <Chip tone="neutral" dot>
-            PR pending · {pr.selectedRepoFullName}
-          </Chip>
-        )}
-        {pr && pr.validationPassed === false && (
-          <Chip tone="danger" dot>
-            Patch validation failed
-          </Chip>
-        )}
+        {prs.map((pr) => (
+          <Fragment key={pr.branchName}>
+            {pr.openStatus === "opened" && pr.url && (
+              <a href={pr.url} target="_blank" rel="noreferrer" className="text-[12px]">
+                <Chip tone="success" dot>
+                  PR opened · {pr.selectedRepoFullName}
+                </Chip>
+              </a>
+            )}
+            {pr.openStatus === "pending" && (
+              <Chip tone="neutral" dot>
+                PR pending · {pr.selectedRepoFullName}
+              </Chip>
+            )}
+            {pr.validationPassed === false && (
+              <Chip tone="danger" dot>
+                Patch validation failed
+              </Chip>
+            )}
+          </Fragment>
+        ))}
         {ticket && ticket.url && (
           <a href={ticket.url} target="_blank" rel="noreferrer" className="text-[12px]">
             <Chip tone="success" dot>
@@ -2333,6 +2342,13 @@ function AgentRunStateChip({ state }: { state: string }) {
     return (
       <Chip tone="warning" dot>
         {state}
+      </Chip>
+    );
+  }
+  if (state === "awaiting_events") {
+    return (
+      <Chip tone="warning" dot>
+        awaiting events
       </Chip>
     );
   }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -2018,7 +2018,9 @@ export type AgentRunPr = {
   patch?: string;
   patchFileId?: string | null;
   patchFilePath?: string | null;
-  validationPassed: boolean;
+  // Legacy fields from the era when propose_pr carried a self-reported
+  // validation verdict; current agents no longer send them.
+  validationPassed?: boolean;
   validationCommands?: string[];
   validationSummary?: string | null;
   changedFiles?: string[];
@@ -2038,22 +2040,21 @@ export type IncidentSeverity = "SEV-1" | "SEV-2" | "SEV-3";
 // the user. 'no_credits' = org over its plan's monthly investigation limit.
 export type IncidentAutoInvestigateBlockedReason = "no_credits";
 
-export type IncidentNoiseReason =
-  | "cosmetic_log_only"
-  | "lifecycle_signal"
-  | "self_telemetry"
-  | "expected_third_party"
-  | "confusing_log_no_impact";
+// Free-form text explaining why the issue is noise. Previously a closed enum
+// (cosmetic_log_only, lifecycle_signal, self_telemetry, expected_third_party,
+// confusing_log_no_impact); those values still occur in stored rows and remain
+// valid strings — render the text as-is.
+export type IncidentNoiseReason = string;
 
 export type IncidentNoiseClassification = {
   reason: IncidentNoiseReason;
   evidence: string;
 };
 
-export type IncidentResolutionReason =
-  | "fixed_in_current_code"
-  | "transient_condition_cleared"
-  | "upstream_recovered";
+// Free-form text explaining why the incident/issue is considered resolved.
+// Previously a closed enum (fixed_in_current_code, transient_condition_cleared,
+// upstream_recovered); stored rows may still carry those values.
+export type IncidentResolutionReason = string;
 
 export type IncidentResolutionClassification = {
   reason: IncidentResolutionReason;
@@ -2065,12 +2066,35 @@ export type AgentRunConfidence = {
   confidence: number;
 };
 
+// One issue-level verdict recorded by the agent mid-run. The issue row itself
+// is the source of truth; this is the run-result record of what was decided
+// and why.
+export type AgentRunIssueClassification = {
+  issueId: string;
+  action: "silence" | "observe" | "resolve";
+  reason: string;
+  evidence: string;
+  trigger?: { kind: "rate"; perMinute: number } | { kind: "count"; count: number } | null;
+};
+
+// The agent's terminal resolve_incident verdict.
+export type AgentRunIncidentResolution = {
+  reason: string;
+  evidence: string;
+};
+
 export type AgentRunResult = {
-  state: "complete" | "awaiting_human" | "failed";
+  state: "complete" | "awaiting_human" | "awaiting_events" | "failed";
   summary: string;
   question?: string | null;
   failureReason?: AgentRunFailureReason | null;
+  // Legacy single-PR record (pre multi-PR contract). New runs record every
+  // opened PR in `prs`; `pr` is kept pointing at the most recent one for old
+  // readers.
   pr?: AgentRunPr | null;
+  prs?: AgentRunPr[] | null;
+  issueClassifications?: AgentRunIssueClassification[] | null;
+  incidentResolution?: AgentRunIncidentResolution | null;
   linearTicket?: AgentRunLinearTicket | null;
   rootCauseConfidence?: "high" | "medium" | "low" | null;
   proposedTitle?: string | null;

--- a/apps/worker/src/agent-outcome-tools.test.ts
+++ b/apps/worker/src/agent-outcome-tools.test.ts
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  ACTION_OUTCOME_TOOL_NAMES,
   OUTCOME_TOOL_DEFINITIONS,
   OUTCOME_TOOL_NAMES,
   REPORT_FINDINGS_TOOL_NAME,
+  RETIRED_OUTCOME_TOOL_NAMES,
   TERMINAL_OUTCOME_TOOL_NAMES,
   assembleAgentRunResult,
+  isActionOutcomeToolName,
   mergeFindings,
   validateOutcomeToolInput,
 } from "./agent-outcome-tools.js";
@@ -22,9 +25,18 @@ const FINDINGS: AgentRunFindings = {
   handoffNotes: "Checked the vendor API timeout config; it is not the cause.",
 };
 
-test("exposes all six tools with API-safe schemas", () => {
-  assert.equal(OUTCOME_TOOL_NAMES.length, 6);
-  assert.equal(OUTCOME_TOOL_DEFINITIONS.length, 6);
+const PROPOSE_PR_INPUT = {
+  repoFullName: "acme/shop",
+  title: "[superlog] Batch vendor lookups",
+  body: "# Summary\n...",
+  branchName: "superlog/batch-vendor-lookups",
+  baseBranch: "dev",
+  patchFilePath: "/mnt/session/outputs/superlog-batch-vendor-lookups.patch",
+};
+
+test("exposes all seven tools with API-safe schemas", () => {
+  assert.equal(OUTCOME_TOOL_NAMES.length, 7);
+  assert.equal(OUTCOME_TOOL_DEFINITIONS.length, 7);
   for (const def of OUTCOME_TOOL_DEFINITIONS) {
     // Some runner APIs reject any top-level composition keyword
     // (allOf/oneOf/if...), which would block every run at agent-create time.
@@ -38,63 +50,56 @@ test("exposes all six tools with API-safe schemas", () => {
   }
 });
 
-// The load-bearing guidance that moved out of the runner's system prompt into
-// tool descriptions. Losing any of these regressed real agent behavior before
-// (structural-only validation, behavior-changing "equivalent" refactors), so
-// pin them here.
-test("propose_pr description carries the validation ladder and refactor-equivalence rules", () => {
+test("splits the contract into action tools and exactly two terminal tools", () => {
+  assert.deepEqual(
+    [...ACTION_OUTCOME_TOOL_NAMES],
+    ["propose_pr", "silence_as_noise", "place_under_observation", "resolve_issue"],
+  );
+  assert.deepEqual([...TERMINAL_OUTCOME_TOOL_NAMES], ["resolve_incident", "ask_human"]);
+  assert.ok(!(TERMINAL_OUTCOME_TOOL_NAMES as readonly string[]).includes(REPORT_FINDINGS_TOOL_NAME));
+  assert.ok(isActionOutcomeToolName("propose_pr"));
+  assert.ok(!isActionOutcomeToolName("resolve_incident"));
+});
+
+// The load-bearing guidance in tool descriptions. Losing any of these
+// regressed real agent behavior before, so pin them.
+test("propose_pr description explains the non-terminal multi-PR contract", () => {
   const proposePr = OUTCOME_TOOL_DEFINITIONS.find((d) => d.name === "propose_pr");
   assert.ok(proposePr);
   const text = proposePr?.description ?? "";
-  assert.ok(text.includes("Validation ladder"));
-  assert.ok(text.includes("Structural checks"));
-  assert.ok(text.includes("are NOT validation"));
-  assert.ok(text.includes("behaviorally identical"));
-  assert.ok(text.includes("first-wins vs last-wins"));
-  assert.ok(text.includes("regression test"));
-  assert.ok(text.includes("/mnt/session/outputs/superlog.patch"));
-  const validationPassed = proposePr?.input_schema.properties.validationPassed as {
-    description?: string;
-  };
-  assert.ok(validationPassed.description?.includes("honest false is acceptable"));
+  assert.ok(text.includes("NOT terminal"));
+  assert.ok(text.includes("NEW branchName"));
+  assert.ok(text.includes("SAME branchName"));
+  assert.ok(text.includes("/mnt/session/outputs/"));
+  // Noise guardrail must survive the rewrite.
+  assert.ok(text.includes("NOT for noise"));
 });
 
-test("noise-outcome descriptions carry the per-reason evidentiary bars", () => {
-  for (const name of ["silence_as_noise", "place_under_observation"]) {
-    const def = OUTCOME_TOOL_DEFINITIONS.find((d) => d.name === name);
-    const text = def?.description ?? "";
-    for (const reason of [
-      "cosmetic_log_only",
-      "lifecycle_signal",
-      "self_telemetry",
-      "expected_third_party",
-      "confusing_log_no_impact",
-    ]) {
-      assert.ok(text.includes(reason), `${name} missing ${reason}`);
-    }
-  }
+test("silence_as_noise keeps the evidentiary bar and the no-quieting-PRs rule", () => {
   const silence = OUTCOME_TOOL_DEFINITIONS.find((d) => d.name === "silence_as_noise");
   assert.ok(silence?.description.includes("the bar is high"));
   assert.ok(silence?.description.includes("Do NOT propose code changes"));
+  assert.ok(silence?.description.includes("resolve_issue"));
 });
 
-test("marks exactly five tools terminal", () => {
-  assert.equal(TERMINAL_OUTCOME_TOOL_NAMES.length, 5);
-  assert.ok(!(TERMINAL_OUTCOME_TOOL_NAMES as readonly string[]).includes(REPORT_FINDINGS_TOOL_NAME));
+test("resolve_incident description requires per-issue classification first", () => {
+  const def = OUTCOME_TOOL_DEFINITIONS.find((d) => d.name === "resolve_incident");
+  assert.ok(def?.description.includes("Every issue linked"));
 });
 
-// Sessions created against the old toolset can resume days later (e.g. from
-// awaiting_human) and still call a retired tool. The validator must reject
-// the call with redirect guidance so the model re-lands on a live outcome —
-// falling through to the unknown-tool path would hard-fail the run instead.
-test("rejects retired terminal tools with redirect guidance", () => {
-  for (const name of ["complete_investigation", "report_failure"]) {
-    const v = validateOutcomeToolInput(name, { disposition: "informational" }, { hasFindings: true });
+// Sessions created against an old toolset can resume days later and still
+// call a retired tool. The validator must reject the call with redirect
+// guidance so the model re-lands on a live outcome — falling through to the
+// unknown-tool path would hard-fail the run instead.
+test("rejects retired tools (incl. mark_already_resolved) with redirect guidance", () => {
+  assert.ok((RETIRED_OUTCOME_TOOL_NAMES as readonly string[]).includes("mark_already_resolved"));
+  for (const name of RETIRED_OUTCOME_TOOL_NAMES) {
+    const v = validateOutcomeToolInput(name, { reason: "upstream_recovered", evidence: "e" }, { hasFindings: true });
     assert.equal(v.ok, false, name);
     if (!v.ok) {
       const text = v.errors.join(" ");
-      assert.ok(text.includes("ask_human"), name);
-      assert.ok(text.includes("propose_pr"), name);
+      assert.ok(text.includes("resolve_incident"), name);
+      assert.ok(text.includes("resolve_issue"), name);
     }
   }
 });
@@ -134,37 +139,40 @@ test("rejects a bad severity with a model-readable message", () => {
   if (!v.ok) assert.ok(v.errors.join(" ").includes("SEV-3"));
 });
 
-test("rejects silence_as_noise with an unknown reason, naming the valid enum", () => {
-  const v = validateOutcomeToolInput(
+test("classification tools take free-text reasons and require issueId", () => {
+  const ok = validateOutcomeToolInput(
     "silence_as_noise",
-    { reason: "not_a_reason", evidence: "e" },
+    { issueId: "issue-1", reason: "Expected 404s from bot traffic probing /wp-admin", evidence: "e" },
     { hasFindings: true },
   );
-  assert.equal(v.ok, false);
-  if (!v.ok) assert.ok(v.errors.join(" ").includes("expected_third_party"));
+  assert.equal(ok.ok, true);
+
+  const missingIssue = validateOutcomeToolInput(
+    "silence_as_noise",
+    { reason: "noise", evidence: "e" },
+    { hasFindings: true },
+  );
+  assert.equal(missingIssue.ok, false);
+  if (!missingIssue.ok) assert.match(missingIssue.errors.join(" "), /issueId/);
+
+  const resolveOk = validateOutcomeToolInput(
+    "resolve_issue",
+    { issueId: "issue-2", reason: "Fixed by the merged retry-guard PR", evidence: "e" },
+    { hasFindings: true },
+  );
+  assert.equal(resolveOk.ok, true);
 });
 
-test("requires findings before complete-family terminals", () => {
+test("requires findings before action tools and resolve_incident", () => {
   const cases: Array<[string, Record<string, unknown>]> = [
-    ["silence_as_noise", { reason: "cosmetic_log_only", evidence: "e" }],
-    ["mark_already_resolved", { reason: "upstream_recovered", evidence: "e" }],
+    ["silence_as_noise", { issueId: "i", reason: "noise", evidence: "e" }],
+    ["resolve_issue", { issueId: "i", reason: "recovered", evidence: "e" }],
     [
       "place_under_observation",
-      { reason: "cosmetic_log_only", evidence: "e", escalateOn: "additional_events", threshold: 10 },
+      { issueId: "i", reason: "one-off", evidence: "e", escalateOn: "additional_events", threshold: 10 },
     ],
-    [
-      "propose_pr",
-      {
-        repoFullName: "acme/shop",
-        title: "[superlog] Fix",
-        body: "# Summary",
-        branchName: "superlog/fix",
-        baseBranch: "main",
-        patchFilePath: "/mnt/session/outputs/superlog.patch",
-        validationPassed: true,
-        validationSummary: "tests pass",
-      },
-    ],
+    ["propose_pr", PROPOSE_PR_INPUT],
+    ["resolve_incident", { reason: "all done", evidence: "e" }],
   ];
   for (const [name, input] of cases) {
     const v = validateOutcomeToolInput(name, input, { hasFindings: false });
@@ -183,7 +191,7 @@ test("allows ask_human without findings", () => {
 test("validates place_under_observation trigger fields", () => {
   const bad = validateOutcomeToolInput(
     "place_under_observation",
-    { reason: "cosmetic_log_only", evidence: "e", escalateOn: "hourly", threshold: 10 },
+    { issueId: "i", reason: "one-off", evidence: "e", escalateOn: "hourly", threshold: 10 },
     { hasFindings: true },
   );
   assert.equal(bad.ok, false);
@@ -191,7 +199,7 @@ test("validates place_under_observation trigger fields", () => {
 
   const badThreshold = validateOutcomeToolInput(
     "place_under_observation",
-    { reason: "cosmetic_log_only", evidence: "e", escalateOn: "additional_events", threshold: 0 },
+    { issueId: "i", reason: "one-off", evidence: "e", escalateOn: "additional_events", threshold: 0 },
     { hasFindings: true },
   );
   assert.equal(badThreshold.ok, false);
@@ -208,36 +216,38 @@ test("validates propose_pr required fields and branch prefix", () => {
 
   const badBranch = validateOutcomeToolInput(
     "propose_pr",
-    {
-      repoFullName: "acme/shop",
-      title: "[superlog] Fix N+1",
-      body: "# Summary",
-      branchName: "claude/fix",
-      baseBranch: "dev",
-      patchFilePath: "/mnt/session/outputs/superlog.patch",
-      validationPassed: true,
-      validationSummary: "tests pass",
-    },
+    { ...PROPOSE_PR_INPUT, branchName: "claude/fix" },
     { hasFindings: true },
   );
   assert.equal(badBranch.ok, false);
   if (!badBranch.ok) assert.ok(badBranch.errors.join(" ").includes("superlog/"));
 });
 
+// Legacy sessions still send validationPassed; an honest false meant "do not
+// open this PR" and must keep being honored.
+test("propose_pr rejects a legacy validationPassed=false", () => {
+  const v = validateOutcomeToolInput(
+    "propose_pr",
+    { ...PROPOSE_PR_INPUT, validationPassed: false },
+    { hasFindings: true },
+  );
+  assert.equal(v.ok, false);
+  if (!v.ok) assert.match(v.errors.join(" "), /validation/i);
+});
+
+test("propose_pr accepts legacy validation fields without carrying them", () => {
+  const v = validateOutcomeToolInput(
+    "propose_pr",
+    { ...PROPOSE_PR_INPUT, validationPassed: true, validationSummary: "tests pass" },
+    { hasFindings: true },
+  );
+  assert.equal(v.ok, true);
+});
+
 test("propose_pr mobile fields are conditionally required", () => {
-  const base = {
-    repoFullName: "acme/shop",
-    title: "[superlog] Fix",
-    body: "# Summary",
-    branchName: "superlog/fix",
-    baseBranch: "main",
-    patchFilePath: "/mnt/session/outputs/superlog.patch",
-    validationPassed: true,
-    validationSummary: "tests pass",
-  };
   const created = validateOutcomeToolInput(
     "propose_pr",
-    { ...base, mobileTestStatus: "created" },
+    { ...PROPOSE_PR_INPUT, mobileTestStatus: "created" },
     { hasFindings: true },
   );
   assert.equal(created.ok, false);
@@ -245,7 +255,7 @@ test("propose_pr mobile fields are conditionally required", () => {
 
   const skipped = validateOutcomeToolInput(
     "propose_pr",
-    { ...base, mobileTestStatus: "skipped" },
+    { ...PROPOSE_PR_INPUT, mobileTestStatus: "skipped" },
     { hasFindings: true },
   );
   assert.equal(skipped.ok, false);
@@ -265,108 +275,134 @@ test("mergeFindings is last-write-wins per defined field", () => {
   assert.equal(b.rootCause, "rc");
 });
 
-test("assembles silence_as_noise into a complete result with a silence action", () => {
+test("assembles resolve_incident with executed actions into a complete result", () => {
   const result = assembleAgentRunResult({
     findings: FINDINGS,
     terminal: {
-      name: "silence_as_noise",
-      payload: { reason: "expected_third_party", evidence: "**a.ts:1**\n```ts\nx\n```" },
+      name: "resolve_incident",
+      payload: { reason: "PR merged and error rate back to zero", evidence: "e" },
     },
+    actions: [
+      {
+        name: "silence_as_noise",
+        payload: { issueId: "issue-1", reason: "bot probe noise", evidence: "e1" },
+      },
+      {
+        name: "resolve_issue",
+        payload: { issueId: "issue-2", reason: "fixed by the merged PR", evidence: "e2" },
+      },
+      { name: "propose_pr", payload: PROPOSE_PR_INPUT },
+    ],
   });
   assert.equal(result.state, "complete");
   assert.equal(result.summary, FINDINGS.summary);
   assert.equal(result.proposedTitle, FINDINGS.proposedTitle);
-  assert.deepEqual(result.noiseClassification, {
-    reason: "expected_third_party",
-    evidence: "**a.ts:1**\n```ts\nx\n```",
-    action: { kind: "silence" },
-  });
-  assert.equal(result.pr, undefined);
-});
-
-test("maps place_under_observation onto an observe action with a parsed trigger", () => {
-  const rate = assembleAgentRunResult({
-    findings: FINDINGS,
-    terminal: {
-      name: "place_under_observation",
-      payload: { reason: "lifecycle_signal", evidence: "e", escalateOn: "events_per_minute", threshold: 5 },
-    },
-  });
-  assert.deepEqual(rate.noiseClassification?.action, {
-    kind: "observe",
-    trigger: { kind: "rate", perMinute: 5 },
-  });
-
-  const count = assembleAgentRunResult({
-    findings: FINDINGS,
-    terminal: {
-      name: "place_under_observation",
-      payload: { reason: "lifecycle_signal", evidence: "e", escalateOn: "additional_events", threshold: 100 },
-    },
-  });
-  assert.deepEqual(count.noiseClassification?.action, {
-    kind: "observe",
-    trigger: { kind: "count", count: 100 },
-  });
-});
-
-test("maps mark_already_resolved onto resolutionClassification", () => {
-  const result = assembleAgentRunResult({
-    findings: FINDINGS,
-    terminal: {
-      name: "mark_already_resolved",
-      payload: { reason: "fixed_in_current_code", evidence: "e" },
-    },
-  });
-  assert.equal(result.state, "complete");
-  assert.deepEqual(result.resolutionClassification, {
-    reason: "fixed_in_current_code",
+  assert.deepEqual(result.incidentResolution, {
+    reason: "PR merged and error rate back to zero",
     evidence: "e",
   });
+  assert.equal(result.issueClassifications?.length, 2);
+  assert.deepEqual(result.issueClassifications?.[0], {
+    issueId: "issue-1",
+    action: "silence",
+    reason: "bot probe noise",
+    evidence: "e1",
+  });
+  assert.equal(result.prs?.length, 1);
+  assert.equal(result.prs?.[0]?.branchName, "superlog/batch-vendor-lookups");
+  assert.equal(result.prs?.[0]?.openStatus, "opened");
+  // Old readers get the singular field pointed at the most recent PR.
+  assert.equal(result.pr?.branchName, "superlog/batch-vendor-lookups");
 });
 
-test("assembles propose_pr into an AgentRunPr with pending openStatus", () => {
+test("latest classification per issue wins and same-branch PRs collapse", () => {
   const result = assembleAgentRunResult({
     findings: FINDINGS,
-    terminal: {
-      name: "propose_pr",
-      payload: {
-        repoFullName: "acme/shop",
-        title: "[superlog] Batch vendor lookups",
-        body: "# Summary\n...",
-        branchName: "superlog/batch-vendor-lookups",
-        baseBranch: "dev",
-        patchFilePath: "/mnt/session/outputs/superlog.patch",
-        validationPassed: true,
-        validationCommands: ["pnpm test"],
-        validationSummary: "repro passes after fix",
-        changedFiles: ["api/pricing.ts"],
-        mobileTestStatus: "not_applicable",
-        mobileTestReason: "backend-only change",
+    terminal: { name: "resolve_incident", payload: { reason: "r", evidence: "e" } },
+    actions: [
+      {
+        name: "place_under_observation",
+        payload: {
+          issueId: "issue-1",
+          reason: "one-off",
+          evidence: "e",
+          escalateOn: "events_per_minute",
+          threshold: 5,
+        },
       },
-    },
+      {
+        name: "resolve_issue",
+        payload: { issueId: "issue-1", reason: "actually fixed", evidence: "e" },
+      },
+      { name: "propose_pr", payload: PROPOSE_PR_INPUT },
+      { name: "propose_pr", payload: { ...PROPOSE_PR_INPUT, title: "[superlog] Follow-up" } },
+    ],
   });
-  assert.equal(result.state, "complete");
-  assert.equal(result.pr?.selectedRepoFullName, "acme/shop");
-  assert.equal(result.pr?.branchName, "superlog/batch-vendor-lookups");
-  assert.equal(result.pr?.baseBranch, "dev");
-  assert.equal(result.pr?.patchFilePath, "/mnt/session/outputs/superlog.patch");
-  assert.equal(result.pr?.validationPassed, true);
-  assert.equal(result.pr?.openStatus, "pending");
-  assert.deepEqual(result.pr?.validationCommands, ["pnpm test"]);
+  assert.equal(result.issueClassifications?.length, 1);
+  assert.equal(result.issueClassifications?.[0]?.action, "resolve");
+  assert.equal(result.prs?.length, 1);
+  assert.equal(result.prs?.[0]?.title, "[superlog] Follow-up");
+});
+
+test("observe classification carries the parsed escalation trigger", () => {
+  const result = assembleAgentRunResult({
+    findings: FINDINGS,
+    terminal: { name: "resolve_incident", payload: { reason: "r", evidence: "e" } },
+    actions: [
+      {
+        name: "place_under_observation",
+        payload: {
+          issueId: "issue-1",
+          reason: "one-off",
+          evidence: "e",
+          escalateOn: "additional_events",
+          threshold: 100,
+        },
+      },
+    ],
+  });
+  assert.deepEqual(result.issueClassifications?.[0]?.trigger, { kind: "count", count: 100 });
+});
+
+test("assembles a parked awaiting_events result when no terminal call happened", () => {
+  const result = assembleAgentRunResult({
+    findings: FINDINGS,
+    terminal: null,
+    actions: [{ name: "propose_pr", payload: PROPOSE_PR_INPUT }],
+  });
+  assert.equal(result.state, "awaiting_events");
+  assert.equal(result.summary, FINDINGS.summary);
+  assert.equal(result.prs?.length, 1);
+  assert.equal(result.incidentResolution, undefined);
+});
+
+test("propose_pr mobile decision lands on the result", () => {
+  const result = assembleAgentRunResult({
+    findings: FINDINGS,
+    terminal: { name: "resolve_incident", payload: { reason: "r", evidence: "e" } },
+    actions: [
+      {
+        name: "propose_pr",
+        payload: {
+          ...PROPOSE_PR_INPUT,
+          changedFiles: ["app/checkout.tsx"],
+          mobileTestStatus: "not_applicable",
+          mobileTestReason: "backend-only change",
+        },
+      },
+    ],
+  });
   assert.deepEqual(result.mobileRegressionTest, {
     status: "not_applicable",
     reason: "backend-only change",
   });
+  assert.deepEqual(result.prs?.[0]?.changedFiles, ["app/checkout.tsx"]);
 });
 
 test("derives the legacy rootCauseConfidence bucket from the numeric confidence", () => {
   const result = assembleAgentRunResult({
     findings: FINDINGS,
-    terminal: {
-      name: "mark_already_resolved",
-      payload: { reason: "transient_condition_cleared", evidence: "e" },
-    },
+    terminal: { name: "resolve_incident", payload: { reason: "r", evidence: "e" } },
   });
   assert.deepEqual(result.rootCause, { text: FINDINGS.rootCause, confidence: 9 });
   assert.equal(result.rootCauseConfidence, "high");

--- a/apps/worker/src/agent-outcome-tools.ts
+++ b/apps/worker/src/agent-outcome-tools.ts
@@ -1,27 +1,36 @@
 // Per-outcome tool contract for investigation agent runs.
 //
-// The agent ends a run by calling exactly one *terminal* outcome tool, after
-// recording shared metadata via `report_findings`. Each tool has a flat JSON
-// schema (top-level `type`/`properties`/`required` only — some runner APIs
-// reject composition keywords like `oneOf`/`allOf` at the top level of a
-// custom tool's input_schema, and a rejected schema blocks every run at
-// agent-create time). Schemas are not enforced server-side by every runner,
-// so `validateOutcomeToolInput` re-validates each call worker-side; its error
-// strings are written for the model, which sees them as tool errors and can
-// correct the call within the same session — instead of the run dying at the
-// end with an unusable result.
+// The contract has three tiers:
+//   - `report_findings` (non-terminal): shared metadata, callable repeatedly.
+//   - Action tools (non-terminal, dispatched server-side mid-run): the worker
+//     executes each call while the session is live and acks the result back,
+//     so the agent can iterate — open a PR, read the URL (or the apply
+//     failure and fix its own patch), classify each linked issue, then keep
+//     going. `propose_pr`, `silence_as_noise`, `place_under_observation`,
+//     `resolve_issue`.
+//   - Terminal tools: `resolve_incident` ends the investigation once every
+//     linked issue is classified; `ask_human` pauses it on a human. A turn may
+//     also legitimately end with NO terminal call when the run is waiting on
+//     external events (open PRs) — the worker parks it and resumes the session
+//     when a PR comment/merge/close arrives.
 //
-// `assembleAgentRunResult` folds the merged findings plus the terminal call
-// into the existing persisted `AgentRunResult` shape, so downstream consumers
-// (sync/completion/PR delivery, web, graders) are unaffected by the tool
-// split.
+// Each tool has a flat JSON schema (top-level `type`/`properties`/`required`
+// only — some runner APIs reject composition keywords like `oneOf`/`allOf` at
+// the top level of a custom tool's input_schema, and a rejected schema blocks
+// every run at agent-create time). Schemas are not enforced server-side by
+// every runner, so `validateOutcomeToolInput` re-validates each call
+// worker-side; its error strings are written for the model, which sees them
+// as tool errors and can correct the call within the same session.
+//
+// `assembleAgentRunResult` folds the merged findings, the mid-run actions,
+// and the terminal call into the persisted `AgentRunResult` shape.
 
 import type {
+  AgentRunIncidentResolution,
+  AgentRunIssueClassification,
   AgentRunMobileRegressionTest,
   AgentRunPr,
   AgentRunResult,
-  IncidentNoiseReason,
-  IncidentResolutionReason,
   IncidentSeverity,
   IssueEscalationTrigger,
 } from "@superlog/db";
@@ -40,40 +49,44 @@ export type OutcomeToolDefinition = {
 
 export const REPORT_FINDINGS_TOOL_NAME = "report_findings";
 
-export const TERMINAL_OUTCOME_TOOL_NAMES = [
+// Non-terminal action tools: executed server-side while the run is live, the
+// result is acked back into the session and the agent continues its turn.
+export const ACTION_OUTCOME_TOOL_NAMES = [
   "propose_pr",
   "silence_as_noise",
   "place_under_observation",
-  "mark_already_resolved",
-  "ask_human",
+  "resolve_issue",
 ] as const;
+
+export type ActionOutcomeToolName = (typeof ACTION_OUTCOME_TOOL_NAMES)[number];
+
+export const TERMINAL_OUTCOME_TOOL_NAMES = ["resolve_incident", "ask_human"] as const;
 
 export type TerminalOutcomeToolName = (typeof TERMINAL_OUTCOME_TOOL_NAMES)[number];
 
-// Terminal tools retired from the contract. Sessions created against the old
-// toolset can outlive a deploy (awaiting_human resumes days later), so a call
-// to one of these must be error-acked with redirect guidance — not routed to
-// the unknown-tool path, which hard-fails the run.
-export const RETIRED_OUTCOME_TOOL_NAMES = ["complete_investigation", "report_failure"] as const;
+// Tools retired from the contract. Sessions created against an old toolset
+// can outlive a deploy (a parked run resumes days later), so a call to one of
+// these must be error-acked with redirect guidance — not routed to the
+// unknown-tool path, which hard-fails the run.
+export const RETIRED_OUTCOME_TOOL_NAMES = [
+  "complete_investigation",
+  "report_failure",
+  "mark_already_resolved",
+] as const;
 
 export const OUTCOME_TOOL_NAMES = [
   REPORT_FINDINGS_TOOL_NAME,
+  ...ACTION_OUTCOME_TOOL_NAMES,
   ...TERMINAL_OUTCOME_TOOL_NAMES,
 ] as const;
 
-const NOISE_REASONS: IncidentNoiseReason[] = [
-  "cosmetic_log_only",
-  "lifecycle_signal",
-  "self_telemetry",
-  "expected_third_party",
-  "confusing_log_no_impact",
-];
+export function isActionOutcomeToolName(name: string): name is ActionOutcomeToolName {
+  return (ACTION_OUTCOME_TOOL_NAMES as readonly string[]).includes(name);
+}
 
-const RESOLUTION_REASONS: IncidentResolutionReason[] = [
-  "fixed_in_current_code",
-  "transient_condition_cleared",
-  "upstream_recovered",
-];
+export function isTerminalOutcomeToolName(name: string): name is TerminalOutcomeToolName {
+  return (TERMINAL_OUTCOME_TOOL_NAMES as readonly string[]).includes(name);
+}
 
 const SEVERITIES: IncidentSeverity[] = ["SEV-1", "SEV-2", "SEV-3"];
 
@@ -102,7 +115,7 @@ export type AgentRunFindings = {
 const REPORT_FINDINGS_DEFINITION: OutcomeToolDefinition = {
   name: REPORT_FINDINGS_TOOL_NAME,
   description:
-    "Record what the investigation found. Call this before any completing outcome tool; call it again to revise — include `summary` on every call (repeat the current one when it hasn't changed); every other field overwrites its previous value when provided and is kept when omitted. This is not a terminal tool: after reporting findings you must still end the run with exactly one outcome tool.",
+    "Record what the investigation found. Call this before any classification, PR, or resolution tool; call it again to revise — include `summary` on every call (repeat the current one when it hasn't changed); every other field overwrites its previous value when provided and is kept when omitted.",
   input_schema: {
     type: "object",
     properties: {
@@ -148,7 +161,7 @@ const REPORT_FINDINGS_DEFINITION: OutcomeToolDefinition = {
       handoffNotes: {
         type: "string",
         description:
-          "5-15 markdown lines for a future follow-up run on this incident (triggered by a PR comment or user reply after this session is gone): files/areas examined, hypotheses ruled out with the evidence that ruled them out, repo gotchas (build quirks, test setup), open uncertainties. Do not repeat rootCause — this is for what is NOT captured elsewhere.",
+          "5-15 markdown lines for a future follow-up turn on this incident (triggered by a PR comment or user reply after this session is gone): files/areas examined, hypotheses ruled out with the evidence that ruled them out, repo gotchas (build quirks, test setup), open uncertainties. Do not repeat rootCause — this is for what is NOT captured elsewhere.",
       },
     },
     required: ["summary"],
@@ -156,7 +169,7 @@ const REPORT_FINDINGS_DEFINITION: OutcomeToolDefinition = {
 };
 
 // ---------------------------------------------------------------------------
-// Terminal tools
+// Action tools (non-terminal, server-dispatched)
 // ---------------------------------------------------------------------------
 
 export type ProposePrPayload = {
@@ -166,9 +179,6 @@ export type ProposePrPayload = {
   branchName: string;
   baseBranch: string;
   patchFilePath: string;
-  validationPassed: boolean;
-  validationSummary: string;
-  validationCommands?: string[];
   changedFiles?: string[];
   mobileTestStatus?: (typeof MOBILE_TEST_STATUSES)[number];
   mobileTestId?: string;
@@ -178,7 +188,7 @@ export type ProposePrPayload = {
 const PROPOSE_PR_DEFINITION: OutcomeToolDefinition = {
   name: "propose_pr",
   description:
-    "Terminal: you produced a validated patch for a defect with REAL user or business impact. NOT for noise: if the error you diagnosed is a false positive or the operation returns its intended response, call silence_as_noise instead — a patch that only quiets a signal (log levels, span statuses, recordException, catching expected errors) is the wrong outcome no matter how clean the fix is, and 'alert fatigue from the noisy signal' does not count as impact (silencing is what fixes alert fatigue). Hand the patch off by writing a unified diff to /mnt/session/outputs/superlog.patch (git diff format, applying cleanly to baseBranch) — never inline the diff in this call. Validate the patch yourself before calling; the worker only applies it and opens the PR. Validation ladder — stop at the strongest rung you can execute: (1) the repo's own build/typecheck/tests; (2) targeted tests for the changed module, including regression tests you add with the patch; (3) direct execution of the changed logic or a scripted repro that fails before and passes after. Structural checks (grepping the new code for expected strings) are NOT validation — never set validationPassed on their basis; validation means executing something and reporting observed output. If your patch restructures existing logic (batching queries, hoisting work out of a loop, caching, dedup, reordering), it must be behaviorally identical on every input, not just fix the headline problem: enumerate what the old code could observe that the new cannot (rows written by earlier loop iterations, first-wins vs last-wins on duplicate keys, ordering, null keys, error paths), check each with a concrete example, and add a regression test encoding the ORIGINAL behavior that passes before and after. Set validationPassed=false only when the validation you executed failed or nothing on the ladder could run at all.",
+    "Open a pull request with a patch you authored, for a defect with REAL user or business impact. NOT terminal: the platform applies your patch and opens the PR while you are still running, and returns the PR URL — or the apply failure, which you can fix and retry. Call it again with a NEW branchName to open an additional, independent PR; calling it again with the SAME branchName pushes the new patch as a follow-up commit on that PR (do this when addressing review feedback). NOT for noise: if the error you diagnosed is a false positive or the operation returns its intended response, call silence_as_noise instead — a patch that only quiets a signal (log levels, span statuses, recordException, catching expected errors) is the wrong outcome no matter how clean the fix is, and 'alert fatigue from the noisy signal' does not count as impact (silencing is what fixes alert fatigue). Hand the patch off by writing a unified diff to a file under /mnt/session/outputs/ (git diff format, applying cleanly to baseBranch; use a distinct file per PR) — never inline the diff in this call. Validate the patch yourself before calling — the worker only applies it and opens the PR. After your PRs are up, either resolve the incident (resolve_incident, once every issue is classified) or end your turn to wait for review — you will be resumed when the PR gets a comment, merge, or close.",
   input_schema: {
     type: "object",
     properties: {
@@ -196,27 +206,14 @@ const PROPOSE_PR_DEFINITION: OutcomeToolDefinition = {
       branchName: {
         type: "string",
         pattern: "^superlog/",
-        description: "Must start with 'superlog/' followed by a short kebab-case slug, e.g. superlog/fix-cart-batching.",
+        description:
+          "Must start with 'superlog/' followed by a short kebab-case slug, e.g. superlog/fix-cart-batching. Reuse a branch name to push to that PR; use a new one to open a separate PR.",
       },
       baseBranch: { type: "string", description: "The branch the PR should target (the repo's active development branch)." },
       patchFilePath: {
         type: "string",
-        description: "Where you wrote the unified diff, normally /mnt/session/outputs/superlog.patch.",
-      },
-      validationPassed: {
-        type: "boolean",
         description:
-          "True only when the strongest validation rung you could actually execute passed. An honest false is acceptable; fabricated validation is not.",
-      },
-      validationSummary: {
-        type: "string",
-        description:
-          "Exactly what ran, what could not run, and why (surfaced in the PR body). Include before/after repro outcomes when you have them.",
-      },
-      validationCommands: {
-        type: "array",
-        items: { type: "string" },
-        description: "The commands you executed as validation. Never list greps/structural checks here.",
+          "Where you wrote the unified diff, e.g. /mnt/session/outputs/superlog-fix-cart-batching.patch. Use a distinct file per PR so a later PR's patch never overwrites an earlier one.",
       },
       changedFiles: { type: "array", items: { type: "string" }, description: "Repo-relative paths the patch touches." },
       mobileTestStatus: {
@@ -228,42 +225,37 @@ const PROPOSE_PR_DEFINITION: OutcomeToolDefinition = {
       mobileTestId: { type: "string", description: "The created mobile regression test id." },
       mobileTestReason: { type: "string", description: "Why the mobile regression test was skipped / not applicable." },
     },
-    required: [
-      "repoFullName",
-      "title",
-      "body",
-      "branchName",
-      "baseBranch",
-      "patchFilePath",
-      "validationPassed",
-      "validationSummary",
-    ],
+    required: ["repoFullName", "title", "body", "branchName", "baseBranch", "patchFilePath"],
   },
 };
 
-export type SilenceAsNoisePayload = { reason: IncidentNoiseReason; evidence: string };
-
-const NOISE_REASON_GUIDE =
-  "Reasons: cosmetic_log_only = the primary operation completed successfully and the ERROR is a downstream cosmetic side-effect (evidence must show the operation returned before the error fired). lifecycle_signal = fires only during process lifecycle (SIGTERM, teardown) and in-flight work completed or is retried (evidence must reference the lifecycle hook). self_telemetry = the customer's own telemetry/observability export failing (OTLP timeout, metrics 429); the application is unaffected — evidence may point at third-party exporter code. expected_third_party = the third-party API error is part of its documented contract for this call site (Slack already_reacted, idempotency conflicts); not for real provider outages the customer must act on. confusing_log_no_impact = the log is technically correct but the surrounding code recovers (retry succeeds, fallback fires) — evidence must show the recovery path runs.";
+export type SilenceAsNoisePayload = { issueId: string; reason: string; evidence: string };
 
 const SILENCE_AS_NOISE_DEFINITION: OutcomeToolDefinition = {
   name: "silence_as_noise",
-  description: `Terminal: the error is proven noise — the operation it describes either succeeded or has no user/business impact. The incident resolves and its issues are silenced: recurrences stop paging permanently, so the bar is high. You must quote the success path, the no-op contract, or the third-party contract clause; if you cannot prove it, use place_under_observation instead. Do NOT propose code changes to make the false positive quieter — downgrading log levels, catching/suppressing expected errors, or changing span statuses / recordException calls for expected conditions. Silencing is the correct action, not a PR, even when the noisy signal comes from the application's own instrumentation. ${NOISE_REASON_GUIDE}`,
+  description:
+    "Silence one linked issue as proven noise — the operation it describes either succeeded or has no user/business impact. NOT terminal: the issue is silenced immediately and you continue; classify each linked issue individually (the issue ids are in the incident issue bundle), then finish with resolve_incident. Recurrences of a silenced issue stop paging permanently, so the bar is high: you must quote the success path, the no-op contract, or the third-party contract clause. If you cannot prove it, use place_under_observation instead. Do NOT propose code changes to make the false positive quieter — downgrading log levels, catching/suppressing expected errors, or changing span statuses / recordException calls for expected conditions. Silencing is the correct action, not a PR, even when the noisy signal comes from the application's own instrumentation. Only error issues can be silenced; alert-episode issues can only be resolved (resolve_issue).",
   input_schema: {
     type: "object",
     properties: {
-      reason: { type: "string", enum: NOISE_REASONS, description: "The noise category that fits the evidence." },
+      issueId: { type: "string", description: "The id of the linked issue to silence (from the incident issue bundle)." },
+      reason: {
+        type: "string",
+        description:
+          "Free text: why this is noise, in one plain-English sentence an operator can read in a list (e.g. 'Expected 404s from bot traffic probing /wp-admin').",
+      },
       evidence: {
         type: "string",
         description: `1-3 sentences quoting the success/recovery/contract clause that justifies silencing. ${EVIDENCE_FORMAT}`,
       },
     },
-    required: ["reason", "evidence"],
+    required: ["issueId", "reason", "evidence"],
   },
 };
 
 export type PlaceUnderObservationPayload = {
-  reason: IncidentNoiseReason;
+  issueId: string;
+  reason: string;
   evidence: string;
   escalateOn: (typeof ESCALATE_ON)[number];
   threshold: number;
@@ -272,11 +264,16 @@ export type PlaceUnderObservationPayload = {
 const PLACE_UNDER_OBSERVATION_DEFINITION: OutcomeToolDefinition = {
   name: "place_under_observation",
   description:
-    `Terminal: the error is plausibly noise (a one-off, a non-critical event) but you cannot fully prove no-impact, or it could matter if it grows. The incident resolves and its issues go under observation: recurrences stay quiet until the escalation trigger trips, then a new investigation starts with your findings as context. Prefer this over silence_as_noise whenever the evidence bar for permanent silencing is not met. ${NOISE_REASON_GUIDE}`,
+    "Place one linked issue under observation — plausibly noise (a one-off, a non-critical event) but you cannot fully prove no-impact, or it could matter if it grows. NOT terminal: the issue goes quiet immediately and you continue; finish with resolve_incident once every issue is classified. Recurrences stay quiet until the escalation trigger trips, then a new investigation starts with your findings as context. Prefer this over silence_as_noise whenever the evidence bar for permanent silencing is not met. Only error issues can be observed; alert-episode issues can only be resolved (resolve_issue).",
   input_schema: {
     type: "object",
     properties: {
-      reason: { type: "string", enum: NOISE_REASONS, description: "Your best-guess noise category." },
+      issueId: { type: "string", description: "The id of the linked issue to observe (from the incident issue bundle)." },
+      reason: {
+        type: "string",
+        description:
+          "Free text: your best guess at why this is noise, in one plain-English sentence an operator can read in a list.",
+      },
       evidence: {
         type: "string",
         description:
@@ -294,23 +291,55 @@ const PLACE_UNDER_OBSERVATION_DEFINITION: OutcomeToolDefinition = {
         description: "The rate (per minute) or event count that should trigger re-investigation.",
       },
     },
-    required: ["reason", "evidence", "escalateOn", "threshold"],
+    required: ["issueId", "reason", "evidence", "escalateOn", "threshold"],
   },
 };
 
-export type MarkAlreadyResolvedPayload = { reason: IncidentResolutionReason; evidence: string };
+export type ResolveIssuePayload = { issueId: string; reason: string; evidence: string };
 
-const MARK_ALREADY_RESOLVED_DEFINITION: OutcomeToolDefinition = {
-  name: "mark_already_resolved",
+const RESOLVE_ISSUE_DEFINITION: OutcomeToolDefinition = {
+  name: "resolve_issue",
   description:
-    "Terminal: the incident was real but is already resolved and needs no remediation now. The incident and its issues are marked resolved (a recurrence starts a fresh investigation). Not for noise/no-impact cases (use silence_as_noise) and not just because errors are quiet in a tiny sample. Reasons: fixed_in_current_code = the current code already contains the fix/guard — quote the fixing code or the merged change. transient_condition_cleared = telemetry shows the failing condition recovered and stayed healthy after the incident window — include the before/after signal and window. upstream_recovered = the failing dependency/provider recovered — name the dependency and the observed recovery signal.",
+    "Resolve one linked issue: its impact has ceased and no further action on it is possible or needed — the current code already contains the fix, the transient condition cleared, the upstream dependency recovered, or your own remediation (a merged PR, an executed approval) addressed it. NOT terminal: the issue resolves immediately and you continue; finish with resolve_incident once every issue is classified. A resolved issue that recurs starts a fresh investigation with this one's findings as context — so this is not for noise (use silence_as_noise / place_under_observation) and not just because errors are quiet in a tiny sample.",
   input_schema: {
     type: "object",
     properties: {
-      reason: { type: "string", enum: RESOLUTION_REASONS, description: "Why the incident is already resolved." },
+      issueId: { type: "string", description: "The id of the linked issue to resolve (from the incident issue bundle)." },
+      reason: {
+        type: "string",
+        description:
+          "Free text: why this issue is resolved, in one plain-English sentence an operator can read in a list (e.g. 'Fixed by the retry-guard PR merged during this investigation').",
+      },
       evidence: {
         type: "string",
-        description: `1-3 sentences citing the code/telemetry/status evidence proving resolution, with concrete windows/counts when telemetry is the proof. ${EVIDENCE_FORMAT}`,
+        description: `1-3 sentences citing the code/telemetry/status evidence proving resolution, with before/after signal and concrete windows/counts when telemetry is the proof. ${EVIDENCE_FORMAT}`,
+      },
+    },
+    required: ["issueId", "reason", "evidence"],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Terminal tools
+// ---------------------------------------------------------------------------
+
+export type ResolveIncidentPayload = { reason: string; evidence: string };
+
+const RESOLVE_INCIDENT_DEFINITION: OutcomeToolDefinition = {
+  name: "resolve_incident",
+  description:
+    "Terminal: resolve the incident. Call this when the impact on the system has ceased (or there never was any), or your actions (merged PRs, executed approvals) have resolved the root cause. Every issue linked to the incident must already be classified — silenced, under observation, or resolved — via the per-issue tools; this call is rejected with the list of unclassified issues otherwise. Do NOT resolve while you are still waiting on an open PR you expect to be merged — end your turn instead and you will be resumed when the PR gets a comment, merge, or close.",
+  input_schema: {
+    type: "object",
+    properties: {
+      reason: {
+        type: "string",
+        description:
+          "Free text: why the incident is resolved, in one plain-English sentence an operator can read in a list.",
+      },
+      evidence: {
+        type: "string",
+        description: `1-3 sentences citing the evidence that the impact has ceased (before/after signal + window when telemetry is the proof). ${EVIDENCE_FORMAT}`,
       },
     },
     required: ["reason", "evidence"],
@@ -322,7 +351,7 @@ export type AskHumanPayload = { question: string };
 const ASK_HUMAN_DEFINITION: OutcomeToolDefinition = {
   name: "ask_human",
   description:
-    "Terminal: a human must act or answer before this investigation can conclude; the run pauses until they reply, then resumes with your session intact. This is the outcome whenever you cannot land on a patch, a noise verdict, or a resolution claim — an investigation never ends with findings merely filed away. Use it when: (1) you need specific missing context (expected behavior, a suspected owner, a recent deploy, a repro hint) — ask for the specific thing and include the best leads you checked; (2) you diagnosed the problem but the remediation is not yours to make (third-party library defect, provider quota, config the customer owns, or a decision needed between remediation paths) — state the diagnosis, then ask the concrete question whose answer unblocks action, naming the options if there are several; (3) you genuinely could not locate the failing code path — say what you searched and ask for the pointer you are missing; (4) telemetry names a concrete code artifact (file path, function, exception class, endpoint) absent from every mounted repo at HEAD and across remote branches — quote the missing artifact, name the repos you searched, and ask which repo owns the code (more repos exist than were mounted into this session). Never fabricate a question to avoid a harder outcome you have the evidence for.",
+    "Terminal: a human must act or answer before this investigation can continue; the run pauses until they reply, then resumes with your session intact. Use it when: (1) you need specific missing context (expected behavior, a suspected owner, a recent deploy, a repro hint) — ask for the specific thing and include the best leads you checked; (2) you diagnosed the problem but the remediation is not yours to make (third-party library defect, provider quota, config the customer owns, or a decision needed between remediation paths) — state the diagnosis, then ask the concrete question whose answer unblocks action, naming the options if there are several; (3) you genuinely could not locate the failing code path — say what you searched and ask for the pointer you are missing; (4) telemetry names a concrete code artifact (file path, function, exception class, endpoint) absent from every mounted repo at HEAD and across remote branches — quote the missing artifact, name the repos you searched, and ask which repo owns the code (more repos exist than were mounted into this session). Never fabricate a question to avoid a harder outcome you have the evidence for.",
   input_schema: {
     type: "object",
     properties: {
@@ -340,7 +369,8 @@ export const OUTCOME_TOOL_DEFINITIONS: OutcomeToolDefinition[] = [
   PROPOSE_PR_DEFINITION,
   SILENCE_AS_NOISE_DEFINITION,
   PLACE_UNDER_OBSERVATION_DEFINITION,
-  MARK_ALREADY_RESOLVED_DEFINITION,
+  RESOLVE_ISSUE_DEFINITION,
+  RESOLVE_INCIDENT_DEFINITION,
   ASK_HUMAN_DEFINITION,
 ];
 
@@ -348,25 +378,30 @@ export const OUTCOME_TOOL_DEFINITIONS: OutcomeToolDefinition[] = [
 // Validation
 // ---------------------------------------------------------------------------
 
-export type TerminalOutcome =
+export type ActionOutcome =
   | { name: "propose_pr"; payload: ProposePrPayload }
   | { name: "silence_as_noise"; payload: SilenceAsNoisePayload }
   | { name: "place_under_observation"; payload: PlaceUnderObservationPayload }
-  | { name: "mark_already_resolved"; payload: MarkAlreadyResolvedPayload }
+  | { name: "resolve_issue"; payload: ResolveIssuePayload };
+
+export type TerminalOutcome =
+  | { name: "resolve_incident"; payload: ResolveIncidentPayload }
   | { name: "ask_human"; payload: AskHumanPayload };
 
 export type ValidateOutcome =
   | { ok: true; tool: "report_findings"; payload: AgentRunFindings }
+  | { ok: true; tool: ActionOutcomeToolName; payload: ActionOutcome["payload"] }
   | { ok: true; tool: TerminalOutcomeToolName; payload: TerminalOutcome["payload"] }
   | { ok: false; errors: string[] };
 
-// Terminal tools that conclude the investigation with findings the humans
-// will read — these refuse to run until report_findings has been called.
+// Tools that conclude with findings humans will read — these refuse to run
+// until report_findings has been called.
 const FINDINGS_REQUIRED = new Set<string>([
   "propose_pr",
   "silence_as_noise",
   "place_under_observation",
-  "mark_already_resolved",
+  "resolve_issue",
+  "resolve_incident",
 ]);
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -446,7 +481,7 @@ export function validateOutcomeToolInput(
     return {
       ok: false,
       errors: [
-        `\`${name}\` is no longer available. End the run with exactly one of: \`propose_pr\`, \`silence_as_noise\`, \`place_under_observation\`, \`mark_already_resolved\`, or \`ask_human\`. If the remediation is not yours to make, or you cannot locate the failing code path, call \`ask_human\` with your findings and the specific question that unblocks action.`,
+        `\`${name}\` is no longer available. Classify each linked issue with \`silence_as_noise\`, \`place_under_observation\`, or \`resolve_issue\`; open PRs with \`propose_pr\`; then finish the run with \`resolve_incident\` (or \`ask_human\` when a human must act or answer first).`,
       ],
     };
   }
@@ -499,16 +534,19 @@ export function validateOutcomeToolInput(
       const branchName = pushRequiredString(errors, input, "branchName");
       const baseBranch = pushRequiredString(errors, input, "baseBranch");
       const patchFilePath = pushRequiredString(errors, input, "patchFilePath");
-      const validationSummary = pushRequiredString(errors, input, "validationSummary");
-      if (typeof input.validationPassed !== "boolean") {
-        errors.push("`validationPassed` is required and must be a boolean.");
-      }
       if (branchName && !branchName.startsWith("superlog/")) {
         errors.push(
           `\`branchName\` must start with \`superlog/\`; you sent ${JSON.stringify(branchName)}.`,
         );
       }
-      const validationCommands = optionalStringArray(errors, input, "validationCommands");
+      // Legacy sessions still send validationPassed; an honest false meant
+      // "do not open this PR", so keep honoring it rather than shipping a
+      // patch its author reported as failing.
+      if (input.validationPassed === false) {
+        errors.push(
+          "You reported `validationPassed: false`. Do not propose a PR whose validation failed — fix the patch and call `propose_pr` again once it validates.",
+        );
+      }
       const changedFiles = optionalStringArray(errors, input, "changedFiles");
       let mobileTestStatus: ProposePrPayload["mobileTestStatus"];
       if (input.mobileTestStatus !== undefined && input.mobileTestStatus !== null) {
@@ -536,10 +574,7 @@ export function validateOutcomeToolInput(
         branchName: branchName as string,
         baseBranch: baseBranch as string,
         patchFilePath: patchFilePath as string,
-        validationPassed: input.validationPassed as boolean,
-        validationSummary: validationSummary as string,
       };
-      if (validationCommands) payload.validationCommands = validationCommands;
       if (changedFiles) payload.changedFiles = changedFiles;
       if (mobileTestStatus) payload.mobileTestStatus = mobileTestStatus;
       if (mobileTestId) payload.mobileTestId = mobileTestId;
@@ -548,30 +583,38 @@ export function validateOutcomeToolInput(
     }
 
     case "silence_as_noise":
-    case "place_under_observation": {
-      const reason = requiredEnum(errors, input, "reason", NOISE_REASONS);
+    case "resolve_issue": {
+      const issueId = pushRequiredString(errors, input, "issueId");
+      const reason = pushRequiredString(errors, input, "reason");
       const evidence = pushRequiredString(errors, input, "evidence");
-      if (name === "silence_as_noise") {
-        if (errors.length > 0) return { ok: false, errors };
-        return {
-          ok: true,
-          tool: name,
-          payload: { reason: reason as IncidentNoiseReason, evidence: evidence as string },
-        };
-      }
+      if (errors.length > 0) return { ok: false, errors };
+      return {
+        ok: true,
+        tool: name,
+        payload: {
+          issueId: issueId as string,
+          reason: reason as string,
+          evidence: evidence as string,
+        },
+      };
+    }
+
+    case "place_under_observation": {
+      const issueId = pushRequiredString(errors, input, "issueId");
+      const reason = pushRequiredString(errors, input, "reason");
+      const evidence = pushRequiredString(errors, input, "evidence");
       const escalateOn = requiredEnum(errors, input, "escalateOn", ESCALATE_ON);
       const threshold = input.threshold;
       if (typeof threshold !== "number" || !Number.isInteger(threshold) || threshold < 1) {
-        errors.push(
-          `\`threshold\` must be an integer >= 1; you sent ${JSON.stringify(threshold)}.`,
-        );
+        errors.push(`\`threshold\` must be an integer >= 1; you sent ${JSON.stringify(threshold)}.`);
       }
       if (errors.length > 0) return { ok: false, errors };
       return {
         ok: true,
         tool: "place_under_observation",
         payload: {
-          reason: reason as IncidentNoiseReason,
+          issueId: issueId as string,
+          reason: reason as string,
           evidence: evidence as string,
           escalateOn: escalateOn as PlaceUnderObservationPayload["escalateOn"],
           threshold: threshold as number,
@@ -579,14 +622,14 @@ export function validateOutcomeToolInput(
       };
     }
 
-    case "mark_already_resolved": {
-      const reason = requiredEnum(errors, input, "reason", RESOLUTION_REASONS);
+    case "resolve_incident": {
+      const reason = pushRequiredString(errors, input, "reason");
       const evidence = pushRequiredString(errors, input, "evidence");
       if (errors.length > 0) return { ok: false, errors };
       return {
         ok: true,
-        tool: "mark_already_resolved",
-        payload: { reason: reason as IncidentResolutionReason, evidence: evidence as string },
+        tool: "resolve_incident",
+        payload: { reason: reason as string, evidence: evidence as string },
       };
     }
 
@@ -652,28 +695,85 @@ function mobileTestFromPr(payload: ProposePrPayload): AgentRunMobileRegressionTe
   return { status: payload.mobileTestStatus, reason: payload.mobileTestReason as string };
 }
 
-function triggerFromObservation(payload: PlaceUnderObservationPayload): IssueEscalationTrigger {
+export function escalationTriggerFromObservation(
+  payload: Pick<PlaceUnderObservationPayload, "escalateOn" | "threshold">,
+): IssueEscalationTrigger {
   return payload.escalateOn === "events_per_minute"
     ? { kind: "rate", perMinute: payload.threshold }
     : { kind: "count", count: payload.threshold };
 }
 
+// A successfully executed mid-run action (the dispatch loop applied its
+// effect and acked ok), replayed from the session event stream so the final
+// result can record what happened during the run.
+export type ExecutedAction = ActionOutcome;
+
+function issueClassificationFromAction(
+  action: ExecutedAction,
+): AgentRunIssueClassification | null {
+  switch (action.name) {
+    case "silence_as_noise":
+      return {
+        issueId: action.payload.issueId,
+        action: "silence",
+        reason: action.payload.reason,
+        evidence: action.payload.evidence,
+      };
+    case "place_under_observation":
+      return {
+        issueId: action.payload.issueId,
+        action: "observe",
+        reason: action.payload.reason,
+        evidence: action.payload.evidence,
+        trigger: escalationTriggerFromObservation(action.payload),
+      };
+    case "resolve_issue":
+      return {
+        issueId: action.payload.issueId,
+        action: "resolve",
+        reason: action.payload.reason,
+        evidence: action.payload.evidence,
+      };
+    default:
+      return null;
+  }
+}
+
+export type AssembledOutcomeState = "complete" | "awaiting_human" | "awaiting_events";
+
 export function assembleAgentRunResult(args: {
   findings: AgentRunFindings | null;
-  terminal: TerminalOutcome;
+  // Null when the turn ended without a terminal call (the run parks on
+  // awaiting_events while its PRs are out for review).
+  terminal: TerminalOutcome | null;
+  // Successfully executed mid-run actions, in call order.
+  actions?: ExecutedAction[];
 }): AgentRunResult {
   const { findings, terminal } = args;
+  const actions = args.actions ?? [];
 
-  const fallbackSummary = terminal.name === "ask_human" ? terminal.payload.question : "";
+  const state: AssembledOutcomeState =
+    terminal === null
+      ? "awaiting_events"
+      : terminal.name === "ask_human"
+        ? "awaiting_human"
+        : "complete";
+  const fallbackSummary = terminal?.name === "ask_human" ? terminal.payload.question : "";
   const result: AgentRunResult = {
-    state: terminal.name === "ask_human" ? "awaiting_human" : "complete",
+    state,
     summary: findings?.summary ?? fallbackSummary,
   };
   if (findings) applyFindings(result, findings);
 
-  switch (terminal.name) {
-    case "propose_pr": {
-      const p = terminal.payload;
+  // Latest action per issue wins (the agent corrected itself mid-run).
+  const classificationsByIssue = new Map<string, AgentRunIssueClassification>();
+  const prs: AgentRunPr[] = [];
+  for (const action of actions) {
+    if (action.name === "propose_pr") {
+      const p = action.payload;
+      const existingIdx = prs.findIndex(
+        (pr) => pr.selectedRepoFullName === p.repoFullName && pr.branchName === p.branchName,
+      );
       const pr: AgentRunPr = {
         selectedRepoFullName: p.repoFullName,
         branchName: p.branchName,
@@ -681,40 +781,35 @@ export function assembleAgentRunResult(args: {
         title: p.title,
         body: p.body,
         patchFilePath: p.patchFilePath,
-        validationPassed: p.validationPassed,
-        validationSummary: p.validationSummary,
-        openStatus: "pending",
+        openStatus: "opened",
       };
-      if (p.validationCommands) pr.validationCommands = p.validationCommands;
       if (p.changedFiles) pr.changedFiles = p.changedFiles;
-      result.pr = pr;
+      if (existingIdx >= 0) prs[existingIdx] = pr;
+      else prs.push(pr);
       const mobile = mobileTestFromPr(p);
       if (mobile) result.mobileRegressionTest = mobile;
-      break;
+      continue;
     }
-    case "silence_as_noise":
-      result.noiseClassification = {
-        reason: terminal.payload.reason,
-        evidence: terminal.payload.evidence,
-        action: { kind: "silence" },
-      };
-      break;
-    case "place_under_observation":
-      result.noiseClassification = {
-        reason: terminal.payload.reason,
-        evidence: terminal.payload.evidence,
-        action: { kind: "observe", trigger: triggerFromObservation(terminal.payload) },
-      };
-      break;
-    case "mark_already_resolved":
-      result.resolutionClassification = {
-        reason: terminal.payload.reason,
-        evidence: terminal.payload.evidence,
-      };
-      break;
-    case "ask_human":
-      result.question = terminal.payload.question;
-      break;
+    const classification = issueClassificationFromAction(action);
+    if (classification) classificationsByIssue.set(classification.issueId, classification);
+  }
+  if (prs.length > 0) {
+    result.prs = prs;
+    // Old readers expect the singular field; point it at the most recent PR.
+    result.pr = prs[prs.length - 1];
+  }
+  if (classificationsByIssue.size > 0) {
+    result.issueClassifications = [...classificationsByIssue.values()];
+  }
+
+  if (terminal?.name === "resolve_incident") {
+    result.incidentResolution = {
+      reason: terminal.payload.reason,
+      evidence: terminal.payload.evidence,
+    };
+  }
+  if (terminal?.name === "ask_human") {
+    result.question = terminal.payload.question;
   }
 
   return result;

--- a/apps/worker/src/agent-run-health-metrics.test.ts
+++ b/apps/worker/src/agent-run-health-metrics.test.ts
@@ -15,6 +15,7 @@ const ACME: AgentRunOrgHealthCounts = {
   stuck: 4,
   queued: 12,
   awaitingHuman: 3,
+  awaitingEvents: 2,
   blocked: 5,
 };
 
@@ -26,6 +27,7 @@ const GLOBEX: AgentRunOrgHealthCounts = {
   stuck: 0,
   queued: 1,
   awaitingHuman: 0,
+  awaitingEvents: 0,
   blocked: 0,
 };
 
@@ -44,6 +46,7 @@ test("per-org counts map onto gauges with tenant org attributes", () => {
   assert.equal(byKey.get("superlog.agent_runs.stuck|Acme|"), 4);
   assert.equal(byKey.get("superlog.agent_runs.queued|Acme|"), 12);
   assert.equal(byKey.get("superlog.agent_runs.awaiting_human|Acme|"), 3);
+  assert.equal(byKey.get("superlog.agent_runs.awaiting_events|Acme|"), 2);
   assert.equal(byKey.get("superlog.agent_runs.blocked|Acme|"), 5);
   assert.equal(byKey.get("superlog.agent_runs.completed_recent|Acme|"), 31);
   assert.equal(byKey.get("superlog.agent_runs.failed_recent|Acme|patch_validation_failed"), 7);
@@ -82,6 +85,7 @@ test("orgs that drop out of the snapshot get one explicit all-zero pass", () => 
   assert.equal(globex.orgName, "Globex");
   assert.equal(globex.stuck, 0);
   assert.equal(globex.queued, 0);
+  assert.equal(globex.awaitingEvents, 0);
   assert.equal(globex.blocked, 0);
   assert.deepEqual(globex.failedRecentByReason, {});
   // Orgs still present are passed through untouched.
@@ -95,6 +99,7 @@ test("no orgs at all still observes every gauge so the series never goes dark", 
     "superlog.agent_runs.stuck",
     "superlog.agent_runs.queued",
     "superlog.agent_runs.awaiting_human",
+    "superlog.agent_runs.awaiting_events",
     "superlog.agent_runs.blocked",
     "superlog.agent_runs.completed_recent",
     "superlog.agent_runs.failed_recent",

--- a/apps/worker/src/agent-run-health-metrics.ts
+++ b/apps/worker/src/agent-run-health-metrics.ts
@@ -22,6 +22,8 @@ export type AgentRunOrgHealthCounts = {
   stuck: number;
   queued: number;
   awaitingHuman: number;
+  // Runs parked while their PRs are out for review (awaiting_events).
+  awaitingEvents: number;
   // Runs parked on missing prerequisites (e.g. no GitHub connected).
   blocked: number;
 };
@@ -75,6 +77,7 @@ export async function loadAgentRunHealthCounts(): Promise<AgentRunOrgHealthCount
     stuck: number;
     queued: number;
     awaiting: number;
+    awaiting_events: number;
     blocked: number;
   }>(sql`
     SELECT
@@ -90,6 +93,7 @@ export async function loadAgentRunHealthCounts(): Promise<AgentRunOrgHealthCount
       )::int AS stuck,
       count(*) FILTER (WHERE ar.state = 'queued')::int AS queued,
       count(*) FILTER (WHERE ar.state = 'awaiting_human')::int AS awaiting,
+      count(*) FILTER (WHERE ar.state = 'awaiting_events')::int AS awaiting_events,
       count(*) FILTER (WHERE ar.state LIKE 'blocked_%')::int AS blocked
     FROM agent_runs ar
     JOIN incidents i ON i.id = ar.incident_id
@@ -103,6 +107,7 @@ export async function loadAgentRunHealthCounts(): Promise<AgentRunOrgHealthCount
     stuck: number;
     queued: number;
     awaiting: number;
+    awaiting_events: number;
     blocked: number;
   }>;
 
@@ -118,6 +123,7 @@ export async function loadAgentRunHealthCounts(): Promise<AgentRunOrgHealthCount
         stuck: 0,
         queued: 0,
         awaitingHuman: 0,
+        awaitingEvents: 0,
         blocked: 0,
       };
       byOrg.set(orgId, entry);
@@ -131,6 +137,7 @@ export async function loadAgentRunHealthCounts(): Promise<AgentRunOrgHealthCount
     entry.stuck = Number(r.stuck);
     entry.queued = Number(r.queued);
     entry.awaitingHuman = Number(r.awaiting);
+    entry.awaitingEvents = Number(r.awaiting_events);
     entry.blocked = Number(r.blocked);
   }
   for (const r of failedRows) {
@@ -143,6 +150,7 @@ export async function loadAgentRunHealthCounts(): Promise<AgentRunOrgHealthCount
       o.stuck > 0 ||
       o.queued > 0 ||
       o.awaitingHuman > 0 ||
+      o.awaitingEvents > 0 ||
       o.blocked > 0 ||
       Object.keys(o.failedRecentByReason).length > 0,
   );
@@ -169,6 +177,7 @@ export function withRecoveryZeros(
       stuck: 0,
       queued: 0,
       awaitingHuman: 0,
+      awaitingEvents: 0,
       blocked: 0,
     });
   }
@@ -193,6 +202,11 @@ export function buildAgentRunHealthObservations(
       { metric: "superlog.agent_runs.stuck", value: org.stuck, attributes: attrs },
       { metric: "superlog.agent_runs.queued", value: org.queued, attributes: attrs },
       { metric: "superlog.agent_runs.awaiting_human", value: org.awaitingHuman, attributes: attrs },
+      {
+        metric: "superlog.agent_runs.awaiting_events",
+        value: org.awaitingEvents,
+        attributes: attrs,
+      },
       { metric: "superlog.agent_runs.blocked", value: org.blocked, attributes: attrs },
       { metric: "superlog.agent_runs.completed_recent", value: org.completedRecent, attributes: attrs },
     );
@@ -211,6 +225,7 @@ export function buildAgentRunHealthObservations(
       { metric: "superlog.agent_runs.stuck", value: 0 },
       { metric: "superlog.agent_runs.queued", value: 0 },
       { metric: "superlog.agent_runs.awaiting_human", value: 0 },
+      { metric: "superlog.agent_runs.awaiting_events", value: 0 },
       { metric: "superlog.agent_runs.blocked", value: 0 },
       { metric: "superlog.agent_runs.completed_recent", value: 0 },
     );
@@ -253,6 +268,10 @@ export function registerAgentRunHealthMetrics(): void {
     "superlog.agent_runs.awaiting_human": meter.createObservableGauge(
       "superlog.agent_runs.awaiting_human",
       { description: "Agent runs parked on a human response, by org." },
+    ),
+    "superlog.agent_runs.awaiting_events": meter.createObservableGauge(
+      "superlog.agent_runs.awaiting_events",
+      { description: "Agent runs parked while their PRs are out for review, by org." },
     ),
     "superlog.agent_runs.blocked": meter.createObservableGauge("superlog.agent_runs.blocked", {
       description: "Agent runs parked on missing prerequisites (e.g. no GitHub connected), by org.",

--- a/apps/worker/src/agent-run.test.ts
+++ b/apps/worker/src/agent-run.test.ts
@@ -82,7 +82,12 @@ type RecordedCall =
   | { op: "transaction.begin" }
   | { op: "transaction.end" };
 
-function recordingDb(opts: { insertReturningRow?: Record<string, unknown> } = {}): {
+function recordingDb(
+  opts: {
+    insertReturningRow?: Record<string, unknown>;
+    updateReturningRows?: Array<Record<string, unknown>>;
+  } = {},
+): {
   db: DB;
   calls: RecordedCall[];
 } {
@@ -103,8 +108,17 @@ function recordingDb(opts: { insertReturningRow?: Record<string, unknown> } = {}
   const updateChain = (table: unknown) => ({
     set(values: Record<string, unknown>) {
       return {
-        async where(_cond: unknown) {
+        where(_cond: unknown) {
           calls.push({ op: "update.where", table, values });
+          // Both `await ...where(...)` and `await ...where(...).returning()`
+          // are used by the module; support the conditional-update pattern by
+          // returning a thenable that also exposes returning().
+          const thenable = Promise.resolve(undefined);
+          return Object.assign(thenable, {
+            async returning() {
+              return opts.updateReturningRows ?? [{ id: "fake-id" }];
+            },
+          });
         },
       };
     },
@@ -497,3 +511,39 @@ function makeIncident(id: string, opts: { issueCount: number; lastSeen: Date }):
     status: "open",
   } as unknown as schema.Incident;
 }
+
+// ─── pauseForEvents race guard ───────────────────────────────────────────
+
+test("pauseForEvents parks the run and reports it won the transition", async () => {
+  const { db, calls } = recordingDb();
+  const lifecycle = createAgentRunLifecycle(db);
+  const result: AgentRunResult = { state: "awaiting_events", summary: "waiting on PRs" };
+
+  const won = await lifecycle.pauseForEvents({ id: "run-1", currentState: "running", result });
+
+  assert.equal(won, true);
+  const update = calls.find((c) => c.op === "update.where");
+  assert.equal((update as { values: Record<string, unknown> } | undefined)?.values.state, "awaiting_events");
+  const event = calls.find((c) => c.op === "insert.onConflictDoNothing");
+  assert.equal(
+    (event as { values: Record<string, unknown> } | undefined)?.values.kind,
+    "awaiting_events",
+  );
+});
+
+test("pauseForEvents that lost the race writes no event and reports false", async () => {
+  // Two sync passes can both observe the session idle; the transition is
+  // folded into the UPDATE's WHERE (state must still be 'running'), so the
+  // loser sees zero updated rows and must skip its side effects.
+  const { db, calls } = recordingDb({ updateReturningRows: [] });
+  const lifecycle = createAgentRunLifecycle(db);
+  const result: AgentRunResult = { state: "awaiting_events", summary: "waiting on PRs" };
+
+  const won = await lifecycle.pauseForEvents({ id: "run-1", currentState: "running", result });
+
+  assert.equal(won, false);
+  assert.equal(
+    calls.find((c) => c.op === "insert.onConflictDoNothing"),
+    undefined,
+  );
+});

--- a/apps/worker/src/agent-run.test.ts
+++ b/apps/worker/src/agent-run.test.ts
@@ -23,6 +23,7 @@ test("ACTIVE_STATES + DORMANT_STATES + TERMINAL_STATES partition the AgentRunSta
     "repo_discovery",
     "running",
     "awaiting_human",
+    "awaiting_events",
     "pr_retry_queued",
     "blocked_no_github",
     "resuming",

--- a/apps/worker/src/agent-run.ts
+++ b/apps/worker/src/agent-run.ts
@@ -124,6 +124,32 @@ export function createAgentRunLifecycle(db: DB) {
     },
 
     /**
+     * `running → awaiting_events`: the turn ended without a terminal outcome
+     * call while the run has PRs out for review. The durable session is kept;
+     * PR events (comment, merge, close) and human messages resume it via the
+     * same continuation path as awaiting_human. Stores the partial result
+     * (findings + actions so far) and emits `awaiting_events`.
+     */
+    async pauseForEvents(opts: {
+      id: string;
+      currentState: AgentRunState | string;
+      result: AgentRunResult;
+    }): Promise<void> {
+      assertAgentRunSourceState("pauseForEvents", opts.currentState, ["running"]);
+      await repository.updateRun(opts.id, {
+        state: "awaiting_events",
+        result: opts.result,
+      });
+      await repository.insertEvent({
+        agentRunId: opts.id,
+        kind: "awaiting_events",
+        summary: "Investigation is waiting on PR review/merge events.",
+        dedupeKey: `awaiting_events:${opts.id}:${Date.now()}`,
+        processed: true,
+      });
+    },
+
+    /**
      * `awaiting_human → queued`, used when no managed session exists yet
      * (the agentRun paused before startRunning ever fired). The next
      * tick reloads ctx and re-enters startQueuedAgentRun. No event —
@@ -197,19 +223,27 @@ export function createAgentRunLifecycle(db: DB) {
     // shared governed path while the bulk update bypasses it.
 
     /**
-     * `awaiting_human | resuming → running`, after the managed session
-     * accepted the human message. Increments resumeCount. Emits `resumed`.
+     * `awaiting_human | awaiting_events | resuming → running`, after the
+     * managed session accepted the inbound message. Increments resumeCount and
+     * resets startedAt: the wall-clock budget is per active leg, so a run that
+     * legitimately waited days on a PR review isn't reaped the moment it
+     * resumes. Emits `resumed`.
      */
     async resumeRunning(opts: {
       id: string;
       currentState: AgentRunState | string;
       currentResumeCount: number;
     }): Promise<void> {
-      assertAgentRunSourceState("resumeRunning", opts.currentState, ["awaiting_human", "resuming"]);
+      assertAgentRunSourceState("resumeRunning", opts.currentState, [
+        "awaiting_human",
+        "awaiting_events",
+        "resuming",
+      ]);
       const nextResumeCount = opts.currentResumeCount + 1;
       await repository.updateRun(opts.id, {
         state: "running",
         resumeCount: nextResumeCount,
+        startedAt: new Date(),
       });
       await repository.insertEvent({
         agentRunId: opts.id,
@@ -359,6 +393,7 @@ export function createAgentRunLifecycle(db: DB) {
         "repo_discovery",
         "running",
         "awaiting_human",
+        "awaiting_events",
         "resuming",
         "pr_retry_queued",
         "blocked_no_github",

--- a/apps/worker/src/agent-run.ts
+++ b/apps/worker/src/agent-run.ts
@@ -224,22 +224,31 @@ export function createAgentRunLifecycle(db: DB) {
 
     /**
      * `awaiting_human | awaiting_events | resuming → running`, after the
-     * managed session accepted the inbound message. Increments resumeCount and
-     * resets startedAt: the wall-clock budget is per active leg, so a run that
-     * legitimately waited days on a PR review isn't reaped the moment it
-     * resumes. Emits `resumed`.
+     * managed session accepted the inbound message. Resets startedAt: the
+     * wall-clock budget is per active leg, so a run that legitimately waited
+     * days on a PR review isn't reaped the moment it resumes. Emits `resumed`.
+     *
+     * resumeCount is the HUMAN-resume budget (it guards a runaway agent that
+     * keeps re-pinging the human), so only awaiting_human resumes increment
+     * it. Continuation resumes (`awaiting_events`, `resuming`) are driven by
+     * external events — PR reviews, merges, replies to a finished run — and
+     * must not eat the budget: several PR round-trips would otherwise fail
+     * the next real human reply as human_resume_budget_exhausted.
      */
     async resumeRunning(opts: {
       id: string;
       currentState: AgentRunState | string;
       currentResumeCount: number;
+      continuation?: boolean;
     }): Promise<void> {
       assertAgentRunSourceState("resumeRunning", opts.currentState, [
         "awaiting_human",
         "awaiting_events",
         "resuming",
       ]);
-      const nextResumeCount = opts.currentResumeCount + 1;
+      const nextResumeCount = opts.continuation
+        ? opts.currentResumeCount
+        : opts.currentResumeCount + 1;
       await repository.updateRun(opts.id, {
         state: "running",
         resumeCount: nextResumeCount,
@@ -249,7 +258,12 @@ export function createAgentRunLifecycle(db: DB) {
         agentRunId: opts.id,
         kind: "resumed",
         summary: "Investigation resumed with human input.",
-        dedupeKey: `resumed:${nextResumeCount}`,
+        // Continuations don't advance the counter, so the count alone can't
+        // dedupe them — suffix a timestamp so each continuation resume still
+        // records a fresh audit event.
+        dedupeKey: opts.continuation
+          ? `resumed:${nextResumeCount}:${Date.now()}`
+          : `resumed:${nextResumeCount}`,
         processed: true,
       });
     },
@@ -405,6 +419,11 @@ export function createAgentRunLifecycle(db: DB) {
         summary: opts.summary,
         failureReason: opts.reason,
         pr: existing?.pr ?? null,
+        // A failing parked run may already have delivered PRs and classified
+        // issues mid-run; those records must survive the failure so the
+        // incident still shows them.
+        prs: existing?.prs ?? null,
+        issueClassifications: existing?.issueClassifications ?? null,
         linearTicket: existing?.linearTicket ?? null,
         rootCauseConfidence: existing?.rootCauseConfidence ?? null,
       };

--- a/apps/worker/src/agent-run.ts
+++ b/apps/worker/src/agent-run.ts
@@ -129,17 +129,23 @@ export function createAgentRunLifecycle(db: DB) {
      * PR events (comment, merge, close) and human messages resume it via the
      * same continuation path as awaiting_human. Stores the partial result
      * (findings + actions so far) and emits `awaiting_events`.
+     *
+     * Two sync passes can both observe the session idle, so the state check
+     * is folded into the UPDATE's WHERE: only the winner parks the run and
+     * returns true; the loser gets false and must skip its side effects
+     * (Slack messaging, metering).
      */
     async pauseForEvents(opts: {
       id: string;
       currentState: AgentRunState | string;
       result: AgentRunResult;
-    }): Promise<void> {
+    }): Promise<boolean> {
       assertAgentRunSourceState("pauseForEvents", opts.currentState, ["running"]);
-      await repository.updateRun(opts.id, {
+      const won = await repository.updateRunIfState(opts.id, "running", {
         state: "awaiting_events",
         result: opts.result,
       });
+      if (!won) return false;
       await repository.insertEvent({
         agentRunId: opts.id,
         kind: "awaiting_events",
@@ -147,6 +153,7 @@ export function createAgentRunLifecycle(db: DB) {
         dedupeKey: `awaiting_events:${opts.id}:${Date.now()}`,
         processed: true,
       });
+      return true;
     },
 
     /**

--- a/apps/worker/src/agent-runner-backend.ts
+++ b/apps/worker/src/agent-runner-backend.ts
@@ -5,6 +5,7 @@ import type {
   AgentRunTrigger,
   PrPolicy,
 } from "@superlog/db";
+import type { AgentRunFindings, ExecutedAction } from "./agent-outcome-tools.js";
 
 export type AgentRunnerRepoCandidate = {
   fullName: string;
@@ -136,6 +137,23 @@ export type AgentRunnerStartInput = {
   predecessors: AgentRunnerPredecessorIncident[];
 };
 
+// A pending outcome-action tool call handed to the worker's executor by the
+// backend's dispatch loop. `hasFindings` reflects whether a valid
+// report_findings call has been seen earlier in the current turn — the
+// executor's validation needs it for the findings-first gate.
+export type OutcomeActionCall = {
+  name: string;
+  input: unknown;
+  hasFindings: boolean;
+};
+
+export type OutcomeActionExecution =
+  // handled: the executor ran (or rejected) the action; ack `payload` back
+  // into the session with is_error = !ok.
+  | { handled: true; ok: boolean; payload: Record<string, unknown> }
+  // Not an outcome action — the dispatch loop tries its other handlers.
+  | { handled: false };
+
 export type AgentRunnerSnapshot = {
   sessionId: string;
   status: "running" | "idle" | "terminated" | "rescheduling";
@@ -148,6 +166,15 @@ export type AgentRunnerSnapshot = {
     detail: Record<string, unknown> | null;
   }>;
   result: AgentRunResult | null;
+  // The current turn's accumulated outcome state even when no terminal tool
+  // has been called: merged findings plus successfully executed mid-run
+  // actions. sync.ts uses it to assemble the parked result when a turn
+  // legitimately ends without a terminal call (open PRs awaiting review).
+  // Optional so runners without the outcome toolset are unaffected.
+  pendingOutcome?: {
+    findings: AgentRunFindings | null;
+    actions: ExecutedAction[];
+  };
   // Custom tools the runtime had no handler for. The collector ack's them
   // with an error result so the session can leave requires_action; sync.ts
   // then fails the run with `unknown_custom_tool` so we can audit them later.
@@ -215,6 +242,11 @@ export type AgentRunnerBackend = {
     orgId: string;
     projectId: string;
     incidentId: string;
+    // Executes the agent's non-terminal outcome-action tools (propose_pr,
+    // issue classification) and guards resolve_incident. When absent (e.g. a
+    // caller without run context), the backend error-acks those calls so the
+    // session never deadlocks in requires_action.
+    executeOutcomeAction?: (call: OutcomeActionCall) => Promise<OutcomeActionExecution>;
   }): Promise<number>;
   // Serve a chat session's pending tool calls (memory tools + the reply
   // tool). `onReply` posts the reply text to the chat's channel — the worker

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -37,25 +37,47 @@ const incidentLifecycle = createIncidentLifecycle(db);
 // which stays the system of record). The turn's origin is the run's trigger for
 // a cold-start follow-up, or the latest human_reply event for a resumed/steered
 // session. Best-effort — a failed PR post never blocks completion.
+// A GitHub comment/PR URL → (repo, PR number), so the reply can land on the
+// PR the human actually wrote on rather than "the incident's latest open PR".
+export function parsePrRefFromGithubUrl(
+  url: string | null | undefined,
+): { repoFullName: string; prNumber: number } | null {
+  if (!url) return null;
+  const match = /github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/.exec(url);
+  if (!match) return null;
+  const prNumber = Number(match[2]);
+  if (!Number.isInteger(prNumber)) return null;
+  return { repoFullName: match[1] as string, prNumber };
+}
+
 export async function replyToPrOriginIfNeeded(
   ctx: AgentRunContext,
   replyText: string,
 ): Promise<void> {
   let isPrOrigin = ctx.agentRun.trigger === "pr_comment";
-  if (!isPrOrigin) {
-    const lastReply = await db.query.incidentEvents.findFirst({
-      where: and(
-        eq(schema.incidentEvents.agentRunId, ctx.agentRun.id),
-        eq(schema.incidentEvents.kind, "human_reply"),
-      ),
-      orderBy: [desc(schema.incidentEvents.createdAt)],
-      columns: { detail: true },
-    });
-    const origin = (lastReply?.detail as { origin?: { channel?: string } } | null)?.origin;
-    isPrOrigin = origin?.channel === "pr_comment";
+  let originUrl: string | null = null;
+  const lastReply = await db.query.incidentEvents.findFirst({
+    where: and(
+      eq(schema.incidentEvents.agentRunId, ctx.agentRun.id),
+      eq(schema.incidentEvents.kind, "human_reply"),
+    ),
+    orderBy: [desc(schema.incidentEvents.createdAt)],
+    columns: { detail: true },
+  });
+  const origin = (lastReply?.detail as { origin?: { channel?: string; url?: string | null } } | null)
+    ?.origin;
+  if (origin?.channel === "pr_comment") {
+    isPrOrigin = true;
+    originUrl = origin.url ?? null;
+  } else if (!isPrOrigin) {
+    return;
   }
   if (!isPrOrigin) return;
 
+  // Prefer the exact PR the triggering comment was on; an incident can carry
+  // several agent PRs. Fall back to the latest open one for legacy events
+  // whose origin has no parseable URL.
+  const originRef = parsePrRefFromGithubUrl(originUrl);
   const [target] = await db
     .select({
       prNumber: schema.agentPullRequests.prNumber,
@@ -68,10 +90,16 @@ export async function replyToPrOriginIfNeeded(
       eq(schema.githubInstallations.id, schema.agentPullRequests.installationId),
     )
     .where(
-      and(
-        eq(schema.agentPullRequests.incidentId, ctx.incident.id),
-        eq(schema.agentPullRequests.state, "open"),
-      ),
+      originRef
+        ? and(
+            eq(schema.agentPullRequests.incidentId, ctx.incident.id),
+            eq(schema.agentPullRequests.repoFullName, originRef.repoFullName),
+            eq(schema.agentPullRequests.prNumber, originRef.prNumber),
+          )
+        : and(
+            eq(schema.agentPullRequests.incidentId, ctx.incident.id),
+            eq(schema.agentPullRequests.state, "open"),
+          ),
     )
     .orderBy(desc(schema.agentPullRequests.createdAt))
     .limit(1);
@@ -184,6 +212,131 @@ async function resolveIncidentFromAgentRunConclusion(
     resolvedAt: now,
     autoInvestigateSuppressedUntil,
   });
+}
+
+// Reason code stored on incidents resolved by the agent's terminal
+// resolve_incident call. The human-readable why lives in reasonText.
+export const AGENT_RESOLVED_REASON_CODE = "agent_resolved";
+
+// Terminal path for the multi-PR contract: the agent classified every linked
+// issue mid-run (silence/observe/resolve — already applied to the issue rows)
+// and called resolve_incident. This resolves the incident WITHOUT cascading an
+// issue disposition (issueOutcome none), records metadata, and closes any PRs
+// the agent left open (it resolved without them, so they're abandoned).
+export async function completeWithIncidentResolution(
+  ctx: AgentRunContext,
+  result: AgentRunResult,
+  sessionId: string,
+  runtimeMinutes: number,
+): Promise<void> {
+  const resolution = result.incidentResolution;
+  if (!resolution) {
+    throw new Error("completeWithIncidentResolution requires result.incidentResolution");
+  }
+  await agentRunLifecycle.completeWithoutPullRequest({
+    id: ctx.agentRun.id,
+    currentState: ctx.agentRun.state,
+    result,
+  });
+  const metadataOutcome = await incidentLifecycle.applyAgentRunResult({
+    incident: ctx.incident,
+    agentRunId: ctx.agentRun.id,
+    result,
+  });
+  if (metadataOutcome.updated) {
+    const refreshed = await db.query.incidents.findFirst({
+      where: eq(schema.incidents.id, ctx.incident.id),
+    });
+    if (refreshed) ctx.incident = refreshed;
+  }
+  await enqueueAgentRunCompleted(ctx.agentRun.id).catch((err) =>
+    logger.error(
+      {
+        scope: "webhooks.enqueue",
+        agent_run_id: ctx.agentRun.id,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "failed to enqueue agent run.completed webhook",
+    ),
+  );
+
+  const { resolved } = await incidentLifecycle.resolve({
+    incidentId: ctx.incident.id,
+    kind: "agent_classification",
+    reasonCode: AGENT_RESOLVED_REASON_CODE,
+    reasonText: resolution.reason,
+    agentRunId: ctx.agentRun.id,
+    eventSummary: "Incident resolved by the investigating agent.",
+    eventDetail: { reason: resolution.reason, evidence: resolution.evidence },
+    eventDedupeKey: `incident_resolved:agent_run:${ctx.agentRun.id}:resolve_incident`,
+    // Issues were classified one by one during the run; nothing to cascade.
+    issueOutcome: { kind: "none" },
+  });
+  if (resolved) {
+    await closeOpenPullRequestsForResolvedIncident(ctx.incident.id);
+    const refreshed = await db.query.incidents.findFirst({
+      where: eq(schema.incidents.id, ctx.incident.id),
+    });
+    if (refreshed) ctx.incident = refreshed;
+  }
+
+  // Linear ticket: file/update deterministically from the findings, linking
+  // the most recent PR when one was opened during the run.
+  const latestPr = await db.query.agentPullRequests.findFirst({
+    where: eq(schema.agentPullRequests.incidentId, ctx.incident.id),
+    orderBy: [desc(schema.agentPullRequests.createdAt)],
+    columns: { url: true },
+  });
+  const deliveredTicket = await deliverLinearTicket(ctx, result, {
+    prUrl: latestPr?.url ?? null,
+  });
+  if (deliveredTicket) {
+    await recordFiledLinearTicket(
+      ctx,
+      {
+        id: deliveredTicket.ticketId,
+        url: deliveredTicket.url,
+        createdByAgent: deliveredTicket.created,
+      },
+      { identifier: deliveredTicket.identifier },
+    );
+  }
+
+  logger.info(
+    {
+      scope: "agent_run",
+      agent_run_id: ctx.agentRun.id,
+      incident_id: ctx.incident.id,
+      session_id: sessionId,
+      runtime_minutes: runtimeMinutes,
+      resolved,
+    },
+    "agent run complete (incident resolved by agent)",
+  );
+
+  const evidence = resolution.evidence?.trim();
+  const lines = [
+    `:white_check_mark: Investigation resolved this incident: ${resolution.reason}`,
+    result.summary,
+  ];
+  if (evidence) lines.push(`Evidence: ${truncateSlackText(evidence, 1800)}`);
+  await postIncidentThreadMessage(ctx.incident.id, lines.join("\n"));
+  const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
+  await updateIncidentMainMessage(
+    ctx.incident.id,
+    `:white_check_mark: ${ctx.incident.title} — Incident resolved`,
+    incidentBlocks({
+      emoji: "white_check_mark",
+      status: "Incident resolved by the agent",
+      title: ctx.incident.title,
+      tagline: truncateSlackText(result.summary),
+      projectName: ctx.project.name,
+      service: ctx.incident.service,
+      buttons: [{ text: "View agent run", url: incidentUrl, actionId: "view_agent_run" }],
+      incidentId: ctx.incident.id,
+    }),
+  );
+  await replyToPrOriginIfNeeded(ctx, result.summary);
 }
 
 export async function completeWithoutPullRequest(

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -55,7 +55,14 @@ export async function replyToPrOriginIfNeeded(
   replyText: string,
 ): Promise<void> {
   let isPrOrigin = ctx.agentRun.trigger === "pr_comment";
-  let originUrl: string | null = null;
+  // A cold-start pr_comment run has no human_reply event yet — its origin PR
+  // lives in the trigger detail. A later human_reply (resumed/steered
+  // session) still overrides below, since the latest interaction wins.
+  let originUrl: string | null = isPrOrigin
+    ? (ctx.agentRun.triggerDetail?.interactions?.find(
+        (interaction) => interaction.channel === "pr_comment",
+      )?.url ?? null)
+    : null;
   const lastReply = await db.query.incidentEvents.findFirst({
     where: and(
       eq(schema.incidentEvents.agentRunId, ctx.agentRun.id),
@@ -64,8 +71,9 @@ export async function replyToPrOriginIfNeeded(
     orderBy: [desc(schema.incidentEvents.createdAt)],
     columns: { detail: true },
   });
-  const origin = (lastReply?.detail as { origin?: { channel?: string; url?: string | null } } | null)
-    ?.origin;
+  const origin = (
+    lastReply?.detail as { origin?: { channel?: string; url?: string | null } } | null
+  )?.origin;
   if (origin?.channel === "pr_comment") {
     isPrOrigin = true;
     originUrl = origin.url ?? null;

--- a/apps/worker/src/agent-runs/domain.ts
+++ b/apps/worker/src/agent-runs/domain.ts
@@ -3,6 +3,7 @@ export type AgentRunState =
   | "repo_discovery"
   | "running"
   | "awaiting_human"
+  | "awaiting_events"
   | "resuming"
   | "pr_retry_queued"
   | "blocked_no_github"
@@ -16,11 +17,14 @@ export type AgentRunState =
 // (no re-investigation). `resuming` is a previously-terminal run that a human
 // message reactivated: the tick resumes its durable provider session in place
 // (no re-investigation) — the heart of "talking to an investigation".
+// `awaiting_events` is a run whose turn ended with PRs out for review: the
+// session stays durable and PR events (comment/merge/close) resume it.
 export const ACTIVE_STATES: readonly AgentRunState[] = [
   "queued",
   "repo_discovery",
   "running",
   "awaiting_human",
+  "awaiting_events",
   "resuming",
   "pr_retry_queued",
 ] as const;
@@ -37,6 +41,7 @@ export type LifecycleEventKind =
   | "agent_run_queued"
   | "agent_run_started"
   | "awaiting_human"
+  | "awaiting_events"
   | "blocked_no_github"
   | "unblocked"
   | "resumed"

--- a/apps/worker/src/agent-runs/mobile-regression.ts
+++ b/apps/worker/src/agent-runs/mobile-regression.ts
@@ -1,0 +1,25 @@
+import type { ResolvedIntegration } from "../integrations.js";
+
+const MOBILE_FILE_PREFIXES = ["app/", "ios/", "android/", "components/", "screens/"];
+
+// Whether a change reads as a mobile-app change — by service name or by the
+// files it touches — and therefore falls under the Revyl regression-test gate.
+export function looksLikeMobileChange(opts: {
+  service: string | null;
+  changedFiles: string[] | undefined;
+}): boolean {
+  if (/mobile/i.test(opts.service ?? "")) return true;
+  return (opts.changedFiles ?? []).some((file) =>
+    MOBILE_FILE_PREFIXES.some((prefix) => file === prefix.slice(0, -1) || file.startsWith(prefix)),
+  );
+}
+
+// Whether the org's Revyl integration exposes the create-test operation the
+// mobile regression-test gate depends on.
+export function hasRevylCreateTestIntegration(integrations: ResolvedIntegration[]): boolean {
+  return integrations.some(
+    (integration) =>
+      integration.definition.slug === "revyl" &&
+      integration.definition.operations.some((op) => op.name === "revyl_create_test_from_yaml"),
+  );
+}

--- a/apps/worker/src/agent-runs/outcome-actions.ts
+++ b/apps/worker/src/agent-runs/outcome-actions.ts
@@ -1,0 +1,175 @@
+// Server-side execution of the agent's non-terminal outcome action tools.
+//
+// The runner backend's dispatch loop (the same one that serves memory and
+// integration tools) hands each pending action call to the executor built
+// here; the executor validates it, applies the effect — open/update a PR,
+// classify one linked issue — and returns a model-readable payload that the
+// dispatch loop acks back into the live session. Failures are acks, not run
+// failures: the agent reads the error (e.g. a patch that didn't apply) and
+// corrects itself within the same session.
+//
+// `resolve_incident` is guarded here but APPLIED by the completion path: the
+// guard (every linked issue classified) needs a DB read at ack time so the
+// rejection reaches the model as a tool error; once the ack is out, the
+// collect pass captures the call as the run's terminal outcome and sync's
+// completion path performs the actual resolve.
+
+import { classifyIncidentIssue, listUnclassifiedIncidentIssues, db } from "@superlog/db";
+import {
+  escalationTriggerFromObservation,
+  isActionOutcomeToolName,
+  type ProposePrPayload,
+  validateOutcomeToolInput,
+} from "../agent-outcome-tools.js";
+import type { AgentRunContext } from "../agent-run-context.js";
+import type { OutcomeActionCall, OutcomeActionExecution } from "../agent-runner-backend.js";
+import { hasRevylCreateTestIntegration, looksLikeMobileChange } from "./mobile-regression.js";
+import { loadEnabledIntegrationsForOrg } from "../integrations.js";
+import { logger } from "../logger.js";
+import { deliverProposedPullRequest } from "./pr-delivery.js";
+
+// Orgs with the Revyl integration must attach a mobile regression-test
+// decision to mobile-looking PRs. Enforced at dispatch time so the agent is
+// told immediately, instead of the old post-hoc completion-repair steer.
+async function missingMobileTestDecision(
+  ctx: AgentRunContext,
+  payload: ProposePrPayload,
+): Promise<boolean> {
+  if (payload.mobileTestStatus) return false;
+  if (!looksLikeMobileChange({ service: ctx.incident.service, changedFiles: payload.changedFiles })) {
+    return false;
+  }
+  try {
+    const integrations = await loadEnabledIntegrationsForOrg(ctx.project.orgId);
+    return hasRevylCreateTestIntegration(integrations);
+  } catch (err) {
+    logger.error(
+      { err, orgId: ctx.project.orgId },
+      "failed to load integrations for mobile regression gate; skipping the gate",
+    );
+    return false;
+  }
+}
+
+// Build the executor the runner backend's dispatch loop calls for each
+// pending outcome-action tool use. Returns `handled: false` for tool names
+// that are not outcome actions (memory/integration/terminal tools).
+export function createOutcomeActionExecutor(
+  ctx: AgentRunContext,
+  sessionId: string,
+): (call: OutcomeActionCall) => Promise<OutcomeActionExecution> {
+  return async (call) => {
+    if (!isActionOutcomeToolName(call.name) && call.name !== "resolve_incident") {
+      return { handled: false };
+    }
+
+    const validated = validateOutcomeToolInput(call.name, call.input, {
+      hasFindings: call.hasFindings,
+    });
+    if (!validated.ok) {
+      return { handled: true, ok: false, payload: { ok: false, errors: validated.errors } };
+    }
+
+    switch (validated.tool) {
+      case "propose_pr": {
+        const payload = validated.payload as ProposePrPayload;
+        if (await missingMobileTestDecision(ctx, payload)) {
+          return {
+            handled: true,
+            ok: false,
+            payload: {
+              ok: false,
+              errors: [
+                'This looks like a mobile change and the Revyl integration is enabled, so propose_pr requires a mobile regression-test decision. If the fix can be covered by a reliable mobile user flow, author the Revyl YAML, call `revyl_validate_yaml`, then `revyl_create_test_from_yaml`, and call `propose_pr` again with `mobileTestStatus="created"` plus the returned test id as `mobileTestId`. Otherwise call it again with `mobileTestStatus="skipped"` (or "not_applicable") and a concrete `mobileTestReason`.',
+              ],
+            },
+          };
+        }
+        const delivery = await deliverProposedPullRequest(ctx, payload, sessionId);
+        if (!delivery.ok) {
+          return { handled: true, ok: false, payload: { ok: false, errors: [delivery.error] } };
+        }
+        return {
+          handled: true,
+          ok: true,
+          payload: {
+            ok: true,
+            prUrl: delivery.url,
+            prNumber: delivery.prNumber,
+            branchName: delivery.branchName,
+            updatedExisting: delivery.updatedExisting,
+          },
+        };
+      }
+
+      case "silence_as_noise":
+      case "place_under_observation":
+      case "resolve_issue": {
+        const payload = validated.payload as {
+          issueId: string;
+          reason: string;
+          evidence: string;
+          escalateOn?: "events_per_minute" | "additional_events";
+          threshold?: number;
+        };
+        const action =
+          validated.tool === "silence_as_noise"
+            ? ({ kind: "silence" } as const)
+            : validated.tool === "place_under_observation"
+              ? ({
+                  kind: "observe",
+                  trigger: escalationTriggerFromObservation({
+                    escalateOn: payload.escalateOn as "events_per_minute" | "additional_events",
+                    threshold: payload.threshold as number,
+                  }),
+                } as const)
+              : ({ kind: "resolve" } as const);
+        const result = await classifyIncidentIssue(db, {
+          incidentId: ctx.incident.id,
+          issueId: payload.issueId,
+          agentRunId: ctx.agentRun.id,
+          action,
+          reason: payload.reason,
+          evidence: payload.evidence,
+        });
+        if (!result.ok) {
+          return { handled: true, ok: false, payload: { ok: false, errors: [result.message] } };
+        }
+        return {
+          handled: true,
+          ok: true,
+          payload: {
+            ok: true,
+            issueId: payload.issueId,
+            status: result.status,
+            alreadyClassified: result.alreadyClassified,
+          },
+        };
+      }
+
+      case "resolve_incident": {
+        const unclassified = await listUnclassifiedIncidentIssues(db, ctx.incident.id);
+        if (unclassified.length > 0) {
+          return {
+            handled: true,
+            ok: false,
+            payload: {
+              ok: false,
+              errors: [
+                `Cannot resolve the incident yet: ${unclassified.length} linked issue(s) are still open and must be classified first (silence_as_noise / place_under_observation / resolve_issue): ${unclassified
+                  .map((issue) => `${issue.id} ("${issue.title}")`)
+                  .join(", ")}.`,
+              ],
+            },
+          };
+        }
+        // Guard passed — ack final; the collect pass captures this call as
+        // the terminal outcome and the completion path applies the resolve.
+        return { handled: true, ok: true, payload: { ok: true, final: true } };
+      }
+
+      default:
+        return { handled: false };
+    }
+  };
+}

--- a/apps/worker/src/agent-runs/outcome-actions.ts
+++ b/apps/worker/src/agent-runs/outcome-actions.ts
@@ -14,18 +14,18 @@
 // collect pass captures the call as the run's terminal outcome and sync's
 // completion path performs the actual resolve.
 
-import { classifyIncidentIssue, listUnclassifiedIncidentIssues, db } from "@superlog/db";
+import { classifyIncidentIssue, db, listUnclassifiedIncidentIssues } from "@superlog/db";
 import {
+  type ProposePrPayload,
   escalationTriggerFromObservation,
   isActionOutcomeToolName,
-  type ProposePrPayload,
   validateOutcomeToolInput,
 } from "../agent-outcome-tools.js";
 import type { AgentRunContext } from "../agent-run-context.js";
 import type { OutcomeActionCall, OutcomeActionExecution } from "../agent-runner-backend.js";
-import { hasRevylCreateTestIntegration, looksLikeMobileChange } from "./mobile-regression.js";
 import { loadEnabledIntegrationsForOrg } from "../integrations.js";
 import { logger } from "../logger.js";
+import { hasRevylCreateTestIntegration, looksLikeMobileChange } from "./mobile-regression.js";
 import { deliverProposedPullRequest } from "./pr-delivery.js";
 
 // Orgs with the Revyl integration must attach a mobile regression-test
@@ -36,7 +36,9 @@ async function missingMobileTestDecision(
   payload: ProposePrPayload,
 ): Promise<boolean> {
   if (payload.mobileTestStatus) return false;
-  if (!looksLikeMobileChange({ service: ctx.incident.service, changedFiles: payload.changedFiles })) {
+  if (
+    !looksLikeMobileChange({ service: ctx.incident.service, changedFiles: payload.changedFiles })
+  ) {
     return false;
   }
   try {
@@ -70,106 +72,127 @@ export function createOutcomeActionExecutor(
       return { handled: true, ok: false, payload: { ok: false, errors: validated.errors } };
     }
 
-    switch (validated.tool) {
-      case "propose_pr": {
-        const payload = validated.payload as ProposePrPayload;
-        if (await missingMobileTestDecision(ctx, payload)) {
-          return {
-            handled: true,
-            ok: false,
-            payload: {
-              ok: false,
-              errors: [
-                'This looks like a mobile change and the Revyl integration is enabled, so propose_pr requires a mobile regression-test decision. If the fix can be covered by a reliable mobile user flow, author the Revyl YAML, call `revyl_validate_yaml`, then `revyl_create_test_from_yaml`, and call `propose_pr` again with `mobileTestStatus="created"` plus the returned test id as `mobileTestId`. Otherwise call it again with `mobileTestStatus="skipped"` (or "not_applicable") and a concrete `mobileTestReason`.',
-              ],
-            },
-          };
-        }
-        const delivery = await deliverProposedPullRequest(ctx, payload, sessionId);
-        if (!delivery.ok) {
-          return { handled: true, ok: false, payload: { ok: false, errors: [delivery.error] } };
-        }
-        return {
-          handled: true,
-          ok: true,
-          payload: {
-            ok: true,
-            prUrl: delivery.url,
-            prNumber: delivery.prNumber,
-            branchName: delivery.branchName,
-            updatedExisting: delivery.updatedExisting,
-          },
-        };
-      }
-
-      case "silence_as_noise":
-      case "place_under_observation":
-      case "resolve_issue": {
-        const payload = validated.payload as {
-          issueId: string;
-          reason: string;
-          evidence: string;
-          escalateOn?: "events_per_minute" | "additional_events";
-          threshold?: number;
-        };
-        const action =
-          validated.tool === "silence_as_noise"
-            ? ({ kind: "silence" } as const)
-            : validated.tool === "place_under_observation"
-              ? ({
-                  kind: "observe",
-                  trigger: escalationTriggerFromObservation({
-                    escalateOn: payload.escalateOn as "events_per_minute" | "additional_events",
-                    threshold: payload.threshold as number,
-                  }),
-                } as const)
-              : ({ kind: "resolve" } as const);
-        const result = await classifyIncidentIssue(db, {
-          incidentId: ctx.incident.id,
-          issueId: payload.issueId,
-          agentRunId: ctx.agentRun.id,
-          action,
-          reason: payload.reason,
-          evidence: payload.evidence,
-        });
-        if (!result.ok) {
-          return { handled: true, ok: false, payload: { ok: false, errors: [result.message] } };
-        }
-        return {
-          handled: true,
-          ok: true,
-          payload: {
-            ok: true,
-            issueId: payload.issueId,
-            status: result.status,
-            alreadyClassified: result.alreadyClassified,
-          },
-        };
-      }
-
-      case "resolve_incident": {
-        const unclassified = await listUnclassifiedIncidentIssues(db, ctx.incident.id);
-        if (unclassified.length > 0) {
-          return {
-            handled: true,
-            ok: false,
-            payload: {
-              ok: false,
-              errors: [
-                `Cannot resolve the incident yet: ${unclassified.length} linked issue(s) are still open and must be classified first (silence_as_noise / place_under_observation / resolve_issue): ${unclassified
-                  .map((issue) => `${issue.id} ("${issue.title}")`)
-                  .join(", ")}.`,
-              ],
-            },
-          };
-        }
-        // Guard passed — ack final; the collect pass captures this call as
-        // the terminal outcome and the completion path applies the resolve.
-        return { handled: true, ok: true, payload: { ok: true, final: true } };
-      }
-
-      default:
-        return { handled: false };
+    // A transient DB/GitHub throw must stay inside the action contract — the
+    // agent gets a tool error it can retry, instead of the call being left
+    // unacked (the backend's dispatch loop also guards this, but the contract
+    // shouldn't depend on it).
+    try {
+      return await executeValidatedCall(ctx, sessionId, validated);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(
+        { err, op: call.name, agentRunId: ctx.agentRun.id, incidentId: ctx.incident.id },
+        "outcome action execution threw",
+      );
+      return { handled: true, ok: false, payload: { ok: false, errors: [message] } };
     }
   };
+}
+
+async function executeValidatedCall(
+  ctx: AgentRunContext,
+  sessionId: string,
+  validated: Extract<ReturnType<typeof validateOutcomeToolInput>, { ok: true }>,
+): Promise<OutcomeActionExecution> {
+  switch (validated.tool) {
+    case "propose_pr": {
+      const payload = validated.payload as ProposePrPayload;
+      if (await missingMobileTestDecision(ctx, payload)) {
+        return {
+          handled: true,
+          ok: false,
+          payload: {
+            ok: false,
+            errors: [
+              'This looks like a mobile change and the Revyl integration is enabled, so propose_pr requires a mobile regression-test decision. If the fix can be covered by a reliable mobile user flow, author the Revyl YAML, call `revyl_validate_yaml`, then `revyl_create_test_from_yaml`, and call `propose_pr` again with `mobileTestStatus="created"` plus the returned test id as `mobileTestId`. Otherwise call it again with `mobileTestStatus="skipped"` (or "not_applicable") and a concrete `mobileTestReason`.',
+            ],
+          },
+        };
+      }
+      const delivery = await deliverProposedPullRequest(ctx, payload, sessionId);
+      if (!delivery.ok) {
+        return { handled: true, ok: false, payload: { ok: false, errors: [delivery.error] } };
+      }
+      return {
+        handled: true,
+        ok: true,
+        payload: {
+          ok: true,
+          prUrl: delivery.url,
+          prNumber: delivery.prNumber,
+          branchName: delivery.branchName,
+          updatedExisting: delivery.updatedExisting,
+        },
+      };
+    }
+
+    case "silence_as_noise":
+    case "place_under_observation":
+    case "resolve_issue": {
+      const payload = validated.payload as {
+        issueId: string;
+        reason: string;
+        evidence: string;
+        escalateOn?: "events_per_minute" | "additional_events";
+        threshold?: number;
+      };
+      const action =
+        validated.tool === "silence_as_noise"
+          ? ({ kind: "silence" } as const)
+          : validated.tool === "place_under_observation"
+            ? ({
+                kind: "observe",
+                trigger: escalationTriggerFromObservation({
+                  escalateOn: payload.escalateOn as "events_per_minute" | "additional_events",
+                  threshold: payload.threshold as number,
+                }),
+              } as const)
+            : ({ kind: "resolve" } as const);
+      const result = await classifyIncidentIssue(db, {
+        incidentId: ctx.incident.id,
+        issueId: payload.issueId,
+        agentRunId: ctx.agentRun.id,
+        action,
+        reason: payload.reason,
+        evidence: payload.evidence,
+      });
+      if (!result.ok) {
+        return { handled: true, ok: false, payload: { ok: false, errors: [result.message] } };
+      }
+      return {
+        handled: true,
+        ok: true,
+        payload: {
+          ok: true,
+          issueId: payload.issueId,
+          status: result.status,
+          alreadyClassified: result.alreadyClassified,
+        },
+      };
+    }
+
+    case "resolve_incident": {
+      const unclassified = await listUnclassifiedIncidentIssues(db, ctx.incident.id);
+      if (unclassified.length > 0) {
+        return {
+          handled: true,
+          ok: false,
+          payload: {
+            ok: false,
+            errors: [
+              `Cannot resolve the incident yet: ${unclassified.length} linked issue(s) are still open and must be classified first (silence_as_noise / place_under_observation / resolve_issue): ${unclassified
+                .map((issue) => `${issue.id} ("${issue.title}")`)
+                .join(", ")}.`,
+            ],
+          },
+        };
+      }
+      // Guard passed — ack final; the collect pass captures this call as
+      // the terminal outcome and the completion path applies the resolve.
+      return { handled: true, ok: true, payload: { ok: true, final: true } };
+    }
+
+    default:
+      return { handled: false };
+  }
 }

--- a/apps/worker/src/agent-runs/pr-delivery.ts
+++ b/apps/worker/src/agent-runs/pr-delivery.ts
@@ -527,6 +527,262 @@ export async function completeWithPullRequest(
   );
 }
 
+// ---------------------------------------------------------------------------
+// Mid-run PR delivery (the non-terminal propose_pr action tool)
+// ---------------------------------------------------------------------------
+
+export type MidRunPrDeliveryResult =
+  | {
+      ok: true;
+      url: string;
+      prNumber: number;
+      branchName: string;
+      // True when the patch landed as a follow-up commit on an existing open
+      // PR with the same branch, instead of opening a new one.
+      updatedExisting: boolean;
+    }
+  | { ok: false; error: string };
+
+// Apply the agent's patch and open (or update) a PR while the session is
+// still live. Unlike completeWithPullRequest this NEVER fails the run: every
+// failure is returned as a model-readable error so the agent can fix its own
+// patch (or pick another branch) and call propose_pr again. PRs are keyed by
+// (incident, repo, branch): the same branchName pushes a follow-up commit to
+// that PR; a new branchName opens an independent PR.
+export async function deliverProposedPullRequest(
+  ctx: AgentRunContext,
+  pr: {
+    repoFullName: string;
+    title: string;
+    body: string;
+    branchName: string;
+    baseBranch: string;
+    patchFilePath: string;
+  },
+  sessionId: string,
+): Promise<MidRunPrDeliveryResult> {
+  if (ctx.prPolicy === "never") {
+    return {
+      ok: false,
+      error:
+        "This organization's policy is do-not-PR. Do not propose patches; record findings and classify/resolve instead.",
+    };
+  }
+  if (ctx.githubInstalls.length === 0) {
+    return { ok: false, error: "Cannot open a PR: no GitHub installation is connected." };
+  }
+
+  let repoMeta: InstalledGithubRepo | undefined;
+  try {
+    const repos = await listAccessibleGithubRepositories(ctx);
+    repoMeta = repos.find((repo) => repo.fullName === pr.repoFullName);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `Cannot open a PR: GitHub repositories could not be listed (${err instanceof Error ? err.message : String(err)}). Try again.`,
+    };
+  }
+  if (!repoMeta) {
+    return {
+      ok: false,
+      error: `Cannot open a PR: GitHub does not grant access to ${pr.repoFullName}. Use one of the mounted repositories.`,
+    };
+  }
+
+  let patch: string;
+  try {
+    const downloaded = await downloadAgentPatchFile({
+      sessionId,
+      patchFileId: null,
+      patchFilePath: pr.patchFilePath,
+    });
+    patch = downloaded.patch;
+  } catch (err) {
+    return {
+      ok: false,
+      error: `Failed to read the patch file at ${pr.patchFilePath} (${err instanceof Error ? err.message : String(err)}). Write the unified diff there first, then call propose_pr again.`,
+    };
+  }
+
+  const commitAuthor =
+    repoMeta.installation.commitAuthorName && repoMeta.installation.commitAuthorEmail
+      ? {
+          name: repoMeta.installation.commitAuthorName,
+          email: repoMeta.installation.commitAuthorEmail,
+        }
+      : DEFAULT_COMMIT_AUTHOR;
+  const prTitle = buildPrTitle({ ctx, result: { summary: pr.title }, pr });
+  const prBody = buildPrBody({
+    incidentUrl: `${WEB_ORIGIN}/incidents/${ctx.incident.id}`,
+    result: { summary: pr.body },
+    pr,
+  });
+
+  // Same branch on the same repo for this incident → push a follow-up commit
+  // to the existing open PR instead of opening a duplicate.
+  const existingPr = await db.query.agentPullRequests.findFirst({
+    where: and(
+      eq(schema.agentPullRequests.incidentId, ctx.incident.id),
+      eq(schema.agentPullRequests.repoFullName, pr.repoFullName),
+      eq(schema.agentPullRequests.branchName, pr.branchName),
+      eq(schema.agentPullRequests.state, "open"),
+    ),
+    orderBy: [desc(schema.agentPullRequests.createdAt)],
+  });
+  if (existingPr) {
+    let pushed: { headSha: string };
+    try {
+      pushed = await pushPatchToExistingAgentPr({
+        installationId: repoMeta.installation.installationId,
+        repositoryId: repoMeta.id,
+        repoFullName: pr.repoFullName,
+        patch,
+        branchName: existingPr.branchName,
+        prNumber: existingPr.prNumber,
+        commitTitle: prTitle,
+        commentBody: pr.body,
+        commitAuthor,
+      });
+    } catch (err) {
+      return { ok: false, error: summarizePrOpenFailure(err) };
+    }
+    const now = new Date();
+    await db
+      .update(schema.agentPullRequests)
+      .set({ headSha: pushed.headSha, lastSyncedAt: now, updatedAt: now })
+      .where(eq(schema.agentPullRequests.id, existingPr.id));
+    await postIncidentThreadMessage(
+      ctx.incident.id,
+      `:arrows_counterclockwise: Pushed an update to PR ${existingPr.url}`,
+    ).catch(() => {});
+    return {
+      ok: true,
+      url: existingPr.url,
+      prNumber: existingPr.prNumber,
+      branchName: existingPr.branchName,
+      updatedExisting: true,
+    };
+  }
+
+  let opened: Awaited<ReturnType<typeof openAgentRunPullRequest>>;
+  try {
+    opened = await openAgentRunPullRequest({
+      installationId: repoMeta.installation.installationId,
+      repositoryId: repoMeta.id,
+      repoFullName: pr.repoFullName,
+      patch,
+      branchName: pr.branchName,
+      baseBranch: resolvePullRequestBaseBranch(ctx, pr),
+      title: prTitle,
+      body: prBody,
+      commitAuthor,
+    });
+  } catch (err) {
+    return { ok: false, error: summarizePrOpenFailure(err) };
+  }
+
+  await recordOpenedAgentPullRequest({
+    incidentId: ctx.incident.id,
+    agentRunId: ctx.agentRun.id,
+    installationRowId: repoMeta.installation.id,
+    repoFullName: pr.repoFullName,
+    prNumber: opened.prNumber,
+    prNodeId: opened.prNodeId,
+    url: opened.prUrl,
+    branchName: opened.branchName,
+    baseBranch: opened.baseBranch,
+    headSha: opened.headSha,
+    title: prTitle,
+    authorLogin: opened.authorLogin,
+    authorGithubId: opened.authorGithubId,
+    authorAvatarUrl: opened.authorAvatarUrl,
+  }).catch((err) =>
+    logger.error(
+      {
+        scope: "agent_run.pr_delivery",
+        agent_run_id: ctx.agentRun.id,
+        incident_id: ctx.incident.id,
+        pr_url: opened.prUrl,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "failed to record opened agent pull request",
+    ),
+  );
+  await agentRunLifecycle.appendAgentEvent({
+    agentRunId: ctx.agentRun.id,
+    kind: "pr_opened",
+    summary: `Opened PR: ${opened.prUrl}`,
+    providerEventId: `pr_opened:${opened.prUrl}`,
+    detail: { url: opened.prUrl },
+  });
+
+  if (ctx.autoMergeFixPrs !== "never") {
+    try {
+      const outcome = await mergeAgentPullRequest({
+        installationId: repoMeta.installation.installationId,
+        repositoryId: repoMeta.id,
+        repoFullName: pr.repoFullName,
+        prNumber: opened.prNumber,
+        prNodeId: opened.prNodeId,
+        policy: ctx.autoMergeFixPrs,
+        method: ctx.autoMergeMethod,
+      });
+      const note =
+        outcome.kind === "merged"
+          ? `:white_check_mark: Auto-merged PR (${ctx.autoMergeMethod})`
+          : outcome.kind === "auto_merge_enabled"
+            ? `:hourglass_flowing_sand: Auto-merge enabled — will land once checks pass (${ctx.autoMergeMethod})`
+            : null;
+      if (note) {
+        await postIncidentThreadMessage(ctx.incident.id, note).catch(() => {});
+      }
+    } catch (err) {
+      logger.warn(
+        {
+          scope: "agent_run.pr_delivery.auto_merge",
+          agent_run_id: ctx.agentRun.id,
+          incident_id: ctx.incident.id,
+          pr_url: opened.prUrl,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "auto-merge attempt failed; leaving PR open for human merge",
+      );
+    }
+  }
+
+  await postIncidentThreadMessage(ctx.incident.id, `:bulb: Opened PR ${opened.prUrl}`).catch(
+    () => {},
+  );
+  const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
+  await updateIncidentMainMessage(
+    ctx.incident.id,
+    `:bulb: PR Ready: ${ctx.incident.title}`,
+    incidentBlocks({
+      emoji: "bulb",
+      status: "PR Ready",
+      title: ctx.incident.title,
+      tagline: pr.title,
+      projectName: ctx.project.name,
+      service: ctx.incident.service,
+      buttons: [
+        { text: "Open in Superlog", url: incidentUrl, actionId: "open_superlog" },
+        { text: "View PR", url: opened.prUrl, actionId: "view_pr" },
+      ],
+      incidentId: ctx.incident.id,
+      showResolveButton: true,
+      showMergePrButton: true,
+    }),
+  ).catch(() => {});
+
+  return {
+    ok: true,
+    url: opened.prUrl,
+    prNumber: opened.prNumber,
+    branchName: opened.branchName,
+    updatedExisting: false,
+  };
+}
+
 export async function retryQueuedPullRequestDelivery(ctx: AgentRunContext): Promise<void> {
   const result = ctx.agentRun.result;
   const pr = result?.pr ?? null;

--- a/apps/worker/src/agent-runs/pr-delivery.ts
+++ b/apps/worker/src/agent-runs/pr-delivery.ts
@@ -681,22 +681,28 @@ export async function deliverProposedPullRequest(
     return { ok: false, error: summarizePrOpenFailure(err) };
   }
 
-  await recordOpenedAgentPullRequest({
-    incidentId: ctx.incident.id,
-    agentRunId: ctx.agentRun.id,
-    installationRowId: repoMeta.installation.id,
-    repoFullName: pr.repoFullName,
-    prNumber: opened.prNumber,
-    prNodeId: opened.prNodeId,
-    url: opened.prUrl,
-    branchName: opened.branchName,
-    baseBranch: opened.baseBranch,
-    headSha: opened.headSha,
-    title: prTitle,
-    authorLogin: opened.authorLogin,
-    authorGithubId: opened.authorGithubId,
-    authorAvatarUrl: opened.authorAvatarUrl,
-  }).catch((err) =>
+  // The agent_pull_requests row is what the awaiting_events park, the PR
+  // webhooks, and same-branch follow-up pushes key on — an unrecorded PR is
+  // invisible to all of them, so recording must succeed before the tool can
+  // report success.
+  try {
+    await recordOpenedAgentPullRequest({
+      incidentId: ctx.incident.id,
+      agentRunId: ctx.agentRun.id,
+      installationRowId: repoMeta.installation.id,
+      repoFullName: pr.repoFullName,
+      prNumber: opened.prNumber,
+      prNodeId: opened.prNodeId,
+      url: opened.prUrl,
+      branchName: opened.branchName,
+      baseBranch: opened.baseBranch,
+      headSha: opened.headSha,
+      title: prTitle,
+      authorLogin: opened.authorLogin,
+      authorGithubId: opened.authorGithubId,
+      authorAvatarUrl: opened.authorAvatarUrl,
+    });
+  } catch (err) {
     logger.error(
       {
         scope: "agent_run.pr_delivery",
@@ -706,8 +712,12 @@ export async function deliverProposedPullRequest(
         err: err instanceof Error ? err.message : String(err),
       },
       "failed to record opened agent pull request",
-    ),
-  );
+    );
+    return {
+      ok: false,
+      error: `The PR was opened at ${opened.prUrl} but could not be recorded on the incident, so Superlog cannot track it. Do not open another PR for this change — include the PR URL in your findings and use ask_human to have the tracking reconciled.`,
+    };
+  }
   await agentRunLifecycle.appendAgentEvent({
     agentRunId: ctx.agentRun.id,
     kind: "pr_opened",

--- a/apps/worker/src/agent-runs/repository.ts
+++ b/apps/worker/src/agent-runs/repository.ts
@@ -1,5 +1,5 @@
 import { type AgentRunResult, type DB, mergeIncidentsInTx, schema } from "@superlog/db";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { LifecycleEventKind } from "./domain.js";
 
 export type AgentRunRepository = ReturnType<typeof createAgentRunRepository>;
@@ -49,6 +49,23 @@ export function createAgentRunRepository(db: DB) {
         .update(schema.agentRuns)
         .set({ ...updates, updatedAt: updates.updatedAt ?? new Date() })
         .where(eq(schema.agentRuns.id, id));
+    },
+
+    // Conditional transition: applies `updates` only while the run is still
+    // in `fromState`, folding the state check into the UPDATE's WHERE so two
+    // racing passes can't both transition. Returns false for the loser, whose
+    // caller must skip its side effects.
+    async updateRunIfState(
+      id: string,
+      fromState: schema.AgentRun["state"],
+      updates: Partial<schema.AgentRun>,
+    ): Promise<boolean> {
+      const updated = await db
+        .update(schema.agentRuns)
+        .set({ ...updates, updatedAt: updates.updatedAt ?? new Date() })
+        .where(and(eq(schema.agentRuns.id, id), eq(schema.agentRuns.state, fromState)))
+        .returning({ id: schema.agentRuns.id });
+      return updated.length > 0;
     },
 
     insertEvent,

--- a/apps/worker/src/agent-runs/resume.ts
+++ b/apps/worker/src/agent-runs/resume.ts
@@ -42,7 +42,11 @@ async function markProcessed(ids: string[]): Promise<void> {
 // re-seeds the prior context, so the human's message is never silently lost.
 export async function resumeAgentRunFromHumanInput(ctx: AgentRunContext): Promise<void> {
   const sessionId = ctx.agentRun.providerSessionId;
-  const isContinuation = ctx.agentRun.state === "resuming";
+  // `resuming` (a reactivated terminal run) and `awaiting_events` (parked on
+  // PR review) are continuations: every resume is driven by an intentional
+  // external event, so the human-resume budget doesn't apply.
+  const isContinuation =
+    ctx.agentRun.state === "resuming" || ctx.agentRun.state === "awaiting_events";
 
   if (!sessionId) {
     // `awaiting_human` paused before any managed session existed (repo

--- a/apps/worker/src/agent-runs/resume.ts
+++ b/apps/worker/src/agent-runs/resume.ts
@@ -96,6 +96,7 @@ export async function resumeAgentRunFromHumanInput(ctx: AgentRunContext): Promis
       id: ctx.agentRun.id,
       currentState: ctx.agentRun.state,
       currentResumeCount: ctx.agentRun.resumeCount,
+      continuation: isContinuation,
     });
     logger.info(
       {

--- a/apps/worker/src/agent-runs/status.ts
+++ b/apps/worker/src/agent-runs/status.ts
@@ -199,17 +199,25 @@ export async function moveAgentRunToAwaitingHuman(
 // Park a run whose turn ended without a terminal call while its PRs are out
 // for review. The session stays durable; a PR comment/merge/close (or any
 // inbound human message) resumes it via the same continuation path as
-// awaiting_human.
+// awaiting_human. Returns false when a concurrent pass already moved the run
+// (the transition is conditional) — the caller must skip its side effects.
 export async function moveAgentRunToAwaitingEvents(
   ctx: AgentRunContext,
   result: AgentRunResult,
   openPrUrls: string[],
-): Promise<void> {
-  await agentRunLifecycle.pauseForEvents({
+): Promise<boolean> {
+  const parked = await agentRunLifecycle.pauseForEvents({
     id: ctx.agentRun.id,
     currentState: ctx.agentRun.state,
     result,
   });
+  if (!parked) {
+    logger.info(
+      { scope: "agent_run", agent_run_id: ctx.agentRun.id, incident_id: ctx.incident.id },
+      "skipping awaiting_events park; a concurrent pass already transitioned the run",
+    );
+    return false;
+  }
   const prList = openPrUrls.length > 0 ? ` Open PRs: ${openPrUrls.join(", ")}` : "";
   await postIncidentThreadMessage(
     ctx.incident.id,
@@ -238,6 +246,7 @@ export async function moveAgentRunToAwaitingEvents(
       showMergePrButton: openPrUrls.length === 1,
     }),
   );
+  return true;
 }
 
 export async function moveAgentRunToBlockedNoGithub(

--- a/apps/worker/src/agent-runs/status.ts
+++ b/apps/worker/src/agent-runs/status.ts
@@ -196,6 +196,49 @@ export async function moveAgentRunToAwaitingHuman(
   );
 }
 
+// Park a run whose turn ended without a terminal call while its PRs are out
+// for review. The session stays durable; a PR comment/merge/close (or any
+// inbound human message) resumes it via the same continuation path as
+// awaiting_human.
+export async function moveAgentRunToAwaitingEvents(
+  ctx: AgentRunContext,
+  result: AgentRunResult,
+  openPrUrls: string[],
+): Promise<void> {
+  await agentRunLifecycle.pauseForEvents({
+    id: ctx.agentRun.id,
+    currentState: ctx.agentRun.state,
+    result,
+  });
+  const prList = openPrUrls.length > 0 ? ` Open PRs: ${openPrUrls.join(", ")}` : "";
+  await postIncidentThreadMessage(
+    ctx.incident.id,
+    `:hourglass_flowing_sand: Investigation is waiting on PR review.${prList}`,
+  );
+  const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
+  await updateIncidentMainMessage(
+    ctx.incident.id,
+    `:hourglass_flowing_sand: ${ctx.incident.title} — Waiting on PR review`,
+    incidentBlocks({
+      emoji: "hourglass_flowing_sand",
+      status: "Waiting on PR review",
+      title: ctx.incident.title,
+      tagline: result.summary || "The investigation opened PRs and is waiting for review or merge.",
+      projectName: ctx.project.name,
+      service: ctx.incident.service,
+      buttons: [
+        { text: "Open in Superlog", url: incidentUrl, actionId: "open_superlog" },
+        ...(openPrUrls[0]
+          ? [{ text: "View PR", url: openPrUrls[0], actionId: "view_pr" }]
+          : []),
+      ],
+      incidentId: ctx.incident.id,
+      showResolveButton: true,
+      showMergePrButton: openPrUrls.length > 0,
+    }),
+  );
+}
+
 export async function moveAgentRunToBlockedNoGithub(
   ctx: AgentRunContext,
   reason: "no_github_install" | "no_accessible_repos",

--- a/apps/worker/src/agent-runs/status.ts
+++ b/apps/worker/src/agent-runs/status.ts
@@ -228,13 +228,14 @@ export async function moveAgentRunToAwaitingEvents(
       service: ctx.incident.service,
       buttons: [
         { text: "Open in Superlog", url: incidentUrl, actionId: "open_superlog" },
-        ...(openPrUrls[0]
-          ? [{ text: "View PR", url: openPrUrls[0], actionId: "view_pr" }]
-          : []),
+        ...(openPrUrls[0] ? [{ text: "View PR", url: openPrUrls[0], actionId: "view_pr" }] : []),
       ],
       incidentId: ctx.incident.id,
       showResolveButton: true,
-      showMergePrButton: openPrUrls.length > 0,
+      // The one-click merge action targets "the incident's latest open PR",
+      // so with several PRs out it would merge only one and resolve the whole
+      // incident — only offer it when the target is unambiguous.
+      showMergePrButton: openPrUrls.length === 1,
     }),
   );
 }

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -324,18 +324,19 @@ test("shouldDeferSteering does not defer settled or concluded snapshots", () => 
   );
 });
 
-test("terminalOutcomeNudgePrompt names every terminal outcome tool", () => {
+test("terminalOutcomeNudgePrompt names every outcome tool", () => {
   const prompt = terminalOutcomeNudgePrompt();
   for (const name of [
+    "report_findings",
     "propose_pr",
     "silence_as_noise",
     "place_under_observation",
-    "mark_already_resolved",
+    "resolve_issue",
+    "resolve_incident",
     "ask_human",
   ]) {
     assert.ok(prompt.includes(name), `missing ${name}`);
   }
-  assert.match(prompt, /exactly ONE/);
 });
 
 test("isSessionBusyError matches the mid-flight steer rejection only", () => {

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -572,22 +572,26 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         if (snapshot.pendingOutcome?.findings) {
           await applyIncidentMetadataFromResult(ctx, parkedResult);
         }
-        await moveAgentRunToAwaitingEvents(
+        const parked = await moveAgentRunToAwaitingEvents(
           ctx,
           parkedResult,
           openPrs.map((pr) => pr.url),
         );
-        await recordAgentRunCompletion({
-          orgId: ctx.project.orgId,
-          projectId: ctx.project.id,
-          incidentId: ctx.incident.id,
-          model: snapshot.modelUsage.model,
-          callSite: "agent_run",
-          usage: snapshot.modelUsage,
-          activeSeconds: snapshot.activeSeconds,
-          outcome: "awaiting_events",
-          hasPr: true,
-        });
+        // A lost park means a concurrent pass owns this turn's conclusion —
+        // it also records the usage, so a duplicate here would double-meter.
+        if (parked) {
+          await recordAgentRunCompletion({
+            orgId: ctx.project.orgId,
+            projectId: ctx.project.id,
+            incidentId: ctx.incident.id,
+            model: snapshot.modelUsage.model,
+            callSite: "agent_run",
+            usage: snapshot.modelUsage,
+            activeSeconds: snapshot.activeSeconds,
+            outcome: "awaiting_events",
+            hasPr: true,
+          });
+        }
         return;
       }
     }

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -9,16 +9,22 @@ import { getAgentRunnerBackend } from "../infra/agent-runner/backend.js";
 import { postIncidentThreadMessage } from "../infra/slack/incident-messages.js";
 import { type ResolvedIntegration, loadEnabledIntegrationsForOrg } from "../integrations.js";
 import { logger } from "../logger.js";
-import { completeWithoutPullRequest } from "./completion.js";
+import { assembleAgentRunResult } from "../agent-outcome-tools.js";
+import { completeWithIncidentResolution, completeWithoutPullRequest } from "./completion.js";
 import { tryMergeAfterAgentRun } from "./merge.js";
+import { hasRevylCreateTestIntegration, looksLikeMobileChange } from "./mobile-regression.js";
+import { createOutcomeActionExecutor } from "./outcome-actions.js";
 import { completeWithPullRequest, resolvePullRequestBaseBranch } from "./pr-delivery.js";
 import { applyIncidentMetadataFromResult } from "./result-metadata.js";
 import {
   exceededWallClockBudget,
   failAgentRun,
   isTransientError,
+  moveAgentRunToAwaitingEvents,
   moveAgentRunToAwaitingHuman,
 } from "./status.js";
+
+export { hasRevylCreateTestIntegration } from "./mobile-regression.js";
 
 const agentRunLifecycle = createAgentRunLifecycle(db);
 
@@ -76,17 +82,8 @@ export async function steerIdleRunnerWithPendingContext(opts: {
   return "steered";
 }
 
-const MOBILE_FILE_PREFIXES = ["app/", "ios/", "android/", "components/", "screens/"];
 type MobileRegressionToolLookupState = "enabled" | "disabled" | "failed";
 type MobileRegressionGateState = "allow" | "repair" | "defer_lookup";
-
-export function hasRevylCreateTestIntegration(integrations: ResolvedIntegration[]): boolean {
-  return integrations.some(
-    (integration) =>
-      integration.definition.slug === "revyl" &&
-      integration.definition.operations.some((op) => op.name === "revyl_create_test_from_yaml"),
-  );
-}
 
 export function needsMobileRegressionRepair(opts: {
   revylEnabled: boolean;
@@ -112,12 +109,9 @@ export function mobileRegressionGateState(opts: {
   if (!pr || pr.validationPassed !== true) return "allow";
   if (opts.result.mobileRegressionTest) return "allow";
 
-  const serviceLooksMobile = /mobile/i.test(opts.service ?? "");
-  const changedFiles = pr.changedFiles ?? [];
-  const changedMobileFiles = changedFiles.some((file) =>
-    MOBILE_FILE_PREFIXES.some((prefix) => file === prefix.slice(0, -1) || file.startsWith(prefix)),
-  );
-  if (!serviceLooksMobile && !changedMobileFiles) return "allow";
+  if (!looksLikeMobileChange({ service: opts.service, changedFiles: pr.changedFiles })) {
+    return "allow";
+  }
   if (opts.toolLookup === "failed") return "defer_lookup";
   if (opts.toolLookup === "enabled") return "repair";
   return "allow";
@@ -167,12 +161,12 @@ export function shouldDeferSteering(snapshot: {
 }
 
 // Steered into a session that went idle without calling any terminal outcome
-// tool (e.g. the model wrote a chat message instead of a tool call). Fired at
-// most once per session; the runtime/wall-clock budgets stay the hard floor.
+// tool and with nothing pending (no open PRs to wait on). Fired at most once
+// per session; the runtime/wall-clock budgets stay the hard floor.
 export function terminalOutcomeNudgePrompt(): string {
   return [
-    "You ended your turn without calling a terminal outcome tool, so your investigation has no recorded result.",
-    "Call `report_findings` now if you have findings to record, then end your turn by calling exactly ONE terminal outcome tool: `propose_pr`, `silence_as_noise`, `place_under_observation`, `mark_already_resolved`, or `ask_human`.",
+    "You ended your turn without concluding the investigation, so it has no recorded outcome and nothing is pending.",
+    "Call `report_findings` now if you have findings to record, classify each linked issue (`silence_as_noise`, `place_under_observation`, or `resolve_issue`), open any needed PR with `propose_pr`, and then end your turn by calling `resolve_incident` — or `ask_human` if a human must act or answer first.",
   ].join("\n");
 }
 
@@ -191,6 +185,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         orgId: ctx.project.orgId,
         projectId: ctx.project.id,
         incidentId: ctx.incident.id,
+        executeOutcomeAction: createOutcomeActionExecutor(ctx, sessionId),
       })
       .catch((err) => {
         logger.error({ err, sessionId }, "integration tool dispatch failed");
@@ -469,6 +464,18 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         return;
       }
 
+      if (snapshot.result.state === "complete" && snapshot.result.incidentResolution) {
+        // Terminal resolve_incident (multi-PR contract): issues were
+        // classified and PRs delivered mid-run; this resolves the incident.
+        const hasPr = !!(await db.query.agentPullRequests.findFirst({
+          where: eq(schema.agentPullRequests.incidentId, ctx.incident.id),
+          columns: { id: true },
+        }));
+        await completeWithIncidentResolution(ctx, snapshot.result, sessionId, nextRuntimeMinutes);
+        await meterAgentRun(hasPr ? "complete_with_pr" : "complete_no_pr");
+        return;
+      }
+
       if (snapshot.result.state === "complete") {
         const pr = snapshot.result.pr ?? null;
         if (pr && pr.validationPassed === false) {
@@ -539,6 +546,50 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
     });
     if (steeredContextOutcome !== "not_applicable") {
       return;
+    }
+
+    // Idle with no terminal call but with PRs out for review: a legitimate
+    // end state in the multi-PR contract. Park the run — the durable session
+    // is resumed by PR comment/merge/close webhooks (or any human message).
+    if (snapshot.status === "idle" && !snapshot.result) {
+      const openPrs = await db.query.agentPullRequests.findMany({
+        where: and(
+          eq(schema.agentPullRequests.incidentId, ctx.incident.id),
+          eq(schema.agentPullRequests.state, "open"),
+        ),
+        columns: { url: true },
+      });
+      if (openPrs.length > 0) {
+        const parkedResult = assembleAgentRunResult({
+          findings: snapshot.pendingOutcome?.findings ?? null,
+          terminal: null,
+          actions: snapshot.pendingOutcome?.actions ?? [],
+        });
+        // Land the turn's findings on the incident before parking, so the
+        // dashboard shows them while the run waits. Skipped when the turn
+        // recorded no findings — an empty summary must not blank out
+        // findings from an earlier turn.
+        if (snapshot.pendingOutcome?.findings) {
+          await applyIncidentMetadataFromResult(ctx, parkedResult);
+        }
+        await moveAgentRunToAwaitingEvents(
+          ctx,
+          parkedResult,
+          openPrs.map((pr) => pr.url),
+        );
+        await recordAgentRunCompletion({
+          orgId: ctx.project.orgId,
+          projectId: ctx.project.id,
+          incidentId: ctx.incident.id,
+          model: snapshot.modelUsage.model,
+          callSite: "agent_run",
+          usage: snapshot.modelUsage,
+          activeSeconds: snapshot.activeSeconds,
+          outcome: "awaiting_events",
+          hasPr: true,
+        });
+        return;
+      }
     }
 
     // Idle with no result = the model never called a terminal outcome tool

--- a/apps/worker/src/agent-runs/tick.ts
+++ b/apps/worker/src/agent-runs/tick.ts
@@ -80,7 +80,11 @@ export async function tickAgentRuns(): Promise<number> {
           await syncRunningAgentRun(ctx);
           continue;
         }
-        if (ctx.agentRun.state === "awaiting_human" || ctx.agentRun.state === "resuming") {
+        if (
+          ctx.agentRun.state === "awaiting_human" ||
+          ctx.agentRun.state === "awaiting_events" ||
+          ctx.agentRun.state === "resuming"
+        ) {
           await resumeAgentRunFromHumanInput(ctx);
           continue;
         }

--- a/apps/worker/src/ai-usage.ts
+++ b/apps/worker/src/ai-usage.ts
@@ -29,7 +29,12 @@ export type CallSite =
   | "autorecovery"
   | "topology";
 
-export type AgentRunOutcome = "complete_with_pr" | "complete_no_pr" | "failed" | "awaiting_human";
+export type AgentRunOutcome =
+  | "complete_with_pr"
+  | "complete_no_pr"
+  | "failed"
+  | "awaiting_human"
+  | "awaiting_events";
 
 export type RecordTokenUsageInput = {
   orgId: string;

--- a/apps/worker/src/incident-result-policy.ts
+++ b/apps/worker/src/incident-result-policy.ts
@@ -10,60 +10,41 @@ export function normalizeSeverity(input: unknown): IncidentSeverity | null {
     : null;
 }
 
-const NOISE_REASONS: ReadonlySet<schema.IncidentNoiseReason> = new Set([
-  "cosmetic_log_only",
-  "lifecycle_signal",
-  "self_telemetry",
-  "expected_third_party",
-  "confusing_log_no_impact",
-]);
+// Reasons are free text in the current contract. These label maps cover the
+// legacy enum values still present in stored rows and produced by pre-cutover
+// sessions; anything else is rendered as-is.
+const LEGACY_NOISE_REASON_LABELS: Record<string, string> = {
+  cosmetic_log_only: "cosmetic log only",
+  lifecycle_signal: "lifecycle signal",
+  self_telemetry: "self-telemetry",
+  expected_third_party: "expected third-party response",
+  confusing_log_no_impact: "recovered/no impact",
+};
 
-const RESOLUTION_REASONS: ReadonlySet<schema.IncidentResolutionReason> = new Set([
-  "fixed_in_current_code",
-  "transient_condition_cleared",
-  "upstream_recovered",
-]);
+const LEGACY_RESOLUTION_REASON_LABELS: Record<string, string> = {
+  fixed_in_current_code: "fixed in current code",
+  transient_condition_cleared: "transient condition cleared",
+  upstream_recovered: "upstream recovered",
+};
 
 export function normalizeNoiseReason(input: unknown): schema.IncidentNoiseReason | null {
   if (typeof input !== "string") return null;
-  const candidate = input.trim().toLowerCase();
-  return NOISE_REASONS.has(candidate as schema.IncidentNoiseReason)
-    ? (candidate as schema.IncidentNoiseReason)
-    : null;
+  const candidate = input.trim();
+  return candidate.length > 0 ? candidate : null;
 }
 
 export function normalizeResolutionReason(input: unknown): schema.IncidentResolutionReason | null {
   if (typeof input !== "string") return null;
-  const candidate = input.trim().toLowerCase();
-  return RESOLUTION_REASONS.has(candidate as schema.IncidentResolutionReason)
-    ? (candidate as schema.IncidentResolutionReason)
-    : null;
+  const candidate = input.trim();
+  return candidate.length > 0 ? candidate : null;
 }
 
 export function noiseReasonLabel(reason: schema.IncidentNoiseReason): string {
-  switch (reason) {
-    case "cosmetic_log_only":
-      return "cosmetic log only";
-    case "lifecycle_signal":
-      return "lifecycle signal";
-    case "self_telemetry":
-      return "self-telemetry";
-    case "expected_third_party":
-      return "expected third-party response";
-    case "confusing_log_no_impact":
-      return "recovered/no impact";
-  }
+  return LEGACY_NOISE_REASON_LABELS[reason] ?? reason;
 }
 
 export function resolutionReasonLabel(reason: schema.IncidentResolutionReason): string {
-  switch (reason) {
-    case "fixed_in_current_code":
-      return "fixed in current code";
-    case "transient_condition_cleared":
-      return "transient condition cleared";
-    case "upstream_recovered":
-      return "upstream recovered";
-  }
+  return LEGACY_RESOLUTION_REASON_LABELS[reason] ?? reason;
 }
 
 export function completedNoiseReason(result: AgentRunResult): schema.IncidentNoiseReason | null {

--- a/packages/db/src/agent-follow-up.ts
+++ b/packages/db/src/agent-follow-up.ts
@@ -32,6 +32,7 @@ const EXECUTING_STATES = [
   "repo_discovery",
   "running",
   "awaiting_human",
+  "awaiting_events",
   "pr_retry_queued",
   "blocked_no_github",
 ];
@@ -73,9 +74,13 @@ export function decideInboundContinuation(
   const run = input.latestRun;
   if (!run) return { action: "skip", reason: "no_prior_run" };
 
-  // The agent explicitly paused for input — always deliver. The worker resumes
-  // the session, or requeues the run if it paused before a session existed.
-  if (run.state === "awaiting_human") return { action: "resume", runId: run.id };
+  // The agent explicitly paused for input (awaiting_human) or parked while its
+  // PRs are out for review (awaiting_events) — always deliver. The worker
+  // resumes the session, or requeues the run if it paused before a session
+  // existed.
+  if (run.state === "awaiting_human" || run.state === "awaiting_events") {
+    return { action: "resume", runId: run.id };
+  }
 
   if (EXECUTING_LIVE_STATES.has(run.state)) {
     // Mid-turn: inject into the live session so the agent adapts in real time.
@@ -426,6 +431,10 @@ function followUpQueuedSummary(trigger: AgentRunFollowUpTrigger): string {
   switch (trigger) {
     case "pr_comment":
       return "Follow-up investigation queued from a pull request comment.";
+    case "pr_merged":
+      return "Follow-up investigation queued: an agent pull request was merged.";
+    case "pr_closed":
+      return "Follow-up investigation queued: an agent pull request was closed.";
     case "feedback":
       return "Follow-up investigation queued from user feedback.";
     case "slack_reply":

--- a/packages/db/src/incident-state.ts
+++ b/packages/db/src/incident-state.ts
@@ -55,7 +55,10 @@ export function buildAgentRunIncidentPatch(opts: {
     updates.severity = result.severity;
   }
 
-  if (result.state === "complete") {
+  // Findings land on the incident both when the run concludes and when it
+  // parks on awaiting_events (PRs out for review) — the dashboard should show
+  // what the investigation found while it waits.
+  if (result.state === "complete" || result.state === "awaiting_events") {
     updates.agentSummary = result.summary ?? null;
     updates.rootCauseText = result.rootCause?.text ?? null;
     updates.rootCauseConfidence = result.rootCause?.confidence ?? null;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -88,6 +88,8 @@ export type {
   AgentRunTriggerDetail,
   AgentRunResult,
   AgentRunPr,
+  AgentRunIssueClassification,
+  AgentRunIncidentResolution,
   AgentRunLinearTicket,
   AgentRunMobileRegressionTest,
   AgentRunFailureReason,
@@ -216,6 +218,12 @@ export {
   type EscalationEvaluationInput,
   type IssueOccurrenceAction,
 } from "./issue-state.js";
+export {
+  classifyIncidentIssue,
+  listUnclassifiedIncidentIssues,
+  type ClassifyIncidentIssueResult,
+  type IssueClassificationAction,
+} from "./issue-classification.js";
 export {
   confirmResolutionProposal,
   createIncidentLifecycle,

--- a/packages/db/src/issue-classification.ts
+++ b/packages/db/src/issue-classification.ts
@@ -1,0 +1,163 @@
+// Per-issue classification applied mid-run by the investigation agent's
+// action tools (silence_as_noise / place_under_observation / resolve_issue).
+// Unlike the incident-resolution cascade in resolve-incident.ts — which
+// disposes of every linked issue at once when an incident closes — this
+// classifies ONE issue while the incident stays open, so the agent can work
+// through a grouped incident issue by issue and only then resolve it.
+
+import { and, eq } from "drizzle-orm";
+import { type DB, db } from "./client.js";
+import {
+  buildIssueObservePatch,
+  buildIssueResolvePatch,
+  buildIssueSilencePatch,
+} from "./issue-state.js";
+import * as schema from "./schema.js";
+
+export type IssueClassificationAction =
+  | { kind: "silence" }
+  | { kind: "observe"; trigger: schema.IssueEscalationTrigger }
+  | { kind: "resolve" };
+
+const TARGET_STATUS: Record<IssueClassificationAction["kind"], schema.IssueStatus> = {
+  silence: "silenced",
+  observe: "under_observation",
+  resolve: "resolved",
+};
+
+export type ClassifyIncidentIssueResult =
+  | { ok: true; issueTitle: string; status: schema.IssueStatus; alreadyClassified: boolean }
+  | {
+      ok: false;
+      error: "issue_not_found" | "not_linked_to_incident" | "alert_issue_not_suppressible";
+      message: string;
+    };
+
+// Classify a single issue linked to an open incident. Idempotent: an issue
+// already in the target status reports alreadyClassified instead of failing,
+// so a re-dispatched tool call (ack lost, worker retried) converges.
+export async function classifyIncidentIssue(
+  database: DB = db,
+  opts: {
+    incidentId: string;
+    issueId: string;
+    agentRunId?: string | null;
+    action: IssueClassificationAction;
+    reason: string;
+    evidence: string;
+    now?: Date;
+  },
+): Promise<ClassifyIncidentIssueResult> {
+  const now = opts.now ?? new Date();
+
+  return database.transaction(async (tx) => {
+    const issue = await tx.query.issues.findFirst({
+      where: eq(schema.issues.id, opts.issueId),
+    });
+    if (!issue) {
+      return {
+        ok: false as const,
+        error: "issue_not_found" as const,
+        message: `No issue with id ${opts.issueId}. Use an issue_id from the incident issue bundle.`,
+      };
+    }
+    const link = await tx.query.incidentIssues.findFirst({
+      where: and(
+        eq(schema.incidentIssues.incidentId, opts.incidentId),
+        eq(schema.incidentIssues.issueId, opts.issueId),
+      ),
+    });
+    if (!link) {
+      return {
+        ok: false as const,
+        error: "not_linked_to_incident" as const,
+        message: `Issue ${opts.issueId} is not linked to this incident. Only classify issues from the incident issue bundle.`,
+      };
+    }
+    // Alert-episode issues track an alert breach period; suppressing future
+    // breaches is an alert-configuration decision, not an issue verdict. They
+    // can only be resolved.
+    if (issue.kind === "alert" && opts.action.kind !== "resolve") {
+      return {
+        ok: false as const,
+        error: "alert_issue_not_suppressible" as const,
+        message: `Issue ${opts.issueId} is an alert episode — it can only be resolved (resolve_issue), not silenced or observed.`,
+      };
+    }
+
+    const targetStatus = TARGET_STATUS[opts.action.kind];
+    if (issue.status === targetStatus) {
+      return {
+        ok: true as const,
+        issueTitle: issue.title,
+        status: targetStatus,
+        alreadyClassified: true,
+      };
+    }
+
+    const patch =
+      opts.action.kind === "silence"
+        ? buildIssueSilencePatch(now)
+        : opts.action.kind === "observe"
+          ? buildIssueObservePatch({
+              trigger: opts.action.trigger,
+              baselineEventCount: issue.eventCount,
+              now,
+            })
+          : buildIssueResolvePatch();
+    await tx.update(schema.issues).set(patch).where(eq(schema.issues.id, opts.issueId));
+
+    const eventKind =
+      opts.action.kind === "silence"
+        ? "issue_silenced"
+        : opts.action.kind === "observe"
+          ? "issue_observed"
+          : "issue_resolved";
+    await tx
+      .insert(schema.incidentEvents)
+      .values({
+        agentRunId: opts.agentRunId ?? null,
+        incidentId: opts.incidentId,
+        kind: eventKind,
+        summary:
+          opts.action.kind === "silence"
+            ? `Issue silenced: ${issue.title}`
+            : opts.action.kind === "observe"
+              ? `Issue placed under observation: ${issue.title}`
+              : `Issue resolved: ${issue.title}`,
+        detail: {
+          issueId: issue.id,
+          issueTitle: issue.title,
+          reason: opts.reason,
+          evidence: opts.evidence,
+          ...(opts.action.kind === "observe"
+            ? { trigger: opts.action.trigger, baselineEventCount: issue.eventCount }
+            : {}),
+        },
+        dedupeKey: `${eventKind}:${issue.id}:${now.getTime()}`,
+        processedAt: now,
+      })
+      .onConflictDoNothing();
+
+    return {
+      ok: true as const,
+      issueTitle: issue.title,
+      status: targetStatus,
+      alreadyClassified: false,
+    };
+  });
+}
+
+// Issues still `open` on the incident — the resolve_incident guard: the
+// terminal call is rejected until this list is empty.
+export async function listUnclassifiedIncidentIssues(
+  database: DB = db,
+  incidentId: string,
+): Promise<Array<{ id: string; title: string }>> {
+  const rows = await database
+    .select({ id: schema.issues.id, title: schema.issues.title, status: schema.issues.status })
+    .from(schema.issues)
+    .innerJoin(schema.incidentIssues, eq(schema.incidentIssues.issueId, schema.issues.id))
+    .where(eq(schema.incidentIssues.incidentId, incidentId));
+  return rows.filter((row) => row.status === "open").map(({ id, title }) => ({ id, title }));
+}

--- a/packages/db/src/issue-classification.ts
+++ b/packages/db/src/issue-classification.ts
@@ -5,8 +5,8 @@
 // classifies ONE issue while the incident stays open, so the agent can work
 // through a grouped incident issue by issue and only then resolve it.
 
-import { and, eq } from "drizzle-orm";
-import { type DB, db } from "./client.js";
+import { desc, eq, inArray } from "drizzle-orm";
+import type { DB } from "./client.js";
 import {
   buildIssueObservePatch,
   buildIssueResolvePatch,
@@ -37,7 +37,7 @@ export type ClassifyIncidentIssueResult =
 // already in the target status reports alreadyClassified instead of failing,
 // so a re-dispatched tool call (ack lost, worker retried) converges.
 export async function classifyIncidentIssue(
-  database: DB = db,
+  database: DB,
   opts: {
     incidentId: string;
     issueId: string;
@@ -61,17 +61,22 @@ export async function classifyIncidentIssue(
         message: `No issue with id ${opts.issueId}. Use an issue_id from the incident issue bundle.`,
       };
     }
-    const link = await tx.query.incidentIssues.findFirst({
-      where: and(
-        eq(schema.incidentIssues.incidentId, opts.incidentId),
-        eq(schema.incidentIssues.issueId, opts.issueId),
-      ),
+    // An issue accumulates one link per incident over its life (recurrence
+    // appends a new link), so "belongs to this incident" means the NEWEST
+    // link points here — mirroring listCurrentIssuesForIncidentInTx. A stale
+    // resumed run must not classify an issue that already recurred into a
+    // newer incident; that verdict belongs to the newer investigation.
+    const latestLink = await tx.query.incidentIssues.findFirst({
+      where: eq(schema.incidentIssues.issueId, opts.issueId),
+      orderBy: [desc(schema.incidentIssues.createdAt), desc(schema.incidentIssues.id)],
     });
-    if (!link) {
+    if (latestLink?.incidentId !== opts.incidentId) {
       return {
         ok: false as const,
         error: "not_linked_to_incident" as const,
-        message: `Issue ${opts.issueId} is not linked to this incident. Only classify issues from the incident issue bundle.`,
+        message: latestLink
+          ? `Issue ${opts.issueId} now belongs to a newer incident; it can no longer be classified from this one. Only classify issues from the incident issue bundle.`
+          : `Issue ${opts.issueId} is not linked to this incident. Only classify issues from the incident issue bundle.`,
       };
     }
     // Alert-episode issues track an alert breach period; suppressing future
@@ -148,10 +153,13 @@ export async function classifyIncidentIssue(
   });
 }
 
-// Issues still `open` on the incident — the resolve_incident guard: the
-// terminal call is rejected until this list is empty.
+// Issues still `open` whose CURRENT incident is this one — the
+// resolve_incident guard: the terminal call is rejected until this list is
+// empty. Same newest-link-wins semantics as classifyIncidentIssue: an issue
+// that already recurred into a newer incident is that investigation's to
+// classify and must not block this incident's resolution.
 export async function listUnclassifiedIncidentIssues(
-  database: DB = db,
+  database: DB,
   incidentId: string,
 ): Promise<Array<{ id: string; title: string }>> {
   const rows = await database
@@ -159,5 +167,27 @@ export async function listUnclassifiedIncidentIssues(
     .from(schema.issues)
     .innerJoin(schema.incidentIssues, eq(schema.incidentIssues.issueId, schema.issues.id))
     .where(eq(schema.incidentIssues.incidentId, incidentId));
-  return rows.filter((row) => row.status === "open").map(({ id, title }) => ({ id, title }));
+  const open = rows.filter((row) => row.status === "open");
+  if (open.length === 0) return [];
+
+  const links = await database.query.incidentIssues.findMany({
+    where: inArray(
+      schema.incidentIssues.issueId,
+      open.map((row) => row.id),
+    ),
+  });
+  const latestByIssue = new Map<string, (typeof links)[number]>();
+  for (const link of links) {
+    const current = latestByIssue.get(link.issueId);
+    if (
+      !current ||
+      link.createdAt > current.createdAt ||
+      (link.createdAt.getTime() === current.createdAt.getTime() && link.id > current.id)
+    ) {
+      latestByIssue.set(link.issueId, link);
+    }
+  }
+  return open
+    .filter((row) => latestByIssue.get(row.id)?.incidentId === incidentId)
+    .map(({ id, title }) => ({ id, title }));
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -88,7 +88,9 @@ export type AgentRunPr = {
   patch?: string;
   patchFileId?: string | null;
   patchFilePath?: string | null;
-  validationPassed: boolean;
+  // Legacy fields from the era when propose_pr carried a self-reported
+  // validation verdict; current agents no longer send them.
+  validationPassed?: boolean;
   validationCommands?: string[];
   validationSummary?: string | null;
   changedFiles?: string[];
@@ -142,12 +144,11 @@ export type IssueEscalationTrigger =
   | { kind: "rate"; perMinute: number }
   | { kind: "count"; count: number };
 
-export type IncidentNoiseReason =
-  | "cosmetic_log_only"
-  | "lifecycle_signal"
-  | "self_telemetry"
-  | "expected_third_party"
-  | "confusing_log_no_impact";
+// Free-form text explaining why the issue is noise. Previously a closed enum
+// (cosmetic_log_only, lifecycle_signal, self_telemetry, expected_third_party,
+// confusing_log_no_impact); those values still occur in stored rows and remain
+// valid strings — render the text as-is.
+export type IncidentNoiseReason = string;
 
 // What to do with the incident's issues once a noise verdict lands. Silence
 // suppresses future occurrences outright; observe suppresses until the
@@ -163,10 +164,10 @@ export type IncidentNoiseClassification = {
   action?: IncidentNoiseAction | null;
 };
 
-export type IncidentResolutionReason =
-  | "fixed_in_current_code"
-  | "transient_condition_cleared"
-  | "upstream_recovered";
+// Free-form text explaining why the incident/issue is considered resolved.
+// Previously a closed enum (fixed_in_current_code, transient_condition_cleared,
+// upstream_recovered); stored rows may still carry those values.
+export type IncidentResolutionReason = string;
 
 export type IncidentResolutionClassification = {
   reason: IncidentResolutionReason;
@@ -202,10 +203,15 @@ export type AgentRunConfidence = {
 // an already-investigated incident. Instead of starting a fresh investigation
 // (which produced duplicate PRs for the same root cause), it steers the existing
 // investigation — same continuation path as the human channels below.
+// "pr_merged" / "pr_closed" are GitHub lifecycle events on an agent PR: they
+// resume the investigation so the agent decides whether the incident is done
+// (resolve_incident) or more work remains.
 export type AgentRunTrigger =
   | "incident"
   | "manual"
   | "pr_comment"
+  | "pr_merged"
+  | "pr_closed"
   | "feedback"
   | "slack_reply"
   | "web_chat"
@@ -245,12 +251,35 @@ export type AgentRunTriggerDetail = {
 // failed: the last turn failed; a new inbound message re-queues it.
 export type AgentChatState = "queued" | "running" | "idle" | "failed";
 
+// One issue-level verdict recorded by the agent mid-run. The issue row itself
+// is the source of truth (the status change is applied when the tool call is
+// dispatched); this is the run-result record of what was decided and why.
+export type AgentRunIssueClassification = {
+  issueId: string;
+  action: "silence" | "observe" | "resolve";
+  reason: string;
+  evidence: string;
+  trigger?: IssueEscalationTrigger | null;
+};
+
+// The agent's terminal resolve_incident verdict.
+export type AgentRunIncidentResolution = {
+  reason: string;
+  evidence: string;
+};
+
 export type AgentRunResult = {
-  state: "complete" | "awaiting_human" | "failed";
+  state: "complete" | "awaiting_human" | "awaiting_events" | "failed";
   summary: string;
   question?: string | null;
   failureReason?: AgentRunFailureReason | null;
+  // Legacy single-PR record (pre multi-PR contract). New runs record opened
+  // PRs as agent_pull_requests rows (the source of truth) and mirror them in
+  // `prs`; `pr` is kept pointing at the most recent one for old readers.
   pr?: AgentRunPr | null;
+  prs?: AgentRunPr[] | null;
+  issueClassifications?: AgentRunIssueClassification[] | null;
+  incidentResolution?: AgentRunIncidentResolution | null;
   linearTicket?: AgentRunLinearTicket | null;
   rootCauseConfidence?: "high" | "medium" | "low" | null;
   // Concise human-readable replacement for incident.title — applied by the worker if present.

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -10,6 +10,20 @@ An **Issue** is the unit that triggers an **Incident**. There are two kinds of *
 - **Errors**: error logs and error traces. Whenever a client sends us a new error trace or error log, we fingerprint it into an **Issue**. Repeated occurrences of the same error log or trace count as one **Issue**.
 - **Alert episodes**: one contiguous breach period of an **Alert** — from the evaluation tick where the alert starts firing to the tick where it recovers. Every new breach is a new **Issue**. An alert episode records the breach window (start and end times) and the observed values (at open, at peak, and latest), and the **Issue** carries the alert's configuration (what is measured, the filter, aggregation, comparator, threshold, and evaluation window).
 
+## Issue kinds
+
+There are two kinds of error issues, and one kind of alert issues.
+
+### Errors
+
+There are two types of error Issues:
+1. Error logs (i.e. log lines with a severity of level attribute indicating it's an error log).
+2. Error spans (i.e. log spans with a status attribute indicating it's an error span).
+
+### Alert episodes
+
+Any alert breach period (called an Episode) is an Issue.
+
 ## Issue states
 
 When an **Issue** is created, it starts as `open`. An `open` **Issue** should trigger an **Incident**. 
@@ -17,12 +31,14 @@ When an **Issue** is created, it starts as `open`. An `open` **Issue** should tr
 The `silenced` and `under observation` states below apply to error **Issues** only. An alert-episode **Issue** is only ever `open` or `resolved`: if an alert fires for a real problem, resolve the **Incident** when the problem is gone or fix the underlying cause; if an alert is noisy, the remedy is to tune its threshold or disable the alert, not to silence its episodes.
 
 - An **Issue** can be `silenced`, in which case any new occurrences will not start new **Incidents**.
-- An **Issue** can be `under observation`. An **Issue** in `under observation` must have an `escalation trigger`.
+    - Only an Error Issue (an error log or an error span) can be silenced.
+- An error **Issue** can be `under observation`. An **Issue** in `under observation` must have an `escalation trigger`.
     - If an `escalation trigger` fires, the **Issue** becomes `open` again and triggers a new **Incident**. The new Incident has access to previously gathered context. 
     - An `escalation trigger` can be:
         - a rate of errors (errors per minute)
         - an absolute count of events
     - Occurrences of the Issue `under observation` do not cause anything until the `escalation trigger` trips.
+    - Only an Error Issue (an error log or an error span) can be under observation.
 - An **Issue** can be `resolved`. New occurrences of the same error will trigger an **Incident**. The investigations of the recurring issue will be able to consult previous findings if necessary.
 
 
@@ -91,6 +107,8 @@ the Superlog agent must attempt to resolve the issue. The resolution is a multi-
     - Opening subsequent PRs
 - Opening Approval prompts 
 
+Opening PRs and Approval prompts continues in a loop until the issue is Resolved.
+
 ### Approval prompt
 
 An Approval prompt is a way for our agent to make changes in the client's infrastructure, databases and other systems with the user's approval. When Superlog has access to the customer's infrastructure, for example, their AWS account, Superlog must always send Approval Prompts before taking action. 
@@ -124,7 +142,7 @@ Humans and agents can add notes on various Superlog entities in order to:
 There are two ways to store memory in Superlog: comments and project memory
 
 ## Comments
-Issues and Incidents have associated Comments. Humans and Agents can add Comments that are visible to the Agent Run investigating the Incident.
+Issues have associated Comments. Humans and Agents can add Comments that are visible to the Agent Run investigating the Incident.
 
 ## Project memory
 Every Project has a list of Memories that can be added by humans and Agents. A Memory is a dated free-form text. All Project memories are visible to the Agent Run investigating the Incident. Agents can add new Memories during investigations and in response to PR comments, Slack messages and other interactions with users.
@@ -134,7 +152,126 @@ Every Project has a list of Memories that can be added by humans and Agents. A M
 Once per week, Superlog must send to the connected Slack channel an update containing a global review of all issues, including the number of issues counted as noise. 
 
 
+# Agent
+
+The following describes how the a Superlog agent should work — how it accomplishes an Agent Run.
+
+## Goal of the agent
+
+An agent needs to accomplish an Agent Run described above.
+
+An Agent Run starts with a new Incident being opened from either a new Issue, a recurrence of a `resolved` Issue, or a trip of an Escalation trigger.
+
+## Agent actions
+
+During an Agent Run, the Agent can:
+
+Manage issues:
+
+- Silence an issue. If the system is operating normally, and an Issue is a false positive, the Issue must be silenced. It will not raise Incidents anymore.
+- Put an issue under observation. If the Issue is a one-off event and needs observation (see above), the Issues needs to be placed under observation with an Escalation trigger.
+- Resolve an issue. If the impact of an issue has ceased due to other factors, and no more action can be taken, the issue needs to be Resolved. 
+
+Take actions to resolve the root cause of the incident (multiple times, iterating and responding to external triggers):
+
+- Modify the source code and open a PR. The agent never holds push credentials: it produces a patch, and the platform applies the patch and opens the PR on its behalf.
+- Produce an Approval prompt for an action that is available to it:
+    - an infra fix via AWS CLI
+    - other tools available to the agent (to be extended)
+When a human approves an Approval prompt, the platform executes the approved command verbatim under the customer-owned action role and reports the result back to the agent's session. The agent does not execute approved commands itself.
+
+- Require a prompt for human input and ask for clarification.
+
+And then, finally,
+
+- Resolve the incident. If the impact on the system has ceased (or there has been no impact), or the action of the agent (PRs, approval prompts) have resolved the root cause of the Incident, the agent can resolve the Incident.
+    - All issues connected to the Incident must be either resolved, silenced or put under observation prior to resolving the incident.
+
+
+## Session continuity
+
+Each Incident is investigated by one durable agent session. Intervention outcomes do not end the investigation — they leave the session waiting on an external event: a PR comment, a PR merge or close, an approval decision, or a human answer to a clarification. Any inbound event on the Incident resumes the same session with its context intact. The agent responds on the channel the inbound event arrived on.
+
+## Inputs of the agent
+
+### Issues
+The agent must have full access to the triggering issue (error log / trace / alert) / trigger as part of its prompt.
+
+If the Incident was opened by a recurrence of a `resolved` Issue or by an Escalation trigger, the findings of the predecessor Incident(s) must be part of the prompt as well.
+
+### Memory
+Comments on the related Issues and Incident, and all Project Memories (see Memory above), must be visible to the agent. The agent must have a tool to add new Memories during the investigation.
+
+### Telemetry
+The agent must have free access to all the telemetry of the related project, but not as part of its prompt and rather as an MCP / tool.
+
+### Source code
+The agent must have access to the Github repositories that this project has access to. The agent should either have the repositories cloned already, or a tool to clone relevant repositories based on its investigations.
+
+### Infrastructure
+When the customer has connected their infrastructure (e.g. an AWS account), the agent must have read-only access to it as a tool. Any change to infrastructure goes through an Approval prompt.
+
+## Structure of the agent
+
+The prompt of the agent must be short and clear. The goal and the workflow of the agent must be explicit.
+
+The outcomes of the agent must be provided as tools that the agent can call based on its investigation.
+
+## Outcome tools
+
+The tool contract (source of truth: `apps/worker/src/agent-outcome-tools.ts`) has three tiers:
+
+1. **`report_findings`** (non-terminal) — shared metadata, callable repeatedly.
+2. **Action tools** (non-terminal, executed server-side mid-run): `propose_pr`, `silence_as_noise`, `place_under_observation`, `resolve_issue`. The platform executes each call while the session is live and returns the result to the agent — a PR call returns the PR URL (or the apply failure, which the agent can fix and retry); a classification call applies to the issue immediately.
+3. **Terminal tools**: `resolve_incident` ends the investigation; `ask_human` pauses it on a human.
+
+A turn may also legitimately end with **no** terminal call when the agent is waiting on external events — open PRs out for review. The run then parks (`awaiting_events`) with its session intact and is resumed by a PR comment, merge, or close (or any human message). Ending a turn with no terminal call *and* nothing pending gets one nudge, then the budget backstops fail the run: a diagnosis that ends with nothing happening is not an outcome.
+
+### report_findings (non-terminal)
+
+Records shared metadata before any acting tool. Callable repeatedly; fields are last-write-wins. All action tools and `resolve_incident` refuse to run until it has been called.
+
+- `summary` (required) — 1-2 sentences, operator's view, symptom before mechanism
+- `proposedTitle` — replacement incident title, symptom-first, never the fix
+- `rootCause` + `rootCauseConfidence` (0-10) — markdown RCA; every claim backed by verbatim quotes
+- `estimatedImpact` + `impactConfidence` (0-10)
+- `severity` — SEV-1 / SEV-2 / SEV-3
+- `handoffNotes` — for a future follow-up run: files examined, ruled-out hypotheses, repo gotchas
+
+### Action tools (non-terminal)
+
+**`propose_pr`** — intervention: a validated patch for a defect with real user/business impact. The agent writes a unified diff to a distinct file under `/mnt/session/outputs/`; the platform applies it and opens the PR mid-run, returning the URL or the failure (the agent never holds push credentials). PRs are keyed by branch: a **new** `branchName` opens an independent PR; the **same** `branchName` pushes the patch as a follow-up commit on that PR (how review feedback is addressed). Params: `repoFullName`, `title`, `body`, `branchName` (must start `superlog/`), `baseBranch`, `patchFilePath`; optional `changedFiles`, mobile-regression fields. The agent validates its own patch before proposing; noise is classified, never patched — no PRs that only quiet a signal.
+
+**`silence_as_noise`** — one issue is proven a false positive; it is silenced permanently, so the evidentiary bar is high (quote the success path / contract clause). Params: `issueId`, `reason` (full-text), `evidence`.
+
+**`place_under_observation`** — one issue is plausibly noise but unproven; it goes quiet until the escalation trigger trips. Params: `issueId`, `reason` (full-text), `evidence`, `escalateOn` (`events_per_minute` | `additional_events`), `threshold` (int ≥ 1).
+
+**`resolve_issue`** — one issue's impact has ceased (already fixed, transient cleared, upstream recovered, or fixed by the agent's own merged PR). Params: `issueId`, `reason` (full-text), `evidence` (before/after signal + window).
+
+Only error issues can be silenced or observed; alert-episode issues can only be resolved.
+
+### Terminal tools
+
+**`resolve_incident`** — the global resolution of the incident: impact has ceased (or never was), or the agent's actions resolved the root cause. Rejected (with the list) while any linked issue is still unclassified. Params: `reason` (full-text), `evidence` (before/after signal + window).
+
+**`ask_human`** — a human must act or answer first; the run pauses and resumes with session intact on reply (waiting indefinitely is by design). Param: `question`. Covers: missing context; a code artifact absent from every mounted repo; a diagnosis whose remediation is not the agent's to make (third-party defect, provider quota, customer-owned config, a decision between fix paths); a failing code path the agent could not locate. In each case the agent states what it found and asks the concrete question that unblocks action.
+
+The Approval-prompt outcome (infra fix via AWS CLI etc.) is not yet a tool; when built it joins this contract as an action-or-waiting tool.
+
+### PR lifecycle events
+
+When an agent PR is merged or closed, the platform resumes the incident's session with the event context and the agent decides what follows — resolve the incident, push more commits, open another PR, or classify remaining issues. Merge only auto-resolves the incident as a fallback when no session can be resumed (e.g. expired), so incidents never stay open forever.
+
+### Contract mechanics
+
+- Tool schemas are flat (`type`/`properties`/`required` only) — runner APIs reject top-level composition keywords at agent-create time.
+- Runner APIs don't enforce custom-tool schemas server-side, so the worker re-validates every call and error-acks invalid input with a model-readable message; the model corrects the call within the same session. Identical-tool error acks are capped per turn, then the budget backstops own the runaway session.
+- Retired tools (`complete_investigation`, `report_failure` — removed 2026-07-08 because they let a run end without anything happening; `mark_already_resolved` — replaced 2026-07-10 by the per-issue `resolve_issue` + `resolve_incident`) are still recognized by the validator: old sessions that resume and call one get an error ack redirecting to the live outcomes, not an unknown-tool hard failure.
+
+
 # Changelog
 
 July 6, 2026 - initial commit
 July 9, 2026 - Issues are either errors or alert episodes. An alert-episode Issue is one breach period (new breach = new Issue), only uses `open`/`resolved`, and groups into Incidents like errors do.
+July 9, 2026 - merged the managed-agent spec into this document
+July 10, 2026 - agent loop rework: full-text reasons, non-terminal propose_pr (multiple PRs, keyed by branch), per-issue classification tools, terminal resolve_incident, awaiting_events parking, PR merge/close resumes the session

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -154,7 +154,7 @@ Once per week, Superlog must send to the connected Slack channel an update conta
 
 # Agent
 
-The following describes how the a Superlog agent should work — how it accomplishes an Agent Run.
+The following describes how a Superlog agent should work — how it accomplishes an Agent Run.
 
 ## Goal of the agent
 
@@ -200,7 +200,7 @@ The agent must have full access to the triggering issue (error log / trace / ale
 If the Incident was opened by a recurrence of a `resolved` Issue or by an Escalation trigger, the findings of the predecessor Incident(s) must be part of the prompt as well.
 
 ### Memory
-Comments on the related Issues and Incident, and all Project Memories (see Memory above), must be visible to the agent. The agent must have a tool to add new Memories during the investigation.
+Comments on the related Issues, and all Project Memories (see Memory above), must be visible to the agent. The agent must have a tool to add new Memories during the investigation.
 
 ### Telemetry
 The agent must have free access to all the telemetry of the related project, but not as part of its prompt and rather as an MCP / tool.


### PR DESCRIPTION
Reworks the investigation agent's outcome contract from "one terminal tool ends the run" to a loop of non-terminal actions plus an explicit terminal resolution. The spec's new **Agent** section (`specs/SPEC.md`) is the source of truth; this PR implements it end-to-end.

## What changes

**`propose_pr` is now a non-terminal action, executed mid-run.** The worker applies the patch and opens the PR while the session is live, acking back the PR URL — or the apply failure, which the agent can fix and re-call. PRs are keyed by branch name: a new `branchName` opens an independent PR, the same `branchName` pushes a follow-up commit onto that PR (how review feedback is addressed). One incident can now carry several PRs per repo. `agent_pull_requests` rows are the source of truth; `result.prs` lists them and `result.pr` remains as a legacy mirror for old readers.

**Per-issue classification tools.** `silence_as_noise`, `place_under_observation`, and `resolve_issue` each take an `issueId` and apply to that issue immediately at dispatch time (`packages/db/src/issue-classification.ts`). Only error issues can be silenced or observed; alert-episode issues can only be resolved (error-acked otherwise).

**`resolve_incident` is the new terminal.** It is rejected — with the list — while any linked issue is still unclassified, so the model corrects in-session. `mark_already_resolved` joins the retired-tool set: old sessions that resume and call it get a redirect ack, not a hard failure.

**`awaiting_events`: a turn may legitimately end with no terminal call.** When the agent's PRs are out for review, the run parks with its durable session intact (findings still land on the incident) and is resumed by PR comments, merges, and closes — new `pr_merged` / `pr_closed` triggers ride the existing inbound-continuation path. The restart endpoint supersedes parked runs, and a health gauge tracks them. Ending a turn with nothing pending keeps the old nudge-then-budget behavior.

**PR merge no longer auto-resolves the incident directly.** The webhook resumes the session and the agent decides whether the incident is done; the old auto-resolve remains only as a fallback when no session can be resumed, so incidents can't stay open forever. A close (without merge) also resumes the session with the close context. PR comments are prefixed with which PR they're on, since an incident can now have several.

**Reasons are free text end-to-end.** The `IncidentNoiseReason` / `IncidentResolutionReason` enums become plain strings; the old enum values remain valid strings in stored rows and keep their display labels.

**The self-reported patch-validation verdict is gone from `propose_pr`.** Legacy `validationPassed` fields are tolerated on old rows; the mobile regression-test gate moved from post-hoc completion repair to dispatch time, where the agent is told immediately.

## Safety rails

- The identical-tool error-ack cap now covers the dispatch-phase tools too: past the per-turn cap, failures downgrade to non-error ok-with-warning acks so the runtime budgets — not an endless error-ack loop — own a runaway session.
- The PR-retry endpoint's eligibility gate (`openStatus === "pending"`) keeps human-triggered re-delivery from double-opening PRs that were already opened mid-run.

## Testing

- Unit: outcome-tool contract, collect reducer, dispatch cap, completion paths, health gauges, follow-up routing (`agent-outcome-tools`, `agent-run*`, `incident-state`, `managed-agent-result`, db suites — all green).
- Integration: the merge/close webhook tests run against a live postgres and confirm the fallback auto-resolve still fires when no session can be resumed.
- No DB migration: the schema changes are jsonb type shapes only (`drizzle-kit generate` is a no-op).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the investigation agent into a loop of non-terminal actions with an explicit terminal `resolve_incident`, enabling mid-run PR creation and multi-PR incidents. Adds an `awaiting_events` state to park runs while PRs are under review and resume them from PR comments, merges, and closes.

- **New Features**
  - `propose_pr` runs mid-session: applies patches, opens/updates PRs keyed by `branchName`; one incident can have multiple PRs. Adds `result.prs` (keeps legacy `result.pr`). Replies and comments route to the exact PR, including cold-start PR comments. DB insert for `agent_pull_requests` is required; failures error‑ack even if GitHub created the PR. The action executor catches side‑effect errors and returns tool errors. Slack “Merge PR” shows only when exactly one PR is open.
  - Per‑issue tools: `silence_as_noise`, `place_under_observation`, `resolve_issue` classify a single linked issue at dispatch time with newest‑link‑wins semantics, so stale runs can’t classify issues that recurred into newer incidents.
  - `resolve_incident` is the terminal action and is rejected until all linked issues are classified; the guard also uses newest‑link‑wins so recurred issues don’t block resolving older incidents. `mark_already_resolved` is retired and redirected for old sessions.
  - New `awaiting_events` state preserves the durable session while PRs wait for review; `pr_merged` and `pr_closed` resume the run. The park transition is race‑safe via a conditional DB update, preventing double Slack posts and duplicate metering. Merge no longer auto‑resolves unless no session can be resumed. Continuation resumes (`awaiting_events`, `resuming`) don’t consume the human‑resume budget, and failures preserve delivered `result.prs` and issue classifications.
  - Reasons are free text end‑to‑end; stored legacy enum strings still render with labels.
  - Mobile regression‑test gate runs at dispatch; drops self‑reported `validationPassed` in `propose_pr` (legacy fields tolerated). Health metrics and restart paths include `awaiting_events`. Web UI shows multiple PRs.

- **Migration**
  - No DB migration (jsonb shape changes only).
  - Clients should read `result.prs` (keep `result.pr` for legacy).
  - Handle new run state `awaiting_events` in APIs, health gauges, and restart flows.
  - Do not rely on auto‑resolve‑on‑merge; the agent now decides after resume.
  - Accept free‑text noise/resolution reasons alongside legacy enum values.

<sup>Written for commit 7d122caef6dfbfcdaadd7947baa4d04d96e92af1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

