### PR TITLE
Spec: alert-episode detail in the Agent inputs

### DIFF
--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -160,7 +160,7 @@ The following describes how a Superlog agent should work — how it accomplishes
 
 An agent needs to accomplish an Agent Run described above.
 
-An Agent Run starts with a new Incident being opened from either a new Issue, a recurrence of a `resolved` Issue, or a trip of an Escalation trigger.
+An Agent Run starts with a new Incident being opened from either a new Issue (an error or an alert episode — see Issue kinds above), a recurrence of a `resolved` Issue, or a trip of an Escalation trigger.
 
 ## Agent actions
 
@@ -195,7 +195,10 @@ Each Incident is investigated by one durable agent session. Intervention outcome
 ## Inputs of the agent
 
 ### Issues
-The agent must have full access to the triggering issue (error log / trace / alert) / trigger as part of its prompt.
+The agent must have full access to the triggering issue as part of its prompt.
+
+- For an error Issue: the error sample (log/trace), stack frames, and trace context.
+- For an alert-episode Issue: the alert's configuration (source/metric, filter, aggregation, comparator, threshold, evaluation window, grouping) and the episode itself (breach start time, end time if recovered, and the observed values at open, peak, and latest). No synthetic error-shaped sample is shown for alerts.
 
 If the Incident was opened by a recurrence of a `resolved` Issue or by an Escalation trigger, the findings of the predecessor Incident(s) must be part of the prompt as well.
 


### PR DESCRIPTION
Follow-up to #204: the Agent section it added predates the alert-episode issue kind. This states that an Agent Run can start from an error or an alert episode, and spells out what the agent's prompt carries for each kind — the error sample (log/trace, stack frames, trace context) for errors, and the alert's configuration plus the episode's breach window and observed values for alert episodes (no synthetic error-shaped sample). Doc-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the agent spec to allow Agent Runs to start from either an error or an alert episode, and defines the prompt inputs for each issue type.
Errors include the error sample (log/trace), stack frames, and trace context; alert episodes include the alert’s configuration and the episode’s breach window and observed values, with no synthetic error-shaped sample.

<sup>Written for commit 3a2b4465bfeea8fe5e794c04bc7f48b942846d0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

