### PR TITLE
Advance agent runs as per-run pg-boss jobs instead of a tick batch

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -20,6 +20,7 @@
     "test:slack-pinning": "tsx --test src/slack-pinning.test.ts",
     "test:incident-cooldown": "tsx --test src/incident-cooldown.test.ts",
     "test:agent-run": "tsx --test src/agent-run.test.ts",
+    "test:agent-run-queue": "tsx --test src/agent-runs/queue.test.ts",
     "test:agent-run-start": "tsx --test src/agent-runs/start.test.ts",
     "test:agent-run-status": "tsx --test src/agent-runs/status.test.ts",
     "test:agent-run-sync": "tsx --test src/agent-runs/sync.test.ts",

--- a/apps/worker/src/agent-runs/enqueue.ts
+++ b/apps/worker/src/agent-runs/enqueue.ts
@@ -1,0 +1,15 @@
+// Process-wide hook for enqueueing an agent-run advance job from code that
+// can't (and shouldn't) hold a pg-boss reference — e.g. the incident workflow
+// that creates runs. Unset (stock boot order, tests, degraded queue) it is a
+// no-op: the minute sweep advances every active run regardless, so this hook
+// only buys latency, never correctness.
+let dispatch: ((agentRunId: string) => Promise<void>) | null = null;
+
+export function setAgentRunJobDispatch(fn: ((agentRunId: string) => Promise<void>) | null): void {
+  dispatch = fn;
+}
+
+export async function dispatchAgentRunJob(agentRunId: string): Promise<void> {
+  if (!dispatch) return;
+  await dispatch(agentRunId);
+}

