### PR TITLE
Show issue status reasons in issue activity

### DIFF
--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -414,6 +414,7 @@ function IssueDetailPage({
   onViewIncident: (incidentId: string) => void;
 }) {
   const q = useIssue(projectId, issueId);
+  const activity = useIssueAgentRun(projectId, issueId);
   const silence = useSilenceIssue(projectId);
   const unsilence = useUnsilenceIssue(projectId);
   const [eventTarget, setEventTarget] = useState<EventTarget>(null);
@@ -443,6 +444,7 @@ function IssueDetailPage({
         silenceUpdating={toggleSilence.isPending}
         onOpenEvidence={latestEvent ? () => setEventTarget(latestEvent) : undefined}
         evidenceLabel={latestEvent?.kind === "trace" ? "Open latest trace" : "Open latest log"}
+        timelineEvents={activity.data?.events ?? []}
         linkedIncident={
           <IssueIncidentLink
             projectId={projectId}

--- a/apps/web/src/issues/IssueDetailView.test.tsx
+++ b/apps/web/src/issues/IssueDetailView.test.tsx
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { renderToStaticMarkup } from "react-dom/server";
-import type { Issue } from "../api.ts";
+import type { IncidentEvent, Issue } from "../api.ts";
 import { IssueDetailView } from "./IssueDetailView.tsx";
 
 const issue: Issue = {
@@ -29,6 +29,22 @@ const issue: Issue = {
   createdAt: "2026-07-10T13:36:06.682Z",
 };
 
+function timelineEvent(overrides: Partial<IncidentEvent>): IncidentEvent {
+  return {
+    id: "event-1",
+    agentRunId: "run-1",
+    kind: "issue_silenced",
+    summary: "Issue silenced: Checkout confirmation fails after payment succeeds",
+    detail: {
+      issueId: issue.id,
+      reason: "The payment is captured and the client safely retries confirmation.",
+      evidence: "The retry completed successfully 240 ms later.",
+    },
+    createdAt: "2026-07-10T13:35:06.682Z",
+    ...overrides,
+  };
+}
+
 test("error detail is a full investigation workspace with a summary rail and evidence", () => {
   const html = renderToStaticMarkup(
     <IssueDetailView
@@ -50,4 +66,87 @@ test("error detail is a full investigation workspace with a summary rail and evi
   assert.match(html, /Open linked incident/);
   assert.doesNotMatch(html, /role="dialog"/);
   assert.doesNotMatch(html, /font-mono/);
+});
+
+test("error detail shows why the issue was silenced in its activity timeline", () => {
+  const html = renderToStaticMarkup(
+    <IssueDetailView
+      issue={issue}
+      environment="production"
+      onBack={() => {}}
+      timelineEvents={[timelineEvent({})]}
+    />,
+  );
+
+  assert.match(html, /Activity/);
+  assert.match(html, /Silenced/);
+  assert.match(html, /The payment is captured and the client safely retries confirmation\./);
+  assert.match(html, /The retry completed successfully 240 ms later\./);
+});
+
+test("error detail shows why the issue was placed under observation", () => {
+  const html = renderToStaticMarkup(
+    <IssueDetailView
+      issue={issue}
+      environment="production"
+      onBack={() => {}}
+      timelineEvents={[
+        timelineEvent({
+          kind: "issue_observed",
+          detail: {
+            issueId: issue.id,
+            reason: "The upstream recovered, but the sample window is still too short.",
+            evidence: "No failed payments in the last 12 minutes.",
+          },
+        }),
+      ]}
+    />,
+  );
+
+  assert.match(html, /Under observation/);
+  assert.match(html, /The upstream recovered, but the sample window is still too short\./);
+  assert.match(html, /No failed payments in the last 12 minutes\./);
+});
+
+test("error detail shows why the issue was resolved", () => {
+  const html = renderToStaticMarkup(
+    <IssueDetailView
+      issue={issue}
+      environment="production"
+      onBack={() => {}}
+      timelineEvents={[
+        timelineEvent({
+          kind: "issue_resolved",
+          detail: {
+            issueId: issue.id,
+            reason: "The fix is live and the affected code path is healthy.",
+            evidence: "The deploy completed and 2,400 subsequent checkouts succeeded.",
+          },
+        }),
+      ]}
+    />,
+  );
+
+  assert.match(html, /Resolved/);
+  assert.match(html, /The fix is live and the affected code path is healthy\./);
+  assert.match(html, /The deploy completed and 2,400 subsequent checkouts succeeded\./);
+});
+
+test("error detail shows system-generated resolution activity without a reason", () => {
+  const html = renderToStaticMarkup(
+    <IssueDetailView
+      issue={issue}
+      environment="production"
+      onBack={() => {}}
+      timelineEvents={[
+        timelineEvent({
+          kind: "issue_resolved",
+          detail: { issueId: issue.id },
+        }),
+      ]}
+    />,
+  );
+
+  assert.match(html, /Activity/);
+  assert.match(html, /Resolved/);
 });

--- a/apps/web/src/issues/IssueDetailView.tsx
+++ b/apps/web/src/issues/IssueDetailView.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import type { Issue } from "../api.ts";
+import type { IncidentEvent, Issue } from "../api.ts";
 import { Btn, Chip } from "../design/ui.tsx";
 
 export type IssueDetailViewProps = {
@@ -10,6 +10,7 @@ export type IssueDetailViewProps = {
   onOpenEvidence?: () => void;
   evidenceLabel?: string;
   silenceUpdating?: boolean;
+  timelineEvents?: IncidentEvent[];
   linkedIncident?: ReactNode;
   feedbackAction?: ReactNode;
 };
@@ -22,6 +23,7 @@ export function IssueDetailView({
   onOpenEvidence,
   evidenceLabel = "Open event",
   silenceUpdating = false,
+  timelineEvents = [],
   linkedIncident,
   feedbackAction,
 }: IssueDetailViewProps) {
@@ -144,6 +146,8 @@ export function IssueDetailView({
               </div>
             </section>
 
+            <IssueActivityTimeline issueId={issue.id} events={timelineEvents} />
+
             <section className="border-t border-border pt-7">
               <SectionLabel>Latest evidence</SectionLabel>
               <div className="mt-4 overflow-hidden rounded-lg border border-border bg-surface">
@@ -181,6 +185,51 @@ export function IssueDetailView({
         </main>
       </div>
     </div>
+  );
+}
+
+function IssueActivityTimeline({ issueId, events }: { issueId: string; events: IncidentEvent[] }) {
+  const items = events.flatMap((event) => {
+    const presentation =
+      event.kind === "issue_silenced"
+        ? { status: "Silenced", tone: "neutral" as const }
+        : event.kind === "issue_observed"
+          ? { status: "Under observation", tone: "warning" as const }
+          : event.kind === "issue_resolved"
+            ? { status: "Resolved", tone: "success" as const }
+            : null;
+    if (!presentation || event.detail?.issueId !== issueId) return [];
+    const reason = typeof event.detail.reason === "string" ? event.detail.reason.trim() : "";
+    const evidence = typeof event.detail.evidence === "string" ? event.detail.evidence.trim() : "";
+    return [{ event, reason, evidence, ...presentation }];
+  });
+  if (items.length === 0) return null;
+
+  return (
+    <section className="border-t border-border pt-7">
+      <SectionLabel>Activity</SectionLabel>
+      <div className="relative mt-5 space-y-5 pl-6">
+        {items.length > 1 && (
+          <div className="absolute bottom-2 left-[5px] top-2 w-px bg-border" aria-hidden="true" />
+        )}
+        {items.map(({ event, reason, evidence, status, tone }) => (
+          <article key={event.id} className="relative">
+            <span
+              className="absolute -left-6 top-1.5 h-2.5 w-2.5 rounded-full border-2 border-border-strong bg-bg"
+              aria-hidden="true"
+            />
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <Chip tone={tone}>{status}</Chip>
+              <time className="text-[11px] text-subtle" dateTime={event.createdAt}>
+                {formatTimestamp(event.createdAt)}
+              </time>
+            </div>
+            {reason && <p className="mt-2 text-[13px] leading-5 text-fg">{reason}</p>}
+            {evidence && <p className="mt-1.5 text-[12px] leading-5 text-muted">{evidence}</p>}
+          </article>
+        ))}
+      </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary

- add an Activity timeline to the error detail workspace
- show silenced, under-observation, and resolved decisions with their timestamps
- keep the recorded reason and supporting evidence visible on the issue itself
- filter incident activity so only decisions for the current issue appear

## Why

Issue classification events already retain structured reasons and evidence, but the error detail page did not surface them. This left teammates without the decision context when reviewing an issue later.

## Validation

- `pnpm --filter @superlog/web typecheck`
- `pnpm --dir apps/web test` (113 tests)
- focused issue-detail rendering tests (4 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Activity timeline on the issue page that shows status decisions (Silenced, Under observation, Resolved) with timestamps, reasons, and evidence for the current issue.

- **New Features**
  - Added `IssueActivityTimeline` in `IssueDetailView` with status chips, timestamps, and reason/evidence display.
  - Fetched events via `useIssueAgentRun` in `IssueDetailPage` and passed as `timelineEvents`.
  - Filtered events by `issueId` to show only relevant activity.
  - Tests cover silenced, observed, resolved, and no-reason cases.

<sup>Written for commit 83e4913995fdc21977613d352dcbacea66035b6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

