### PR TITLE
Serialize same-trace incident intake to close the grouping race

### DIFF
--- a/apps/worker/src/incident-intake.ts
+++ b/apps/worker/src/incident-intake.ts
@@ -48,14 +48,15 @@ export async function ensureIncidentForIssue(
     lifecycle: incidentLifecycle,
     analyzeGrouping: analyzeIssueGrouping,
     logger,
-    // Alert-episode issues are the one path where concurrent duplicates of the
-    // SAME issue can reach intake together (racing evaluations fold into one
-    // episode issue and both proceed): serialize the workflow's create/link
-    // section with a per-issue advisory lock so the second racer re-lands on
-    // the first's incident. The workflow keeps the LLM grouping call outside
-    // the hook; notifications and agent queueing happen in the caller, after
-    // the lock is released. Error ingest doesn't need this — its transition
-    // classification already picks a single notifier per occurrence.
-    serializeCreate: issue.kind === "alert" ? withIssueIntakeLock : undefined,
+    // Serialize the workflow's read-then-create section with an advisory lock so
+    // concurrent intakes (pg-boss issue-transition jobs) can't each open an
+    // incident for what should be one. The workflow keys the lock by trace id
+    // when present — same-request symptoms (a span exception and its own log
+    // line) are DIFFERENT issues, so a per-issue lock wouldn't serialize them —
+    // and re-checks the same-trace match inside the lock so the loser re-lands on
+    // the winner's incident. Falls back to the issue id (the alert-episode case:
+    // racing evaluations fold into one episode issue). The LLM grouping call
+    // stays outside the hook; notifications happen in the caller after release.
+    serializeCreate: withIssueIntakeLock,
   });
 }

--- a/apps/worker/src/incidents/intake.test.ts
+++ b/apps/worker/src/incidents/intake.test.ts
@@ -683,3 +683,60 @@ test("intake: LLM error logs a warning and marks issue 'failed'", async () => {
     ),
   );
 });
+
+test("intake: joins a same-trace incident that appears during the serialize lock", async () => {
+  // The span exception's incident is opened by a racing transition while this
+  // (log) transition is between its outside-lock grouping and the create. The
+  // incident only becomes visible on the inside-lock same-trace re-check (the
+  // 3rd cross-service candidate read); we must join it, not open a duplicate.
+  const calls: string[] = [];
+  const racer = makeIncident({ id: "inc-racer", service: "superlog-sample-nextjs" });
+  const issue = makeIssue({
+    id: "iss-log",
+    service: "superlog-sample",
+    exceptionType: "ERROR",
+    lastSample: { traceId: "trace-1", spanId: "span-log" } as schema.Issue["lastSample"],
+  });
+
+  let crossServiceReads = 0;
+  const base = makeRepo({ calls });
+  const repo: IntakeRepository = {
+    ...base,
+    async findOpenIncidentCandidates(_issue, queryOpts) {
+      calls.push(`findOpenIncidentCandidates:${queryOpts.filterService}`);
+      if (queryOpts.filterService) return [];
+      crossServiceReads += 1;
+      return crossServiceReads >= 3 ? [racer] : [];
+    },
+    async loadLinkedIncidentIssues(incidents) {
+      calls.push(`loadLinkedIncidentIssues:${incidents.length}`);
+      return incidents.map((inc) => ({
+        incidentId: inc.id,
+        title: "span exception",
+        exceptionType: "TypeError",
+        message: null,
+        topFrame: null,
+        normalizedFrames: [],
+        lastSample: { traceId: "trace-1", spanId: "span-exc" },
+        lastSeen: NOW,
+      })) as unknown as Awaited<ReturnType<IntakeRepository["loadLinkedIncidentIssues"]>>;
+    },
+    async findIncident(incidentId) {
+      calls.push(`findIncident:${incidentId}`);
+      return incidentId === "inc-racer" ? racer : undefined;
+    },
+  };
+  const deps = makeDeps({
+    repo,
+    lifecycle: makeLifecycle({ calls }),
+    calls,
+    serializeCreate: (_key, fn) => fn(),
+  });
+
+  const result = await ensureIncidentForIssueWorkflow(issue, "new", deps);
+
+  assert.equal(result.createdIncident, false);
+  assert.equal(result.incident.id, "inc-racer");
+  assert.ok(calls.includes("linkIssueToIncident:iss-log->inc-racer"));
+  assert.ok(!calls.some((c) => c.startsWith("createOpen")));
+});

