### PR TITLE
Refresh the application design language

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -15,7 +15,8 @@ The sheet is how we catch drift — a change that isn't visible there didn't hap
 - Route: `/design` (served by `src/design/DesignLanguage.tsx`, wired in `src/main.tsx`).
 - It renders with only a QueryClient — **no backend, no auth**. To view it:
   `pnpm --filter @superlog/web dev`, then open `http://localhost:<port>/design`.
-- Sections: Tokens (color · type · space · radius), Card, Buttons, Dropdowns, Tabs.
+- Sections: Principles, operational palette, typography & rhythm, actions &
+  fields, selection & status, data display, and feedback.
 - Keep it lean. It's a component catalog, not a page gallery. Don't grow it back
   into full-page route mocks — those lived here once and were removed on purpose.
 
@@ -25,6 +26,7 @@ The sheet is how we catch drift — a change that isn't visible there didn't hap
 |---|---|
 | Color / radius / font tokens | `src/index.css` (CSS vars, dark `:root` + light `:root[data-theme="light"]`) → mapped in `tailwind.config.ts` |
 | Core primitives | `src/design/ui.tsx` |
+| Signed-in product shell | `src/design/ProductShell.tsx` |
 | Dropdown (themed single-select) | `src/design/Dropdown.tsx` |
 | Range picker, row menu, scroll area | `src/design/RangePicker.tsx`, `RowMenu.tsx`, `scroll-area.tsx` |
 | The catalog page | `src/design/DesignLanguage.tsx` |
@@ -38,39 +40,38 @@ Use the Tailwind classes backed by the CSS vars — **never hardcode hexes** in
 components (the sheet may display a hex as a *label*, but styling goes through the
 token). This keeps light/dark theming automatic.
 
-- **Color:** `bg`, `surface`, `surface-2`, `surface-3` (elevation); `fg`, `muted`,
-  `subtle` (ink); `border`, `border-strong`; `accent` / `accent-ink` /
-  `accent-soft` (single action color — one intense moment, used sparingly);
-  `success` / `warning` / `danger` (signal).
-- **Radius:** `sm` 2 · `DEFAULT` 4 · `md` 6 · `lg` 10 · `xl` 12 · `2xl` 14 (px).
-  `rounded-full` for pills.
+- **Color:** `bg`, `surface`, `surface-2`, `surface-3` are near-black layers;
+  `fg`, `muted`, `subtle` are warm neutral ink; `border`, `border-strong` create
+  hierarchy with hairlines. `accent` / `accent-ink` / `accent-soft` are reserved
+  for selection, links, and information. Primary actions use neutral `fg` on
+  `bg`. `success` / `warning` / `danger` communicate state.
+- **Radius:** `xs` 2 · `sm` 4 · `DEFAULT` 6 · `md` 8 · `lg` 12 · `xl` 14 ·
+  `2xl` 18 (px). Use `rounded-full` only for dots, progress tracks, avatars, and
+  objects that are genuinely circular—not for tabs or tags.
 - **Spacing:** eight-pixel rhythm (4, 8, 12, 16, 24, 32, 48, 64).
-- **Type:** `font-sans` = Inter, `font-mono` = JetBrains Mono.
+- **Type:** Inter is the single interface family. The legacy `font-mono` Tailwind
+  alias intentionally resolves to the same sans stack so older screens inherit
+  this rule. True source-code blocks use the dedicated `.superlog-code` class.
 
-## Typography — NEVER USE MONOSPACE CAPS
+## Typography — ONE INTERFACE TYPEFACE
 
-Do **not** combine a monospace font with uppercased text. No `font-mono` +
-`uppercase`, no all-caps labels, eyebrows, table headers, badges, or section
-titles set in a monospace typeface — anywhere, in product UI or in mockups.
+Do not introduce a second typeface for IDs, timestamps, metrics, table values,
+filters, badges, labels, shortcuts, or other interface chrome. Sans typography
+keeps dense operational pages calm and lets weight, size, color, alignment, and
+tabular numerals establish hierarchy.
 
-- **Why:** monospace caps read as cramped, dated, "terminal-cosplay"; the even
-  glyph widths plus capital letterforms kill the hierarchy small labels should
-  provide.
-- **Instead:** use the sans (Inter) in its natural case. For a quiet small label,
-  reach for size, weight, and color (`text-muted` / `text-subtle`) — not
-  monospace and not all-caps.
-- **Monospace is still fine** for genuinely monospaced content: code, log lines,
-  JSON, ids, keys, numeric/tabular values. Keep it in its natural case.
+- Use natural-case labels. For a quiet small label, reach for size, weight, and
+  color (`text-muted` / `text-subtle`), not uppercase tracking.
+- Use `tabular-nums` when vertically aligned numbers need stable widths.
+- Genuine source code, JSON payloads, and stack traces may use
+  `.superlog-code`; this is content rendering, not interface typography.
 
 ```tsx
-// ✗ banned
-<span className="font-mono text-[10px] uppercase tracking-[0.2em]">Telemetry sources</span>
-
-// ✓ small label — capitalized sans
+// ✓ small interface label
 <span className="text-[13px] font-medium text-muted">Telemetry sources</span>
 
-// ✓ monospace in its natural case (code / values)
-<code className="font-mono">sl_public_…</code>
+// ✓ genuine code content opts in explicitly
+<pre className="superlog-code">curl https://api.superlog.sh</pre>
 ```
 
 ## Canonical components (`src/design/ui.tsx` unless noted)
@@ -79,28 +80,30 @@ Reuse these. Don't hand-roll a new button/dropdown/tab/card inline — if a
 primitive is missing, add it here and add a panel to the `/design` sheet.
 
 - **`Btn`** — variants `primary` · `secondary` · `ghost` · `danger`; sizes
-  `sm` · `md` · `lg`; `loading` / `disabled`.
-- **`Chip`** (`ChipTone`) — small status/label token.
-- **`Tile`** — the card: bordered `surface`, `rounded-lg`, consistent padding.
+  `sm` · `md` · `lg`; `loading` / `disabled`. Primary is neutral high contrast;
+  do not make every primary action blue.
+- **`Chip`** (`ChipTone`) — small rectangular status/label token. The `dot`
+  mode removes the fill and is preferred for live state.
+- **`Tile`** — the card: bordered `surface`, `rounded-xl`, consistent padding.
   Compose content inside it. `MetricTile` is the number variant.
+- **`DataList`, `DataListHeader`, `DataListRow`** — responsive table-like lists
+  with semantic roles, quiet column headers, shared row rhythm, and hover state.
 - **`Input`, `SearchInput`, `Select`** — form fields.
 - **`Dropdown`** (`Dropdown.tsx`) — themed single-select, searchable by default;
   prefer over the native `Select` for anything non-trivial.
-- **`Tabs`** — view switch. Capitalized sans, **fully rounded** (`rounded-full`),
-  **no shadow**, no outer track. Active tab = filled `bg-surface-3 text-fg` pill;
-  inactive = `text-muted hover:text-fg`. Sizes `sm` · `md`. Use for switching
-  what a panel shows.
-- **`PillToggle`** — the other segmented control (rounded-full, raised active
-  pill); interchangeable with `Tabs` in style, radio semantics.
+- **`Tabs`** — view switch. Capitalized sans, compact `rounded-md`, **no
+  shadow**, no outer track. Active tab = `bg-surface-3 text-fg`; inactive =
+  `text-muted hover:text-fg`. Sizes `sm` · `md`. Use for switching what a panel
+  shows.
+- **`PillToggle`** — the radio-semantic counterpart to `Tabs`; it shares the
+  same compact rectangular selection language.
+- **`PageHeader`** — the canonical title, supporting copy, and action row for a
+  primary route.
+- **`ProductShell`** (`ProductShell.tsx`) — the signed-in left rail, responsive
+  navigation, and route toolbar. Primary product pages live inside this shell.
 - **`Wordmark`, `ThemeToggle`, `useTheme`, `AppShell`, `CenteredShell`,
-  `Sparkline`, `ShortcutKey`** — chrome and helpers.
+  `Sparkline`, `ShortcutKey`** — lower-level chrome and helpers.
 
-### Legacy — being phased out
-
-`Label`, `FieldLabel`, and `MetricTile`'s label in `src/design/ui.tsx` still
-render the old mono-caps style and are used widely. **Don't use them in new UI**
-— prefer a plain capitalized-sans label (`text-[13px] font-medium text-muted`),
-as the `/design` sheet now does. Treat each one you touch as a chance to drop the
-mono-caps. Flipping them at the source is a deliberate app-wide change (many call
-sites pass lowercase strings that rely on the `uppercase` CSS) — audit call sites
-first.
+`Label`, `FieldLabel`, and `MetricTile` now follow the same natural-case sans
+language as the rest of the system. Prefer them over hand-rolled tracked or
+uppercase labels.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
-    "@superlog/topology": "workspace:*",
     "@git-diff-view/file": "^0.1.3",
     "@git-diff-view/react": "^0.1.3",
     "@hugeicons/core-free-icons": "^4.1.4",
@@ -28,8 +27,10 @@
     "@opentelemetry/resources": "^2.7.0",
     "@opentelemetry/sdk-trace-web": "^2.7.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
+    "@phosphor-icons/react": "^2.1.10",
     "@pierre/diffs": "^1.2.7",
     "@radix-ui/react-scroll-area": "^1.2.10",
+    "@superlog/topology": "workspace:*",
     "@tanstack/react-query": "^5.62.8",
     "@types/react-grid-layout": "^2.1.0",
     "autumn-js": "^1.2.27",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -33,10 +33,12 @@ import { authClient, useSession } from "./auth-client.ts";
 import { signalAtHardCap } from "./billing.ts";
 import { DashboardView } from "./dashboards/DashboardView.tsx";
 import { DashboardsList } from "./dashboards/DashboardsList.tsx";
-import { AppShell, ThemeToggle, Wordmark } from "./design/ui.tsx";
+import { ProductShell } from "./design/ProductShell.tsx";
+import { ThemeToggle } from "./design/ui.tsx";
 import { McpInstallPill } from "./onboarding/McpInstallPill.tsx";
 import { OnboardingGate } from "./onboarding/OnboardingGate.tsx";
 import { useDemoExploration } from "./onboarding/demoExploration.tsx";
