### PR TITLE
Drain worker queue jobs during shutdown

### DIFF
--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -21,4 +21,7 @@ COPY apps/worker apps/worker
 
 RUN pnpm --filter @superlog/worker typecheck
 
-CMD ["pnpm", "--filter", "@superlog/worker", "start"]
+# Keep Node as PID 1 so container SIGTERM reaches index.ts and its queue drain.
+# Package-manager script runners do not reliably forward termination signals.
+WORKDIR /app/apps/worker
+CMD ["node", "--import", "tsx", "--import", "./tracing.ts", "src/index.ts"]

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -12,6 +12,7 @@
     "pgboss:migrate": "tsx scripts/pgboss-migrate.ts",
     "test:jobs-loader": "tsx --test src/jobs.test.ts",
     "test:jobs-runner": "tsx --test src/jobs/runner.test.ts",
+    "test:worker-runtime": "tsx --test src/worker/runtime.test.ts src/worker/shutdown.test.ts",
     "test:demo-feed": "tsx --test src/jobs/demo-feed.test.ts",
     "test:git-auth-no-argv": "tsx scripts/test-git-auth-no-argv.ts",
     "test:patch-normalization": "tsx scripts/test-patch-normalization.ts",

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,6 +1,6 @@
 import "./env.js";
 import { createClient } from "@clickhouse/client";
-import { db } from "@superlog/db";
+import { db, shutdownAnalytics } from "@superlog/db";
 import { registerAgentRunHealthMetrics } from "./agent-run-health-metrics.js";
 import { startAgentRunQueue } from "./agent-runs/queue-wiring.js";
 import { initAiUsageSink } from "./ai-usage.js";
@@ -14,9 +14,11 @@ import { startJobRunner } from "./jobs/runner.js";
 import { logger } from "./logger.js";
 import { registerDatastoreObservability } from "./observability/datastores.js";
 import { registerQueueHealthMetrics } from "./queue-health.js";
+import { shutdownTelemetry } from "./telemetry-shutdown.js";
 import { createTelemetryIngestor, registerTelemetryIngestMetrics } from "./telemetry/ingest.js";
 import { registerTenantMetrics } from "./tenant-metrics.js";
 import { runWorker } from "./worker/runtime.js";
+import { drainWorker, shutdownWorkerProcess } from "./worker/shutdown.js";
 import { createWorkerTick } from "./worker/tick.js";
 
 logger.info({ scope: "boot" }, "env loaded");
@@ -126,7 +128,39 @@ const tick = createWorkerTick({
   includeAgentRuns: !agentRunQueueReady,
 });
 