--- a/apps/worker/src/incidents/intake.ts
+++ b/apps/worker/src/incidents/intake.ts
@@ -209,16 +209,23 @@ export async function ensureIncidentForIssueWorkflow(
     };
   }
 
-  const grouping = await findMatchingIncident(issue, deps);
-  const matched = grouping.match?.incident ?? null;
+  let grouping = await findMatchingIncident(issue, deps);
+  let matched = grouping.match?.incident ?? null;
 
   // The tail below is the workflow's one read-then-create section: everything
   // above only joins existing incidents with idempotent writes. It runs under
   // the optional serialization hook with a link re-check inside, so a racer
   // that created the incident first wins and the loser re-lands on it. The
   // grouping analysis (which can call an LLM) stays outside the hook.
-  const serialize = deps.serializeCreate ?? ((_issueId, fn) => fn());
-  return serialize(issue.id, async () => {
+  //
+  // Key the lock by trace id when present, so same-request symptoms — a span
+  // exception and its own log line, which are DIFFERENT issues — serialize on
+  // the same lock (a per-issue lock wouldn't). Fall back to the issue id for
+  // no-trace issues (e.g. alert episodes).
+  const traceId = issueSample(issue)?.traceId;
+  const serializeKey = traceId ? `trace:${traceId}` : issue.id;
+  const serialize = deps.serializeCreate ?? ((_key, fn) => fn());
+  return serialize(serializeKey, async () => {
     const raceLink = await deps.repo.findLatestIncidentIssueLink(issue.id);
     if (raceLink) {
       const existing = await deps.repo.findIncident(raceLink.incidentId);
@@ -240,6 +247,17 @@ export async function ensureIncidentForIssueWorkflow(
           linkedIssue: false,
           recurrenceIncident: false,
         };
+      }
+    }
+
+    // Same-request race: we resolved grouping outside the lock, so a sibling
+    // symptom sharing this trace may have opened the incident since. Now that we
+    // hold the trace-keyed lock, re-check and join it rather than duplicating.
+    if (!matched) {
+      const sameTrace = await findSameTraceMatchingIncident(issue, deps);
+      if (sameTrace) {
+        grouping = { match: sameTrace, standaloneSource: null, standaloneReason: null, failedReason: null };
+        matched = sameTrace.incident;
       }
     }
 


### PR DESCRIPTION
Follow-up to #224. The deterministic same-trace join fixed the *logic* but not concurrency: since issue transitions run as pg-boss jobs, a span exception and its own log line (different issues, same request) are processed ~concurrently. Both resolved grouping (read "no matching incident") **outside** any lock, so both opened an incident — three incidents for one failed request, still.

Fix:
- **Key the intake advisory lock by trace id** (`incidents/intake.ts`), falling back to issue id. Same-request symptoms are *different* issues, so the existing per-issue lock couldn't serialize them; a trace-keyed lock does.
- **Re-run the same-trace match inside the lock**, so the loser re-lands on the winner's incident instead of creating a duplicate (mirrors the existing same-issue re-check).
- **Enable `serializeCreate` for all issues**, not just alert episodes (`incident-intake.ts`).

Test: `incidents/intake.test.ts` adds a case where the racer's incident only becomes visible on the inside-lock re-check and asserts the issue joins it (no `createOpen`). Worker typecheck clean; intake+domain tests 20/20.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize incident intake by trace ID to prevent duplicate incidents when multiple issues from the same request race. Span exceptions and their log lines now join the same incident instead of opening separate ones.

- **Bug Fixes**
  - Key advisory lock by trace ID (fallback to issue ID) during create/link to serialize same-request symptoms.
  - Re-run same-trace match inside the lock so the second racer joins the first incident.
  - Enable `serializeCreate` for all issues, not just alerts.
  - Add test to ensure a same-trace incident discovered inside the lock is joined, not duplicated.

<sup>Written for commit 0dab0345d531d0aef16db1c9cf30c4b67eb3d6e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

