### PR TITLE
Make the product sidebar collapsible

### DIFF
--- a/apps/web/src/design/ProductShell.test.tsx
+++ b/apps/web/src/design/ProductShell.test.tsx
@@ -4,6 +4,7 @@ import test from "node:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
 import { ProductShell } from "./ProductShell.tsx";
+import { readSidebarCollapsed, writeSidebarCollapsed } from "./sidebarCollapsed.ts";
 
 test("the signed-in shell uses standard icons without workspace status copy", async () => {
   const html = renderToStaticMarkup(
@@ -24,6 +25,41 @@ test("the signed-in shell uses standard icons without workspace status copy", as
   const source = await readFile(new URL("./ProductShell.tsx", import.meta.url), "utf8");
   assert.match(source, /@phosphor-icons\/react/);
   assert.doesNotMatch(source, /function NavigationIcon/);
+});
+
+test("the shell renders a collapse toggle and expanded nav labels by default", () => {
+  const html = renderToStaticMarkup(
+    <MemoryRouter initialEntries={["/"]}>
+      <ProductShell>
+        <main>Page body</main>
+      </ProductShell>
+    </MemoryRouter>,
+  );
+
+  // Server render has no localStorage, so the sidebar defaults to expanded.
+  assert.match(html, /aria-label="Collapse sidebar"/);
+  assert.match(html, /aria-pressed="false"/);
+  assert.match(html, />Overview<\/span>/);
+});
+
+test("sidebar collapse state round-trips through localStorage", () => {
+  const store = new Map<string, string>();
+  const original = globalThis.window;
+  const localStorage = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => void store.set(key, value),
+    removeItem: (key: string) => void store.delete(key),
+  };
+  globalThis.window = { localStorage } as unknown as Window & typeof globalThis;
+  try {
+    assert.equal(readSidebarCollapsed(), false);
+    writeSidebarCollapsed(true);
+    assert.equal(readSidebarCollapsed(), true);
+    writeSidebarCollapsed(false);
+    assert.equal(readSidebarCollapsed(), false);
+  } finally {
+    globalThis.window = original;
+  }
 });
 
 test("errors and incidents are separate primary navigation destinations", () => {

--- a/apps/web/src/design/ProductShell.tsx
+++ b/apps/web/src/design/ProductShell.tsx
@@ -4,10 +4,12 @@ import { BugIcon } from "@phosphor-icons/react/dist/csr/Bug";
 import { ChartBarIcon } from "@phosphor-icons/react/dist/csr/ChartBar";
 import { GearIcon } from "@phosphor-icons/react/dist/csr/Gear";
 import { MagnifyingGlassIcon } from "@phosphor-icons/react/dist/csr/MagnifyingGlass";
+import { SidebarSimpleIcon } from "@phosphor-icons/react/dist/csr/SidebarSimple";
 import { SirenIcon } from "@phosphor-icons/react/dist/csr/Siren";
 import { SquaresFourIcon } from "@phosphor-icons/react/dist/csr/SquaresFour";
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
+import { readSidebarCollapsed, writeSidebarCollapsed } from "./sidebarCollapsed.ts";
 import { Wordmark } from "./ui.tsx";
 
 type NavigationItem = {
@@ -46,24 +48,50 @@ export function ProductShell({
   children: ReactNode;
 }) {
   const { pathname } = useLocation();
+  const [collapsed, setCollapsed] = useState(readSidebarCollapsed);
+  useEffect(() => {
+    writeSidebarCollapsed(collapsed);
+  }, [collapsed]);
   const current = [...NAVIGATION_GROUPS.flatMap((group) => group.items), SETTINGS_ITEM].find(
     (item) => isActive(item, pathname),
   );
 
   return (
     <div className="flex min-h-0 flex-1 bg-bg font-sans text-fg" data-product-shell>
-      <aside className="sticky top-0 hidden h-full w-56 shrink-0 flex-col border-r border-border bg-surface/55 px-4 py-5 backdrop-blur md:flex">
-        <div className="px-2">
-          <Wordmark size="sm" />
+      <aside
+        data-collapsed={collapsed || undefined}
+        className={`sticky top-0 hidden h-full shrink-0 flex-col border-r border-border bg-surface/55 py-5 backdrop-blur md:flex ${
+          collapsed ? "w-16 px-2" : "w-56 px-4"
+        }`}
+      >
+        <div className={`flex items-center ${collapsed ? "justify-center" : "justify-between px-2"}`}>
+          {!collapsed && <Wordmark size="sm" />}
+          <button
+            type="button"
+            onClick={() => setCollapsed((value) => !value)}
+            aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+            aria-pressed={collapsed}
+            title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+            className="grid h-7 w-7 place-items-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-fg"
+          >
+            <SidebarSimpleIcon size={17} weight="regular" aria-hidden />
+          </button>
         </div>
 
         <nav aria-label="Primary navigation" className="mt-9 space-y-7">
           {NAVIGATION_GROUPS.map((group) => (
             <div key={group.label}>
-              <div className="px-2 text-[11px] font-medium text-subtle">{group.label}</div>
+              {!collapsed && (
+                <div className="px-2 text-[11px] font-medium text-subtle">{group.label}</div>
+              )}
               <div className="mt-2 space-y-0.5">
                 {group.items.map((item) => (
-                  <NavigationLink key={item.href} item={item} pathname={pathname} />
+                  <NavigationLink
+                    key={item.href}
+                    item={item}
+                    pathname={pathname}
+                    collapsed={collapsed}
+                  />
                 ))}
               </div>
             </div>
@@ -71,7 +99,7 @@ export function ProductShell({
         </nav>
 
         <div className="mt-auto border-t border-border pt-3">
-          <NavigationLink item={SETTINGS_ITEM} pathname={pathname} />
+          <NavigationLink item={SETTINGS_ITEM} pathname={pathname} collapsed={collapsed} />
         </div>
       </aside>
 
@@ -96,19 +124,28 @@ export function ProductShell({
   );
 }
 
-function NavigationLink({ item, pathname }: { item: NavigationItem; pathname: string }) {
+function NavigationLink({
+  item,
+  pathname,
+  collapsed,
+}: {
+  item: NavigationItem;
+  pathname: string;
+  collapsed?: boolean;
+}) {
   const active = isActive(item, pathname);
   const Icon = item.icon;
   return (
     <Link
       to={item.href}
       aria-current={active ? "page" : undefined}
-      className={`flex items-center gap-3 rounded-md px-2 py-1.5 text-[13px] transition-colors ${
-        active ? "bg-surface-3 text-fg" : "text-muted hover:bg-surface-2 hover:text-fg"
-      }`}
+      title={collapsed ? item.label : undefined}
+      className={`flex items-center rounded-md py-1.5 text-[13px] transition-colors ${
+        collapsed ? "justify-center px-0" : "gap-3 px-2"
+      } ${active ? "bg-surface-3 text-fg" : "text-muted hover:bg-surface-2 hover:text-fg"}`}
     >
       <Icon size={17} weight="regular" className="shrink-0" aria-hidden />
-      <span>{item.label}</span>
+      {!collapsed && <span>{item.label}</span>}
     </Link>
   );
 }

--- a/apps/web/src/design/sidebarCollapsed.ts
+++ b/apps/web/src/design/sidebarCollapsed.ts
@@ -1,0 +1,20 @@
+const SIDEBAR_COLLAPSED_KEY = "superlog.sidebar.collapsed";
+
+export function readSidebarCollapsed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function writeSidebarCollapsed(collapsed: boolean) {
+  if (typeof window === "undefined") return;
+  try {
+    if (collapsed) window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, "1");
+    else window.localStorage.removeItem(SIDEBAR_COLLAPSED_KEY);
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
Adds a collapse toggle to the product shell's left navigation.

## What
- A toggle button (Phosphor `SidebarSimpleIcon`) in the sidebar header collapses the nav rail from `w-56` to an icon-only `w-16` rail.
- Collapsed state hides the wordmark, the group labels ("Workspace"/"Observe"), and each item's text label, centers the icons, and adds a `title` tooltip so every destination stays identifiable.
- The choice is persisted to `localStorage` under `superlog.sidebar.collapsed`, following the existing `demoExploration`/`mcpPill` persistence pattern, so it survives reloads. Read/write helpers live in a small `sidebarCollapsed.ts` so they're unit-testable.

## Scope
- The sidebar is `hidden md:flex`, so the toggle only applies at `md+`; the mobile horizontal nav bar is unchanged.

## Tests
- `ProductShell.test.tsx`: the toggle renders with expanded labels by default (SSR has no `localStorage`), and the collapse state round-trips through storage.
- `pnpm --filter @superlog/web typecheck` clean; all ProductShell tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the product sidebar collapsible on desktop to save space. Adds a toggle to switch between full-width and icon-only nav, and remembers the choice across reloads.

- **New Features**
  - Toggle button in the sidebar header collapses/expands the nav rail.
  - Collapsed mode shrinks from `w-56` to `w-16`, hides labels and wordmark, centers icons, and adds title tooltips.
  - Persists choice in `localStorage` under `superlog.sidebar.collapsed` via `sidebarCollapsed.ts`; SSR defaults to expanded.
  - Desktop only (`md+`); mobile nav is unchanged.

<sup>Written for commit 6f0441c585eff8eaabd773512b5a3c252d28139d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