+import { isDetailWorkspacePath } from "./route-layout.ts";
 import {
   buildSignupEventProperties,
   parseAttribution,
@@ -223,7 +225,7 @@ function AuthenticatedApp() {
           email={data.user.email}
           billingPaused={billingPaused}
         />
-        <AppShell nav={<TopNav />}>
+        <ProductShell toolbar={<ProductToolbar />}>
           <RouteContainer>
             <Routes>
               <Route path="/explore/*" element={<Explore />} />
@@ -240,7 +242,7 @@ function AuthenticatedApp() {
               <Route path="*" element={<Overview />} />
             </Routes>
           </RouteContainer>
-        </AppShell>
+        </ProductShell>
       </div>
       <CommandPalette />
       <McpInstallPill />
@@ -314,7 +316,7 @@ function DemoModeBar() {
 
 function ImpersonationBar({ email }: { email: string }) {
   return (
-    <div className="flex h-7 w-full items-center justify-center gap-3 bg-amber-500 px-3 font-mono text-[11px] text-black">
+    <div className="flex h-7 w-full items-center justify-center gap-3 bg-amber-500 px-3 text-[11px] text-black">
       <span className="uppercase tracking-[0.2em]">impersonating</span>
       <span className="font-medium">{email}</span>
       <span className="opacity-70">·</span>
@@ -350,59 +352,27 @@ function BillingLimitBar() {
 
 function RouteContainer({ children }: { children: ReactNode }) {
   const { pathname } = useLocation();
-  const incidentDetail = /^\/incidents\/[^/]+/.test(pathname);
+  const detailWorkspace = isDetailWorkspacePath(pathname);
   const wide = pathname.startsWith("/dashboards/");
-  if (incidentDetail) {
+  if (detailWorkspace) {
     return <div className="flex min-h-0 flex-1 flex-col">{children}</div>;
   }
   return (
-    <div className={`mx-auto w-full px-6 pb-24 pt-6 ${wide ? "max-w-[2400px]" : "max-w-6xl"}`}>
+    <div
+      className={`mx-auto w-full px-5 pb-24 pt-8 sm:px-6 lg:px-8 ${wide ? "max-w-[2400px]" : "max-w-[1180px]"}`}
+    >
       {children}
     </div>
   );
 }
 
-function TopNav() {
-  const { pathname } = useLocation();
-  const navLink = (href: string, label: string, extraPrefixes: string[] = []) => {
-    const active =
-      href === "/"
-        ? pathname === "/" || pathname === ""
-        : pathname.startsWith(href) || extraPrefixes.some((p) => pathname.startsWith(p));
-    return (
-      <Link
-        key={href}
-        to={href}
-        className={
-          active
-            ? "text-[13px] font-medium text-fg underline underline-offset-[6px] decoration-1"
-            : "text-[13px] font-medium text-muted transition-opacity hover:text-fg"
-        }
-      >
-        {label}
-      </Link>
-    );
-  };
-
+function ProductToolbar() {
   return (
-    <nav className="flex items-center justify-between py-5">
-      <div className="flex items-center gap-8">
-        <Wordmark />
-        <div className="hidden items-center gap-6 md:flex">
-          {navLink("/", "Overview")}
-          {navLink("/incidents", "Issues", ["/issues"])}
-          {navLink("/alerts", "Alerts")}
-          {navLink("/explore", "Explore")}
-          {navLink("/dashboards", "Dashboards")}
-          {navLink("/settings", "Settings")}
-        </div>
-      </div>
-      <div className="flex items-center gap-3">
-        <ThemeToggle />
-        <OrgProjectSwitcher />
-        <UserMenu />
-      </div>
-    </nav>
+    <>
+      <ThemeToggle />
+      <OrgProjectSwitcher />
+      <UserMenu />
+    </>
   );
 }
 

--- a/apps/web/src/CommandPalette.tsx
+++ b/apps/web/src/CommandPalette.tsx
@@ -76,7 +76,8 @@ export function CommandPalette() {
     if (mode === "root") {
       const navItems: Item[] = [
         { id: "nav-overview", label: "Overview", group: "Navigate", haystack: "overview home", onSelect: () => navigate("/") },
-        { id: "nav-issues", label: "Issues", group: "Navigate", haystack: "issues incidents", onSelect: () => navigate("/incidents") },
+        { id: "nav-incidents", label: "Incidents", group: "Navigate", haystack: "incidents", onSelect: () => navigate("/incidents") },
+        { id: "nav-errors", label: "Errors", group: "Navigate", haystack: "errors issues", onSelect: () => navigate("/issues") },
         { id: "nav-alerts", label: "Alerts", group: "Navigate", haystack: "alerts", onSelect: () => navigate("/alerts") },
         { id: "nav-explore", label: "Explore", group: "Navigate", haystack: "explore traces logs metrics", onSelect: () => navigate("/explore") },
         { id: "nav-dashboards", label: "Dashboards", group: "Navigate", haystack: "dashboards", onSelect: () => navigate("/dashboards") },

--- a/apps/web/src/Explore.tsx
+++ b/apps/web/src/Explore.tsx
@@ -52,7 +52,7 @@ import {
   rangeFromSeconds,
 } from "./design/RangePicker.tsx";
 import { ScrollArea } from "./design/scroll-area.tsx";
-import { Btn, Chip, Input, ShortcutKey, Tile } from "./design/ui.tsx";
+import { Btn, Chip, Input, PageHeader, ShortcutKey, Tile } from "./design/ui.tsx";
 import { addAttrFilter } from "./exploreAttrFilter.ts";
 import { tracer } from "./instrumentation.ts";
 import {
@@ -86,11 +86,7 @@ export function Explore() {
     return <div className="font-sans text-[12px] text-muted">Loading…</div>;
   }
   if (me.error || !me.data || !me.data.project) {
-    return (
-      <div className="font-mono text-[11px] text-danger">
-        error: {String(me.error ?? "no session")}
-      </div>
-    );
+    return <div className="text-[12px] text-danger">Error: {String(me.error ?? "no session")}</div>;
   }
   return <ExploreInner projectId={me.data.project.id} />;
 }
@@ -302,6 +298,10 @@ function ExploreInner({ projectId }: { projectId: string }) {
 
   return (
     <div className="relative flex flex-col gap-6">
+      <PageHeader
+        title="Explore"
+        description="Search, filter, and compare every signal in the current project."
+      />
       <section className="flex flex-wrap items-center justify-between gap-4">
         <ExploreTabs />
         {/* Resources are inventory, not time-ranged telemetry — no range picker. */}
@@ -550,7 +550,7 @@ function ResourcesPanel({ projectId }: { projectId: string }) {
           searchable={regions.length > 8}
         />
         <div className="ml-auto flex items-center gap-3">
-          <span className="font-mono text-[11px] text-subtle">
+          <span className="font-sans text-[11px] text-subtle">
             {filtered.length} of {rows.length}
           </span>
           {connected && (
@@ -568,11 +568,11 @@ function ResourcesPanel({ projectId }: { projectId: string }) {
 
       <div className="overflow-auto">
         {filtered.length === 0 ? (
-          <div className="px-5 py-8 text-center font-mono text-[11px] text-subtle">
+          <div className="px-5 py-8 text-center font-sans text-[11px] text-subtle">
             {resources.isLoading ? "loading…" : "no resources"}
           </div>
         ) : (
-          <table className="w-full border-collapse font-mono text-[12px]">
+          <table className="w-full border-collapse font-sans text-[12px]">
             <thead>
               <tr className="text-left text-subtle">
                 <th className="px-5 py-2 font-normal">name</th>
@@ -629,8 +629,8 @@ export function ExploreTabs() {
           to={`/explore/${t.source}`}
           className={({ isActive }) =>
             isActive
-              ? "rounded-lg bg-surface-2 px-3 py-1.5 text-[13px] font-medium tracking-tight text-fg"
-              : "rounded-lg px-3 py-1.5 text-[13px] font-medium tracking-tight text-muted hover:text-fg"
+              ? "rounded-md bg-surface-3 px-3 py-1.5 text-[13px] font-medium tracking-tight text-fg"
+              : "rounded-md px-3 py-1.5 text-[13px] font-medium tracking-tight text-muted hover:text-fg"
           }
         >
           {t.label}
@@ -658,8 +658,8 @@ export function ExploreTabsStatic({
             onClick={() => onChange(t.source)}
             className={
               active
-                ? "rounded-lg bg-surface-2 px-3 py-1.5 text-[13px] font-medium tracking-tight text-fg"
-                : "rounded-lg px-3 py-1.5 text-[13px] font-medium tracking-tight text-muted hover:text-fg"
+                ? "rounded-md bg-surface-3 px-3 py-1.5 text-[13px] font-medium tracking-tight text-fg"
+                : "rounded-md px-3 py-1.5 text-[13px] font-medium tracking-tight text-muted hover:text-fg"
             }
           >
             {t.label}
@@ -830,7 +830,7 @@ type AddedFilter =
 
 function PickerKbd({ children }: { children: React.ReactNode }) {
   return (
-    <span className="rounded-sm border border-border bg-surface px-1 py-px font-mono text-[10px] text-muted">
+    <span className="rounded-sm border border-border bg-surface px-1 py-px font-sans text-[10px] text-muted">
       {children}
     </span>
   );
@@ -1929,7 +1929,7 @@ function MetricChartBody({
     );
   }
   return (
-    <div className="flex h-48 items-center justify-center font-mono text-[11px] text-subtle">
+    <div className="flex h-48 items-center justify-center font-sans text-[11px] text-subtle">
       {metricName ? "no data" : "pick a metric above"}
     </div>
   );
@@ -2413,7 +2413,7 @@ function ExploreSignalDetailDrawerSkeleton({
           type="button"
           onClick={onClose}
           title="close (esc)"
-          className="absolute right-4 top-4 z-10 rounded-sm border border-border bg-bg px-2 py-1 font-mono text-[11px] text-muted hover:text-fg"
+          className="absolute right-4 top-4 z-10 rounded-sm border border-border bg-bg px-2 py-1 font-sans text-[11px] text-muted hover:text-fg"
         >
           ✕
         </button>
@@ -2563,7 +2563,7 @@ export function LogsTable({
     );
   }
   return (
-    <table className="w-full border-collapse font-mono text-[12px]">
+    <table className="w-full border-collapse font-sans text-[12px]">
       <thead className="font-sans">
         <tr className="text-left text-subtle">
           <th className="px-5 py-2 font-normal">Timestamp</th>
@@ -2646,7 +2646,7 @@ export function TracesTable({
     );
   }
   return (
-    <table className="w-full border-collapse font-mono text-[12px]">
+    <table className="w-full border-collapse font-sans text-[12px]">
       <thead className="font-sans">
         <tr className="text-left text-subtle">
           <th className="px-5 py-2 font-normal">Timestamp</th>
@@ -2696,7 +2696,7 @@ export function TracesAggregatedTable({
     );
   }
   return (
-    <table className="w-full border-collapse font-mono text-[12px]">
+    <table className="w-full border-collapse font-sans text-[12px]">
       <thead className="font-sans">
         <tr className="text-left text-subtle">
           <th className="px-5 py-2 font-normal">Started</th>
@@ -2748,11 +2748,11 @@ export function TracesAggregatedTable({
 export function MetricsTable({ rows }: { rows: MetricRow[] }) {
   if (rows.length === 0) {
     return (
-      <div className="px-5 py-8 text-center font-mono text-[11px] text-subtle">no results</div>
+      <div className="px-5 py-8 text-center font-sans text-[11px] text-subtle">no results</div>
     );
   }
   return (
-    <table className="w-full border-collapse font-mono text-[12px]">
+    <table className="w-full border-collapse font-sans text-[12px]">
       <thead>
         <tr className="text-left text-subtle">
           <th className="px-5 py-2 font-normal">timestamp</th>

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -54,7 +54,14 @@ import {
   useUnsilenceIssue,
   useUpdateIncident,
 } from "./api.ts";
-import { Btn, Chip, OutOfCreditsBadge, OutOfCreditsBanner, Tabs } from "./design/ui.tsx";
+import {
+  Btn,
+  Chip,
+  OutOfCreditsBadge,
+  OutOfCreditsBanner,
+  PageHeader,
+  Tabs,
+} from "./design/ui.tsx";
 import { type IncidentStatusAction, getIncidentStatusActions } from "./incident-status-action.ts";
 import {
   IncidentActivityFeed,
@@ -67,6 +74,7 @@ import {
 } from "./incidents/incident-detail-view-model.ts";
 import { IncidentDetailScrollArea } from "./incidents/IncidentDetailScrollArea.tsx";
 import { getIssueIncidentLinkState } from "./issue-incident-link-state.ts";
+import { IssueDetailView } from "./issues/IssueDetailView.tsx";
 import {
   IncidentDetailSkeleton,
   IncidentListSkeleton,
@@ -146,41 +154,47 @@ export function Issues() {
 function IssuesShell({ projectId }: { projectId: string }) {
   const tab = useTab();
   const params = useParams<{ id?: string }>();
-  const labels: Record<Tab, string> = { incidents: "Incidents", issues: "Issues" };
+  const navigate = useNavigate();
+  const labels: Record<Tab, string> = { incidents: "Incidents", issues: "Errors" };
 
   if (tab === "incidents" && params.id) {
     return <IncidentsTab projectId={projectId} />;
   }
 
+  if (tab === "issues" && params.id) {
+    return (
+      <IssueDetailPage
+        projectId={projectId}
+        issueId={params.id}
+        onClose={() => navigate("/issues")}
+        onViewIncident={(incidentId) => navigate(`/incidents/${incidentId}`)}
+      />
+    );
+  }
+
   return (
-    <div>
-      <div className="mb-6 flex items-center gap-1">
-        {(["incidents", "issues"] as const).map((t) => (
-          <Link
-            key={t}
-            to={tabBasePath(t)}
-            replace={tab === t}
-            className={
-              tab === t
-                ? "rounded-lg bg-surface-2 px-3 py-1.5 text-[13px] font-medium tracking-tight text-fg"
-                : "rounded-lg px-3 py-1.5 text-[13px] font-medium tracking-tight text-muted hover:text-fg"
-            }
-          >
-            {labels[t]}
-          </Link>
-        ))}
+    <div className="relative">
+      <PageHeader
+        title={labels[tab]}
+        description={
+          tab === "issues"
+            ? "Triage recurring errors and follow investigations from first signal to resolution."
+            : "Investigate operational incidents from first signal to resolution."
+        }
+      />
+      <div className="mt-6">
+        {tab === "issues" ? (
+          <IssuesTab projectId={projectId} />
+        ) : (
+          <IncidentsTab projectId={projectId} />
+        )}
       </div>
-      {tab === "issues" ? (
-        <IssuesTab projectId={projectId} />
-      ) : (
-        <IncidentsTab projectId={projectId} />
-      )}
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Issues tab
+// Errors tab
 // ---------------------------------------------------------------------------
 
 type EventTarget =
@@ -230,8 +244,8 @@ function IssuesTab({ projectId }: { projectId: string }) {
               }}
               className={
                 filter === t.id
-                  ? "rounded-lg bg-surface-2 px-3 py-1.5 text-[13px] font-medium tracking-tight text-fg"
-                  : "rounded-lg px-3 py-1.5 text-[13px] font-medium tracking-tight text-muted hover:text-fg"
+                  ? "rounded-md bg-surface-3 px-3 py-1.5 text-[13px] font-medium tracking-tight text-fg"
+                  : "rounded-md px-3 py-1.5 text-[13px] font-medium tracking-tight text-muted hover:text-fg"
               }
             >
               {t.label}
@@ -240,7 +254,7 @@ function IssuesTab({ projectId }: { projectId: string }) {
         </div>
         {issues.data && (
           <span className="text-[12px] text-muted">
-            {issues.data.length} issue{issues.data.length !== 1 ? "s" : ""}
+            {issues.data.length} error{issues.data.length !== 1 ? "s" : ""}
           </span>
         )}
       </div>
@@ -250,14 +264,14 @@ function IssuesTab({ projectId }: { projectId: string }) {
         <div className="text-[13px] text-danger">Failed to load: {String(issues.error)}</div>
       )}
       {issues.data && issues.data.length === 0 && (
-        <div className="rounded-2xl border border-border bg-surface p-12 text-center">
+        <div className="rounded-xl border border-border bg-surface p-12 text-center">
           <p className="text-[13px] text-muted">
-            No {filter === "all" ? "" : filter + " "}ungrouped issues
+            No {filter === "all" ? "" : filter + " "}ungrouped errors
           </p>
         </div>
       )}
       {issues.data && issues.data.length > 0 && (
-        <div className="divide-y divide-border overflow-hidden rounded-2xl border border-border bg-surface">
+        <div className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
           {issues.data.map((issue) => (
             <IssueRow
               key={issue.id}
@@ -353,19 +367,19 @@ export function IssueRow({
             <KindChip issue={issue} />
             <IssueStatusChip issue={issue} />
             <GroupingChip state={issue.groupingState} />
-            <span className="font-mono text-[11px] text-muted">{issue.exceptionType}</span>
+            <span className="font-sans text-[11px] text-muted">{issue.exceptionType}</span>
             <ServiceEnv service={issue.service} environment={issueEnvironment(issue)} />
           </div>
           <p className="truncate text-[13px] font-medium text-fg">{issue.title}</p>
           {issue.message && (
-            <p className="mt-0.5 truncate font-mono text-[11px] text-muted">{issue.message}</p>
+            <p className="mt-0.5 truncate font-sans text-[11px] text-muted">{issue.message}</p>
           )}
         </div>
         <div className="shrink-0 text-right">
-          <div className="font-mono text-[11px] tabular-nums text-muted">
+          <div className="font-sans text-[11px] tabular-nums text-muted">
             {fmtRelative(issue.lastSeen)}
           </div>
-          <div className="mt-1 font-mono text-[11px] tabular-nums text-subtle">
+          <div className="mt-1 font-sans text-[11px] tabular-nums text-subtle">
             {fmtCount(issue.eventCount)} event{issue.eventCount !== 1 ? "s" : ""}
           </div>
         </div>
@@ -383,6 +397,92 @@ type IssueDetailProps = {
   onOpenEvent?: (target: NonNullable<EventTarget>) => void;
   silenceUpdating?: boolean;
 };
+
+function IssueDetailPage({
+  projectId,
+  issueId,
+  onClose,
+  onViewIncident,
+}: {
+  projectId: string;
+  issueId: string;
+  onClose: () => void;
+  onViewIncident: (incidentId: string) => void;
+}) {
+  const q = useIssue(projectId, issueId);
+  const silence = useSilenceIssue(projectId);
+  const unsilence = useUnsilenceIssue(projectId);
+  const [eventTarget, setEventTarget] = useState<EventTarget>(null);
+
+  if (q.isLoading) {
+    return <IssueDetailSkeleton />;
+  }
+  if (q.error || !q.data) {
+    return (
+      <div className="p-6 text-[12px] text-danger">
+        Failed to load error: {String(q.error ?? "no data")}
+      </div>
+    );
+  }
+
+  const issue = q.data;
+  const latestEvent = eventTargetFromIssue(issue);
+  const toggleSilence = issue.silencedAt ? unsilence : silence;
+
+  return (
+    <>
+      <IssueDetailView
+        issue={issue}
+        environment={issueEnvironment(issue)}
+        onBack={onClose}
+        onToggleSilence={() => toggleSilence.mutate(issue.id)}
+        silenceUpdating={toggleSilence.isPending}
+        onOpenEvidence={latestEvent ? () => setEventTarget(latestEvent) : undefined}
+        evidenceLabel={latestEvent?.kind === "trace" ? "Open latest trace" : "Open latest log"}
+        linkedIncident={
+          <IssueIncidentLink
+            projectId={projectId}
+            issueId={issue.id}
+            groupingState={issue.groupingState}
+            groupingReason={issue.groupingReason}
+            onViewIncident={onViewIncident}
+            showHeading={false}
+          />
+        }
+        feedbackAction={
+          <FeedbackTrigger
+            kind="issue"
+            refId={issue.id}
+            projectId={projectId}
+            className="w-full justify-center"
+          />
+        }
+      />
+
+      {eventTarget?.kind === "trace" && (
+        <TraceDrawer
+          projectId={projectId}
+          traceId={eventTarget.traceId}
+          focusSpanId={eventTarget.spanId}
+          onClose={() => setEventTarget(null)}
+        />
+      )}
+      {eventTarget?.kind === "log" && (
+        <LogDrawer
+          log={eventTarget.log}
+          onClose={() => setEventTarget(null)}
+          onOpenTrace={(traceId) =>
+            setEventTarget({
+              kind: "trace",
+              traceId,
+              spanId: eventTarget.log.span_id || undefined,
+            })
+          }
+        />
+      )}
+    </>
+  );
+}
 
 export function IssueDrawer(props: IssueDetailProps) {
   useEffect(() => {
@@ -460,7 +560,7 @@ function IssueDetailContent({
         <div className="flex flex-wrap items-center gap-2">
           {!issue.topFrame && (
             <>
-              <span className="font-mono text-[11px] text-muted">{issue.exceptionType}</span>
+              <span className="font-sans text-[11px] text-muted">{issue.exceptionType}</span>
               <KindChip issue={issue} />
             </>
           )}
@@ -470,7 +570,7 @@ function IssueDetailContent({
         {issue.topFrame && (
           <div className="space-y-0.5">
             <SectionHeader>Top frame</SectionHeader>
-            <p className="font-mono text-[12px] text-muted">{issue.topFrame}</p>
+            <p className="font-sans text-[12px] text-muted">{issue.topFrame}</p>
           </div>
         )}
       </div>
@@ -478,7 +578,7 @@ function IssueDetailContent({
       {issue.message && (
         <div className="space-y-3">
           <SectionHeading>Error body</SectionHeading>
-          <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-sm border border-border bg-surface-2 px-3 py-2 font-mono text-[11px] text-fg">
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-sm border border-border bg-surface-2 px-3 py-2 font-sans text-[11px] text-fg">
             {issue.message}
           </pre>
         </div>
@@ -488,11 +588,11 @@ function IssueDetailContent({
         <div className="space-y-3">
           <div className="flex items-center justify-between gap-3">
             <SectionHeading>Original stack</SectionHeading>
-            <span className="font-mono text-[10px] text-subtle">
+            <span className="font-sans text-[10px] text-subtle">
               {issue.symbolication.artifact.platform} - {issue.symbolication.artifact.release}
             </span>
           </div>
-          <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-sm border border-border bg-surface-2 px-3 py-2 font-mono text-[11px] text-fg">
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-sm border border-border bg-surface-2 px-3 py-2 font-sans text-[11px] text-fg">
             {issue.symbolication.stacktrace}
           </pre>
         </div>
@@ -549,12 +649,14 @@ function IssueIncidentLink({
   groupingState,
   groupingReason,
   onViewIncident,
+  showHeading = true,
 }: {
   projectId: string;
   issueId: string;
   groupingState: Issue["groupingState"];
   groupingReason: string | null;
   onViewIncident?: (incidentId: string) => void;
+  showHeading?: boolean;
 }) {
   const q = useIssueAgentRun(projectId, issueId);
   const incident = q.data?.incident ?? null;
@@ -563,11 +665,12 @@ function IssueIncidentLink({
     incident,
     isLoading: q.isLoading,
   });
+  const heading = showHeading ? <SectionHeading>Incident</SectionHeading> : null;
 
   if (linkState === "pending") {
     return (
       <div className="space-y-3">
-        <SectionHeading>Incident</SectionHeading>
+        {heading}
         <p className="text-[12px] text-muted">Analysing — grouping in progress.</p>
       </div>
     );
@@ -575,7 +678,7 @@ function IssueIncidentLink({
   if (linkState === "failed") {
     return (
       <div className="space-y-3">
-        <SectionHeading>Incident</SectionHeading>
+        {heading}
         <p className="text-[12px] text-danger">Grouping analysis failed.</p>
       </div>
     );
@@ -585,7 +688,7 @@ function IssueIncidentLink({
   if (linkState === "loading") {
     return (
       <div className="space-y-3">
-        <SectionHeading>Incident</SectionHeading>
+        {heading}
         <p className="text-[12px] text-muted">loading…</p>
       </div>
     );
@@ -593,10 +696,10 @@ function IssueIncidentLink({
   if (!incident) {
     return (
       <div className="space-y-3">
-        <SectionHeading>Incident</SectionHeading>
+        {heading}
         <p className="text-[12px] text-muted">
           {groupingState === "standalone"
-            ? "Standalone — not bundled with other issues."
+            ? "Standalone — not bundled with other errors."
             : "loading…"}
         </p>
       </div>
@@ -604,10 +707,11 @@ function IssueIncidentLink({
   }
   return (
     <div className="space-y-3">
-      <SectionHeading>Incident</SectionHeading>
+      {heading}
       <button
+        type="button"
         onClick={() => onViewIncident?.(incident.id)}
-        className="block w-full rounded-sm border border-border bg-surface-2 px-3 py-2 text-left transition-colors hover:bg-surface-3"
+        className="block w-full rounded-lg border border-border bg-surface-2 px-3 py-2.5 text-left transition-colors hover:bg-surface-3"
       >
         <div className="mb-1 flex items-center gap-2">
           <StatusChip status={incident.status} />
@@ -715,8 +819,8 @@ function IncidentsTab({ projectId }: { projectId: string }) {
               }}
               className={
                 status === t.id
-                  ? "rounded-lg bg-surface-2 px-3 py-1.5 text-[13px] font-medium tracking-tight text-fg"
-                  : "rounded-lg px-3 py-1.5 text-[13px] font-medium tracking-tight text-muted hover:text-fg"
+                  ? "rounded-md bg-surface-3 px-3 py-1.5 text-[13px] font-medium tracking-tight text-fg"
+                  : "rounded-md px-3 py-1.5 text-[13px] font-medium tracking-tight text-muted hover:text-fg"
               }
             >
               {t.label}
@@ -750,7 +854,7 @@ function IncidentsTab({ projectId }: { projectId: string }) {
         <div className="text-[13px] text-danger">Failed to load: {String(incidents.error)}</div>
       )}
       {incidents.data && incidents.data.length === 0 && (
-        <div className="rounded-2xl border border-border bg-surface p-12 text-center">
+        <div className="rounded-xl border border-border bg-surface p-12 text-center">
           <p className="text-[13px] text-muted">
             No {status === "all" ? "" : status + " "}incidents
           </p>
@@ -761,9 +865,7 @@ function IncidentsTab({ projectId }: { projectId: string }) {
           {groups.map((group) => (
             <section key={group.key}>
               <div className="mb-2 flex items-center justify-between px-1">
-                <h3 className="text-[11px] font-medium uppercase tracking-wide text-muted">
-                  {group.label}
-                </h3>
+                <h3 className="text-[11px] font-medium text-muted">{group.label}</h3>
                 {group.key === "recovery" && (
                   <Btn
                     variant="secondary"
@@ -790,7 +892,7 @@ function IncidentsTab({ projectId }: { projectId: string }) {
                   resolved — refresh to see the current state.
                 </div>
               )}
-              <div className="divide-y divide-border overflow-hidden rounded-2xl border border-border bg-surface">
+              <div className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
                 {group.items.map((row) => (
                   <IncidentRow
                     key={row.incident.id}
@@ -951,14 +1053,14 @@ export function IncidentRow({
           </div>
           <p className="truncate text-[13px] font-medium text-fg">{incident.title}</p>
           {incident.codename && (
-            <p className="mt-0.5 font-mono text-[11px] text-subtle">{incident.codename}</p>
+            <p className="mt-0.5 font-sans text-[11px] text-subtle">{incident.codename}</p>
           )}
         </div>
         <div className="hidden shrink-0 self-center sm:block">
           <LazyRowSparkline activity={activity} error={!!stats.error} />
         </div>
         <div className="shrink-0 text-right">
-          <div className="font-mono text-[11px] tabular-nums text-muted">
+          <div className="font-sans text-[11px] tabular-nums text-muted">
             {fmtRelative(incident.lastSeen)}
           </div>
           <LazyRowUsersImpacted activity={activity} error={!!stats.error} />
@@ -1014,7 +1116,7 @@ function IncidentDetailBody({
   }
   if (q.error || !q.data) {
     return (
-      <div className="p-4 font-mono text-[11px] text-danger">
+      <div className="p-4 font-sans text-[11px] text-danger">
         failed: {String(q.error ?? "no data")}
       </div>
     );
@@ -1096,7 +1198,7 @@ function buildAgentRunPrompt({
     `- Project ID: ${incident.projectId}`,
   );
 
-  lines.push("", `## Issues in this incident (${issues.length})`);
+  lines.push("", `## Errors in this incident (${issues.length})`);
   if (issues.length === 0) {
     lines.push("(none)");
   } else {
@@ -1110,7 +1212,7 @@ function buildAgentRunPrompt({
         `   - Symbolicated top frame: ${formatSymbolicatedTopFrame(issue) ?? "(none)"}`,
         `   - Event count: ${issue.eventCount}`,
         `   - First/last seen: ${issue.firstSeen} → ${issue.lastSeen}`,
-        `   - Issue ID: ${issue.id}`,
+        `   - Error ID: ${issue.id}`,
       );
     });
   }
@@ -1158,7 +1260,7 @@ function buildAgentRunPrompt({
   lines.push(
     "",
     "## Task",
-    `1. Query the Superlog MCP for traces, logs, and metrics around \`${incident.lastSeen}\` for service \`${incident.service ?? "(see above)"}\` and project \`${incident.projectId}\`. Pull representative samples for each issue ID above.`,
+    `1. Query the Superlog MCP for traces, logs, and metrics around \`${incident.lastSeen}\` for service \`${incident.service ?? "(see above)"}\` and project \`${incident.projectId}\`. Pull representative samples for each error ID above.`,
     "2. If a sample includes a `session.id` attribute, use it to query preceding traces and logs from the same user/app session before focusing only on the failing trace or log line.",
     "3. Identify the root cause. Cite specific trace IDs, span attributes, log lines, and (if you have repo access) the offending file + line.",
     "4. Propose a fix. If a prior agent run is shown above, treat it as a hypothesis — verify or refute it against the data rather than restating it.",
@@ -1266,7 +1368,7 @@ function LazyRowUsersImpacted({
   }
   if (!error) return <RowUsersSkeleton />;
   return (
-    <div className="mt-1 font-mono text-[11px] tabular-nums text-subtle" title="Activity failed">
+    <div className="mt-1 font-sans text-[11px] tabular-nums text-subtle" title="Activity failed">
       — users
     </div>
   );
@@ -1308,7 +1410,7 @@ function RowUsersImpacted({
     // Empty signal: the incident's events had no `user.id`, so we can't say.
     return (
       <div
-        className="mt-1 font-mono text-[11px] tabular-nums text-subtle"
+        className="mt-1 font-sans text-[11px] tabular-nums text-subtle"
         title="No user.id attribute on this incident's events"
       >
         — users
@@ -1317,7 +1419,7 @@ function RowUsersImpacted({
   }
   const label = capped ? `${count.toLocaleString()}+` : count.toLocaleString();
   return (
-    <div className="mt-1 font-mono text-[11px] tabular-nums text-subtle">
+    <div className="mt-1 font-sans text-[11px] tabular-nums text-subtle">
       {label} user{count === 1 && !capped ? "" : "s"}
     </div>
   );
@@ -1363,7 +1465,7 @@ function RowSparkline({ buckets }: { buckets: { day: string; count: number }[] }
 function PeakMarker({ value }: { value: number }) {
   return (
     <span
-      className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 whitespace-nowrap pb-0.5 font-mono text-[9px] leading-none tabular-nums"
+      className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 whitespace-nowrap pb-0.5 font-sans text-[9px] leading-none tabular-nums"
       style={{ color: "var(--color-accent)" }}
       aria-hidden
     >
@@ -1385,7 +1487,7 @@ function TriggeredByAlertEpisodes({ episodes }: { episodes: IncidentAlertEpisode
             >
               <div className="mb-0.5 flex items-center gap-2">
                 <Chip tone="accent">alert</Chip>
-                <span className="font-mono text-[11px] text-muted">Episode #{ep.seq}</span>
+                <span className="font-sans text-[11px] text-muted">Episode #{ep.seq}</span>
                 <span className="inline-flex items-center gap-1.5 text-[11px] text-muted">
                   <span
                     className={`h-1.5 w-1.5 rounded-full ${firing ? "bg-danger" : "bg-subtle"}`}
@@ -1521,7 +1623,7 @@ export function IncidentDetailContent({
       <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[390px_minmax(0,1fr)]">
         <aside className="flex min-w-0 flex-col border-b border-border bg-bg lg:border-b-0 lg:border-r">
           <div className="px-7 pb-7 pt-7">
-            <div className="font-mono text-[11px] text-subtle">#{incident.codename}</div>
+            <div className="font-sans text-[11px] text-subtle">#{incident.codename}</div>
             <h2 className="mt-2 break-words text-[20px] font-semibold leading-[1.1] tracking-tight text-fg">
               {incident.title}
             </h2>
@@ -1835,7 +1937,7 @@ function LinkedIssuesMetaRow({
   const count = issues.length;
   return (
     <div className="grid grid-cols-[132px_minmax(0,1fr)] items-start gap-3 text-[13px]">
-      <div className="text-muted">Linked issues</div>
+      <div className="text-muted">Linked errors</div>
       <div ref={ref} className="relative flex min-w-0 items-center gap-[5px] text-fg">
         <ArrowUpRightIcon />
         {count === 0 ? (
@@ -1849,7 +1951,7 @@ function LinkedIssuesMetaRow({
               onClick={() => setOpen((v) => !v)}
               className="text-fg transition-colors hover:text-muted"
             >
-              {count} issue{count === 1 ? "" : "s"}
+              {count} error{count === 1 ? "" : "s"}
             </button>
             {open && (
               <div className="absolute left-0 top-full z-20 mt-1.5 w-80 overflow-hidden rounded-lg border border-border bg-surface p-1 shadow-[0_10px_30px_-10px_rgba(0,0,0,0.4)]">
@@ -2238,7 +2340,7 @@ export function AgentRunView({
       {agentRuns.length > 1 && (
         <div className="space-y-2">
           <SectionHeading>Run history</SectionHeading>
-          <ul className="space-y-1 font-mono text-[11px]">
+          <ul className="space-y-1 font-sans text-[11px]">
             {agentRuns.map((run, i) => (
               <li key={run.id} className="flex items-center gap-2">
                 <span className="text-muted">#{agentRuns.length - i}</span>
@@ -2291,7 +2393,7 @@ export function ResolutionProposalBanner({
 }) {
   return (
     <div className="rounded-md border border-border bg-surface p-4">
-      <div className="mb-3 flex items-center gap-2 text-[11px] uppercase tracking-wide">
+      <div className="mb-3 flex items-center gap-2 text-[11px] font-medium">
         <span className="text-success">Recovery detected</span>
         <span aria-hidden className="text-muted">
           ·
@@ -2514,7 +2616,7 @@ function ServiceEnv({
 }) {
   const parts = [service, environment].filter((part): part is string => Boolean(part));
   if (parts.length === 0) return null;
-  return <span className="font-mono text-[11px] text-subtle">{parts.join(" | ")}</span>;
+  return <span className="font-sans text-[11px] text-subtle">{parts.join(" | ")}</span>;
 }
 
 function IssueStatusChip({ issue }: { issue: Issue }) {
@@ -2543,7 +2645,7 @@ function MetaField({ label, value }: { label: string; value: string }) {
   return (
     <div>
       <SectionHeader>{label}</SectionHeader>
-      <p className="mt-0.5 font-mono text-[12px] text-fg">{value}</p>
+      <p className="mt-0.5 font-sans text-[12px] text-fg">{value}</p>
     </div>
   );
 }
@@ -2552,7 +2654,7 @@ function MetaInline({ label, value }: { label: string; value: string }) {
   return (
     <span className="inline-flex items-baseline gap-1.5">
       <SectionHeader>{label}</SectionHeader>
-      <span className="font-mono text-[12px] text-fg">{value}</span>
+      <span className="font-sans text-[12px] text-fg">{value}</span>
     </span>
   );
 }
@@ -2591,7 +2693,7 @@ function ConfidenceMeter({ value }: { value: number }) {
   const clamped = Math.max(0, Math.min(10, Math.round(value)));
   const toneClass = clamped >= 8 ? "text-success" : clamped >= 5 ? "text-warning" : "text-danger";
   return (
-    <span className={`font-mono text-[11px] tabular-nums ${toneClass}`}>
+    <span className={`font-sans text-[11px] tabular-nums ${toneClass}`}>
       confidence {clamped}/10
     </span>
   );
@@ -2623,8 +2725,8 @@ function IssueCard({
         <div className="min-w-0 flex-1">
           <div className="mb-0.5 flex items-center gap-2">
             <KindChip issue={issue} />
-            <span className="text-[11px] text-muted">{issue.exceptionType}</span>
-            <span className="text-[11px] tabular-nums text-subtle">
+            <span className="font-sans text-[11px] text-muted">{issue.exceptionType}</span>
+            <span className="font-sans text-[11px] tabular-nums text-subtle">
               {fmtCount(issue.eventCount)} event{issue.eventCount !== 1 ? "s" : ""}
             </span>
           </div>
@@ -2662,12 +2764,12 @@ function IssueOccurrenceGraph({ buckets }: { buckets: { day: string; count: numb
     <div className="border-t border-border pt-2.5 sm:w-44 sm:flex-none sm:border-l sm:border-t-0 sm:pl-4 sm:pt-0">
       <div className="flex items-center justify-between text-[10px] text-subtle">
         <span>Occurrences · last {buckets.length} days</span>
-        <span className="font-mono tabular-nums text-fg">{total.toLocaleString()}</span>
+        <span className="font-sans tabular-nums text-fg">{total.toLocaleString()}</span>
       </div>
       <div
         className="mt-2 flex h-16 items-end gap-1 border-b border-border"
         role="img"
-        aria-label={`${total.toLocaleString()} issue occurrences over the last ${buckets.length} days`}
+        aria-label={`${total.toLocaleString()} error occurrences over the last ${buckets.length} days`}
       >
         {buckets.map((bucket) => {
           const occurrenceLabel = `${formatOccurrenceDate(bucket.day)} · ${bucket.count.toLocaleString()} occurrence${bucket.count === 1 ? "" : "s"}`;

--- a/apps/web/src/LogDetail.tsx
+++ b/apps/web/src/LogDetail.tsx
@@ -105,7 +105,7 @@ function LogDrawerBody({
     <div className="flex flex-col gap-5">
       {issue && onOpenIssue ? (
         <section>
-          <SectionHeader>Issue</SectionHeader>
+          <SectionHeader>Error</SectionHeader>
           <button
             type="button"
             onClick={() => onOpenIssue(issue.id)}
@@ -116,7 +116,7 @@ function LogDrawerBody({
               {issue.title ? <span className="ml-2">{issue.title}</span> : null}
             </span>
             <span className="shrink-0 rounded-sm border border-border px-1.5 py-0.5 text-[10px] text-muted">
-              open issue →
+              open error →
             </span>
           </button>
         </section>

--- a/apps/web/src/Overview.tsx
+++ b/apps/web/src/Overview.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { IncidentRow } from "./Issues.tsx";
 import { useCloudConnections, useIncidents, useMe } from "./api.ts";
+import { PageHeader } from "./design/ui.tsx";
 import { SetupTodos } from "./onboarding/SetupTodos.tsx";
 import { ServiceMap } from "./service-map/ServiceMap.tsx";
 
@@ -11,18 +12,20 @@ export function Overview() {
   const me = useMe();
 
   if (me.isLoading) {
-    return (
-      <div className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted">loading…</div>
-    );
+    return <div className="text-[12px] text-muted">Loading…</div>;
   }
   if (me.error) {
-    return <div className="font-mono text-[11px] text-danger">error: {String(me.error)}</div>;
+    return <div className="text-[12px] text-danger">Error: {String(me.error)}</div>;
   }
   if (!me.data || !me.data.project) return null;
   const projectId = me.data.project.id;
 
   return (
     <div className="flex flex-col gap-10">
+      <PageHeader
+        title="Overview"
+        description="Project health, recent critical activity, and the connections that shape your system."
+      />
       <SetupTodos projectId={projectId} />
       <ActiveIncidentsSection projectId={projectId} />
       <ServiceMapSection projectId={projectId} />
@@ -54,29 +57,25 @@ function ActiveIncidentsSection({ projectId }: { projectId: string }) {
   return (
     <section>
       <div className="mb-4 flex items-baseline justify-between">
-        <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-subtle">
-          Active critical incidents
-        </span>
-        {incidents.isFetching && (
-          <span className="text-[11px] uppercase tracking-[0.08em] text-subtle">refreshing…</span>
-        )}
+        <h2 className="text-[15px] font-medium text-fg">Active critical incidents</h2>
+        {incidents.isFetching && <span className="text-[11px] text-subtle">Refreshing…</span>}
       </div>
       {incidents.isLoading ? (
-        <div className="rounded-2xl border border-border bg-surface p-6 text-[13px] text-muted">
+        <div className="rounded-xl border border-border bg-surface p-6 text-[13px] text-muted">
           Loading…
         </div>
       ) : incidents.error ? (
-        <div className="rounded-2xl border border-border bg-surface p-6 text-[13px] text-danger">
+        <div className="rounded-xl border border-border bg-surface p-6 text-[13px] text-danger">
           Failed to load: {String(incidents.error)}
         </div>
       ) : important.length === 0 ? (
-        <div className="rounded-2xl border border-border bg-surface p-6 text-center">
+        <div className="rounded-xl border border-border bg-surface p-6 text-center">
           <p className="text-[13px] text-muted">
             All clear — no SEV-1 or SEV-2 incidents in the last 24h
           </p>
         </div>
       ) : (
-        <div className="divide-y divide-border overflow-hidden rounded-2xl border border-border bg-surface">
+        <div className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
           {important.map((row) => (
             <IncidentRow
               key={row.incident.id}

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -111,7 +111,7 @@ import {
 } from "./api";
 import { AWS_REGIONS } from "./awsRegions.ts";
 import { Dropdown, type DropdownOption } from "./design/Dropdown.tsx";
-import { Btn, Chip, FieldLabel, Input, Label, Tile } from "./design/ui";
+import { Btn, Chip, FieldLabel, Input, Label, PageHeader, Tile } from "./design/ui";
 import { McpInstallPanel } from "./onboarding/McpInstallDialog.tsx";
 import { useDemoExploration } from "./onboarding/demoExploration.tsx";
 import { InfoIcon } from "./onboarding/icons.tsx";
@@ -203,6 +203,10 @@ export function Settings() {
 
   return (
     <div className="space-y-6">
+      <PageHeader
+        title="Settings"
+        description="Manage the project, organization, integrations, and investigation defaults."
+      />
       {(linearStatus || notionStatus || githubStatus || githubAuthorStatus) && (
         <header className="space-y-2">
           {linearStatus && <LinearStatusBanner status={linearStatus} />}
@@ -350,9 +354,7 @@ function SettingsSideNav({
         {groups.map((group, gi) => (
           <li key={group.label ?? gi}>
             {group.label && (
-              <p className="mb-1 mt-4 px-3 text-[11px] uppercase tracking-wider text-muted">
-                {group.label}
-              </p>
+              <p className="mb-1 mt-5 px-3 text-[11px] font-medium text-subtle">{group.label}</p>
             )}
             <ul className="flex flex-col gap-0.5">
               {group.items.map((item) => (
@@ -694,8 +696,8 @@ function ProjectSectionView({
     case "issue-filter":
       return (
         <Section
-          title="Issue filter"
-          subtitle="Drop error logs and traces whose attributes don't match before they create issues."
+          title="Error filter"
+          subtitle="Drop error logs and traces whose attributes don't match before they create errors."
         >
           <IssueFilterCard projectId={projectId} />
         </Section>
@@ -807,7 +809,7 @@ function ProjectGeneralCard({
           description="Used in URLs — fixed after creation"
           control={
             <div className="w-60">
-              <Input className="font-mono text-[12.5px]" value={project?.slug ?? ""} disabled />
+              <Input className="font-sans text-[12.5px]" value={project?.slug ?? ""} disabled />
             </div>
           }
         />
@@ -821,9 +823,9 @@ function ProjectGeneralCard({
             onChange={(e) => setDraft(e.target.value.slice(0, PROJECT_CONTEXT_MAX_LEN))}
             rows={7}
             placeholder="e.g. This project is the billing API. Stripe customer IDs are org-scoped. Prefer touching packages/billing before app code."
-            className="w-full rounded-lg border border-border bg-surface-2 p-3 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
+            className="w-full rounded-lg border border-border bg-surface-2 p-3 font-sans text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
           />
-          <div className="mt-1 flex justify-end font-mono text-[12px] tabular-nums text-muted">
+          <div className="mt-1 flex justify-end font-sans text-[12px] tabular-nums text-muted">
             {draft.length} / {PROJECT_CONTEXT_MAX_LEN}
           </div>
         </SettingsRow>
@@ -1101,7 +1103,7 @@ function GithubCard() {
                           {installation.accountLogin ??
                             `Installation ${installation.installationId}`}
                         </div>
-                        <div className="font-mono text-[11px] text-muted">
+                        <div className="font-sans text-[11px] text-muted">
                           {installation.enabled
                             ? installation.repos.filter((repo) => repo.enabled).length
                             : 0}
@@ -1142,7 +1144,7 @@ function GithubCard() {
                                 })
                               }
                             />
-                            <span className="truncate font-mono text-[11px] text-fg">
+                            <span className="truncate font-sans text-[11px] text-fg">
                               {repo.fullName}
                             </span>
                           </span>
@@ -1162,7 +1164,7 @@ function GithubCard() {
                 <img src={commitAuthor.avatarUrl} alt="" className="h-6 w-6 flex-none rounded-sm" />
               )}
               {!commitAuthor?.avatarUrl && (
-                <div className="flex h-6 w-6 flex-none items-center justify-center rounded-sm border border-border font-mono text-[10px] text-muted">
+                <div className="flex h-6 w-6 flex-none items-center justify-center rounded-sm border border-border font-sans text-[10px] text-muted">
                   SL
                 </div>
               )}
@@ -1175,7 +1177,7 @@ function GithubCard() {
                     {commitAuthor?.source === "github_user" ? "installer" : "default"}
                   </Chip>
                 </div>
-                <div className="truncate font-mono text-[11px] text-muted">
+                <div className="truncate font-sans text-[11px] text-muted">
                   {commitAuthor?.email ?? "bot@superlog.sh"}
                 </div>
               </div>
@@ -1633,7 +1635,7 @@ function RenderCard({ projectId }: { projectId: string | undefined }) {
               placeholder="rnd_…"
               autoComplete="off"
               spellCheck={false}
-              className="h-[32px] min-w-0 flex-1 rounded-[8px] border border-border bg-surface-2 px-2.5 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:outline-none"
+              className="h-[32px] min-w-0 flex-1 rounded-[8px] border border-border bg-surface-2 px-2.5 font-sans text-[12.5px] text-fg placeholder:text-subtle focus:outline-none"
             />
             <Btn
               size="sm"
@@ -2093,7 +2095,7 @@ const AWS_REGION_OPTIONS = AWS_REGIONS.map((r) => ({
   value: r.code,
   label: (
     <span>
-      <span className="font-mono">{r.code}</span>
+      <span className="font-sans">{r.code}</span>
       <span className="text-muted"> · {r.name}</span>
     </span>
   ),
@@ -2492,11 +2494,11 @@ function OrgGuidanceCard() {
           onChange={(e) => setDraft(e.target.value.slice(0, ORG_GUIDANCE_MAX_LEN))}
           rows={5}
           placeholder="e.g. Always link incidents to the on-call runbook before filing a ticket. Prefer reverts over forward fixes for prod regressions."
-          className="w-full rounded-lg border border-border bg-surface-2 p-3 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
+          className="w-full rounded-lg border border-border bg-surface-2 p-3 font-sans text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
         />
         <div className="flex items-center justify-between text-[12px] text-muted">
           <span>Prepended to every agent run prompt across all projects in this org.</span>
-          <span className="font-mono tabular-nums">
+          <span className="font-sans tabular-nums">
             {draft.length} / {ORG_GUIDANCE_MAX_LEN}
           </span>
         </div>
@@ -2751,7 +2753,7 @@ function PrBaseBranchField({
       searchText: branch.name,
       label: (
         <span className="flex items-center gap-2">
-          <span className="font-mono">{branch.name}</span>
+          <span className="font-sans">{branch.name}</span>
           {branch.isDefault && <span className="text-[11px] text-subtle">default</span>}
         </span>
       ),
@@ -2804,25 +2806,25 @@ const BUCKET_META: Record<
 > = {
   includeLogs: {
     label: "Include only logs with",
-    subtitle: "If set, only error logs that match one of these attributes can create issues.",
+    subtitle: "If set, only error logs that match one of these attributes can create errors.",
     kind: "log",
     mode: "include",
   },
   includeSpans: {
     label: "Include only traces with",
-    subtitle: "If set, only exception spans that match one of these attributes can create issues.",
+    subtitle: "If set, only exception spans that match one of these attributes can create errors.",
     kind: "span",
     mode: "include",
   },
   excludeLogs: {
     label: "Exclude all logs with",
-    subtitle: "Error logs matching any of these are dropped before issue creation.",
+    subtitle: "Error logs matching any of these are dropped before error creation.",
     kind: "log",
     mode: "exclude",
   },
   excludeSpans: {
     label: "Exclude all traces with",
-    subtitle: "Exception spans matching any of these are dropped before issue creation.",
+    subtitle: "Exception spans matching any of these are dropped before error creation.",
     kind: "span",
     mode: "exclude",
   },
@@ -2893,7 +2895,7 @@ function IssueFilterCard({ projectId }: { projectId: string | undefined }) {
               </li>
               <li>
                 <b>Include is OR within a bucket.</b> If you set any include clauses for a kind, an
-                event of that kind must match at least one to create an issue.
+                event of that kind must match at least one to create an error.
               </li>
               <li>
                 <b>Logs and traces are independent.</b> Filters for "logs" only affect error logs;
@@ -2932,7 +2934,7 @@ function IssueFilterCard({ projectId }: { projectId: string | undefined }) {
             <FieldLabel>
               {totalClauses === 0
                 ? "Recent errors (last 24h)"
-                : "Errors that would still create issues (last 24h)"}
+                : "Errors that would still be created (last 24h)"}
             </FieldLabel>
             {preview.isFetching && <span className="text-[11px] text-subtle">refreshing…</span>}
           </div>
@@ -3039,9 +3041,9 @@ function FilterPill({
     <span
       className={`inline-flex h-6 items-center gap-1 rounded-sm border border-border bg-surface px-2 text-[11.5px] text-fg ${accent}`}
     >
-      <span className="font-mono text-subtle">{clause.key}</span>
+      <span className="font-sans text-subtle">{clause.key}</span>
       <span className="text-subtle">=</span>
-      <span className="font-mono">{clause.value}</span>
+      <span className="font-sans">{clause.value}</span>
       <button
         type="button"
         disabled={disabled}
@@ -3128,7 +3130,7 @@ function IssueFilterPicker({
             }}
             className="mb-1.5 flex items-center gap-1.5 text-[11px] text-subtle hover:text-fg"
           >
-            ← <span className="truncate font-mono">{drillKey}</span>
+            ← <span className="truncate font-sans">{drillKey}</span>
           </button>
           <input
             ref={searchInputRef}
@@ -3176,7 +3178,7 @@ function IssueFilterPicker({
                         highlight === i ? "bg-surface-2" : ""
                       } ${already ? "cursor-not-allowed opacity-50" : "hover:bg-surface-2"}`}
                     >
-                      <span className="truncate font-mono text-fg">{r.value || "(empty)"}</span>
+                      <span className="truncate font-sans text-fg">{r.value || "(empty)"}</span>
                       <span className="shrink-0 text-[10px] text-subtle">
                         {already ? "added" : r.count}
                       </span>
@@ -3244,7 +3246,7 @@ function IssueFilterPicker({
                     highlight === i ? "bg-surface-2" : ""
                   }`}
                 >
-                  <span className="truncate font-mono text-fg">{k.key}</span>
+                  <span className="truncate font-sans text-fg">{k.key}</span>
                   <span className="shrink-0 text-[10px] text-subtle">{k.count} ›</span>
                 </button>
               </li>
@@ -3286,19 +3288,19 @@ function IssueFilterPreviewList({
           <div className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-2 text-[11px] text-subtle">
               <Chip tone={e.kind === "log" ? "warning" : "danger"}>{e.kind}</Chip>
-              <span className="font-mono">{e.service || "(no service)"}</span>
-              {e.exception_type && <span className="font-mono text-muted">{e.exception_type}</span>}
+              <span className="font-sans">{e.service || "(no service)"}</span>
+              {e.exception_type && <span className="font-sans text-muted">{e.exception_type}</span>}
             </div>
-            <span className="font-mono text-[10px] text-subtle">{formatRelative(e.ts)}</span>
+            <span className="font-sans text-[10px] text-subtle">{formatRelative(e.ts)}</span>
           </div>
-          <div className="line-clamp-2 break-words font-mono text-[12px] text-fg">
+          <div className="line-clamp-2 break-words font-sans text-[12px] text-fg">
             {e.message || "(no message)"}
           </div>
           <div className="flex flex-wrap gap-1">
             {pickPreviewAttrs(e.attrs, clauseKeys).map(([k, v]) => (
               <span
                 key={`${k}=${v}`}
-                className="inline-flex items-center gap-1 rounded-sm border border-border bg-surface-2 px-1.5 py-0.5 font-mono text-[10.5px] text-muted"
+                className="inline-flex items-center gap-1 rounded-sm border border-border bg-surface-2 px-1.5 py-0.5 font-sans text-[10.5px] text-muted"
               >
                 <span className="text-subtle">{k}</span>
                 <span className="text-subtle">=</span>
@@ -3380,7 +3382,7 @@ function FlowNode({
     <div className={`relative grid grid-cols-[40px_1fr] gap-4 ${dim}`}>
       <div className="relative flex flex-col items-center">
         <div
-          className={`flex h-8 w-8 items-center justify-center rounded-full border font-mono text-[11px] tabular-nums ${
+          className={`flex h-8 w-8 items-center justify-center rounded-full border font-sans text-[11px] tabular-nums ${
             off
               ? "border-border bg-surface-2 text-muted"
               : accent && spineActive
@@ -3487,7 +3489,7 @@ function AutoMergeControls({
   };
   return (
     <div className="space-y-3 rounded-sm border border-border bg-surface-2 p-3">
-      <div className="text-[11px] font-mono uppercase tracking-tight text-muted">
+      <div className="text-[11px] font-sans uppercase tracking-tight text-muted">
         Auto-merge fix PRs
       </div>
       <div className="flex flex-wrap gap-1.5">
@@ -3499,7 +3501,7 @@ function AutoMergeControls({
               type="button"
               disabled={disabled}
               onClick={() => onChange({ autoMergeFixPrs: opt })}
-              className={`rounded-sm border px-2.5 py-1 font-mono text-[11px] tracking-tight transition-colors ${
+              className={`rounded-sm border px-2.5 py-1 font-sans text-[11px] tracking-tight transition-colors ${
                 active
                   ? "border-accent bg-accent-soft text-accent"
                   : "border-border bg-surface-2 text-muted hover:text-fg"
@@ -3513,7 +3515,7 @@ function AutoMergeControls({
       <p className="text-[12px] text-muted">{policyHints[policy]}</p>
       {policy !== "never" && (
         <div className="space-y-2">
-          <div className="text-[11px] font-mono uppercase tracking-tight text-muted">
+          <div className="text-[11px] font-sans uppercase tracking-tight text-muted">
             Merge method
           </div>
           <div className="flex flex-wrap gap-1.5">
@@ -3525,7 +3527,7 @@ function AutoMergeControls({
                   type="button"
                   disabled={disabled}
                   onClick={() => onChange({ autoMergeMethod: opt })}
-                  className={`rounded-sm border px-2.5 py-1 font-mono text-[11px] tracking-tight transition-colors ${
+                  className={`rounded-sm border px-2.5 py-1 font-sans text-[11px] tracking-tight transition-colors ${
                     active
                       ? "border-accent bg-accent-soft text-accent"
                       : "border-border bg-surface-2 text-muted hover:text-fg"
@@ -3567,7 +3569,7 @@ function PolicyControls<T extends string>({
               type="button"
               disabled={disabled}
               onClick={() => onChange(opt as T)}
-              className={`rounded-sm border px-2.5 py-1 font-mono text-[11px] tracking-tight transition-colors ${
+              className={`rounded-sm border px-2.5 py-1 font-sans text-[11px] tracking-tight transition-colors ${
                 active
                   ? "border-accent bg-accent-soft text-accent"
                   : "border-border bg-surface-2 text-muted hover:text-fg"
@@ -3632,11 +3634,11 @@ function InstructionsField({
         placeholder={
           "e.g. Prefer one-line fixes when possible. When patching the billing service, run pnpm typecheck before declaring the patch validated."
         }
-        className="w-full rounded-lg border border-border bg-surface-2 p-3 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
+        className="w-full rounded-lg border border-border bg-surface-2 p-3 font-sans text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
       />
       <div className="flex items-center justify-between text-[12px] text-muted">
         <span>Appended to every agent run prompt for this workspace.</span>
-        <span className="font-mono tabular-nums">{draft.length} / 8000</span>
+        <span className="font-sans tabular-nums">{draft.length} / 8000</span>
       </div>
       <div className="flex items-center gap-2">
         <Btn
@@ -3834,7 +3836,7 @@ function InstructionForm({
         onChange={(e) => onTextChange(e.target.value)}
         rows={3}
         placeholder="Describe the requirement the agent must follow when filing this ticket…"
-        className="w-full rounded-lg border border-border bg-surface-1 p-2 font-mono text-[12px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
+        className="w-full rounded-lg border border-border bg-surface-1 p-2 font-sans text-[12px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none disabled:opacity-60"
       />
       <div className="flex items-center gap-2">
         <Btn size="sm" variant="primary" disabled={!title.trim() || disabled} onClick={onSave}>
@@ -4005,7 +4007,7 @@ function IntegrationEditor({
           <div className="text-[12px] text-muted">{integration.description}</div>
         </div>
         <div className="flex items-center gap-2">
-          <span className="font-mono text-[11px] uppercase tracking-[0.15em] text-muted">
+          <span className="font-sans text-[11px] uppercase tracking-[0.15em] text-muted">
             {enabled ? "On" : "Off"}
           </span>
           <Toggle checked={enabled} onChange={setEnabled} disabled={save.isPending} />
@@ -4022,7 +4024,7 @@ function IntegrationEditor({
               placeholder={spec.present ? "•••••••• stored — type to replace" : "Paste key"}
               value={secrets[spec.name] ?? ""}
               onChange={(e) => setSecrets((s) => ({ ...s, [spec.name]: e.target.value }))}
-              className="font-mono"
+              className="font-sans"
             />
             <div className="text-[12px] text-muted">{spec.description}</div>
           </div>
@@ -4134,7 +4136,7 @@ function ApiKeysCard({ projectId }: { projectId: string | undefined }) {
                 dismiss
               </button>
             </div>
-            <code className="block break-all font-mono text-[12.5px] text-fg">
+            <code className="block break-all font-sans text-[12.5px] text-fg">
               {reveal.plaintext}
             </code>
           </div>
@@ -4151,23 +4153,23 @@ function ApiKeysCard({ projectId }: { projectId: string | undefined }) {
             <table className="w-full text-[13px]">
               <thead>
                 <tr className="border-b border-border text-left text-muted">
-                  <th className="py-2 pr-4 font-mono text-[10px] uppercase tracking-[0.2em]">
+                  <th className="py-2 pr-4 font-sans text-[10px] uppercase tracking-[0.2em]">
                     Name
                   </th>
-                  <th className="py-2 pr-4 font-mono text-[10px] uppercase tracking-[0.2em]">
+                  <th className="py-2 pr-4 font-sans text-[10px] uppercase tracking-[0.2em]">
                     Prefix
                   </th>
-                  <th className="py-2 pr-4 font-mono text-[10px] uppercase tracking-[0.2em]">
+                  <th className="py-2 pr-4 font-sans text-[10px] uppercase tracking-[0.2em]">
                     Last used
                   </th>
-                  <th className="py-2 font-mono text-[10px] uppercase tracking-[0.2em]" />
+                  <th className="py-2 font-sans text-[10px] uppercase tracking-[0.2em]" />
                 </tr>
               </thead>
               <tbody>
                 {live.map((k) => (
                   <tr key={k.id} className="border-b border-border last:border-0">
                     <td className="py-3 pr-4">{k.name}</td>
-                    <td className="py-3 pr-4 font-mono tabular-nums text-muted">{k.keyPrefix}…</td>
+                    <td className="py-3 pr-4 font-sans tabular-nums text-muted">{k.keyPrefix}…</td>
                     <td className="py-3 pr-4 text-muted">
                       {k.lastUsedAt ? new Date(k.lastUsedAt).toLocaleString() : "never"}
                     </td>
@@ -4297,11 +4299,11 @@ function McpTokensCard({ projectId }: { projectId: string | undefined }) {
                 dismiss
               </button>
             </div>
-            <code className="block break-all font-mono text-[12.5px] text-fg">
+            <code className="block break-all font-sans text-[12.5px] text-fg">
               {reveal.plaintext}
             </code>
             <p className="mt-2 text-[12px] text-muted">Add it to your agent, for example:</p>
-            <code className="mt-1 block break-all font-mono text-[12px] text-subtle">
+            <code className="mt-1 block break-all font-sans text-[12px] text-subtle">
               claude mcp add --transport http superlog https://api.superlog.sh/mcp --header
               "Authorization: Bearer {reveal.plaintext}"
             </code>
@@ -4319,19 +4321,19 @@ function McpTokensCard({ projectId }: { projectId: string | undefined }) {
             <table className="w-full text-[13px]">
               <thead>
                 <tr className="border-b border-border text-left text-muted">
-                  <th className="py-2 pr-4 font-mono text-[10px] uppercase tracking-[0.2em]">
+                  <th className="py-2 pr-4 font-sans text-[10px] uppercase tracking-[0.2em]">
                     Name
                   </th>
-                  <th className="py-2 pr-4 font-mono text-[10px] uppercase tracking-[0.2em]">
+                  <th className="py-2 pr-4 font-sans text-[10px] uppercase tracking-[0.2em]">
                     Project
                   </th>
-                  <th className="py-2 pr-4 font-mono text-[10px] uppercase tracking-[0.2em]">
+                  <th className="py-2 pr-4 font-sans text-[10px] uppercase tracking-[0.2em]">
                     Expires
                   </th>
-                  <th className="py-2 pr-4 font-mono text-[10px] uppercase tracking-[0.2em]">
+                  <th className="py-2 pr-4 font-sans text-[10px] uppercase tracking-[0.2em]">
                     Last used
                   </th>
-                  <th className="py-2 font-mono text-[10px] uppercase tracking-[0.2em]" />
+                  <th className="py-2 font-sans text-[10px] uppercase tracking-[0.2em]" />
                 </tr>
               </thead>
               <tbody>
@@ -4339,7 +4341,7 @@ function McpTokensCard({ projectId }: { projectId: string | undefined }) {
                   <tr key={t.id} className="border-b border-border last:border-0">
                     <td className="py-3 pr-4">
                       <div>{t.name}</div>
-                      <div className="font-mono text-[11px] text-muted">{t.tokenPrefix}…</div>
+                      <div className="font-sans text-[11px] text-muted">{t.tokenPrefix}…</div>
                     </td>
                     <td className="py-3 pr-4 text-muted">{t.projectName ?? "—"}</td>
                     <td className="py-3 pr-4 text-muted">
@@ -4434,7 +4436,7 @@ function OrgApiKeysCard() {
                 dismiss
               </button>
             </div>
-            <code className="block break-all font-mono text-[12.5px] text-fg">
+            <code className="block break-all font-sans text-[12.5px] text-fg">
               {reveal.plaintext}
             </code>
           </div>
@@ -4451,23 +4453,23 @@ function OrgApiKeysCard() {
             <table className="w-full text-[13px]">
               <thead>
                 <tr className="border-b border-border text-left text-muted">
-                  <th className="py-2 pr-4 font-mono text-[10px] uppercase tracking-[0.2em]">
+                  <th className="py-2 pr-4 font-sans text-[10px] uppercase tracking-[0.2em]">
                     Name
                   </th>
-                  <th className="py-2 pr-4 font-mono text-[10px] uppercase tracking-[0.2em]">
+                  <th className="py-2 pr-4 font-sans text-[10px] uppercase tracking-[0.2em]">
                     Prefix
                   </th>
-                  <th className="py-2 pr-4 font-mono text-[10px] uppercase tracking-[0.2em]">
+                  <th className="py-2 pr-4 font-sans text-[10px] uppercase tracking-[0.2em]">
                     Last used
                   </th>
-                  <th className="py-2 font-mono text-[10px] uppercase tracking-[0.2em]" />
+                  <th className="py-2 font-sans text-[10px] uppercase tracking-[0.2em]" />
                 </tr>
               </thead>
               <tbody>
                 {live.map((k) => (
                   <tr key={k.id} className="border-b border-border last:border-0">
                     <td className="py-3 pr-4">{k.name}</td>
-                    <td className="py-3 pr-4 font-mono tabular-nums text-muted">{k.key_prefix}…</td>
+                    <td className="py-3 pr-4 font-sans tabular-nums text-muted">{k.key_prefix}…</td>
                     <td className="py-3 pr-4 text-muted">
                       {k.last_used_at ? new Date(k.last_used_at).toLocaleString() : "never"}
                     </td>
@@ -4617,12 +4619,12 @@ function OrgGithubInstallRow({
           onClick={() => setExpanded((v) => !v)}
           className="flex min-w-0 items-center gap-2 text-left"
         >
-          <span className="font-mono text-[10px] text-muted">{expanded ? "▾" : "▸"}</span>
+          <span className="font-sans text-[10px] text-muted">{expanded ? "▾" : "▸"}</span>
           <div className="min-w-0">
             <div className="truncate text-[13px] text-fg">
               {install.account_login ?? `Installation ${install.installation_id}`}
             </div>
-            <div className="font-mono text-[11px] text-muted">
+            <div className="font-sans text-[11px] text-muted">
               {install.account_type ?? "—"} · install {install.installation_id}
             </div>
           </div>
@@ -4683,7 +4685,7 @@ function OrgGithubInstallRow({
                       className="flex min-w-0 items-center justify-between gap-2 px-1 py-1"
                     >
                       <span className="flex min-w-0 items-center gap-2">
-                        <span className="truncate font-mono text-[11px] text-fg">
+                        <span className="truncate font-sans text-[11px] text-fg">
                           {repo.full_name}
                         </span>
                         <Chip tone={repo.private ? "muted" : "neutral"}>
@@ -4722,8 +4724,8 @@ function OrgGithubInstallRow({
                               }}
                               className={
                                 isGranted
-                                  ? "inline-flex items-center gap-1 border border-accent bg-accent/15 px-1.5 py-0.5 font-mono text-[10px] text-accent"
-                                  : "inline-flex items-center gap-1 border border-border px-1.5 py-0.5 font-mono text-[10px] text-muted hover:border-fg/40 hover:text-fg"
+                                  ? "inline-flex items-center gap-1 border border-accent bg-accent/15 px-1.5 py-0.5 font-sans text-[10px] text-accent"
+                                  : "inline-flex items-center gap-1 border border-border px-1.5 py-0.5 font-sans text-[10px] text-muted hover:border-fg/40 hover:text-fg"
                               }
                               title={
                                 isGranted
@@ -4792,7 +4794,7 @@ function WebhookEventPicker({
             onChange={() => toggle(event.id)}
           />
           <span>
-            <code className="font-mono text-[11.5px] text-fg">{event.id}</code>
+            <code className="font-sans text-[11.5px] text-fg">{event.id}</code>
             <span className="block text-[11px] text-muted">{event.label}</span>
           </span>
         </label>
@@ -4825,7 +4827,7 @@ function WebhooksCard({ projectId }: { projectId: string | undefined }) {
           <button
             type="button"
             onClick={() => setSchemaOpen(true)}
-            className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted hover:text-fg"
+            className="font-sans text-[11px] uppercase tracking-[0.2em] text-muted hover:text-fg"
           >
             view payloads
           </button>
@@ -4891,7 +4893,7 @@ function WebhooksCard({ projectId }: { projectId: string | undefined }) {
                 dismiss
               </button>
             </div>
-            <code className="block break-all font-mono text-[12.5px] text-fg">{reveal.secret}</code>
+            <code className="block break-all font-sans text-[12.5px] text-fg">{reveal.secret}</code>
           </div>
         )}
 
@@ -5114,7 +5116,7 @@ function WebhookSchemaModal({ onClose }: { onClose: () => void }) {
             <button
               type="button"
               onClick={onClose}
-              className="font-mono text-[11px] uppercase tracking-[0.2em] text-subtle hover:text-fg"
+              className="font-sans text-[11px] uppercase tracking-[0.2em] text-subtle hover:text-fg"
             >
               close
             </button>
@@ -5138,7 +5140,7 @@ function WebhookSchemaModal({ onClose }: { onClose: () => void }) {
                     key={event.id}
                     className="flex flex-col gap-0.5 px-3 py-2 sm:flex-row sm:items-baseline sm:gap-3"
                   >
-                    <code className="font-mono text-[12px] text-fg sm:w-[200px] sm:shrink-0">
+                    <code className="font-sans text-[12px] text-fg sm:w-[200px] sm:shrink-0">
                       {event.id}
                     </code>
                     <span className="text-[12px] text-muted">{event.label}</span>
@@ -5149,7 +5151,7 @@ function WebhookSchemaModal({ onClose }: { onClose: () => void }) {
 
             <section>
               <h3 className="mb-2 text-[13px] font-medium text-fg">Headers</h3>
-              <div className="rounded-sm border border-border bg-surface-2 p-3 font-mono text-[12px]">
+              <div className="rounded-sm border border-border bg-surface-2 p-3 font-sans text-[12px]">
                 <div>
                   <span className="text-muted">Content-Type:</span> application/json
                 </div>
@@ -5169,7 +5171,7 @@ function WebhookSchemaModal({ onClose }: { onClose: () => void }) {
 
             <section>
               <h3 className="mb-2 text-[13px] font-medium text-fg">Example body</h3>
-              <pre className="max-h-[400px] overflow-auto rounded-sm border border-border bg-surface-2 p-3 font-mono text-[11.5px] leading-[1.55] text-fg">
+              <pre className="max-h-[400px] overflow-auto rounded-sm border border-border bg-surface-2 p-3 font-sans text-[11.5px] leading-[1.55] text-fg">
                 {INCIDENT_UPDATED_EXAMPLE}
               </pre>
             </section>
@@ -5184,7 +5186,7 @@ function WebhookSchemaModal({ onClose }: { onClose: () => void }) {
                   onClick={() => {
                     navigator.clipboard?.writeText(IMPLEMENT_PROMPT).catch(() => {});
                   }}
-                  className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted hover:text-fg"
+                  className="font-sans text-[11px] uppercase tracking-[0.2em] text-muted hover:text-fg"
                 >
                   copy
                 </button>
@@ -5193,7 +5195,7 @@ function WebhookSchemaModal({ onClose }: { onClose: () => void }) {
                 Paste this into Claude Code / Cursor / your IDE agent. It describes the headers,
                 signature scheme, payload, and what to build.
               </p>
-              <pre className="max-h-[260px] overflow-auto rounded-sm border border-border bg-surface-2 p-3 font-mono text-[11.5px] leading-[1.55] text-fg whitespace-pre-wrap">
+              <pre className="max-h-[260px] overflow-auto rounded-sm border border-border bg-surface-2 p-3 font-sans text-[11.5px] leading-[1.55] text-fg whitespace-pre-wrap">
                 {IMPLEMENT_PROMPT}
               </pre>
             </section>
@@ -5205,7 +5207,7 @@ function WebhookSchemaModal({ onClose }: { onClose: () => void }) {
                 endpoint's signing secret and compare against the <code>v1</code> value. Verify
                 against the raw body, before JSON-parsing.
               </p>
-              <pre className="max-h-[260px] overflow-auto rounded-sm border border-border bg-surface-2 p-3 font-mono text-[11.5px] leading-[1.55] text-fg">
+              <pre className="max-h-[260px] overflow-auto rounded-sm border border-border bg-surface-2 p-3 font-sans text-[11.5px] leading-[1.55] text-fg">
                 {VERIFY_SNIPPET}
               </pre>
             </section>
@@ -5299,7 +5301,7 @@ function WebhookEndpointRow({
           <button
             type="button"
             onClick={onToggle}
-            className="block w-full truncate text-left font-mono text-[12.5px] text-fg hover:underline"
+            className="block w-full truncate text-left font-sans text-[12.5px] text-fg hover:underline"
           >
             {endpoint.url}
           </button>
@@ -5405,14 +5407,14 @@ function WebhookDeliveriesPanel({
         <table className="w-full text-[12px]">
           <thead>
             <tr className="border-b border-border text-left text-muted">
-              <th className="py-1 pr-3 font-mono text-[10px] uppercase tracking-[0.2em]">When</th>
-              <th className="py-1 pr-3 font-mono text-[10px] uppercase tracking-[0.2em]">Event</th>
-              <th className="py-1 pr-3 font-mono text-[10px] uppercase tracking-[0.2em]">Status</th>
-              <th className="py-1 pr-3 font-mono text-[10px] uppercase tracking-[0.2em]">
+              <th className="py-1 pr-3 font-sans text-[10px] uppercase tracking-[0.2em]">When</th>
+              <th className="py-1 pr-3 font-sans text-[10px] uppercase tracking-[0.2em]">Event</th>
+              <th className="py-1 pr-3 font-sans text-[10px] uppercase tracking-[0.2em]">Status</th>
+              <th className="py-1 pr-3 font-sans text-[10px] uppercase tracking-[0.2em]">
                 Attempts
               </th>
-              <th className="py-1 pr-3 font-mono text-[10px] uppercase tracking-[0.2em]">HTTP</th>
-              <th className="py-1 font-mono text-[10px] uppercase tracking-[0.2em]" />
+              <th className="py-1 pr-3 font-sans text-[10px] uppercase tracking-[0.2em]">HTTP</th>
+              <th className="py-1 font-sans text-[10px] uppercase tracking-[0.2em]" />
             </tr>
           </thead>
           <tbody>
@@ -5440,7 +5442,7 @@ function DeliveryRow({
     <>
       <tr className="border-b border-border last:border-0">
         <td className="py-1.5 pr-3 text-muted">{new Date(delivery.createdAt).toLocaleString()}</td>
-        <td className="py-1.5 pr-3 font-mono">{delivery.eventType}</td>
+        <td className="py-1.5 pr-3 font-sans">{delivery.eventType}</td>
         <td className="py-1.5 pr-3">
           <Chip tone={tone} dot>
             {delivery.status}
@@ -5470,7 +5472,7 @@ function DeliveryRow({
       {open && (
         <tr>
           <td colSpan={6} className="bg-surface-1 py-2 pr-3">
-            <div className="space-y-1 font-mono text-[11px] text-muted">
+            <div className="space-y-1 font-sans text-[11px] text-muted">
               <div>next attempt: {new Date(delivery.nextAttemptAt).toLocaleString()}</div>
               {delivery.deliveredAt && (
                 <div>delivered: {new Date(delivery.deliveredAt).toLocaleString()}</div>

--- a/apps/web/src/alerts/AlertsList.tsx
+++ b/apps/web/src/alerts/AlertsList.tsx
@@ -1,23 +1,26 @@
 import { Link, useNavigate } from "react-router-dom";
 import { useMe } from "../api.ts";
 import { RowMenu } from "../design/RowMenu.tsx";
-import { Btn, Chip, Tile } from "../design/ui.tsx";
+import {
+  Btn,
+  Chip,
+  DataList,
+  DataListCell,
+  DataListHeader,
+  DataListHeaderCell,
+  DataListRow,
+  PageHeader,
+} from "../design/ui.tsx";
 import { useAlerts, useDeleteAlert } from "./api.ts";
 import type { Alert } from "./types.ts";
 
 export function AlertsList() {
   const me = useMe();
   if (me.isLoading) {
-    return (
-      <div className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted">loading…</div>
-    );
+    return <div className="text-[12px] text-muted">Loading…</div>;
   }
   if (me.error || !me.data || !me.data.project) {
-    return (
-      <div className="font-mono text-[11px] text-danger">
-        error: {String(me.error ?? "no session")}
-      </div>
-    );
+    return <div className="text-[12px] text-danger">Error: {String(me.error ?? "no session")}</div>;
   }
   return <AlertsListInner projectId={me.data.project.id} />;
 }
@@ -33,60 +36,78 @@ function AlertsListInner({ projectId }: { projectId: string }) {
 
   return (
     <div className="flex flex-col gap-6">
-      <section className="flex items-center justify-between">
-        <h1 className="text-[20px] font-semibold tracking-tight text-fg">Alerts</h1>
-        <Btn onClick={() => navigate("/alerts/new")}>+ new alert</Btn>
-      </section>
+      <PageHeader
+        title="Alerts"
+        description="Turn important telemetry thresholds into focused, actionable notifications."
+        actions={<Btn onClick={() => navigate("/alerts/new")}>New alert</Btn>}
+      />
 
-      <Tile padded={false}>
+      <DataList label="Alert rules">
+        <DataListHeader className="grid grid-cols-[minmax(0,1fr)_auto_28px] items-center gap-4 sm:grid-cols-[minmax(0,1.4fr)_auto_minmax(100px,.7fr)_28px] lg:grid-cols-[minmax(0,1.4fr)_auto_minmax(100px,.7fr)_minmax(150px,1fr)_minmax(130px,.9fr)_28px]">
+          <DataListHeaderCell>Name</DataListHeaderCell>
+          <DataListHeaderCell>Status</DataListHeaderCell>
+          <DataListHeaderCell className="hidden sm:block">Source</DataListHeaderCell>
+          <DataListHeaderCell className="hidden lg:block">Condition</DataListHeaderCell>
+          <DataListHeaderCell className="hidden lg:block">Last evaluated</DataListHeaderCell>
+          <DataListHeaderCell ariaLabel="Actions" />
+        </DataListHeader>
         {list.isLoading && (
-          <div className="px-5 py-8 text-center font-mono text-[11px] text-subtle">loading…</div>
+          <div className="px-5 py-8 text-center text-[12px] text-subtle">Loading…</div>
         )}
         {list.data && list.data.length === 0 && (
           <div className="px-5 py-12 text-center">
-            <div className="font-mono text-[11px] text-subtle">no alerts yet</div>
+            <div className="text-[12px] text-subtle">No alerts yet</div>
             <div className="mt-3">
               <Btn variant="secondary" size="sm" onClick={() => navigate("/alerts/new")}>
-                + create your first alert
+                Create your first alert
               </Btn>
             </div>
           </div>
         )}
         {list.data?.map((a) => (
-          <div
+          <DataListRow
             key={a.id}
-            className="flex items-center gap-4 border-b border-border px-5 py-3 last:border-b-0 hover:bg-surface-2"
+            className="grid grid-cols-[minmax(0,1fr)_auto_28px] items-center gap-4 sm:grid-cols-[minmax(0,1.4fr)_auto_minmax(100px,.7fr)_28px] lg:grid-cols-[minmax(0,1.4fr)_auto_minmax(100px,.7fr)_minmax(150px,1fr)_minmax(130px,.9fr)_28px]"
           >
-            <Link to={`/alerts/${a.id}`} className="flex-1 text-[13px] text-fg hover:underline">
-              {a.name}
-            </Link>
-            <Chip tone={a.enabled ? "accent" : "neutral"}>
-              {a.enabled ? "enabled" : "disabled"}
-            </Chip>
-            <span className="font-mono text-[11px] text-muted">
+            <DataListCell className="min-w-0">
+              <Link
+                to={`/alerts/${a.id}`}
+                className="block truncate text-[13px] font-medium text-fg hover:underline"
+              >
+                {a.name}
+              </Link>
+            </DataListCell>
+            <DataListCell>
+              <Chip tone={a.enabled ? "accent" : "neutral"}>
+                {a.enabled ? "enabled" : "disabled"}
+              </Chip>
+            </DataListCell>
+            <DataListCell className="hidden truncate text-[11px] text-muted sm:block">
               {a.source}
               {a.source === "metric" && a.metricName ? ` · ${a.metricName}` : ""}
-            </span>
-            <span className="font-mono text-[11px] text-muted">
+            </DataListCell>
+            <DataListCell className="hidden truncate text-[11px] text-muted lg:block">
               {a.aggregation} {comparatorOp(a.comparator)} {a.threshold}
-            </span>
-            <span className="font-mono text-[10px] tabular-nums text-subtle">
+            </DataListCell>
+            <DataListCell className="hidden truncate text-[10px] tabular-nums text-subtle lg:block">
               {a.lastEvaluatedAt ? new Date(a.lastEvaluatedAt).toLocaleString() : "never run"}
-            </span>
-            <RowMenu
-              items={[
-                {
-                  label: "Delete",
-                  danger: true,
-                  onClick: () => {
-                    if (confirm(`delete "${a.name}"?`)) remove.mutate(a.id);
+            </DataListCell>
+            <DataListCell>
+              <RowMenu
+                items={[
+                  {
+                    label: "Delete",
+                    danger: true,
+                    onClick: () => {
+                      if (confirm(`delete "${a.name}"?`)) remove.mutate(a.id);
+                    },
                   },
-                },
-              ]}
-            />
-          </div>
+                ]}
+              />
+            </DataListCell>
+          </DataListRow>
         ))}
-      </Tile>
+      </DataList>
     </div>
   );
 }

--- a/apps/web/src/dashboards/DashboardsList.tsx
+++ b/apps/web/src/dashboards/DashboardsList.tsx
@@ -1,7 +1,15 @@
 import { Link, useNavigate } from "react-router-dom";
 import { useMe } from "../api.ts";
 import { RowMenu } from "../design/RowMenu.tsx";
-import { Btn, Tile } from "../design/ui.tsx";
+import {
+  Btn,
+  DataList,
+  DataListCell,
+  DataListHeader,
+  DataListHeaderCell,
+  DataListRow,
+  PageHeader,
+} from "../design/ui.tsx";
 import { useCreateDashboard, useDashboards, useDeleteDashboard } from "./api.ts";
 
 const RANDOM_NAMES = [
@@ -18,16 +26,10 @@ function randomName() {
 export function DashboardsList() {
   const me = useMe();
   if (me.isLoading) {
-    return (
-      <div className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted">loading…</div>
-    );
+    return <div className="text-[12px] text-muted">Loading…</div>;
   }
   if (me.error || !me.data || !me.data.project) {
-    return (
-      <div className="font-mono text-[11px] text-danger">
-        error: {String(me.error ?? "no session")}
-      </div>
-    );
+    return <div className="text-[12px] text-danger">Error: {String(me.error ?? "no session")}</div>;
   }
   return <DashboardsListInner projectId={me.data.project.id} />;
 }
@@ -45,52 +47,67 @@ function DashboardsListInner({ projectId }: { projectId: string }) {
 
   return (
     <div className="flex flex-col gap-6">
-      <section className="flex items-center justify-between">
-        <h1 className="text-[20px] font-semibold tracking-tight text-fg">Dashboards</h1>
-        <Btn onClick={handleCreate} loading={create.isPending}>
-          + new dashboard
-        </Btn>
-      </section>
+      <PageHeader
+        title="Dashboards"
+        description="Compose durable views of the signals your team returns to every day."
+        actions={
+          <Btn onClick={handleCreate} loading={create.isPending}>
+            New dashboard
+          </Btn>
+        }
+      />
 
-      <Tile padded={false}>
+      <DataList label="Dashboards">
+        <DataListHeader className="grid grid-cols-[minmax(0,1fr)_auto_28px] items-center gap-4">
+          <DataListHeaderCell>Name</DataListHeaderCell>
+          <DataListHeaderCell>Last updated</DataListHeaderCell>
+          <DataListHeaderCell ariaLabel="Actions" />
+        </DataListHeader>
         {list.isLoading && (
-          <div className="px-5 py-8 text-center font-mono text-[11px] text-subtle">loading…</div>
+          <div className="px-5 py-8 text-center text-[12px] text-subtle">Loading…</div>
         )}
         {list.data && list.data.length === 0 && (
           <div className="px-5 py-12 text-center">
-            <div className="font-mono text-[11px] text-subtle">no dashboards yet</div>
+            <div className="text-[12px] text-subtle">No dashboards yet</div>
             <div className="mt-3">
               <Btn variant="secondary" size="sm" onClick={handleCreate} loading={create.isPending}>
-                + create your first dashboard
+                Create your first dashboard
               </Btn>
             </div>
           </div>
         )}
         {list.data?.map((d) => (
-          <div
+          <DataListRow
             key={d.id}
-            className="flex items-center justify-between border-b border-border px-5 py-3 last:border-b-0 hover:bg-surface-2"
+            className="grid grid-cols-[minmax(0,1fr)_auto_28px] items-center gap-4"
           >
-            <Link to={`/dashboards/${d.id}`} className="flex-1 text-[13px] text-fg hover:underline">
-              {d.name}
-            </Link>
-            <span className="mr-4 font-mono text-[10px] tabular-nums text-subtle">
+            <DataListCell className="min-w-0">
+              <Link
+                to={`/dashboards/${d.id}`}
+                className="block truncate text-[13px] font-medium text-fg hover:underline"
+              >
+                {d.name}
+              </Link>
+            </DataListCell>
+            <DataListCell className="text-[10px] tabular-nums text-subtle">
               updated {new Date(d.updatedAt).toLocaleString()}
-            </span>
-            <RowMenu
-              items={[
-                {
-                  label: "Delete",
-                  danger: true,
-                  onClick: () => {
-                    if (confirm(`delete "${d.name}"?`)) remove.mutate(d.id);
+            </DataListCell>
+            <DataListCell>
+              <RowMenu
+                items={[
+                  {
+                    label: "Delete",
+                    danger: true,
+                    onClick: () => {
+                      if (confirm(`delete "${d.name}"?`)) remove.mutate(d.id);
+                    },
                   },
-                },
-              ]}
-            />
-          </div>
+                ]}
+              />
+            </DataListCell>
+          </DataListRow>
         ))}
-      </Tile>
+      </DataList>
     </div>
   );
 }

--- a/apps/web/src/design/DataList.test.tsx
+++ b/apps/web/src/design/DataList.test.tsx
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DataList, DataListCell, DataListHeader, DataListHeaderCell, DataListRow } from "./ui.tsx";
+
+test("dense lists expose table structure without introducing a second visual language", () => {
+  const html = renderToStaticMarkup(
+    <DataList label="Alert rules">
+      <DataListHeader>
+        <DataListHeaderCell>Name</DataListHeaderCell>
+        <DataListHeaderCell>Status</DataListHeaderCell>
+      </DataListHeader>
+      <DataListRow>
+        <DataListCell>Checkout latency</DataListCell>
+        <DataListCell>Enabled</DataListCell>
+      </DataListRow>
+    </DataList>,
+  );
+
+  assert.match(html, /role="table"/);
+  assert.match(html, /aria-label="Alert rules"/);
+  assert.match(html, /role="columnheader"/);
+  assert.match(html, /role="row"/);
+  assert.doesNotMatch(html, /font-mono|uppercase/);
+});

--- a/apps/web/src/design/DesignLanguage.test.tsx
+++ b/apps/web/src/design/DesignLanguage.test.tsx
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { DesignLanguage } from "./DesignLanguage.tsx";
+
+test("the design catalog presents the quiet operational interface language", () => {
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <DesignLanguage />
+    </MemoryRouter>,
+  );
+
+  assert.match(html, /A quiet interface.*for noisy systems/s);
+  assert.match(html, /Dense data, clear hierarchy/);
+  assert.match(html, /Operational palette/);
+  assert.match(html, /<aside/);
+  assert.doesNotMatch(html, /font-mono/);
+
+  const sidebar = html.match(/<aside.*?<\/aside>/s)?.[0] ?? "";
+  assert.doesNotMatch(sidebar, />0[1-9]</);
+});
+
+test("the dark operational surfaces use the deeper palette without changing light mode", async () => {
+  const css = await readFile(new URL("../index.css", import.meta.url), "utf8");
+
+  assert.match(css, /--color-bg-rgb:\s*18 18 18/);
+  assert.match(css, /--color-surface-rgb:\s*23 23 23/);
+  assert.match(css, /--color-surface-2-rgb:\s*28 28 28/);
+  assert.match(css, /--color-surface-3-rgb:\s*35 35 35/);
+  assert.match(css, /:root\[data-theme="light"\][\s\S]*--color-bg-rgb:\s*245 245 245/);
+});

--- a/apps/web/src/design/DesignLanguage.tsx
+++ b/apps/web/src/design/DesignLanguage.tsx
@@ -3,432 +3,414 @@ import { Dropdown, type DropdownOption } from "./Dropdown.tsx";
 import {
   Btn,
   Chip,
+  DataList,
+  DataListCell,
+  DataListHeader,
+  DataListHeaderCell,
+  DataListRow,
+  Input,
   OutOfCreditsBadge,
   OutOfCreditsBanner,
+  PageHeader,
+  SearchInput,
   Tabs,
   ThemeToggle,
   Tile,
   Wordmark,
 } from "./ui.tsx";
 
-// ---------------------------------------------------------------------------
-// Design Language — /design
-//
-// The living design sheet: a focused catalog of the canonical primitives and
-// tokens. Cobalt accent · soft corners · eight-pixel rhythm · capitalized sans
-// labels (no mono caps). Each section renders one component family straight from
-// the shared home (ui.tsx / Dropdown.tsx) so the page and the app can't drift.
-//
-// This page is paired with the written contract in apps/web/DESIGN.md — change a
-// primitive or token and you MUST update both the component and its panel here.
-// Keep it lean: a component catalog, not a page gallery.
-// ---------------------------------------------------------------------------
+// The living system sheet for the real primitives shipped by the product.
+// It intentionally reads like an operational workspace: quiet chrome, dense
+// data, hairline structure, and color reserved for state and selection.
 
-const SECTIONS = [
-  { id: "tokens", label: "Tokens" },
-  { id: "card", label: "Card" },
-  { id: "buttons", label: "Buttons" },
-  { id: "dropdowns", label: "Dropdowns" },
-  { id: "tabs", label: "Tabs" },
-  { id: "chips", label: "Chips" },
-  { id: "callouts", label: "Callouts" },
+const NAV_GROUPS = [
+  {
+    label: "Foundation",
+    items: [
+      { id: "overview", label: "Overview" },
+      { id: "tokens", label: "Tokens" },
+      { id: "typography", label: "Typography" },
+    ],
+  },
+  {
+    label: "Patterns",
+    items: [
+      { id: "actions", label: "Actions & fields" },
+      { id: "selection", label: "Selection" },
+      { id: "data", label: "Data display" },
+      { id: "feedback", label: "Feedback" },
+    ],
+  },
 ];
 
 export function DesignLanguage() {
   return (
-    <div className="relative min-h-screen bg-bg font-sans text-fg">
-      <TopNav />
-      <main className="mx-auto max-w-6xl px-6 pb-32">
-        <Hero />
-
-        <Section id="tokens" title="Tokens" subtitle="Color, type, space & radius.">
-          <ColorBento />
-          <div className="mt-3">
-            <TypeBento />
-          </div>
-          <div className="mt-3">
-            <SpaceBento />
-          </div>
-        </Section>
-
-        <Section id="card" title="Card" subtitle="Surface, border, metric.">
-          <CardBento />
-        </Section>
-
-        <Section id="buttons" title="Buttons" subtitle="Primary, secondary, ghost, danger.">
-          <ButtonsBento />
-        </Section>
-
-        <Section id="dropdowns" title="Dropdowns" subtitle="Themed single-select menu.">
-          <DropdownsBento />
-        </Section>
-
-        <Section id="tabs" title="Tabs" subtitle="Segmented view switch.">
-          <TabsBento />
-        </Section>
-
-        <Section
-          id="chips"
-          title="Chips"
-          subtitle="Fully-rounded sans pills; six tones, or a bare dot + label for status."
-        >
-          <ChipsBento />
-        </Section>
-
-        <Section
-          id="callouts"
-          title="Callouts"
-          subtitle="Out-of-credits status chip & banner."
-        >
-          <CalloutsBento />
-        </Section>
-
-        <Footer />
-      </main>
+    <div className="min-h-screen bg-bg font-sans text-fg">
+      <Sidebar />
+      <div className="md:pl-56">
+        <TopBar />
+        <main className="mx-auto max-w-[1180px] px-5 pb-28 sm:px-8 lg:px-12">
+          <Hero />
+          <Overview />
+          <Tokens />
+          <Typography />
+          <Actions />
+          <Selection />
+          <DataDisplay />
+          <Feedback />
+          <Footer />
+        </main>
+      </div>
     </div>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Shared label helpers — capitalized sans, never mono caps
-// ---------------------------------------------------------------------------
-
-function PanelLabel({ children }: { children: ReactNode }) {
-  return <div className="mb-4 text-[13px] font-medium text-muted">{children}</div>;
-}
-
-function FieldName({ children }: { children: ReactNode }) {
-  return <div className="mb-2 text-[13px] font-medium text-muted">{children}</div>;
-}
-
-// ---------------------------------------------------------------------------
-// Chrome
-// ---------------------------------------------------------------------------
-
-function TopNav() {
+function Sidebar() {
   return (
-    <header className="sticky top-0 z-10 bg-bg/80 backdrop-blur">
-      <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-        <div className="flex items-center gap-3">
-          <Wordmark size="sm" />
-          <span className="h-4 w-px bg-border-strong" />
-          <span className="text-[13px] font-medium text-muted">Design system</span>
+    <aside className="fixed inset-y-0 left-0 z-20 hidden w-56 flex-col border-r border-border bg-surface/55 px-4 py-5 backdrop-blur md:flex">
+      <div className="px-2">
+        <Wordmark size="sm" />
+        <div className="mt-4 flex items-center gap-2 text-[12px] text-muted">
+          <span className="h-1.5 w-1.5 rounded-full bg-success" />
+          Interface system
         </div>
-        <nav className="hidden items-center gap-7 md:flex">
-          {SECTIONS.map((s) => (
-            <a
-              key={s.id}
-              href={`#${s.id}`}
-              className="text-[13px] font-medium text-muted transition-colors hover:text-fg"
-            >
-              {s.label}
-            </a>
-          ))}
-        </nav>
-        <ThemeToggle />
       </div>
-      <div className="h-px bg-border" />
+
+      <nav aria-label="Design language sections" className="mt-10 space-y-7">
+        {NAV_GROUPS.map((group) => (
+          <div key={group.label}>
+            <div className="px-2 text-[11px] font-medium text-subtle">{group.label}</div>
+            <div className="mt-2 space-y-0.5">
+              {group.items.map((item, index) => (
+                <a
+                  key={item.id}
+                  href={`#${item.id}`}
+                  className={`flex items-center justify-between rounded-md px-2 py-1.5 text-[13px] transition-colors hover:bg-surface-2 hover:text-fg ${
+                    group.label === "Foundation" && index === 0
+                      ? "bg-surface-3 text-fg"
+                      : "text-muted"
+                  }`}
+                >
+                  {item.label}
+                </a>
+              ))}
+            </div>
+          </div>
+        ))}
+      </nav>
+
+      <div className="mt-auto border-t border-border px-2 pt-4">
+        <div className="flex items-center justify-between text-[11px] text-subtle">
+          <span>Superlog UI</span>
+          <span className="font-sans">v2.0</span>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function TopBar() {
+  return (
+    <header className="sticky top-0 z-10 border-b border-border bg-bg/90 backdrop-blur-md">
+      <div className="flex h-14 items-center justify-between px-5 sm:px-8 lg:px-12">
+        <div className="flex items-center gap-2 text-[12px] text-muted">
+          <span className="md:hidden">
+            <Wordmark size="sm" />
+          </span>
+          <span className="hidden md:inline">Library</span>
+          <span className="hidden text-subtle md:inline">/</span>
+          <span className="hidden text-fg md:inline">Design language</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="hidden h-7 w-44 items-center justify-between rounded-md border border-border bg-surface px-2.5 text-[11px] text-subtle sm:flex">
+            <span>Search components…</span>
+            <span className="font-sans">⌘K</span>
+          </div>
+          <ThemeToggle />
+        </div>
+      </div>
     </header>
   );
 }
 
 function Hero() {
   return (
-    <section className="py-20 text-center">
-      <span className="text-[13px] font-medium tracking-tight text-accent">House style</span>
-      <h1
-        className="mx-auto mt-5 max-w-2xl text-balance text-[2.25rem] leading-[1.02] tracking-tight text-fg md:text-[3rem]"
-        style={{ fontWeight: 460 }}
-      >
-        Canonical components,
-        <br />
-        one source of truth.
-      </h1>
-      <p className="mx-auto mt-5 max-w-md text-[14px] leading-relaxed text-muted">
-        Every primitive on this page is imported from the same modules the product ships — change it
-        here and it changes everywhere.
-      </p>
-    </section>
-  );
-}
-
-function Section({
-  id,
-  title,
-  subtitle,
-  children,
-}: {
-  id: string;
-  title: string;
-  subtitle: string;
-  children: ReactNode;
-}) {
-  return (
-    <section id={id} className="mt-24 scroll-mt-24">
-      <header className="mb-6 flex items-baseline gap-4">
-        <h2 className="text-[26px] font-semibold tracking-tight text-fg md:text-[30px]">{title}</h2>
-        <p className="text-[13px] text-muted">{subtitle}</p>
-      </header>
-      {children}
-    </section>
-  );
-}
-
-function Footer() {
-  return (
-    <footer className="mt-28 flex items-center justify-between border-t border-border pt-6">
-      <span className="text-[13px] text-subtle">Superlog · Design language</span>
-      <span className="text-[13px] text-subtle">Sourced from ui.tsx and Dropdown.tsx</span>
-    </footer>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// 01 — Tokens
-// ---------------------------------------------------------------------------
-
-function Swatch({ name, hex, className }: { name: string; hex: string; className: string }) {
-  return (
-    <div>
-      <div
-        className={`h-14 w-full rounded-md ${className}`}
-        style={{ boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.06)" }}
-      />
-      <div className="mt-2 text-[13px] font-medium text-fg">{name}</div>
-      <div className="font-mono text-[11px] tabular-nums text-subtle">{hex}</div>
-    </div>
-  );
-}
-
-function ColorBento() {
-  return (
-    <div className="grid grid-cols-12 gap-3">
-      <Tile className="col-span-12 md:col-span-5">
-        <PanelLabel>Accent</PanelLabel>
-        <div
-          className="h-24 w-full rounded-md bg-accent"
-          style={{ boxShadow: "0 0 40px -8px rgba(72,90,226,0.5)" }}
-        />
-        <div className="mt-3 flex items-baseline justify-between">
-          <span className="text-[13px] font-medium text-fg">Accent</span>
-          <span className="font-mono text-[11px] tabular-nums text-subtle">#485AE2</span>
+    <section className="pb-14 pt-16 sm:pb-16 sm:pt-24">
+      <div className="max-w-3xl">
+        <div className="mb-5 flex items-center gap-2 text-[12px] font-medium text-accent">
+          <span className="h-px w-5 bg-accent" />
+          Superlog interface system
         </div>
-        <p className="mt-1 text-[13px] leading-relaxed text-muted">
-          The single action color. One intense moment against calm surfaces.
-        </p>
-      </Tile>
-
-      <Tile className="col-span-12 md:col-span-7">
-        <PanelLabel>Surfaces</PanelLabel>
-        <div className="grid grid-cols-4 gap-2">
-          <Swatch name="Background" hex="#141414" className="bg-bg" />
-          <Swatch name="Surface" hex="#1C1C1E" className="bg-surface" />
-          <Swatch name="Surface 2" hex="#232325" className="bg-surface-2" />
-          <Swatch name="Surface 3" hex="#2B2B2E" className="bg-surface-3" />
-        </div>
-      </Tile>
-
-      <Tile className="col-span-12 md:col-span-7">
-        <PanelLabel>Ink</PanelLabel>
-        <div className="space-y-2.5">
-          {[
-            { name: "Primary", hex: "#F5F5F6", cls: "text-fg" },
-            { name: "Secondary", hex: "#8A8A8F", cls: "text-muted" },
-            { name: "Tertiary", hex: "#5A5A60", cls: "text-subtle" },
-          ].map((i) => (
-            <div key={i.name} className="flex items-baseline justify-between">
-              <span className={`text-[15px] font-medium ${i.cls}`}>{i.name} text</span>
-              <span className="font-mono text-[11px] tabular-nums text-subtle">{i.hex}</span>
-            </div>
-          ))}
-        </div>
-      </Tile>
-
-      <Tile className="col-span-12 md:col-span-5">
-        <PanelLabel>Signal</PanelLabel>
-        <div className="grid grid-cols-3 gap-3">
-          <Swatch name="Success" hex="#41D195" className="bg-success" />
-          <Swatch name="Warning" hex="#E7B15A" className="bg-warning" />
-          <Swatch name="Danger" hex="#EF5A6F" className="bg-danger" />
-        </div>
-      </Tile>
-    </div>
-  );
-}
-
-function TypeBento() {
-  return (
-    <div className="grid grid-cols-12 gap-3">
-      <Tile className="col-span-12 md:col-span-8">
-        <PanelLabel>Display · Inter</PanelLabel>
-        <div className="text-[64px] font-medium leading-[0.95] tracking-tightest text-fg">
-          Signals in,
+        <h1 className="text-balance text-[44px] font-semibold leading-[0.98] tracking-tightest text-fg sm:text-[64px] lg:text-[72px]">
+          A quiet interface
           <br />
-          fixes out.
-        </div>
-      </Tile>
-      <Tile className="col-span-12 md:col-span-4">
-        <PanelLabel>Scale</PanelLabel>
-        <div className="space-y-2.5">
-          {[
-            { name: "Display", size: 64, weight: 500 },
-            { name: "Heading 1", size: 30, weight: 600 },
-            { name: "Heading 2", size: 20, weight: 600 },
-            { name: "Body", size: 14, weight: 400 },
-            { name: "Small", size: 12, weight: 400 },
-            { name: "Mono", size: 11, weight: 500 },
-          ].map((t) => (
-            <div
-              key={t.name}
-              className="flex items-baseline justify-between border-b border-border pb-2 last:border-0"
-            >
-              <span className="text-[13px] text-muted">{t.name}</span>
-              <span className="font-mono text-[11px] tabular-nums text-subtle">
-                {t.size}px · {t.weight}
-              </span>
-            </div>
-          ))}
-        </div>
-      </Tile>
-    </div>
-  );
-}
-
-const spaceSteps = [4, 8, 12, 16, 24, 32, 48, 64];
-// Mirrors the borderRadius scale in tailwind.config.ts — keep in sync.
-const radiusSteps = [
-  { name: "Small", px: 2 },
-  { name: "Base", px: 4 },
-  { name: "Medium", px: 6 },
-  { name: "Large", px: 10 },
-  { name: "XL", px: 12 },
-  { name: "2XL", px: 14 },
-];
-
-function SpaceBento() {
-  return (
-    <div className="grid grid-cols-12 gap-3">
-      <Tile className="col-span-12 md:col-span-8">
-        <PanelLabel>Spacing · 8-pixel grid</PanelLabel>
-        <div className="space-y-2.5">
-          {spaceSteps.map((s) => (
-            <div key={s} className="flex items-center gap-4">
-              <span className="w-10 font-mono text-[11px] tabular-nums text-subtle">{s}px</span>
-              <span className="h-2.5 rounded-sm bg-accent/70" style={{ width: `${s * 4}px` }} />
-            </div>
-          ))}
-        </div>
-      </Tile>
-      <Tile className="col-span-12 md:col-span-4">
-        <PanelLabel>Radius</PanelLabel>
-        <div className="grid grid-cols-3 gap-3">
-          {radiusSteps.map((r) => (
-            <div key={r.name} className="flex flex-col items-center gap-2">
-              <div
-                className="h-12 w-12 bg-surface-3"
-                style={{
-                  borderRadius: `${r.px}px`,
-                  boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.08)",
-                }}
-              />
-              <div className="text-[12px] text-muted">{r.name}</div>
-              <div className="font-mono text-[11px] tabular-nums text-subtle">{r.px}px</div>
-            </div>
-          ))}
-        </div>
-      </Tile>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// 02 — Card
-// ---------------------------------------------------------------------------
-
-function StatCard({
-  label,
-  value,
-  unit,
-  className = "",
-}: {
-  label: string;
-  value: string;
-  unit: string;
-  className?: string;
-}) {
-  return (
-    <Tile className={className}>
-      <span className="text-[13px] font-medium text-muted">{label}</span>
-      <div className="mt-3 flex items-baseline gap-1.5">
-        <span className="text-4xl font-semibold tabular-nums tracking-tight text-fg">{value}</span>
-        <span className="text-[12px] text-subtle">{unit}</span>
-      </div>
-    </Tile>
-  );
-}
-
-function CardBento() {
-  return (
-    <div className="grid grid-cols-12 gap-3">
-      <Tile className="col-span-12 md:col-span-6">
-        <PanelLabel>Content card</PanelLabel>
-        <h3 className="text-[16px] font-semibold tracking-tight text-fg">Checkout latency</h3>
-        <p className="mt-1.5 text-[13px] leading-relaxed text-muted">
-          A plain <code className="font-mono text-fg">Tile</code> — bordered surface, soft radius,
-          consistent padding. Compose anything inside it.
+          for noisy systems.
+        </h1>
+        <p className="mt-6 max-w-xl text-[15px] leading-7 text-muted">
+          Operational software should make dense information feel calm. Structure comes from spacing
+          and hairlines; color appears only when it carries meaning.
         </p>
-        <div className="mt-4 flex gap-2">
-          <Btn size="sm">Open</Btn>
-          <Btn size="sm" variant="ghost">
-            Dismiss
+        <div className="mt-8 flex flex-wrap gap-2">
+          <Btn size="lg">
+            Browse components <span aria-hidden>→</span>
+          </Btn>
+          <Btn size="lg" variant="secondary">
+            Read the principles
           </Btn>
         </div>
-      </Tile>
-      <StatCard className="col-span-6 md:col-span-3" label="p99 latency" value="284" unit="ms" />
-      <StatCard className="col-span-6 md:col-span-3" label="Error rate" value="1.82" unit="%" />
-    </div>
+      </div>
+
+      <div className="mt-16 grid border-y border-border sm:grid-cols-2 lg:grid-cols-4">
+        {[
+          ["07", "core primitives"],
+          ["08px", "spacing rhythm"],
+          ["AA", "contrast target"],
+          ["01", "action accent"],
+        ].map(([value, label], index) => (
+          <div
+            key={label}
+            className={`py-5 sm:px-5 ${index > 0 ? "sm:border-l sm:border-border" : ""}`}
+          >
+            <span className="font-sans text-[20px] font-semibold tabular-nums text-fg">
+              {value}
+            </span>
+            <span className="ml-2 text-[12px] text-subtle">{label}</span>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }
 
-// ---------------------------------------------------------------------------
-// 03 — Buttons
-// ---------------------------------------------------------------------------
-
-function ButtonsBento() {
+function SectionHeading({
+  number,
+  title,
+  copy,
+}: {
+  number: string;
+  title: string;
+  copy: string;
+}) {
   return (
-    <div className="grid grid-cols-12 gap-3">
-      <Tile className="col-span-12 md:col-span-7">
-        <PanelLabel>Variants</PanelLabel>
-        <div className="flex flex-wrap gap-2.5">
-          <Btn variant="primary">Deploy agent</Btn>
-          <Btn variant="secondary">Preview</Btn>
-          <Btn variant="ghost">Cancel</Btn>
-          <Btn variant="danger">Delete project</Btn>
+    <header className="mb-6 grid gap-3 border-t border-border pt-5 sm:grid-cols-[1fr_1fr] sm:items-end">
+      <div className="flex items-baseline gap-3">
+        <span className="font-sans text-[11px] tabular-nums text-subtle">{number}</span>
+        <h2 className="text-[25px] font-semibold tracking-tight text-fg">{title}</h2>
+      </div>
+      <p className="max-w-md text-[13px] leading-6 text-muted sm:justify-self-end">{copy}</p>
+    </header>
+  );
+}
+
+function Overview() {
+  const principles = [
+    {
+      title: "Dense data, clear hierarchy",
+      copy: "Keep telemetry close together, then separate meaning with type, alignment, and rhythm.",
+      preview: <DensityPreview />,
+    },
+    {
+      title: "Quiet by default",
+      copy: "Surfaces differ by a few points. Hairlines do the work that shadows usually try to do.",
+      preview: <SurfacePreview />,
+    },
+    {
+      title: "Color carries state",
+      copy: "Blue selects. Green confirms. Amber warns. Red interrupts. Everything else stays neutral.",
+      preview: <StatePreview />,
+    },
+  ];
+
+  return (
+    <section id="overview" className="scroll-mt-20 pb-24">
+      <SectionHeading
+        number="01"
+        title="Principles"
+        copy="A system for observability work: information-rich, low-glare, and precise without feeling clinical."
+      />
+      <div className="grid gap-3 lg:grid-cols-3">
+        {principles.map((principle) => (
+          <Tile key={principle.title} className="overflow-hidden" padded={false}>
+            <div className="h-36 border-b border-border bg-bg/35 p-5">{principle.preview}</div>
+            <div className="p-5">
+              <h3 className="text-[15px] font-medium text-fg">{principle.title}</h3>
+              <p className="mt-2 text-[13px] leading-5 text-muted">{principle.copy}</p>
+            </div>
+          </Tile>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function DensityPreview() {
+  return (
+    <div className="overflow-hidden rounded-md border border-border bg-surface">
+      {["checkout-api", "billing-worker", "edge-proxy"].map((service, index) => (
+        <div
+          key={service}
+          className="flex items-center border-b border-border px-3 py-2 last:border-0"
+        >
+          <span className="w-5 font-sans text-[10px] text-subtle">0{index + 1}</span>
+          <span className="flex-1 text-[11px] text-muted">{service}</span>
+          <span className="font-sans text-[10px] tabular-nums text-fg">
+            {[128, 84, 211][index]}ms
+          </span>
         </div>
-      </Tile>
-      <Tile className="col-span-12 md:col-span-5">
-        <PanelLabel>Sizes</PanelLabel>
-        <div className="flex flex-wrap items-center gap-2.5">
-          <Btn size="sm">Small</Btn>
-          <Btn>Medium</Btn>
-          <Btn size="lg">Large</Btn>
-        </div>
-      </Tile>
-      <Tile className="col-span-12">
-        <PanelLabel>States</PanelLabel>
-        <div className="flex flex-wrap items-center gap-2.5">
-          <Btn>Default</Btn>
-          <Btn disabled>Disabled</Btn>
-          <Btn loading>Loading</Btn>
-        </div>
-      </Tile>
+      ))}
     </div>
   );
 }
 
-// ---------------------------------------------------------------------------
-// 04 — Dropdowns
-// ---------------------------------------------------------------------------
+function SurfacePreview() {
+  return (
+    <div className="relative h-full">
+      <div className="absolute inset-x-7 inset-y-2 rounded-lg border border-border bg-surface-3" />
+      <div className="absolute inset-x-3 inset-y-5 rounded-lg border border-border bg-surface-2" />
+      <div className="absolute inset-x-0 inset-y-8 flex items-center justify-center rounded-lg border border-border bg-surface text-[11px] text-muted">
+        structure, not shadow
+      </div>
+    </div>
+  );
+}
+
+function StatePreview() {
+  return (
+    <div className="grid h-full grid-cols-2 gap-2">
+      {[
+        ["Selected", "bg-accent", "text-accent"],
+        ["Healthy", "bg-success", "text-success"],
+        ["Degraded", "bg-warning", "text-warning"],
+        ["Failed", "bg-danger", "text-danger"],
+      ].map(([label, dot, text]) => (
+        <div
+          key={label}
+          className="flex items-center rounded-md border border-border bg-surface px-3"
+        >
+          <span className={`mr-2 h-1.5 w-1.5 rounded-full ${dot}`} />
+          <span className={`text-[11px] ${text}`}>{label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const SWATCHES = [
+  { name: "Canvas", value: "#171717", className: "bg-bg" },
+  { name: "Surface", value: "#1D1D1D", className: "bg-surface" },
+  { name: "Raised", value: "#222222", className: "bg-surface-2" },
+  { name: "Selected", value: "#2B2B2B", className: "bg-surface-3" },
+  { name: "Primary ink", value: "#DCDCDC", className: "bg-fg" },
+  { name: "Muted ink", value: "#8C8C8C", className: "bg-muted" },
+];
+
+function Tokens() {
+  return (
+    <section id="tokens" className="scroll-mt-20 pb-24">
+      <SectionHeading
+        number="02"
+        title="Operational palette"
+        copy="Near-black layers carry the interface. Muted, slightly desaturated signals stay legible without glowing."
+      />
+      <div className="grid gap-3 lg:grid-cols-[1.45fr_1fr]">
+        <Tile>
+          <PanelLabel>Neutral foundation</PanelLabel>
+          <div className="grid grid-cols-2 gap-x-3 gap-y-5 sm:grid-cols-3">
+            {SWATCHES.map((swatch) => (
+              <div key={swatch.name}>
+                <div className={`h-16 rounded-md border border-border ${swatch.className}`} />
+                <div className="mt-2 flex items-baseline justify-between gap-2">
+                  <span className="text-[11px] text-muted">{swatch.name}</span>
+                  <span className="font-sans text-[10px] tabular-nums text-subtle">
+                    {swatch.value}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </Tile>
+        <Tile>
+          <PanelLabel>Semantic signals</PanelLabel>
+          <div className="space-y-2">
+            {[
+              ["Selection", "#73B2DE", "bg-accent"],
+              ["Healthy", "#7FC797", "bg-success"],
+              ["Attention", "#C99D66", "bg-warning"],
+              ["Critical", "#D97178", "bg-danger"],
+            ].map(([name, value, fill]) => (
+              <div
+                key={name}
+                className="flex items-center rounded-md border border-border bg-bg/30 p-2.5"
+              >
+                <span className={`mr-3 h-7 w-7 rounded ${fill}`} />
+                <span className="flex-1 text-[12px] text-muted">{name}</span>
+                <span className="font-sans text-[10px] text-subtle">{value}</span>
+              </div>
+            ))}
+          </div>
+        </Tile>
+      </div>
+    </section>
+  );
+}
+
+function Typography() {
+  return (
+    <section id="typography" className="scroll-mt-20 pb-24">
+      <SectionHeading
+        number="03"
+        title="Typography & rhythm"
+        copy="One sans-serif family carries hierarchy, reading, identifiers, timing, and tabular values without changing visual voice."
+      />
+      <div className="grid gap-3 lg:grid-cols-[1.45fr_1fr]">
+        <Tile>
+          <PanelLabel>Display · Inter</PanelLabel>
+          <div className="mt-10 text-[42px] font-semibold leading-[0.98] tracking-tightest text-fg sm:text-[58px]">
+            Signals in,
+            <br />
+            clarity out.
+          </div>
+          <p className="mt-8 max-w-lg text-[14px] leading-6 text-muted">
+            Calm typography gives operational data room to breathe without making the interface feel
+            sparse.
+          </p>
+        </Tile>
+        <Tile>
+          <PanelLabel>Scale</PanelLabel>
+          <div className="divide-y divide-border">
+            {[
+              ["Display", "64 / 64", "Semibold"],
+              ["Title", "25 / 30", "Semibold"],
+              ["Body", "14 / 24", "Regular"],
+              ["Small", "12 / 18", "Regular"],
+              ["Data", "11 / 16", "Medium"],
+            ].map(([name, size, weight]) => (
+              <div key={name} className="grid grid-cols-[1fr_auto_auto] gap-4 py-3 text-[11px]">
+                <span className="text-muted">{name}</span>
+                <span className="font-sans text-subtle">{size}</span>
+                <span className="w-16 text-right text-subtle">{weight}</span>
+              </div>
+            ))}
+          </div>
+          <div className="mt-6 border-t border-border pt-5">
+            <PanelLabel>8px rhythm</PanelLabel>
+            <div className="flex items-end gap-2">
+              {[4, 8, 12, 16, 24, 32, 48].map((space) => (
+                <div key={space} className="flex flex-1 flex-col items-center gap-2">
+                  <span
+                    className="w-full rounded-sm bg-accent/55"
+                    style={{ height: `${space}px` }}
+                  />
+                  <span className="font-sans text-[9px] text-subtle">{space}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </Tile>
+      </div>
+    </section>
+  );
+}
 
 const ENV_OPTIONS: DropdownOption[] = [
   { value: "production", label: "production" },
@@ -436,155 +418,234 @@ const ENV_OPTIONS: DropdownOption[] = [
   { value: "preview", label: "preview" },
 ];
 
-const SERVICE_OPTIONS: DropdownOption[] = [
-  { value: "checkout-api", label: "checkout-api" },
-  { value: "cart-api", label: "cart-api" },
-  { value: "payments-worker", label: "payments-worker" },
-  { value: "auth", label: "auth" },
-  { value: "webhook-dispatcher", label: "webhook-dispatcher" },
-];
-
-function DropdownsBento() {
-  const [env, setEnv] = useState("production");
-  const [service, setService] = useState("checkout-api");
+function Actions() {
+  const [environment, setEnvironment] = useState("production");
   return (
-    <div className="grid grid-cols-12 gap-3">
-      <Tile className="col-span-12 md:col-span-4">
-        <PanelLabel>Short list</PanelLabel>
-        <FieldName>Environment</FieldName>
-        <Dropdown value={env} onChange={setEnv} options={ENV_OPTIONS} searchable={false} />
-      </Tile>
-      <Tile className="col-span-12 md:col-span-4">
-        <PanelLabel>Searchable</PanelLabel>
-        <FieldName>Service</FieldName>
-        <Dropdown value={service} onChange={setService} options={SERVICE_OPTIONS} />
-      </Tile>
-      <Tile className="col-span-12 md:col-span-4">
-        <PanelLabel>Disabled</PanelLabel>
-        <FieldName>Region</FieldName>
-        <Dropdown
-          value="us-east-1"
-          onChange={() => {}}
-          options={[{ value: "us-east-1", label: "us-east-1" }]}
-          disabled
-        />
-      </Tile>
-    </div>
+    <section id="actions" className="scroll-mt-20 pb-24">
+      <SectionHeading
+        number="04"
+        title="Actions & fields"
+        copy="Primary actions use neutral contrast. Blue remains available for selection and links instead of competing with every button."
+      />
+      <div className="grid gap-3 lg:grid-cols-2">
+        <Tile className="lg:col-span-2">
+          <PanelLabel>Page heading</PanelLabel>
+          <PageHeader
+            title="Explore"
+            description="Search and compare telemetry across the current project."
+            actions={<Btn>Save view</Btn>}
+          />
+        </Tile>
+        <Tile>
+          <PanelLabel>Buttons</PanelLabel>
+          <div className="flex flex-wrap items-center gap-2">
+            <Btn>Investigate</Btn>
+            <Btn variant="secondary">Open trace</Btn>
+            <Btn variant="ghost">Dismiss</Btn>
+            <Btn variant="danger">Delete</Btn>
+          </div>
+          <div className="mt-6 flex flex-wrap items-center gap-2 border-t border-border pt-5">
+            <Btn size="sm">Small</Btn>
+            <Btn>Medium</Btn>
+            <Btn size="lg">Large</Btn>
+            <Btn disabled>Disabled</Btn>
+          </div>
+        </Tile>
+        <Tile>
+          <PanelLabel>Fields</PanelLabel>
+          <div className="space-y-4">
+            <div>
+              <FieldName>Search telemetry</FieldName>
+              <SearchInput placeholder="service.name = checkout-api" />
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <FieldName>Project name</FieldName>
+                <Input defaultValue="Production" />
+              </div>
+              <div>
+                <FieldName>Environment</FieldName>
+                <Dropdown
+                  value={environment}
+                  onChange={setEnvironment}
+                  options={ENV_OPTIONS}
+                  searchable={false}
+                />
+              </div>
+            </div>
+          </div>
+        </Tile>
+      </div>
+    </section>
   );
 }
 
-// ---------------------------------------------------------------------------
-// 05 — Tabs
-// ---------------------------------------------------------------------------
+type View = "open" | "resolved" | "noise";
 
-type TabKey = "open" | "resolved" | "noise" | "all";
-
-const TAB_LABELS: Record<TabKey, string> = {
-  open: "Open",
-  resolved: "Resolved",
-  noise: "Noise",
-  all: "All",
-};
-
-const TAB_COPY: Record<TabKey, string> = {
-  open: "Active incidents that still need attention.",
-  resolved: "Incidents an agent or human has already closed out.",
-  noise: "Low-signal incidents auto-classified as noise, still counted.",
-  all: "Every incident regardless of its current status.",
-};
-
-function TabsBento() {
-  const [tab, setTab] = useState<TabKey>("open");
-  const [size, setSize] = useState<"sm" | "md">("md");
+function Selection() {
+  const [view, setView] = useState<View>("open");
   return (
-    <div className="grid grid-cols-12 gap-3">
-      <Tile className="col-span-12 md:col-span-8">
-        <PanelLabel>View switch</PanelLabel>
-        <Tabs
-          value={tab}
-          onChange={setTab}
-          size={size}
-          options={(Object.keys(TAB_LABELS) as TabKey[]).map((k) => ({
-            value: k,
-            label: TAB_LABELS[k],
-          }))}
-        />
-        <div className="mt-4 rounded-md border border-border bg-surface-2 p-4">
-          <span className="text-[13px] font-medium text-accent">{TAB_LABELS[tab]}</span>
-          <p className="mt-1.5 text-[13px] leading-relaxed text-fg">{TAB_COPY[tab]}</p>
-        </div>
-      </Tile>
-      <Tile className="col-span-12 md:col-span-4">
-        <PanelLabel>Size</PanelLabel>
-        <div className="flex flex-col items-start gap-4">
+    <section id="selection" className="scroll-mt-20 pb-24">
+      <SectionHeading
+        number="05"
+        title="Selection & status"
+        copy="Compact rectangular tags echo the data grid. Bare dots identify ongoing state without creating visual clutter."
+      />
+      <div className="grid gap-3 lg:grid-cols-[1.25fr_1fr]">
+        <Tile>
+          <PanelLabel>Tabs</PanelLabel>
           <Tabs
-            value={size}
-            onChange={(v) => setSize(v)}
+            value={view}
+            onChange={setView}
             options={[
-              { value: "md", label: "Medium" },
-              { value: "sm", label: "Small" },
+              { value: "open", label: "Open" },
+              { value: "resolved", label: "Resolved" },
+              { value: "noise", label: "Noise" },
             ]}
           />
-          <span className="text-[13px] text-muted">Controls the switch on the left.</span>
-        </div>
-      </Tile>
-    </div>
+          <div className="mt-5 rounded-lg border border-border bg-bg/35 p-4">
+            <span className="text-[12px] font-medium text-fg capitalize">{view} incidents</span>
+            <p className="mt-1 text-[12px] text-muted">
+              The selected view changes; the surrounding frame stays quiet.
+            </p>
+          </div>
+        </Tile>
+        <Tile>
+          <PanelLabel>Tags & live state</PanelLabel>
+          <div className="flex flex-wrap gap-2">
+            <Chip tone="neutral">neutral</Chip>
+            <Chip tone="accent">selected</Chip>
+            <Chip tone="success">healthy</Chip>
+            <Chip tone="warning">degraded</Chip>
+            <Chip tone="danger">critical</Chip>
+          </div>
+          <div className="mt-5 flex flex-wrap gap-4 border-t border-border pt-5">
+            <Chip tone="success" dot>
+              Live
+            </Chip>
+            <Chip tone="warning" dot>
+              Delayed
+            </Chip>
+            <Chip tone="danger" dot>
+              Failed
+            </Chip>
+          </div>
+        </Tile>
+      </div>
+    </section>
   );
 }
 
-// ---------------------------------------------------------------------------
-// 06 — Chips
-// ---------------------------------------------------------------------------
+const SERVICES = [
+  { service: "checkout-api", type: "trace", latency: "128ms", rate: "99.98%", tone: "success" },
+  { service: "billing-worker", type: "log", latency: "842ms", rate: "98.41%", tone: "warning" },
+  { service: "edge-proxy", type: "metric", latency: "74ms", rate: "99.99%", tone: "accent" },
+  { service: "email-dispatch", type: "trace", latency: "1.24s", rate: "94.08%", tone: "danger" },
+] as const;
 
-function ChipsBento() {
+function DataDisplay() {
   return (
-    <div className="grid grid-cols-12 gap-3">
-      <Tile className="col-span-12 md:col-span-7">
-        <PanelLabel>Tones</PanelLabel>
-        <div className="flex flex-wrap items-center gap-2.5">
-          <Chip tone="neutral">neutral</Chip>
-          <Chip tone="accent">accent</Chip>
-          <Chip tone="success">success</Chip>
-          <Chip tone="warning">warning</Chip>
-          <Chip tone="danger">danger</Chip>
-          <Chip tone="muted">muted</Chip>
-        </div>
-      </Tile>
-      <Tile className="col-span-12 md:col-span-5">
-        <PanelLabel>With status dot</PanelLabel>
-        <div className="flex flex-wrap items-center gap-2.5">
-          <Chip tone="danger" dot>
-            open
-          </Chip>
-          <Chip tone="success" dot>
-            resolved
-          </Chip>
-          <Chip tone="accent" dot>
-            active
-          </Chip>
-        </div>
-      </Tile>
-    </div>
+    <section id="data" className="scroll-mt-20 pb-24">
+      <SectionHeading
+        number="06"
+        title="Data display"
+        copy="Rows align on a stable grid. Weight, alignment, and tabular numerals make dense values scan without changing typeface."
+      />
+      <div className="grid gap-3 lg:grid-cols-[1.6fr_0.7fr]">
+        <DataList label="Service health">
+          <div className="flex items-center justify-between border-b border-border px-4 py-3">
+            <span className="text-[12px] font-medium text-fg">Service health</span>
+            <span className="font-sans text-[10px] text-subtle">live · 10s</span>
+          </div>
+          <DataListHeader className="grid grid-cols-[1.5fr_0.8fr_0.7fr_0.7fr]">
+            <DataListHeaderCell>Service</DataListHeaderCell>
+            <DataListHeaderCell>Signal</DataListHeaderCell>
+            <DataListHeaderCell className="text-right">p95</DataListHeaderCell>
+            <DataListHeaderCell className="text-right">Success</DataListHeaderCell>
+          </DataListHeader>
+          {SERVICES.map((row) => (
+            <DataListRow
+              key={row.service}
+              className="grid grid-cols-[1.5fr_0.8fr_0.7fr_0.7fr] items-center"
+            >
+              <DataListCell className="truncate text-[12px] text-fg">{row.service}</DataListCell>
+              <DataListCell>
+                <Chip tone={row.tone}>{row.type}</Chip>
+              </DataListCell>
+              <DataListCell className="text-right font-sans text-[11px] tabular-nums text-muted">
+                {row.latency}
+              </DataListCell>
+              <DataListCell className="text-right font-sans text-[11px] tabular-nums text-fg">
+                {row.rate}
+              </DataListCell>
+            </DataListRow>
+          ))}
+        </DataList>
+        <Tile>
+          <PanelLabel>Current window</PanelLabel>
+          <div className="font-sans text-[42px] font-semibold tracking-tight text-fg">12.8k</div>
+          <div className="mt-1 text-[12px] text-muted">events / minute</div>
+          <div className="mt-7 space-y-3 border-t border-border pt-5">
+            {[
+              ["Traces", "7.2k", "bg-accent", "56%"],
+              ["Logs", "4.1k", "bg-success", "32%"],
+              ["Metrics", "1.5k", "bg-warning", "12%"],
+            ].map(([label, value, color, width]) => (
+              <div key={label}>
+                <div className="mb-1.5 flex justify-between text-[11px]">
+                  <span className="text-muted">{label}</span>
+                  <span className="font-sans text-subtle">{value}</span>
+                </div>
+                <div className="h-1 overflow-hidden rounded-full bg-surface-3">
+                  <div className={`h-full rounded-full ${color}`} style={{ width }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </Tile>
+      </div>
+    </section>
   );
 }
 
-// ---------------------------------------------------------------------------
-// 07 — Callouts
-// ---------------------------------------------------------------------------
-
-function CalloutsBento() {
+function Feedback() {
   return (
-    <div className="grid grid-cols-12 gap-3">
-      <Tile className="col-span-12 md:col-span-4">
-        <PanelLabel>Status chip</PanelLabel>
-        <div className="flex flex-wrap items-center gap-2.5">
+    <section id="feedback" className="scroll-mt-20 pb-10">
+      <SectionHeading
+        number="07"
+        title="Feedback"
+        copy="Use persistent feedback only when the system needs a decision. Keep labels brief and pair them with a clear next action."
+      />
+      <div className="grid gap-3 lg:grid-cols-[0.7fr_1.5fr]">
+        <Tile>
+          <PanelLabel>Inline status</PanelLabel>
           <OutOfCreditsBadge />
-        </div>
-      </Tile>
-      <Tile className="col-span-12 md:col-span-8">
-        <PanelLabel>Banner</PanelLabel>
-        <OutOfCreditsBanner />
-      </Tile>
-    </div>
+          <p className="mt-4 text-[12px] leading-5 text-muted">
+            A compact tag for rows and summaries.
+          </p>
+        </Tile>
+        <Tile>
+          <PanelLabel>Decision banner</PanelLabel>
+          <OutOfCreditsBanner />
+        </Tile>
+      </div>
+    </section>
+  );
+}
+
+function PanelLabel({ children }: { children: ReactNode }) {
+  return <div className="mb-4 text-[11px] font-medium text-subtle">{children}</div>;
+}
+
+function FieldName({ children }: { children: ReactNode }) {
+  return <div className="mb-2 text-[11px] font-medium text-muted">{children}</div>;
+}
+
+function Footer() {
+  return (
+    <footer className="mt-20 flex flex-col gap-2 border-t border-border pt-5 text-[11px] text-subtle sm:flex-row sm:items-center sm:justify-between">
+      <span>Superlog · Interface system</span>
+      <span>Shared tokens and production primitives</span>
+    </footer>
   );
 }

--- a/apps/web/src/design/Dropdown.tsx
+++ b/apps/web/src/design/Dropdown.tsx
@@ -102,7 +102,7 @@ export function Dropdown({
         aria-haspopup="menu"
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
-        className="flex h-9 w-full items-center gap-2 rounded-lg border border-border bg-surface-2 px-3 text-left text-[13px] text-fg transition-colors hover:border-border-strong focus:border-border-strong focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+        className="flex h-9 w-full items-center gap-2 rounded-md border border-border bg-surface-2 px-3 text-left text-[13px] text-fg transition-colors hover:border-border-strong focus:border-border-strong focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
       >
         <span className={`flex-1 truncate ${selected ? "text-fg" : "text-subtle"}`}>
           {selected ? (selected.searchText ?? selected.label) : placeholder}
@@ -114,7 +114,7 @@ export function Dropdown({
           ref={listRef}
           tabIndex={-1}
           onKeyDown={onKey}
-          className="absolute left-0 top-full z-20 mt-1.5 w-full overflow-hidden rounded-lg border border-border bg-surface shadow-[0_10px_30px_-10px_rgba(0,0,0,0.4)]"
+          className="absolute left-0 top-full z-20 mt-1.5 w-full overflow-hidden rounded-lg border border-border bg-surface shadow-[0_16px_40px_-16px_rgba(0,0,0,0.7)]"
         >
           {searchable && (
             <div className="border-b border-border px-2.5">

--- a/apps/web/src/design/ProductShell.test.tsx
+++ b/apps/web/src/design/ProductShell.test.tsx
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { ProductShell } from "./ProductShell.tsx";
+
+test("the signed-in shell uses standard icons without workspace status copy", async () => {
+  const html = renderToStaticMarkup(
+    <MemoryRouter initialEntries={["/explore/logs"]}>
+      <ProductShell toolbar={<button type="button">Project controls</button>}>
+        <main>Page body</main>
+      </ProductShell>
+    </MemoryRouter>,
+  );
+
+  assert.match(html, /<aside/);
+  assert.match(html, /aria-current="page"[^>]*href="\/explore"/);
+  assert.match(html, /Project controls/);
+  assert.match(html, /Page body/);
+  assert.doesNotMatch(html, /font-mono/);
+  assert.doesNotMatch(html, /Operational workspace/);
+
+  const source = await readFile(new URL("./ProductShell.tsx", import.meta.url), "utf8");
+  assert.match(source, /@phosphor-icons\/react/);
+  assert.doesNotMatch(source, /function NavigationIcon/);
+});
+
+test("errors and incidents are separate primary navigation destinations", () => {
+  const issuesHtml = renderToStaticMarkup(
+    <MemoryRouter initialEntries={["/issues"]}>
+      <ProductShell>
+        <main>Issues page</main>
+      </ProductShell>
+    </MemoryRouter>,
+  );
+  const incidentsHtml = renderToStaticMarkup(
+    <MemoryRouter initialEntries={["/incidents"]}>
+      <ProductShell>
+        <main>Incidents page</main>
+      </ProductShell>
+    </MemoryRouter>,
+  );
+
+  assert.match(issuesHtml, /aria-current="page"[^>]*href="\/issues"/);
+  assert.doesNotMatch(issuesHtml, /aria-current="page"[^>]*href="\/incidents"/);
+  assert.match(incidentsHtml, /aria-current="page"[^>]*href="\/incidents"/);
+  assert.doesNotMatch(incidentsHtml, /aria-current="page"[^>]*href="\/issues"/);
+  assert.match(issuesHtml, />Errors<\/span>/);
+  assert.doesNotMatch(issuesHtml, />Issues<\/span>/);
+  assert.match(incidentsHtml, />Incidents<\/span>/);
+
+  const incidentsPosition = issuesHtml.indexOf(">Incidents</span>");
+  const errorsPosition = issuesHtml.indexOf(">Errors</span>");
+  assert.ok(incidentsPosition >= 0 && errorsPosition >= 0);
+  assert.ok(incidentsPosition < errorsPosition, "Incidents should appear above Errors");
+});
+
+test("the command palette mirrors the incidents and errors navigation", async () => {
+  const source = await readFile(new URL("../CommandPalette.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /label: "Incidents"[^\n]*navigate\("\/incidents"\)/);
+  assert.match(source, /label: "Errors"[^\n]*navigate\("\/issues"\)/);
+  assert.doesNotMatch(source, /label: "Issues"/);
+});
+
+test("incident and error pages do not repeat primary navigation as horizontal tabs", async () => {
+  const source = await readFile(new URL("../Issues.tsx", import.meta.url), "utf8");
+
+  assert.doesNotMatch(source, /\(\["incidents", "issues"\] as const\)\.map/);
+});

--- a/apps/web/src/design/ProductShell.tsx
+++ b/apps/web/src/design/ProductShell.tsx
@@ -1,0 +1,149 @@
+import type { Icon } from "@phosphor-icons/react";
+import { BellIcon } from "@phosphor-icons/react/dist/csr/Bell";
+import { BugIcon } from "@phosphor-icons/react/dist/csr/Bug";
+import { ChartBarIcon } from "@phosphor-icons/react/dist/csr/ChartBar";
+import { GearIcon } from "@phosphor-icons/react/dist/csr/Gear";
+import { MagnifyingGlassIcon } from "@phosphor-icons/react/dist/csr/MagnifyingGlass";
+import { SirenIcon } from "@phosphor-icons/react/dist/csr/Siren";
+import { SquaresFourIcon } from "@phosphor-icons/react/dist/csr/SquaresFour";
+import type { ReactNode } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { Wordmark } from "./ui.tsx";
+
+type NavigationItem = {
+  href: string;
+  label: string;
+  icon: Icon;
+  match?: string[];
+};
+
+const NAVIGATION_GROUPS: Array<{ label: string; items: NavigationItem[] }> = [
+  {
+    label: "Workspace",
+    items: [
+      { href: "/", label: "Overview", icon: SquaresFourIcon },
+      { href: "/incidents", label: "Incidents", icon: SirenIcon },
+      { href: "/issues", label: "Errors", icon: BugIcon },
+      { href: "/alerts", label: "Alerts", icon: BellIcon },
+    ],
+  },
+  {
+    label: "Observe",
+    items: [
+      { href: "/explore", label: "Explore", icon: MagnifyingGlassIcon },
+      { href: "/dashboards", label: "Dashboards", icon: ChartBarIcon },
+    ],
+  },
+];
+
+const SETTINGS_ITEM: NavigationItem = { href: "/settings", label: "Settings", icon: GearIcon };
+
+export function ProductShell({
+  toolbar,
+  children,
+}: {
+  toolbar?: ReactNode;
+  children: ReactNode;
+}) {
+  const { pathname } = useLocation();
+  const current = [...NAVIGATION_GROUPS.flatMap((group) => group.items), SETTINGS_ITEM].find(
+    (item) => isActive(item, pathname),
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 bg-bg font-sans text-fg" data-product-shell>
+      <aside className="sticky top-0 hidden h-screen w-56 shrink-0 flex-col border-r border-border bg-surface/55 px-4 py-5 backdrop-blur md:flex">
+        <div className="px-2">
+          <Wordmark size="sm" />
+        </div>
+
+        <nav aria-label="Primary navigation" className="mt-9 space-y-7">
+          {NAVIGATION_GROUPS.map((group) => (
+            <div key={group.label}>
+              <div className="px-2 text-[11px] font-medium text-subtle">{group.label}</div>
+              <div className="mt-2 space-y-0.5">
+                {group.items.map((item) => (
+                  <NavigationLink key={item.href} item={item} pathname={pathname} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </nav>
+
+        <div className="mt-auto border-t border-border pt-3">
+          <NavigationLink item={SETTINGS_ITEM} pathname={pathname} />
+        </div>
+      </aside>
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="sticky top-0 z-20 border-b border-border bg-bg/90 backdrop-blur-md">
+          <div className="flex h-14 items-center justify-between gap-4 px-5 sm:px-6 lg:px-8">
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="shrink-0 md:hidden">
+                <Wordmark size="sm" />
+              </span>
+              <span className="hidden text-[12px] text-muted md:inline">Workspace</span>
+              <span className="hidden text-[12px] text-subtle md:inline">/</span>
+              <span className="truncate text-[12px] text-fg">{current?.label ?? "Overview"}</span>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">{toolbar}</div>
+          </div>
+          <MobileNavigation pathname={pathname} />
+        </header>
+        <div className="flex min-h-0 flex-1 flex-col">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function NavigationLink({ item, pathname }: { item: NavigationItem; pathname: string }) {
+  const active = isActive(item, pathname);
+  const Icon = item.icon;
+  return (
+    <Link
+      to={item.href}
+      aria-current={active ? "page" : undefined}
+      className={`flex items-center gap-3 rounded-md px-2 py-1.5 text-[13px] transition-colors ${
+        active ? "bg-surface-3 text-fg" : "text-muted hover:bg-surface-2 hover:text-fg"
+      }`}
+    >
+      <Icon size={17} weight="regular" className="shrink-0" aria-hidden />
+      <span>{item.label}</span>
+    </Link>
+  );
+}
+
+function MobileNavigation({ pathname }: { pathname: string }) {
+  const items = [...NAVIGATION_GROUPS.flatMap((group) => group.items), SETTINGS_ITEM];
+  return (
+    <nav
+      aria-label="Mobile navigation"
+      className="overflow-x-auto border-t border-border px-3 md:hidden"
+    >
+      <div className="flex min-w-max items-center gap-1 py-2">
+        {items.map((item) => {
+          const active = isActive(item, pathname);
+          return (
+            <Link
+              key={item.href}
+              to={item.href}
+              aria-current={active ? "page" : undefined}
+              className={`rounded-md px-2.5 py-1 text-[12px] ${
+                active ? "bg-surface-3 text-fg" : "text-muted"
+              }`}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}
+
+function isActive(item: NavigationItem, pathname: string) {
+  if (item.href === "/") return pathname === "/" || pathname === "";
+  return (
+    pathname.startsWith(item.href) || item.match?.some((prefix) => pathname.startsWith(prefix))
+  );
+}

--- a/apps/web/src/design/ui.tsx
+++ b/apps/web/src/design/ui.tsx
@@ -5,13 +5,12 @@ import { Link } from "react-router-dom";
 
 // ---------------------------------------------------------------------------
 // Canonical shared primitives — used across the app and the /design sheet.
-// Dark canvas · cobalt accent · soft corners (6px buttons, 10px inputs,
-// 10-12px cards).
+// Quiet dark canvas · neutral actions · blue selection · soft utility corners.
 //
 // Rules + catalog: apps/web/DESIGN.md. Live reference: /design
 // (DesignLanguage.tsx). Changing a primitive here? Update its panel on the
-// /design sheet too — the sheet is how we catch drift. No mono caps: labels are
-// capitalized sans (Label/FieldLabel below are legacy mono-caps, being retired).
+// /design sheet too — the sheet is how we catch drift. All interface typography
+// uses the same sans family; true source code opts into `.superlog-code`.
 // ---------------------------------------------------------------------------
 
 export function ShortcutKey({
@@ -23,7 +22,7 @@ export function ShortcutKey({
 }) {
   return (
     <kbd
-      className={`inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded border border-border bg-surface-2 px-1 font-mono text-[10px] text-muted ${className}`}
+      className={`inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-sm border border-border bg-surface-2 px-1 font-sans text-[10px] text-muted ${className}`}
     >
       {children}
     </kbd>
@@ -43,7 +42,7 @@ export function Tile({
 }) {
   return (
     <div
-      className={`relative rounded-lg border border-border bg-surface ${padded ? "p-5" : ""} ${className}`}
+      className={`relative rounded-xl border border-border bg-surface ${padded ? "p-5" : ""} ${className}`}
     >
       {label && (
         <div className="mb-4 flex items-center justify-between">
@@ -52,6 +51,92 @@ export function Tile({
       )}
       {children}
     </div>
+  );
+}
+
+export function DataList({
+  label,
+  children,
+  className = "",
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      role="table"
+      aria-label={label}
+      className={`overflow-hidden rounded-xl border border-border bg-surface ${className}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DataListHeader({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      role="row"
+      className={`border-b border-border bg-bg/30 px-4 py-2 text-[10px] font-medium text-subtle ${className}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DataListHeaderCell({
+  children,
+  className = "",
+  ariaLabel,
+}: {
+  children?: ReactNode;
+  className?: string;
+  ariaLabel?: string;
+}) {
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: CSS-grid cells must remain independently hideable for responsive lists.
+    <span role="columnheader" aria-label={ariaLabel} className={className}>
+      {children}
+    </span>
+  );
+}
+
+export function DataListRow({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      role="row"
+      className={`border-b border-border px-4 py-3 transition-colors last:border-b-0 hover:bg-surface-2/70 ${className}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DataListCell({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: CSS-grid cells must remain independently hideable for responsive lists.
+    <span role="cell" className={className}>
+      {children}
+    </span>
   );
 }
 
@@ -72,17 +157,11 @@ export function SkeletonBlock({
 }
 
 export function Label({ children }: { children: ReactNode }) {
-  return (
-    <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-subtle">{children}</span>
-  );
+  return <span className="text-[11px] font-medium text-subtle">{children}</span>;
 }
 
 export function FieldLabel({ children }: { children: ReactNode }) {
-  return (
-    <label className="mb-2 block font-mono text-[10px] uppercase tracking-[0.2em] text-muted">
-      {children}
-    </label>
-  );
+  return <label className="mb-2 block text-[11px] font-medium text-muted">{children}</label>;
 }
 
 export function Arrow() {
@@ -99,6 +178,28 @@ export function Arrow() {
       <path d="M7 17 17 7" />
       <path d="M8 7h9v9" />
     </svg>
+  );
+}
+
+export function PageHeader({
+  title,
+  description,
+  actions,
+}: {
+  title: string;
+  description?: ReactNode;
+  actions?: ReactNode;
+}) {
+  return (
+    <header className="flex flex-col gap-4 border-b border-border pb-5 sm:flex-row sm:items-end sm:justify-between">
+      <div className="min-w-0">
+        <h1 className="text-[28px] font-semibold leading-tight tracking-tight text-fg">{title}</h1>
+        {description && (
+          <p className="mt-2 max-w-2xl text-[13px] leading-5 text-muted">{description}</p>
+        )}
+      </div>
+      {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+    </header>
   );
 }
 
@@ -128,16 +229,16 @@ export function Btn({
   onClick,
 }: BtnProps) {
   const base =
-    "inline-flex items-center gap-2 rounded-md font-medium tracking-tight transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 select-none";
+    "inline-flex items-center justify-center gap-2 rounded-md font-medium tracking-tight transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-40 select-none";
   const sizes = {
     sm: "h-7 px-2.5 text-[12px]",
     md: "h-8 px-3 text-[13px]",
     lg: "h-10 px-4 text-[14px]",
   };
   const variants = {
-    primary:
-      "bg-accent text-accent-ink hover:brightness-110 active:brightness-95 shadow-[0_1px_0_0_rgba(255,255,255,0.12)_inset,0_6px_14px_-6px_rgba(72,90,226,0.55)]",
-    secondary: "bg-transparent text-fg border border-border hover:border-border-strong",
+    primary: "bg-fg text-bg hover:bg-fg/90 active:bg-fg/80",
+    secondary:
+      "border border-border bg-surface-2 text-fg hover:border-border-strong hover:bg-surface-3",
     ghost: "bg-transparent text-fg hover:bg-surface-2",
     danger: "bg-danger/20 text-danger hover:bg-danger/30 active:bg-danger/25",
   };
@@ -187,12 +288,12 @@ export function Chip({
     muted: "bg-subtle",
     accent: "bg-accent",
   };
-  // Sans, fully rounded, capitalized label. Two modes: a filled pill in the tone
+  // Sans, compact rectangular, capitalized label. Two modes: a filled tag in the tone
   // color, or — with `dot` — a bare status indicator (no fill, no border) that's
   // just the colored dot + label.
   return (
     <span
-      className={`inline-flex items-center gap-1.5 rounded-full text-[11px] capitalize ${
+      className={`inline-flex items-center gap-1.5 rounded text-[11px] font-medium capitalize ${
         dot ? "text-fg" : `px-2 py-0.5 ${tones[tone]}`
       }`}
     >
@@ -202,7 +303,7 @@ export function Chip({
   );
 }
 
-// Rounded-pill segmented toggle. The selected option gets a raised pill;
+// Compact segmented toggle. The selected option gets a quiet surface;
 // the rest are muted text on the shared track. Sans, no caps.
 export function PillToggle({
   value,
@@ -227,8 +328,8 @@ export function PillToggle({
             role="radio"
             aria-checked={active}
             onClick={() => onChange(o.value)}
-            className={`rounded-full ${pad} transition-colors ${
-              active ? "bg-surface-3 text-fg shadow-sm" : "text-muted hover:text-fg"
+            className={`rounded-md ${pad} transition-colors ${
+              active ? "bg-surface-3 text-fg" : "text-muted hover:text-fg"
             }`}
           >
             {o.label}
@@ -240,7 +341,7 @@ export function PillToggle({
 }
 
 // Tab bar. Capitalized sans labels with no outer track — only the active tab
-// gets a soft raised pill (surface-2 fill + hairline border); the rest are
+// gets a soft rectangular fill; the rest are
 // muted text that brightens on hover.
 export function Tabs<T extends string>({
   value,
@@ -265,7 +366,7 @@ export function Tabs<T extends string>({
             role="tab"
             aria-selected={active}
             onClick={() => onChange(o.value)}
-            className={`rounded-full font-medium tracking-tight transition-colors ${pad} ${
+            className={`rounded-md font-medium tracking-tight transition-colors ${pad} ${
               active ? "bg-surface-3 text-fg" : "text-muted hover:text-fg"
             }`}
           >
@@ -286,7 +387,7 @@ export function Input(props: React.InputHTMLAttributes<HTMLInputElement>) {
   return (
     <input
       {...rest}
-      className={`h-9 w-full rounded-lg border border-border bg-surface-2 px-3 text-[13px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none ${className}`}
+      className={`h-9 w-full rounded-md border border-border bg-surface-2 px-3 text-[13px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none ${className}`}
     />
   );
 }
@@ -312,9 +413,9 @@ export function SearchInput({
       </svg>
       <input
         placeholder={placeholder}
-        className="h-9 w-full rounded-lg border border-border bg-surface-2 pl-8 pr-16 font-mono text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none"
+        className="h-9 w-full rounded-md border border-border bg-surface-2 pl-8 pr-16 font-sans text-[12.5px] text-fg placeholder:text-subtle focus:border-border-strong focus:outline-none"
       />
-      <span className="absolute right-2 top-1/2 -translate-y-1/2 rounded-sm border border-border bg-surface-3 px-1.5 py-0.5 font-mono text-[10px] text-muted">
+      <span className="absolute right-2 top-1/2 -translate-y-1/2 rounded-sm border border-border bg-surface-3 px-1.5 py-0.5 font-sans text-[10px] text-muted">
         {shortcut}
       </span>
     </div>
@@ -326,7 +427,7 @@ export function Select({ options }: { options: string[] }) {
     <div className="relative">
       <select
         defaultValue={options[0]}
-        className="h-9 w-full appearance-none rounded-lg border border-border bg-surface-2 pl-3 pr-8 text-[13px] text-fg focus:border-border-strong focus:outline-none"
+        className="h-9 w-full appearance-none rounded-md border border-border bg-surface-2 pl-3 pr-8 text-[13px] text-fg focus:border-border-strong focus:outline-none"
       >
         {options.map((o) => (
           <option key={o} value={o}>
@@ -373,11 +474,11 @@ export function MetricTile({
   const tone = positive ? "text-success" : "text-danger";
   const sign = hasDelta && (delta as number) > 0 ? "+" : "";
   return (
-    <div className={`relative rounded-2xl border border-border bg-surface p-5 ${className}`}>
+    <div className={`relative rounded-xl border border-border bg-surface p-5 ${className}`}>
       <div className="flex items-center justify-between">
-        <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted">{label}</span>
+        <span className="text-[12px] font-medium text-muted">{label}</span>
         {hasDelta && (
-          <span className={`font-mono text-[11px] tabular-nums ${tone}`}>
+          <span className={`font-sans text-[11px] tabular-nums ${tone}`}>
             {sign}
             {(delta as number).toFixed(2)}%
           </span>
@@ -387,7 +488,7 @@ export function MetricTile({
         <span className="font-sans text-4xl font-semibold tabular-nums tracking-tight text-fg">
           {value}
         </span>
-        {unit && <span className="font-mono text-[11px] text-subtle">{unit}</span>}
+        {unit && <span className="font-sans text-[11px] text-subtle">{unit}</span>}
       </div>
       {sparkline && <Sparkline className="mt-4" tone={positive ? "success" : "danger"} />}
     </div>
@@ -406,7 +507,12 @@ export function Sparkline({
   const d = pts
     .map((y, i) => `${i === 0 ? "M" : "L"} ${(i / (pts.length - 1)) * 100} ${40 - (y / max) * 38}`)
     .join(" ");
-  const color = tone === "success" ? "#41D195" : tone === "danger" ? "#EF5A6F" : "#485AE2";
+  const color =
+    tone === "success"
+      ? "var(--color-success)"
+      : tone === "danger"
+        ? "var(--color-danger)"
+        : "var(--color-accent)";
   return (
     <svg
       className={className}
@@ -507,7 +613,7 @@ export function ThemeToggle() {
       onClick={() => apply(next)}
       aria-label={`Switch to ${next} theme`}
       title={`Switch to ${next} theme`}
-      className="grid h-7 w-7 place-items-center border border-border text-muted transition-colors hover:text-fg"
+      className="grid h-7 w-7 place-items-center rounded-md border border-border bg-surface text-muted transition-colors hover:border-border-strong hover:text-fg"
     >
       {theme === "dark" ? (
         <svg
@@ -554,7 +660,7 @@ export function ThemeToggle() {
 export function OutOfCreditsBadge() {
   return (
     <span
-      className="inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] text-danger"
+      className="inline-flex items-center gap-1 rounded border px-2 py-0.5 text-[11px] text-danger"
       style={{
         backgroundColor: "color-mix(in srgb, var(--color-danger) 20%, transparent)",
         borderColor: "color-mix(in srgb, var(--color-danger) 25%, transparent)",
@@ -585,9 +691,8 @@ export function OutOfCreditsBanner() {
         // foreground so the longer paragraph stays legible on the tinted bg.
         style={{ color: "color-mix(in srgb, var(--color-danger) 82%, var(--color-fg))" }}
       >
-        Your organization is over its plan's monthly investigation limit, so
-        auto-investigation was skipped. Upgrade to pay-as-you-go to keep
-        investigating new incidents.
+        Your organization is over its plan's monthly investigation limit, so auto-investigation was
+        skipped. Upgrade to pay-as-you-go to keep investigating new incidents.
       </p>
       <div className="flex items-center justify-end">
         <Link

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -15,26 +15,26 @@
      modifiers (bg-danger/20 etc.) can inject <alpha-value>. The legacy
      --color-* hex-style vars are derived from them — raw CSS/chart code keeps
      reading var(--color-x) and stays theme-aware. */
-  --color-bg-rgb: 20 20 20;
-  --color-surface-rgb: 28 28 30;
-  --color-surface-2-rgb: 35 35 37;
-  --color-surface-3-rgb: 43 43 46;
-  --color-fg-rgb: 245 245 246;
-  --color-muted-rgb: 138 138 143;
-  --color-subtle-rgb: 90 90 96;
-  --color-accent-rgb: 72 90 226;
-  --color-accent-ink-rgb: 255 255 255;
-  --color-accent-deep-rgb: 49 64 184;
-  --color-danger-rgb: 239 90 111;
-  --color-warning-rgb: 231 177 90;
-  --color-success-rgb: 65 209 149;
+  --color-bg-rgb: 18 18 18;
+  --color-surface-rgb: 23 23 23;
+  --color-surface-2-rgb: 28 28 28;
+  --color-surface-3-rgb: 35 35 35;
+  --color-fg-rgb: 220 220 220;
+  --color-muted-rgb: 140 140 140;
+  --color-subtle-rgb: 91 91 91;
+  --color-accent-rgb: 115 178 222;
+  --color-accent-ink-rgb: 20 24 27;
+  --color-accent-deep-rgb: 82 144 187;
+  --color-danger-rgb: 217 113 120;
+  --color-warning-rgb: 201 157 102;
+  --color-success-rgb: 127 199 151;
 
   --color-bg: rgb(var(--color-bg-rgb));
   --color-surface: rgb(var(--color-surface-rgb));
   --color-surface-2: rgb(var(--color-surface-2-rgb));
   --color-surface-3: rgb(var(--color-surface-3-rgb));
-  --color-border: rgba(255, 255, 255, 0.07);
-  --color-border-strong: rgba(255, 255, 255, 0.12);
+  --color-border: rgba(255, 255, 255, 0.09);
+  --color-border-strong: rgba(255, 255, 255, 0.16);
 
   --color-fg: rgb(var(--color-fg-rgb));
   --color-muted: rgb(var(--color-muted-rgb));
@@ -42,14 +42,14 @@
 
   --color-accent: rgb(var(--color-accent-rgb));
   --color-accent-ink: rgb(var(--color-accent-ink-rgb));
-  --color-accent-soft: rgba(72, 90, 226, 0.14);
+  --color-accent-soft: rgba(115, 178, 222, 0.14);
   --color-accent-deep: rgb(var(--color-accent-deep-rgb));
 
   --color-danger: rgb(var(--color-danger-rgb));
   --color-warning: rgb(var(--color-warning-rgb));
   --color-success: rgb(var(--color-success-rgb));
 
-  --dot-color: rgba(245, 245, 246, 0.05);
+  --dot-color: rgba(220, 220, 220, 0.045);
 }
 
 :root[data-theme="light"] {
@@ -64,13 +64,16 @@
   --color-fg-rgb: 35 35 35;
   --color-muted-rgb: 91 94 102;
   --color-subtle-rgb: 156 159 166;
+  --color-accent-rgb: 65 126 168;
+  --color-accent-ink-rgb: 255 255 255;
+  --color-accent-deep-rgb: 48 100 136;
   --color-danger-rgb: 214 56 64;
   --color-warning-rgb: 184 117 3;
   --color-success-rgb: 31 143 95;
 
   --color-border: rgba(15, 17, 21, 0.08);
   --color-border-strong: rgba(15, 17, 21, 0.16);
-  --color-accent-soft: rgba(72, 90, 226, 0.1);
+  --color-accent-soft: rgba(65, 126, 168, 0.1);
 
   --dot-color: rgba(0, 0, 0, 0.06);
 }
@@ -644,13 +647,7 @@ body {
 
 /* Feather both edges to transparent so logos glide in and out of the band. */
 .marquee-fade {
-  -webkit-mask-image: linear-gradient(
-    to right,
-    transparent 0,
-    #000 9%,
-    #000 91%,
-    transparent 100%
-  );
+  -webkit-mask-image: linear-gradient(to right, transparent 0, #000 9%, #000 91%, transparent 100%);
   mask-image: linear-gradient(to right, transparent 0, #000 9%, #000 91%, transparent 100%);
 }
 

--- a/apps/web/src/issues/IssueDetailView.test.tsx
+++ b/apps/web/src/issues/IssueDetailView.test.tsx
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Issue } from "../api.ts";
+import { IssueDetailView } from "./IssueDetailView.tsx";
+
+const issue: Issue = {
+  id: "issue-1",
+  projectId: "project-1",
+  fingerprint: "checkout-confirmation",
+  kind: "span",
+  service: "checkout-api",
+  exceptionType: "CheckoutConfirmationError",
+  title: "Checkout confirmation fails after payment succeeds",
+  message: "Payment capture completes, but confirmation rendering raises.",
+  topFrame: "renderConfirmation (checkout-api/src/confirmation.ts:118:21)",
+  firstSeen: "2026-07-10T12:49:06.682Z",
+  lastSeen: "2026-07-10T13:34:06.682Z",
+  status: "open",
+  silencedAt: null,
+  escalationTrigger: null,
+  observationStartedAt: null,
+  eventCount: 184,
+  groupingState: "grouped",
+  groupingSource: "manual",
+  groupingReason: "Repeated errors share the same checkout transition.",
+  lastSample: null,
+  symbolication: null,
+  createdAt: "2026-07-10T13:36:06.682Z",
+};
+
+test("error detail is a full investigation workspace with a summary rail and evidence", () => {
+  const html = renderToStaticMarkup(
+    <IssueDetailView
+      issue={issue}
+      environment="production"
+      onBack={() => {}}
+      linkedIncident={<button type="button">Open linked incident</button>}
+    />,
+  );
+
+  assert.match(html, /data-issue-detail-workspace="true"/);
+  assert.match(html, /Errors/);
+  assert.doesNotMatch(html, />Issues</);
+  assert.match(html, /Checkout confirmation fails after payment succeeds/);
+  assert.match(html, /Error overview/);
+  assert.match(html, /Latest evidence/);
+  assert.match(html, /184 events/);
+  assert.match(html, /renderConfirmation/);
+  assert.match(html, /Open linked incident/);
+  assert.doesNotMatch(html, /role="dialog"/);
+  assert.doesNotMatch(html, /font-mono/);
+});

--- a/apps/web/src/issues/IssueDetailView.tsx
+++ b/apps/web/src/issues/IssueDetailView.tsx
@@ -1,0 +1,307 @@
+import type { ReactNode } from "react";
+import type { Issue } from "../api.ts";
+import { Btn, Chip } from "../design/ui.tsx";
+
+export type IssueDetailViewProps = {
+  issue: Issue;
+  environment: string | null;
+  onBack: () => void;
+  onToggleSilence?: () => void;
+  onOpenEvidence?: () => void;
+  evidenceLabel?: string;
+  silenceUpdating?: boolean;
+  linkedIncident?: ReactNode;
+  feedbackAction?: ReactNode;
+};
+
+export function IssueDetailView({
+  issue,
+  environment,
+  onBack,
+  onToggleSilence,
+  onOpenEvidence,
+  evidenceLabel = "Open event",
+  silenceUpdating = false,
+  linkedIncident,
+  feedbackAction,
+}: IssueDetailViewProps) {
+  const silenced = Boolean(issue.silencedAt) || issue.status === "silenced";
+  const sample = issue.lastSample;
+  const stacktrace = issue.symbolication?.stacktrace ?? sample?.stacktrace ?? null;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-bg text-fg" data-issue-detail-workspace="true">
+      <header className="flex shrink-0 items-center gap-2 border-b border-border bg-bg px-5 py-3">
+        <button
+          type="button"
+          onClick={onBack}
+          className="text-[13px] text-muted transition-colors hover:text-fg"
+        >
+          Errors
+        </button>
+        <span className="text-subtle">›</span>
+        <span className="min-w-0 flex-1 truncate text-[13px] text-fg">{issue.title}</span>
+        <div className="flex shrink-0 items-center gap-2">
+          {onToggleSilence && (
+            <Btn variant="secondary" size="sm" onClick={onToggleSilence} loading={silenceUpdating}>
+              {silenced ? "Unsilence" : "Silence"}
+            </Btn>
+          )}
+          <button
+            type="button"
+            onClick={onBack}
+            className="grid h-7 w-7 place-items-center text-muted transition-colors hover:text-fg"
+            aria-label="Back to errors"
+          >
+            <CloseIcon />
+          </button>
+        </div>
+      </header>
+
+      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[380px_minmax(0,1fr)]">
+        <aside className="min-w-0 border-b border-border bg-bg lg:overflow-y-auto lg:border-b-0 lg:border-r">
+          <div className="px-6 pb-7 pt-7 lg:px-7">
+            <div className="flex flex-wrap items-center gap-2">
+              <KindChip kind={issue.kind} />
+              <StatusChip issue={issue} />
+              {issue.groupingState === "grouped" && <Chip tone="neutral">grouped</Chip>}
+              {issue.groupingState === "pending" && <Chip tone="warning">analysing</Chip>}
+              {issue.groupingState === "failed" && <Chip tone="danger">grouping failed</Chip>}
+            </div>
+
+            <div className="mt-5 text-[11px] text-subtle">{issue.exceptionType}</div>
+            <h1 className="mt-2 break-words text-[22px] font-semibold leading-[1.12] tracking-tight text-fg">
+              {issue.title}
+            </h1>
+            {issue.message && (
+              <p className="mt-4 break-words text-[12.5px] leading-5 text-muted">{issue.message}</p>
+            )}
+
+            <dl className="mt-7 grid gap-3.5">
+              <MetaRow label="Status" value={statusLabel(issue)} />
+              <MetaRow label="Service" value={issue.service ?? "Not recorded"} />
+              <MetaRow label="Environment" value={environment ?? "Not recorded"} />
+              <MetaRow
+                label="Activity"
+                value={`${formatCount(issue.eventCount)} event${issue.eventCount === 1 ? "" : "s"}`}
+              />
+              <MetaRow label="First seen" value={formatTimestamp(issue.firstSeen)} />
+              <MetaRow label="Last seen" value={formatTimestamp(issue.lastSeen)} />
+              <MetaRow label="Grouping" value={groupingLabel(issue)} />
+            </dl>
+
+            {linkedIncident && (
+              <section className="mt-7 border-t border-border pt-6">
+                <SectionLabel>Linked incident</SectionLabel>
+                <div className="mt-2">{linkedIncident}</div>
+              </section>
+            )}
+
+            <div className="mt-7 grid gap-2">
+              {onOpenEvidence && (
+                <Btn
+                  variant="primary"
+                  size="sm"
+                  onClick={onOpenEvidence}
+                  className="w-full justify-center"
+                >
+                  {evidenceLabel}
+                </Btn>
+              )}
+              {feedbackAction}
+            </div>
+          </div>
+        </aside>
+
+        <main className="min-h-0 min-w-0 overflow-y-auto bg-bg px-5 py-7 sm:px-7 lg:px-10">
+          <div className="mx-auto w-full max-w-[900px] space-y-9">
+            <section>
+              <SectionLabel>Error overview</SectionLabel>
+              <h2 className="mt-2 text-[18px] font-semibold tracking-tight text-fg">
+                A recurring failure in {issue.service ?? "an unknown service"}
+              </h2>
+              <p className="mt-3 max-w-[760px] text-[13px] leading-6 text-muted">
+                {issue.message ??
+                  "Superlog grouped matching telemetry into this error. Open the latest event to inspect the original signal."}
+              </p>
+
+              <div className="mt-6 grid gap-3 sm:grid-cols-3">
+                <OverviewMetric
+                  label="Occurrences"
+                  value={formatCount(issue.eventCount)}
+                  detail="matching events"
+                />
+                <OverviewMetric
+                  label="First detected"
+                  value={formatShortDate(issue.firstSeen)}
+                  detail={formatShortTime(issue.firstSeen)}
+                />
+                <OverviewMetric
+                  label="Latest detected"
+                  value={formatShortDate(issue.lastSeen)}
+                  detail={formatShortTime(issue.lastSeen)}
+                />
+              </div>
+            </section>
+
+            <section className="border-t border-border pt-7">
+              <SectionLabel>Latest evidence</SectionLabel>
+              <div className="mt-4 overflow-hidden rounded-lg border border-border bg-surface">
+                <EvidenceRow label="Exception" value={issue.exceptionType} />
+                <EvidenceRow
+                  label="Top frame"
+                  value={issue.topFrame ?? sample?.topFrame ?? "No frame was captured"}
+                />
+                <EvidenceRow
+                  label="Signal"
+                  value={`${kindLabel(issue.kind)} from ${issue.service ?? "unknown service"}`}
+                />
+                {sample?.severity && <EvidenceRow label="Severity" value={sample.severity} />}
+              </div>
+            </section>
+
+            {stacktrace && (
+              <section className="border-t border-border pt-7">
+                <SectionLabel>Stack trace</SectionLabel>
+                <pre className="mt-4 overflow-x-auto whitespace-pre-wrap break-words rounded-lg border border-border bg-surface px-4 py-3 font-sans text-[12px] leading-5 text-muted">
+                  {stacktrace}
+                </pre>
+              </section>
+            )}
+
+            {issue.groupingReason && (
+              <section className="border-t border-border pt-7">
+                <SectionLabel>Why these events were grouped</SectionLabel>
+                <p className="mt-3 max-w-[760px] text-[13px] leading-6 text-muted">
+                  {issue.groupingReason}
+                </p>
+              </section>
+            )}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function KindChip({ kind }: { kind: string }) {
+  const tone = kind === "log" ? "accent" : kind === "alert" ? "warning" : "neutral";
+  return <Chip tone={tone}>{kindLabel(kind)}</Chip>;
+}
+
+function StatusChip({ issue }: { issue: Issue }) {
+  const tone =
+    issue.status === "resolved"
+      ? "success"
+      : issue.status === "under_observation"
+        ? "warning"
+        : issue.status === "silenced"
+          ? "neutral"
+          : "danger";
+  return (
+    <Chip tone={tone} dot>
+      {statusLabel(issue)}
+    </Chip>
+  );
+}
+
+function MetaRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[116px_minmax(0,1fr)] gap-3 text-[12px]">
+      <dt className="text-subtle">{label}</dt>
+      <dd className="min-w-0 break-words text-fg">{value}</dd>
+    </div>
+  );
+}
+
+function OverviewMetric({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-surface px-4 py-3.5">
+      <div className="text-[11px] text-subtle">{label}</div>
+      <div className="mt-2 text-[20px] font-semibold tracking-tight text-fg">{value}</div>
+      <div className="mt-1 text-[11px] text-muted">{detail}</div>
+    </div>
+  );
+}
+
+function EvidenceRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid gap-1 border-b border-border px-4 py-3 last:border-b-0 sm:grid-cols-[120px_minmax(0,1fr)] sm:gap-5">
+      <div className="text-[11px] text-subtle">{label}</div>
+      <div className="break-words text-[12.5px] leading-5 text-fg">{value}</div>
+    </div>
+  );
+}
+
+function SectionLabel({ children }: { children: ReactNode }) {
+  return <div className="text-[11px] font-medium text-subtle">{children}</div>;
+}
+
+function statusLabel(issue: Issue) {
+  if (issue.status === "under_observation") return "Under observation";
+  return issue.status.charAt(0).toUpperCase() + issue.status.slice(1);
+}
+
+function groupingLabel(issue: Issue) {
+  if (issue.groupingState === "grouped") return "Grouped into an incident";
+  if (issue.groupingState === "pending") return "Analysis in progress";
+  if (issue.groupingState === "failed") return "Grouping failed";
+  return "Standalone error";
+}
+
+function kindLabel(kind: string) {
+  return kind === "span" ? "Trace" : kind.charAt(0).toUpperCase() + kind.slice(1);
+}
+
+function formatCount(value: number) {
+  return new Intl.NumberFormat("en-US", {
+    notation: value >= 10_000 ? "compact" : "standard",
+  }).format(value);
+}
+
+function formatTimestamp(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function formatShortDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  return new Intl.DateTimeFormat("en", { month: "short", day: "numeric" }).format(date);
+}
+
+function formatShortTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "time unavailable";
+  return new Intl.DateTimeFormat("en", { hour: "2-digit", minute: "2-digit" }).format(date);
+}
+
+function CloseIcon() {
+  return (
+    <svg
+      className="h-4 w-4"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <path d="M18 6 6 18M6 6l12 12" />
+    </svg>
+  );
+}

--- a/apps/web/src/onboarding/McpInstallPill.test.ts
+++ b/apps/web/src/onboarding/McpInstallPill.test.ts
@@ -26,11 +26,12 @@ test("pill stays hidden after the user dismisses it", () => {
   assert.equal(shouldShowMcpPill({ projectId: "p1", connected: false, dismissed: true }), false);
 });
 
-test("pill is fixed to the bottom-left and opens the install dialog", async () => {
+test("pill is fixed to the bottom-right and opens the install dialog", async () => {
   const source = await readFile(new URL("./McpInstallPill.tsx", import.meta.url), "utf8");
   assert.match(source, /fixed/);
   assert.match(source, /bottom-/);
-  assert.match(source, /left-/);
+  assert.match(source, /right-/);
+  assert.doesNotMatch(source, /bottom-5 left-5/);
   assert.match(source, /McpInstallDialog/);
   assert.match(source, /useMcpStatus/);
 });

--- a/apps/web/src/onboarding/McpInstallPill.tsx
+++ b/apps/web/src/onboarding/McpInstallPill.tsx
@@ -4,7 +4,7 @@ import { McpInstallDialog } from "./McpInstallDialog.tsx";
 import { TerminalIcon } from "./icons.tsx";
 import { isMcpPillDismissed, rememberMcpPillDismiss, shouldShowMcpPill } from "./mcpPill.ts";
 
-// Floating bottom-left reminder for users who skipped the MCP install during
+// Floating bottom-right reminder for users who skipped the MCP install during
 // onboarding. Mounted app-wide; auto-hides once the MCP OAuth flow completes.
 export function McpInstallPill() {
   const me = useMe();
@@ -19,7 +19,7 @@ export function McpInstallPill() {
 
   return (
     <>
-      <div className="fixed bottom-5 left-5 z-40 flex items-center overflow-hidden rounded-full border border-border-strong bg-surface shadow-[0_10px_30px_rgba(0,0,0,0.35)]">
+      <div className="fixed bottom-5 right-5 z-40 flex items-center overflow-hidden rounded-full border border-border-strong bg-surface shadow-[0_10px_30px_rgba(0,0,0,0.35)]">
         <button
           type="button"
           onClick={() => setOpen(true)}

--- a/apps/web/src/route-layout.test.ts
+++ b/apps/web/src/route-layout.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isDetailWorkspacePath } from "./route-layout.ts";
+
+test("issue and incident detail routes use the full-width investigation workspace", () => {
+  assert.equal(isDetailWorkspacePath("/issues/issue-1"), true);
+  assert.equal(isDetailWorkspacePath("/incidents/incident-1"), true);
+  assert.equal(isDetailWorkspacePath("/issues"), false);
+  assert.equal(isDetailWorkspacePath("/settings"), false);
+});

--- a/apps/web/src/route-layout.ts
+++ b/apps/web/src/route-layout.ts
@@ -1,0 +1,3 @@
+export function isDetailWorkspacePath(pathname: string) {
+  return /^\/(?:issues|incidents)\/[^/]+\/?$/.test(pathname);
+}

--- a/apps/web/src/skeletons.test.tsx
+++ b/apps/web/src/skeletons.test.tsx
@@ -20,14 +20,14 @@ test("skeleton blocks are decorative and respect reduced motion", () => {
   assert.match(html, /motion-safe:animate-pulse/);
 });
 
-test("issue skeletons cover list and detail loading surfaces", () => {
+test("error skeletons cover list and detail loading surfaces", () => {
   const list = renderToStaticMarkup(<IssueListSkeleton />);
   const detail = renderToStaticMarkup(<IssueDetailSkeleton />);
 
   assert.match(list, /role="status"/);
   assert.match(detail, /role="status"/);
-  assert.match(list, /aria-label="Loading issues"/);
-  assert.match(detail, /aria-label="Loading issue detail"/);
+  assert.match(list, /aria-label="Loading errors"/);
+  assert.match(detail, /aria-label="Loading error detail"/);
 });
 
 test("incident skeletons cover list and detail loading surfaces", () => {

--- a/apps/web/src/skeletons.tsx
+++ b/apps/web/src/skeletons.tsx
@@ -82,7 +82,7 @@ function EntityListSkeleton({
 }
 
 export function IssueListSkeleton() {
-  return <EntityListSkeleton label="Loading issues" />;
+  return <EntityListSkeleton label="Loading errors" />;
 }
 
 export function IncidentListSkeleton() {
@@ -91,40 +91,59 @@ export function IncidentListSkeleton() {
 
 export function IssueDetailSkeleton() {
   return (
-    <SkeletonStatus label="Loading issue detail" className="space-y-8 p-4">
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <SkeletonBlock className="h-5 w-14" />
-          <SkeletonBlock className="h-5 w-2/3" />
-        </div>
+    <SkeletonStatus label="Loading error detail" className="flex min-h-0 flex-1 flex-col bg-bg">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-5 py-3">
+        <SkeletonBlock className="h-4 w-16" />
+        <SkeletonBlock className="h-4 w-2/5" />
+        <SkeletonBlock className="ml-auto h-7 w-20" />
         <SkeletonBlock className="h-7 w-7" />
       </div>
-      <div className="space-y-2">
-        <div className="flex gap-2">
-          <SkeletonBlock className="h-5 w-20" />
-          <SkeletonBlock className="h-5 w-24" />
-          <SkeletonBlock className="h-5 w-28" />
-        </div>
-        <SkeletonBlock className="h-4 w-3/5" />
-      </div>
-      <div className="space-y-3">
-        <SkeletonBlock className="h-4 w-24" />
-        <SkeletonBlock className="h-28 w-full" />
-      </div>
-      <div className="grid grid-cols-2 gap-3">
-        {ISSUE_META_CELLS.map((cell) => (
-          <div
-            key={`issue-meta-${cell}`}
-            className="space-y-2 border border-border bg-surface-2 p-3"
-          >
-            <SkeletonBlock className="h-3 w-20" />
-            <SkeletonBlock className="h-4 w-28" />
+      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[380px_minmax(0,1fr)]">
+        <aside className="border-b border-border px-7 py-7 lg:border-b-0 lg:border-r">
+          <div className="flex gap-2">
+            <SkeletonBlock className="h-5 w-16" />
+            <SkeletonBlock className="h-5 w-16" />
           </div>
-        ))}
-      </div>
-      <div className="space-y-2">
-        <SkeletonBlock className="h-8 w-full" />
-        <SkeletonBlock className="h-8 w-full" />
+          <div className="mt-5 space-y-3">
+            <SkeletonBlock className="h-3 w-32" />
+            <SkeletonBlock className="h-7 w-4/5" />
+            <SkeletonBlock className="h-4 w-full" />
+            <SkeletonBlock className="h-4 w-5/6" />
+          </div>
+          <div className="mt-7 grid gap-3.5">
+            {ISSUE_META_CELLS.map((cell) => (
+              <div
+                key={`issue-meta-${cell}`}
+                className="grid grid-cols-[116px_minmax(0,1fr)] gap-3"
+              >
+                <SkeletonBlock className="h-3 w-20" />
+                <SkeletonBlock className="h-4 w-full" />
+              </div>
+            ))}
+          </div>
+          <div className="mt-7 space-y-2">
+            <SkeletonBlock className="h-8 w-full" />
+            <SkeletonBlock className="h-8 w-full" />
+          </div>
+        </aside>
+        <main className="min-h-0 min-w-0 px-5 py-7 sm:px-7 lg:px-10">
+          <div className="mx-auto max-w-[900px] space-y-8">
+            <div className="space-y-3">
+              <SkeletonBlock className="h-3 w-24" />
+              <SkeletonBlock className="h-6 w-3/5" />
+              <SkeletonBlock className="h-4 w-4/5" />
+              <div className="grid gap-3 pt-2 sm:grid-cols-3">
+                <SkeletonBlock className="h-24 w-full" />
+                <SkeletonBlock className="h-24 w-full" />
+                <SkeletonBlock className="h-24 w-full" />
+              </div>
+            </div>
+            <div className="border-t border-border pt-7">
+              <SkeletonBlock className="h-3 w-24" />
+              <SkeletonBlock className="mt-4 h-40 w-full" />
+            </div>
+          </div>
+        </main>
       </div>
     </SkeletonStatus>
   );

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -14,7 +14,17 @@ export default {
           "Roboto",
           "sans-serif",
         ],
-        mono: ["JetBrains Mono", "ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
+        // Compatibility alias for older call sites. Interface typography is
+        // intentionally single-family; true source code uses `.superlog-code`.
+        mono: [
+          "Inter",
+          "ui-sans-serif",
+          "system-ui",
+          "-apple-system",
+          "Segoe UI",
+          "Roboto",
+          "sans-serif",
+        ],
       },
       colors: {
         // Solid colors use RGB-triplet vars (see index.css) so opacity
@@ -37,13 +47,13 @@ export default {
         success: "rgb(var(--color-success-rgb) / <alpha-value>)",
       },
       borderRadius: {
-        xs: "1px",
-        sm: "2px",
-        DEFAULT: "4px",
-        md: "6px",
-        lg: "10px",
-        xl: "12px",
-        "2xl": "14px",
+        xs: "2px",
+        sm: "4px",
+        DEFAULT: "6px",
+        md: "8px",
+        lg: "12px",
+        xl: "14px",
+        "2xl": "18px",
       },
       letterSpacing: {
         tightest: "-0.04em",
@@ -58,7 +68,7 @@ export default {
           "0 1px 0 0 rgba(255,255,255,0.05) inset, 0 1px 2px 0 rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.04)",
         "lift-md":
           "0 1px 0 0 rgba(255,255,255,0.06) inset, 0 2px 8px -1px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.05)",
-        "glow-accent": "0 0 0 1px rgba(72,90,226,0.35), 0 0 24px -4px rgba(72,90,226,0.42)",
+        "glow-accent": "0 0 0 1px rgba(115,178,222,0.28), 0 0 24px -6px rgba(115,178,222,0.3)",
       },
       keyframes: {
         "pulse-dot": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,10 +148,10 @@ importers:
         version: link:../../packages/render
       autumn-js:
         specifier: ^1.2.27
-        version: 1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.6.11
-        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -353,6 +353,9 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.40.0
         version: 1.40.0
+      '@phosphor-icons/react':
+        specifier: ^2.1.10
+        version: 2.1.10(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@pierre/diffs':
         specifier: ^1.2.7
         version: 1.2.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -370,10 +373,10 @@ importers:
         version: 2.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       autumn-js:
         specifier: ^1.2.27
-        version: 1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.6.11
-        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       echarts:
         specifier: ^6
         version: 6.1.0
@@ -555,7 +558,7 @@ importers:
     dependencies:
       better-auth:
         specifier: ^1.6.11
-        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
@@ -2590,6 +2593,13 @@ packages:
 
   '@oslojs/jwt@0.2.0':
     resolution: {integrity: sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==}
+
+  '@phosphor-icons/react@2.1.10':
+    resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>= 16.8'
+      react-dom: '>= 16.8'
 
   '@pierre/diffs@1.2.7':
     resolution: {integrity: sha512-YrHmFZLDtiLZ4DkiVqMDUFqTFIct3ML3t20nMp0UeuiUtqrmRcenYVxPb4IafiNkhZZURhCiwcs89tVb/HrSDA==}
@@ -8463,6 +8473,11 @@ snapshots:
     dependencies:
       '@oslojs/encoding': 0.4.1
 
+  '@phosphor-icons/react@2.1.10(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
   '@pierre/diffs@1.2.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@pierre/theme': 1.0.3
@@ -9225,13 +9240,13 @@ snapshots:
       postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  autumn-js@1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
+  autumn-js@1.2.27(better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.5(zod@4.4.3))(express@5.2.1)(hono@4.12.14)(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
     dependencies:
       query-string: 9.4.0
       rou3: 0.6.3
       zod: 4.4.3
     optionalDependencies:
-      better-auth: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      better-auth: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       better-call: 1.3.5(zod@4.4.3)
       express: 5.2.1
       hono: 4.12.14
@@ -9256,7 +9271,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.21: {}
 
-  better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))


### PR DESCRIPTION
## Summary

- introduce a persistent signed-in product shell with a compact sidebar and standard Phosphor icons
- refresh the shared palette, typography, spacing, controls, loading states, and main application pages
- separate Incidents and Errors in navigation, rename issue-facing UI to Errors, and redesign the error detail workspace
- reposition the MCP setup nudge and document the updated design language

## Impact

The application now uses a quieter, darker operational interface with clearer navigation and denser, more consistent data presentation. Existing routes and underlying issue APIs remain unchanged.

## Validation

- 19 focused UI tests
- `pnpm --filter @superlog/web build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the app design language with a quieter dark UI, a persistent product shell, and clearer Errors vs Incidents navigation. Improves data density and adds a full‑width investigation workspace without changing routes, light mode, or APIs.

- **New Features**
  - Added `ProductShell` with a compact sidebar, toolbar slot, and standard icons via `@phosphor-icons/react`.
  - Split navigation into Incidents and Errors; updated command palette; introduced full‑width detail workspace via `isDetailWorkspacePath` and a new `IssueDetailView` for errors.
  - Introduced `DataList` and `PageHeader`; applied to Alerts, Dashboards, and Settings; refined loading/error copy and skeletons; renamed log drawer section to “Error”.
  - Moved the MCP install pill to bottom-right; expanded the `/design` catalog and `DESIGN.md`; added focused tests for shell, lists, catalog, route layout, and error detail.

- **Refactors**
  - Updated dark palette, typography (single sans across UI), spacing, and radii (`index.css`, `tailwind.config.ts`); standardized control corners.
  - Replaced “Issue” with “Error” across UI and skeleton labels.
  - Adopted `@phosphor-icons/react`; replaced legacy `AppShell` with `ProductShell`; added `isDetailWorkspacePath` for detail routes.

<sup>Written for commit 24a77b2f3b8f9c1cc8a35cbda499688502a4341a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

