### PR TITLE
Isolate agent-run jobs: independent consumers + per-job timeout

### DIFF
--- a/apps/worker/src/agent-runs/queue-wiring.ts
+++ b/apps/worker/src/agent-runs/queue-wiring.ts
@@ -13,7 +13,7 @@ import { syncRunningAgentRun } from "./sync.js";
 
 const lifecycle = createAgentRunLifecycle(db);
 
-function parseConcurrency(value: string | undefined): number | undefined {
+function parsePositive(value: string | undefined): number | undefined {
   if (value === undefined) return undefined;
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
@@ -49,7 +49,8 @@ export async function startAgentRunQueue(boss: AgentRunQueueBoss): Promise<void>
       resume: resumeAgentRunFromHumanInput,
       retryPrDelivery: retryQueuedPullRequestDelivery,
     },
-    concurrency: parseConcurrency(process.env.AGENT_RUN_JOB_CONCURRENCY),
+    concurrency: parsePositive(process.env.AGENT_RUN_JOB_CONCURRENCY),
+    jobTimeoutMs: parsePositive(process.env.AGENT_RUN_JOB_TIMEOUT_MS),
   });
   setAgentRunJobDispatch(createAgentRunJobSender(boss));
 }

--- a/apps/worker/src/agent-runs/queue.test.ts
+++ b/apps/worker/src/agent-runs/queue.test.ts
@@ -13,6 +13,7 @@ import {
 type SentJob = { name: string; data: unknown; options: unknown };
 type InsertedJob = { name: string; jobs: Array<Record<string, unknown>> };
 type WorkHandler = (jobs: Array<{ id: string; data: unknown }>) => Promise<unknown>;
+type WorkOptions = { batchSize: number; localConcurrency?: number };
 
 function fakeBoss() {
   const sent: SentJob[] = [];
@@ -20,15 +21,17 @@ function fakeBoss() {
   const queues: Array<{ name: string; options: unknown }> = [];
   const schedules: Array<{ name: string; cron: string }> = [];
   const workers = new Map<string, WorkHandler>();
+  const workOptions = new Map<string, WorkOptions>();
   const ops: string[] = [];
   const boss: AgentRunQueueBoss = {
     async createQueue(name, options) {
       ops.push(`createQueue:${name}`);
       queues.push({ name, options });
     },
-    async work(name, _options, handler) {
+    async work(name, options, handler) {
       ops.push(`work:${name}`);
       workers.set(name, handler as WorkHandler);
+      workOptions.set(name, options as WorkOptions);
     },
     async send(name, data, options) {
       sent.push({ name, data, options });
@@ -43,7 +46,7 @@ function fakeBoss() {
       schedules.push({ name, cron });
     },
   };
-  return { boss, sent, inserted, queues, schedules, workers, ops };
+  return { boss, sent, inserted, queues, schedules, workers, workOptions, ops };
 }
 
 function runOf(id: string, state: string): schema.AgentRun {
@@ -100,6 +103,14 @@ test("registration creates both queues, workers, and the sweep schedule", async 
   assert.ok(fb.workers.get(AGENT_RUN_ADVANCE_QUEUE));
   assert.ok(fb.workers.get(AGENT_RUN_SWEEP_QUEUE));
   assert.deepEqual(fb.schedules, [{ name: AGENT_RUN_SWEEP_QUEUE, cron: "* * * * *" }]);
+  // Concurrency must come from independent single-job consumers, NOT a fetch
+  // batch: pg-boss completes a batch only when the whole handler resolves, so
+  // batchSize > 1 lets one hung provider call hold every slot hostage
+  // (observed in prod: one stuck sync pinned 10 jobs active for 15 minutes).
+  assert.deepEqual(fb.workOptions.get(AGENT_RUN_ADVANCE_QUEUE), {
+    batchSize: 1,
+    localConcurrency: 10,
+  });
   // The advance consumer must be registered LAST: the caller enables the
   // tick's batch-rotation fallback when registration throws, so a partial
   // failure must never leave a live advance consumer behind — that would
@@ -186,6 +197,30 @@ test("one job's failure is swallowed and the rest of the batch still runs", asyn
   ]);
 
   assert.deepEqual(calls, ["sync"], "the healthy job must still be processed");
+});
+
+test("a job exceeding the per-job timeout is abandoned and the handler resolves", async () => {
+  const fb = fakeBoss();
+  let lateFailureLogged = false;
+  const never = new Promise<void>(() => {});
+  const { deps } = makeDeps({
+    handlers: { start: () => never },
+  });
+  deps.jobTimeoutMs = 5;
+  deps.logger = {
+    warn: () => {},
+    error: () => {
+      lateFailureLogged = true;
+    },
+  };
+  await registerAgentRunQueue(fb.boss, deps);
+  const worker = fb.workers.get(AGENT_RUN_ADVANCE_QUEUE);
+  assert.ok(worker);
+
+  // Must resolve despite the hung handler — a hung provider call may only
+  // cost its own slot a bounded delay, never wedge the consumer.
+  await worker([{ id: "job-1", data: { agentRunId: "run-1" } }]);
+  assert.ok(lateFailureLogged, "the timeout must be logged");
 });
 
 test("sweep enqueues one deduped advance job per active run", async () => {

--- a/apps/worker/src/agent-runs/queue.test.ts
+++ b/apps/worker/src/agent-runs/queue.test.ts
@@ -223,6 +223,51 @@ test("a job exceeding the per-job timeout is abandoned and the handler resolves"
   assert.ok(lateFailureLogged, "the timeout must be logged");
 });
 
+test("a run with an abandoned in-flight attempt is not advanced concurrently", async () => {
+  const fb = fakeBoss();
+  let startCalls = 0;
+  let releaseHung: (() => void) | undefined;
+  const hung = new Promise<void>((resolve) => {
+    releaseHung = resolve;
+  });
+  const { deps, calls } = makeDeps({
+    handlers: {
+      start: async (ctx) => {
+        if (ctx.agentRun.id === "hung-run") {
+          startCalls += 1;
+          await hung;
+          return;
+        }
+        calls.push("start");
+      },
+    },
+  });
+  deps.jobTimeoutMs = 5;
+  deps.logger = { warn: () => {}, error: () => {} };
+  await registerAgentRunQueue(fb.boss, deps);
+  const worker = fb.workers.get(AGENT_RUN_ADVANCE_QUEUE);
+  assert.ok(worker);
+
+  // First attempt times out and is abandoned — but its promise is still
+  // running.
+  await worker([{ id: "job-1", data: { agentRunId: "hung-run" } }]);
+  assert.equal(startCalls, 1);
+
+  // A re-enqueued job for the same run must be skipped (no second concurrent
+  // attempt), while other runs advance normally.
+  await worker([{ id: "job-2", data: { agentRunId: "hung-run" } }]);
+  assert.equal(startCalls, 1, "the hung run must not be advanced concurrently");
+  await worker([{ id: "job-3", data: { agentRunId: "other-run" } }]);
+  assert.deepEqual(calls, ["start"], "other runs must be unaffected");
+
+  // Once the abandoned attempt finally settles, the run may be advanced again.
+  releaseHung?.();
+  await hung;
+  await new Promise((resolve) => setImmediate(resolve));
+  await worker([{ id: "job-4", data: { agentRunId: "hung-run" } }]);
+  assert.equal(startCalls, 2, "a settled run must be advanceable again");
+});
+
 test("sweep enqueues one deduped advance job per active run", async () => {
   const fb = fakeBoss();
   const { deps } = makeDeps({ listActiveRunIds: async () => ["run-1", "run-2"] });

--- a/apps/worker/src/agent-runs/queue.ts
+++ b/apps/worker/src/agent-runs/queue.ts
@@ -30,19 +30,31 @@ export const AGENT_RUN_ADVANCE_QUEUE = "agent-run-advance";
 export const AGENT_RUN_SWEEP_QUEUE = "agent-run-sweep";
 const SWEEP_SCHEDULE = "* * * * *";
 
-// How many advance jobs a single fetch works on; batches run concurrently, so
-// this is the effective per-process concurrency. Starting a run is dominated
+// How many advance jobs run concurrently per process, as INDEPENDENT
+// single-job consumers (`localConcurrency`), never a fetch batch: pg-boss
+// completes a batch only when the whole handler resolves, so with
+// batchSize > 1 one hung provider call holds every fetched job active until
+// queue expiry (observed in prod: one stuck sync pinned 10 jobs for 15
+// minutes while nine of them were long finished). Starting a run is dominated
 // by provider/GitHub round-trips (IO-bound), so a moderate default drains a
-// queued backlog far faster than the old one-batch-per-tick rotation without
-// saturating the task.
+// queued backlog without saturating the task.
 const DEFAULT_CONCURRENCY = 10;
 const MAX_CONCURRENCY = 50;
+
+// Upper bound on a single advance attempt. Legitimate work (repo discovery +
+// session creation + Slack) finishes well under a minute; the pathological
+// case is a provider call hanging into the SDK's 10-minute default timeout,
+// which would otherwise pin a consumer slot for the duration. On timeout the
+// attempt is abandoned (logged, including a late-failure hook so an eventual
+// rejection can't become an unhandled rejection) and the minute sweep
+// re-enqueues the run.
+const DEFAULT_JOB_TIMEOUT_MS = 180_000;
 
 export type AgentRunQueueBoss = {
   createQueue(name: string, options?: unknown): Promise<unknown>;
   work(
     name: string,
-    options: { batchSize: number },
+    options: { batchSize: number; localConcurrency?: number },
     handler: (jobs: Array<{ id: string; data: unknown }>) => Promise<unknown>,
   ): Promise<unknown>;
   send(name: string, data: object, options?: object): Promise<unknown>;
@@ -66,6 +78,7 @@ export type AgentRunQueueDeps = {
     retryPrDelivery(ctx: AgentRunContext): Promise<void>;
   };
   concurrency?: number;
+  jobTimeoutMs?: number;
   logger?: LoggerLike;
 };
 
@@ -141,19 +154,24 @@ export async function registerAgentRunQueue(
   });
   await boss.schedule(AGENT_RUN_SWEEP_QUEUE, SWEEP_SCHEDULE);
 
-  await boss.work(AGENT_RUN_ADVANCE_QUEUE, { batchSize: concurrency }, async (jobs) => {
-    await Promise.all(
-      jobs.map(async (job) => {
+  const jobTimeoutMs = deps.jobTimeoutMs ?? DEFAULT_JOB_TIMEOUT_MS;
+  await boss.work(
+    AGENT_RUN_ADVANCE_QUEUE,
+    { batchSize: 1, localConcurrency: concurrency },
+    async (jobs) => {
+      // batchSize is 1, so this loop sees a single job; each of the
+      // `localConcurrency` consumers runs this handler independently.
+      for (const job of jobs) {
         const data = parseJobData(job.data);
         if (!data) {
           logger.warn(
             { scope: "agent-run-queue", jobId: job.id },
             "skipping malformed agent-run job",
           );
-          return;
+          continue;
         }
         try {
-          await advanceRun(deps, data);
+          await advanceWithTimeout(deps, data, jobTimeoutMs, logger);
         } catch (err) {
           logger.error(
             {
@@ -164,9 +182,47 @@ export async function registerAgentRunQueue(
             "agent-run advance failed; the next sweep re-enqueues it",
           );
         }
-      }),
-    );
+      }
+    },
+  );
+}
+
+// Run one advance attempt with a hard deadline. On timeout the attempt is
+// abandoned — its promise keeps running in the background until the
+// underlying SDK/network timeout fires, so a late rejection is routed to the
+// logger instead of becoming an unhandled rejection.
+async function advanceWithTimeout(
+  deps: AgentRunQueueDeps,
+  data: AgentRunJobData,
+  timeoutMs: number,
+  logger: LoggerLike,
+): Promise<void> {
+  let timer: NodeJS.Timeout | undefined;
+  const timedOut = new Promise<"timeout">((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), timeoutMs);
   });
+  const attempt = advanceRun(deps, data).then(() => "done" as const);
+  try {
+    const outcome = await Promise.race([attempt, timedOut]);
+    if (outcome === "timeout") {
+      logger.error(
+        { scope: "agent-run-queue", agent_run_id: data.agentRunId, timeout_ms: timeoutMs },
+        "agent-run advance timed out; abandoning the attempt (the sweep re-enqueues the run)",
+      );
+      attempt.catch((err) =>
+        logger.error(
+          {
+            scope: "agent-run-queue",
+            agent_run_id: data.agentRunId,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          "abandoned agent-run advance eventually failed",
+        ),
+      );
+    }
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 // A send function for code that creates or touches a run and wants it

--- a/apps/worker/src/agent-runs/queue.ts
+++ b/apps/worker/src/agent-runs/queue.ts
@@ -155,6 +155,16 @@ export async function registerAgentRunQueue(
   await boss.schedule(AGENT_RUN_SWEEP_QUEUE, SWEEP_SCHEDULE);
 
   const jobTimeoutMs = deps.jobTimeoutMs ?? DEFAULT_JOB_TIMEOUT_MS;
+  // Runs with an attempt still executing — including attempts whose JOB was
+  // completed by the timeout below while the underlying promise keeps
+  // running. A new job for such a run is skipped so two attempts never
+  // advance the same run concurrently (duplicated provider calls, racing
+  // lifecycle writes); the sweep re-enqueues it after the attempt settles.
+  // In-process state is sufficient while one worker task consumes this queue
+  // (the stately policy already caps cross-process concurrency at one ACTIVE
+  // job per run); a durable per-run lease is part of the multi-task
+  // scale-out, not this hotfix.
+  const inFlight = new Set<string>();
   await boss.work(
     AGENT_RUN_ADVANCE_QUEUE,
     { batchSize: 1, localConcurrency: concurrency },
@@ -170,8 +180,15 @@ export async function registerAgentRunQueue(
           );
           continue;
         }
+        if (inFlight.has(data.agentRunId)) {
+          logger.warn(
+            { scope: "agent-run-queue", agent_run_id: data.agentRunId },
+            "previous advance attempt still in flight; skipping (the sweep retries)",
+          );
+          continue;
+        }
         try {
-          await advanceWithTimeout(deps, data, jobTimeoutMs, logger);
+          await advanceWithTimeout(deps, data, jobTimeoutMs, inFlight, logger);
         } catch (err) {
           logger.error(
             {
@@ -190,18 +207,24 @@ export async function registerAgentRunQueue(
 // Run one advance attempt with a hard deadline. On timeout the attempt is
 // abandoned — its promise keeps running in the background until the
 // underlying SDK/network timeout fires, so a late rejection is routed to the
-// logger instead of becoming an unhandled rejection.
+// logger instead of becoming an unhandled rejection. The run id stays in
+// `inFlight` until the underlying promise settles, which is what blocks a
+// concurrent second attempt for the same run.
 async function advanceWithTimeout(
   deps: AgentRunQueueDeps,
   data: AgentRunJobData,
   timeoutMs: number,
+  inFlight: Set<string>,
   logger: LoggerLike,
 ): Promise<void> {
   let timer: NodeJS.Timeout | undefined;
   const timedOut = new Promise<"timeout">((resolve) => {
     timer = setTimeout(() => resolve("timeout"), timeoutMs);
   });
-  const attempt = advanceRun(deps, data).then(() => "done" as const);
+  inFlight.add(data.agentRunId);
+  const attempt = advanceRun(deps, data)
+    .then(() => "done" as const)
+    .finally(() => inFlight.delete(data.agentRunId));
   try {
     const outcome = await Promise.race([attempt, timedOut]);
     if (outcome === "timeout") {

--- a/apps/worker/src/issue-transitions.test.ts
+++ b/apps/worker/src/issue-transitions.test.ts
@@ -3,9 +3,9 @@ import { test } from "node:test";
 import type { schema } from "@superlog/db";
 import {
   ISSUE_TRANSITION_QUEUE,
+  type TransitionQueueBoss,
   createIssueTransitionDispatcher,
   registerIssueTransitionWorker,
-  type TransitionQueueBoss,
 } from "./issue-transitions.js";
 
 function issueOf(id: string, projectId: string): schema.Issue {
@@ -19,19 +19,21 @@ function fakeBoss() {
   const sent: SentJob[] = [];
   const queues: Array<{ name: string; options: unknown }> = [];
   const workers = new Map<string, WorkHandler>();
+  const workOptions = new Map<string, unknown>();
   const boss: TransitionQueueBoss = {
     async createQueue(name, options) {
       queues.push({ name, options });
     },
-    async work(name, _options, handler) {
+    async work(name, options, handler) {
       workers.set(name, handler as WorkHandler);
+      workOptions.set(name, options);
     },
     async send(name, data, options) {
       sent.push({ name, data, options });
       return "job-id";
     },
   };
-  return { boss, sent, queues, workers };
+  return { boss, sent, queues, workers, workOptions };
 }
 
 test("dispatcher enqueues the transition instead of running it inline", async () => {
@@ -107,6 +109,13 @@ test("worker registration creates a standard queue and a batch worker", async ()
   // unlike the exclusive cron-job queues.
   assert.equal(fb.queues[0]?.options, undefined);
   assert.ok(fb.workers.get(ISSUE_TRANSITION_QUEUE), "a worker must be registered");
+  // Independent single-job consumers, not a fetch batch: pg-boss completes a
+  // batch only when the whole handler resolves, so batchSize > 1 lets one
+  // hung LLM grouping call pin every fetched transition until queue expiry.
+  assert.deepEqual(fb.workOptions.get(ISSUE_TRANSITION_QUEUE), {
+    batchSize: 1,
+    localConcurrency: 5,
+  });
 });
 
 test("the queue worker reloads each issue and runs the handler", async () => {

--- a/apps/worker/src/issue-transitions.ts
+++ b/apps/worker/src/issue-transitions.ts
@@ -23,9 +23,13 @@ import { logger as defaultLogger } from "./logger.js";
 
 export const ISSUE_TRANSITION_QUEUE = "issue-transition";
 
-// How many queued transitions a single fetch works on. Batches are processed
-// concurrently within the worker, so this is also the effective concurrency.
-const WORKER_BATCH_SIZE = 5;
+// How many transitions run concurrently, as independent single-job consumers
+// (`localConcurrency`), never a fetch batch: pg-boss completes a batch only
+// when the whole handler resolves, so with batchSize > 1 one hung LLM
+// grouping call would hold every fetched transition active until queue
+// expiry (the agent-run queue hit exactly this in prod — see
+// agent-runs/queue.ts).
+const WORKER_CONCURRENCY = 5;
 
 // Covers every dispatch site: telemetry ingest and alerts send "new" /
 // "recurred"; observation escalations send "escalated".
@@ -48,7 +52,7 @@ export type TransitionQueueBoss = {
   createQueue(name: string, options?: unknown): Promise<unknown>;
   work(
     name: string,
-    options: { batchSize: number },
+    options: { batchSize: number; localConcurrency?: number },
     handler: (jobs: Array<{ id: string; data: unknown }>) => Promise<unknown>,
   ): Promise<unknown>;
   send(name: string, data: object, options?: object): Promise<unknown>;
@@ -125,9 +129,10 @@ export function createIssueTransitionDispatcher(opts: {
   };
 }
 
-// Register the queue and its worker. Jobs in a batch run concurrently; each
-// job's failure is logged and swallowed (at-most-once, matching the previous
-// inline behavior) so one poisoned transition can't wedge or re-run the rest.
+// Register the queue and its worker. Each consumer processes one job at a
+// time; a job's failure is logged and swallowed (at-most-once, matching the
+// previous inline behavior) so one poisoned transition can't wedge or re-run
+// the rest.
 export async function registerIssueTransitionWorker(
   boss: Pick<TransitionQueueBoss, "createQueue" | "work">,
   opts: {
@@ -138,40 +143,44 @@ export async function registerIssueTransitionWorker(
 ): Promise<void> {
   const logger = opts.logger ?? defaultLogger;
   await boss.createQueue(ISSUE_TRANSITION_QUEUE);
-  await boss.work(ISSUE_TRANSITION_QUEUE, { batchSize: WORKER_BATCH_SIZE }, async (jobs) => {
-    await Promise.all(
-      jobs.map(async (job) => {
-        const data = parseJobData(job.data);
-        if (!data) {
-          logger.warn(
-            { scope: "issue-transitions", jobId: job.id },
-            "skipping malformed issue-transition job",
-          );
-          return;
-        }
-        try {
-          const issue = await opts.loadIssue(data.issueId);
-          if (!issue) {
+  await boss.work(
+    ISSUE_TRANSITION_QUEUE,
+    { batchSize: 1, localConcurrency: WORKER_CONCURRENCY },
+    async (jobs) => {
+      await Promise.all(
+        jobs.map(async (job) => {
+          const data = parseJobData(job.data);
+          if (!data) {
             logger.warn(
-              { scope: "issue-transitions", issueId: data.issueId, jobId: job.id },
-              "issue no longer exists; skipping transition",
+              { scope: "issue-transitions", jobId: job.id },
+              "skipping malformed issue-transition job",
             );
             return;
           }
-          await opts.handle(issue, data.transition);
-        } catch (err) {
-          logger.error(
-            {
-              scope: "issue-transitions",
-              issueId: data.issueId,
-              transition: data.transition,
-              projectId: data.projectId,
-              err: err instanceof Error ? err.message : String(err),
-            },
-            "issue transition failed; skipping",
-          );
-        }
-      }),
-    );
-  });
+          try {
+            const issue = await opts.loadIssue(data.issueId);
+            if (!issue) {
+              logger.warn(
+                { scope: "issue-transitions", issueId: data.issueId, jobId: job.id },
+                "issue no longer exists; skipping transition",
+              );
+              return;
+            }
+            await opts.handle(issue, data.transition);
+          } catch (err) {
+            logger.error(
+              {
+                scope: "issue-transitions",
+                issueId: data.issueId,
+                transition: data.transition,
+                projectId: data.projectId,
+                err: err instanceof Error ? err.message : String(err),
+              },
+              "issue transition failed; skipping",
+            );
+          }
+        }),
+      );
+    },
+  );
 }


### PR DESCRIPTION
## Problem

Follow-up to #217, found in the first hours of running it: the advance worker used `work({ batchSize: N })` with a `Promise.all` handler. pg-boss completes a fetched batch only when the entire handler resolves and fetches nothing new for that worker until then — so one hung provider call (the Anthropic SDK's default request timeout is 10 minutes, with retries) held all N fetched jobs active until queue expiry (15 min). Observed live: 10 jobs pinned active for 15 minutes, zero throughput, while nine of them had finished long ago. The old tick's head-of-line blocking, reproduced in miniature.

## Change

- Concurrency now comes from `localConcurrency: N` with `batchSize: 1` — N independent single-job consumers, each with its own fetch loop. A hung or slow job delays only its own slot; the other N−1 keep cycling.
- Every advance attempt gets a hard deadline (`AGENT_RUN_JOB_TIMEOUT_MS`, default 180s — comfortably above legitimate start/sync work, far below the SDK's pathological 10-minute hang). On timeout the attempt is abandoned and logged with the run id (giving a direct culprit list for hung sessions); a late-failure hook routes the eventual rejection to the logger so it can't become an unhandled rejection. The minute sweep re-enqueues the run.

## Tests

New: a hung handler resolves within the job timeout and is logged. Updated: registration asserts `{ batchSize: 1, localConcurrency: 10 }` with a comment explaining why batch concurrency is forbidden here. `test:agent-run-queue` and `test:issue-transitions` green; typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated agent-run and issue-transition queues with independent single-job consumers, added a per-job timeout for agent runs, and now skip re-enqueued jobs while a timed-out attempt is still executing. This prevents head-of-line blocking and duplicate provider calls; hung jobs only block their own slot and are logged.

- **Bug Fixes**
  - Agent-run: switched to `batchSize: 1` with `localConcurrency: N`, so one slow job only blocks its own slot.
  - Agent-run: enforced a per-job deadline (default 180s); on timeout we log and abandon the attempt, and the sweep re-enqueues the run.
  - Agent-run: track in-flight run ids and skip jobs for runs with an abandoned attempt until it settles, preventing concurrent advances.
  - Issue-transition: switched to `batchSize: 1` with `localConcurrency: 5` to prevent batch head‑of‑line blocking.

- **New Features**
  - `AGENT_RUN_JOB_TIMEOUT_MS` config to control per-job timeout; `AGENT_RUN_JOB_CONCURRENCY` now sets `localConcurrency`.

<sup>Written for commit 34230e11879ecbc2875420ca696a9a11278c2a7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

