### PR TITLE
Optimize usage metering queries

### DIFF
--- a/apps/worker/src/billing/usage-count-query.test.ts
+++ b/apps/worker/src/billing/usage-count-query.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { buildUsageCountQuery } from "./usage-count-query.js";
+
+test("log usage counts preserve precise bounds while pruning by TimestampTime", () => {
+  const query = buildUsageCountQuery("logs");
+
+  assert.match(query, /Timestamp > \{after:DateTime64\(9\)\}/);
+  assert.match(query, /Timestamp <= \{until:DateTime64\(9\)\}/);
+  assert.match(query, /TimestampTime >= \{after:DateTime64\(9\)\} - INTERVAL 1 SECOND/);
+  assert.match(query, /TimestampTime <= \{until:DateTime64\(9\)\}/);
+});

--- a/apps/worker/src/billing/usage-count-query.ts
+++ b/apps/worker/src/billing/usage-count-query.ts
@@ -1,0 +1,35 @@
+import type { UsageSignal } from "./usage-metering.js";
+
+// One bounded-window count query per signal. Metrics span five OTel tables.
+export function buildUsageCountQuery(signal: UsageSignal): string {
+  if (signal === "spans") {
+    return `SELECT ResourceAttributes['superlog.project_id'] AS pid, count() AS c
+            FROM otel_traces
+            WHERE Timestamp > {after:DateTime64(9)} AND Timestamp <= {until:DateTime64(9)} AND pid != ''
+            GROUP BY pid`;
+  }
+  if (signal === "logs") {
+    return `SELECT ResourceAttributes['superlog.project_id'] AS pid, count() AS c
+            FROM otel_logs
+            WHERE Timestamp > {after:DateTime64(9)} AND Timestamp <= {until:DateTime64(9)}
+              AND TimestampTime >= {after:DateTime64(9)} - INTERVAL 1 SECOND
+              AND TimestampTime <= {until:DateTime64(9)}
+              AND pid != ''
+            GROUP BY pid`;
+  }
+  const metricTables = [
+    "otel_metrics_sum",
+    "otel_metrics_gauge",
+    "otel_metrics_histogram",
+    "otel_metrics_summary",
+    "otel_metrics_exp_histogram",
+  ];
+  const union = metricTables
+    .map(
+      (t) =>
+        `SELECT ResourceAttributes['superlog.project_id'] AS pid, count() AS c FROM ${t}
+         WHERE TimeUnix > {after:DateTime64(9)} AND TimeUnix <= {until:DateTime64(9)} AND pid != '' GROUP BY pid`,
+    )
+    .join(" UNION ALL ");
+  return `SELECT pid, sum(c) AS c FROM (${union}) GROUP BY pid`;
+}

--- a/apps/worker/src/billing/usage-meter-ticker.ts
+++ b/apps/worker/src/billing/usage-meter-ticker.ts
@@ -5,6 +5,7 @@
 import type { ClickHouseClient } from "@clickhouse/client";
 import { type DB, db as defaultDb, schema } from "@superlog/db";
 import { inArray } from "drizzle-orm";