-runWorker({ pollIntervalMs: POLL_INTERVAL_MS, batchSize: BATCH_SIZE, tick }).catch((err) => {
+const workerController = new AbortController();
+const workerLoop = runWorker({
+  pollIntervalMs: POLL_INTERVAL_MS,
+  batchSize: BATCH_SIZE,
+  signal: workerController.signal,
+  tick,
+}).catch((err) => {
   logger.fatal({ err }, "worker crashed");
   process.exit(1);
 });
+
+let shuttingDown = false;
+async function shutdown(signal: NodeJS.Signals): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  logger.info({ signal }, "received shutdown signal; draining");
+
+  const exitCode = await shutdownWorkerProcess({
+    drain: () =>
+      drainWorker({
+        stopTickLoop: () => workerController.abort(),
+        tickLoop: workerLoop,
+        jobRunner: jobBoss,
+        closeClickHouse: () => ch.close(),
+      }),
+    shutdownAnalytics,
+    shutdownTelemetry,
+    onError: (phase, err) => {
+      logger.error({ err, phase }, "worker shutdown phase failed");
+    },
+  });
+  process.exit(exitCode);
+}
+
+process.once("SIGTERM", () => void shutdown("SIGTERM"));
+process.once("SIGINT", () => void shutdown("SIGINT"));

--- a/apps/worker/src/telemetry-shutdown.ts
+++ b/apps/worker/src/telemetry-shutdown.ts
@@ -1,0 +1,16 @@
+// tracing.ts loads before the worker entry point via Node's --import flag. It
+// registers its SDK flush here so index.ts can run it after active work drains.
+// Keeping signal ownership in the entry point prevents a faster telemetry
+// handler from exiting the process while queue jobs are still active.
+
+let flush: () => Promise<void> = async () => {};
+
+/** Called once by tracing.ts when the telemetry SDK starts. */
+export function setTelemetryShutdown(fn: () => Promise<void>): void {
+  flush = fn;
+}
+
+/** Flush and shut down telemetry. No-op unless the SDK registered a flush. */
+export function shutdownTelemetry(): Promise<void> {
+  return flush();
+}

--- a/apps/worker/src/worker/runtime.test.ts
+++ b/apps/worker/src/worker/runtime.test.ts
@@ -1,0 +1,49 @@
+import "../agent-run.test-env.js";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { runWorker } from "./runtime.js";
+
+const EMPTY_TICK = {
+  spans: 0,
+  logs: 0,
+  agentRuns: 0,
+  agentChats: 0,
+  alerts: 0,
+  digests: 0,
+  webhooks: 0,
+  autorecoveryProposals: 0,
+  observedEscalations: 0,
+  usageReported: 0,
+};
+
+test("the worker finishes its current tick and stops polling when shutdown begins", async () => {
+  const controller = new AbortController();
+  let ticks = 0;
+  let releaseTick!: () => void;
+  let markStarted!: () => void;
+  const tickStarted = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const tickFinished = new Promise<void>((resolve) => {
+    releaseTick = resolve;
+  });
+
+  const worker = runWorker({
+    pollIntervalMs: 60_000,
+    batchSize: 1,
+    signal: controller.signal,
+    tick: async () => {
+      ticks += 1;
+      markStarted();
+      await tickFinished;
+      return EMPTY_TICK;
+    },
+  });
+
+  await tickStarted;
+  controller.abort();
+  releaseTick();
+  await worker;
+
+  assert.equal(ticks, 1);
+});

--- a/apps/worker/src/worker/runtime.ts
+++ b/apps/worker/src/worker/runtime.ts
@@ -2,17 +2,30 @@ import { logger } from "../logger.js";
 import { recordTickHeartbeat } from "../queue-health.js";
 import type { WorkerTickResult } from "./tick.js";
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, ms);
+    signal?.addEventListener("abort", finish, { once: true });
+  });
 }
 
 export async function runWorker(opts: {
   pollIntervalMs: number;
   batchSize: number;
+  signal?: AbortSignal;
   tick(): Promise<WorkerTickResult>;
 }): Promise<void> {
   logger.info({ pollMs: opts.pollIntervalMs, batchSize: opts.batchSize }, "worker up");
-  while (true) {
+  while (!opts.signal?.aborted) {
     try {
       const { spans, logs, agentRuns, alerts, digests, webhooks, autorecoveryProposals } =
         await opts.tick();
@@ -45,6 +58,6 @@ export async function runWorker(opts: {
     } catch (err) {
       logger.error({ err }, "tick failed");
     }
-    await sleep(opts.pollIntervalMs);
+    await sleep(opts.pollIntervalMs, opts.signal);
   }
 }

--- a/apps/worker/src/worker/shutdown.test.ts
+++ b/apps/worker/src/worker/shutdown.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { drainWorker, shutdownWorkerProcess } from "./shutdown.js";
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+test("shutdown drains the tick loop and active jobs before closing shared clients", async () => {
+  const tick = deferred();
+  const jobs = deferred();
+  let pollingStopped = false;
+  let clickhouseClosed = false;
+  let stopOptions: unknown;
+
+  const shutdown = drainWorker({
+    stopTickLoop() {
+      pollingStopped = true;
+    },
+    tickLoop: tick.promise,
+    jobRunner: {
+      async stop(options) {
+        stopOptions = options;
+        await jobs.promise;
+      },
+    },
+    async closeClickHouse() {
+      clickhouseClosed = true;
+    },
+  });
+
+  await Promise.resolve();
+  assert.equal(pollingStopped, true);
+  assert.deepEqual(stopOptions, { graceful: true, timeout: 90_000 });
+  assert.equal(clickhouseClosed, false);
+
+  tick.resolve();
+  await Promise.resolve();
+  assert.equal(clickhouseClosed, false, "active jobs are still draining");
+
+  jobs.resolve();
+  await shutdown;
+  assert.equal(clickhouseClosed, true);
+});
+
+test("shutdown closes shared clients even when draining active jobs fails", async () => {
+  const tick = deferred();
+  const jobStopCalled = deferred();
+  let clickhouseClosed = false;
+  const expected = new Error("job drain failed");
+
+  const shutdown = drainWorker({
+    stopTickLoop() {},
+    tickLoop: tick.promise,
+    jobRunner: {
+      async stop() {
+        jobStopCalled.resolve();
+        throw expected;
+      },
+    },
+    async closeClickHouse() {
+      clickhouseClosed = true;
+    },
+  });
+  const rejected = assert.rejects(shutdown, expected);
+
+  await jobStopCalled.promise;
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(clickhouseClosed, false, "the tick loop is still draining");
+
+  tick.resolve();
+  await rejected;
+  assert.equal(clickhouseClosed, true);
+});
+
+test("process shutdown drains work before flushing analytics and telemetry", async () => {
+  const order: string[] = [];
+
+  const exitCode = await shutdownWorkerProcess({
+    async drain() {
+      order.push("drain");
+    },
+    async shutdownAnalytics() {
+      order.push("analytics");
+    },
+    async shutdownTelemetry() {
+      order.push("telemetry");
+    },
+    onError() {},
+  });
+
+  assert.deepEqual(order, ["drain", "analytics", "telemetry"]);
+  assert.equal(exitCode, 0);
+});
+
+test("process shutdown flushes remaining clients and exits non-zero after a failed phase", async () => {
+  const order: string[] = [];
+  const errors: string[] = [];
+
+  const exitCode = await shutdownWorkerProcess({
+    async drain() {
+      order.push("drain");
+      throw new Error("drain failed");
+    },
+    async shutdownAnalytics() {
+      order.push("analytics");
+    },
+    async shutdownTelemetry() {
+      order.push("telemetry");
+    },
+    onError(phase, error) {
+      errors.push(`${phase}:${error instanceof Error ? error.message : String(error)}`);
+    },
+  });
+
+  assert.deepEqual(order, ["drain", "analytics", "telemetry"]);
+  assert.deepEqual(errors, ["drain:drain failed"]);
+  assert.equal(exitCode, 1);
+});

--- a/apps/worker/src/worker/shutdown.ts
+++ b/apps/worker/src/worker/shutdown.ts
@@ -1,0 +1,58 @@
+const DEFAULT_JOB_DRAIN_TIMEOUT_MS = 90_000;
+
+type JobRunner = {
+  stop(options: { graceful: boolean; timeout: number }): Promise<void>;
+};
+
+export async function drainWorker(deps: {
+  stopTickLoop(): void;
+  tickLoop: Promise<void>;
+  jobRunner: JobRunner | null;
+  closeClickHouse(): Promise<void>;
+  jobDrainTimeoutMs?: number;
+}): Promise<void> {
+  deps.stopTickLoop();
+  const results = await Promise.allSettled([
+    deps.tickLoop,
+    deps.jobRunner?.stop({
+      graceful: true,
+      timeout: deps.jobDrainTimeoutMs ?? DEFAULT_JOB_DRAIN_TIMEOUT_MS,
+    }),
+  ]);
+  await deps.closeClickHouse();
+
+  const failures = results.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  const [failure] = failures;
+  if (failures.length === 1 && failure) throw failure.reason;
+  if (failures.length > 1) {
+    throw new AggregateError(
+      failures.map((failure) => failure.reason),
+      "worker drain failed",
+    );
+  }
+}
+
+export async function shutdownWorkerProcess(deps: {
+  drain(): Promise<void>;
+  shutdownAnalytics(): Promise<void>;
+  shutdownTelemetry(): Promise<void>;
+  onError(phase: string, error: unknown): void;
+}): Promise<0 | 1> {
+  let failed = false;
+  const phases: Array<[string, () => Promise<void>]> = [
+    ["drain", deps.drain],
+    ["analytics", deps.shutdownAnalytics],
+    ["telemetry", deps.shutdownTelemetry],
+  ];
+  for (const [phase, run] of phases) {
+    try {
+      await run();
+    } catch (error) {
+      failed = true;
+      deps.onError(phase, error);
+    }
+  }
+  return failed ? 1 : 0;
+}

--- a/apps/worker/tracing.ts
+++ b/apps/worker/tracing.ts
@@ -48,6 +48,7 @@ import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import { setTelemetryShutdown } from "./src/telemetry-shutdown.js";
 
 if (process.env.OTEL_DIAG_DEBUG === "1") {
   diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
@@ -132,25 +133,10 @@ if (telemetryEnabled) {
       // Don't crash shutdown on a flush failure.
       console.error("[otel] shutdown error", err);
     }
-    // This SIGTERM handler is the worker's single shutdown owner (it exits
-    // below), so flush server-side analytics here too — otherwise an
-    // agent_pr_opened / agent_pr_rejected event still queued in posthog-node is
-    // dropped by the SIGKILL that follows an ECS deploy's SIGTERM. Dynamic
-    // import so the OTel bootstrap doesn't pull in @superlog/db; index.ts
-    // already loaded it, so this resolves to the same module + queued client.
-    // Best-effort.
-    try {
-      const { shutdownAnalytics } = await import("@superlog/db");
-      await shutdownAnalytics();
-    } catch (err) {
-      console.error("[analytics] shutdown error", err);
-    }
   };
 
-  process.once("SIGTERM", () => {
-    void shutdown().finally(() => process.exit(0));
-  });
-  process.once("SIGINT", () => {
-    void shutdown().finally(() => process.exit(0));
-  });
+  // index.ts owns SIGTERM/SIGINT and invokes this only after the tick loop and
+  // pg-boss workers drain. A second signal handler here could exit as soon as
+  // telemetry flushes and orphan active queue jobs during a rolling restart.
+  setTelemetryShutdown(shutdown);
 }


### PR DESCRIPTION
## Summary

- stop the polling loop after its in-flight tick completes
- gracefully drain pg-boss workers before closing ClickHouse
- make the worker entry point the single owner of analytics and telemetry shutdown
- run Node directly as PID 1 so container termination signals reach the drain handler

## Root cause

A rolling container replacement could terminate the worker while pg-boss jobs were active. Those jobs remained leased until expiration, while replacement jobs with the same singleton keys waited behind them and increased the oldest-pending queue age.

The shutdown path now gives pg-boss up to 90 seconds to finish active work. Any work still active at the deadline is explicitly failed by pg-boss instead of being left leased, allowing the existing sweep to retry it after restart.

## Validation

- `pnpm --filter @superlog/worker test:worker-runtime`
- `pnpm --filter @superlog/worker test:jobs-runner`
- `pnpm --filter @superlog/worker test:agent-run-queue`
- `pnpm --filter @superlog/worker test:queue-health`
- `pnpm --filter @superlog/worker typecheck`
- focused Biome checks
- worker Docker image build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gracefully drain worker jobs on shutdown to prevent stuck `pg-boss` leases and long pending times. The worker now finishes the current tick, gives `pg-boss` up to 90s to complete or fail active jobs, then flushes analytics and telemetry before exit.

- **Bug Fixes**
  - Stop the poll loop after the in-flight tick using an `AbortSignal`.
  - Drain `pg-boss` with a 90s grace; fail any still-active jobs so singletons can retry.
  - Close ClickHouse only after jobs drain; then run `shutdownAnalytics` and telemetry flush.
  - Make the worker entry point the single owner of shutdown; `tracing.ts` registers a flush instead of exiting.
  - Run Node as PID 1 in the worker image so SIGTERM/SIGINT reach the drain handler.
  - Added targeted tests for tick-loop stop, job drain ordering, and process shutdown.

<sup>Written for commit b069b2404334ad93c1771ca33ace782c9d939422. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

