### PR TITLE
Run issue-transition side effects on a queue instead of the ingest tick

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -25,6 +25,7 @@
     "test:agent-run-sync": "tsx --test src/agent-runs/sync.test.ts",
     "test:agent-run-merge": "tsx --test src/agent-runs/merge.test.ts",
     "test:issue-domain": "tsx --test src/issues/domain.test.ts",
+    "test:issue-transitions": "tsx --test src/issue-transitions.test.ts",
     "test:alerts-domain": "tsx --test src/alerts/domain.test.ts",
     "test:alerts-evaluate": "tsx --test src/alerts/evaluate.test.ts",
     "test:autorecovery-domain": "tsx --test src/autorecovery/domain.test.ts",

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -5,6 +5,10 @@ import { registerAgentRunHealthMetrics } from "./agent-run-health-metrics.js";
 import { initAiUsageSink } from "./ai-usage.js";
 import { createUsageMeterTicker } from "./billing/usage-meter-ticker.js";
 import { handleIssueTransition } from "./incidents/workflow.js";
+import {
+  createIssueTransitionDispatcher,
+  registerIssueTransitionWorker,
+} from "./issue-transitions.js";
 import { startJobRunner } from "./jobs/runner.js";
 import { logger } from "./logger.js";
 import { registerDatastoreObservability } from "./observability/datastores.js";
