### PR TITLE
Fix Cloudflare reconnect destinations

### DIFF
--- a/apps/api/src/cloudflare-service.test.ts
+++ b/apps/api/src/cloudflare-service.test.ts
@@ -8,6 +8,7 @@ import {
   cloudflareConfigFromEnv,
   createDestination,
   deleteDestination,
+  ensureDestination,
   exchangeCodeForToken,
   getScriptObservability,
   intakeUrlForSignal,
@@ -106,7 +107,7 @@ test("buildDestinationPayload builds a project-scoped Logpush OTLP destination",
   });
   assert.equal(payload.enabled, true);
   // Name is project-scoped so two projects on one Cloudflare account don't collide
-  // (upsert-by-name would otherwise hijack each other's destination). Must also
+  // (Cloudflare requires account-wide unique names). Must also
   // match Cloudflare's ^[a-z0-9-]+$ rule.
   assert.equal(payload.name, "superlog-aa49a851b727-logs");
   assert.match(payload.name, /^[a-z0-9-]+$/);
@@ -217,7 +218,7 @@ test("staleDestinationSlugs only deletes prior slugs for signals that got a repl
     traces: "old-t",
   });
 
-  // Cloudflare returned the same slug (upsert-by-name) → it's the live one, keep it.
+  // Reconnect updated the same slug in place → it's the live one, keep it.
   assert.deepEqual(staleDestinationSlugs({ traces: "same" }, { traces: "same" }), {});
 });
 
@@ -465,6 +466,84 @@ test("createDestination hits the account-scoped destinations endpoint", async ()
   );
   assert.equal(result.ok, true);
   if (result.ok) assert.equal(result.slug, "dest-xyz");
