### PR TITLE
Bound the trace-context span lookup by event time

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -21,6 +21,7 @@
     "test:incident-cooldown": "tsx --test src/incident-cooldown.test.ts",
     "test:agent-run": "tsx --test src/agent-run.test.ts",
     "test:agent-run-queue": "tsx --test src/agent-runs/queue.test.ts",
+    "test:trace-context": "tsx --test src/infra/clickhouse/trace-context.test.ts",
     "test:agent-run-start": "tsx --test src/agent-runs/start.test.ts",
     "test:agent-run-status": "tsx --test src/agent-runs/status.test.ts",
     "test:agent-run-sync": "tsx --test src/agent-runs/sync.test.ts",

--- a/apps/worker/src/agent-runs/prompt-context.ts
+++ b/apps/worker/src/agent-runs/prompt-context.ts
@@ -42,7 +42,14 @@ export async function buildIssueSummaryWithTrace(
   const traceId = sample?.traceId ?? null;
   const spanId = sample?.spanId ?? null;
   if (!traceId) return base;
-  const traceContext = await fetchTraceContext(projectId, traceId, spanId ?? null);
+  // The sample's own timestamp bounds the span lookup (see fetchTraceContext);
+  // fall back to the issue's lastSeen, which the sample tracks by construction.
+  const sampleSeenAt = sample?.seenAt ? new Date(sample.seenAt) : null;
+  const hintTs =
+    sampleSeenAt && Number.isFinite(sampleSeenAt.getTime())
+      ? sampleSeenAt
+      : (issue.lastSeen ?? null);
+  const traceContext = await fetchTraceContext(projectId, traceId, spanId ?? null, hintTs);
   return { ...base, traceContext };
 }
 

--- a/apps/worker/src/infra/clickhouse/trace-context.test.ts
+++ b/apps/worker/src/infra/clickhouse/trace-context.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { traceContextTimeBounds } from "./trace-context.js";
+
+const NOW = new Date("2026-07-13T16:00:00.000Z");
+
+test("a hint timestamp bounds the window to ±1 hour around the event", () => {
+  const hint = new Date("2026-07-10T02:30:00.000Z");
+  const { fromMs, toMs } = traceContextTimeBounds(hint, NOW);
+  assert.equal(fromMs, hint.getTime() - 60 * 60 * 1000);
+  assert.equal(toMs, hint.getTime() + 60 * 60 * 1000);
+});
+
+test("no hint falls back to a 72-hour floor ending shortly after now", () => {
+  const { fromMs, toMs } = traceContextTimeBounds(null, NOW);
+  assert.equal(fromMs, NOW.getTime() - 72 * 60 * 60 * 1000);
+  assert.equal(toMs, NOW.getTime() + 5 * 60 * 1000);
+});
+
+test("an invalid hint date falls back to the 72-hour floor", () => {
+  const { fromMs, toMs } = traceContextTimeBounds(new Date("nonsense"), NOW);
+  assert.equal(fromMs, NOW.getTime() - 72 * 60 * 60 * 1000);
+  assert.equal(toMs, NOW.getTime() + 5 * 60 * 1000);
+});

--- a/apps/worker/src/infra/clickhouse/trace-context.ts
+++ b/apps/worker/src/infra/clickhouse/trace-context.ts
@@ -190,12 +190,37 @@ function formatTraceContext(
   return joined;
 }
 