+import { buildUsageCountQuery } from "./usage-count-query.js";
 import {
   type UsageMeterDeps,
   type UsageSignal,
@@ -14,37 +15,6 @@ import {
 const DEFAULT_WINDOW_MS = 5 * 60 * 1000;
 const DEFAULT_INTERVAL_MS = 60 * 1000;
 
-// One bounded-window count query per signal. Metrics span five OTel tables.
-function countQuery(signal: UsageSignal): string {
-  if (signal === "spans") {
-    return `SELECT ResourceAttributes['superlog.project_id'] AS pid, count() AS c
-            FROM otel_traces
-            WHERE Timestamp > {after:DateTime64(9)} AND Timestamp <= {until:DateTime64(9)} AND pid != ''
-            GROUP BY pid`;
-  }
-  if (signal === "logs") {
-    return `SELECT ResourceAttributes['superlog.project_id'] AS pid, count() AS c
-            FROM otel_logs
-            WHERE Timestamp > {after:DateTime64(9)} AND Timestamp <= {until:DateTime64(9)} AND pid != ''
-            GROUP BY pid`;
-  }
-  const metricTables = [
-    "otel_metrics_sum",
-    "otel_metrics_gauge",
-    "otel_metrics_histogram",
-    "otel_metrics_summary",
-    "otel_metrics_exp_histogram",
-  ];
-  const union = metricTables
-    .map(
-      (t) =>
-        `SELECT ResourceAttributes['superlog.project_id'] AS pid, count() AS c FROM ${t}
-         WHERE TimeUnix > {after:DateTime64(9)} AND TimeUnix <= {until:DateTime64(9)} AND pid != '' GROUP BY pid`,
-    )
-    .join(" UNION ALL ");
-  return `SELECT pid, sum(c) AS c FROM (${union}) GROUP BY pid`;
-}
-
 // ClickHouse DateTime64 params want "YYYY-MM-DD hh:mm:ss.fffffffff" (UTC, no Z).
 function chTime(iso: string): string {
   return iso.replace("T", " ").replace("Z", "");
@@ -53,7 +23,7 @@ function chTime(iso: string): string {
 function createCountByProject(clickhouse: Pick<ClickHouseClient, "query">) {
   return async (signal: UsageSignal, afterIso: string, untilIso: string) => {
     const result = await clickhouse.query({
-      query: countQuery(signal),
+      query: buildUsageCountQuery(signal),
       query_params: { after: chTime(afterIso), until: chTime(untilIso) },
       format: "JSONEachRow",
     });

--- a/apps/worker/src/billing/usage-metering.test.ts
+++ b/apps/worker/src/billing/usage-metering.test.ts
@@ -1,10 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import {
-  type UsageMeterDeps,
-  aggregateByOrg,
-  meterTelemetryUsageTick,
-} from "./usage-metering.js";
+import { type UsageMeterDeps, aggregateByOrg, meterTelemetryUsageTick } from "./usage-metering.js";
 
 test("aggregateByOrg sums projects into their org and drops unknown projects", () => {
   const perProject = new Map([
@@ -48,10 +44,7 @@ test("reports per-org deltas for each signal and advances the cursor by one wind
   const reported = await meterTelemetryUsageTick(d);
   // 3 signals × 1 org each
   assert.equal(reported, 3);
-  assert.deepEqual(
-    tracks.map((t) => t.featureId).sort(),
-    ["logs", "metric_points", "spans"],
-  );
+  assert.deepEqual(tracks.map((t) => t.featureId).sort(), ["logs", "metric_points", "spans"]);
   assert.ok(tracks.every((t) => t.orgId === "orgA" && t.value === 10));
   // cursor advanced to start + windowMs (capped below now)
   assert.equal(cursors.get("usage-meter-spans")?.toISOString(), "2026-05-01T00:05:00.000Z");
@@ -76,17 +69,44 @@ test("a track failure is swallowed and the cursor still advances (at-most-once)"
   assert.ok(cursors.get("usage-meter-spans") instanceof Date);
 });
 
+test("a signal count failure preserves its cursor and does not block later signals", async () => {
+  const counted: string[] = [];
+  const {
+    deps: d,
+    tracks,
+    cursors,
+  } = deps({
+    countByProject: async (signal) => {
+      counted.push(signal);
+      if (signal === "logs") throw new Error("clickhouse timeout");
+      return new Map([["p1", 10]]);
+    },
+  });
+
+  const reported = await meterTelemetryUsageTick(d);
+
+  assert.equal(reported, 2);
+  assert.deepEqual(counted, ["spans", "logs", "metric_points"]);
+  assert.deepEqual(
+    tracks.map((track) => track.featureId),
+    ["spans", "metric_points"],
+  );
+  assert.ok(cursors.get("usage-meter-spans") instanceof Date);
+  assert.equal(cursors.has("usage-meter-logs"), false);
+  assert.ok(cursors.get("usage-meter-metric_points") instanceof Date);
+});
+
 test("does not scan past now (window capped at current time)", async () => {
-  let counted: { after: string; until: string } | null = null;
+  const counted: Array<{ after: string; until: string }> = [];
   const { deps: d } = deps({
     getCursor: async () => new Date("2026-05-01T00:09:30Z"),
     now: () => new Date("2026-05-01T00:10:00Z"),
     countByProject: async (_s, after, until) => {
-      counted = { after, until };
+      counted.push({ after, until });
       return new Map();
     },
   });
   await meterTelemetryUsageTick(d);
   // 30s remaining < 5min window → until clamps to now, not cursor+window
-  assert.equal(counted!.until, "2026-05-01T00:10:00.000Z");
+  assert.equal(counted[0]?.until, "2026-05-01T00:10:00.000Z");
 });

--- a/apps/worker/src/billing/usage-metering.test.ts
+++ b/apps/worker/src/billing/usage-metering.test.ts
@@ -96,6 +96,31 @@ test("a signal count failure preserves its cursor and does not block later signa
   assert.ok(cursors.get("usage-meter-metric_points") instanceof Date);
 });
 
+test("an org lookup failure preserves its cursor and does not block later signals", async () => {
+  const {
+    deps: d,
+    tracks,
+    cursors,
+  } = deps({
+    countByProject: async (signal) => new Map([[`project-${signal}`, 10]]),
+    resolveOrgIds: async (projectIds) => {
+      if (projectIds.includes("project-logs")) throw new Error("postgres timeout");
+      return new Map(projectIds.map((projectId) => [projectId, "orgA"]));
+    },
+  });
+
+  const reported = await meterTelemetryUsageTick(d);
+
+  assert.equal(reported, 2);
+  assert.deepEqual(
+    tracks.map((track) => track.featureId),
+    ["spans", "metric_points"],
+  );
+  assert.ok(cursors.get("usage-meter-spans") instanceof Date);
+  assert.equal(cursors.has("usage-meter-logs"), false);
+  assert.ok(cursors.get("usage-meter-metric_points") instanceof Date);
+});
+
 test("does not scan past now (window capped at current time)", async () => {
   const counted: Array<{ after: string; until: string }> = [];
   const { deps: d } = deps({

--- a/apps/worker/src/billing/usage-metering.ts
+++ b/apps/worker/src/billing/usage-metering.ts
@@ -56,36 +56,51 @@ export type UsageMeterDeps = {
 export async function meterTelemetryUsageTick(deps: UsageMeterDeps): Promise<number> {
   let reported = 0;
   for (const signal of Object.keys(SIGNAL_FEATURE_IDS) as UsageSignal[]) {
-    const cursorName = `${CURSOR_PREFIX}${signal}`;
-    const cursor = await deps.getCursor(cursorName);
-    const until = new Date(Math.min(cursor.getTime() + deps.windowMs, deps.now().getTime()));
-    if (until.getTime() <= cursor.getTime()) continue; // nothing new to scan yet
+    try {
+      const cursorName = `${CURSOR_PREFIX}${signal}`;
+      const cursor = await deps.getCursor(cursorName);
+      const until = new Date(Math.min(cursor.getTime() + deps.windowMs, deps.now().getTime()));
+      if (until.getTime() <= cursor.getTime()) continue; // nothing new to scan yet
 
-    const perProject = await deps.countByProject(signal, cursor.toISOString(), until.toISOString());
-    // Persist the cursor BEFORE issuing the non-idempotent track() calls. track()
-    // is additive, so a setCursor failure AFTER tracking would replay this window
-    // next tick and double-charge. Advancing first makes it strictly at-most-once:
-    // a track failure below under-reports one window rather than risk double-count.
-    await deps.setCursor(cursorName, until);
-    if (perProject.size > 0) {
-      const orgMap = await deps.resolveOrgIds([...perProject.keys()]);
-      for (const [orgId, value] of aggregateByOrg(perProject, orgMap)) {
-        try {
-          await deps.track(orgId, SIGNAL_FEATURE_IDS[signal], value);
-          reported += 1;
-        } catch (err) {
-          logger.error(
-            {
-              scope: "billing.usage",
-              signal,
-              orgId,
-              value,
-              err: err instanceof Error ? err.message : String(err),
-            },
-            "usage track failed; window not re-reported (cursor already advanced)",
-          );
+      const perProject = await deps.countByProject(
+        signal,
+        cursor.toISOString(),
+        until.toISOString(),
+      );
+      // Persist the cursor BEFORE issuing the non-idempotent track() calls. track()
+      // is additive, so a setCursor failure AFTER tracking would replay this window
+      // next tick and double-charge. Advancing first makes it strictly at-most-once:
+      // a track failure below under-reports one window rather than risk double-count.
+      await deps.setCursor(cursorName, until);
+      if (perProject.size > 0) {
+        const orgMap = await deps.resolveOrgIds([...perProject.keys()]);
+        for (const [orgId, value] of aggregateByOrg(perProject, orgMap)) {
+          try {
+            await deps.track(orgId, SIGNAL_FEATURE_IDS[signal], value);
+            reported += 1;
+          } catch (err) {
+            logger.error(
+              {
+                scope: "billing.usage",
+                signal,
+                orgId,
+                value,
+                err: err instanceof Error ? err.message : String(err),
+              },
+              "usage track failed; window not re-reported (cursor already advanced)",
+            );
+          }
         }
       }
+    } catch (err) {
+      logger.error(
+        {
+          scope: "billing.usage",
+          signal,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "usage signal metering failed; continuing with remaining signals",
+      );
     }
   }
   return reported;

--- a/apps/worker/src/billing/usage-metering.ts
+++ b/apps/worker/src/billing/usage-metering.ts
@@ -67,13 +67,14 @@ export async function meterTelemetryUsageTick(deps: UsageMeterDeps): Promise<num
         cursor.toISOString(),
         until.toISOString(),
       );
-      // Persist the cursor BEFORE issuing the non-idempotent track() calls. track()
-      // is additive, so a setCursor failure AFTER tracking would replay this window
-      // next tick and double-charge. Advancing first makes it strictly at-most-once:
-      // a track failure below under-reports one window rather than risk double-count.
+      const orgMap = perProject.size > 0 ? await deps.resolveOrgIds([...perProject.keys()]) : null;
+      // Complete the idempotent reads before advancing, then persist the cursor
+      // BEFORE issuing the non-idempotent track() calls. track() is additive, so
+      // a setCursor failure AFTER tracking would replay this window next tick and
+      // double-charge. Advancing first makes tracking strictly at-most-once: a
+      // track failure below under-reports one window rather than risk double-count.
       await deps.setCursor(cursorName, until);
-      if (perProject.size > 0) {
-        const orgMap = await deps.resolveOrgIds([...perProject.keys()]);
+      if (orgMap) {
         for (const [orgId, value] of aggregateByOrg(perProject, orgMap)) {
           try {
             await deps.track(orgId, SIGNAL_FEATURE_IDS[signal], value);


### PR DESCRIPTION
## Summary

- add `TimestampTime` bounds to log usage-count queries while retaining precise `Timestamp` bounds
- isolate metering failures by signal so one ClickHouse timeout does not block the remaining signals
- preserve the failed signal's cursor for a safe retry
- extract the ClickHouse SQL builder into a small, independently testable infrastructure module

## Root cause

`otel_logs` is partitioned and ordered using `TimestampTime`, but usage metering filtered only on the nanosecond `Timestamp` column. ClickHouse therefore scanned most of the relevant daily partition for every small metering window, regularly exceeding the client's request timeout.

The additional `TimestampTime` predicate is deliberately one second wider at the lower bound because that column truncates sub-second precision. The original `Timestamp` predicates remain authoritative for exact counting.

## Performance

For the same five-minute high-volume window:

| Query | Duration | Rows read | Bytes read |
| --- | ---: | ---: | ---: |
| Previous | 29.9s | 93.2M | 4.38GB |
| Revised, five runs | 0.50–0.81s | 0.88–1.19M | 43–56MB |

The revised query was 37–60× faster and read roughly two orders of magnitude less data.

## Validation

- `pnpm exec tsx --test apps/worker/src/billing/usage-count-query.test.ts apps/worker/src/billing/usage-metering.test.ts`
- `pnpm --filter @superlog/worker typecheck`
- formatting and diff checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized usage metering by pruning `otel_logs` with `TimestampTime` and isolating per-signal failures, including org lookups. Queries are 37–60x faster and a failure in one signal no longer blocks others; failed signals keep their cursors for a safe retry.

- **Bug Fixes**
  - Added `TimestampTime` bounds for log counts (lower bound widened by 1s) while keeping precise `Timestamp` filters.
  - Per-signal isolation: ClickHouse count or org lookup errors skip that signal and retain its cursor; track failures are logged after advancing the cursor to keep at-most-once.

- **Refactors**
  - Extracted `buildUsageCountQuery()` into a small module with focused tests.
  - Simplified `usage-meter-ticker` to use the builder and clarified cursor advance before tracking.

<sup>Written for commit 1d8ab2bfe2260e2ebec49f47c2c686f72eb6596e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

