### PR TITLE
Localize incident-detail scrolling to the activity timeline

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -38,7 +38,11 @@ import { ThemeToggle } from "./design/ui.tsx";
 import { McpInstallPill } from "./onboarding/McpInstallPill.tsx";
 import { OnboardingGate } from "./onboarding/OnboardingGate.tsx";
 import { useDemoExploration } from "./onboarding/demoExploration.tsx";
-import { isDetailWorkspacePath } from "./route-layout.ts";
+import {
+  APP_FRAME_CLASS,
+  PAGE_SCROLL_CONTAINER_CLASS,
+  isDetailWorkspacePath,
+} from "./route-layout.ts";
 import {
   buildSignupEventProperties,
   parseAttribution,
@@ -219,7 +223,7 @@ function AuthenticatedApp() {
   if (!data) return <Landing />;
   return (
     <OnboardingGate>
-      <div className="flex min-h-screen flex-col bg-bg">
+      <div className={APP_FRAME_CLASS}>
         <TopRibbon
           impersonating={impersonating}
           email={data.user.email}
@@ -358,10 +362,12 @@ function RouteContainer({ children }: { children: ReactNode }) {
     return <div className="flex min-h-0 flex-1 flex-col">{children}</div>;
   }
   return (
-    <div
-      className={`mx-auto w-full px-5 pb-24 pt-8 sm:px-6 lg:px-8 ${wide ? "max-w-[2400px]" : "max-w-[1180px]"}`}
-    >
-      {children}
+    <div className={PAGE_SCROLL_CONTAINER_CLASS}>
+      <div
+        className={`mx-auto w-full px-5 pb-24 pt-8 sm:px-6 lg:px-8 ${wide ? "max-w-[2400px]" : "max-w-[1180px]"}`}
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/design/ProductShell.tsx
+++ b/apps/web/src/design/ProductShell.tsx
@@ -52,7 +52,7 @@ export function ProductShell({
 
   return (
     <div className="flex min-h-0 flex-1 bg-bg font-sans text-fg" data-product-shell>
-      <aside className="sticky top-0 hidden h-screen w-56 shrink-0 flex-col border-r border-border bg-surface/55 px-4 py-5 backdrop-blur md:flex">
+      <aside className="sticky top-0 hidden h-full w-56 shrink-0 flex-col border-r border-border bg-surface/55 px-4 py-5 backdrop-blur md:flex">
         <div className="px-2">
           <Wordmark size="sm" />
         </div>

--- a/apps/web/src/incidents/IncidentTranscript.test.ts
+++ b/apps/web/src/incidents/IncidentTranscript.test.ts
@@ -16,6 +16,14 @@ function event(overrides: Partial<IncidentEvent>): IncidentEvent {
   };
 }
 
+test("buildActivityFeed marks the start without carrying the raw system prompt", () => {
+  const prompt =
+    "Investigate incident amber-otter. Internal instructions and telemetry dump follow…";
+  const feed = buildActivityFeed([event({ id: "start-1", kind: "user.message", summary: prompt })]);
+
+  assert.deepEqual(feed, [{ type: "start", id: "start-1" }]);
+});
+
 test("buildActivityFeed starts with the issue that triggered the incident", () => {
   const feed = buildActivityFeed(
     [event({ kind: "agent_run_queued", summary: "Investigation queued." })],

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -72,7 +72,7 @@ export function IncidentActivityFeed({
     if (item.type === "telemetry") return <TelemetryEntry key={item.id} item={item} />;
     if (item.type === "memory") return <MemoryEntry key={item.id} item={item} />;
     if (item.type === "tool") return <ToolEntry key={item.id} item={item} />;
-    if (item.type === "start") return <StartEntry key={item.id} prompt={item.prompt} />;
+    if (item.type === "start") return <StartEntry key={item.id} />;
     if (item.type === "question")
       return (
         <QuestionEntry key={item.id} question={item.question} ctx={ctx} awaiting={item.awaiting} />
@@ -197,11 +197,10 @@ function CollapseToggle({
   );
 }
 
-// The initial investigation prompt, shown as a compact "Started investigation"
-// node. The raw prompt is verbose (incident id, telemetry dump), so it's tucked
-// behind a toggle.
-function StartEntry({ prompt }: { prompt: string }) {
-  const [open, setOpen] = useState(false);
+// The "Started investigation" marker. The raw initial prompt is a
+// system-generated brief (incident id, telemetry dump, internal instructions),
+// not user content, so it's not surfaced in the timeline — only the node itself.
+function StartEntry() {
   return (
     <div className="relative mb-6">
       <span className="absolute -left-7 top-0 grid h-[22px] w-[22px] place-items-center rounded-full border border-accent/40 bg-surface-2">
@@ -219,21 +218,7 @@ function StartEntry({ prompt }: { prompt: string }) {
       </span>
       <div className="flex min-h-[22px] items-center gap-2">
         <span className="text-[12px] font-semibold text-fg">Started investigation</span>
-        {prompt && (
-          <button
-            type="button"
-            onClick={() => setOpen((v) => !v)}
-            className="text-[11px] text-subtle hover:text-fg"
-          >
-            {open ? "hide prompt" : "show prompt"}
-          </button>
-        )}
       </div>
-      {open && prompt && (
-        <pre className="mt-1.5 whitespace-pre-wrap break-words text-[12px] leading-relaxed text-muted">
-          {prompt}
-        </pre>
-      )}
     </div>
   );
 }

--- a/apps/web/src/incidents/incident-activity-feed.ts
+++ b/apps/web/src/incidents/incident-activity-feed.ts
@@ -35,7 +35,10 @@ export type TranscriptItem =
     }
   | MemoryActivity
   | { type: "question"; id: string; question: string; awaiting: boolean }
-  | { type: "start"; id: string; prompt: string };
+  // The raw initial prompt is a system-generated brief (internal instructions +
+  // telemetry dump), not user content, so it is intentionally not carried into
+  // the feed — the node is a bare "Started investigation" marker.
+  | { type: "start"; id: string };
 
 export type FeedItem =
   | TranscriptItem
@@ -150,7 +153,7 @@ export function buildActivityFeed(
     if (event.kind === "agent.thinking" || TOOL_RESULT_KINDS.has(event.kind)) continue;
     if (event.kind.startsWith("agent.") || isFeedNoise(event.kind)) continue;
     if (event.kind === "user.message") {
-      items.push({ type: "start", id: event.id, prompt: (event.summary ?? "").trim() });
+      items.push({ type: "start", id: event.id });
       continue;
     }
     if (event.kind === "awaiting_human") continue;

--- a/apps/web/src/route-layout.test.ts
+++ b/apps/web/src/route-layout.test.ts
@@ -1,10 +1,28 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { isDetailWorkspacePath } from "./route-layout.ts";
+import {
+  APP_FRAME_CLASS,
+  PAGE_SCROLL_CONTAINER_CLASS,
+  isDetailWorkspacePath,
+} from "./route-layout.ts";
 
 test("issue and incident detail routes use the full-width investigation workspace", () => {
   assert.equal(isDetailWorkspacePath("/issues/issue-1"), true);
   assert.equal(isDetailWorkspacePath("/incidents/incident-1"), true);
   assert.equal(isDetailWorkspacePath("/issues"), false);
   assert.equal(isDetailWorkspacePath("/settings"), false);
+});
+
+test("the app frame is pinned to the viewport so route content scrolls in its own region", () => {
+  // Not `min-h-screen`: a min-height frame grows past the viewport and lets the
+  // whole document scroll, so a route's inner overflow-y-auto never engages.
+  assert.doesNotMatch(APP_FRAME_CLASS, /min-h-screen/);
+  assert.match(APP_FRAME_CLASS, /h-\[100dvh\]/);
+  assert.match(APP_FRAME_CLASS, /overflow-hidden/);
+});
+
+test("non-detail routes scroll inside their own container, not the document body", () => {
+  assert.match(PAGE_SCROLL_CONTAINER_CLASS, /overflow-y-auto/);
+  assert.match(PAGE_SCROLL_CONTAINER_CLASS, /min-h-0/);
+  assert.match(PAGE_SCROLL_CONTAINER_CLASS, /flex-1/);
 });

--- a/apps/web/src/route-layout.ts
+++ b/apps/web/src/route-layout.ts
@@ -1,3 +1,17 @@
 export function isDetailWorkspacePath(pathname: string) {
   return /^\/(?:issues|incidents)\/[^/]+\/?$/.test(pathname);
 }
+
+// The authenticated app frame is pinned to the viewport height rather than
+// `min-h-screen`. A `min-h-screen` frame is free to grow past the viewport, so a
+// tall route (e.g. the incident detail's activity timeline) scrolls the whole
+// document and the route's own `overflow-y-auto` region never engages. Pinning
+// the frame to `100dvh` and clipping its overflow keeps the sticky chrome fixed
+// and lets each route scroll inside its own container — so the incident timeline
+// scrolls in `IncidentDetailScrollArea`, not by growing the page.
+export const APP_FRAME_CLASS = "flex h-[100dvh] flex-col overflow-hidden bg-bg";
+
+// Ordinary (non-detail) routes — overview, lists, settings — are still plain
+// scrolling pages, but under a viewport-bounded frame they must scroll inside
+// their own container instead of the document body.
+export const PAGE_SCROLL_CONTAINER_CLASS = "min-h-0 flex-1 overflow-y-auto";


### PR DESCRIPTION
## What

Two fixes to the incident detail view:

**1. Scroll is localized to the timeline.** The incident detail already had a dedicated inner scroll region (`IncidentDetailScrollArea`), but it never engaged — the authenticated app frame used `min-h-screen`, which is free to grow past the viewport. A tall activity timeline scrolled the whole document, pushing the tabs and chat composer off-screen, while the inner `overflow-y-auto` region stayed at full content height and never scrolled.

The frame is now pinned to the viewport (`h-[100dvh]` + `overflow-hidden`), so the sticky chrome stays fixed and each route scrolls inside its own region:
- The incident timeline scrolls inside `IncidentDetailScrollArea`; tabs, sidebar, and the chat composer stay put.
- Non-detail routes (overview, lists, settings, explore) scroll inside their own container instead of the document body.
- The sidebar switches to `h-full` so it fits the bounded frame when a top ribbon is showing.

**2. The raw initial prompt is no longer shown on the "Started investigation" node.** That prompt is a system-generated brief (internal instructions plus a telemetry dump), not user-authored content, so it isn't surfaced in the timeline and no longer enters the feed model — the node is a bare marker.

## Testing

- New/updated unit tests: `route-layout.test.ts` locks in the pinned-frame + internal-scroll invariants; `IncidentTranscript.test.ts` asserts the start node carries no prompt.
- Full `@superlog/web` suite (110 tests) + typecheck pass.
- Verified in a browser: document overflow drops from 224px to 0 on the incident detail while the timeline region scrolls internally; overview/explore/settings still scroll (internally) with nothing clipped.

## Note for reviewers

The frame change touches the shared app shell — every route's scroll moves from the document body to an internal container (visually identical, scrollbar relocates). Verified across incident detail, overview, issues list, explore, and settings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized incident-detail scrolling to the activity timeline so tabs and the chat composer stay fixed. Also hid the raw system prompt on the “Started investigation” node.

- **Bug Fixes**
  - Pinned the authenticated app frame to the viewport (`h-[100dvh]` + `overflow-hidden`) so the timeline scrolls inside its own region and the sticky chrome doesn’t move; non-detail pages now scroll in an internal container and the sidebar uses `h-full`.
  - Removed the system-generated initial prompt from the feed; the “Started investigation” item is now a marker only.

<sup>Written for commit 66e7a74a351d9a517d03794733ca408e1b516fd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