--- a/apps/worker/src/agent-runs/queue-wiring.ts
+++ b/apps/worker/src/agent-runs/queue-wiring.ts
@@ -1,0 +1,55 @@
+// Production wiring for the agent-run queue: binds queue.ts (pure, tested
+// against fakes) to the real database, context loader, and state handlers.
+import { db, schema } from "@superlog/db";
+import { asc, inArray } from "drizzle-orm";
+import { loadAgentRunContext } from "../agent-run-context.js";
+import { ACTIVE_STATES, createAgentRunLifecycle } from "../agent-run.js";
+import { setAgentRunJobDispatch } from "./enqueue.js";
+import { retryQueuedPullRequestDelivery } from "./pr-delivery.js";
+import { type AgentRunQueueBoss, createAgentRunJobSender, registerAgentRunQueue } from "./queue.js";
+import { resumeAgentRunFromHumanInput } from "./resume.js";
+import { startQueuedAgentRun } from "./start-run.js";
+import { syncRunningAgentRun } from "./sync.js";
+
+const lifecycle = createAgentRunLifecycle(db);
+
+function parseConcurrency(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+// Register the advance + sweep queues on the boss and install the process-wide
+// dispatch hook so run creation enqueues immediately.
+export async function startAgentRunQueue(boss: AgentRunQueueBoss): Promise<void> {
+  await registerAgentRunQueue(boss, {
+    loadRun: async (id) =>
+      db.query.agentRuns.findFirst({ where: (runs, { eq }) => eq(runs.id, id) }),
+    loadContext: loadAgentRunContext,
+    failContextUnavailable: async (agentRun) => {
+      await lifecycle.fail({
+        id: agentRun.id,
+        currentState: agentRun.state,
+        reason: "context_unavailable",
+        summary: "Investigation's incident or project no longer exists.",
+        category: "infra",
+      });
+    },
+    listActiveRunIds: async () => {
+      const rows = await db
+        .select({ id: schema.agentRuns.id })
+        .from(schema.agentRuns)
+        .where(inArray(schema.agentRuns.state, [...ACTIVE_STATES]))
+        .orderBy(asc(schema.agentRuns.updatedAt));
+      return rows.map((row) => row.id);
+    },
+    handlers: {
+      start: startQueuedAgentRun,
+      sync: syncRunningAgentRun,
+      resume: resumeAgentRunFromHumanInput,
+      retryPrDelivery: retryQueuedPullRequestDelivery,
+    },
+    concurrency: parseConcurrency(process.env.AGENT_RUN_JOB_CONCURRENCY),
+  });
+  setAgentRunJobDispatch(createAgentRunJobSender(boss));
+}

--- a/apps/worker/src/agent-runs/queue.test.ts
+++ b/apps/worker/src/agent-runs/queue.test.ts
@@ -20,11 +20,14 @@ function fakeBoss() {
   const queues: Array<{ name: string; options: unknown }> = [];
   const schedules: Array<{ name: string; cron: string }> = [];
   const workers = new Map<string, WorkHandler>();
+  const ops: string[] = [];
   const boss: AgentRunQueueBoss = {
     async createQueue(name, options) {
+      ops.push(`createQueue:${name}`);
       queues.push({ name, options });
     },
     async work(name, _options, handler) {
+      ops.push(`work:${name}`);
       workers.set(name, handler as WorkHandler);
     },
     async send(name, data, options) {
@@ -36,10 +39,11 @@ function fakeBoss() {
       return [];
     },
     async schedule(name, cron) {
+      ops.push(`schedule:${name}`);
       schedules.push({ name, cron });
     },
   };
-  return { boss, sent, inserted, queues, schedules, workers };
+  return { boss, sent, inserted, queues, schedules, workers, ops };
 }
 
 function runOf(id: string, state: string): schema.AgentRun {
@@ -96,6 +100,11 @@ test("registration creates both queues, workers, and the sweep schedule", async 
   assert.ok(fb.workers.get(AGENT_RUN_ADVANCE_QUEUE));
   assert.ok(fb.workers.get(AGENT_RUN_SWEEP_QUEUE));
   assert.deepEqual(fb.schedules, [{ name: AGENT_RUN_SWEEP_QUEUE, cron: "* * * * *" }]);
+  // The advance consumer must be registered LAST: the caller enables the
+  // tick's batch-rotation fallback when registration throws, so a partial
+  // failure must never leave a live advance consumer behind — that would
+  // advance the same run from two places at once.
+  assert.equal(fb.ops.at(-1), `work:${AGENT_RUN_ADVANCE_QUEUE}`);
 });
 
 test("advance worker dispatches by run state", async () => {

--- a/apps/worker/src/agent-runs/queue.test.ts
+++ b/apps/worker/src/agent-runs/queue.test.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { schema } from "@superlog/db";
+import {
+  AGENT_RUN_ADVANCE_QUEUE,
+  AGENT_RUN_SWEEP_QUEUE,
+  type AgentRunQueueBoss,
+  type AgentRunQueueDeps,
+  createAgentRunJobSender,
+  registerAgentRunQueue,
+} from "./queue.js";
+
+type SentJob = { name: string; data: unknown; options: unknown };
+type InsertedJob = { name: string; jobs: Array<Record<string, unknown>> };
+type WorkHandler = (jobs: Array<{ id: string; data: unknown }>) => Promise<unknown>;
+
+function fakeBoss() {
+  const sent: SentJob[] = [];
+  const inserted: InsertedJob[] = [];
+  const queues: Array<{ name: string; options: unknown }> = [];
+  const schedules: Array<{ name: string; cron: string }> = [];
+  const workers = new Map<string, WorkHandler>();
+  const boss: AgentRunQueueBoss = {
+    async createQueue(name, options) {
+      queues.push({ name, options });
+    },
+    async work(name, _options, handler) {
+      workers.set(name, handler as WorkHandler);
+    },
+    async send(name, data, options) {
+      sent.push({ name, data, options });
+      return "job-id";
+    },
+    async insert(name, jobs) {
+      inserted.push({ name, jobs: jobs as Array<Record<string, unknown>> });
+      return [];
+    },
+    async schedule(name, cron) {
+      schedules.push({ name, cron });
+    },
+  };
+  return { boss, sent, inserted, queues, schedules, workers };
+}
+
+function runOf(id: string, state: string): schema.AgentRun {
+  return { id, state } as schema.AgentRun;
+}
+
+function contextOf(run: schema.AgentRun): { agentRun: schema.AgentRun } {
+  return { agentRun: run };
+}
+
+type DepsOverrides = Omit<Partial<AgentRunQueueDeps>, "handlers"> & {
+  handlers?: Partial<AgentRunQueueDeps["handlers"]>;
+};
+
+function makeDeps(overrides: DepsOverrides = {}) {
+  const calls: string[] = [];
+  const handler = (name: string) => async () => {
+    calls.push(name);
+  };
+  const deps: AgentRunQueueDeps = {
+    loadRun: overrides.loadRun ?? (async (id) => runOf(id, "queued")),
+    loadContext:
+      overrides.loadContext ??
+      (async (run) => contextOf(run) as Awaited<ReturnType<AgentRunQueueDeps["loadContext"]>>),
+    failContextUnavailable:
+      overrides.failContextUnavailable ??
+      (async () => {
+        calls.push("fail_context_unavailable");
+      }),
+    listActiveRunIds: overrides.listActiveRunIds ?? (async () => []),
+    handlers: {
+      start: overrides.handlers?.start ?? handler("start"),
+      sync: overrides.handlers?.sync ?? handler("sync"),
+      resume: overrides.handlers?.resume ?? handler("resume"),
+      retryPrDelivery: overrides.handlers?.retryPrDelivery ?? handler("retry_pr_delivery"),
+    },
+    logger: { warn: () => {}, error: () => {} },
+  };
+  return { deps, calls };
+}
+
+test("registration creates both queues, workers, and the sweep schedule", async () => {
+  const fb = fakeBoss();
+  const { deps } = makeDeps();
+  await registerAgentRunQueue(fb.boss, deps);
+
+  const advance = fb.queues.find((q) => q.name === AGENT_RUN_ADVANCE_QUEUE);
+  // `stately` allows one queued + one active job per run id, so an
+  // event-driven enqueue during processing is preserved while duplicates
+  // still collapse.
+  assert.deepEqual(advance?.options, { policy: "stately" });
+  const sweep = fb.queues.find((q) => q.name === AGENT_RUN_SWEEP_QUEUE);
+  assert.deepEqual(sweep?.options, { policy: "exclusive" });
+  assert.ok(fb.workers.get(AGENT_RUN_ADVANCE_QUEUE));
+  assert.ok(fb.workers.get(AGENT_RUN_SWEEP_QUEUE));
+  assert.deepEqual(fb.schedules, [{ name: AGENT_RUN_SWEEP_QUEUE, cron: "* * * * *" }]);
+});
+
+test("advance worker dispatches by run state", async () => {
+  const states: Array<[string, string]> = [
+    ["queued", "start"],
+    ["repo_discovery", "start"],
+    ["running", "sync"],
+    ["awaiting_human", "resume"],
+    ["awaiting_events", "resume"],
+    ["resuming", "resume"],
+    ["pr_retry_queued", "retry_pr_delivery"],
+  ];
+  for (const [state, expected] of states) {
+    const fb = fakeBoss();
+    const { deps, calls } = makeDeps({ loadRun: async (id) => runOf(id, state) });
+    await registerAgentRunQueue(fb.boss, deps);
+    const worker = fb.workers.get(AGENT_RUN_ADVANCE_QUEUE);
+    assert.ok(worker);
+    await worker([{ id: "job-1", data: { agentRunId: "run-1" } }]);
+    assert.deepEqual(calls, [expected], `state ${state} must dispatch ${expected}`);
+  }
+});
+
+test("advance worker skips missing runs, terminal states, and malformed jobs", async () => {
+  const fb = fakeBoss();
+  const { deps, calls } = makeDeps({
+    loadRun: async (id) =>
+      id === "gone" ? null : runOf(id, id === "done" ? "complete" : "queued"),
+  });
+  await registerAgentRunQueue(fb.boss, deps);
+  const worker = fb.workers.get(AGENT_RUN_ADVANCE_QUEUE);
+  assert.ok(worker);
+
+  await worker([
+    { id: "job-1", data: { agentRunId: "gone" } },
+    { id: "job-2", data: { agentRunId: "done" } },
+    { id: "job-3", data: { nonsense: true } },
+  ]);
+
+  assert.deepEqual(calls, [], "no handler may run for missing/terminal/malformed jobs");
+});
+
+test("a run whose incident or project is gone is failed as context_unavailable", async () => {
+  const fb = fakeBoss();
+  const failed: string[] = [];
+  const { deps, calls } = makeDeps({
+    loadContext: async () => null,
+    failContextUnavailable: async (run) => {
+      failed.push(run.id);
+    },
+  });
+  await registerAgentRunQueue(fb.boss, deps);
+  const worker = fb.workers.get(AGENT_RUN_ADVANCE_QUEUE);
+  assert.ok(worker);
+
+  await worker([{ id: "job-1", data: { agentRunId: "run-1" } }]);
+
+  assert.deepEqual(failed, ["run-1"]);
+  assert.deepEqual(calls, []);
+});
+
+test("one job's failure is swallowed and the rest of the batch still runs", async () => {
+  const fb = fakeBoss();
+  const { deps, calls } = makeDeps({
+    handlers: {
+      start: async () => {
+        throw new Error("boom");
+      },
+    },
+    loadRun: async (id) => runOf(id, id === "poison" ? "queued" : "running"),
+  });
+  await registerAgentRunQueue(fb.boss, deps);
+  const worker = fb.workers.get(AGENT_RUN_ADVANCE_QUEUE);
+  assert.ok(worker);
+
+  await worker([
+    { id: "job-1", data: { agentRunId: "poison" } },
+    { id: "job-2", data: { agentRunId: "run-2" } },
+  ]);
+
+  assert.deepEqual(calls, ["sync"], "the healthy job must still be processed");
+});
+
+test("sweep enqueues one deduped advance job per active run", async () => {
+  const fb = fakeBoss();
+  const { deps } = makeDeps({ listActiveRunIds: async () => ["run-1", "run-2"] });
+  await registerAgentRunQueue(fb.boss, deps);
+  const sweep = fb.workers.get(AGENT_RUN_SWEEP_QUEUE);
+  assert.ok(sweep);
+
+  await sweep([{ id: "sweep-1", data: {} }]);
+
+  assert.equal(fb.inserted.length, 1);
+  assert.equal(fb.inserted[0]?.name, AGENT_RUN_ADVANCE_QUEUE);
+  assert.deepEqual(fb.inserted[0]?.jobs, [
+    { data: { agentRunId: "run-1" }, singletonKey: "run-1" },
+    { data: { agentRunId: "run-2" }, singletonKey: "run-2" },
+  ]);
+});
+
+test("the job sender enqueues with a per-run singleton key and never throws", async () => {
+  const fb = fakeBoss();
+  const send = createAgentRunJobSender(fb.boss, { warn: () => {}, error: () => {} });
+
+  await send("run-1");
+  assert.deepEqual(fb.sent, [
+    {
+      name: AGENT_RUN_ADVANCE_QUEUE,
+      data: { agentRunId: "run-1" },
+      options: { singletonKey: "run-1" },
+    },
+  ]);
+
+  const failing = createAgentRunJobSender(
+    {
+      ...fb.boss,
+      async send() {
+        throw new Error("pg-boss unavailable");
+      },
+    },
+    { warn: () => {}, error: () => {} },
+  );
+  await failing("run-2"); // must not throw — the sweep re-enqueues within a minute
+});

--- a/apps/worker/src/agent-runs/queue.ts
+++ b/apps/worker/src/agent-runs/queue.ts
@@ -1,0 +1,186 @@
+// pg-boss execution for agent-run advancement.
+//
+// Previously every active run was advanced by a fixed-size batch inside the
+// worker tick: each cycle selected the 20 stalest rows across all states and
+// tenants and processed them sequentially. Under load the rotation interval
+// grew with the size of the active set, so a backlog in one tenant delayed
+// every other tenant's investigations by hours or days.
+//
+// Here each run advances as its own queue job:
+//   - `agent-run-advance` holds one job per run (`stately` policy +
+//     singletonKey = run id: at most one queued and one active per run).
+//     Jobs in a fetch batch run concurrently, so wall-clock throughput no
+//     longer depends on how many other runs exist.
+//   - `agent-run-sweep` fires every minute and blind-enqueues every run in an
+//     active state; the singleton key collapses duplicates. The sweep is both
+//     the pickup for inbound events recorded outside this process (human
+//     replies land as unprocessed incident_events rows) and the safety net
+//     for lost jobs. Run creation additionally enqueues directly (see
+//     enqueue.ts) so new investigations start in seconds, not at the next
+//     sweep.
+//
+// Failure semantics match the old tick: a job's error is logged and swallowed
+// (the handlers are not written to be safely re-runnable, so pg-boss retries
+// stay out of the picture) and the next sweep re-enqueues the run.
+import type { schema } from "@superlog/db";
+import type { AgentRunContext } from "../agent-run-context.js";
+import { logger as defaultLogger } from "../logger.js";
+
+export const AGENT_RUN_ADVANCE_QUEUE = "agent-run-advance";
+export const AGENT_RUN_SWEEP_QUEUE = "agent-run-sweep";
+const SWEEP_SCHEDULE = "* * * * *";
+
+// How many advance jobs a single fetch works on; batches run concurrently, so
+// this is the effective per-process concurrency. Starting a run is dominated
+// by provider/GitHub round-trips (IO-bound), so a moderate default drains a
+// queued backlog far faster than the old one-batch-per-tick rotation without
+// saturating the task.
+const DEFAULT_CONCURRENCY = 10;
+const MAX_CONCURRENCY = 50;
+
+export type AgentRunQueueBoss = {
+  createQueue(name: string, options?: unknown): Promise<unknown>;
+  work(
+    name: string,
+    options: { batchSize: number },
+    handler: (jobs: Array<{ id: string; data: unknown }>) => Promise<unknown>,
+  ): Promise<unknown>;
+  send(name: string, data: object, options?: object): Promise<unknown>;
+  insert(name: string, jobs: object[]): Promise<unknown>;
+  schedule(name: string, cron: string, data?: unknown, options?: unknown): Promise<unknown>;
+};
+
+type LoggerLike = Pick<typeof defaultLogger, "warn" | "error">;
+
+export type AgentRunQueueDeps = {
+  loadRun(id: string): Promise<schema.AgentRun | null | undefined>;
+  loadContext(run: schema.AgentRun): Promise<AgentRunContext | null>;
+  // Permanent condition (incident/project deleted): the run can never make
+  // progress, so failing it is the only way it leaves the active set.
+  failContextUnavailable(run: schema.AgentRun): Promise<void>;
+  listActiveRunIds(): Promise<string[]>;
+  handlers: {
+    start(ctx: AgentRunContext): Promise<void>;
+    sync(ctx: AgentRunContext): Promise<void>;
+    resume(ctx: AgentRunContext): Promise<void>;
+    retryPrDelivery(ctx: AgentRunContext): Promise<void>;
+  };
+  concurrency?: number;
+  logger?: LoggerLike;
+};
+
+export type AgentRunJobData = { agentRunId: string };
+
+function parseJobData(data: unknown): AgentRunJobData | null {
+  if (!data || typeof data !== "object") return null;
+  const record = data as Record<string, unknown>;
+  if (typeof record.agentRunId !== "string") return null;
+  return { agentRunId: record.agentRunId };
+}
+
+function clampConcurrency(value: number | undefined): number {
+  if (value === undefined || !Number.isInteger(value) || value < 1) return DEFAULT_CONCURRENCY;
+  return Math.min(value, MAX_CONCURRENCY);
+}
+
+async function advanceRun(deps: AgentRunQueueDeps, data: AgentRunJobData): Promise<void> {
+  const agentRun = await deps.loadRun(data.agentRunId);
+  if (!agentRun) return;
+  const ctx = await deps.loadContext(agentRun);
+  if (!ctx) {
+    await deps.failContextUnavailable(agentRun);
+    return;
+  }
+  const state = ctx.agentRun.state;
+  if (state === "queued" || state === "repo_discovery") {
+    await deps.handlers.start(ctx);
+    return;
+  }
+  if (state === "running") {
+    await deps.handlers.sync(ctx);
+    return;
+  }
+  if (state === "awaiting_human" || state === "awaiting_events" || state === "resuming") {
+    await deps.handlers.resume(ctx);
+    return;
+  }
+  if (state === "pr_retry_queued") {
+    await deps.handlers.retryPrDelivery(ctx);
+  }
+  // Terminal and dormant states: the job is stale (the run moved on between
+  // enqueue and fetch) — nothing to do.
+}
+
+// Register both queues and their workers, plus the minute cron for the sweep.
+export async function registerAgentRunQueue(
+  boss: AgentRunQueueBoss,
+  deps: AgentRunQueueDeps,
+): Promise<void> {
+  const logger = deps.logger ?? defaultLogger;
+  const concurrency = clampConcurrency(deps.concurrency);
+
+  await boss.createQueue(AGENT_RUN_ADVANCE_QUEUE, { policy: "stately" });
+  await boss.work(AGENT_RUN_ADVANCE_QUEUE, { batchSize: concurrency }, async (jobs) => {
+    await Promise.all(
+      jobs.map(async (job) => {
+        const data = parseJobData(job.data);
+        if (!data) {
+          logger.warn(
+            { scope: "agent-run-queue", jobId: job.id },
+            "skipping malformed agent-run job",
+          );
+          return;
+        }
+        try {
+          await advanceRun(deps, data);
+        } catch (err) {
+          logger.error(
+            {
+              scope: "agent-run-queue",
+              agent_run_id: data.agentRunId,
+              err: err instanceof Error ? err.message : String(err),
+            },
+            "agent-run advance failed; the next sweep re-enqueues it",
+          );
+        }
+      }),
+    );
+  });
+
+  await boss.createQueue(AGENT_RUN_SWEEP_QUEUE, { policy: "exclusive" });
+  await boss.work(AGENT_RUN_SWEEP_QUEUE, { batchSize: 1 }, async () => {
+    const ids = await deps.listActiveRunIds();
+    if (ids.length === 0) return;
+    await boss.insert(
+      AGENT_RUN_ADVANCE_QUEUE,
+      ids.map((id) => ({ data: { agentRunId: id } satisfies AgentRunJobData, singletonKey: id })),
+    );
+  });
+  await boss.schedule(AGENT_RUN_SWEEP_QUEUE, SWEEP_SCHEDULE);
+}
+
+// A send function for code that creates or touches a run and wants it
+// advanced now rather than at the next sweep (run creation, steering). Send
+// failures are logged and swallowed: the sweep re-enqueues within a minute,
+// so an enqueue must never break the caller's transaction commit path.
+export function createAgentRunJobSender(
+  boss: Pick<AgentRunQueueBoss, "send">,
+  logger: LoggerLike = defaultLogger,
+): (agentRunId: string) => Promise<void> {
+  return async (agentRunId) => {
+    try {
+      await boss.send(AGENT_RUN_ADVANCE_QUEUE, { agentRunId } satisfies AgentRunJobData, {
+        singletonKey: agentRunId,
+      });
+    } catch (err) {
+      logger.warn(
+        {
+          scope: "agent-run-queue",
+          agent_run_id: agentRunId,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "agent-run enqueue failed; the sweep will pick the run up",
+      );
+    }
+  };
+}

--- a/apps/worker/src/agent-runs/queue.ts
+++ b/apps/worker/src/agent-runs/queue.ts
@@ -112,6 +112,15 @@ async function advanceRun(deps: AgentRunQueueDeps, data: AgentRunJobData): Promi
 }
 
 // Register both queues and their workers, plus the minute cron for the sweep.
+//
+// Ordering is load-bearing: the advance CONSUMER is registered last. When any
+// call here throws, the caller (index.ts) falls back to the tick's batch
+// rotation — if an advance consumer were already live at that point (it starts
+// consuming leftover jobs from a previous boot immediately), the same run
+// could be advanced concurrently from both paths. Failing before the final
+// `work` leaves at most queues/cron/sweep behind, all of which are inert or
+// idempotent without a consumer: sweep-inserted jobs sit deduped until a
+// healthy boot picks them up, and each job reloads its run's current state.
 export async function registerAgentRunQueue(
   boss: AgentRunQueueBoss,
   deps: AgentRunQueueDeps,
@@ -120,6 +129,18 @@ export async function registerAgentRunQueue(
   const concurrency = clampConcurrency(deps.concurrency);
 
   await boss.createQueue(AGENT_RUN_ADVANCE_QUEUE, { policy: "stately" });
+  await boss.createQueue(AGENT_RUN_SWEEP_QUEUE, { policy: "exclusive" });
+
+  await boss.work(AGENT_RUN_SWEEP_QUEUE, { batchSize: 1 }, async () => {
+    const ids = await deps.listActiveRunIds();
+    if (ids.length === 0) return;
+    await boss.insert(
+      AGENT_RUN_ADVANCE_QUEUE,
+      ids.map((id) => ({ data: { agentRunId: id } satisfies AgentRunJobData, singletonKey: id })),
+    );
+  });
+  await boss.schedule(AGENT_RUN_SWEEP_QUEUE, SWEEP_SCHEDULE);
+
   await boss.work(AGENT_RUN_ADVANCE_QUEUE, { batchSize: concurrency }, async (jobs) => {
     await Promise.all(
       jobs.map(async (job) => {
@@ -146,17 +167,6 @@ export async function registerAgentRunQueue(
       }),
     );
   });
-
-  await boss.createQueue(AGENT_RUN_SWEEP_QUEUE, { policy: "exclusive" });
-  await boss.work(AGENT_RUN_SWEEP_QUEUE, { batchSize: 1 }, async () => {
-    const ids = await deps.listActiveRunIds();
-    if (ids.length === 0) return;
-    await boss.insert(
-      AGENT_RUN_ADVANCE_QUEUE,
-      ids.map((id) => ({ data: { agentRunId: id } satisfies AgentRunJobData, singletonKey: id })),
-    );
-  });
-  await boss.schedule(AGENT_RUN_SWEEP_QUEUE, SWEEP_SCHEDULE);
 }
 
 // A send function for code that creates or touches a run and wants it

--- a/apps/worker/src/incidents/workflow.ts
+++ b/apps/worker/src/incidents/workflow.ts
@@ -13,6 +13,7 @@ import {
   isActiveState as isActiveAgentRunState,
 } from "../agent-run.js";
 import { TERMINAL_STATES as AGENT_RUN_TERMINAL_STATES } from "../agent-runs/domain.js";
+import { dispatchAgentRunJob } from "../agent-runs/enqueue.js";
 import { investigationGate } from "../billing/investigation-gate.js";
 import { usageNotifier } from "../billing/usage-notifier-infra.js";
 import { isAutoAgentRunSuppressed } from "../incident-cooldown.js";
@@ -102,39 +103,50 @@ async function queueAgentRunIfNeeded(incident: schema.Incident): Promise<{
     return { agentRun: null, queueStatus: "no_credits" };
   }
 
-  return db.transaction(async (tx) => {
-    await tx
-      .select({ id: schema.incidents.id })
-      .from(schema.incidents)
-      .where(eq(schema.incidents.id, incident.id))
-      .for("update");
-
-    const existing = await tx.query.agentRuns.findFirst({
-      where: and(
-        eq(schema.agentRuns.incidentId, incident.id),
-        inArray(schema.agentRuns.state, [...AGENT_RUN_ACTIVE_STATES]),
-      ),
-      orderBy: [desc(schema.agentRuns.createdAt)],
-    });
-    if (existing) return { agentRun: existing, queueStatus: "existing_active" };
-
-    const queued = await createAgentRunLifecycle(tx as unknown as DB).enqueue({
-      incidentId: incident.id,
-      runtime: automation.agentRunProvider,
-    });
-    if (!queued) throw new Error("failed to queue agent run");
-
-    // Clear a stale "out of credits" mark now that a run is queued (e.g. the org
-    // upgraded or the monthly limit reset since the last blocked transition).
-    if (incident.autoInvestigateBlockedReason !== null) {
+  const result = await db.transaction(
+    async (
+      tx,
+    ): Promise<{ agentRun: schema.AgentRun | null; queueStatus: ReopenedIncidentQueueStatus }> => {
       await tx
-        .update(schema.incidents)
-        .set({ autoInvestigateBlockedReason: null })
-        .where(eq(schema.incidents.id, incident.id));
-    }
+        .select({ id: schema.incidents.id })
+        .from(schema.incidents)
+        .where(eq(schema.incidents.id, incident.id))
+        .for("update");
 
-    return { agentRun: queued, queueStatus: "queued" };
-  });
+      const existing = await tx.query.agentRuns.findFirst({
+        where: and(
+          eq(schema.agentRuns.incidentId, incident.id),
+          inArray(schema.agentRuns.state, [...AGENT_RUN_ACTIVE_STATES]),
+        ),
+        orderBy: [desc(schema.agentRuns.createdAt)],
+      });
+      if (existing) return { agentRun: existing, queueStatus: "existing_active" };
+
+      const queued = await createAgentRunLifecycle(tx as unknown as DB).enqueue({
+        incidentId: incident.id,
+        runtime: automation.agentRunProvider,
+      });
+      if (!queued) throw new Error("failed to queue agent run");
+
+      // Clear a stale "out of credits" mark now that a run is queued (e.g. the org
+      // upgraded or the monthly limit reset since the last blocked transition).
+      if (incident.autoInvestigateBlockedReason !== null) {
+        await tx
+          .update(schema.incidents)
+          .set({ autoInvestigateBlockedReason: null })
+          .where(eq(schema.incidents.id, incident.id));
+      }
+
+      return { agentRun: queued, queueStatus: "queued" };
+    },
+  );
+  if (result.queueStatus === "queued" && result.agentRun) {
+    // Post-commit: put the new run on the advance queue now so the
+    // investigation starts in seconds. Best-effort — the minute sweep picks
+    // it up regardless.
+    await dispatchAgentRunJob(result.agentRun.id);
+  }
+  return result;
 }
 
 // Steer the incident's existing investigation with a newly-arrived error

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -2,6 +2,7 @@ import "./env.js";
 import { createClient } from "@clickhouse/client";
 import { db } from "@superlog/db";
 import { registerAgentRunHealthMetrics } from "./agent-run-health-metrics.js";
+import { startAgentRunQueue } from "./agent-runs/queue-wiring.js";
 import { initAiUsageSink } from "./ai-usage.js";
 import { createUsageMeterTicker } from "./billing/usage-meter-ticker.js";
 import { handleIssueTransition } from "./incidents/workflow.js";
@@ -82,6 +83,24 @@ const dispatchIssueTransition = createIssueTransitionDispatcher({
   inline: handleIssueTransition,
 });
 
+// Agent runs advance as per-run jobs on their own pg-boss queue (one job per
+// run, minute sweep as the safety net) so investigation throughput no longer
+// depends on the size of the global active set. If registration fails, the
+// tick's batch rotation below remains the fallback — degraded cadence, but
+// investigations still advance.
+let agentRunQueueReady = false;
+if (jobBoss) {
+  try {
+    await startAgentRunQueue(jobBoss);
+    agentRunQueueReady = true;
+  } catch (err) {
+    logger.error(
+      { scope: "boot", err: err instanceof Error ? err.message : String(err) },
+      "agent-run queue failed to register; falling back to tick batch rotation",
+    );
+  }
+}
+
 const telemetryIngestor = createTelemetryIngestor({
   clickhouse: ch,
   batchSize: BATCH_SIZE,
@@ -102,6 +121,7 @@ const tick = createWorkerTick({
   telemetryIngestor,
   usageMeter,
   handleIssueTransition: dispatchIssueTransition,
+  includeAgentRuns: !agentRunQueueReady,
 });
 
 runWorker({ pollIntervalMs: POLL_INTERVAL_MS, batchSize: BATCH_SIZE, tick }).catch((err) => {

--- a/apps/worker/src/worker/tick.ts
+++ b/apps/worker/src/worker/tick.ts
@@ -34,8 +34,14 @@ export function createWorkerTick(opts: {
   // Injected so callers can route transition side effects out-of-band (see
   // issue-transitions.ts); defaults to the direct inline workflow.
   handleIssueTransition?: typeof handleIssueTransition;
+  // Agent runs normally advance on their own pg-boss queue (agent-runs/
+  // queue.ts). The tick's batch rotation is kept only as the fallback for a
+  // boot where that queue failed to register — pass false once the queue is
+  // live so runs aren't advanced from two places at once.
+  includeAgentRuns?: boolean;
 }): () => Promise<WorkerTickResult> {
   const onIssueTransition = opts.handleIssueTransition ?? handleIssueTransition;
+  const includeAgentRuns = opts.includeAgentRuns ?? true;
   return () =>
     tracer.startActiveSpan("worker.tick", async (span) => {
       async function safe<T>(name: string, run: () => Promise<T>, fallback: T): Promise<T> {
@@ -66,7 +72,7 @@ export function createWorkerTick(opts: {
       try {
         const spans = await safe("spans", opts.telemetryIngestor.tickSpans, 0);
         const logs = await safe("logs", opts.telemetryIngestor.tickLogs, 0);
-        const agentRuns = await safe("agent_runs", tickAgentRuns, 0);
+        const agentRuns = includeAgentRuns ? await safe("agent_runs", tickAgentRuns, 0) : 0;
         const agentChats = await safe("agent_chats", tickAgentChats, 0);
         const alerts = await safe(
           "alerts",


### PR DESCRIPTION
## Problem

Agent runs were advanced by a fixed-size batch inside the worker tick: every cycle selected the 20 stalest active rows across all states and tenants and processed them sequentially. Investigation latency therefore scaled with the size of the global active set — one project's backlog (e.g. a burst of auto-investigations) delayed every other project's investigations by hours or days. The batch also had no per-run error isolation: one throwing run aborted the rest of the batch for that cycle.

## Change

- **`agent-run-advance` queue** — one job per run (`stately` policy + `singletonKey` = run id: at most one queued and one active job per run, so duplicate enqueues collapse while an event arriving mid-processing is preserved). Jobs in a fetch batch run concurrently (`AGENT_RUN_JOB_CONCURRENCY`, default 10, max 50). A job's failure is logged and swallowed, matching the old inline semantics — no pg-boss retries, since the handlers aren't written to be safely re-runnable.
- **`agent-run-sweep` queue** — a minute cron that blind-enqueues every run in an active state; the singleton key dedupes. This is both the pickup for inbound events recorded outside the worker process (human replies land as unprocessed `incident_events` rows) and the safety net for jobs lost to a crash.
- **Immediate start** — run creation (`queueAgentRunIfNeeded`) enqueues the new run post-commit via a process-wide hook (`agent-runs/enqueue.ts`), so investigations start in seconds instead of waiting for the next sweep or a batch rotation slot.
- **Fallback** — if queue registration fails at boot, the tick's old batch rotation stays active (`includeAgentRuns`), so a degraded queue means degraded cadence, not stopped investigations. When the queue is live the tick skips the step to avoid advancing runs from two places.

## Tests

`pnpm --filter @superlog/worker run test:agent-run-queue` (new, 7 cases: state dispatch, missing/terminal/malformed jobs, context_unavailable, per-job isolation, sweep dedupe, sender never throws). Existing suites green: agent-run-start, agent-run-sync, issue-transitions, incident-intake, issue-routing, jobs-runner. Typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advance agent runs via per-run `pg-boss` jobs instead of a tick batch to remove cross-tenant backlog blocking and start investigations within seconds. This decouples throughput from the global active set and isolates failures per run.

- **New Features**
  - `agent-run-advance` queue: one job per run (`stately` + singleton key). Batched jobs run concurrently; `AGENT_RUN_JOB_CONCURRENCY` controls concurrency (default 10, max 50).
  - `agent-run-sweep` cron (every minute): enqueues all active runs; picks up external events and re-enqueues jobs lost to crashes.
  - Immediate enqueue on run creation post-commit via a process-wide dispatch hook; best effort, with the sweep as backup.
  - Fallback: if queue registration fails at boot, the tick’s batch rotation remains active; when the queue is live, the tick skips agent runs to avoid double-advancing. The advance consumer is registered last to prevent partial registration from double-advancing runs.

<sup>Written for commit 759a057517b209383f4f879c389378800daff0ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