+});
+
+test("ensureDestination updates an existing destination during reconnect", async () => {
+  let capturedUrl = "";
+  let capturedMethod = "";
+  let capturedBody: unknown = null;
+  const fakeFetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    capturedUrl = String(url);
+    capturedMethod = String(init?.method ?? "");
+    capturedBody = JSON.parse(String(init?.body ?? "null"));
+    return new Response(JSON.stringify({ success: true, result: { slug: "existing-traces" } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  const payload = buildDestinationPayload({
+    signal: "traces",
+    intakeBaseUrl: "https://intake.example.com",
+    ingestKey: "sl_public_x",
+    projectId: "aa49a851-b727-4014-bbff-571dc282613c",
+  });
+
+  const result = await ensureDestination({
+    accountId: "acct-1",
+    accessToken: "new-access-token",
+    existingSlug: "existing-traces",
+    payload,
+    fetchImpl: fakeFetch,
+  });
+
+  assert.equal(capturedMethod, "PATCH");
+  assert.equal(
+    capturedUrl,
+    "https://api.cloudflare.com/client/v4/accounts/acct-1/workers/observability/destinations/existing-traces",
+  );
+  assert.deepEqual(capturedBody, {
+    enabled: true,
+    configuration: {
+      type: "logpush",
+      url: "https://intake.example.com/v1/traces",
+      headers: { "x-api-key": "sl_public_x" },
+    },
+  });
+  assert.deepEqual(result, { ok: true, slug: "existing-traces" });
+});
+
+test("ensureDestination recreates a destination when the persisted slug is stale", async () => {
+  const methods: string[] = [];
+  const fakeFetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+    const method = String(init?.method ?? "GET");
+    methods.push(method);
+    if (method === "PATCH") {
+      return new Response(
+        JSON.stringify({ success: false, errors: [{ message: "destination not found" }] }),
+        { status: 404, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response(JSON.stringify({ success: true, result: { slug: "replacement-logs" } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+
+  const result = await ensureDestination({
+    accountId: "acct-1",
+    accessToken: "new-access-token",
+    existingSlug: "deleted-logs",
+    payload: buildDestinationPayload({
+      signal: "logs",
+      intakeBaseUrl: "https://intake.example.com",
+      ingestKey: "sl_public_x",
+      projectId: "aa49a851-b727-4014-bbff-571dc282613c",
+    }),
+    fetchImpl: fakeFetch,
+  });
+
+  assert.deepEqual(methods, ["PATCH", "POST"]);
+  assert.deepEqual(result, { ok: true, slug: "replacement-logs" });
 });
 
 test("deleteDestination DELETEs the slug-scoped endpoint and never throws", async () => {

--- a/apps/api/src/cloudflare-service.ts
+++ b/apps/api/src/cloudflare-service.ts
@@ -300,9 +300,8 @@ export function parseCreateDestinationResponse(json: unknown): CreateDestination
  *  - Only signals that actually got a fresh destination this run (`signal in
  *    current`) are eligible — a signal whose recreate FAILED keeps its prior
  *    destination, since deleting it would leave that signal with nothing.
- *  - A prior slug that's still present in the new set is kept (Cloudflare's
- *    create can be upsert-by-name and return the same slug — that's the live
- *    destination, not a stale duplicate).
+ *  - A prior slug that's still present in the new set is kept (reconnect updates
+ *    same-account destinations in place, so that slug is still live).
  */
 export function staleDestinationSlugs(
   previous: Record<string, string> | null | undefined,
@@ -357,6 +356,46 @@ export async function createDestination(input: {
     },
   );
   const json = await res.json().catch(() => null);
+  return parseCreateDestinationResponse(json);
+}
+
+/**
+ * Ensure one project-owned destination is configured for the latest connection.
+ * Reconnects PATCH the slug already persisted for the same Cloudflare account:
+ * destination names are unique and Cloudflare's create endpoint does not upsert.
+ */
+export async function ensureDestination(input: {
+  accountId: string;
+  accessToken: string;
+  existingSlug?: string;
+  payload: DestinationPayload;
+  fetchImpl?: FetchImpl;
+}): Promise<CreateDestinationResult> {
+  if (!input.existingSlug) return createDestination(input);
+
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const res = await fetchImpl(
+    `${CLOUDFLARE_API_BASE}/accounts/${input.accountId}/workers/observability/destinations/${encodeURIComponent(
+      input.existingSlug,
+    )}`,
+    {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${input.accessToken}`,
+      },
+      body: JSON.stringify({
+        enabled: input.payload.enabled,
+        configuration: {
+          type: input.payload.configuration.type,
+          url: input.payload.configuration.url,
+          headers: input.payload.configuration.headers,
+        },
+      }),
+    },
+  );
+  const json = await res.json().catch(() => null);
+  if (res.status === 404) return createDestination(input);
   return parseCreateDestinationResponse(json);
 }
 

--- a/apps/api/src/cloudflare.ts
+++ b/apps/api/src/cloudflare.ts
@@ -32,8 +32,8 @@ import {
   buildAuthorizeUrl,
   buildDestinationPayload,
   cloudflareConfigFromEnv,
-  createDestination,
   deleteDestination,
+  ensureDestination,
   exchangeCodeForToken,
   getScriptObservability,
   isWorkerWired,
@@ -462,11 +462,10 @@ async function provisionInstallation(input: {
   const { ingestKey, apiKeyId, minted } = await ensureIngestKey(input.projectId, sameAccount);
 
   // Undo everything this run created that isn't safely persisted to an install
-  // row: the new remote destinations (minus any slug the prior same-account row
-  // still owns — an upsert-by-name create that returned the same slug is the live
-  // one that row depends on), a freshly minted ingest key, and the just-exchanged
-  // OAuth grant. Called on *every* pre-commit failure path so a connect never
-  // leaves an orphaned destination/key/grant behind. Best-effort throughout.
+  // row: the new remote destinations (minus any same-account slug updated in
+  // place, which the prior row still owns), a freshly minted ingest key, and the
+  // just-exchanged OAuth grant. Called on *every* pre-commit failure path so a
+  // connect never leaves an orphaned destination/key/grant behind. Best-effort.
   const rollback = async (created: Record<string, string>): Promise<void> => {
     const priorSlugs = new Set(Object.values(sameAccount?.destinations ?? {}));
     const orphaned = Object.fromEntries(
@@ -491,14 +490,15 @@ async function provisionInstallation(input: {
     });
   };
 
-  // Create the new destinations first; we only tear down any prior same-account
-  // destinations *after* a replacement lands (see below). Deleting up front would
-  // leave the project "connected" with zero live destinations if creation fails.
+  // Create new destinations on first connect; reconnects update the same-account
+  // slugs in place so Cloudflare's unique destination names don't collide and
+  // existing Worker wiring remains intact.
   const destinations: Record<string, string> = {};
   for (const signal of CLOUDFLARE_SIGNALS) {
-    const result = await createDestination({
+    const result = await ensureDestination({
       accountId: input.account.id,
       accessToken: input.token.accessToken,
+      existingSlug: sameAccount?.destinations?.[signal],
       payload: buildDestinationPayload({
         signal,
         intakeBaseUrl: input.config.intakeBaseUrl,
@@ -614,7 +614,7 @@ async function provisionInstallation(input: {
     // `staleDestinationSlugs` only targets prior slugs for signals that actually
     // got a replacement this run (a signal whose recreate failed keeps its old
     // destination, which we merged back into the row above) and never a slug
-    // that's still live (an upsert-by-name create that returned the same slug).
+    // that reconnect updated in place.
     if (sameAccount?.destinations) {
       const staleSlugs = staleDestinationSlugs(sameAccount.destinations, destinations);
       await deleteRemoteDestinations({


### PR DESCRIPTION
## Summary

Reconnect existing Cloudflare accounts by updating their existing Workers Observability destinations instead of attempting duplicate creation.

## Root cause

Cloudflare destination names are account-wide unique. The reconnect flow attempted to create destinations with names it already owned, so Cloudflare rejected the request before the new OAuth token set could be persisted.

## Changes

- PATCH persisted destination slugs on same-account reconnects
- Recreate a destination only when the persisted slug is no longer present
- Cover both paths with focused tests

## Validation

- `pnpm --filter @superlog/api test`
- `pnpm --filter @superlog/api typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cloudflare reconnects by updating existing Workers Observability destinations instead of creating duplicates. Prevents account-wide name collisions and keeps reconnects reliable.

- **Bug Fixes**
  - Added ensureDestination to PATCH existing slugs on reconnect; falls back to create on 404.
  - Provisioning now uses ensureDestination with prior same‑account slugs; only truly stale slugs are removed.
  - Updated tests to cover both update and recreate paths; adjusted staleDestinationSlugs to treat in‑place updates as live.

<sup>Written for commit 8407c9dd3d14174034a71c415facca6d2ab12c5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

