### PR TITLE
Collapse short hex runs and id-shaped tokens in log fingerprints

### DIFF
--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -48,6 +48,96 @@ test("messageBucketFor still separates genuinely different messages", () => {
   );
 });
 
+// Serverless platforms stamp every runtime log line with a per-request ID
+// whose tail is a short (8-16 char) hex run plus a mixed letter-digit node
+// token, e.g. `sin1::h4p45-1783721553799-7973d118dc17`. The old rules only
+// collapsed hex runs of 20+ chars, so every request produced a unique
+// fingerprint — one flooding deployment can mint tens of thousands of issues.
+test("fingerprintLog groups request-scoped runtime log lines from serverless drains", () => {
+  const line = (region: string, node: string, epoch: string, hexTail: string, path: string) =>
+    `START RequestId: ${region}::${node}-${epoch}-${hexTail}\n[GET] ${path}`;
+  const base = {
+    service: "storefront",
+    severity: "ERROR",
+    exceptionType: "ERROR",
+    stacktrace: null,
+  };
+  const fp1 = fingerprintLog({
+    ...base,
+    body: line("sin1", "h4p45", "1783721553799", "7973d118dc17", "/collections/bath?filter=a"),
+  });
+  // Node tokens with a single digit run (sv2np) and other regions must group
+  // too: the whole digit-bearing `scope::token` blob collapses to one id.
+  const fp2 = fingerprintLog({
+    ...base,
+    body: line("gru1", "sv2np", "1783721551971", "8ab18e6846a0", "/collections/kids?filter=b"),
+  });
+  assert.equal(fp1.hash, fp2.hash);
+});
+
+test("digit-free scoped tokens like C++ symbols survive normalization", () => {
+  const a = fingerprintLog({
+    service: "s",
+    severity: "ERROR",
+    body: "terminate called after throwing an instance of std::bad_alloc",
+    exceptionType: null,
+    stacktrace: null,
+  });
+  const b = fingerprintLog({
+    service: "s",
+    severity: "ERROR",
+    body: "terminate called after throwing an instance of std::length_error",
+    exceptionType: null,
+    stacktrace: null,
+  });
+  assert.notEqual(a.hash, b.hash);
+});
+
+test("normalized log bodies collapse short hex runs and mixed letter-digit id tokens", () => {
+  const a = fingerprintLog({
+    service: "s",
+    severity: "ERROR",
+    body: "cache write failed for entry 7973d118dc17 on node h4p45",
+    exceptionType: null,
+    stacktrace: null,
+  });
+  const b = fingerprintLog({
+    service: "s",
+    severity: "ERROR",
+    body: "cache write failed for entry 8ab18e6846a0 on node 2kxk8",
+    exceptionType: null,
+    stacktrace: null,
+  });
+  assert.equal(a.hash, b.hash);
+});
+
+test("meaningful single-digit-run tokens are not collapsed", () => {
+  // utf8 / sha256 / base64-style tokens carry meaning and have one digit run;
+  // only tokens with 2+ separate digit runs (id shapes) may collapse.
+  const a = fingerprintLog({
+    service: "s",
+    severity: "ERROR",
+    body: "sha256 digest mismatch decoding utf8 payload",
+    exceptionType: null,
+    stacktrace: null,
+  });
+  const b = fingerprintLog({
+    service: "s",
+    severity: "ERROR",
+    body: "base64 padding error decoding utf8 payload",
+    exceptionType: null,
+    stacktrace: null,
+  });
+  assert.notEqual(a.hash, b.hash);
+});
+
+test("messageBucketFor collapses short hex runs and id tokens for span messages", () => {
+  assert.equal(
+    messageBucketFor("upstream call failed (request 7973d118dc17 via sin1::h4p45)"),
+    messageBucketFor("upstream call failed (request 8ab18e6846a0 via gru1::sv2np)"),
+  );
+});
+
 // Postgres text and jsonb columns reject the NUL byte (0x00) — it raises
 // `22021 invalid byte sequence for encoding "UTF8": 0x00`. Telemetry can carry
 // a raw NUL in a message or stack frame; the fingerprint outputs feed straight

--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -75,6 +75,40 @@ test("fingerprintLog groups request-scoped runtime log lines from serverless dra
   assert.equal(fp1.hash, fp2.hash);
 });
 
