### PR TITLE
Improve incident activity and issue detail UX

### DIFF
--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -152,7 +152,7 @@ function IssuesShell({ projectId }: { projectId: string }) {
   }
 
   return (
-    <div className="relative">
+    <div>
       <div className="mb-6 flex items-center gap-1">
         {(["incidents", "issues"] as const).map((t) => (
           <Link
@@ -324,7 +324,7 @@ function IssueDrawerSkeleton({ onClose }: { onClose: () => void }) {
         onClick={onClose}
       />
       <aside className="absolute inset-y-0 right-0 flex w-full max-w-[720px] flex-col border-l border-border bg-bg shadow-2xl">
-        <div className="flex-1 overflow-y-auto">
+        <div className="min-h-0 flex-1 overflow-y-auto">
           <IssueDetailSkeleton />
         </div>
       </aside>
@@ -401,7 +401,7 @@ export function IssueDrawer(props: IssueDetailProps) {
         onClick={props.onClose}
       />
       <aside className="absolute inset-y-0 right-0 flex w-full max-w-[720px] flex-col border-l border-border bg-bg shadow-2xl">
-        <div className="flex-1 overflow-y-auto">
+        <div className="min-h-0 flex-1 overflow-y-auto">
           <IssueDetailContent {...props} />
         </div>
       </aside>
@@ -1002,6 +1002,7 @@ function IncidentDetailBody({
   onViewIssue: (issueId: string) => void;
 }) {
   const q = useIncident(projectId, incidentId);
+  const stats = useIncidentStats(projectId, incidentId);
   const updateIncident = useUpdateIncident(projectId);
   const restartAgentRun = useRestartAgentRun(projectId);
   const retryPrDelivery = useRetryPrDelivery(projectId);
@@ -1059,6 +1060,7 @@ function IncidentDetailBody({
       updatingIncident={updateIncident.isPending}
       restartingAgentRun={restartAgentRun.isPending}
       retryingPrDelivery={retryPrDelivery.isPending}
+      occurrenceBuckets={stats.data?.buckets}
     />
   );
 }
@@ -1425,6 +1427,7 @@ export function IncidentDetailContent({
   restartingAgentRun = false,
   retryingPrDelivery = false,
   summaryTelemetry,
+  occurrenceBuckets,
 }: {
   incident: Incident;
   issues: Issue[];
@@ -1448,6 +1451,7 @@ export function IncidentDetailContent({
   retryingPrDelivery?: boolean;
   /** Telemetry widgets the agent quoted in its summary, rendered inside the Summary section. */
   summaryTelemetry?: ReactNode;
+  occurrenceBuckets?: { day: string; count: number }[];
 }) {
   const [detailTab, setDetailTab] = useState<IncidentDetailTab>("activity");
   // A run paused on `ask_human` stores its question on the run result, not as an
@@ -1471,6 +1475,10 @@ export function IncidentDetailContent({
     incident.agentSummary ??
     agentRun?.result?.summary ??
     "No investigation summary has been recorded yet.";
+  const triggeringIssue = issues.reduce<Issue | null>((earliest, issue) => {
+    if (!earliest) return issue;
+    return Date.parse(issue.firstSeen) < Date.parse(earliest.firstSeen) ? issue : earliest;
+  }, null);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-bg text-fg">
@@ -1575,11 +1583,15 @@ export function IncidentDetailContent({
                     !eventsError &&
                     events.length === 0 &&
                     !outOfCredits &&
-                    !awaitingQuestion && (
-                    <p className="text-[12px] text-muted">No activity yet.</p>
-                  )}
+                    !awaitingQuestion &&
+                    !triggeringIssue && <p className="text-[12px] text-muted">No activity yet.</p>}
                   <IncidentActivityFeed
                     events={events}
+                    triggeringIssue={
+                      triggeringIssue
+                        ? { issueId: triggeringIssue.id, createdAt: incident.firstSeen }
+                        : null
+                    }
                     awaiting={
                       awaitingQuestion
                         ? {
@@ -1591,12 +1603,18 @@ export function IncidentDetailContent({
                           }
                         : null
                     }
-                    renderIssueCard={(issueId) => {
+                    renderIssueCard={(issueId, options) => {
                       const issue = issues.find((i) => i.id === issueId);
                       if (!issue) return null;
                       return (
                         <div className="rounded-lg border border-border bg-surface px-3 py-2">
-                          <IssueCard issue={issue} onViewIssue={onViewIssue} />
+                          <IssueCard
+                            issue={issue}
+                            onViewIssue={onViewIssue}
+                            occurrenceBuckets={
+                              options?.showOccurrences ? occurrenceBuckets : undefined
+                            }
+                          />
                         </div>
                       );
                     }}
@@ -1710,8 +1728,12 @@ function IncidentChatComposer({
   }
 
   return (
-    <div className="shrink-0 border-t border-border bg-bg px-6 py-4 lg:px-8">
-      <div className="flex items-end gap-2">
+    <div className="shrink-0 bg-bg px-6 py-4 lg:px-8">
+      <div
+        className={`relative rounded-lg border border-border bg-surface-2 transition-colors focus-within:border-border-strong ${
+          disabled ? "opacity-40" : ""
+        }`}
+      >
         <textarea
           value={text}
           onChange={(e) => onDraftChange(e.target.value)}
@@ -1728,17 +1750,24 @@ function IncidentChatComposer({
               ? "No investigation to talk to yet — start one from the Findings tab."
               : "Reply to the investigation — request PR changes, explain the issue, add context…"
           }
-          className="min-h-[58px] flex-1 resize-none rounded-lg border border-border bg-surface-2 px-3 py-2 text-[14px] leading-relaxed text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+          className="min-h-[124px] w-full resize-none bg-transparent px-3 pb-12 pt-2 text-[14px] leading-relaxed text-fg placeholder:text-subtle focus:outline-none disabled:cursor-not-allowed"
         />
-        <Btn
-          variant="primary"
-          size="lg"
-          onClick={submit}
-          loading={send.isPending}
-          disabled={disabled || !text.trim()}
-        >
-          Send
-        </Btn>
+        <div className="absolute bottom-3 right-3 flex items-center gap-2.5">
+          {!disabled && (
+            <span className="text-[10px] leading-[14px] text-subtle">
+              Shift Enter for a new line
+            </span>
+          )}
+          <Btn
+            variant="primary"
+            size="md"
+            onClick={submit}
+            loading={send.isPending}
+            disabled={disabled || !text.trim()}
+          >
+            Send
+          </Btn>
+        </div>
       </div>
       {error && <p className="mt-2 text-[12px] text-danger">{error}</p>}
       {!error && justSent && (
@@ -1771,7 +1800,9 @@ function IncidentSidebarMetaRows({ rows }: { rows: IncidentMetaRow[] }) {
             className={`flex min-w-0 items-center gap-2 ${row.tone === "danger" ? "text-danger" : "text-fg"}`}
           >
             <IncidentMetaIcon row={row} />
-            <span className="min-w-0 break-words">{row.value}</span>
+            <span className="min-w-0 break-words" title={row.title}>
+              {row.value}
+            </span>
           </div>
         </div>
       ))}
@@ -2570,24 +2601,95 @@ function ConfidenceMeter({ value }: { value: number }) {
 function IssueCard({
   issue,
   onViewIssue,
+  occurrenceBuckets,
 }: {
   issue: Issue;
   onViewIssue: (id: string) => void;
+  occurrenceBuckets?: { day: string; count: number }[];
 }) {
   return (
     <button
       onClick={() => onViewIssue(issue.id)}
-      className="block w-full min-w-0 overflow-hidden text-left transition-colors hover:text-muted"
+      className="block w-full min-w-0 text-left transition-colors hover:text-muted"
     >
-      <div className="mb-0.5 flex items-center gap-2">
-        <KindChip issue={issue} />
-        <span className="font-mono text-[11px] text-muted">{issue.exceptionType}</span>
-        <span className="font-mono text-[11px] tabular-nums text-subtle">
-          {fmtCount(issue.eventCount)} event{issue.eventCount !== 1 ? "s" : ""}
-        </span>
+      <div
+        className={
+          occurrenceBuckets && occurrenceBuckets.length > 0
+            ? "flex flex-col gap-3 sm:flex-row sm:gap-4"
+            : undefined
+        }
+      >
+        <div className="min-w-0 flex-1">
+          <div className="mb-0.5 flex items-center gap-2">
+            <KindChip issue={issue} />
+            <span className="text-[11px] text-muted">{issue.exceptionType}</span>
+            <span className="text-[11px] tabular-nums text-subtle">
+              {fmtCount(issue.eventCount)} event{issue.eventCount !== 1 ? "s" : ""}
+            </span>
+          </div>
+          <p className="truncate text-[12px] text-fg">{issue.message ?? issue.title}</p>
+          {occurrenceBuckets && occurrenceBuckets.length > 0 && (
+            <p className="mt-3 text-[10px] text-subtle">
+              First {fmtRelative(issue.firstSeen)} · Last {fmtRelative(issue.lastSeen)}
+            </p>
+          )}
+        </div>
+        {occurrenceBuckets && occurrenceBuckets.length > 0 && (
+          <IssueOccurrenceGraph buckets={occurrenceBuckets} />
+        )}
       </div>
-      <p className="truncate text-[12px] text-fg">{issue.message ?? issue.title}</p>
     </button>
+  );
+}
+
+function formatOccurrenceDate(day: string) {
+  const [year = Number.NaN, month = Number.NaN, date = Number.NaN] = day
+    .split("-")
+    .map(Number);
+  const parsed =
+    Number.isFinite(year) && Number.isFinite(month) && Number.isFinite(date)
+      ? new Date(year, month - 1, date)
+      : new Date(day);
+  if (Number.isNaN(parsed.getTime())) return day;
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(parsed);
+}
+
+function IssueOccurrenceGraph({ buckets }: { buckets: { day: string; count: number }[] }) {
+  const max = Math.max(1, ...buckets.map((bucket) => bucket.count));
+  const total = buckets.reduce((sum, bucket) => sum + bucket.count, 0);
+  return (
+    <div className="border-t border-border pt-2.5 sm:w-44 sm:flex-none sm:border-l sm:border-t-0 sm:pl-4 sm:pt-0">
+      <div className="flex items-center justify-between text-[10px] text-subtle">
+        <span>Occurrences · last {buckets.length} days</span>
+        <span className="font-mono tabular-nums text-fg">{total.toLocaleString()}</span>
+      </div>
+      <div
+        className="mt-2 flex h-16 items-end gap-1 border-b border-border"
+        role="img"
+        aria-label={`${total.toLocaleString()} issue occurrences over the last ${buckets.length} days`}
+      >
+        {buckets.map((bucket) => {
+          const occurrenceLabel = `${formatOccurrenceDate(bucket.day)} · ${bucket.count.toLocaleString()} occurrence${bucket.count === 1 ? "" : "s"}`;
+          return (
+            <span key={bucket.day} className="group relative flex h-full min-w-0 flex-1 items-end">
+              <span
+                className="min-h-px w-full rounded-t-[2px] bg-accent"
+                style={{
+                  height: `max(1px, ${(bucket.count / max) * 100}%)`,
+                  opacity: bucket.count === 0 ? 0.12 : 0.75,
+                }}
+              />
+              <span
+                aria-hidden="true"
+                className="pointer-events-none absolute bottom-full left-1/2 z-20 mb-1 -translate-x-1/2 whitespace-nowrap rounded-md border border-border bg-surface-3 px-2 py-1 font-sans text-[10px] text-fg opacity-0 shadow-lift-sm transition-opacity group-hover:opacity-100"
+              >
+                {occurrenceLabel}
+              </span>
+            </span>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/src/incidents/IncidentTranscript.test.ts
+++ b/apps/web/src/incidents/IncidentTranscript.test.ts
@@ -1,6 +1,63 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import type { IncidentEvent } from "../api.ts";
+import { buildActivityFeed } from "./incident-activity-feed.ts";
 import { memoryActivityFromTool } from "./memory-tool-activity.ts";
+
+function event(overrides: Partial<IncidentEvent>): IncidentEvent {
+  return {
+    id: "event-1",
+    agentRunId: "run-1",
+    kind: "agent.message",
+    summary: null,
+    detail: null,
+    createdAt: "2026-07-09T00:37:38.370Z",
+    ...overrides,
+  };
+}
+
+test("buildActivityFeed starts with the issue that triggered the incident", () => {
+  const feed = buildActivityFeed(
+    [event({ kind: "agent_run_queued", summary: "Investigation queued." })],
+    {
+      triggeringIssue: {
+        issueId: "issue-1",
+        createdAt: "2026-07-09T00:26:18.068Z",
+      },
+    },
+  );
+
+  assert.deepEqual(feed[0], {
+    type: "triggering_issue",
+    id: "triggering-issue-issue-1",
+    issueId: "issue-1",
+    createdAt: "2026-07-09T00:26:18.068Z",
+  });
+});
+
+test("buildActivityFeed turns ask_human into a question node with the exact prompt", () => {
+  const feed = buildActivityFeed([
+    event({
+      id: "ask-1",
+      kind: "agent.custom_tool_use",
+      detail: {
+        toolUse: {
+          name: "ask_human",
+          input: { question: "Which remediation path should we take?" },
+        },
+      },
+    }),
+  ]);
+
+  assert.deepEqual(feed, [
+    {
+      type: "question",
+      id: "ask-1",
+      question: "Which remediation path should we take?",
+      awaiting: false,
+    },
+  ]);
+});
 
 test("memoryActivityFromTool decorates save_memory calls as memory activity", () => {
   assert.deepEqual(

--- a/apps/web/src/incidents/IncidentTranscript.test.ts
+++ b/apps/web/src/incidents/IncidentTranscript.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { IncidentEvent } from "../api.ts";
-import { buildActivityFeed } from "./incident-activity-feed.ts";
+import { buildActivityFeed, markAwaitingQuestion } from "./incident-activity-feed.ts";
 import { memoryActivityFromTool } from "./memory-tool-activity.ts";
 
 function event(overrides: Partial<IncidentEvent>): IncidentEvent {
@@ -55,6 +55,46 @@ test("buildActivityFeed turns ask_human into a question node with the exact prom
       id: "ask-1",
       question: "Which remediation path should we take?",
       awaiting: false,
+    },
+  ]);
+});
+
+test("markAwaitingQuestion marks the latest repeated ask_human prompt", () => {
+  const feed = buildActivityFeed([
+    event({
+      id: "ask-1",
+      kind: "agent.custom_tool_use",
+      detail: {
+        toolUse: {
+          name: "ask_human",
+          input: { question: "Which remediation path should we take?" },
+        },
+      },
+    }),
+    event({
+      id: "ask-2",
+      kind: "agent.custom_tool_use",
+      detail: {
+        toolUse: {
+          name: "ask_human",
+          input: { question: "Which remediation path should we take?" },
+        },
+      },
+    }),
+  ]);
+
+  assert.deepEqual(markAwaitingQuestion(feed, "Which remediation path should we take?"), [
+    {
+      type: "question",
+      id: "ask-1",
+      question: "Which remediation path should we take?",
+      awaiting: false,
+    },
+    {
+      type: "question",
+      id: "ask-2",
+      question: "Which remediation path should we take?",
+      awaiting: true,
     },
   ]);
 });

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -10,6 +10,7 @@ import {
   type TranscriptItem,
   buildActivityFeed,
   buildTranscript,
+  markAwaitingQuestion,
 } from "./incident-activity-feed.ts";
 import {
   type TelemetryKind,
@@ -61,29 +62,7 @@ export function IncidentActivityFeed({
   // The question is sourced only from the current run state, appended as the
   // terminal node so a paused run ends on what it needs from the human.
   const base = buildActivityFeed(events, { triggeringIssue });
-  const matchingQuestionId = awaiting
-    ? base.find(
-        (item) => item.type === "question" && item.question.trim() === awaiting.question.trim(),
-      )?.id
-    : undefined;
-  let feed: FeedItem[] = base;
-  if (awaiting && matchingQuestionId) {
-    feed = base.map((item) =>
-      item.id === matchingQuestionId && item.type === "question"
-        ? { ...item, awaiting: true }
-        : item,
-    );
-  } else if (awaiting) {
-    feed = [
-      ...base,
-      {
-        type: "question",
-        id: "awaiting-question",
-        question: awaiting.question,
-        awaiting: true,
-      },
-    ];
-  }
+  const feed: FeedItem[] = awaiting ? markAwaitingQuestion(base, awaiting.question) : base;
 
   const renderItem = (item: FeedItem) => {
     if (item.type === "message") return <MessageEntry key={item.id} text={item.text} />;

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -1,21 +1,26 @@
 import { type ReactNode, useLayoutEffect, useRef, useState } from "react";
+import { type EvidenceLinkContext, EvidenceMarkdown } from "../EvidenceMarkdown.tsx";
+import { LogsTable, TracesTable } from "../Explore.tsx";
 import type { IncidentEvent } from "../api.ts";
 import { CountChart } from "../dashboards/widgets/CountChart.tsx";
 import { DEFAULT_TOP_N } from "../dashboards/widgets/series-topn.ts";
 import { Chip, type ChipTone } from "../design/ui.tsx";
-import { type EvidenceLinkContext, EvidenceMarkdown } from "../EvidenceMarkdown.tsx";
-import { LogsTable, TracesTable } from "../Explore.tsx";
-import { type MemoryActivity, memoryActivityFromTool } from "./memory-tool-activity.ts";
+import {
+  type FeedItem,
+  type TranscriptItem,
+  buildActivityFeed,
+  buildTranscript,
+} from "./incident-activity-feed.ts";
 import {
   type TelemetryKind,
   exploreHref,
   formatRangeLabel,
-  parseResultRows,
-  telemetryToolKind,
   toLogRows,
   toMetricRows,
   toTraceRows,
 } from "./telemetry-result.ts";
+
+export { buildActivityFeed, buildTranscript } from "./incident-activity-feed.ts";
 
 // ---------------------------------------------------------------------------
 // IncidentTranscript — renders an agent run's conversation from incident_events:
@@ -24,174 +29,21 @@ import {
 // in the timeline; this is only the agent.* conversation.
 // ---------------------------------------------------------------------------
 
-type ToolUseDetail = { name?: string; input?: Record<string, unknown>; mcpServerName?: string };
-type ToolResultDetail = { toolUseId?: string; isError?: boolean };
-
-function readToolUse(e: IncidentEvent): ToolUseDetail | null {
-  const d = e.detail as { toolUse?: ToolUseDetail } | null;
-  return d?.toolUse ?? null;
-}
-function readToolResult(e: IncidentEvent): ToolResultDetail | null {
-  const d = e.detail as { toolResult?: ToolResultDetail } | null;
-  return d?.toolResult ?? null;
-}
-
-type TranscriptItem =
-  | { type: "message"; id: string; text: string }
-  | {
-      type: "telemetry";
-      id: string;
-      kind: TelemetryKind;
-      input: Record<string, unknown>;
-      rows: Record<string, unknown>[];
-      isError: boolean;
-    }
-  | {
-      type: "tool";
-      id: string;
-      name: string;
-      input: Record<string, unknown>;
-      result: string | null;
-      isError: boolean;
-    }
-  | MemoryActivity
-  // The run paused on `ask_human`. The question lives in the awaiting_human
-  // event's detail (or, absent that event, on the run result). Rendered as a
-  // rich terminal node rather than a bare lifecycle one-liner.
-  | { type: "question"; id: string; question: string }
-  // The initial investigation prompt (a user.message). Rendered as a
-  // "Started investigation" node with the raw prompt tucked behind a toggle.
-  | { type: "start"; id: string; prompt: string };
-
-type FeedItem =
-  | TranscriptItem
-  // A human talking to the investigation (incident chat, Slack thread reply, PR
-  // comment), mirrored into the timeline as a chat message from whoever sent it.
-  | { type: "human"; id: string; author: string | null; text: string; createdAt: string }
-  | { type: "lifecycle"; id: string; event: IncidentEvent };
-
-const TOOL_USE_KINDS = new Set(["agent.tool_use", "agent.mcp_tool_use", "agent.custom_tool_use"]);
-const TOOL_RESULT_KINDS = new Set([
-  "agent.tool_result",
-  "agent.mcp_tool_result",
-  "user.custom_tool_result",
-]);
-
-// Provider heartbeats that carry no narrative: model-request spans and
-// session/thread status flips. `session.error` is kept — it explains failures.
-function isFeedNoise(kind: string): boolean {
-  if (kind === "session.error") return false;
-  return kind.startsWith("span.") || kind.startsWith("session.");
-}
-
-// The full activity feed: the agent's conversation (messages, telemetry
-// queries, tool calls) interleaved in event order with lifecycle / external
-// events (run started, status changes, PR & Linear activity).
-export function buildActivityFeed(events: IncidentEvent[]): FeedItem[] {
-  // Pair each result to its use by the provider tool-use id.
-  const resultByUseId = new Map<string, IncidentEvent>();
-  for (const e of events) {
-    if (TOOL_RESULT_KINDS.has(e.kind)) {
-      const id = readToolResult(e)?.toolUseId;
-      if (id) resultByUseId.set(id, e);
-    }
-  }
-
-  const items: FeedItem[] = [];
-  for (const e of events) {
-    // A human talking to the investigation (incident chat, Slack thread reply,
-    // PR comment) — rendered as a chat message, not a one-line lifecycle note.
-    if (e.kind === "human_reply") {
-      const origin = (e.detail as { origin?: { author?: string | null } } | null)?.origin;
-      const text = (e.summary ?? "").trim();
-      if (text) {
-        items.push({
-          type: "human",
-          id: e.id,
-          author: origin?.author ?? null,
-          text,
-          createdAt: e.createdAt,
-        });
-      }
-      continue;
-    }
-    if (e.kind === "agent.message") {
-      const text = (e.summary ?? "").trim();
-      if (text) items.push({ type: "message", id: e.id, text });
-      continue;
-    }
-    if (TOOL_USE_KINDS.has(e.kind)) {
-      const use = readToolUse(e);
-      const name = use?.name ?? "tool";
-      const result = resultByUseId.get(e.providerEventId ?? e.id) ?? null;
-      const isError = result ? (readToolResult(result)?.isError ?? false) : false;
-      const kind = telemetryToolKind(name);
-      const memory = memoryActivityFromTool(
-        e.id,
-        name,
-        use?.input ?? {},
-        result?.summary ?? null,
-        isError,
-      );
-      if (kind) {
-        items.push({
-          type: "telemetry",
-          id: e.id,
-          kind,
-          input: use?.input ?? {},
-          rows: parseResultRows(result?.summary),
-          isError,
-        });
-      } else if (memory) {
-        items.push(memory);
-      } else if (name !== "submit_agent_run_result") {
-        items.push({
-          type: "tool",
-          id: e.id,
-          name,
-          input: use?.input ?? {},
-          result: result?.summary ?? null,
-          isError,
-        });
-      }
-      continue;
-    }
-    // agent.thinking is a content-free heartbeat; tool results are consumed above.
-    if (e.kind === "agent.thinking" || TOOL_RESULT_KINDS.has(e.kind)) continue;
-    if (e.kind.startsWith("agent.") || isFeedNoise(e.kind)) continue;
-    if (e.kind === "user.message") {
-      items.push({ type: "start", id: e.id, prompt: (e.summary ?? "").trim() });
-      continue;
-    }
-    // The ask_human question is surfaced from the *current* run state (the
-    // `awaiting` prop), not from events. Incident events are append-only, so an
-    // awaiting_human event from a run that has since resumed or completed must
-    // not render a stale "Awaiting you" card — skip it here.
-    if (e.kind === "awaiting_human") continue;
-    items.push({ type: "lifecycle", id: e.id, event: e });
-  }
-  return items;
-}
-
-// Conversation-only projection, used where lifecycle events live elsewhere
-// (the drawer's separate timeline, summary-cited telemetry).
-export function buildTranscript(events: IncidentEvent[]): TranscriptItem[] {
-  return buildActivityFeed(events).filter(
-    (item): item is TranscriptItem => item.type !== "lifecycle" && item.type !== "human",
-  );
-}
-
 // The incident detail's main feed: transcript + lifecycle events on one rail,
 // in chronological order.
 export function IncidentActivityFeed({
   events,
+  triggeringIssue,
   renderIssueCard,
   awaiting,
 }: {
   events: IncidentEvent[];
+  /** The issue that opened the incident. It is projected as the first feed
+   *  entry without writing a fictional lifecycle row to incident_events. */
+  triggeringIssue?: { issueId: string; createdAt: string } | null;
   /** Renders the referenced issue as a card under lifecycle events whose
    *  detail carries an `issueId` (recurrence, reopen). */
-  renderIssueCard?: (issueId: string) => ReactNode;
+  renderIssueCard?: (issueId: string, options?: { showOccurrences?: boolean }) => ReactNode;
   /** When the run paused on `ask_human`, the question is not an incident event
    *  — it lives on the run result. Render it as a terminal node so the timeline
    *  ends on what the agent needs from the human. */
@@ -208,20 +60,44 @@ export function IncidentActivityFeed({
   const ctx = awaiting?.ctx ?? {};
   // The question is sourced only from the current run state, appended as the
   // terminal node so a paused run ends on what it needs from the human.
-  const base = buildActivityFeed(events);
-  const feed: FeedItem[] = awaiting
-    ? [...base, { type: "question", id: "awaiting-question", question: awaiting.question }]
-    : base;
+  const base = buildActivityFeed(events, { triggeringIssue });
+  const matchingQuestionId = awaiting
+    ? base.find(
+        (item) => item.type === "question" && item.question.trim() === awaiting.question.trim(),
+      )?.id
+    : undefined;
+  let feed: FeedItem[] = base;
+  if (awaiting && matchingQuestionId) {
+    feed = base.map((item) =>
+      item.id === matchingQuestionId && item.type === "question"
+        ? { ...item, awaiting: true }
+        : item,
+    );
+  } else if (awaiting) {
+    feed = [
+      ...base,
+      {
+        type: "question",
+        id: "awaiting-question",
+        question: awaiting.question,
+        awaiting: true,
+      },
+    ];
+  }
 
   const renderItem = (item: FeedItem) => {
     if (item.type === "message") return <MessageEntry key={item.id} text={item.text} />;
+    if (item.type === "triggering_issue")
+      return <TriggeringIssueEntry key={item.id} item={item} renderIssueCard={renderIssueCard} />;
     if (item.type === "human") return <HumanEntry key={item.id} item={item} />;
     if (item.type === "telemetry") return <TelemetryEntry key={item.id} item={item} />;
     if (item.type === "memory") return <MemoryEntry key={item.id} item={item} />;
     if (item.type === "tool") return <ToolEntry key={item.id} item={item} />;
     if (item.type === "start") return <StartEntry key={item.id} prompt={item.prompt} />;
     if (item.type === "question")
-      return <QuestionEntry key={item.id} question={item.question} ctx={ctx} />;
+      return (
+        <QuestionEntry key={item.id} question={item.question} ctx={ctx} awaiting={item.awaiting} />
+      );
     return <LifecycleEntry key={item.id} event={item.event} renderIssueCard={renderIssueCard} />;
   };
 
@@ -386,7 +262,15 @@ function StartEntry({ prompt }: { prompt: string }) {
 // Terminal node for an `ask_human` pause: the agent's question to the human,
 // rendered as markdown inside a warning-toned card so it reads as the open
 // action at the end of the trail.
-function QuestionEntry({ question, ctx }: { question: string; ctx: EvidenceLinkContext }) {
+function QuestionEntry({
+  question,
+  ctx,
+  awaiting,
+}: {
+  question: string;
+  ctx: EvidenceLinkContext;
+  awaiting: boolean;
+}) {
   return (
     <div className="relative mb-6">
       <span className="absolute -left-7 top-0 grid h-[22px] w-[22px] place-items-center rounded-full border border-warning/50 bg-surface-2">
@@ -405,11 +289,35 @@ function QuestionEntry({ question, ctx }: { question: string; ctx: EvidenceLinkC
       </span>
       <div className="mb-1.5 flex min-h-[22px] items-center gap-2">
         <span className="text-[12px] font-semibold text-fg">Investigation agent</span>
-        <Chip tone="warning">Awaiting you</Chip>
+        <Chip tone="warning">{awaiting ? "Awaiting you" : "Asked for input"}</Chip>
       </div>
       <div className="rounded-lg border border-warning/30 bg-warning/[0.06] px-3.5 py-3">
         <EvidenceMarkdown text={question} ctx={ctx} />
       </div>
+    </div>
+  );
+}
+
+function TriggeringIssueEntry({
+  item,
+  renderIssueCard,
+}: {
+  item: Extract<FeedItem, { type: "triggering_issue" }>;
+  renderIssueCard?: (issueId: string, options?: { showOccurrences?: boolean }) => ReactNode;
+}) {
+  const issueCard = renderIssueCard?.(item.issueId, { showOccurrences: true });
+  return (
+    <div className="relative mb-6">
+      <Node tone="accent">
+        <path d="M12 3v9" />
+        <path d="M12 17h.01" />
+        <circle cx="12" cy="12" r="9" />
+      </Node>
+      <div className="mb-1.5 flex min-h-[22px] items-baseline gap-2">
+        <span className="text-[12px] font-semibold text-fg">Issue detected</span>
+        <span className="text-[11px] text-subtle">{fmtRelative(item.createdAt)}</span>
+      </div>
+      {issueCard}
     </div>
   );
 }
@@ -478,7 +386,7 @@ function LifecycleEntry({
   renderIssueCard,
 }: {
   event: IncidentEvent;
-  renderIssueCard?: (issueId: string) => ReactNode;
+  renderIssueCard?: (issueId: string, options?: { showOccurrences?: boolean }) => ReactNode;
 }) {
   const [expanded, setExpanded] = useState(false);
   const summary = (event.summary ?? "").trim() || humanizeEventKind(event.kind);

--- a/apps/web/src/incidents/incident-activity-feed.ts
+++ b/apps/web/src/incidents/incident-activity-feed.ts
@@ -1,0 +1,167 @@
+import type { IncidentEvent } from "../api.ts";
+import { type MemoryActivity, memoryActivityFromTool } from "./memory-tool-activity.ts";
+import { type TelemetryKind, parseResultRows, telemetryToolKind } from "./telemetry-result.ts";
+
+type ToolUseDetail = { name?: string; input?: Record<string, unknown>; mcpServerName?: string };
+type ToolResultDetail = { toolUseId?: string; isError?: boolean };
+
+function readToolUse(e: IncidentEvent): ToolUseDetail | null {
+  const detail = e.detail as { toolUse?: ToolUseDetail } | null;
+  return detail?.toolUse ?? null;
+}
+
+function readToolResult(e: IncidentEvent): ToolResultDetail | null {
+  const detail = e.detail as { toolResult?: ToolResultDetail } | null;
+  return detail?.toolResult ?? null;
+}
+
+export type TranscriptItem =
+  | { type: "message"; id: string; text: string }
+  | {
+      type: "telemetry";
+      id: string;
+      kind: TelemetryKind;
+      input: Record<string, unknown>;
+      rows: Record<string, unknown>[];
+      isError: boolean;
+    }
+  | {
+      type: "tool";
+      id: string;
+      name: string;
+      input: Record<string, unknown>;
+      result: string | null;
+      isError: boolean;
+    }
+  | MemoryActivity
+  | { type: "question"; id: string; question: string; awaiting: boolean }
+  | { type: "start"; id: string; prompt: string };
+
+export type FeedItem =
+  | TranscriptItem
+  | { type: "triggering_issue"; id: string; issueId: string; createdAt: string }
+  | { type: "human"; id: string; author: string | null; text: string; createdAt: string }
+  | { type: "lifecycle"; id: string; event: IncidentEvent };
+
+export type ActivityFeedOptions = {
+  triggeringIssue?: { issueId: string; createdAt: string } | null;
+};
+
+const TOOL_USE_KINDS = new Set(["agent.tool_use", "agent.mcp_tool_use", "agent.custom_tool_use"]);
+const TOOL_RESULT_KINDS = new Set([
+  "agent.tool_result",
+  "agent.mcp_tool_result",
+  "user.custom_tool_result",
+]);
+
+function isFeedNoise(kind: string): boolean {
+  if (kind === "session.error") return false;
+  return kind.startsWith("span.") || kind.startsWith("session.");
+}
+
+export function buildActivityFeed(
+  events: IncidentEvent[],
+  options: ActivityFeedOptions = {},
+): FeedItem[] {
+  const resultByUseId = new Map<string, IncidentEvent>();
+  for (const event of events) {
+    if (TOOL_RESULT_KINDS.has(event.kind)) {
+      const id = readToolResult(event)?.toolUseId;
+      if (id) resultByUseId.set(id, event);
+    }
+  }
+
+  const items: FeedItem[] = options.triggeringIssue
+    ? [
+        {
+          type: "triggering_issue",
+          id: `triggering-issue-${options.triggeringIssue.issueId}`,
+          issueId: options.triggeringIssue.issueId,
+          createdAt: options.triggeringIssue.createdAt,
+        },
+      ]
+    : [];
+  for (const event of events) {
+    if (event.kind === "human_reply") {
+      const origin = (event.detail as { origin?: { author?: string | null } } | null)?.origin;
+      const text = (event.summary ?? "").trim();
+      if (text) {
+        items.push({
+          type: "human",
+          id: event.id,
+          author: origin?.author ?? null,
+          text,
+          createdAt: event.createdAt,
+        });
+      }
+      continue;
+    }
+    if (event.kind === "agent.message") {
+      const text = (event.summary ?? "").trim();
+      if (text) items.push({ type: "message", id: event.id, text });
+      continue;
+    }
+    if (TOOL_USE_KINDS.has(event.kind)) {
+      const use = readToolUse(event);
+      const name = use?.name ?? "tool";
+      const question = use?.input?.question;
+      if (name === "ask_human" && typeof question === "string" && question.trim()) {
+        items.push({
+          type: "question",
+          id: event.id,
+          question: question.trim(),
+          awaiting: false,
+        });
+        continue;
+      }
+      const result = resultByUseId.get(event.providerEventId ?? event.id) ?? null;
+      const isError = result ? (readToolResult(result)?.isError ?? false) : false;
+      const kind = telemetryToolKind(name);
+      const memory = memoryActivityFromTool(
+        event.id,
+        name,
+        use?.input ?? {},
+        result?.summary ?? null,
+        isError,
+      );
+      if (kind) {
+        items.push({
+          type: "telemetry",
+          id: event.id,
+          kind,
+          input: use?.input ?? {},
+          rows: parseResultRows(result?.summary),
+          isError,
+        });
+      } else if (memory) {
+        items.push(memory);
+      } else if (name !== "submit_agent_run_result") {
+        items.push({
+          type: "tool",
+          id: event.id,
+          name,
+          input: use?.input ?? {},
+          result: result?.summary ?? null,
+          isError,
+        });
+      }
+      continue;
+    }
+    if (event.kind === "agent.thinking" || TOOL_RESULT_KINDS.has(event.kind)) continue;
+    if (event.kind.startsWith("agent.") || isFeedNoise(event.kind)) continue;
+    if (event.kind === "user.message") {
+      items.push({ type: "start", id: event.id, prompt: (event.summary ?? "").trim() });
+      continue;
+    }
+    if (event.kind === "awaiting_human") continue;
+    items.push({ type: "lifecycle", id: event.id, event });
+  }
+  return items;
+}
+
+export function buildTranscript(events: IncidentEvent[]): TranscriptItem[] {
+  return buildActivityFeed(events).filter(
+    (item): item is TranscriptItem =>
+      item.type !== "lifecycle" && item.type !== "human" && item.type !== "triggering_issue",
+  );
+}

--- a/apps/web/src/incidents/incident-activity-feed.ts
+++ b/apps/web/src/incidents/incident-activity-feed.ts
@@ -159,6 +159,34 @@ export function buildActivityFeed(
   return items;
 }
 
+export function markAwaitingQuestion(feed: FeedItem[], question: string): FeedItem[] {
+  const normalizedQuestion = question.trim();
+  let matchingIndex = -1;
+  for (let index = feed.length - 1; index >= 0; index--) {
+    const item = feed[index];
+    if (item?.type === "question" && item.question.trim() === normalizedQuestion) {
+      matchingIndex = index;
+      break;
+    }
+  }
+
+  if (matchingIndex === -1) {
+    return [
+      ...feed,
+      {
+        type: "question",
+        id: "awaiting-question",
+        question,
+        awaiting: true,
+      },
+    ];
+  }
+
+  return feed.map((item, index) =>
+    index === matchingIndex && item.type === "question" ? { ...item, awaiting: true } : item,
+  );
+}
+
 export function buildTranscript(events: IncidentEvent[]): TranscriptItem[] {
   return buildActivityFeed(events).filter(
     (item): item is TranscriptItem =>

--- a/apps/web/src/incidents/incident-detail-view-model.test.ts
+++ b/apps/web/src/incidents/incident-detail-view-model.test.ts
@@ -3,8 +3,11 @@ import test from "node:test";
 import {
   buildIncidentDetailMeta,
   formatIncidentDuration,
+  formatIncidentLocalTimestamp,
   incidentDisplayStatus,
 } from "./incident-detail-view-model.ts";
+
+const now = Date.parse("2026-07-01T16:39:01.388Z");
 
 const incident = {
   id: "inc_1",
@@ -55,6 +58,7 @@ test("buildIncidentDetailMeta returns one sidebar row list without duplicating t
     incident,
     agentRunState: "complete",
     pendingRecovery: false,
+    now,
   });
 
   // Linked issues renders as its own interactive sidebar row, not a meta row.
@@ -65,8 +69,8 @@ test("buildIncidentDetailMeta returns one sidebar row list without duplicating t
       ["Status", "Active"],
       ["Service", "superlog-api"],
       ["Environment", "production"],
-      ["First detection", "Jun 30, 16:39 UTC"],
-      ["Latest detection", "Jun 30, 16:41 UTC"],
+      ["First detection", "1d ago"],
+      ["Last detection", "23h ago"],
       ["Duration", "2 min 29 s"],
       ["Investigation", "complete"],
     ],
@@ -118,8 +122,19 @@ test("buildIncidentDetailMeta formats midnight UTC with hour zero", () => {
     },
     agentRunState: "complete",
     pendingRecovery: false,
+    now,
   });
 
-  assert.equal(meta.find((row) => row.label === "First detection")?.value, "Jun 30, 00:05 UTC");
-  assert.equal(meta.find((row) => row.label === "Latest detection")?.value, "Jun 30, 00:06 UTC");
+  assert.equal(meta.find((row) => row.label === "First detection")?.value, "1d ago");
+  assert.equal(meta.find((row) => row.label === "Last detection")?.value, "1d ago");
+});
+
+test("formatIncidentLocalTimestamp uses the visitor's timezone", () => {
+  assert.equal(
+    formatIncidentLocalTimestamp("2026-06-30T16:39:01.388Z", {
+      locale: "en-US",
+      timeZone: "America/Los_Angeles",
+    }),
+    "Jun 30, 2026, 09:39 PDT",
+  );
 });

--- a/apps/web/src/incidents/incident-detail-view-model.ts
+++ b/apps/web/src/incidents/incident-detail-view-model.ts
@@ -3,6 +3,8 @@ import type { AgentRun, Incident } from "../api.ts";
 export type IncidentMetaRow = {
   label: string;
   value: string;
+  /** Exact value shown on hover; timestamp rows use the visitor's locale and zone. */
+  title?: string;
   kind?: "priority" | "status" | "environment" | "findings" | "agent";
   // Emphasis for the value (and its icon). "danger" (red) flags an
   // attention-worthy state like an out-of-credits investigation.
@@ -32,10 +34,12 @@ export function buildIncidentDetailMeta({
   incident,
   agentRunState,
   pendingRecovery,
+  now = Date.now(),
 }: {
   incident: Incident;
   agentRunState: AgentRun["state"] | null;
   pendingRecovery: boolean;
+  now?: number;
 }): IncidentMetaRow[] {
   return [
     { label: "Priority", value: incident.severity ?? "Unset", kind: "priority" },
@@ -46,8 +50,16 @@ export function buildIncidentDetailMeta({
     },
     { label: "Service", value: incident.service ?? "Unknown" },
     { label: "Environment", value: incident.environment ?? "Unknown", kind: "environment" },
-    { label: "First detection", value: formatIncidentUtc(incident.firstSeen) },
-    { label: "Latest detection", value: formatIncidentUtc(incident.lastSeen) },
+    {
+      label: "First detection",
+      value: formatIncidentRelative(incident.firstSeen, now),
+      title: formatIncidentLocalTimestamp(incident.firstSeen),
+    },
+    {
+      label: "Last detection",
+      value: formatIncidentRelative(incident.lastSeen, now),
+      title: formatIncidentLocalTimestamp(incident.lastSeen),
+    },
     { label: "Duration", value: formatIncidentDuration(incident.firstSeen, incident.lastSeen) },
     {
       label: "Investigation",
@@ -73,17 +85,30 @@ export function agentRunLabel(
   return "not queued";
 }
 
-function formatIncidentUtc(iso: string): string {
-  const date = new Date(iso);
-  const month = new Intl.DateTimeFormat("en-US", { month: "short", timeZone: "UTC" }).format(date);
-  const day = new Intl.DateTimeFormat("en-US", { day: "numeric", timeZone: "UTC" }).format(date);
-  const time = new Intl.DateTimeFormat("en-US", {
+export function formatIncidentRelative(iso: string, now = Date.now()): string {
+  const seconds = Math.max(0, Math.floor((now - Date.parse(iso)) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function formatIncidentLocalTimestamp(
+  iso: string,
+  options: { locale?: string; timeZone?: string } = {},
+): string {
+  return new Intl.DateTimeFormat(options.locale, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
     hour: "2-digit",
     hourCycle: "h23",
     minute: "2-digit",
-    timeZone: "UTC",
-  }).format(date);
-  return `${month} ${day}, ${time} UTC`;
+    timeZoneName: "short",
+    timeZone: options.timeZone,
+  }).format(new Date(iso));
 }
 
 function titleizeStatus(status: string): string {

--- a/scripts/portless-run.sh
+++ b/scripts/portless-run.sh
@@ -31,15 +31,19 @@ set +a
 #   1. routes.json is 0-bytes / missing / not a JSON array — portless then
 #      reads it as empty and the user gets "No app registered for ...".
 #   2. routes.lock/ (a directory portless uses as a mutex) was left held by
-#      a crashed register call — addRoute blocks for ~30s then errors with
-#      "Failed to acquire route lock", so the service prints "Proxy is
-#      running" but never actually registers.
+#      a crashed register call. Portless 0.11 reclaims locks older than 10s;
+#      only remove locks past that threshold here. A fresh lock can belong to
+#      a sibling service registering concurrently, and deleting it can drop
+#      otherwise healthy routes from routes.json.
 # See .agents/skills/worktree-bootstrap/SKILL.md "Common pitfalls".
 portless_dir="$HOME/.portless"
 routes_file="$portless_dir/routes.json"
 lock_dir="$portless_dir/routes.lock"
 mkdir -p "$portless_dir"
-if [[ -d "$lock_dir" ]]; then
+if [[ -d "$lock_dir" ]] && node -e '
+  const ageMs = Date.now() - require("fs").statSync(process.argv[1]).mtimeMs;
+  process.exit(ageMs > 10_000 ? 0 : 1);
+' "$lock_dir"; then
   echo "[portless-run:$service] clearing stale routes.lock at $lock_dir" >&2
   rm -rf "$lock_dir"
 fi

--- a/scripts/portless-stack.sh
+++ b/scripts/portless-stack.sh
@@ -135,23 +135,25 @@ fi
 # required so any process — including node fetch in seed scripts — can hit
 # the route.
 PORTLESS_PORT_FILE="$HOME/.portless/proxy.port"
-PORTLESS_DEFAULT_PROXY_PORT="${SUPERLOG_PORTLESS_PROXY_PORT:-1355}"
 PORT_SUFFIX=""
 PROXY_PORT_VAL=""
 if [[ -s "$PORTLESS_PORT_FILE" ]]; then
   PROXY_PORT_VAL="$(tr -d '[:space:]' < "$PORTLESS_PORT_FILE")"
 fi
-# A missing marker makes the portless CLI fall back to privileged port 443 and
-# attempt sudo. That cannot succeed from non-interactive worktree setup even if
-# this machine normally uses the shared unprivileged proxy. Seed the standard
-# unprivileged port so both URL generation and the CLI agree on first boot.
-if [[ ! "$PROXY_PORT_VAL" =~ ^[0-9]+$ ]]; then
-  PROXY_PORT_VAL="$PORTLESS_DEFAULT_PROXY_PORT"
+# Preserve portless' native no-marker behavior: privileged installs bind 443.
+# Non-privileged setup can opt into a shared port explicitly; writing the marker
+# keeps URL generation and the portless CLI in agreement on first boot.
+if [[ ! "$PROXY_PORT_VAL" =~ ^[0-9]+$ ]] && [[ -n "${SUPERLOG_PORTLESS_PROXY_PORT:-}" ]]; then
+  if [[ ! "$SUPERLOG_PORTLESS_PROXY_PORT" =~ ^[0-9]+$ ]]; then
+    echo "SUPERLOG_PORTLESS_PROXY_PORT must be a numeric port" >&2
+    exit 1
+  fi
+  PROXY_PORT_VAL="$SUPERLOG_PORTLESS_PROXY_PORT"
   mkdir -p "$(dirname "$PORTLESS_PORT_FILE")"
   printf '%s\n' "$PROXY_PORT_VAL" > "$PORTLESS_PORT_FILE"
-  echo "==> portless proxy port was unset; defaulting to $PROXY_PORT_VAL" >&2
+  echo "==> portless proxy port was unset; using explicit port $PROXY_PORT_VAL" >&2
 fi
-if [[ "$PROXY_PORT_VAL" != "443" ]]; then
+if [[ "$PROXY_PORT_VAL" =~ ^[0-9]+$ ]] && [[ "$PROXY_PORT_VAL" != "443" ]]; then
   PORT_SUFFIX=":$PROXY_PORT_VAL"
 fi
 

--- a/scripts/portless-stack.sh
+++ b/scripts/portless-stack.sh
@@ -135,12 +135,24 @@ fi
 # required so any process — including node fetch in seed scripts — can hit
 # the route.
 PORTLESS_PORT_FILE="$HOME/.portless/proxy.port"
+PORTLESS_DEFAULT_PROXY_PORT="${SUPERLOG_PORTLESS_PROXY_PORT:-1355}"
 PORT_SUFFIX=""
-if [[ -f "$PORTLESS_PORT_FILE" ]]; then
+PROXY_PORT_VAL=""
+if [[ -s "$PORTLESS_PORT_FILE" ]]; then
   PROXY_PORT_VAL="$(tr -d '[:space:]' < "$PORTLESS_PORT_FILE")"
-  if [[ -n "$PROXY_PORT_VAL" && "$PROXY_PORT_VAL" != "443" ]]; then
-    PORT_SUFFIX=":$PROXY_PORT_VAL"
-  fi
+fi
+# A missing marker makes the portless CLI fall back to privileged port 443 and
+# attempt sudo. That cannot succeed from non-interactive worktree setup even if
+# this machine normally uses the shared unprivileged proxy. Seed the standard
+# unprivileged port so both URL generation and the CLI agree on first boot.
+if [[ ! "$PROXY_PORT_VAL" =~ ^[0-9]+$ ]]; then
+  PROXY_PORT_VAL="$PORTLESS_DEFAULT_PROXY_PORT"
+  mkdir -p "$(dirname "$PORTLESS_PORT_FILE")"
+  printf '%s\n' "$PROXY_PORT_VAL" > "$PORTLESS_PORT_FILE"
+  echo "==> portless proxy port was unset; defaulting to $PROXY_PORT_VAL" >&2
+fi
+if [[ "$PROXY_PORT_VAL" != "443" ]]; then
+  PORT_SUFFIX=":$PROXY_PORT_VAL"
 fi
 
 WEB_URL="https://$WEB_ROUTE.localhost$PORT_SUFFIX"
@@ -227,10 +239,10 @@ ensure_portless_routes_healthy() {
   #       Symptom shows up even when `overmind ps` says services are running.
   #
   #   (b) `routes.lock/` (a directory — portless uses mkdir-as-mutex) is
-  #       held by a process that crashed mid-write. addRoute() blocks for
-  #       LOCK_TIMEOUT_MS (default 30s) and STALE_LOCK_THRESHOLD_MS (~10min)
-  #       before reclaiming. New service starts during that window fail to
-  #       register, even though they print "registered" to stdout.
+  #       held by a process that crashed mid-write. Portless 0.11 retries for
+  #       5s and reclaims locks older than 10s. Never remove a fresh lock here:
+  #       a sibling service may be registering concurrently, and deleting its
+  #       lock can overwrite routes.json with an incomplete snapshot.
   #
   # Reset both before bringing the stack up. Backups go next to the file so
   # we can post-mortem if needed.
@@ -240,7 +252,10 @@ ensure_portless_routes_healthy() {
 
   mkdir -p "$portless_dir"
 
-  if [[ -d "$lock_dir" ]]; then
+  if [[ -d "$lock_dir" ]] && node -e '
+    const ageMs = Date.now() - require("fs").statSync(process.argv[1]).mtimeMs;
+    process.exit(ageMs > 10_000 ? 0 : 1);
+  ' "$lock_dir"; then
     echo "==> clearing stale portless routes.lock at $lock_dir" >&2
     rm -rf "$lock_dir"
   fi

--- a/scripts/portless-stack.test.sh
+++ b/scripts/portless-stack.test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_HOME="$(mktemp -d)"
+STACK_NAME="portless-port-test-$$"
+
+cleanup() {
+  rm -rf "$TMP_HOME" "$REPO_ROOT/tmp/portless-stacks/$STACK_NAME"
+}
+trap cleanup EXIT
+
+output="$(HOME="$TMP_HOME" "$REPO_ROOT/scripts/portless-stack.sh" env --name "$STACK_NAME")"
+
+if ! grep -Fqx "web:        https://$STACK_NAME.superlog.localhost" <<< "$output"; then
+  echo "expected a missing proxy marker to preserve the privileged port 443 URL" >&2
+  printf '%s\n' "$output" >&2
+  exit 1
+fi
+
+if [[ -e "$TMP_HOME/.portless/proxy.port" ]]; then
+  echo "expected a missing proxy marker not to be created implicitly" >&2
+  exit 1
+fi
+
+output="$(
+  HOME="$TMP_HOME" SUPERLOG_PORTLESS_PROXY_PORT=2443 \
+    "$REPO_ROOT/scripts/portless-stack.sh" env --name "$STACK_NAME"
+)"
+
+if ! grep -Fqx "web:        https://$STACK_NAME.superlog.localhost:2443" <<< "$output"; then
+  echo "expected the explicit proxy port override in generated URLs" >&2
+  printf '%s\n' "$output" >&2
+  exit 1
+fi
+
+if [[ "$(tr -d '[:space:]' < "$TMP_HOME/.portless/proxy.port")" != "2443" ]]; then
+  echo "expected the explicit proxy port override to seed the marker" >&2
+  exit 1
+fi
+
+echo "portless-stack proxy port: ok"


### PR DESCRIPTION
## Summary

- Project the incident’s triggering issue as the first activity item, including a split occurrence pulse with per-day hover details.
- Render `ask_human` pauses as dedicated question nodes with the exact prompt and awaiting state.
- Add the inset-send incident composer and use visitor-local detection timestamps.
- Repair the issue-detail drawer’s height, scrolling, and full-content-area positioning.
- Harden portless startup and route recovery against missing proxy-port markers, invalid route state, and fresh-lock races.

## Why

The activity feed previously represented only persisted lifecycle events, while the triggering issue and an agent’s pending human question live in separate data sources. Issue detail drawers were also positioned relative to a centered route container, causing collapsed height and a large right gutter. During local verification, unconditional removal of the shared route mutex could discard healthy sibling routes.

## Impact

Incident activity now starts with the originating signal, paused investigations clearly show what input is needed, chat actions are aligned inside the composer, occurrence history is inspectable, and issue details use the available app viewport correctly. Local worktree routing is less likely to lose services during startup recovery.

## Validation

- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web exec tsx --test src/incidents/IncidentTranscript.test.ts src/incidents/incident-detail-view-model.test.ts`
- `bash -n scripts/portless-run.sh scripts/portless-stack.sh`
- Local issue and incident routes verified over the worktree HTTPS endpoints

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the incident activity feed and issue drawer for clarity. The feed starts with the triggering issue, shows a per‑day occurrence graph with totals and hover details, and renders `ask_human` prompts as clear questions with the correct awaiting state; local startup is safer and preserves portless’ privileged‑port behavior.

- **New Features**
  - Show the triggering issue first with a compact per‑day occurrence graph, total count, and hover details.
  - Render `ask_human` prompts as question nodes; chip reads “Awaiting you” only for the active prompt, otherwise “Asked for input.”
  - Inset chat composer with an in‑field Send button and a “Shift Enter for a new line” hint.
  - Use relative “First/Last detection” timestamps, with hover tooltips in the visitor’s timezone.

- **Bug Fixes**
  - Fix issue‑drawer height and scrolling by using full viewport space.
  - Portless hardening: only clear `routes.lock` if older than 10s; keep the no‑marker privileged 443 URL by default and seed `proxy.port` only when `SUPERLOG_PORTLESS_PROXY_PORT` is set.

<sup>Written for commit 74e79b713b5bbe62ffd1d8075a049eebe9525a4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