+// Time bounds for the span lookup. TraceId alone can't be found efficiently:
+// otel_traces is sorted by (ServiceName, SpanName, Timestamp) and partitioned
+// by day, so an unbounded TraceId query probes the bloom index across every
+// partition in retention (~20s+ on a large deployment, and it saturates the
+// read pool under concurrency). A time bound restores partition pruning. The
+// caller passes the event timestamp the trace id came from (issue sample
+// seenAt / issue lastSeen) — spans of that trace lie within ±1h of it. With
+// no usable hint, bound to the last 72h: investigations are about recent
+// events, and an unbounded scan is never worth its cost.
+const HINT_MARGIN_MS = 60 * 60 * 1000;
+const NO_HINT_LOOKBACK_MS = 72 * 60 * 60 * 1000;
+const NO_HINT_HEADROOM_MS = 5 * 60 * 1000;
+
+export function traceContextTimeBounds(
+  hintTs: Date | null,
+  now: Date,
+): { fromMs: number; toMs: number } {
+  if (hintTs && Number.isFinite(hintTs.getTime())) {
+    return { fromMs: hintTs.getTime() - HINT_MARGIN_MS, toMs: hintTs.getTime() + HINT_MARGIN_MS };
+  }
+  return { fromMs: now.getTime() - NO_HINT_LOOKBACK_MS, toMs: now.getTime() + NO_HINT_HEADROOM_MS };
+}
+
 export async function fetchTraceContext(
   projectId: string,
   traceId: string,
   anchorSpanId: string | null,
+  hintTs: Date | null = null,
 ): Promise<string | null> {
   if (!traceId) return null;
+  const { fromMs, toMs } = traceContextTimeBounds(hintTs, new Date());
   try {
     const result = await ch.query({
       query: `
@@ -216,11 +241,16 @@ export async function fetchTraceContext(
         FROM otel_traces
         WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
           AND TraceId = {traceId:String}
+          AND Timestamp >= fromUnixTimestamp64Milli({fromMs:Int64})
+          AND Timestamp <= fromUnixTimestamp64Milli({toMs:Int64})
         ORDER BY Timestamp ASC, SpanId ASC
         LIMIT 200
       `,
-      query_params: { projectId, traceId },
+      query_params: { projectId, traceId, fromMs, toMs },
       format: "JSONEachRow",
+      // Fail fast instead of holding an agent-run advance slot until the
+      // socket timeout — the prompt degrades gracefully without trace context.
+      clickhouse_settings: { max_execution_time: 10 },
     });
     const rows = (await result.json()) as TraceSpanRow[];
     if (rows.length === 0) return null;


### PR DESCRIPTION
## Problem

`fetchTraceContext` fetched a trace's spans from `otel_traces` filtered only by project + TraceId. The table's sort key is `(ServiceName, SpanName, Timestamp)` and it partitions by day, so a TraceId point lookup can't use the primary index — it probes the TraceId bloom skip-index across **every partition in retention**. Measured on a production-sized deployment: **21.7s and 474k rows read for a 2-span trace** (count-only; the real query drags the wide attribute/event columns and breaches the client socket timeout under load). Several of these in parallel — investigation prompt builds fetch context for multiple sample traces concurrently — saturate the ClickHouse read pool and stall every agent-run start for high-volume projects.

## Change

Every caller of this lookup already holds the timestamp of the event the trace id came from (`issue.lastSample.seenAt`, falling back to `issue.lastSeen`). The lookup now takes that as a hint and bounds the scan to **±1h around the event**, restoring partition pruning: the probe drops from all-of-retention to one or two daily partitions. Measured on the same trace: **0.4s, 12.9k rows read (~50×)**. With no usable hint the bound falls back to `now() − 72h` — investigations concern recent events — so the unbounded query shape no longer exists. The query also sets `max_execution_time: 10` so any residual slow lookup fails fast and the prompt degrades to no trace context instead of holding an advance slot.

Bounds logic is extracted as pure `traceContextTimeBounds()` with tests (hint window, no-hint floor, invalid-date fallback).

## Notes

Longer term the raw tables want a tenant-first sort key, which shrinks this further — this change is the tactical fix and stays correct under any layout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the trace-context span lookup by event time to restore partition pruning and cut ClickHouse scan times. This reduces unbounded scans (~21.7s/474k rows) to a bounded query (~0.4s/12.9k rows) and prevents agent-run stalls.

- **Changes**
  - `fetchTraceContext` now takes a hint timestamp and bounds spans to ±1h around the event.
  - Falls back to a 72h window when no valid hint is available.
  - Adds `Timestamp` filters and sets `max_execution_time: 10` to fail fast on slow queries.
  - Uses `sample.seenAt` (or `issue.lastSeen`) as the hint in `buildIssueSummaryWithTrace`.
  - Extracts `traceContextTimeBounds()` with tests and adds `test:trace-context` script.

<sup>Written for commit c1ae10e1c84a54650f13cf3c1d86771af2aa5b52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