+// URLs collapse host-preservingly: the host is a bounded discriminator that
+// names which dependency failed, so it must survive; the path/query vary per
+// request and must not.
+test("same error against different hosts stays distinct", () => {
+  const mk = (body: string) =>
+    fingerprintLog({ service: "s", severity: "ERROR", body, exceptionType: null, stacktrace: null });
+  assert.notEqual(
+    mk("OutOfMemory: http://web.company.com").hash,
+    mk("OutOfMemory: http://api.company.com").hash,
+  );
+  assert.notEqual(
+    messageBucketFor("OutOfMemory: http://web.company.com"),
+    messageBucketFor("OutOfMemory: http://api.company.com"),
+  );
+});
+
+test("same error against the same host groups across request paths", () => {
+  const mk = (body: string) =>
+    fingerprintLog({ service: "s", severity: "ERROR", body, exceptionType: null, stacktrace: null });
+  assert.equal(
+    mk("fetch failed: https://api.stripe.com/v1/charges/ch_1a2b3c?expand=customer").hash,
+    mk("fetch failed: https://api.stripe.com/v1/charges/ch_9z8y7x").hash,
+  );
+});
+
+test("id-shaped host labels still collapse", () => {
+  const mk = (body: string) =>
+    fingerprintLog({ service: "s", severity: "ERROR", body, exceptionType: null, stacktrace: null });
+  assert.equal(
+    mk("upstream timeout: https://customer-7973d118dc17.workers.dev/render").hash,
+    mk("upstream timeout: https://customer-8ab18e6846a0.workers.dev/render").hash,
+  );
+});
+
 test("digit-free scoped tokens like C++ symbols survive normalization", () => {
   const a = fingerprintLog({
     service: "s",

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -96,7 +96,7 @@ const MESSAGE_BUCKET_MAX = 160;
 export function messageBucketFor(message: string | null | undefined): string {
   if (!message) return "";
   let s = unwrapAnthropicErrorMessage(message);
-  s = s.replace(/https?:\/\/\S+/gi, "<url>");
+  s = collapseUrls(s);
   s = collapseRequestPaths(s);
   s = s.replace(/\b[\w.+-]+@[\w.-]+\.\w+\b/g, "<email>");
   s = s.replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi, "<uuid>");
@@ -118,6 +118,18 @@ export function messageBucketFor(message: string | null | undefined): string {
 // unique fingerprint. The lookahead requires at least one a-f char so pure
 // numbers keep normalizing to `<n>` (no hash churn for numeric messages).
 const HEX_RUN = /\b(?=\d*[a-f])[0-9a-f]{8,}\b/gi;
+
+// The guiding rule for every collapse here: erase UNBOUNDED-cardinality
+// tokens (paths, query strings, request ids, numbers) and keep BOUNDED
+// discriminators. A URL's host names which dependency failed — collapsing
+// `OutOfMemory: http://web.company.com` and `http://api.company.com` onto one
+// fingerprint would merge two different errors — while its path/query vary
+// per request. So keep the host, drop the rest. Id-shaped host labels
+// (`customer-7973d118dc17.workers.dev`) still collapse because the hex/id
+// rules run over the kept host text afterwards.
+function collapseUrls(s: string): string {
+  return s.replace(/https?:\/\/([^\s/:?#]+)\S*/gi, (_m, host: string) => `<url:${host}>`);
+}
 
 // Tokens mixing letters with TWO OR MORE separate digit runs (h4p45, 5t6gm)
 // are id shapes: machine/instance tokens in request IDs. One digit run is
@@ -157,7 +169,7 @@ function unwrapAnthropicErrorMessage(raw: string): string {
 
 export function normalizeMessage(body: string): string {
   let s = body;
-  s = s.replace(/https?:\/\/\S+/gi, "<url>");
+  s = collapseUrls(s);
   s = collapseRequestPaths(s);
   s = s.replace(/\b[\w.+-]+@[\w.-]+\.\w+\b/g, "<email>");
   s = s.replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi, "<uuid>");

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -103,10 +103,36 @@ export function messageBucketFor(message: string | null | undefined): string {
   s = s.replace(/\b\d{4}-\d{2}-\d{2}[T ][\d:.]+Z?(?:[+-]\d{2}:?\d{2})?\b/g, "<ts>");
   s = s.replace(/\b(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?\b/g, "<ip>");
   s = s.replace(/\b0x[0-9a-f]+\b/gi, "<hex>");
+  s = collapseScopedIds(s);
+  s = s.replace(HEX_RUN, "<hex>");
   s = s.replace(/\b[A-Za-z0-9_]{20,}\b/g, "<id>");
+  s = s.replace(ID_TOKEN, "<id>");
   s = s.replace(/\b\d+\b/g, "<n>");
   s = s.replace(/\s+/g, " ").trim().toLowerCase();
   return s.length > MESSAGE_BUCKET_MAX ? s.slice(0, MESSAGE_BUCKET_MAX) : s;
+}
+
+// Hex runs of 8+ chars are identifiers (request-id tails, short digests),
+// never words. The old 20-char bound let serverless request IDs — whose hex
+// tail is typically 12 chars — through, so every request log line minted a
+// unique fingerprint. The lookahead requires at least one a-f char so pure
+// numbers keep normalizing to `<n>` (no hash churn for numeric messages).
+const HEX_RUN = /\b(?=\d*[a-f])[0-9a-f]{8,}\b/gi;
+
+// Tokens mixing letters with TWO OR MORE separate digit runs (h4p45, 5t6gm)
+// are id shapes: machine/instance tokens in request IDs. One digit run is
+// meaningful vocabulary (utf8, sha256, base64, es2022) and must survive; the
+// leading lookahead also keeps pure numbers out (they stay `<n>`).
+const ID_TOKEN = /\b(?=\d*[a-z])(?:[a-z]*\d+){2,}[a-z]*\b/gi;
+
+// `scope::token` pairs that contain a digit are request/instance IDs
+// (`sin1::sv2np-1783721553799-7973d118dc17`); ones without a digit are
+// vocabulary (C++ `std::bad_alloc`, Ruby `Net::ReadTimeout`) and survive.
+// Checked on the matched token itself via the replace callback, not a
+// lookahead, so a digit elsewhere in the message can't trigger a collapse.
+const SCOPED_TOKEN = /\b[a-z0-9]+::[a-z0-9][a-z0-9-]*\b/gi;
+function collapseScopedIds(s: string): string {
+  return s.replace(SCOPED_TOKEN, (token) => (/\d/.test(token) ? "<id>" : token));
 }
 
 // Collapse leading-slash request paths to a single `<path>` token. A route
@@ -140,7 +166,9 @@ export function normalizeMessage(body: string): string {
   s = s.replace(/\b0x[0-9a-f]+\b/gi, "<hex>");
   s = s.replace(/"(?:[^"\\]|\\.)*"/g, "<str>");
   s = s.replace(/'(?:[^'\\]|\\.)*'/g, "<str>");
-  s = s.replace(/\b[0-9a-f]{20,}\b/gi, "<hex>");
+  s = collapseScopedIds(s);
+  s = s.replace(HEX_RUN, "<hex>");
+  s = s.replace(ID_TOKEN, "<id>");
   s = s.replace(/\b\d+\b/g, "<n>");
   s = s.replace(/\s+/g, " ").trim().toLowerCase();
   return s;


### PR DESCRIPTION
## Problem

Serverless platforms stamp every runtime log line with a per-request ID like `sin1::h4p45-1783721553799-7973d118dc17`. `normalizeMessage` only collapsed hex runs of **20+** chars, so the 12-char hex tail and the mixed letter-digit node token both survived normalization — every request log line produced a unique fingerprint. One flooding deployment (e.g. a bot sweep against a storefront whose request logs land at error severity) mints tens of thousands of issues from a handful of real error classes, which is exactly the noisy-neighbor load that stresses issue ingestion.

## Change

Three rules, applied in both `normalizeMessage` (log fingerprints) and `messageBucketFor` (span message buckets):

1. **Hex runs of 8+ chars → `<hex>`.** A lookahead requires at least one `a-f` char, so pure numbers keep normalizing to `<n>` — no hash churn for numeric-only messages.
2. **`scope::token` pairs containing a digit → `<id>`.** Digit-free scoped tokens (`std::bad_alloc`, `Net::ReadTimeout`) survive. The digit check runs on the matched token itself via a replace callback, not a lookahead, so a digit elsewhere in the message can't trigger a collapse.
3. **Tokens mixing letters with 2+ separate digit runs (`h4p45`, `2kxk8`) → `<id>`.** Single-digit-run vocabulary (`utf8`, `sha256`, `base64`, `es2022`) survives.

With these, the request-ID line above and its siblings across regions/nodes/requests collapse to one fingerprint per error class.

## Notes

- Fingerprints for messages containing these token shapes are re-keyed once (new hashes → occurrences start a fresh issue); messages without them are unaffected.
- `pnpm --filter @superlog/fingerprint test` — 12/12, including regression tests for the serverless request-ID shape, C++/Ruby scoped symbols, and single-digit-run vocabulary. Worker ingest/grouping/issue-domain suites green; typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses short hex runs and id-shaped tokens in `@superlog/fingerprint` to stabilize serverless request-scoped log fingerprints and cut issue spam. Preserves URL hosts while collapsing paths/queries so distinct dependencies stay separate; the same rules apply to span message buckets.

- **Bug Fixes**
  - Hex runs of 8+ chars with at least one a–f → `<hex>`; numeric-only stays `<n>`.
  - `scope::token` containing a digit → `<id>`; digit-free scoped tokens (e.g., `std::bad_alloc`) stay.
  - Tokens with letters and 2+ digit runs (e.g., `h4p45`) → `<id>`; single-run vocab (`utf8`, `sha256`, `base64`, `es2022`) stays.
  - Preserve URL hosts; collapse only path/query to `<url:host>`; id-shaped host labels still collapse via later `<hex>`/`<id>` passes.
  - Rules applied in both `normalizeMessage` and `messageBucketFor`.

- **Migration**
  - Fingerprints matching these shapes will re-key once; others are unchanged.

<sup>Written for commit 82a1935abe3317ca1ed5e236ed14924844088cc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

