### PR TITLE
Prevent horizontal scrolling in incident detail

### DIFF
--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -65,6 +65,7 @@ import {
   type IncidentMetaRow,
   buildIncidentDetailMeta,
 } from "./incidents/incident-detail-view-model.ts";
+import { IncidentDetailScrollArea } from "./incidents/IncidentDetailScrollArea.tsx";
 import { getIssueIncidentLinkState } from "./issue-incident-link-state.ts";
 import {
   IncidentDetailSkeleton,
@@ -1570,7 +1571,7 @@ export function IncidentDetailContent({
         <div className="flex min-h-0 min-w-0 flex-col bg-bg">
           <IncidentDetailTabs active={detailTab} onChange={setDetailTab} />
 
-          <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6 lg:px-8">
+          <IncidentDetailScrollArea>
             {detailTab === "activity" && (
               <div className="space-y-8">
                 {outOfCredits && <OutOfCreditsBanner />}
@@ -1662,7 +1663,7 @@ export function IncidentDetailContent({
             {detailTab === "pr" && (
               <IncidentPullRequestPanel projectId={incident.projectId} incidentId={incident.id} />
             )}
-          </div>
+          </IncidentDetailScrollArea>
 
           {detailTab === "activity" && (
             <IncidentChatComposer

--- a/apps/web/src/incident-detail-layout.test.ts
+++ b/apps/web/src/incident-detail-layout.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React, { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { IncidentDetailScrollArea } from "./incidents/IncidentDetailScrollArea.tsx";
+
+test("incident detail content scrolls vertically without exposing a horizontal scrollbar", () => {
+  (globalThis as typeof globalThis & { React: typeof React }).React = React;
+  const html = renderToStaticMarkup(
+    createElement(IncidentDetailScrollArea, null, "Incident activity"),
+  );
+
+  assert.match(html, /overflow-x-hidden overflow-y-auto/);
+});

--- a/apps/web/src/incidents/IncidentDetailScrollArea.tsx
+++ b/apps/web/src/incidents/IncidentDetailScrollArea.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export function IncidentDetailScrollArea({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-6 py-6 lg:px-8">
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- prevent the incident detail activity pane from exposing a page-level horizontal scrollbar
- preserve vertical scrolling and the local scrolling behavior of nested evidence blocks
- add regression coverage for the incident detail scroll contract

## Root cause

The activity pane declared `overflow-y: auto` while leaving horizontal overflow at its default. CSS computes the other axis as scrollable in that combination, so small amounts of overflowing content produced a horizontal scrollbar across the pane.

## Validation

- `pnpm --filter @superlog/web test` (107 tests)
- `pnpm --filter @superlog/web typecheck`
- targeted formatting and diff checks


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the horizontal scrollbar in the incident detail view while keeping vertical scrolling and nested evidence scrolling intact.

- **Bug Fixes**
  - Replaces the activity pane container with `IncidentDetailScrollArea` to centralize scroll behavior.
  - Applies `overflow-x-hidden` with `overflow-y-auto` to remove page-level horizontal scroll.
  - Adds a regression test (`incident-detail-layout.test.ts`) to assert the scroll class contract.

<sup>Written for commit b249189359fe2ec8edc621f855672ecb966902f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

