### PR TITLE
Export worker loop heartbeat and pg-boss queue-health gauges

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -22,6 +22,7 @@
     "test:agent-run": "tsx --test src/agent-run.test.ts",
     "test:agent-run-queue": "tsx --test src/agent-runs/queue.test.ts",
     "test:trace-context": "tsx --test src/infra/clickhouse/trace-context.test.ts",
+    "test:queue-health": "tsx --test src/queue-health.test.ts",
     "test:agent-run-start": "tsx --test src/agent-runs/start.test.ts",
     "test:agent-run-status": "tsx --test src/agent-runs/status.test.ts",
     "test:agent-run-sync": "tsx --test src/agent-runs/sync.test.ts",

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -13,6 +13,7 @@ import {
 import { startJobRunner } from "./jobs/runner.js";
 import { logger } from "./logger.js";
 import { registerDatastoreObservability } from "./observability/datastores.js";
+import { registerQueueHealthMetrics } from "./queue-health.js";
 import { createTelemetryIngestor, registerTelemetryIngestMetrics } from "./telemetry/ingest.js";
 import { registerTenantMetrics } from "./tenant-metrics.js";
 import { runWorker } from "./worker/runtime.js";
@@ -26,6 +27,7 @@ await initAiUsageSink();
 
 registerTenantMetrics();
 registerAgentRunHealthMetrics();
+registerQueueHealthMetrics();
 
 const CLICKHOUSE_URL = process.env.CLICKHOUSE_URL ?? "http://localhost:8123";
 const CLICKHOUSE_DB = process.env.CLICKHOUSE_DB ?? "superlog";

--- a/apps/worker/src/queue-health.test.ts
+++ b/apps/worker/src/queue-health.test.ts
@@ -1,0 +1,72 @@
+import "./agent-run.test-env.js";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildQueueHealthObservations,
+  pgbossSchemaName,
+  recordTickHeartbeat,
+  tickHeartbeatAgeMs,
+} from "./queue-health.js";
+
+const NOW = new Date("2026-07-13T18:00:00.000Z");
+
+test("per-queue gauges carry the queue name and oldest pending age", () => {
+  const observations = buildQueueHealthObservations(
+    [
+      {
+        queue: "agent-run-advance",
+        pending: 12,
+        active: 10,
+        oldestPendingAt: new Date("2026-07-13T17:58:00.000Z"),
+      },
+      { queue: "issue-transition", pending: 0, active: 0, oldestPendingAt: null },
+    ],
+    NOW,
+  );
+
+  const advance = observations.filter((o) => o.attributes?.["queue.name"] === "agent-run-advance");
+  assert.deepEqual(
+    advance.map((o) => [o.metric, o.value]),
+    [
+      ["superlog.worker.jobs.pending", 12],
+      ["superlog.worker.jobs.active", 10],
+      ["superlog.worker.jobs.oldest_pending_age_ms", 120_000],
+    ],
+  );
+  const transition = observations.filter(
+    (o) => o.attributes?.["queue.name"] === "issue-transition",
+  );
+  // No pending jobs → age reports 0, not a stale/frozen value.
+  assert.deepEqual(
+    transition.map((o) => [o.metric, o.value]),
+    [
+      ["superlog.worker.jobs.pending", 0],
+      ["superlog.worker.jobs.active", 0],
+      ["superlog.worker.jobs.oldest_pending_age_ms", 0],
+    ],
+  );
+});
+
+test("an empty snapshot still emits explicit zeros so series don't freeze", () => {
+  const observations = buildQueueHealthObservations([], NOW);
+  assert.deepEqual(
+    observations.map((o) => [o.metric, o.value, o.attributes?.["queue.name"]]),
+    [
+      ["superlog.worker.jobs.pending", 0, "none"],
+      ["superlog.worker.jobs.active", 0, "none"],
+      ["superlog.worker.jobs.oldest_pending_age_ms", 0, "none"],
+    ],
+  );
+});
+
+test("tick heartbeat age measures time since the last recorded tick", () => {
+  recordTickHeartbeat(new Date("2026-07-13T17:59:30.000Z"));
+  assert.equal(tickHeartbeatAgeMs(NOW), 30_000);
+});
+
+test("pgboss schema name rejects unsafe identifiers", () => {
+  assert.equal(pgbossSchemaName(undefined), "pgboss");
+  assert.equal(pgbossSchemaName("pgboss_test"), "pgboss_test");
+  assert.equal(pgbossSchemaName("bad; DROP TABLE x"), "pgboss");
+  assert.equal(pgbossSchemaName("1leading"), "pgboss");
+});

