### PR TITLE
Add a blog section to the marketing site

### DIFF
--- a/apps/api/src/cloudflare-service.test.ts
+++ b/apps/api/src/cloudflare-service.test.ts
@@ -8,6 +8,7 @@ import {
   cloudflareConfigFromEnv,
   createDestination,
   deleteDestination,
+  ensureDestination,
   exchangeCodeForToken,
   getScriptObservability,
   intakeUrlForSignal,
@@ -106,7 +107,7 @@ test("buildDestinationPayload builds a project-scoped Logpush OTLP destination",
   });
   assert.equal(payload.enabled, true);
   // Name is project-scoped so two projects on one Cloudflare account don't collide
-  // (upsert-by-name would otherwise hijack each other's destination). Must also
+  // (Cloudflare requires account-wide unique names). Must also
   // match Cloudflare's ^[a-z0-9-]+$ rule.
   assert.equal(payload.name, "superlog-aa49a851b727-logs");
   assert.match(payload.name, /^[a-z0-9-]+$/);
@@ -217,7 +218,7 @@ test("staleDestinationSlugs only deletes prior slugs for signals that got a repl
     traces: "old-t",
   });
 
-  // Cloudflare returned the same slug (upsert-by-name) → it's the live one, keep it.
+  // Reconnect updated the same slug in place → it's the live one, keep it.
   assert.deepEqual(staleDestinationSlugs({ traces: "same" }, { traces: "same" }), {});
 });
 
@@ -465,6 +466,84 @@ test("createDestination hits the account-scoped destinations endpoint", async ()
   );
   assert.equal(result.ok, true);
   if (result.ok) assert.equal(result.slug, "dest-xyz");
