### PR TITLE
Defer steering when the dispatch pass just acked outcome tools

### DIFF
--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -312,6 +312,18 @@ test("shouldDeferSteering defers when collect just acked tool calls and there is
   assert.equal(shouldDeferSteering({ result: null, sentToolAckCount: 3 }), true);
 });
 
+test("shouldDeferSteering defers when the dispatch pass just acked outcome tools", () => {
+  // Dispatch-pass acks (action tools, the resolve_incident guard) unblock the
+  // model exactly like collect-pass acks do, but they are not counted in
+  // sentToolAckCount — the dispatch loop sends them before collect runs. A
+  // steer sent in that window races the model's terminal outcome call.
+  assert.equal(shouldDeferSteering({ result: null, dispatchedToolCallCount: 1 }), true);
+  assert.equal(
+    shouldDeferSteering({ result: null, sentToolAckCount: 0, dispatchedToolCallCount: 2 }),
+    true,
+  );
+});
+
 test("shouldDeferSteering does not defer settled or concluded snapshots", () => {
   // No acks sent: the idle status is genuine, steers are safe.
   assert.equal(shouldDeferSteering({ result: null, sentToolAckCount: 0 }), false);
@@ -320,6 +332,10 @@ test("shouldDeferSteering does not defer settled or concluded snapshots", () => 
   // A result landed: the run is concluding; the completion path owns it.
   assert.equal(
     shouldDeferSteering({ result: { state: "complete", summary: "x" }, sentToolAckCount: 1 }),
+    false,
+  );
+  assert.equal(
+    shouldDeferSteering({ result: { state: "complete", summary: "x" }, dispatchedToolCallCount: 1 }),
     false,
   );
 });

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -180,7 +180,7 @@ export function mobileRegressionRepairPrompt(): string {
   ].join("\n");
 }
 
-// A collect pass that just sent custom_tool_result acks has unblocked the
+// A sync pass that just sent custom_tool_result acks has unblocked the
 // model: the snapshot's "idle" status predates those acks, so the agent is
 // about to resume with the tool results. A steer (human reply, context delta,
 // or the terminal nudge) sent into that window is queued behind the open turn
@@ -188,16 +188,30 @@ export function mobileRegressionRepairPrompt(): string {
 // outcome call, whose turn would then be reset out from under it. Defer all
 // steering to the next tick, when the session state has settled. A result
 // means the run is concluding; the completion paths below own it.
+//
+// Acks reach the session on two paths, and both open the same race window:
+// `sentToolAckCount` counts the collect pass's acks (report_findings etc.),
+// `dispatchedToolCallCount` counts the dispatch pass's (action tools, the
+// resolve_incident guard) — the dispatch loop sends those before collect
+// runs, so they never show up in the collect count.
 export function shouldDeferSteering(snapshot: {
   result: unknown;
   sentToolAckCount?: number;
+  dispatchedToolCallCount?: number;
 }): boolean {
-  return !snapshot.result && (snapshot.sentToolAckCount ?? 0) > 0;
+  return (
+    !snapshot.result &&
+    ((snapshot.sentToolAckCount ?? 0) > 0 || (snapshot.dispatchedToolCallCount ?? 0) > 0)
+  );
 }
 
 // Steered into a session that went idle without calling any terminal outcome
 // tool and with nothing pending (no open PRs to wait on). Fired at most once
 // per session; the runtime/wall-clock budgets stay the hard floor.
+//
+// The first line doubles as a stable marker: the redelivery check below and
+// runner backends detect a delivered nudge in the session event stream by
+// substring-matching it. Don't reword it without checking those call sites.
 export function terminalOutcomeNudgePrompt(): string {
   return [
     "You ended your turn without concluding the investigation, so it has no recorded outcome and nothing is pending.",
@@ -317,8 +331,15 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
       .set(baseUpdate)
       .where(eq(schema.agentRuns.id, ctx.agentRun.id));
 
-    if (shouldDeferSteering(snapshot)) {
-      // This pass acked tool calls (e.g. report_findings) and the model is
+    if (
+      shouldDeferSteering({
+        result: snapshot.result,
+        sentToolAckCount: snapshot.sentToolAckCount,
+        dispatchedToolCallCount: dispatched,
+      })
+    ) {
+      // This pass acked tool calls (report_findings via collect, action
+      // tools / the resolve_incident guard via dispatch) and the model is
       // resuming; the idle status is stale. Steering now races the model's
       // next event — retry every steer on the next tick instead. The budget
       // checks above already ran, so a run can't hide here indefinitely.


### PR DESCRIPTION
## Problem

`shouldDeferSteering` guards against steering into the window where the model was just unblocked by tool acks — but it only counted the **collect** pass's acks (`sentToolAckCount`). The **dispatch** pass's acks (action tools like `silence_as_noise`, and the ok/`final:true` ack from the `resolve_incident` guard) are sent before collect runs and never show up in that count.

So a sync tick that dispatch-acked an action tool still looked settled, saw idle-with-no-result, and fired the one-shot terminal nudge. The nudge gets queued behind the reopened turn and is delivered as a `user.message` **after** the model's next event — which in the observed failure was its `resolve_incident` call (delivered 3 ms after the resolve ack). The turn reset on that message discards the fully-acked conclusion, every later collect replays the stream to the same wiped state, and the run sits with no result until the wall-clock backstop reaps it as `wall_clock_timeout` — a completed investigation recorded as a timeout, incident left open.

## Fix

Count dispatch-pass acks in the defer guard: `shouldDeferSteering` takes a `dispatchedToolCallCount` alongside `sentToolAckCount`, and the sync call site passes the tick's dispatch count. Both ack paths unblock the model identically; the snapshot's idle status predates both.

Also documents that the nudge prompt's first line is a stable marker that the redelivery check and runner backends substring-match against.

## Testing

- New `shouldDeferSteering` cases in `sync.test.ts` (red first, then green).
- `pnpm --filter @superlog/worker test:agent-run-sync` — 16/16 pass.
- `pnpm --filter @superlog/worker typecheck` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers steering when the dispatch pass just acked outcome tools (not only collect acks). This closes a race with the model’s terminal call and prevents dropping a concluded result.

- **Bug Fixes**
  - `shouldDeferSteering` now checks `dispatchedToolCallCount` along with `sentToolAckCount`.
  - `syncRunningAgentRun` passes the tick’s dispatch count so steering defers to the next tick if either path acked.
  - Documented that the first line of `terminalOutcomeNudgePrompt()` is a stable marker for redelivery checks; added focused tests in `apps/worker/src/agent-runs/sync.test.ts`.

<sup>Written for commit c58c7ec745f84c9d00e2e1442a8f18e66f8b6033. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