--- a/apps/worker/src/queue-health.test.ts
+++ b/apps/worker/src/queue-health.test.ts
@@ -6,6 +6,7 @@ import {
   pgbossSchemaName,
   recordTickHeartbeat,
   tickHeartbeatAgeMs,
+  withQueueRecoveryZeros,
 } from "./queue-health.js";
 
 const NOW = new Date("2026-07-13T18:00:00.000Z");
@@ -57,6 +58,21 @@ test("an empty snapshot still emits explicit zeros so series don't freeze", () =
       ["superlog.worker.jobs.oldest_pending_age_ms", 0, "none"],
     ],
   );
+});
+
+test("a queue that drains out of the snapshot gets one recovery zero, then drops", () => {
+  const drained = withQueueRecoveryZeros([], new Set(["agent-run-advance"]));
+  assert.deepEqual(drained, [
+    { queue: "agent-run-advance", pending: 0, active: 0, oldestPendingAt: null },
+  ]);
+
+  // The recovery zero must not keep itself alive: with the previous snapshot
+  // also empty, nothing is emitted for the queue on the following pass.
+  assert.deepEqual(withQueueRecoveryZeros([], new Set()), []);
+
+  // A queue still present in the snapshot is not duplicated.
+  const live = [{ queue: "agent-run-advance", pending: 3, active: 1, oldestPendingAt: null }];
+  assert.deepEqual(withQueueRecoveryZeros(live, new Set(["agent-run-advance"])), live);
 });
 
 test("tick heartbeat age measures time since the last recorded tick", () => {

--- a/apps/worker/src/queue-health.ts
+++ b/apps/worker/src/queue-health.ts
@@ -111,8 +111,27 @@ export async function loadQueueHealthCounts(): Promise<QueueHealthCounts[]> {
   }));
 }
 
+// A queue that drains out of the snapshot (the pgboss query only returns
+// queues with live jobs) gets one explicit all-zero entry so its series ends
+// at 0 instead of freezing at the last non-zero value. `previous` tracks the
+// queues the snapshot contained, so recovery zeros live exactly one pass —
+// same convention as agent-run-health-metrics' withRecoveryZeros.
+export function withQueueRecoveryZeros(
+  current: QueueHealthCounts[],
+  previous: ReadonlySet<string>,
+): QueueHealthCounts[] {
+  const seen = new Set(current.map((q) => q.queue));
+  const out = [...current];
+  for (const queue of previous) {
+    if (seen.has(queue)) continue;
+    out.push({ queue, pending: 0, active: 0, oldestPendingAt: null });
+  }
+  return out;
+}
+
 let cached: { at: number; counts: QueueHealthCounts[] } | null = null;
 const CACHE_TTL_MS = 30_000;
+let previousSnapshotQueues = new Set<string>();
 // Structured log cadence for deployment-side metric filters — one flat line
 // per queue plus one heartbeat line, once a minute.
 const LOG_INTERVAL_MS = 60_000;