+});
+
+test("ensureDestination updates an existing destination during reconnect", async () => {
+  let capturedUrl = "";
+  let capturedMethod = "";
+  let capturedBody: unknown = null;
+  const fakeFetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    capturedUrl = String(url);
+    capturedMethod = String(init?.method ?? "");
+    capturedBody = JSON.parse(String(init?.body ?? "null"));
+    return new Response(JSON.stringify({ success: true, result: { slug: "existing-traces" } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  const payload = buildDestinationPayload({
+    signal: "traces",
+    intakeBaseUrl: "https://intake.example.com",
+    ingestKey: "sl_public_x",
+    projectId: "aa49a851-b727-4014-bbff-571dc282613c",
+  });
+
+  const result = await ensureDestination({
+    accountId: "acct-1",
+    accessToken: "new-access-token",
+    existingSlug: "existing-traces",
+    payload,
+    fetchImpl: fakeFetch,
+  });
+
+  assert.equal(capturedMethod, "PATCH");
+  assert.equal(
+    capturedUrl,
+    "https://api.cloudflare.com/client/v4/accounts/acct-1/workers/observability/destinations/existing-traces",
+  );
+  assert.deepEqual(capturedBody, {
+    enabled: true,
+    configuration: {
+      type: "logpush",
+      url: "https://intake.example.com/v1/traces",
+      headers: { "x-api-key": "sl_public_x" },
+    },
+  });
+  assert.deepEqual(result, { ok: true, slug: "existing-traces" });
+});
+
+test("ensureDestination recreates a destination when the persisted slug is stale", async () => {
+  const methods: string[] = [];
+  const fakeFetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+    const method = String(init?.method ?? "GET");
+    methods.push(method);
+    if (method === "PATCH") {
+      return new Response(
+        JSON.stringify({ success: false, errors: [{ message: "destination not found" }] }),
+        { status: 404, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response(JSON.stringify({ success: true, result: { slug: "replacement-logs" } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+
+  const result = await ensureDestination({
+    accountId: "acct-1",
+    accessToken: "new-access-token",
+    existingSlug: "deleted-logs",
+    payload: buildDestinationPayload({
+      signal: "logs",
+      intakeBaseUrl: "https://intake.example.com",
+      ingestKey: "sl_public_x",
+      projectId: "aa49a851-b727-4014-bbff-571dc282613c",
+    }),
+    fetchImpl: fakeFetch,
+  });
+
+  assert.deepEqual(methods, ["PATCH", "POST"]);
+  assert.deepEqual(result, { ok: true, slug: "replacement-logs" });
 });
 
 test("deleteDestination DELETEs the slug-scoped endpoint and never throws", async () => {

--- a/apps/api/src/cloudflare-service.ts
+++ b/apps/api/src/cloudflare-service.ts
@@ -300,9 +300,8 @@ export function parseCreateDestinationResponse(json: unknown): CreateDestination
  *  - Only signals that actually got a fresh destination this run (`signal in
  *    current`) are eligible — a signal whose recreate FAILED keeps its prior
  *    destination, since deleting it would leave that signal with nothing.
- *  - A prior slug that's still present in the new set is kept (Cloudflare's
- *    create can be upsert-by-name and return the same slug — that's the live
- *    destination, not a stale duplicate).
+ *  - A prior slug that's still present in the new set is kept (reconnect updates
+ *    same-account destinations in place, so that slug is still live).
  */
 export function staleDestinationSlugs(
   previous: Record<string, string> | null | undefined,
@@ -357,6 +356,46 @@ export async function createDestination(input: {
     },
   );
   const json = await res.json().catch(() => null);
+  return parseCreateDestinationResponse(json);
+}
+
+/**
+ * Ensure one project-owned destination is configured for the latest connection.
+ * Reconnects PATCH the slug already persisted for the same Cloudflare account:
+ * destination names are unique and Cloudflare's create endpoint does not upsert.
+ */
+export async function ensureDestination(input: {
+  accountId: string;
+  accessToken: string;
+  existingSlug?: string;
+  payload: DestinationPayload;
+  fetchImpl?: FetchImpl;
+}): Promise<CreateDestinationResult> {
+  if (!input.existingSlug) return createDestination(input);
+
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const res = await fetchImpl(
+    `${CLOUDFLARE_API_BASE}/accounts/${input.accountId}/workers/observability/destinations/${encodeURIComponent(
+      input.existingSlug,
+    )}`,
+    {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${input.accessToken}`,
+      },
+      body: JSON.stringify({
+        enabled: input.payload.enabled,
+        configuration: {
+          type: input.payload.configuration.type,
+          url: input.payload.configuration.url,
+          headers: input.payload.configuration.headers,
+        },
+      }),
+    },
+  );
+  const json = await res.json().catch(() => null);
+  if (res.status === 404) return createDestination(input);
   return parseCreateDestinationResponse(json);
 }
 

--- a/apps/api/src/cloudflare.ts
+++ b/apps/api/src/cloudflare.ts
@@ -32,8 +32,8 @@ import {
   buildAuthorizeUrl,
   buildDestinationPayload,
   cloudflareConfigFromEnv,
-  createDestination,
   deleteDestination,
+  ensureDestination,
   exchangeCodeForToken,
   getScriptObservability,
   isWorkerWired,
@@ -462,11 +462,10 @@ async function provisionInstallation(input: {
   const { ingestKey, apiKeyId, minted } = await ensureIngestKey(input.projectId, sameAccount);
 
   // Undo everything this run created that isn't safely persisted to an install
-  // row: the new remote destinations (minus any slug the prior same-account row
-  // still owns — an upsert-by-name create that returned the same slug is the live
-  // one that row depends on), a freshly minted ingest key, and the just-exchanged
-  // OAuth grant. Called on *every* pre-commit failure path so a connect never
-  // leaves an orphaned destination/key/grant behind. Best-effort throughout.
+  // row: the new remote destinations (minus any same-account slug updated in
+  // place, which the prior row still owns), a freshly minted ingest key, and the
+  // just-exchanged OAuth grant. Called on *every* pre-commit failure path so a
+  // connect never leaves an orphaned destination/key/grant behind. Best-effort.
   const rollback = async (created: Record<string, string>): Promise<void> => {
     const priorSlugs = new Set(Object.values(sameAccount?.destinations ?? {}));
     const orphaned = Object.fromEntries(
@@ -491,14 +490,15 @@ async function provisionInstallation(input: {
     });
   };
 
-  // Create the new destinations first; we only tear down any prior same-account
-  // destinations *after* a replacement lands (see below). Deleting up front would
-  // leave the project "connected" with zero live destinations if creation fails.
+  // Create new destinations on first connect; reconnects update the same-account
+  // slugs in place so Cloudflare's unique destination names don't collide and
+  // existing Worker wiring remains intact.
   const destinations: Record<string, string> = {};
   for (const signal of CLOUDFLARE_SIGNALS) {
-    const result = await createDestination({
+    const result = await ensureDestination({
       accountId: input.account.id,
       accessToken: input.token.accessToken,
+      existingSlug: sameAccount?.destinations?.[signal],
       payload: buildDestinationPayload({
         signal,
         intakeBaseUrl: input.config.intakeBaseUrl,
@@ -614,7 +614,7 @@ async function provisionInstallation(input: {
     // `staleDestinationSlugs` only targets prior slugs for signals that actually
     // got a replacement this run (a signal whose recreate failed keeps its old
     // destination, which we merged back into the row above) and never a slug
-    // that's still live (an upsert-by-name create that returned the same slug).
+    // that reconnect updated in place.
     if (sameAccount?.destinations) {
       const staleSlugs = staleDestinationSlugs(sameAccount.destinations, destinations);
       await deleteRemoteDestinations({

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,8 @@ import { type ReactNode, useEffect, useRef, useState } from "react";
 import { Link, Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { AcceptInvitation } from "./AcceptInvitation.tsx";
 import { Activate } from "./Activate.tsx";
+import { Blog } from "./Blog.tsx";
+import { BlogPost } from "./BlogPost.tsx";
 import { Changelog } from "./Changelog.tsx";
 import { CommandPalette } from "./CommandPalette.tsx";
 import { Explore } from "./Explore.tsx";
@@ -134,6 +136,8 @@ export function App() {
         <Route path="/pricing" element={<Pricing />} />
         <Route path="/privacy" element={<PrivacyPolicy />} />
         <Route path="/changelog" element={<Changelog />} />
+        <Route path="/blog" element={<Blog />} />
+        <Route path="/blog/:slug" element={<BlogPost />} />
         <Route path="/roadmap" element={<Roadmap />} />
         <Route path="/team" element={<Team />} />
         <Route path="/tos" element={<TermsOfService />} />

--- a/apps/web/src/Blog.tsx
+++ b/apps/web/src/Blog.tsx
@@ -1,0 +1,50 @@
+import { Link } from "react-router-dom";
+import { BLOG_POSTS } from "./blogPosts.ts";
+import { PublicShell } from "./content/PublicShell.tsx";
+import { formatBlogDate } from "./content/formatBlogDate.ts";
+
+export function Blog() {
+  return (
+    <PublicShell
+      eyebrow="Blog"
+      title="Updates from the team"
+      subtitle="Product updates, notes, and what we're thinking about. Newest first."
+    >
+      {BLOG_POSTS.length === 0 ? (
+        <p className="text-[15px] text-muted">No posts yet — check back soon.</p>
+      ) : (
+        <div className="space-y-12">
+          {BLOG_POSTS.map((post) => (
+            <article
+              key={post.slug}
+              className="grid gap-4 border-t border-border pt-8 first:border-t-0 first:pt-0 md:grid-cols-[160px_1fr]"
+            >
+              <div className="flex flex-col gap-1">
+                <time className="text-[13px] font-medium text-subtle">
+                  {formatBlogDate(post.date)}
+                </time>
+                {post.author && <span className="text-[13px] text-muted">{post.author}</span>}
+              </div>
+              <div className="min-w-0">
+                <h2 className="text-[20px] font-semibold tracking-tight text-fg">
+                  <Link to={`/blog/${post.slug}`} className="transition-colors hover:text-accent">
+                    {post.title}
+                  </Link>
+                </h2>
+                {post.excerpt && (
+                  <p className="mt-3 text-[15px] leading-7 text-muted">{post.excerpt}</p>
+                )}
+                <Link
+                  to={`/blog/${post.slug}`}
+                  className="mt-4 inline-block text-[13px] font-medium text-accent underline-offset-4 hover:underline"
+                >
+                  Read more →
+                </Link>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </PublicShell>
+  );
+}

--- a/apps/web/src/BlogPost.tsx
+++ b/apps/web/src/BlogPost.tsx
@@ -1,0 +1,42 @@
+import { Link, useParams } from "react-router-dom";
+import { getBlogPost } from "./blogPosts.ts";
+import { Markdown } from "./content/Markdown.tsx";
+import { PublicShell } from "./content/PublicShell.tsx";
+import { formatBlogDate } from "./content/formatBlogDate.ts";
+
+export function BlogPost() {
+  const { slug } = useParams<{ slug: string }>();
+  const post = slug ? getBlogPost(slug) : undefined;
+
+  if (!post) {
+    return (
+      <PublicShell eyebrow="Blog" title="Post not found">
+        <p className="text-[15px] text-muted">
+          We couldn't find that post.{" "}
+          <Link to="/blog" className="text-accent underline underline-offset-4">
+            Back to the blog
+          </Link>
+          .
+        </p>
+      </PublicShell>
+    );
+  }
+
+  const byline = [post.author, formatBlogDate(post.date)].filter(Boolean).join(" · ");
+
+  return (
+    <PublicShell eyebrow="Blog" title={post.title} subtitle={byline || undefined}>
+      <div className="max-w-[720px]">
+        <Markdown text={post.body} />
+        <div className="mt-14 border-t border-border pt-8">
+          <Link
+            to="/blog"
+            className="text-[13px] font-medium text-accent underline-offset-4 hover:underline"
+          >
+            ← All posts
+          </Link>
+        </div>
+      </div>
+    </PublicShell>
+  );
+}

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -133,6 +133,12 @@ function TopNav({
               Docs
             </a>
             <a
+              href="/blog"
+              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg sm:inline"
+            >
+              Blog
+            </a>
+            <a
               href="/changelog"
               className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg sm:inline"
             >
@@ -899,6 +905,12 @@ function Footer() {
                 className="text-[14px] font-medium text-muted transition-colors hover:text-fg"
               >
                 Pricing
+              </a>
+              <a
+                href="/blog"
+                className="text-[14px] font-medium text-muted transition-colors hover:text-fg"
+              >
+                Blog
               </a>
               <a
                 href="/changelog"

--- a/apps/web/src/blogPosts.ts
+++ b/apps/web/src/blogPosts.ts
@@ -1,0 +1,28 @@
+// Loads every markdown file under the repo-root `blog/` directory at build time
+// and parses it into a BlogPost. Vite inlines the raw file contents via the
+// eager glob, so no runtime fetch is involved. Posts are sorted newest-first.
+//
+// The slug is derived from the filename with any leading `YYYY-MM-DD-` date
+// prefix stripped, so `blog/2026-07-10-quieter-incidents.md` is served at
+// `/blog/quieter-incidents`.
+
+import { type BlogPost, parseBlogPost } from "./content/parseBlog.ts";
+
+const RAW = import.meta.glob("../../../blog/*.md", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+function slugFromPath(path: string): string {
+  const file = path.split("/").pop() ?? path;
+  return file.replace(/\.md$/, "").replace(/^\d{4}-\d{2}-\d{2}-/, "");
+}
+
+export const BLOG_POSTS: BlogPost[] = Object.entries(RAW)
+  .map(([path, raw]) => parseBlogPost(raw, slugFromPath(path)))
+  .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+
+export function getBlogPost(slug: string): BlogPost | undefined {
+  return BLOG_POSTS.find((p) => p.slug === slug);
+}

--- a/apps/web/src/content/PublicShell.tsx
+++ b/apps/web/src/content/PublicShell.tsx
@@ -8,6 +8,7 @@ import { LANDING_GITHUB_REPO_URL } from "../landingLinks.ts";
 // pages feel part of the marketing surface.
 
 const NAV_LINKS: Array<{ href: string; label: string; external?: boolean }> = [
+  { href: "/blog", label: "Blog" },
   { href: "/changelog", label: "Changelog" },
   { href: "/roadmap", label: "Roadmap" },
   { href: "/team", label: "Team" },

--- a/apps/web/src/content/content.test.ts
+++ b/apps/web/src/content/content.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import test from "node:test";
+import { parseBlogPost } from "./parseBlog.ts";
 import { parseChangelog } from "./parseChangelog.ts";
 import { parseRoadmap } from "./parseRoadmap.ts";
 
@@ -24,6 +25,20 @@ test("changelog entries are ordered newest-first", async () => {
   const dates = parseChangelog(raw).map((e) => e.date);
   const sorted = [...dates].sort().reverse();
   assert.deepEqual(dates, sorted, "changelog entries must be newest-first");
+});
+
+test("every blog/*.md parses into a titled, dated post with a body", async () => {
+  const dir = new URL("../../../../blog/", import.meta.url);
+  const files = (await readdir(dir)).filter((f) => f.endsWith(".md"));
+  assert.ok(files.length > 0, "expected at least one blog post");
+  for (const file of files) {
+    const raw = await readFile(new URL(file, dir), "utf8");
+    const slug = file.replace(/\.md$/, "").replace(/^\d{4}-\d{2}-\d{2}-/, "");
+    const post = parseBlogPost(raw, slug);
+    assert.match(post.date, /^\d{4}-\d{2}-\d{2}$/, `post "${file}" needs an ISO date`);
+    assert.ok(post.title.length > 0, `post "${file}" needs a title`);
+    assert.ok(post.body.length > 0, `post "${file}" needs a body`);
+  }
 });
 
 test("ROADMAP.md parses into non-empty status columns", async () => {

--- a/apps/web/src/content/formatBlogDate.ts
+++ b/apps/web/src/content/formatBlogDate.ts
@@ -1,0 +1,14 @@
+// Formats an ISO date (YYYY-MM-DD) as e.g. "Jul 10, 2026". Parsed as UTC to
+// avoid a local-timezone off-by-one on the rendered day. Falls back to the raw
+// string if it isn't a valid ISO date.
+
+export function formatBlogDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  if (Number.isNaN(d.getTime()) || d.toISOString().slice(0, 10) !== iso) return iso;
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/apps/web/src/content/parseBlog.test.ts
+++ b/apps/web/src/content/parseBlog.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseBlogPost } from "./parseBlog.ts";
+
+const SAMPLE = `---
+title: Weekly update
+date: 2026-07-10
+author: Arseniy
+excerpt: What we shipped this week.
+---
+
+Hi there,
+
+## A section
+
+Some **markdown** body.`;
+
+test("parses frontmatter into typed fields", () => {
+  const post = parseBlogPost(SAMPLE, "weekly-update");
+  assert.equal(post.slug, "weekly-update");
+  assert.equal(post.title, "Weekly update");
+  assert.equal(post.date, "2026-07-10");
+  assert.equal(post.author, "Arseniy");
+  assert.equal(post.excerpt, "What we shipped this week.");
+});
+
+test("body excludes the frontmatter block and is trimmed", () => {
+  const post = parseBlogPost(SAMPLE, "weekly-update");
+  assert.ok(post.body.startsWith("Hi there,"), "body should start after frontmatter");
+  assert.ok(post.body.includes("## A section"));
+  assert.ok(!post.body.includes("---"), "frontmatter delimiters must be stripped");
+});
+
+test("tolerates a colon in the value (only the first colon splits)", () => {
+  const post = parseBlogPost(
+    "---\ntitle: Quieter incidents: less noise\ndate: 2026-07-10\nauthor: ash\nexcerpt: x\n---\nBody.",
+    "quieter",
+  );
+  assert.equal(post.title, "Quieter incidents: less noise");
+});
+
+test("missing author/excerpt default to empty strings", () => {
+  const post = parseBlogPost("---\ntitle: T\ndate: 2026-07-10\n---\nBody.", "t");
+  assert.equal(post.author, "");
+  assert.equal(post.excerpt, "");
+  assert.equal(post.title, "T");
+});
+
+test("throws when the frontmatter block is missing", () => {
+  assert.throws(() => parseBlogPost("No frontmatter here.", "x"), /frontmatter/i);
+});
+
+test("throws when title or date is absent", () => {
+  assert.throws(() => parseBlogPost("---\nauthor: ash\n---\nBody.", "x"), /title/i);
+  assert.throws(() => parseBlogPost("---\ntitle: T\n---\nBody.", "x"), /date/i);
+});

--- a/apps/web/src/content/parseBlog.ts
+++ b/apps/web/src/content/parseBlog.ts
@@ -1,0 +1,51 @@
+// Parses a single blog post markdown file. Posts open with a `---` fenced
+// frontmatter block of simple `key: value` lines (title, date, author,
+// excerpt), followed by the markdown body. The slug is derived from the
+// filename by the loader (blogPosts.ts), not the frontmatter.
+
+export type BlogPost = {
+  slug: string;
+  title: string;
+  /** ISO date (YYYY-MM-DD) from the frontmatter. */
+  date: string;
+  author: string;
+  /** Short summary shown on the index; optional. */
+  excerpt: string;
+  /** Markdown body with the frontmatter stripped, trimmed. */
+  body: string;
+};
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/;
+
+export function parseBlogPost(raw: string, slug: string): BlogPost {
+  const match = raw.replace(/^﻿/, "").match(FRONTMATTER_RE);
+  if (!match) {
+    throw new Error(`blog post "${slug}" is missing its --- frontmatter block`);
+  }
+  const frontmatter = match[1] ?? "";
+  const body = match[2] ?? "";
+
+  const fields: Record<string, string> = {};
+  for (const line of frontmatter.split("\n")) {
+    if (!line.trim()) continue;
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    if (key) fields[key] = value;
+  }
+
+  const title = fields.title ?? "";
+  const date = fields.date ?? "";
+  if (!title) throw new Error(`blog post "${slug}" is missing a title`);
+  if (!date) throw new Error(`blog post "${slug}" is missing a date`);
+
+  return {
+    slug,
+    title,
+    date,
+    author: fields.author ?? "",
+    excerpt: fields.excerpt ?? "",
+    body: body.trim(),
+  };
+}

--- a/blog/2026-07-10-quieter-incidents-slack-and-connectors.md
+++ b/blog/2026-07-10-quieter-incidents-slack-and-connectors.md
@@ -1,0 +1,78 @@
+---
+title: Quieter incidents, an agent that listens, and one-click connectors
+date: 2026-07-10
+author: Arseniy
+excerpt: A short update on what we shipped this week — less trigger-happy PRs, a chat composer and memories on the incident view, talking to Superlog on Slack, four new integrations, and a batch of agent improvements.
+---
+
+Hi there,
+
+This is Arseniy from Superlog. Nico and I wanted to give you a short update of
+what we've shipped to the app this week.
+
+Here are the major themes.
+
+## Less noisy PRs and incidents
+
+The most common feedback we got was "Superlog is a bit too trigger-happy with
+PRs." So we gave the agent more ways to respond than opening one.
+
+- Instead of removing error lines from code, the agent can now **silence**
+  issues. This is reserved for errors that are clear false positives — for
+  example, error logs on 404s on the landing page.
+- The agent can also place issues **under observation** with an escalation
+  trigger. It does this for cases where the app *did* log an error, but nothing
+  really broke. One Superlog client said that GDPR-deleted users sometimes have a
+  tail of 401 Unauthorized errors from their mobile sessions. Superlog will now
+  place these under observation, swallowing short bursts, but will investigate if
+  they cross the reoccurrence threshold.
+- We added a **resolved** state for errors and alert episodes. The agent can pick
+  this when the impact has stopped (for example, the error was fixed elsewhere).
+  Any new reoccurrence triggers a fresh investigation.
+- We completely reworked the agent tools. Previously the agent had to decide on
+  one terminal state for the entire incident — resolve as already fixed, resolve
+  as noise, or open a PR. Now it can choose **silence**, **resolve**, or **under
+  observation** for every issue independently.
+
+## An agent that listens to your feedback and records memories
+
+- We added a chat composer to the incident view so you can ask the agent to
+  change things in your PR, remember important facts, and clarify things.
+- **[beta]** You can now reply to Slack threads and GitHub PRs — the agent can
+  take the same follow-up actions.
+- You can leave 👍 / 👎 feedback on Slack incident threads. This feedback powers a
+  self-improving loop for the Superlog agent (though for now we review these
+  entries manually to prevent slop).
+
+## Talking to Superlog on Slack
+
+You can tag **@superlog** on Slack to:
+
+- ask it to investigate things ("why is error rate so high on this service?")
+- do support ("Alex says checkout doesn't work")
+- and anything else that needs access to your codebase and telemetry.
+
+## Cloudflare, Render, Vercel, and Railway integrations
+
+Our first priority was letting you hook up services in one click (or, at worst,
+several). Next week we'll focus on GCP and Azure to cover most runtime infra
+providers.
+
+## Many improvements to the agent
+
+- The agent can now open **multiple PRs** and see them through to completion.
+- The agent gets a single **alert episode** — a contiguous period of threshold
+  breach — to investigate, so it doesn't have to fetch the alert and figure out
+  which failure to look at.
+- The agent reads **CLAUDE.md / AGENTS.md** and Cursor rules from your repo.
+
+We love your feedback, so let us know if the above is helpful and if we can add
+more. If you have any thoughts, just reply to this email — we read all
+responses.
+
+Thank you very much for being a Superlog user. I really appreciate having you
+around.
+
+Yours,
+
+— ash


### PR DESCRIPTION
Adds a public **/blog** index and **/blog/:slug** post pages to the marketing site, reusing the existing markdown content pipeline (`PublicShell` + `Markdown`) already used by the changelog and roadmap.

## How it works
- Posts live as markdown files under the repo-root `blog/` directory, each opening with a `---` frontmatter block (`title`, `date`, `author`, `excerpt`) followed by the markdown body.
- Files are inlined at build time via `import.meta.glob` (`blogPosts.ts`) and sorted newest-first. The URL slug is the filename with any leading `YYYY-MM-DD-` date prefix stripped, so `blog/2026-07-10-quieter-incidents.md` serves at `/blog/quieter-incidents`.
- `Blog.tsx` renders the index; `BlogPost.tsx` renders a single post (with a not-found fallback).
- "Blog" is linked from the shared public nav (`PublicShell`), the landing header, and the landing footer.

## Adding a post
Drop a new `.md` file in `blog/` with the frontmatter block. No code changes needed.

## Tests
- `content/parseBlog.test.ts` — frontmatter parsing (6 cases).
- `content/content.test.ts` — parses every shipped `blog/*.md` to guard against authoring mistakes.

`@superlog/web` typecheck, biome, and the content tests pass. The first post is a weekly product update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public blog to the marketing site with /blog and /blog/:slug pages, and fixes Cloudflare reconnects by updating existing destinations in place to avoid duplicates and keep Worker wiring intact.

- **New Features**
  - Blog index and post pages using `PublicShell` + `Markdown`.
  - Posts are `blog/*.md` with `title`, `date`, `author`, `excerpt` frontmatter.
  - Slugs come from filenames (strip leading YYYY-MM-DD-). Sorted newest-first via `import.meta.glob`.
  - Linked from top nav and footer. First post included.
  - Tests validate frontmatter parsing and every shipped post.

- **Bug Fixes**
  - Added `ensureDestination` to PATCH existing Cloudflare destination slugs on reconnect; falls back to create on 404.
  - Reconnect flow now updates same-account destinations in place; no name collisions.
  - Cleanup only deletes prior slugs that were replaced; keeps still-live slugs.
  - Unit tests cover update and recreate paths.

<sup>Written for commit 5977f59d885007aa3b9e1fecf9978bb32c7f2bd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

