### PR TITLE
Add a 'Book a call' help tile to the onboarding connect chooser

### DIFF
--- a/apps/web/src/onboarding/ConnectDataChooser.tsx
+++ b/apps/web/src/onboarding/ConnectDataChooser.tsx
@@ -8,14 +8,20 @@ import {
 } from "./connectChoices.ts";
 import {
   AwsIcon,
+  CalendarIcon,
   ChevronRightIcon,
   CloudflareIcon,
+  ExternalLinkIcon,
   RailwayIcon,
   RenderIcon,
   TerminalIcon,
   VercelIcon,
 } from "./icons.tsx";
 import { ExploreDemoLink, SOFT_LINE } from "./wizardChrome.tsx";
+
+// Where the "Book a call" tile sends people. Onboarding-only human-help escape
+// hatch — not a data source, so it lives outside the CONNECT_SECTIONS catalog.
+const ONBOARDING_CALL_URL = "https://cal.com/ash-superlog/onboarding";
 
 // The path chooser: a flat, low-color list (modeled on a Plugins page). Peer
 // lanes — the no-code integrations (AWS, Cloudflare, Vercel, integration-first)
@@ -101,6 +107,33 @@ function Section({
   );
 }
 
+// A row that looks like a connector tile but opens an external booking link
+// instead of routing into a connect flow. Kept out of CONNECT_SECTIONS so the
+// data-source catalog stays a pure list of telemetry sources.
+function BookCallTile() {
+  return (
+    <a
+      href={ONBOARDING_CALL_URL}
+      target="_blank"
+      rel="noreferrer"
+      className={`group flex w-full items-center gap-3.5 overflow-hidden rounded-[14px] border bg-surface px-[18px] py-[14px] text-left transition-colors hover:bg-surface-2 ${SOFT_LINE}`}
+    >
+      <span className="grid h-9 w-9 shrink-0 place-items-center rounded-[9px] border border-border bg-surface-2 text-muted">
+        <CalendarIcon size={18} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-[14px] font-medium text-fg">Need help onboarding?</span>
+        <span className="mt-0.5 block text-[12.5px] leading-[1.45] text-muted">
+          Book a call with our experts and we'll walk you through getting your data in.
+        </span>
+      </span>
+      <span className="text-subtle transition-colors group-hover:text-muted">
+        <ExternalLinkIcon size={15} />
+      </span>
+    </a>
+  );
+}
+
 export function ConnectDataChooser({
   onPick,
   onExploreDemo,
@@ -133,6 +166,7 @@ export function ConnectDataChooser({
         {sections.map((section) => (
           <Section key={section.id} section={section} onPick={onPick} />
         ))}
+        <BookCallTile />
       </div>
 
       <ExploreDemoLink onExploreDemo={onExploreDemo} />

--- a/apps/web/src/onboarding/icons.tsx
+++ b/apps/web/src/onboarding/icons.tsx
@@ -235,6 +235,26 @@ export function ExternalLinkIcon({ size = 13, className }: IconProps) {
   );
 }
 
+export function CalendarIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <rect x="1.5" y="2.5" width="11" height="10" rx="1.5" />
+      <path d="M1.5 5.5h11M4.5 1v2.5M9.5 1v2.5" />
+    </svg>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Connect-source glyphs. Neutral monochrome line icons (currentColor) so no
 // per-integration brand color competes for attention on the chooser.


### PR DESCRIPTION
## What

Adds a low-emphasis **"Need help onboarding?"** tile at the bottom of the "Connect your data" onboarding chooser. It links to a booking page so a new user who'd rather get help from a human than self-serve the connect flow has an obvious path.

The tile is styled like the existing connector rows (icon tile on the left, title + description, glyph on the right), but it's an external link — it opens the booking URL in a new tab (`target="_blank" rel="noreferrer"`) instead of routing into a connect flow.

## Why it's not in `CONNECT_SECTIONS`

`connectChoices.ts` is the pure telemetry-source catalog, and its tests assert exact membership (the six connectors) and that every entry is actionable. A "book a call" entry there would break those invariants and misrepresent it as a data source. So the tile is rendered directly by `ConnectDataChooser` as a sibling of the connector card, leaving the catalog untouched.

## Changes

- `onboarding/ConnectDataChooser.tsx` — new `BookCallTile` (external-link tile) + the booking URL constant; rendered as the last card in the list.
- `onboarding/icons.tsx` — new `CalendarIcon`, matching the existing monochrome line-icon style.

## Verification

- `pnpm --filter @superlog/web typecheck` passes.
- `connectChoices` tests untouched and green (catalog unchanged).
- Drove a fresh sign-up in the browser and confirmed the tile renders at the bottom of the chooser, with the correct icons and an anchor pointing at the booking URL. Also confirmed it coexists cleanly with the "Explore with sample data" demo link when demo mode is enabled (tile as a card, demo link as quiet text below it).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a low‑emphasis “Need help onboarding?” tile at the bottom of the “Connect your data” chooser that links to a booking page, giving users a human-help path without touching `CONNECT_SECTIONS`.

- **New Features**
  - Renders `BookCallTile` in `ConnectDataChooser` after the connector list using `ONBOARDING_CALL_URL`.
  - Opens as an external link (`target="_blank" rel="noreferrer"`) with an external-link glyph; the data-source catalog (`CONNECT_SECTIONS`) remains unchanged.
  - Adds `CalendarIcon` to `onboarding/icons.tsx` to match the existing line-icon set.

<sup>Written for commit 023d0ad23a84f574f895a62f922efeeb2ec410c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