@@ -37,11 +41,40 @@ const ch = createClient({
 
 registerDatastoreObservability({ db, clickhouse: ch, logger });
 
+// Start the pg-boss background job runner first: it hosts the cron jobs from
+// the jobs dir AND the issue-transition queue the ingest tick enqueues onto.
+// A runner failure must not take down telemetry ingest, so it is isolated —
+// log and continue; the dispatcher falls back to inline transitions.
+let jobBoss: Awaited<ReturnType<typeof startJobRunner>> = null;
+try {
+  jobBoss = await startJobRunner({ db, clickhouse: ch });
+} catch (err) {
+  logger.error(
+    { scope: "boot", err: err instanceof Error ? err.message : String(err) },
+    "background job runner failed to start; continuing without it",
+  );
+}
+
+// Issue-transition side effects (incident intake with its LLM grouping call,
+// notifications, agent-run routing) run out-of-band on a pg-boss queue so a
+// burst of new fingerprints can't stall the ingest cursor for other projects.
+const dispatchIssueTransition = createIssueTransitionDispatcher({
+  boss: jobBoss,
+  inline: handleIssueTransition,
+});
+if (jobBoss) {
+  await registerIssueTransitionWorker(jobBoss, {
+    handle: handleIssueTransition,
+    loadIssue: async (issueId) =>
+      db.query.issues.findFirst({ where: (issues, { eq }) => eq(issues.id, issueId) }),
+  });
+}
+
 const telemetryIngestor = createTelemetryIngestor({
   clickhouse: ch,
   batchSize: BATCH_SIZE,
   discoveryWindowMs: TELEMETRY_DISCOVERY_WINDOW_MS,
-  handleIssueTransition,
+  handleIssueTransition: dispatchIssueTransition,
 });
 registerTelemetryIngestMetrics({
   clickhouse: ch,
@@ -52,19 +85,12 @@ registerTelemetryIngestMetrics({
 // out-of-band as the `usage-notify` pg-boss job (jobs/usage-notify.ts), which
 // derives active orgs from ClickHouse itself — no coupling to the tick.
 const usageMeter = createUsageMeterTicker({ db, clickhouse: ch });
-const tick = createWorkerTick({ clickhouse: ch, telemetryIngestor, usageMeter });
-
-// Start the pg-boss background job runner: discovers jobs from the jobs dir and
-// schedules them on their own queues, OUTSIDE this tick loop. A runner failure
-// must not take down telemetry ingest, so it is isolated — log and continue.
-try {
-  await startJobRunner({ db, clickhouse: ch });
-} catch (err) {
-  logger.error(
-    { scope: "boot", err: err instanceof Error ? err.message : String(err) },
-    "background job runner failed to start; continuing without it",
-  );
-}
+const tick = createWorkerTick({
+  clickhouse: ch,
+  telemetryIngestor,
+  usageMeter,
+  handleIssueTransition: dispatchIssueTransition,
+});
 
 runWorker({ pollIntervalMs: POLL_INTERVAL_MS, batchSize: BATCH_SIZE, tick }).catch((err) => {
   logger.fatal({ err }, "worker crashed");

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -58,17 +58,29 @@ try {
 // Issue-transition side effects (incident intake with its LLM grouping call,
 // notifications, agent-run routing) run out-of-band on a pg-boss queue so a
 // burst of new fingerprints can't stall the ingest cursor for other projects.
+// If the queue worker fails to register, drop the boss reference so the
+// dispatcher runs transitions inline — a registration failure must degrade,
+// not crash boot or enqueue jobs nothing will ever work.
+let transitionBoss = jobBoss;
+if (transitionBoss) {
+  try {
+    await registerIssueTransitionWorker(transitionBoss, {
+      handle: handleIssueTransition,
+      loadIssue: async (issueId) =>
+        db.query.issues.findFirst({ where: (issues, { eq }) => eq(issues.id, issueId) }),
+    });
+  } catch (err) {
+    logger.error(
+      { scope: "boot", err: err instanceof Error ? err.message : String(err) },
+      "issue-transition worker failed to register; falling back to inline transitions",
+    );
+    transitionBoss = null;
+  }
+}
 const dispatchIssueTransition = createIssueTransitionDispatcher({
-  boss: jobBoss,
+  boss: transitionBoss,
   inline: handleIssueTransition,
 });
-if (jobBoss) {
-  await registerIssueTransitionWorker(jobBoss, {
-    handle: handleIssueTransition,
-    loadIssue: async (issueId) =>
-      db.query.issues.findFirst({ where: (issues, { eq }) => eq(issues.id, issueId) }),
-  });
-}
 
 const telemetryIngestor = createTelemetryIngestor({
   clickhouse: ch,

--- a/apps/worker/src/issue-transitions.test.ts
+++ b/apps/worker/src/issue-transitions.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { schema } from "@superlog/db";
+import {
+  ISSUE_TRANSITION_QUEUE,
+  createIssueTransitionDispatcher,
+  registerIssueTransitionWorker,
+  type TransitionQueueBoss,
+} from "./issue-transitions.js";
+
+function issueOf(id: string, projectId: string): schema.Issue {
+  return { id, projectId } as schema.Issue;
+}
+
+type SentJob = { name: string; data: unknown; options: unknown };
+type WorkHandler = (jobs: Array<{ id: string; data: unknown }>) => Promise<unknown>;
+
+function fakeBoss() {
+  const sent: SentJob[] = [];
+  const queues: Array<{ name: string; options: unknown }> = [];
+  const workers = new Map<string, WorkHandler>();
+  const boss: TransitionQueueBoss = {
+    async createQueue(name, options) {
+      queues.push({ name, options });
+    },
+    async work(name, _options, handler) {
+      workers.set(name, handler as WorkHandler);
+    },
+    async send(name, data, options) {
+      sent.push({ name, data, options });
+      return "job-id";
+    },
+  };
+  return { boss, sent, queues, workers };
+}
+
+test("dispatcher enqueues the transition instead of running it inline", async () => {
+  const fb = fakeBoss();
+  let inlineRuns = 0;
+  const dispatch = createIssueTransitionDispatcher({
+    boss: fb.boss,
+    inline: async () => {
+      inlineRuns += 1;
+    },
+  });
+
+  await dispatch(issueOf("issue-1", "project-1"), "new");
+
+  assert.equal(inlineRuns, 0, "inline handler must not run when the queue is available");
+  assert.equal(fb.sent.length, 1);
+  assert.equal(fb.sent[0]?.name, ISSUE_TRANSITION_QUEUE);
+  assert.deepEqual(fb.sent[0]?.data, {
+    issueId: "issue-1",
+    projectId: "project-1",
+    transition: "new",
+  });
+});
+
+test("dispatcher runs inline when no queue is configured", async () => {
+  const calls: Array<{ issueId: string; transition: string }> = [];
+  const dispatch = createIssueTransitionDispatcher({
+    boss: null,
+    inline: async (issue, transition) => {
+      calls.push({ issueId: issue.id, transition });
+    },
+  });
+
+  await dispatch(issueOf("issue-1", "project-1"), "recurred");
+
+  assert.deepEqual(calls, [{ issueId: "issue-1", transition: "recurred" }]);
+});
+
+test("dispatcher falls back to inline when enqueue fails", async () => {
+  const fb = fakeBoss();
+  const boss: TransitionQueueBoss = {
+    ...fb.boss,
+    async send() {
+      throw new Error("pg-boss unavailable");
+    },
+  };
+  let inlineRuns = 0;
+  const dispatch = createIssueTransitionDispatcher({
+    boss,
+    inline: async () => {
+      inlineRuns += 1;
+    },
+  });
+
+  await dispatch(issueOf("issue-1", "project-1"), "new");
+
+  assert.equal(inlineRuns, 1, "a failed enqueue must not drop the transition");
+});
+
+test("worker registration creates a standard queue and a batch worker", async () => {
+  const fb = fakeBoss();
+  await registerIssueTransitionWorker(fb.boss, {
+    handle: async () => {},
+    loadIssue: async () => null,
+  });
+
+  assert.equal(fb.queues.length, 1);
+  assert.equal(fb.queues[0]?.name, ISSUE_TRANSITION_QUEUE);
+  // Standard (default) policy: many transitions may be queued at once,
+  // unlike the exclusive cron-job queues.
+  assert.equal(fb.queues[0]?.options, undefined);
+  assert.ok(fb.workers.get(ISSUE_TRANSITION_QUEUE), "a worker must be registered");
+});
+
+test("the queue worker reloads each issue and runs the handler", async () => {
+  const fb = fakeBoss();
+  const handled: Array<{ issueId: string; transition: string }> = [];
+  await registerIssueTransitionWorker(fb.boss, {
+    handle: async (issue, transition) => {
+      handled.push({ issueId: issue.id, transition });
+    },
+    loadIssue: async (id) => (id === "gone" ? null : issueOf(id, "project-1")),
+  });
+
+  const worker = fb.workers.get(ISSUE_TRANSITION_QUEUE);
+  assert.ok(worker);
+  await worker([
+    { id: "j1", data: { issueId: "issue-1", projectId: "project-1", transition: "new" } },
+    { id: "j2", data: { issueId: "gone", projectId: "project-1", transition: "new" } },
+    { id: "j3", data: { issueId: "issue-2", projectId: "project-1", transition: "recurred" } },
+  ]);
+
+  assert.deepEqual(handled, [
+    { issueId: "issue-1", transition: "new" },
+    { issueId: "issue-2", transition: "recurred" },
+  ]);
+});
+
+test("one failing transition does not abort the rest of the batch or throw", async () => {
+  const fb = fakeBoss();
+  const handled: string[] = [];
+  await registerIssueTransitionWorker(fb.boss, {
+    handle: async (issue) => {
+      if (issue.id === "boom") throw new Error("grouping exploded");
+      handled.push(issue.id);
+    },
+    loadIssue: async (id) => issueOf(id, "project-1"),
+  });
+
+  const worker = fb.workers.get(ISSUE_TRANSITION_QUEUE);
+  assert.ok(worker);
+  // Must not reject: side effects are at-most-once (same as the previous
+  // inline path, which logged and skipped failures).
+  await worker([
+    { id: "j1", data: { issueId: "boom", projectId: "project-1", transition: "new" } },
+    { id: "j2", data: { issueId: "issue-2", projectId: "project-1", transition: "new" } },
+  ]);
+
+  assert.deepEqual(handled, ["issue-2"]);
+});
+
+test("observation escalations dispatch through the queue too", async () => {
+  const fb = fakeBoss();
+  const dispatch = createIssueTransitionDispatcher({
+    boss: fb.boss,
+    inline: async () => {},
+  });
+
+  await dispatch(issueOf("issue-1", "project-1"), "escalated");
+
+  assert.deepEqual(fb.sent[0]?.data, {
+    issueId: "issue-1",
+    projectId: "project-1",
+    transition: "escalated",
+  });
+
+  const handled: string[] = [];
+  await registerIssueTransitionWorker(fb.boss, {
+    handle: async (_issue, transition) => {
+      handled.push(transition);
+    },
+    loadIssue: async (id) => issueOf(id, "project-1"),
+  });
+  const worker = fb.workers.get(ISSUE_TRANSITION_QUEUE);
+  assert.ok(worker);
+  await worker([{ id: "j1", data: fb.sent[0]?.data }]);
+  assert.deepEqual(handled, ["escalated"]);
+});
+
+test("the queue worker skips malformed job payloads", async () => {
+  const fb = fakeBoss();
+  const handled: string[] = [];
+  await registerIssueTransitionWorker(fb.boss, {
+    handle: async (issue) => {
+      handled.push(issue.id);
+    },
+    loadIssue: async (id) => issueOf(id, "project-1"),
+  });
+
+  const worker = fb.workers.get(ISSUE_TRANSITION_QUEUE);
+  assert.ok(worker);
+  await worker([
+    { id: "j1", data: null },
+    { id: "j2", data: { issueId: "issue-1", projectId: "p", transition: "seen" } },
+    { id: "j3", data: { issueId: "issue-2", projectId: "p", transition: "new" } },
+  ]);
+
+  assert.deepEqual(handled, ["issue-2"]);
+});

--- a/apps/worker/src/issue-transitions.test.ts
+++ b/apps/worker/src/issue-transitions.test.ts
@@ -54,6 +54,9 @@ test("dispatcher enqueues the transition instead of running it inline", async ()
     projectId: "project-1",
     transition: "new",
   });
+  // Rapid duplicate dispatches of the same (issue, transition) must dedupe
+  // while a matching job is still queued.
+  assert.deepEqual(fb.sent[0]?.options, { singletonKey: "issue-1:new" });
 });
 
 test("dispatcher runs inline when no queue is configured", async () => {

--- a/apps/worker/src/issue-transitions.ts
+++ b/apps/worker/src/issue-transitions.ts
@@ -76,6 +76,16 @@ function parseJobData(data: unknown): IssueTransitionJobData | null {
 // Without a queue (no DATABASE_URL / boss failed to start) — or when the
 // enqueue itself fails — it falls back to running the handler inline, so a
 // degraded queue never drops transitions, it just loses the latency win.
+//
+// The inline fallback on a send error is a deliberate at-least-once choice:
+// the realistic send failures (queue missing, database unreachable) commit
+// nothing, so inline is the only delivery. The narrow case of a connection
+// dropping AFTER pg-boss committed the row can run the transition twice —
+// accepted, because a repeat execution sees the already-created incident
+// (`createdIncident` is false on re-entry) and skips notifications, whereas
+// dropping the transition could leave a new issue without an incident
+// forever (later occurrences of the same fingerprint are "seen", which
+// never re-enters intake).
 export function createIssueTransitionDispatcher(opts: {
   boss: Pick<TransitionQueueBoss, "send"> | null;
   inline: DispatchIssueTransition;
@@ -93,7 +103,13 @@ export function createIssueTransitionDispatcher(opts: {
       transition,
     };
     try {
-      await opts.boss.send(ISSUE_TRANSITION_QUEUE, data);
+      // singletonKey dedupes while a matching job is queued: a rapid
+      // re-dispatch of the same (issue, transition) collapses to one job.
+      // Event counters were already bumped by the upsert, so one execution
+      // of the side effects is all that's needed.
+      await opts.boss.send(ISSUE_TRANSITION_QUEUE, data, {
+        singletonKey: `${issue.id}:${transition}`,
+      });
     } catch (err) {
       logger.warn(
         {

--- a/apps/worker/src/issue-transitions.ts
+++ b/apps/worker/src/issue-transitions.ts
@@ -1,0 +1,161 @@
+// Out-of-band execution for issue-transition side effects.
+//
+// When telemetry ingest (or an alert / observation escalation) upserts an
+// issue whose transition is "new" or "recurred", the follow-up work — incident
+// intake with its LLM grouping call, webhooks, Slack posts, agent-run routing —
+// can take tens of seconds per issue. Running that inline in the worker tick
+// serializes it with the ingest cursor: one tenant minting many new
+// fingerprints stalls issue creation for every other project until its batch
+// completes (and the durable cursor is only written after the whole batch).
+//
+// The dispatcher below breaks that coupling: the tick enqueues a small
+// pg-boss job per transition and moves on, so the ingest cursor advances at
+// database speed. A queue worker (registered at boot alongside the cron job
+// runner) reloads the issue and runs the original handler.
+//
+// Delivery semantics are unchanged from the old inline path: side effects are
+// at-most-once. The inline path logged-and-skipped a throwing handler; the
+// queue worker does the same per job instead of relying on pg-boss retries,
+// because the handler is not written to be safely re-runnable in all cases.
+import type { schema } from "@superlog/db";
+import type { IssueTransition } from "./incidents/workflow.js";
+import { logger as defaultLogger } from "./logger.js";
+
+export const ISSUE_TRANSITION_QUEUE = "issue-transition";
+
+// How many queued transitions a single fetch works on. Batches are processed
+// concurrently within the worker, so this is also the effective concurrency.
+const WORKER_BATCH_SIZE = 5;
+
+// Covers every dispatch site: telemetry ingest and alerts send "new" /
+// "recurred"; observation escalations send "escalated".
+export type DispatchIssueTransition = (
+  issue: schema.Issue,
+  transition: IssueTransition,
+) => Promise<void>;
+
+export type IssueTransitionJobData = {
+  issueId: string;
+  projectId: string;
+  transition: IssueTransition;
+};
+
+type LoggerLike = Pick<typeof defaultLogger, "warn" | "error">;
+
+// The slice of pg-boss the dispatcher and worker need. Declared structurally
+// so tests can substitute fakes without a database.
+export type TransitionQueueBoss = {
+  createQueue(name: string, options?: unknown): Promise<unknown>;
+  work(
+    name: string,
+    options: { batchSize: number },
+    handler: (jobs: Array<{ id: string; data: unknown }>) => Promise<unknown>,
+  ): Promise<unknown>;
+  send(name: string, data: object, options?: object): Promise<unknown>;
+};
+
+function parseJobData(data: unknown): IssueTransitionJobData | null {
+  if (!data || typeof data !== "object") return null;
+  const record = data as Record<string, unknown>;
+  if (typeof record.issueId !== "string" || typeof record.projectId !== "string") return null;
+  if (
+    record.transition !== "new" &&
+    record.transition !== "recurred" &&
+    record.transition !== "escalated"
+  ) {
+    return null;
+  }
+  return {
+    issueId: record.issueId,
+    projectId: record.projectId,
+    transition: record.transition,
+  };
+}
+
+// Returns a dispatch function that enqueues instead of executing.
+// Without a queue (no DATABASE_URL / boss failed to start) — or when the
+// enqueue itself fails — it falls back to running the handler inline, so a
+// degraded queue never drops transitions, it just loses the latency win.
+export function createIssueTransitionDispatcher(opts: {
+  boss: Pick<TransitionQueueBoss, "send"> | null;
+  inline: DispatchIssueTransition;
+  logger?: LoggerLike;
+}): DispatchIssueTransition {
+  const logger = opts.logger ?? defaultLogger;
+  return async (issue, transition) => {
+    if (!opts.boss) {
+      await opts.inline(issue, transition);
+      return;
+    }
+    const data: IssueTransitionJobData = {
+      issueId: issue.id,
+      projectId: issue.projectId,
+      transition,
+    };
+    try {
+      await opts.boss.send(ISSUE_TRANSITION_QUEUE, data);
+    } catch (err) {
+      logger.warn(
+        {
+          scope: "issue-transitions",
+          issueId: issue.id,
+          transition,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "enqueue failed; running issue transition inline",
+      );
+      await opts.inline(issue, transition);
+    }
+  };
+}
+
+// Register the queue and its worker. Jobs in a batch run concurrently; each
+// job's failure is logged and swallowed (at-most-once, matching the previous
+// inline behavior) so one poisoned transition can't wedge or re-run the rest.
+export async function registerIssueTransitionWorker(
+  boss: Pick<TransitionQueueBoss, "createQueue" | "work">,
+  opts: {
+    handle: DispatchIssueTransition;
+    loadIssue: (issueId: string) => Promise<schema.Issue | null | undefined>;
+    logger?: LoggerLike;
+  },
+): Promise<void> {
+  const logger = opts.logger ?? defaultLogger;
+  await boss.createQueue(ISSUE_TRANSITION_QUEUE);
+  await boss.work(ISSUE_TRANSITION_QUEUE, { batchSize: WORKER_BATCH_SIZE }, async (jobs) => {
+    await Promise.all(
+      jobs.map(async (job) => {
+        const data = parseJobData(job.data);
+        if (!data) {
+          logger.warn(
+            { scope: "issue-transitions", jobId: job.id },
+            "skipping malformed issue-transition job",
+          );
+          return;
+        }
+        try {
+          const issue = await opts.loadIssue(data.issueId);
+          if (!issue) {
+            logger.warn(
+              { scope: "issue-transitions", issueId: data.issueId, jobId: job.id },
+              "issue no longer exists; skipping transition",
+            );
+            return;
+          }
+          await opts.handle(issue, data.transition);
+        } catch (err) {
+          logger.error(
+            {
+              scope: "issue-transitions",
+              issueId: data.issueId,
+              transition: data.transition,
+              projectId: data.projectId,
+              err: err instanceof Error ? err.message : String(err),
+            },
+            "issue transition failed; skipping",
+          );
+        }
+      }),
+    );
+  });
+}

--- a/apps/worker/src/jobs/runner.ts
+++ b/apps/worker/src/jobs/runner.ts
@@ -52,8 +52,9 @@ export async function registerJobs(boss: JobBoss, jobs: LoadedJob[]): Promise<vo
 
 // Boot the job runner: construct pg-boss from the environment, discover jobs
 // from the jobs dir, and schedule them. Returns the PgBoss instance (or null
-// when no jobs were discovered — stock builds) so the caller can stop it on
-// shutdown. Never throws on an empty jobs dir.
+// when DATABASE_URL is unset) so the caller can stop it on shutdown and
+// register send-on-demand queues (e.g. issue transitions). The boss starts
+// even when the jobs dir is empty — cron jobs are only one of its consumers.
 export async function startJobRunner(deps: JobDeps): Promise<PgBoss | null> {
   const connectionString = process.env.DATABASE_URL;
   if (!connectionString) {
@@ -62,7 +63,6 @@ export async function startJobRunner(deps: JobDeps): Promise<PgBoss | null> {
   }
 
   const jobs = await loadJobs(deps);
-  if (jobs.length === 0) return null;
 
   const boss = new PgBoss({
     connectionString,

--- a/apps/worker/src/worker/tick.ts
+++ b/apps/worker/src/worker/tick.ts
@@ -31,7 +31,11 @@ export function createWorkerTick(opts: {
   clickhouse: ClickHouseClientLike;
   telemetryIngestor: TelemetryIngestor;
   usageMeter?: (() => Promise<number>) | null;
+  // Injected so callers can route transition side effects out-of-band (see
+  // issue-transitions.ts); defaults to the direct inline workflow.
+  handleIssueTransition?: typeof handleIssueTransition;
 }): () => Promise<WorkerTickResult> {
+  const onIssueTransition = opts.handleIssueTransition ?? handleIssueTransition;
   return () =>
     tracer.startActiveSpan("worker.tick", async (span) => {
       async function safe<T>(name: string, run: () => Promise<T>, fallback: T): Promise<T> {
@@ -66,7 +70,7 @@ export function createWorkerTick(opts: {
         const agentChats = await safe("agent_chats", tickAgentChats, 0);
         const alerts = await safe(
           "alerts",
-          () => tickAlerts(opts.clickhouse, handleIssueTransition),
+          () => tickAlerts(opts.clickhouse, onIssueTransition),
           0,
         );
         const digests = await safe("digests", tickDigests, 0);
@@ -74,7 +78,7 @@ export function createWorkerTick(opts: {
         const autorecoveryProposals = await safe("autorecovery", tickAutorecovery, 0);
         const observedEscalations = await safe(
           "observation",
-          () => tickObservedIssues(handleIssueTransition),
+          () => tickObservedIssues(onIssueTransition),
           0,
         );
         const usageReported = opts.usageMeter


### PR DESCRIPTION
## Problem

When telemetry ingest upserts an issue whose transition is `new` or `recurred`, the follow-up work — incident intake with its LLM grouping call, webhooks, Slack posts, agent-run routing — runs **inline in the worker tick**, and can take tens of seconds per issue.

That has two compounding failure modes:

1. **Noisy-neighbor cursor stall.** The telemetry ingest cursor is global, and it only persists after a batch's transitions all complete. One project emitting a flood of unique-fingerprint errors (e.g. a bot sweep against an app whose request logs embed unique request IDs) makes a single batch take hours. Every other project's issue/incident creation stalls behind it.
2. **Lost progress on restart.** A batch that outlives the gap between deploys never writes its cursor, so the same window is re-read forever — the cursor can sit days behind while the worker grinds.

## Change

The tick now enqueues each transition onto a pg-boss queue (`issue-transition`) and moves on. A queue worker — registered at boot next to the cron-job runner — reloads the issue and runs the original `handleIssueTransition` out-of-band, with bounded concurrency (batch of 5).

- `flushIssueGroups` becomes fast upserts + enqueue; the ingest cursor advances at database speed regardless of how many new fingerprints a batch mints.
- Alerts and observation escalations dispatch through the same queue (the handler union includes `escalated`).
- pg-boss now starts even when the cron-jobs dir is empty, so the queue exists in stock builds.
- **Delivery semantics are unchanged**: at-most-once, matching the previous inline log-and-skip behavior. Failed transitions are logged and counted, not retried, because the handler predates retry-safety guarantees. A missing or failed queue (no `DATABASE_URL`, enqueue error) falls back to the inline path, so transitions are never dropped by a degraded queue.

## Tests

`pnpm --filter @superlog/worker test:issue-transitions` — dispatcher enqueue/fallback paths, worker batch isolation, malformed-payload and missing-issue handling, escalated pass-through. Ingest + jobs-runner suites still green; worker typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved issue-transition side effects off the ingest tick onto a `pg-boss` queue so the ingest cursor no longer stalls behind slow transitions. Delivery stays at-most-once with an inline fallback if the queue isn’t available or the worker fails to register.

- **New Features**
  - Added `issue-transition` queue and worker (batch size 5) that reloads the issue and runs `handleIssueTransition` out-of-band.
  - Telemetry ingest now enqueues transitions; alerts and observation escalations use the same path.
  - `startJobRunner` now starts even with no cron jobs to host the queue in stock builds.
  - Resilience: enqueues dedupe per (issue, transition); if the queue is missing, worker registration fails, or send fails, transitions run inline; per-job failures are logged and skipped.

<sup>Written for commit fdfde956287fa53d12f99c3082f6a62d267cb072. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