@@ -121,8 +140,10 @@ let lastLoggedAt = 0;
 async function snapshot(): Promise<QueueHealthCounts[]> {
   if (cached && Date.now() - cached.at < CACHE_TTL_MS) return cached.counts;
   const counts = await loadQueueHealthCounts();
-  cached = { at: Date.now(), counts };
-  return counts;
+  const withZeros = withQueueRecoveryZeros(counts, previousSnapshotQueues);
+  previousSnapshotQueues = new Set(counts.map((q) => q.queue));
+  cached = { at: Date.now(), counts: withZeros };
+  return withZeros;
 }
 
 function logQueueHealth(counts: QueueHealthCounts[], now: Date): void {

--- a/apps/worker/src/queue-health.ts
+++ b/apps/worker/src/queue-health.ts
@@ -1,0 +1,184 @@
+// Queue and loop health gauges, exported through the worker's own OTel
+// pipeline (same pattern as agent-run-health-metrics.ts), plus flat
+// structured log lines that deployment-side log tooling can turn into
+// alarm metrics without parsing nested JSON.
+//
+// Why this exists: every past worker outage (wedged ingest cursor, starved
+// agent-run rotation, a queue whose consumer died) was discovered by a human
+// noticing missing product behavior, hours or days late. The signals below
+// make those failure modes directly observable:
+//   - superlog.worker.jobs.pending / .active / .oldest_pending_age_ms per
+//     pg-boss queue — a growing oldest-pending age on a queue whose consumer
+//     should be draining it is the "stuck queue" page.
+//   - superlog.worker.tick.heartbeat_age_ms — the tick loop's last completed
+//     cycle age; a climbing heartbeat means the loop is wedged or the process
+//     is stuck, regardless of which step is at fault.
+import { metrics } from "@opentelemetry/api";
+import { db } from "@superlog/db";
+import { sql } from "drizzle-orm";
+import { logger } from "./logger.js";
+
+const meter = metrics.getMeter("@superlog/worker/queue-health");
+
+export type QueueHealthCounts = {
+  queue: string;
+  pending: number;
+  active: number;
+  oldestPendingAt: Date | null;
+};
+
+export type QueueHealthObservation = {
+  metric: string;
+  value: number;
+  attributes?: Record<string, string>;
+};
+
+// The pgboss schema name is interpolated as an identifier (it can't be a
+// bind parameter), so it must never carry anything but a plain identifier.
+export function pgbossSchemaName(raw: string | undefined): string {
+  if (raw && /^[a-z_][a-z0-9_]*$/i.test(raw)) return raw;
+  return "pgboss";
+}
+
+// Process boot counts as the first heartbeat so the gauge is meaningful
+// before the first tick completes (a worker that never completes one is
+// exactly what the alarm must catch).
+let lastTickAt: Date = new Date();
+
+export function recordTickHeartbeat(at: Date = new Date()): void {
+  lastTickAt = at;
+}
+
+export function tickHeartbeatAgeMs(now: Date = new Date()): number {
+  return Math.max(0, now.getTime() - lastTickAt.getTime());
+}
+
+// Pure mapping from counts to gauge observations. Queues in the snapshot emit
+// every gauge (explicit zeros) so a drained queue drops to 0 instead of its
+// series freezing at the last bad value; an empty snapshot emits one zero set
+// under queue.name="none" to keep the series alive.
+export function buildQueueHealthObservations(
+  queues: QueueHealthCounts[],
+  now: Date,
+): QueueHealthObservation[] {
+  const observations: QueueHealthObservation[] = [];
+  const emit = (queue: string, pending: number, active: number, oldestPendingAt: Date | null) => {
+    const attributes = { "queue.name": queue };
+    const oldestAgeMs = oldestPendingAt
+      ? Math.max(0, now.getTime() - oldestPendingAt.getTime())
+      : 0;
+    observations.push(
+      { metric: "superlog.worker.jobs.pending", value: pending, attributes },
+      { metric: "superlog.worker.jobs.active", value: active, attributes },
+      { metric: "superlog.worker.jobs.oldest_pending_age_ms", value: oldestAgeMs, attributes },
+    );
+  };
+  for (const q of queues) emit(q.queue, q.pending, q.active, q.oldestPendingAt);
+  if (queues.length === 0) emit("none", 0, 0, null);
+  return observations;
+}
+
+// Pending = created + retry: both are jobs waiting for a consumer. A job
+// sitting in either past its expected latency means the consumer is gone or
+// saturated.
+export async function loadQueueHealthCounts(): Promise<QueueHealthCounts[]> {
+  const schema = pgbossSchemaName(process.env.PGBOSS_SCHEMA);
+  const rows = (await db.execute<{
+    queue: string;
+    pending: number;
+    active: number;
+    oldest_pending: Date | null;
+  }>(sql`
+    SELECT
+      name AS queue,
+      count(*) FILTER (WHERE state IN ('created', 'retry'))::int AS pending,
+      count(*) FILTER (WHERE state = 'active')::int AS active,
+      min(created_on) FILTER (WHERE state IN ('created', 'retry')) AS oldest_pending
+    FROM ${sql.raw(schema)}.job
+    WHERE state IN ('created', 'retry', 'active')
+    GROUP BY 1
+  `)) as unknown as Array<{
+    queue: string;
+    pending: number;
+    active: number;
+    oldest_pending: Date | string | null;
+  }>;
+  return rows.map((r) => ({
+    queue: r.queue,
+    pending: Number(r.pending),
+    active: Number(r.active),
+    oldestPendingAt: r.oldest_pending ? new Date(r.oldest_pending) : null,
+  }));
+}
+
+let cached: { at: number; counts: QueueHealthCounts[] } | null = null;
+const CACHE_TTL_MS = 30_000;
+// Structured log cadence for deployment-side metric filters — one flat line
+// per queue plus one heartbeat line, once a minute.
+const LOG_INTERVAL_MS = 60_000;
+let lastLoggedAt = 0;
+
+async function snapshot(): Promise<QueueHealthCounts[]> {
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return cached.counts;
+  const counts = await loadQueueHealthCounts();
+  cached = { at: Date.now(), counts };
+  return counts;
+}
+
+function logQueueHealth(counts: QueueHealthCounts[], now: Date): void {
+  if (now.getTime() - lastLoggedAt < LOG_INTERVAL_MS) return;
+  lastLoggedAt = now.getTime();
+  for (const q of counts) {
+    logger.info(
+      {
+        scope: "queue-health",
+        queue: q.queue,
+        pending: q.pending,
+        active: q.active,
+        oldest_pending_ms: q.oldestPendingAt
+          ? Math.max(0, now.getTime() - q.oldestPendingAt.getTime())
+          : 0,
+      },
+      "queue health",
+    );
+  }
+  logger.info({ scope: "queue-health", tick_age_ms: tickHeartbeatAgeMs(now) }, "tick heartbeat");
+}
+
+export function registerQueueHealthMetrics(): void {
+  const pending = meter.createObservableGauge("superlog.worker.jobs.pending", {
+    description: "pg-boss jobs waiting for a consumer (created + retry), by queue.",
+  });
+  const active = meter.createObservableGauge("superlog.worker.jobs.active", {
+    description: "pg-boss jobs currently being processed, by queue.",
+  });
+  const oldestAge = meter.createObservableGauge("superlog.worker.jobs.oldest_pending_age_ms", {
+    description: "Age of the oldest pending pg-boss job, by queue.",
+  });
+  const heartbeat = meter.createObservableGauge("superlog.worker.tick.heartbeat_age_ms", {
+    description: "Milliseconds since the worker loop last completed a cycle.",
+  });
+  const gaugeFor = (metric: string) =>
+    metric === "superlog.worker.jobs.pending"
+      ? pending
+      : metric === "superlog.worker.jobs.active"
+        ? active
+        : oldestAge;
+
+  meter.addBatchObservableCallback(
+    async (result) => {
+      const now = new Date();
+      result.observe(heartbeat, tickHeartbeatAgeMs(now));
+      try {
+        const counts = await snapshot();
+        for (const obs of buildQueueHealthObservations(counts, now)) {
+          result.observe(gaugeFor(obs.metric), obs.value, obs.attributes);
+        }
+        logQueueHealth(counts, now);
+      } catch (err) {
+        logger.error({ err, scope: "queue-health" }, "queue health observe failed");
+      }
+    },
+    [pending, active, oldestAge, heartbeat],
+  );
+}

--- a/apps/worker/src/telemetry/ingest.ts
+++ b/apps/worker/src/telemetry/ingest.ts
@@ -147,6 +147,12 @@ export function createTelemetryIngestor(opts: {
   };
 }
 
+// Flat once-a-minute log line per kind so deployment-side log tooling can
+// alarm on ingest cursor lag without parsing nested JSON (same convention as
+// queue-health.ts).
+const CURSOR_LOG_INTERVAL_MS = 60_000;
+let cursorLastLoggedAt = 0;
+
 export function registerTelemetryIngestMetrics(opts: {
   clickhouse: ClickHouseClientLike;
   database?: DB;
@@ -159,6 +165,8 @@ export function registerTelemetryIngestMetrics(opts: {
   meter.addBatchObservableCallback(
     async (result) => {
       const observedAt = Date.now();
+      const shouldLog = observedAt - cursorLastLoggedAt >= CURSOR_LOG_INTERVAL_MS;
+      if (shouldLog) cursorLastLoggedAt = observedAt;
       for (const kind of ["span", "log"] as const) {
         try {
           const stats = await loadBacklogStats({
@@ -172,6 +180,12 @@ export function registerTelemetryIngestMetrics(opts: {
           result.observe(pendingRowsGauge, stats.pendingRows, attrs);
           result.observe(oldestPendingAgeMsGauge, stats.oldestPendingAgeMs, attrs);
           result.observe(cursorLagMsGauge, stats.cursorLagMs, attrs);
+          if (shouldLog) {
+            logger.info(
+              { scope: "queue-health", cursor_kind: kind, cursor_lag_ms: stats.cursorLagMs },
+              "ingest cursor lag",
+            );
+          }
         } catch (err) {
           logger.error(
             { err, scope: "telemetry-ingest-metrics", kind, now: observedAt },

--- a/apps/worker/src/worker/runtime.ts
+++ b/apps/worker/src/worker/runtime.ts
@@ -1,4 +1,5 @@
 import { logger } from "../logger.js";
+import { recordTickHeartbeat } from "../queue-health.js";
 import type { WorkerTickResult } from "./tick.js";
 
 function sleep(ms: number): Promise<void> {
@@ -13,15 +14,12 @@ export async function runWorker(opts: {
   logger.info({ pollMs: opts.pollIntervalMs, batchSize: opts.batchSize }, "worker up");
   while (true) {
     try {
-      const {
-        spans,
-        logs,
-        agentRuns,
-        alerts,
-        digests,
-        webhooks,
-        autorecoveryProposals,
-      } = await opts.tick();
+      const { spans, logs, agentRuns, alerts, digests, webhooks, autorecoveryProposals } =
+        await opts.tick();
+      // Heartbeat for the tick-lateness gauge/alarm: recorded only on a
+      // completed cycle, so a wedged step shows up as a climbing age even
+      // while the process stays alive.
+      recordTickHeartbeat();
       if (
         spans > 0 ||
         logs > 0 ||


### PR DESCRIPTION
## Why

Every worker failure mode we've hit — a wedged ingest cursor, a starved run rotation, a queue whose consumer died at boot — was discovered by a human noticing missing product behavior, long after the fact. The worker already exports ingest cursor lag; this adds the two missing signals so an alarm can notice instead:

- **`superlog.worker.jobs.pending` / `.active` / `.oldest_pending_age_ms`** per pg-boss queue, read from the `pgboss.job` table with a 30s cache. A climbing oldest-pending age on a queue that should be draining = stuck consumer.
- **`superlog.worker.tick.heartbeat_age_ms`** — age of the loop's last *completed* cycle (recorded post-tick, so a wedged step shows as climbing age even while the process is alive; boot counts as the first beat so a worker that never completes a cycle alarms too).

Exported two ways: OTel gauges through the worker's own pipeline (product dashboards/alerts), and flat structured log lines once a minute (`scope=queue-health`, one line per queue + one heartbeat line) so deployment-side log tooling can derive alarm metrics from fields like `$.oldest_pending_ms` without nested-JSON parsing.

Explicit zeros are emitted for drained queues and empty snapshots so series drop to zero instead of freezing at their last bad value (same convention as agent-run-health-metrics).

## Tests

`test:queue-health`: per-queue observation mapping, empty-snapshot zeros, heartbeat age math, pgboss schema-identifier sanitization (it's interpolated as an identifier). Typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exports per-queue pg-boss gauges and a worker tick heartbeat, and adds flat once-a-minute log lines for queues, heartbeat, and ingest cursor lag to enable log-based alarms.

- **New Features**
  - Per-queue gauges: `superlog.worker.jobs.pending`, `superlog.worker.jobs.active`, `superlog.worker.jobs.oldest_pending_age_ms` (from `pgboss.job`, 30s cache).
  - Heartbeat gauge: `superlog.worker.tick.heartbeat_age_ms`, recorded after each completed tick (boot counts).
  - Flat logs once per minute (`scope=queue-health`): one line per queue, one heartbeat line, and ingest cursor lag lines per kind (`cursor_kind`, `cursor_lag_ms`).
  - One-pass recovery zeros for queues that drain out of the snapshot, plus explicit zeros for empty snapshots; metrics wired into the worker and tick loop; `test:queue-health` covers mapping, zero behavior, heartbeat math, and schema sanitization.

<sup>Written for commit 275a40229b841c9b60f62650a273fdbff2463e2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

