### PR TITLE
Demo-mode top ribbon + block billing while exploring demo data

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -36,6 +36,7 @@ import { DashboardsList } from "./dashboards/DashboardsList.tsx";
 import { AppShell, ThemeToggle, Wordmark } from "./design/ui.tsx";
 import { McpInstallPill } from "./onboarding/McpInstallPill.tsx";
 import { OnboardingGate } from "./onboarding/OnboardingGate.tsx";
+import { useDemoExploration } from "./onboarding/demoExploration.tsx";
 import {
   buildSignupEventProperties,
   parseAttribution,
@@ -217,11 +218,11 @@ function AuthenticatedApp() {
   return (
     <OnboardingGate>
       <div className="flex min-h-screen flex-col bg-bg">
-        {impersonating ? (
-          <ImpersonationBar email={data.user.email} />
-        ) : (
-          billingPaused && <BillingLimitBar />
-        )}
+        <TopRibbon
+          impersonating={impersonating}
+          email={data.user.email}
+          billingPaused={billingPaused}
+        />
         <AppShell nav={<TopNav />}>
           <RouteContainer>
             <Routes>
@@ -273,6 +274,42 @@ function useGlobalKeybinds(enabled: boolean) {
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, [enabled]);
+}
+
+// Single app-wide status ribbon slot. Only one bar shows at a time, in priority
+// order: impersonation (staff) > demo mode > billing paused. Demo mode reads the
+// exploration context so the bar tracks the same opt-in that gates the demo app.
+function TopRibbon({
+  impersonating,
+  email,
+  billingPaused,
+}: {
+  impersonating: boolean;
+  email: string;
+  billingPaused: boolean;
+}) {
+  const { exploring } = useDemoExploration();
+  if (impersonating) return <ImpersonationBar email={email} />;
+  if (exploring) return <DemoModeBar />;
+  if (billingPaused) return <BillingLimitBar />;
+  return null;
+}
+
+function DemoModeBar() {
+  const { stopExploring } = useDemoExploration();
+  return (
+    <div className="flex h-7 w-full items-center justify-center gap-2 bg-[#8C98F0] px-3 text-[11px] text-black">
+      <span className="font-semibold">Demo mode</span>
+      <span className="opacity-80">You’re viewing sample data.</span>
+      <button
+        type="button"
+        onClick={stopExploring}
+        className="font-medium underline underline-offset-2 hover:opacity-80"
+      >
+        Connect your app →
+      </button>
+    </div>
+  );
 }
 
 function ImpersonationBar({ email }: { email: string }) {

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -113,6 +113,7 @@ import { AWS_REGIONS } from "./awsRegions.ts";
 import { Dropdown, type DropdownOption } from "./design/Dropdown.tsx";
 import { Btn, Chip, FieldLabel, Input, Label, Tile } from "./design/ui";
 import { McpInstallPanel } from "./onboarding/McpInstallDialog.tsx";
+import { useDemoExploration } from "./onboarding/demoExploration.tsx";
 import { InfoIcon } from "./onboarding/icons.tsx";
 import { renderErrorMessage } from "./onboarding/renderConnectModel.ts";
 import { VERCEL_PLAN_REQUIREMENT } from "./onboarding/vercelConnectModel.ts";
@@ -336,7 +337,13 @@ function SettingsSideNav({
   section: SectionId;
   onNavigate: (target: NavTarget) => void;
 }) {
-  const groups = scope === "org" ? ORG_NAV_GROUPS : PROJECT_NAV_GROUPS;
+  const { exploring } = useDemoExploration();
+  const rawGroups = scope === "org" ? ORG_NAV_GROUPS : PROJECT_NAV_GROUPS;
+  // Billing is blocked while exploring demo data (no real project to bill yet),
+  // so drop its tab from the org sidebar.
+  const groups = exploring
+    ? rawGroups.map((g) => ({ ...g, items: g.items.filter((i) => i.id !== "billing") }))
+    : rawGroups;
   return (
     <nav className="shrink-0 md:sticky md:top-6 md:w-56">
       <ul className="flex flex-col gap-0.5">
@@ -543,6 +550,21 @@ function NewProjectForm({
 }
 
 function OrgSectionView({ section }: { section: OrgSectionId }) {
+  const { exploring } = useDemoExploration();
+  // Billing is unavailable while exploring demo data — guard the section in case
+  // it's reached by a deep link (the sidebar tab is already hidden).
+  if (section === "billing" && exploring) {
+    return (
+      <Section title="Billing" subtitle="Your plan, usage this period, and payment — billed per org.">
+        <Tile>
+          <p className="text-[13px] text-muted">
+            Billing is unavailable while you’re exploring demo data. Connect your app to start
+            sending your own telemetry, then manage your plan here.
+          </p>
+        </Tile>
+      </Section>
+    );
+  }
   switch (section) {
     case "general":
       return (


### PR DESCRIPTION
## What

When a user explores the shared demo project (before instrumenting their own app), give them a clear, persistent signal and keep them out of billing.

- **Top ribbon**: a new `TopRibbon` component owns the single app-wide status-bar slot, choosing one bar by priority — impersonation > demo mode > billing paused (previously an inline impersonation/billing ternary). The new `DemoModeBar` reads the existing `useDemoExploration()` context, so it shows exactly while the user is exploring demo data. Its "Connect your app →" button drops the demo opt-in and returns to the install wizard (same action as the floating install nudge).
- **Billing blocked in demo mode**: billing is per-org and has nothing to bill until the user connects their own app, so while exploring we hide the org **Billing** settings tab and guard the section itself (defends against a deep link) with an explanatory notice instead of the plan/payment card.

## Notes

- The canonical nav model (`settings/nav.ts`) is untouched — the Billing tab is filtered at render time — so `nav.test.ts` still asserts it present.
- No new state: everything keys off the `demoExploration` context that already gates the demo experience (safe outside the provider via its default `{exploring:false}`).

## Testing

- `pnpm --filter @superlog/web typecheck` clean.
- `nav.test.ts` 10/10.
- Verified on a local stack: a fresh signup reports `demoMode=true`; opting into demo shows the ribbon, and the org Billing tab/section is blocked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an app-wide top ribbon for demo mode and block access to Billing while exploring demo data. This gives a clear status and avoids billing until the user connects their own app.

- **New Features**
  - Added `TopRibbon` as the single status bar (priority: impersonation > demo mode > billing paused).
  - Introduced `DemoModeBar` tied to `useDemoExploration`; shows only during demo. “Connect your app →” exits demo and returns to install.
  - Hid the org Billing tab in demo mode and guarded the Billing section with an explanatory notice for deep links.
  - Kept the canonical nav model unchanged; Billing is filtered at render time.

<sup>Written for commit cb7757a79ad63efdbb0d89e459b7c1d208509050. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

