### PR TITLE
Export the terminal-outcome nudge marker as a shared constant

### DIFF
--- a/apps/worker/src/agent-outcome-tools.ts
+++ b/apps/worker/src/agent-outcome-tools.ts
@@ -80,6 +80,18 @@ export const OUTCOME_TOOL_NAMES = [
   ...TERMINAL_OUTCOME_TOOL_NAMES,
 ] as const;
 
+// First line of the worker's one-shot "conclude your turn" steer (the full
+// prompt lives with the sync loop). It doubles as the machine-readable way to
+// recognize that steer in a session's own event stream — the sync loop uses
+// it to skip redelivering the nudge, and stream-replaying runner backends use
+// it to exempt the nudge from turn-boundary handling: unlike a human reply or
+// a context delta, the nudge carries no new information, so it must never
+// reset (and thereby discard) outcome state the turn already produced. The
+// wording must stay stable; live sessions can carry an already-delivered
+// nudge across a deploy.
+export const TERMINAL_OUTCOME_NUDGE_MARKER =
+  "You ended your turn without concluding the investigation, so it has no recorded outcome and nothing is pending.";
+
 export function isActionOutcomeToolName(name: string): name is ActionOutcomeToolName {
   return (ACTION_OUTCOME_TOOL_NAMES as readonly string[]).includes(name);
 }

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -1,6 +1,7 @@
 import "../agent-run.test-env.js";
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { TERMINAL_OUTCOME_NUDGE_MARKER } from "../agent-outcome-tools.js";
 import {
   isSessionBusyError,
   mobileRegressionGateState,
@@ -338,6 +339,14 @@ test("shouldDeferSteering does not defer settled or concluded snapshots", () => 
     shouldDeferSteering({ result: { state: "complete", summary: "x" }, dispatchedToolCallCount: 1 }),
     false,
   );
+});
+
+test("terminalOutcomeNudgePrompt opens with the shared nudge marker", () => {
+  // The marker is the contract runner backends use to recognize the worker's
+  // own nudge in a session's event stream (redelivery detection here, and
+  // turn-boundary exemption in stream-replaying runners). The prompt must
+  // keep it as its exact first line.
+  assert.equal(terminalOutcomeNudgePrompt().split("\n")[0], TERMINAL_OUTCOME_NUDGE_MARKER);
 });
 
 test("terminalOutcomeNudgePrompt names every outcome tool", () => {

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -9,7 +9,10 @@ import { getAgentRunnerBackend } from "../infra/agent-runner/backend.js";
 import { postIncidentThreadMessage } from "../infra/slack/incident-messages.js";
 import { type ResolvedIntegration, loadEnabledIntegrationsForOrg } from "../integrations.js";
 import { logger } from "../logger.js";
-import { assembleAgentRunResult } from "../agent-outcome-tools.js";
+import {
+  TERMINAL_OUTCOME_NUDGE_MARKER,
+  assembleAgentRunResult,
+} from "../agent-outcome-tools.js";
 import { completeWithIncidentResolution, completeWithoutPullRequest } from "./completion.js";
 import { tryMergeAfterAgentRun } from "./merge.js";
 import { hasRevylCreateTestIntegration, looksLikeMobileChange } from "./mobile-regression.js";
@@ -209,12 +212,14 @@ export function shouldDeferSteering(snapshot: {
 // tool and with nothing pending (no open PRs to wait on). Fired at most once
 // per session; the runtime/wall-clock budgets stay the hard floor.
 //
-// The first line doubles as a stable marker: the redelivery check below and
+// Opens with TERMINAL_OUTCOME_NUDGE_MARKER: the redelivery check below and
 // runner backends detect a delivered nudge in the session event stream by
-// substring-matching it. Don't reword it without checking those call sites.
+// substring-matching that line (a test pins it as the prompt's exact first
+// line). Reword it only via the exported constant, never here — live
+// sessions can carry an already-delivered nudge across a deploy.
 export function terminalOutcomeNudgePrompt(): string {
   return [
-    "You ended your turn without concluding the investigation, so it has no recorded outcome and nothing is pending.",
+    TERMINAL_OUTCOME_NUDGE_MARKER,
     "Call `report_findings` now if you have findings to record, classify each linked issue (`silence_as_noise`, `place_under_observation`, or `resolve_issue`), open any needed PR with `propose_pr`, and then end your turn by calling `resolve_incident` — or `ask_human` if a human must act or answer first.",
   ].join("\n");
 }
@@ -690,10 +695,11 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         // landed. The delivered nudge is visible in the session's own event
         // stream, so a retry can detect it and keep the claim without
         // steering a duplicate.
-        const nudgeMarker = terminalOutcomeNudgePrompt().split("\n")[0] ?? "";
         const nudgeAlreadyDelivered = snapshot.events.some(
           (event) =>
-            event.type === "user.message" && !!event.summary && event.summary.includes(nudgeMarker),
+            event.type === "user.message" &&
+            !!event.summary &&
+            event.summary.includes(TERMINAL_OUTCOME_NUDGE_MARKER),
         );
         if (!nudgeAlreadyDelivered) {
           try {


### PR DESCRIPTION
Follow-up to #234, which fixed the steer race (deferring steers on dispatch-pass acks) and documented the nudge prompt's first line as a stable marker that the redelivery check and stream-replaying runner backends substring-match — the nudge must never act as a turn boundary, since it carries no new information and resetting on it discards outcome state the turn already produced.

This turns that documented contract into an enforced one:

- `TERMINAL_OUTCOME_NUDGE_MARKER` is exported next to the outcome-tool contract (`agent-outcome-tools.ts`), which both the sync loop and runner backends already import — one source of truth instead of a comment here and hardcoded copies in backends.
- `terminalOutcomeNudgePrompt()` builds its first line from the constant, and the redelivery check matches against it.
- A test pins the marker as the prompt's exact first line, so a wording tweak can't silently break the stream matching.

Wording is unchanged — nudges already delivered into live sessions still match.

## Testing

- `pnpm --filter @superlog/worker test:agent-run-sync` — 17/17.
- `pnpm --filter @superlog/worker typecheck` — clean.