### PR TITLE
Make Linear investigation handoffs deterministic

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1231,7 +1231,7 @@ async function getProjectAutomation(projectId: string): Promise<{
     linearTicketInstructions: row?.linearTicketInstructions ?? [],
     prPolicy: row?.prPolicy ?? "on_ready_to_pr",
     approvalPromptsEnabled: row?.approvalPromptsEnabled ?? true,
-    createLinearTicketOnResolve: row?.createLinearTicketOnResolve ?? true,
+    createLinearTicketOnResolve: row?.createLinearTicketOnResolve ?? false,
     prBaseBranch: schema.normalizePrBaseBranch(row?.prBaseBranch),
     autoMergeFixPrs: row?.autoMergeFixPrs ?? "never",
     autoMergeMethod: row?.autoMergeMethod ?? "squash",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1209,6 +1209,8 @@ async function getProjectAutomation(projectId: string): Promise<{
   linearTicketPolicy: schema.LinearTicketPolicy;
   linearTicketInstructions: schema.LinearTicketInstruction[];
   prPolicy: schema.PrPolicy;
+  approvalPromptsEnabled: boolean;
+  createLinearTicketOnResolve: boolean;
   prBaseBranch: string | null;
   autoMergeFixPrs: schema.AutoMergePolicy;
   autoMergeMethod: schema.AutoMergeMethod;
@@ -1228,6 +1230,8 @@ async function getProjectAutomation(projectId: string): Promise<{
     linearTicketPolicy: row?.linearTicketPolicy ?? "on_ready_to_pr",
     linearTicketInstructions: row?.linearTicketInstructions ?? [],
     prPolicy: row?.prPolicy ?? "on_ready_to_pr",
+    approvalPromptsEnabled: row?.approvalPromptsEnabled ?? true,
+    createLinearTicketOnResolve: row?.createLinearTicketOnResolve ?? true,
     prBaseBranch: schema.normalizePrBaseBranch(row?.prBaseBranch),
     autoMergeFixPrs: row?.autoMergeFixPrs ?? "never",
     autoMergeMethod: row?.autoMergeMethod ?? "squash",
@@ -1756,6 +1760,8 @@ app.patch("/api/projects/:projectId/automation", async (c) => {
     linearTicketPolicy?: unknown;
     linearTicketInstructions?: unknown;
     prPolicy?: unknown;
+    approvalPromptsEnabled?: unknown;
+    createLinearTicketOnResolve?: unknown;
     prBaseBranch?: unknown;
     autoMergeFixPrs?: unknown;
     autoMergeMethod?: unknown;
@@ -1811,6 +1817,14 @@ app.patch("/api/projects/:projectId/automation", async (c) => {
     typeof body.prPolicy === "string" && VALID_AGENT_POLICIES.has(body.prPolicy)
       ? (body.prPolicy as schema.PrPolicy)
       : current.prPolicy;
+  const approvalPromptsEnabled =
+    typeof body.approvalPromptsEnabled === "boolean"
+      ? body.approvalPromptsEnabled
+      : current.approvalPromptsEnabled;
+  const createLinearTicketOnResolve =
+    typeof body.createLinearTicketOnResolve === "boolean"
+      ? body.createLinearTicketOnResolve
+      : current.createLinearTicketOnResolve;
   const prBaseBranch = parsePrBaseBranch(body.prBaseBranch, current.prBaseBranch);
   const autoMergeFixPrs: schema.AutoMergePolicy =
     typeof body.autoMergeFixPrs === "string" && VALID_AUTO_MERGE_POLICIES.has(body.autoMergeFixPrs)
@@ -1867,6 +1881,8 @@ app.patch("/api/projects/:projectId/automation", async (c) => {
     linearTicketPolicy,
     linearTicketInstructions,
     prPolicy,
+    approvalPromptsEnabled,
+    createLinearTicketOnResolve,
     prBaseBranch,
     autoMergeFixPrs,
     autoMergeMethod,
@@ -1890,6 +1906,8 @@ app.patch("/api/projects/:projectId/automation", async (c) => {
         linearTicketPolicy,
         linearTicketInstructions,
         prPolicy,
+        approvalPromptsEnabled,
+        createLinearTicketOnResolve,
         prBaseBranch,
         autoMergeFixPrs,
         autoMergeMethod,
@@ -2116,7 +2134,7 @@ app.get("/api/projects/:projectId/incidents/:incidentId", async (c) => {
   const incident = await getProjectIncident(projectId, incidentId);
   if (!incident) throw new HTTPException(404, { message: "incident not found" });
 
-  const [links, agentRuns] = await Promise.all([
+  const [links, agentRuns, linearTickets] = await Promise.all([
     db.query.incidentIssues.findMany({
       where: eq(schema.incidentIssues.incidentId, incidentId),
       orderBy: [desc(schema.incidentIssues.createdAt)],
@@ -2124,6 +2142,10 @@ app.get("/api/projects/:projectId/incidents/:incidentId", async (c) => {
     db.query.agentRuns.findMany({
       where: eq(schema.agentRuns.incidentId, incident.id),
       orderBy: [desc(schema.agentRuns.createdAt)],
+    }),
+    db.query.agentLinearTickets.findMany({
+      where: eq(schema.agentLinearTickets.incidentId, incident.id),
+      orderBy: [desc(schema.agentLinearTickets.createdAt)],
     }),
   ]);
   const issues =
@@ -2154,6 +2176,7 @@ app.get("/api/projects/:projectId/incidents/:incidentId", async (c) => {
     issues,
     agentRun: latestAgentRun,
     agentRuns,
+    linearTickets,
     timeline,
     alertEpisodes,
     pendingResolutionProposal: pendingProposalMap.get(incident.id) ?? null,

--- a/apps/api/src/linear.test.ts
+++ b/apps/api/src/linear.test.ts
@@ -27,8 +27,16 @@ test("buildLinearAuthorizeUrl requests app-actor authorization", async () => {
 });
 
 test("completed is the only Linear state type that accepts the investigation", async () => {
-  const { isLinearCompletedState } = await import("./linear.js");
+  const { isLinearCompletedState, linearCompletionPlan } = await import("./linear.js");
   assert.equal(isLinearCompletedState("completed"), true);
   assert.equal(isLinearCompletedState("started"), false);
   assert.equal(isLinearCompletedState(undefined), false);
+  assert.deepEqual(linearCompletionPlan("started", "completed"), {
+    processCompletion: true,
+    recordAcceptance: true,
+  });
+  assert.deepEqual(linearCompletionPlan("completed", "completed"), {
+    processCompletion: true,
+    recordAcceptance: false,
+  });
 });

--- a/apps/api/src/linear.test.ts
+++ b/apps/api/src/linear.test.ts
@@ -25,3 +25,10 @@ test("buildLinearAuthorizeUrl requests app-actor authorization", async () => {
   assert.equal(url.searchParams.get("prompt"), "consent");
   assert.equal(url.searchParams.get("actor"), "app");
 });
+
+test("completed is the only Linear state type that accepts the investigation", async () => {
+  const { isLinearCompletedState } = await import("./linear.js");
+  assert.equal(isLinearCompletedState("completed"), true);
+  assert.equal(isLinearCompletedState("started"), false);
+  assert.equal(isLinearCompletedState(undefined), false);
+});

--- a/apps/api/src/linear.ts
+++ b/apps/api/src/linear.ts
@@ -1,20 +1,28 @@
 import crypto from "node:crypto";
 import {
+  captureAgentPrLifecycleEvent,
+  createIncidentLifecycle,
   createLinearWebhook,
+  daysBetween,
   db,
   deleteLinearWebhook,
   exchangeLinearCode,
   fetchLinearViewer,
+  linearTicketAcceptanceUnit,
+  resolveIncidentOrg,
   revokeLinearToken,
   schema,
 } from "@superlog/db";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, ne, or } from "drizzle-orm";
 import type { Hono } from "hono";
 import type { Context } from "hono";
+import { closeAgentPullRequestOnGithub } from "./github.js";
+import { runResolvedIncidentSideEffectsForIncident } from "./incidents/resolution-side-effects.js";
 import { logger } from "./logger.js";
 import { resolveActiveOrgContext } from "./org-context.js";
 
 const log = logger.child({ scope: "linear" });
+const incidentLifecycle = createIncidentLifecycle(db);
 
 const SCOPES = "read,write,issues:create,comments:create";
 
@@ -176,6 +184,10 @@ type LinearWebhookPayload = {
   actor?: LinearWebhookActor;
 };
 
+export function isLinearCompletedState(stateType: string | null | undefined): boolean {
+  return stateType === "completed";
+}
+
 function verifyLinearSignature(body: string, header: string, secret: string): boolean {
   if (!header) return false;
   const expected = crypto.createHmac("sha256", secret).update(body).digest("hex");
@@ -235,10 +247,34 @@ async function handleLinearWebhook(
       updates.assigneeName = data.assignee.name ?? null;
       updates.assigneeLinearId = data.assignee.id ?? null;
     }
-    await db
+    const completedState = isLinearCompletedState(data.state?.type);
+    const updated = await db
       .update(schema.agentLinearTickets)
       .set(updates)
-      .where(eq(schema.agentLinearTickets.id, ticket.id));
+      .where(
+        completedState
+          ? and(
+              eq(schema.agentLinearTickets.id, ticket.id),
+              or(
+                isNull(schema.agentLinearTickets.stateType),
+                ne(schema.agentLinearTickets.stateType, "completed"),
+              ),
+            )
+          : eq(schema.agentLinearTickets.id, ticket.id),
+      )
+      .returning({ id: schema.agentLinearTickets.id });
+
+    if (completedState && updated.length > 0) {
+      await acceptCompletedLinearTicket({
+        ticket: {
+          ...ticket,
+          state: data.state?.name ?? ticket.state,
+          stateType: "completed",
+          url: typeof data.url === "string" ? data.url : ticket.url,
+        },
+        occurredAt,
+      });
+    }
   }
 
   const { kind, summary, actor } = describeLinearEvent(payload);
@@ -258,6 +294,55 @@ async function handleLinearWebhook(
       occurredAt,
     })
     .onConflictDoNothing();
+}
+
+async function acceptCompletedLinearTicket(args: {
+  ticket: schema.AgentLinearTicket;
+  occurredAt: Date;
+}): Promise<void> {
+  const { ticket, occurredAt } = args;
+  const agentPr = await db.query.agentPullRequests.findFirst({
+    where: eq(schema.agentPullRequests.agentRunId, ticket.agentRunId),
+    orderBy: [schema.agentPullRequests.createdAt],
+  });
+  const acceptanceUnit = agentPr ?? linearTicketAcceptanceUnit(ticket);
+  const org = await resolveIncidentOrg(ticket.incidentId);
+  captureAgentPrLifecycleEvent({
+    kind: "accepted",
+    pr: acceptanceUnit,
+    org,
+    daysToOutcome: daysBetween(agentPr?.createdAt ?? ticket.createdAt, occurredAt),
+    acceptanceSource: "linear",
+  });
+
+  const { resolved } = await incidentLifecycle.resolve({
+    incidentId: ticket.incidentId,
+    kind: "linear_ticket_completed",
+    reasonCode: "linear_ticket_completed",
+    reasonText: `Resolved because Linear ticket ${ticket.ticketIdentifier ?? ticket.ticketId} entered a completed state.`,
+    agentRunId: ticket.agentRunId,
+    eventSummary: `Incident resolved because Linear ticket ${ticket.ticketIdentifier ?? ticket.ticketId} was completed.`,
+    eventDetail: {
+      agentLinearTicketId: ticket.id,
+      ticketId: ticket.ticketId,
+      ticketIdentifier: ticket.ticketIdentifier,
+      ticketUrl: ticket.url,
+    },
+    eventDedupeKey: `incident_resolved:linear_ticket:${ticket.id}`,
+  });
+  if (resolved) {
+    await runResolvedIncidentSideEffectsForIncident({
+      incidentId: ticket.incidentId,
+      closePullRequest: (pr) =>
+        closeAgentPullRequestOnGithub({
+          installationId: pr.githubInstallationId,
+          fallbackInstallationIds: pr.fallbackGithubInstallationIds,
+          repoFullName: pr.repoFullName,
+          prNumber: pr.prNumber,
+          prNodeId: pr.prNodeId,
+        }),
+    });
+  }
 }
 
 function describeLinearEvent(payload: LinearWebhookPayload): {

--- a/apps/api/src/linear.ts
+++ b/apps/api/src/linear.ts
@@ -188,6 +188,17 @@ export function isLinearCompletedState(stateType: string | null | undefined): bo
   return stateType === "completed";
 }
 
+export function linearCompletionPlan(
+  previousState: schema.AgentLinearTicketState | null,
+  nextState: string | null | undefined,
+): { processCompletion: boolean; recordAcceptance: boolean } {
+  const processCompletion = isLinearCompletedState(nextState);
+  return {
+    processCompletion,
+    recordAcceptance: processCompletion && previousState !== "completed",
+  };
+}
+
 function verifyLinearSignature(body: string, header: string, secret: string): boolean {
   if (!header) return false;
   const expected = crypto.createHmac("sha256", secret).update(body).digest("hex");
@@ -247,12 +258,12 @@ async function handleLinearWebhook(
       updates.assigneeName = data.assignee.name ?? null;
       updates.assigneeLinearId = data.assignee.id ?? null;
     }
-    const completedState = isLinearCompletedState(data.state?.type);
+    const completion = linearCompletionPlan(ticket.stateType, data.state?.type);
     const updated = await db
       .update(schema.agentLinearTickets)
       .set(updates)
       .where(
-        completedState
+        completion.recordAcceptance
           ? and(
               eq(schema.agentLinearTickets.id, ticket.id),
               or(
@@ -264,7 +275,7 @@ async function handleLinearWebhook(
       )
       .returning({ id: schema.agentLinearTickets.id });
 
-    if (completedState && updated.length > 0) {
+    if (completion.processCompletion) {
       await acceptCompletedLinearTicket({
         ticket: {
           ...ticket,
@@ -273,6 +284,7 @@ async function handleLinearWebhook(
           url: typeof data.url === "string" ? data.url : ticket.url,
         },
         occurredAt,
+        recordAcceptance: completion.recordAcceptance && updated.length > 0,
       });
     }
   }
@@ -299,23 +311,26 @@ async function handleLinearWebhook(
 async function acceptCompletedLinearTicket(args: {
   ticket: schema.AgentLinearTicket;
   occurredAt: Date;
+  recordAcceptance: boolean;
 }): Promise<void> {
-  const { ticket, occurredAt } = args;
+  const { ticket, occurredAt, recordAcceptance } = args;
   const agentPr = await db.query.agentPullRequests.findFirst({
     where: eq(schema.agentPullRequests.agentRunId, ticket.agentRunId),
     orderBy: [schema.agentPullRequests.createdAt],
   });
   const acceptanceUnit = agentPr ?? linearTicketAcceptanceUnit(ticket);
-  const org = await resolveIncidentOrg(ticket.incidentId);
-  captureAgentPrLifecycleEvent({
-    kind: "accepted",
-    pr: acceptanceUnit,
-    org,
-    daysToOutcome: daysBetween(agentPr?.createdAt ?? ticket.createdAt, occurredAt),
-    acceptanceSource: "linear",
-  });
+  if (recordAcceptance) {
+    const org = await resolveIncidentOrg(ticket.incidentId).catch(() => null);
+    captureAgentPrLifecycleEvent({
+      kind: "accepted",
+      pr: acceptanceUnit,
+      org,
+      daysToOutcome: daysBetween(agentPr?.createdAt ?? ticket.createdAt, occurredAt),
+      acceptanceSource: "linear",
+    });
+  }
 
-  const { resolved } = await incidentLifecycle.resolve({
+  await incidentLifecycle.resolve({
     incidentId: ticket.incidentId,
     kind: "linear_ticket_completed",
     reasonCode: "linear_ticket_completed",
@@ -330,19 +345,19 @@ async function acceptCompletedLinearTicket(args: {
     },
     eventDedupeKey: `incident_resolved:linear_ticket:${ticket.id}`,
   });
-  if (resolved) {
-    await runResolvedIncidentSideEffectsForIncident({
-      incidentId: ticket.incidentId,
-      closePullRequest: (pr) =>
-        closeAgentPullRequestOnGithub({
-          installationId: pr.githubInstallationId,
-          fallbackInstallationIds: pr.fallbackGithubInstallationIds,
-          repoFullName: pr.repoFullName,
-          prNumber: pr.prNumber,
-          prNodeId: pr.prNodeId,
-        }),
-    });
-  }
+  // These effects are idempotent and must be retried even if an earlier
+  // webhook attempt already won the incident-resolution write.
+  await runResolvedIncidentSideEffectsForIncident({
+    incidentId: ticket.incidentId,
+    closePullRequest: (pr) =>
+      closeAgentPullRequestOnGithub({
+        installationId: pr.githubInstallationId,
+        fallbackInstallationIds: pr.fallbackGithubInstallationIds,
+        repoFullName: pr.repoFullName,
+        prNumber: pr.prNumber,
+        prNodeId: pr.prNodeId,
+      }),
+  });
 }
 
 function describeLinearEvent(payload: LinearWebhookPayload): {

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -75,6 +75,7 @@ import {
 import {
   type IncidentMetaRow,
   buildIncidentDetailMeta,
+  latestIncidentLinearTicket,
 } from "./incidents/incident-detail-view-model.ts";
 import { IncidentDetailScrollArea } from "./incidents/IncidentDetailScrollArea.tsx";
 import { getIssueIncidentLinkState } from "./issue-incident-link-state.ts";
@@ -1127,7 +1128,7 @@ function IncidentDetailBody({
       </div>
     );
   }
-  const { incident, issues, agentRun, agentRuns, timeline, alertEpisodes } = q.data;
+  const { incident, issues, agentRun, agentRuns, linearTickets, timeline, alertEpisodes } = q.data;
 
   function handleStatusAction(action: IncidentStatusAction) {
     updateIncident.mutate({
@@ -1151,6 +1152,7 @@ function IncidentDetailBody({
       issues={issues}
       agentRun={agentRun}
       agentRuns={agentRuns}
+      linearTickets={linearTickets}
       alertEpisodes={alertEpisodes}
       pendingResolutionProposal={q.data.pendingResolutionProposal ?? null}
       events={timeline}
@@ -1519,6 +1521,7 @@ export function IncidentDetailContent({
   issues,
   agentRun,
   agentRuns = [],
+  linearTickets = [],
   alertEpisodes = [],
   pendingResolutionProposal,
   events,
@@ -1544,6 +1547,7 @@ export function IncidentDetailContent({
   issues: Issue[];
   agentRun: AgentRun | null;
   agentRuns?: AgentRun[];
+  linearTickets?: import("./api.ts").IncidentLinearTicket[];
   alertEpisodes?: IncidentAlertEpisode[];
   pendingResolutionProposal?: PendingResolutionProposal | null;
   events: IncidentEvent[];
@@ -1591,6 +1595,7 @@ export function IncidentDetailContent({
     incident.agentSummary ??
     agentRun?.result?.summary ??
     "No investigation summary has been recorded yet.";
+  const latestLinearTicket = latestIncidentLinearTicket(linearTickets);
   const triggeringIssue = issues.reduce<Issue | null>((earliest, issue) => {
     if (!earliest) return issue;
     return Date.parse(issue.firstSeen) < Date.parse(earliest.firstSeen) ? issue : earliest;
@@ -1646,6 +1651,22 @@ export function IncidentDetailContent({
               {/* "Agent run" stays last; Linked issues slots in where Findings used to be. */}
               <IncidentSidebarMetaRows rows={detailMeta.slice(0, -1)} />
               <LinkedIssuesMetaRow issues={issues} onViewIssue={onViewIssue} />
+              {latestLinearTicket?.url && (
+                <div className="grid grid-cols-[132px_minmax(0,1fr)] items-start gap-3 text-[13px]">
+                  <div className="text-muted">Linear ticket</div>
+                  <a
+                    href={latestLinearTicket.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="flex min-w-0 items-center gap-[5px] text-fg transition-colors hover:text-muted"
+                  >
+                    <ArrowUpRightIcon />
+                    <span className="min-w-0 truncate">
+                      {latestLinearTicket.ticketIdentifier ?? "View ticket"}
+                    </span>
+                  </a>
+                </div>
+              )}
               <IncidentSidebarMetaRows rows={detailMeta.slice(-1)} />
             </div>
 

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -76,6 +76,7 @@ import {
   type IncidentMetaRow,
   buildIncidentDetailMeta,
   latestIncidentLinearTicket,
+  linearTicketSidebarTarget,
 } from "./incidents/incident-detail-view-model.ts";
 import { IncidentDetailScrollArea } from "./incidents/IncidentDetailScrollArea.tsx";
 import { getIssueIncidentLinkState } from "./issue-incident-link-state.ts";
@@ -1596,6 +1597,9 @@ export function IncidentDetailContent({
     agentRun?.result?.summary ??
     "No investigation summary has been recorded yet.";
   const latestLinearTicket = latestIncidentLinearTicket(linearTickets);
+  const linearTicketTarget = latestLinearTicket
+    ? linearTicketSidebarTarget(latestLinearTicket)
+    : null;
   const triggeringIssue = issues.reduce<Issue | null>((earliest, issue) => {
     if (!earliest) return issue;
     return Date.parse(issue.firstSeen) < Date.parse(earliest.firstSeen) ? issue : earliest;
@@ -1651,20 +1655,22 @@ export function IncidentDetailContent({
               {/* "Agent run" stays last; Linked issues slots in where Findings used to be. */}
               <IncidentSidebarMetaRows rows={detailMeta.slice(0, -1)} />
               <LinkedIssuesMetaRow issues={issues} onViewIssue={onViewIssue} />
-              {latestLinearTicket?.url && (
+              {linearTicketTarget && (
                 <div className="grid grid-cols-[132px_minmax(0,1fr)] items-start gap-3 text-[13px]">
                   <div className="text-muted">Linear ticket</div>
-                  <a
-                    href={latestLinearTicket.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="flex min-w-0 items-center gap-[5px] text-fg transition-colors hover:text-muted"
-                  >
-                    <ArrowUpRightIcon />
-                    <span className="min-w-0 truncate">
-                      {latestLinearTicket.ticketIdentifier ?? "View ticket"}
-                    </span>
-                  </a>
+                  {linearTicketTarget.url ? (
+                    <a
+                      href={linearTicketTarget.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="flex min-w-0 items-center gap-[5px] text-fg transition-colors hover:text-muted"
+                    >
+                      <ArrowUpRightIcon />
+                      <span className="min-w-0 truncate">{linearTicketTarget.label}</span>
+                    </a>
+                  ) : (
+                    <span className="min-w-0 truncate text-fg">{linearTicketTarget.label}</span>
+                  )}
                 </div>
               )}
               <IncidentSidebarMetaRows rows={detailMeta.slice(-1)} />

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -12,7 +12,6 @@ import {
   type IssueFilterConfig,
   type IssueFilterPreviewEvent,
   type LinearTicketInstruction,
-  type LinearTicketPolicy,
   type PrPolicy,
   type RenderOwner,
   type RepoBranch,
@@ -2570,6 +2569,8 @@ function AgentFlowchart({ projectId }: { projectId: string | undefined }) {
     linearTicketPolicy: "on_ready_to_pr",
     linearTicketInstructions: [],
     prPolicy: "on_ready_to_pr",
+    approvalPromptsEnabled: true,
+    createLinearTicketOnResolve: true,
     prBaseBranch: null,
     autoMergeFixPrs: "never",
     autoMergeMethod: "squash",
@@ -2614,10 +2615,24 @@ function AgentFlowchart({ projectId }: { projectId: string | undefined }) {
               onSave={(v) => patch({ customInstructions: v })}
             />
             <ToolsSection disabled={!investigateOn} />
+            <div className="flex items-start justify-between gap-4 rounded-md border border-border px-3 py-3">
+              <div>
+                <div className="text-[12.5px] font-medium text-foreground">Approval prompts</div>
+                <p className="mt-1 text-[12px] text-muted">
+                  Let the agent request approval before changing connected infrastructure or other
+                  external systems. Turn this off for findings-and-ticket-only investigations.
+                </p>
+              </div>
+              <Toggle
+                checked={data.approvalPromptsEnabled}
+                disabled={!investigateOn || save.isPending}
+                onChange={(v) => patch({ approvalPromptsEnabled: v })}
+              />
+            </div>
           </div>
         </FlowNode>
 
-        <FlowConnector active={downstreamEligible && data.linearTicketPolicy !== "never"} />
+        <FlowConnector active={downstreamEligible && linearConnected} />
 
         <FlowNode
           step={3}
@@ -2635,21 +2650,13 @@ function AgentFlowchart({ projectId }: { projectId: string | undefined }) {
               <Chip tone="warning" dot>
                 Linear not connected
               </Chip>
-            ) : data.linearTicketPolicy === "never" ? (
-              <Chip tone="muted" dot>
-                Off
-              </Chip>
-            ) : data.linearTicketPolicy === "always" ? (
-              <Chip tone="success" dot>
-                Every incident
-              </Chip>
             ) : (
               <Chip tone="success" dot>
-                On identified fix
+                On handoff
               </Chip>
             )
           }
-          spineActive={downstreamEligible && linearConnected && data.linearTicketPolicy !== "never"}
+          spineActive={downstreamEligible && linearConnected}
           off={!downstreamEligible}
         >
           {!linearConnected ? (
@@ -2660,31 +2667,32 @@ function AgentFlowchart({ projectId }: { projectId: string | undefined }) {
             </div>
           ) : (
             <div className="space-y-4">
-              <PolicyControls
-                value={data.linearTicketPolicy}
-                disabled={!downstreamEligible || save.isPending}
-                onChange={(v) => patch({ linearTicketPolicy: v as LinearTicketPolicy })}
-                labels={{
-                  on_ready_to_pr: "Only when the fix is identifiable",
-                  always: "Every incident",
-                  never: "Never",
-                }}
-                hints={{
-                  on_ready_to_pr:
-                    "The agent files a ticket only after pinpointing a concrete fix or root cause.",
-                  always:
-                    "The agent ensures every incident has a Linear ticket — useful for audit trails.",
-                  never:
-                    "Linear stays connected, but the agent will not touch it during agent_runs.",
-                }}
-              />
-              {data.linearTicketPolicy !== "never" && (
-                <LinearTicketInstructionsField
-                  value={data.linearTicketInstructions}
+              <p className="text-[12.5px] text-muted">
+                Each findings-only handoff creates a new Linear ticket with a link back to the
+                incident. Paused and failed investigations do not create tickets; resolve-time
+                filing is controlled below.
+              </p>
+              <div className="flex items-start justify-between gap-4 rounded-md border border-border px-3 py-3">
+                <div>
+                  <div className="text-[12.5px] font-medium text-foreground">
+                    Also create a ticket on incident resolution
+                  </div>
+                  <p className="mt-1 text-[12px] text-muted">
+                    Applies when the agent finishes with resolve_incident instead of handing off an
+                    open incident.
+                  </p>
+                </div>
+                <Toggle
+                  checked={data.createLinearTicketOnResolve}
                   disabled={!downstreamEligible || save.isPending}
-                  onSave={(v) => patch({ linearTicketInstructions: v })}
+                  onChange={(v) => patch({ createLinearTicketOnResolve: v })}
                 />
-              )}
+              </div>
+              <LinearTicketInstructionsField
+                value={data.linearTicketInstructions}
+                disabled={!downstreamEligible || save.isPending}
+                onSave={(v) => patch({ linearTicketInstructions: v })}
+              />
             </div>
           )}
         </FlowNode>
@@ -3571,47 +3579,6 @@ function AutoMergeControls({
           </div>
         </div>
       )}
-    </div>
-  );
-}
-
-function PolicyControls<T extends string>({
-  value,
-  disabled,
-  onChange,
-  labels,
-  hints,
-}: {
-  value: T;
-  disabled: boolean;
-  onChange: (v: T) => void;
-  labels: Record<string, string>;
-  hints: Record<string, string>;
-}) {
-  const options = ["on_ready_to_pr", "always", "never"] as const;
-  return (
-    <div className="space-y-3">
-      <div className="flex flex-wrap gap-1.5">
-        {options.map((opt) => {
-          const active = value === opt;
-          return (
-            <button
-              key={opt}
-              type="button"
-              disabled={disabled}
-              onClick={() => onChange(opt as T)}
-              className={`rounded-sm border px-2.5 py-1 font-sans text-[11px] tracking-tight transition-colors ${
-                active
-                  ? "border-accent bg-accent-soft text-accent"
-                  : "border-border bg-surface-2 text-muted hover:text-fg"
-              } ${disabled ? "cursor-not-allowed opacity-60" : ""}`}
-            >
-              {labels[opt]}
-            </button>
-          );
-        })}
-      </div>
-      <p className="text-[12px] text-muted">{hints[value]}</p>
     </div>
   );
 }

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -2570,7 +2570,7 @@ function AgentFlowchart({ projectId }: { projectId: string | undefined }) {
     linearTicketInstructions: [],
     prPolicy: "on_ready_to_pr",
     approvalPromptsEnabled: true,
-    createLinearTicketOnResolve: true,
+    createLinearTicketOnResolve: false,
     prBaseBranch: null,
     autoMergeFixPrs: "never",
     autoMergeMethod: "squash",

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1568,6 +1568,8 @@ export type AgentSettings = {
   linearTicketPolicy: LinearTicketPolicy;
   linearTicketInstructions: LinearTicketInstruction[];
   prPolicy: PrPolicy;
+  approvalPromptsEnabled: boolean;
+  createLinearTicketOnResolve: boolean;
   prBaseBranch: string | null;
   autoMergeFixPrs: AutoMergePolicy;
   autoMergeMethod: AutoMergeMethod;
@@ -2420,6 +2422,7 @@ export type IncidentDetail = {
   agentRun: AgentRun | null;
   // Full agent-run history for this incident, newest first.
   agentRuns: AgentRun[];
+  linearTickets: IncidentLinearTicket[];
   // Timeline events scoped to the latest run, plus PR/Linear ticket events.
   // Empty array when there is no agent run yet.
   timeline: IncidentEvent[];
@@ -2427,6 +2430,16 @@ export type IncidentDetail = {
   // back-link. Empty for incidents not raised by an alert.
   alertEpisodes: IncidentAlertEpisode[];
   pendingResolutionProposal: PendingResolutionProposal | null;
+};
+
+export type IncidentLinearTicket = {
+  id: string;
+  agentRunId: string;
+  ticketIdentifier: string | null;
+  url: string | null;
+  state: string | null;
+  stateType: "open" | "completed" | "canceled" | "unstarted" | "started" | null;
+  createdAt: string;
 };
 
 export type IncidentAlertEpisode = {

--- a/apps/web/src/incidents/incident-detail-view-model.test.ts
+++ b/apps/web/src/incidents/incident-detail-view-model.test.ts
@@ -6,6 +6,7 @@ import {
   formatIncidentLocalTimestamp,
   incidentDisplayStatus,
   latestIncidentLinearTicket,
+  linearTicketSidebarTarget,
 } from "./incident-detail-view-model.ts";
 
 const now = Date.parse("2026-07-01T16:39:01.388Z");
@@ -164,4 +165,11 @@ test("latestIncidentLinearTicket selects the newest recorded ticket for the side
 
   assert.equal(latest?.identifier, "ENG-42");
   assert.equal(latestIncidentLinearTicket([]), null);
+});
+
+test("linearTicketSidebarTarget preserves a recorded ticket without a provider URL", () => {
+  assert.deepEqual(
+    linearTicketSidebarTarget({ ticketIdentifier: "ENG-42", id: "row-uuid", url: null }),
+    { label: "ENG-42", url: null },
+  );
 });

--- a/apps/web/src/incidents/incident-detail-view-model.test.ts
+++ b/apps/web/src/incidents/incident-detail-view-model.test.ts
@@ -5,6 +5,7 @@ import {
   formatIncidentDuration,
   formatIncidentLocalTimestamp,
   incidentDisplayStatus,
+  latestIncidentLinearTicket,
 } from "./incident-detail-view-model.ts";
 
 const now = Date.parse("2026-07-01T16:39:01.388Z");
@@ -137,4 +138,30 @@ test("formatIncidentLocalTimestamp uses the visitor's timezone", () => {
     }),
     "Jun 30, 2026, 09:39 PDT",
   );
+});
+
+test("latestIncidentLinearTicket selects the newest recorded ticket for the sidebar", () => {
+  const latest = latestIncidentLinearTicket([
+    {
+      id: "row-1",
+      agentRunId: "run-1",
+      identifier: "ENG-41",
+      url: "https://linear.app/acme/issue/ENG-41",
+      state: "In Progress",
+      stateType: "started",
+      createdAt: "2026-07-01T10:00:00.000Z",
+    },
+    {
+      id: "row-2",
+      agentRunId: "run-2",
+      identifier: "ENG-42",
+      url: "https://linear.app/acme/issue/ENG-42",
+      state: "Todo",
+      stateType: "unstarted",
+      createdAt: "2026-07-02T10:00:00.000Z",
+    },
+  ]);
+
+  assert.equal(latest?.identifier, "ENG-42");
+  assert.equal(latestIncidentLinearTicket([]), null);
 });

--- a/apps/web/src/incidents/incident-detail-view-model.ts
+++ b/apps/web/src/incidents/incident-detail-view-model.ts
@@ -10,6 +10,17 @@ export function latestIncidentLinearTicket<T extends { createdAt: string }>(
   );
 }
 
+export function linearTicketSidebarTarget(ticket: {
+  ticketIdentifier: string | null;
+  id: string;
+  url: string | null;
+}): { label: string; url: string | null } {
+  return {
+    label: ticket.ticketIdentifier ?? "Recorded ticket",
+    url: ticket.url,
+  };
+}
+
 export type IncidentMetaRow = {
   label: string;
   value: string;

--- a/apps/web/src/incidents/incident-detail-view-model.ts
+++ b/apps/web/src/incidents/incident-detail-view-model.ts
@@ -1,5 +1,15 @@
 import type { AgentRun, Incident } from "../api.ts";
 
+export function latestIncidentLinearTicket<T extends { createdAt: string }>(
+  tickets: T[],
+): T | null {
+  return tickets.reduce<T | null>(
+    (latest, ticket) =>
+      !latest || Date.parse(ticket.createdAt) > Date.parse(latest.createdAt) ? ticket : latest,
+    null,
+  );
+}
+
 export type IncidentMetaRow = {
   label: string;
   value: string;

--- a/apps/worker/src/agent-outcome-tools.test.ts
+++ b/apps/worker/src/agent-outcome-tools.test.ts
@@ -10,6 +10,7 @@ import {
   assembleAgentRunResult,
   isActionOutcomeToolName,
   mergeFindings,
+  outcomeToolDefinitionsForCapabilities,
   validateOutcomeToolInput,
 } from "./agent-outcome-tools.js";
 import type { AgentRunFindings } from "./agent-outcome-tools.js";
@@ -34,8 +35,8 @@ const PROPOSE_PR_INPUT = {
   patchFilePath: "/mnt/session/outputs/superlog-batch-vendor-lookups.patch",
 };
 
-test("exposes all seven tools with API-safe schemas", () => {
-  assert.equal(OUTCOME_TOOL_NAMES.length, 7);
+test("exposes the default seven tools with API-safe schemas", () => {
+  assert.equal(OUTCOME_TOOL_NAMES.length, 8);
   assert.equal(OUTCOME_TOOL_DEFINITIONS.length, 7);
   for (const def of OUTCOME_TOOL_DEFINITIONS) {
     // Some runner APIs reject any top-level composition keyword
@@ -50,15 +51,42 @@ test("exposes all seven tools with API-safe schemas", () => {
   }
 });
 
-test("splits the contract into action tools and exactly two terminal tools", () => {
+test("splits the contract into action tools and terminal tools", () => {
   assert.deepEqual(
     [...ACTION_OUTCOME_TOOL_NAMES],
     ["propose_pr", "silence_as_noise", "place_under_observation", "resolve_issue"],
   );
-  assert.deepEqual([...TERMINAL_OUTCOME_TOOL_NAMES], ["resolve_incident", "ask_human"]);
-  assert.ok(!(TERMINAL_OUTCOME_TOOL_NAMES as readonly string[]).includes(REPORT_FINDINGS_TOOL_NAME));
+  assert.deepEqual(
+    [...TERMINAL_OUTCOME_TOOL_NAMES],
+    ["resolve_incident", "complete_investigation", "ask_human"],
+  );
+  assert.ok(
+    !(TERMINAL_OUTCOME_TOOL_NAMES as readonly string[]).includes(REPORT_FINDINGS_TOOL_NAME),
+  );
   assert.ok(isActionOutcomeToolName("propose_pr"));
   assert.ok(!isActionOutcomeToolName("resolve_incident"));
+});
+
+test("offers complete_investigation only when no intervention tool is available", () => {
+  const withPrs = outcomeToolDefinitionsForCapabilities({
+    prCreation: true,
+    approvalPrompts: false,
+  }).map((definition) => definition.name);
+  assert.ok(withPrs.includes("propose_pr"));
+  assert.ok(!withPrs.includes("complete_investigation"));
+
+  const ticketOnly = outcomeToolDefinitionsForCapabilities({
+    prCreation: false,
+    approvalPrompts: false,
+  }).map((definition) => definition.name);
+  assert.ok(!ticketOnly.includes("propose_pr"));
+  assert.ok(ticketOnly.includes("complete_investigation"));
+
+  const withApprovals = outcomeToolDefinitionsForCapabilities({
+    prCreation: false,
+    approvalPrompts: true,
+  }).map((definition) => definition.name);
+  assert.ok(!withApprovals.includes("complete_investigation"));
 });
 
 // The load-bearing guidance in tool descriptions. Losing any of these
@@ -94,7 +122,11 @@ test("resolve_incident description requires per-issue classification first", () 
 test("rejects retired tools (incl. mark_already_resolved) with redirect guidance", () => {
   assert.ok((RETIRED_OUTCOME_TOOL_NAMES as readonly string[]).includes("mark_already_resolved"));
   for (const name of RETIRED_OUTCOME_TOOL_NAMES) {
-    const v = validateOutcomeToolInput(name, { reason: "upstream_recovered", evidence: "e" }, { hasFindings: true });
+    const v = validateOutcomeToolInput(
+      name,
+      { reason: "upstream_recovered", evidence: "e" },
+      { hasFindings: true },
+    );
     assert.equal(v.ok, false, name);
     if (!v.ok) {
       const text = v.errors.join(" ");
@@ -142,7 +174,11 @@ test("rejects a bad severity with a model-readable message", () => {
 test("classification tools take free-text reasons and require issueId", () => {
   const ok = validateOutcomeToolInput(
     "silence_as_noise",
-    { issueId: "issue-1", reason: "Expected 404s from bot traffic probing /wp-admin", evidence: "e" },
+    {
+      issueId: "issue-1",
+      reason: "Expected 404s from bot traffic probing /wp-admin",
+      evidence: "e",
+    },
     { hasFindings: true },
   );
   assert.equal(ok.ok, true);
@@ -169,10 +205,17 @@ test("requires findings before action tools and resolve_incident", () => {
     ["resolve_issue", { issueId: "i", reason: "recovered", evidence: "e" }],
     [
       "place_under_observation",
-      { issueId: "i", reason: "one-off", evidence: "e", escalateOn: "additional_events", threshold: 10 },
+      {
+        issueId: "i",
+        reason: "one-off",
+        evidence: "e",
+        escalateOn: "additional_events",
+        threshold: 10,
+      },
     ],
     ["propose_pr", PROPOSE_PR_INPUT],
     ["resolve_incident", { reason: "all done", evidence: "e" }],
+    ["complete_investigation", {}],
   ];
   for (const [name, input] of cases) {
     const v = validateOutcomeToolInput(name, input, { hasFindings: false });
@@ -181,9 +224,26 @@ test("requires findings before action tools and resolve_incident", () => {
   }
 });
 
+test("complete_investigation finishes without resolving the incident", () => {
+  const validation = validateOutcomeToolInput("complete_investigation", {}, { hasFindings: true });
+  assert.equal(validation.ok, true);
+
+  const result = assembleAgentRunResult({
+    findings: FINDINGS,
+    terminal: { name: "complete_investigation", payload: {} },
+  });
+  assert.equal(result.state, "complete");
+  assert.equal(result.completionKind, "investigation_complete");
+  assert.equal(result.incidentResolution, undefined);
+});
+
 test("allows ask_human without findings", () => {
   assert.equal(
-    validateOutcomeToolInput("ask_human", { question: "which repo owns api-gw?" }, { hasFindings: false }).ok,
+    validateOutcomeToolInput(
+      "ask_human",
+      { question: "which repo owns api-gw?" },
+      { hasFindings: false },
+    ).ok,
     true,
   );
 });
@@ -199,7 +259,13 @@ test("validates place_under_observation trigger fields", () => {
 
   const badThreshold = validateOutcomeToolInput(
     "place_under_observation",
-    { issueId: "i", reason: "one-off", evidence: "e", escalateOn: "additional_events", threshold: 0 },
+    {
+      issueId: "i",
+      reason: "one-off",
+      evidence: "e",
+      escalateOn: "additional_events",
+      threshold: 0,
+    },
     { hasFindings: true },
   );
   assert.equal(badThreshold.ok, false);

--- a/apps/worker/src/agent-outcome-tools.ts
+++ b/apps/worker/src/agent-outcome-tools.ts
@@ -9,7 +9,9 @@
 //     going. `propose_pr`, `silence_as_noise`, `place_under_observation`,
 //     `resolve_issue`.
 //   - Terminal tools: `resolve_incident` ends the investigation once every
-//     linked issue is classified; `ask_human` pauses it on a human. A turn may
+//     linked issue is classified; `complete_investigation` finishes a
+//     findings-only run while leaving the incident open; `ask_human` pauses it
+//     on a human. A turn may
 //     also legitimately end with NO terminal call when the run is waiting on
 //     external events (open PRs) — the worker parks it and resumes the session
 //     when a PR comment/merge/close arrives.
@@ -60,7 +62,11 @@ export const ACTION_OUTCOME_TOOL_NAMES = [
 
 export type ActionOutcomeToolName = (typeof ACTION_OUTCOME_TOOL_NAMES)[number];
 
-export const TERMINAL_OUTCOME_TOOL_NAMES = ["resolve_incident", "ask_human"] as const;
+export const TERMINAL_OUTCOME_TOOL_NAMES = [
+  "resolve_incident",
+  "complete_investigation",
+  "ask_human",
+] as const;
 
 export type TerminalOutcomeToolName = (typeof TERMINAL_OUTCOME_TOOL_NAMES)[number];
 
@@ -68,11 +74,7 @@ export type TerminalOutcomeToolName = (typeof TERMINAL_OUTCOME_TOOL_NAMES)[numbe
 // can outlive a deploy (a parked run resumes days later), so a call to one of
 // these must be error-acked with redirect guidance — not routed to the
 // unknown-tool path, which hard-fails the run.
-export const RETIRED_OUTCOME_TOOL_NAMES = [
-  "complete_investigation",
-  "report_failure",
-  "mark_already_resolved",
-] as const;
+export const RETIRED_OUTCOME_TOOL_NAMES = ["report_failure", "mark_already_resolved"] as const;
 
 export const OUTCOME_TOOL_NAMES = [
   REPORT_FINDINGS_TOOL_NAME,
@@ -204,7 +206,10 @@ const PROPOSE_PR_DEFINITION: OutcomeToolDefinition = {
   input_schema: {
     type: "object",
     properties: {
-      repoFullName: { type: "string", description: "owner/repo of the mounted repository the patch targets." },
+      repoFullName: {
+        type: "string",
+        description: "owner/repo of the mounted repository the patch targets.",
+      },
       title: {
         type: "string",
         description:
@@ -221,13 +226,20 @@ const PROPOSE_PR_DEFINITION: OutcomeToolDefinition = {
         description:
           "Must start with 'superlog/' followed by a short kebab-case slug, e.g. superlog/fix-cart-batching. Reuse a branch name to push to that PR; use a new one to open a separate PR.",
       },
-      baseBranch: { type: "string", description: "The branch the PR should target (the repo's active development branch)." },
+      baseBranch: {
+        type: "string",
+        description: "The branch the PR should target (the repo's active development branch).",
+      },
       patchFilePath: {
         type: "string",
         description:
           "Where you wrote the unified diff, e.g. /mnt/session/outputs/superlog-fix-cart-batching.patch. Use a distinct file per PR so a later PR's patch never overwrites an earlier one.",
       },
-      changedFiles: { type: "array", items: { type: "string" }, description: "Repo-relative paths the patch touches." },
+      changedFiles: {
+        type: "array",
+        items: { type: "string" },
+        description: "Repo-relative paths the patch touches.",
+      },
       mobileTestStatus: {
         type: "string",
         enum: MOBILE_TEST_STATUSES,
@@ -235,7 +247,10 @@ const PROPOSE_PR_DEFINITION: OutcomeToolDefinition = {
           "Only for orgs with a mobile-regression integration: whether you created a regression test for this fix ('created' requires mobileTestId; 'skipped'/'not_applicable' require mobileTestReason).",
       },
       mobileTestId: { type: "string", description: "The created mobile regression test id." },
-      mobileTestReason: { type: "string", description: "Why the mobile regression test was skipped / not applicable." },
+      mobileTestReason: {
+        type: "string",
+        description: "Why the mobile regression test was skipped / not applicable.",
+      },
     },
     required: ["repoFullName", "title", "body", "branchName", "baseBranch", "patchFilePath"],
   },
@@ -250,7 +265,10 @@ const SILENCE_AS_NOISE_DEFINITION: OutcomeToolDefinition = {
   input_schema: {
     type: "object",
     properties: {
-      issueId: { type: "string", description: "The id of the linked issue to silence (from the incident issue bundle)." },
+      issueId: {
+        type: "string",
+        description: "The id of the linked issue to silence (from the incident issue bundle).",
+      },
       reason: {
         type: "string",
         description:
@@ -280,7 +298,10 @@ const PLACE_UNDER_OBSERVATION_DEFINITION: OutcomeToolDefinition = {
   input_schema: {
     type: "object",
     properties: {
-      issueId: { type: "string", description: "The id of the linked issue to observe (from the incident issue bundle)." },
+      issueId: {
+        type: "string",
+        description: "The id of the linked issue to observe (from the incident issue bundle).",
+      },
       reason: {
         type: "string",
         description:
@@ -316,7 +337,10 @@ const RESOLVE_ISSUE_DEFINITION: OutcomeToolDefinition = {
   input_schema: {
     type: "object",
     properties: {
-      issueId: { type: "string", description: "The id of the linked issue to resolve (from the incident issue bundle)." },
+      issueId: {
+        type: "string",
+        description: "The id of the linked issue to resolve (from the incident issue bundle).",
+      },
       reason: {
         type: "string",
         description:
@@ -360,6 +384,19 @@ const RESOLVE_INCIDENT_DEFINITION: OutcomeToolDefinition = {
 
 export type AskHumanPayload = { question: string };
 
+export type CompleteInvestigationPayload = Record<string, never>;
+
+const COMPLETE_INVESTIGATION_DEFINITION: OutcomeToolDefinition = {
+  name: "complete_investigation",
+  description:
+    "Terminal: finish the investigation and hand the recorded findings to the configured external ticket workflow, while leaving the incident open. Use this only after report_findings when no PR or approval action is available. This does not resolve the incident and does not require every linked issue to be classified.",
+  input_schema: {
+    type: "object",
+    properties: {},
+    required: [],
+  },
+};
+
 const ASK_HUMAN_DEFINITION: OutcomeToolDefinition = {
   name: "ask_human",
   description:
@@ -386,6 +423,30 @@ export const OUTCOME_TOOL_DEFINITIONS: OutcomeToolDefinition[] = [
   ASK_HUMAN_DEFINITION,
 ];
 
+export type AgentInterventionCapabilities = {
+  prCreation: boolean;
+  approvalPrompts: boolean;
+};
+
+export function hasInterventionTools(capabilities: AgentInterventionCapabilities): boolean {
+  return capabilities.prCreation || capabilities.approvalPrompts;
+}
+
+export function outcomeToolDefinitionsForCapabilities(
+  capabilities: AgentInterventionCapabilities,
+): OutcomeToolDefinition[] {
+  return [
+    REPORT_FINDINGS_DEFINITION,
+    ...(capabilities.prCreation ? [PROPOSE_PR_DEFINITION] : []),
+    SILENCE_AS_NOISE_DEFINITION,
+    PLACE_UNDER_OBSERVATION_DEFINITION,
+    RESOLVE_ISSUE_DEFINITION,
+    RESOLVE_INCIDENT_DEFINITION,
+    ...(!hasInterventionTools(capabilities) ? [COMPLETE_INVESTIGATION_DEFINITION] : []),
+    ASK_HUMAN_DEFINITION,
+  ];
+}
+
 // ---------------------------------------------------------------------------
 // Validation
 // ---------------------------------------------------------------------------
@@ -398,6 +459,7 @@ export type ActionOutcome =
 
 export type TerminalOutcome =
   | { name: "resolve_incident"; payload: ResolveIncidentPayload }
+  | { name: "complete_investigation"; payload: CompleteInvestigationPayload }
   | { name: "ask_human"; payload: AskHumanPayload };
 
 export type ValidateOutcome =
@@ -414,6 +476,7 @@ const FINDINGS_REQUIRED = new Set<string>([
   "place_under_observation",
   "resolve_issue",
   "resolve_incident",
+  "complete_investigation",
 ]);
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -568,14 +631,14 @@ export function validateOutcomeToolInput(
       const mobileTestId = optionalString(errors, input, "mobileTestId");
       const mobileTestReason = optionalString(errors, input, "mobileTestReason");
       if (mobileTestStatus === "created" && !mobileTestId) {
-        errors.push("`mobileTestId` is required when `mobileTestStatus` is \"created\".");
+        errors.push('`mobileTestId` is required when `mobileTestStatus` is "created".');
       }
       if (
         (mobileTestStatus === "skipped" || mobileTestStatus === "not_applicable") &&
         !mobileTestReason
       ) {
         errors.push(
-          "`mobileTestReason` is required when `mobileTestStatus` is \"skipped\" or \"not_applicable\".",
+          '`mobileTestReason` is required when `mobileTestStatus` is "skipped" or "not_applicable".',
         );
       }
       if (errors.length > 0) return { ok: false, errors };
@@ -618,7 +681,9 @@ export function validateOutcomeToolInput(
       const escalateOn = requiredEnum(errors, input, "escalateOn", ESCALATE_ON);
       const threshold = input.threshold;
       if (typeof threshold !== "number" || !Number.isInteger(threshold) || threshold < 1) {
-        errors.push(`\`threshold\` must be an integer >= 1; you sent ${JSON.stringify(threshold)}.`);
+        errors.push(
+          `\`threshold\` must be an integer >= 1; you sent ${JSON.stringify(threshold)}.`,
+        );
       }
       if (errors.length > 0) return { ok: false, errors };
       return {
@@ -644,6 +709,9 @@ export function validateOutcomeToolInput(
         payload: { reason: reason as string, evidence: evidence as string },
       };
     }
+
+    case "complete_investigation":
+      return { ok: true, tool: "complete_investigation", payload: {} };
 
     case "ask_human": {
       const question = pushRequiredString(errors, input, "question");
@@ -720,9 +788,7 @@ export function escalationTriggerFromObservation(
 // result can record what happened during the run.
 export type ExecutedAction = ActionOutcome;
 
-function issueClassificationFromAction(
-  action: ExecutedAction,
-): AgentRunIssueClassification | null {
+function issueClassificationFromAction(action: ExecutedAction): AgentRunIssueClassification | null {
   switch (action.name) {
     case "silence_as_noise":
       return {
@@ -819,6 +885,9 @@ export function assembleAgentRunResult(args: {
       reason: terminal.payload.reason,
       evidence: terminal.payload.evidence,
     };
+  }
+  if (terminal?.name === "complete_investigation") {
+    result.completionKind = "investigation_complete";
   }
   if (terminal?.name === "ask_human") {
     result.question = terminal.payload.question;

--- a/apps/worker/src/agent-run-context.ts
+++ b/apps/worker/src/agent-run-context.ts
@@ -45,6 +45,8 @@ export type AgentRunContext = {
   linearTicketInstructions: schema.LinearTicketInstruction[];
   linearDefaultTeamId: string | null;
   prPolicy: schema.PrPolicy;
+  approvalPromptsEnabled: boolean;
+  createLinearTicketOnResolve: boolean;
   prBaseBranch: string | null;
   autoMergeFixPrs: schema.AutoMergePolicy;
   autoMergeMethod: schema.AutoMergeMethod;
@@ -152,6 +154,8 @@ export async function getProjectAutomation(projectId: string): Promise<{
   linearTicketInstructions: schema.LinearTicketInstruction[];
   linearDefaultTeamId: string | null;
   prPolicy: schema.PrPolicy;
+  approvalPromptsEnabled: boolean;
+  createLinearTicketOnResolve: boolean;
   prBaseBranch: string | null;
   autoMergeFixPrs: schema.AutoMergePolicy;
   autoMergeMethod: schema.AutoMergeMethod;
@@ -171,6 +175,8 @@ export async function getProjectAutomation(projectId: string): Promise<{
     linearTicketInstructions: row?.linearTicketInstructions ?? [],
     linearDefaultTeamId: row?.linearDefaultTeamId ?? null,
     prPolicy: row?.prPolicy ?? "on_ready_to_pr",
+    approvalPromptsEnabled: row?.approvalPromptsEnabled ?? true,
+    createLinearTicketOnResolve: row?.createLinearTicketOnResolve ?? true,
     prBaseBranch: schema.normalizePrBaseBranch(row?.prBaseBranch),
     autoMergeFixPrs: row?.autoMergeFixPrs ?? "never",
     autoMergeMethod: row?.autoMergeMethod ?? "squash",
@@ -258,6 +264,8 @@ export async function loadAgentRunContext(
     linearTicketInstructions: automation.linearTicketInstructions,
     linearDefaultTeamId: automation.linearDefaultTeamId,
     prPolicy: automation.prPolicy,
+    approvalPromptsEnabled: automation.approvalPromptsEnabled,
+    createLinearTicketOnResolve: automation.createLinearTicketOnResolve,
     prBaseBranch: automation.prBaseBranch,
     autoMergeFixPrs: automation.autoMergeFixPrs,
     autoMergeMethod: automation.autoMergeMethod,

--- a/apps/worker/src/agent-run-context.ts
+++ b/apps/worker/src/agent-run-context.ts
@@ -176,7 +176,7 @@ export async function getProjectAutomation(projectId: string): Promise<{
     linearDefaultTeamId: row?.linearDefaultTeamId ?? null,
     prPolicy: row?.prPolicy ?? "on_ready_to_pr",
     approvalPromptsEnabled: row?.approvalPromptsEnabled ?? true,
-    createLinearTicketOnResolve: row?.createLinearTicketOnResolve ?? true,
+    createLinearTicketOnResolve: row?.createLinearTicketOnResolve ?? false,
     prBaseBranch: schema.normalizePrBaseBranch(row?.prBaseBranch),
     autoMergeFixPrs: row?.autoMergeFixPrs ?? "never",
     autoMergeMethod: row?.autoMergeMethod ?? "squash",

--- a/apps/worker/src/agent-runner-backend.ts
+++ b/apps/worker/src/agent-runner-backend.ts
@@ -120,6 +120,10 @@ export type AgentRunnerStartInput = {
   repoCandidates: AgentRunnerRepoCandidate[];
   mcpResource: string | null;
   prPolicy: PrPolicy;
+  approvalPromptsEnabled: boolean;
+  // True only when at least one currently registered integration operation
+  // is implemented as an approval prompt for this run.
+  approvalPromptToolsAvailable: boolean;
   prBaseBranch: string | null;
   githubConnected: boolean;
   telemetryInvestigationHint: string;
@@ -145,6 +149,7 @@ export type OutcomeActionCall = {
   name: string;
   input: unknown;
   hasFindings: boolean;
+  findings: import("./agent-outcome-tools.js").AgentRunFindings | null;
 };
 
 export type OutcomeActionExecution =

--- a/apps/worker/src/agent-runs/completion-policy.test.ts
+++ b/apps/worker/src/agent-runs/completion-policy.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { shouldCreateLinearTicketForTerminalOutcome } from "./completion-policy.js";
+
+test("complete_investigation always attempts the connected Linear handoff", () => {
+  assert.equal(shouldCreateLinearTicketForTerminalOutcome("complete_investigation", false), true);
+});
+
+test("resolve_incident follows the project's create-ticket-on-resolve toggle", () => {
+  assert.equal(shouldCreateLinearTicketForTerminalOutcome("resolve_incident", true), true);
+  assert.equal(shouldCreateLinearTicketForTerminalOutcome("resolve_incident", false), false);
+});

--- a/apps/worker/src/agent-runs/completion-policy.ts
+++ b/apps/worker/src/agent-runs/completion-policy.ts
@@ -1,0 +1,8 @@
+export type TicketCreatingTerminalOutcome = "complete_investigation" | "resolve_incident";
+
+export function shouldCreateLinearTicketForTerminalOutcome(
+  outcome: TicketCreatingTerminalOutcome,
+  createOnResolve: boolean,
+): boolean {
+  return outcome === "complete_investigation" || createOnResolve;
+}

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -24,6 +24,7 @@ import {
 } from "../infra/slack/incident-messages.js";
 import { logger } from "../logger.js";
 import { enqueueAgentRunCompleted } from "../webhooks.js";
+import { shouldCreateLinearTicketForTerminalOutcome } from "./completion-policy.js";
 import { recordFiledLinearTicket } from "./deliverable-records.js";
 import { deliverLinearTicket } from "./linear-delivery.js";
 import { isAlertIncident, truncateSlackText } from "./result-metadata.js";
@@ -290,14 +291,20 @@ export async function completeWithIncidentResolution(
 
   // Linear ticket: file/update deterministically from the findings, linking
   // the most recent PR when one was opened during the run.
-  const latestPr = await db.query.agentPullRequests.findFirst({
-    where: eq(schema.agentPullRequests.incidentId, ctx.incident.id),
-    orderBy: [desc(schema.agentPullRequests.createdAt)],
-    columns: { url: true },
-  });
-  const deliveredTicket = await deliverLinearTicket(ctx, result, {
-    prUrl: latestPr?.url ?? null,
-  });
+  const shouldCreateTicket = shouldCreateLinearTicketForTerminalOutcome(
+    "resolve_incident",
+    ctx.createLinearTicketOnResolve,
+  );
+  const latestPr = shouldCreateTicket
+    ? await db.query.agentPullRequests.findFirst({
+        where: eq(schema.agentPullRequests.incidentId, ctx.incident.id),
+        orderBy: [desc(schema.agentPullRequests.createdAt)],
+        columns: { url: true },
+      })
+    : null;
+  const deliveredTicket = shouldCreateTicket
+    ? await deliverLinearTicket(ctx, result, { prUrls: latestPr?.url ? [latestPr.url] : [] })
+    : null;
   if (deliveredTicket) {
     await recordFiledLinearTicket(
       ctx,
@@ -328,6 +335,9 @@ export async function completeWithIncidentResolution(
     result.summary,
   ];
   if (evidence) lines.push(`Evidence: ${truncateSlackText(evidence, 1800)}`);
+  if (deliveredTicket?.url) {
+    lines.push(`Linear: <${deliveredTicket.url}|${deliveredTicket.identifier}>`);
+  }
   await postIncidentThreadMessage(ctx.incident.id, lines.join("\n"));
   const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
   await updateIncidentMainMessage(
@@ -341,6 +351,7 @@ export async function completeWithIncidentResolution(
       projectName: ctx.project.name,
       service: ctx.incident.service,
       buttons: [{ text: "View incident", url: incidentUrl, actionId: "view_incident" }],
+      links: deliveredTicket?.url ? [{ text: "View ticket", url: deliveredTicket.url }] : [],
       incidentId: ctx.incident.id,
     }),
   );
@@ -391,7 +402,7 @@ export async function completeWithoutPullRequest(
   // agent-proposed title). The agent no longer self-reports ticket ids —
   // except legacy in-flight runs finishing on the old contract, whose
   // self-reported ticket link is preserved below.
-  const deliveredTicket = await deliverLinearTicket(ctx, result, { prUrl: null });
+  const deliveredTicket = await deliverLinearTicket(ctx, result, { prUrls: [] });
   if (deliveredTicket) {
     await recordFiledLinearTicket(
       ctx,
@@ -452,6 +463,13 @@ export async function completeWithoutPullRequest(
       result.summary,
     ];
     if (evidence) lines.push(`Evidence: ${truncateSlackText(evidence, 1800)}`);
+    if (ticket) {
+      lines.push(
+        ticket.url
+          ? `Linear: <${ticket.url}|${ticket.identifier}>`
+          : `Linear: ${ticket.identifier}`,
+      );
+    }
     await postIncidentThreadMessage(ctx.incident.id, lines.join("\n"));
   } else if (resolutionReason) {
     const label = resolutionReasonLabel(resolutionReason);
@@ -461,6 +479,13 @@ export async function completeWithoutPullRequest(
       result.summary,
     ];
     if (evidence) lines.push(`Evidence: ${truncateSlackText(evidence, 1800)}`);
+    if (ticket) {
+      lines.push(
+        ticket.url
+          ? `Linear: <${ticket.url}|${ticket.identifier}>`
+          : `Linear: ${ticket.identifier}`,
+      );
+    }
     await postIncidentThreadMessage(ctx.incident.id, lines.join("\n"));
   } else {
     const badge = ticket

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -26,7 +26,7 @@ import { logger } from "../logger.js";
 import { enqueueAgentRunCompleted } from "../webhooks.js";
 import { shouldCreateLinearTicketForTerminalOutcome } from "./completion-policy.js";
 import { recordFiledLinearTicket } from "./deliverable-records.js";
-import { deliverLinearTicket } from "./linear-delivery.js";
+import { scheduleLinearHandoff } from "./linear-handoff.js";
 import { isAlertIncident, truncateSlackText } from "./result-metadata.js";
 
 const WEB_ORIGIN = process.env.WEB_ORIGIN ?? "http://localhost:5173";
@@ -289,33 +289,16 @@ export async function completeWithIncidentResolution(
     if (refreshed) ctx.incident = refreshed;
   }
 
-  // Linear ticket: file/update deterministically from the findings, linking
-  // the most recent PR when one was opened during the run.
+  // Linear ticket: file/update deterministically from the findings. The
+  // reconciliation boundary links every PR recorded for the incident and
+  // remains pending when either provider is temporarily unavailable.
   const shouldCreateTicket = shouldCreateLinearTicketForTerminalOutcome(
     "resolve_incident",
     ctx.createLinearTicketOnResolve,
   );
-  const latestPr = shouldCreateTicket
-    ? await db.query.agentPullRequests.findFirst({
-        where: eq(schema.agentPullRequests.incidentId, ctx.incident.id),
-        orderBy: [desc(schema.agentPullRequests.createdAt)],
-        columns: { url: true },
-      })
-    : null;
   const deliveredTicket = shouldCreateTicket
-    ? await deliverLinearTicket(ctx, result, { prUrls: latestPr?.url ? [latestPr.url] : [] })
+    ? await scheduleLinearHandoff(ctx, result, "resolve_incident")
     : null;
-  if (deliveredTicket) {
-    await recordFiledLinearTicket(
-      ctx,
-      {
-        id: deliveredTicket.ticketId,
-        url: deliveredTicket.url,
-        createdByAgent: deliveredTicket.created,
-      },
-      { identifier: deliveredTicket.identifier },
-    );
-  }
 
   logger.info(
     {
@@ -402,18 +385,12 @@ export async function completeWithoutPullRequest(
   // agent-proposed title). The agent no longer self-reports ticket ids —
   // except legacy in-flight runs finishing on the old contract, whose
   // self-reported ticket link is preserved below.
-  const deliveredTicket = await deliverLinearTicket(ctx, result, { prUrls: [] });
-  if (deliveredTicket) {
-    await recordFiledLinearTicket(
-      ctx,
-      {
-        id: deliveredTicket.ticketId,
-        url: deliveredTicket.url,
-        createdByAgent: deliveredTicket.created,
-      },
-      { identifier: deliveredTicket.identifier },
-    );
-  } else if (result.linearTicket) {
+  const deliveredTicket = await scheduleLinearHandoff(
+    ctx,
+    result,
+    result.completionKind ?? "complete_without_pr",
+  );
+  if (!deliveredTicket && result.linearTicket) {
     await recordFiledLinearTicket(ctx, result.linearTicket);
   }
   const ticketDisplay = deliveredTicket

--- a/apps/worker/src/agent-runs/deliverable-records.test.ts
+++ b/apps/worker/src/agent-runs/deliverable-records.test.ts
@@ -1,0 +1,12 @@
+import "../agent-run.test-env.js";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { resolveIncidentOrgBestEffort } from "./deliverable-records.js";
+
+test("resolveIncidentOrgBestEffort preserves ticket completion when org lookup fails", async () => {
+  const org = await resolveIncidentOrgBestEffort(async () => {
+    throw new Error("database temporarily unavailable");
+  });
+
+  assert.equal(org, null);
+});

--- a/apps/worker/src/agent-runs/deliverable-records.ts
+++ b/apps/worker/src/agent-runs/deliverable-records.ts
@@ -9,6 +9,16 @@ import { eq } from "drizzle-orm";
 import type { AgentRunContext } from "../agent-run-context.js";
 import { recordPrCreatedMetric } from "../pr-metrics.js";
 
+export async function resolveIncidentOrgBestEffort(
+  resolve: () => Promise<{ id: string; name: string } | null>,
+): Promise<{ id: string; name: string } | null> {
+  try {
+    return await resolve();
+  } catch {
+    return null;
+  }
+}
+
 export async function recordFiledLinearTicket(
   ctx: AgentRunContext,
   ticket: schema.AgentRunLinearTicket | null | undefined,
@@ -55,7 +65,7 @@ export async function recordFiledLinearTicket(
     columns: { id: true },
   });
   if (!pr) {
-    const org = await resolveIncidentOrg(ctx.incident.id);
+    const org = await resolveIncidentOrgBestEffort(() => resolveIncidentOrg(ctx.incident.id));
     captureAgentPrLifecycleEvent({
       kind: "opened",
       pr: linearTicketAcceptanceUnit({

--- a/apps/worker/src/agent-runs/deliverable-records.ts
+++ b/apps/worker/src/agent-runs/deliverable-records.ts
@@ -1,4 +1,11 @@
-import { db, schema } from "@superlog/db";
+import {
+  captureAgentPrLifecycleEvent,
+  db,
+  linearTicketAcceptanceUnit,
+  resolveIncidentOrg,
+  schema,
+} from "@superlog/db";
+import { eq } from "drizzle-orm";
 import type { AgentRunContext } from "../agent-run-context.js";
 import { recordPrCreatedMetric } from "../pr-metrics.js";
 
@@ -39,6 +46,27 @@ export async function recordFiledLinearTicket(
       occurredAt: now,
     })
     .onConflictDoNothing();
+
+  // Findings-only investigations still belong in the PR-acceptance funnel.
+  // When this run has no PR, the durable ticket row is its stable acceptance
+  // unit and this newly-inserted path emits the denominator exactly once.
+  const pr = await db.query.agentPullRequests.findFirst({
+    where: eq(schema.agentPullRequests.agentRunId, ctx.agentRun.id),
+    columns: { id: true },
+  });
+  if (!pr) {
+    const org = await resolveIncidentOrg(ctx.incident.id);
+    captureAgentPrLifecycleEvent({
+      kind: "opened",
+      pr: linearTicketAcceptanceUnit({
+        id: row.id,
+        incidentId: ctx.incident.id,
+        agentRunId: ctx.agentRun.id,
+        url: ticket.url ?? null,
+      }),
+      org,
+    });
+  }
 }
 
 export async function recordOpenedAgentPullRequest(opts: {

--- a/apps/worker/src/agent-runs/linear-delivery.test.ts
+++ b/apps/worker/src/agent-runs/linear-delivery.test.ts
@@ -118,6 +118,33 @@ test("reuses the ticket already recorded for the same completed investigation", 
   assert.equal(deps.calls.createIssue.length, 0);
 });
 
+test("resolves a legacy recorded Linear identifier to the issue UUID", async () => {
+  const deps = makeDeps({
+    findKnownTicket: async () => ({
+      ticketId: "ENG-7",
+      identifier: "ENG-7",
+      url: "https://linear.app/eng/issue/ENG-7",
+    }),
+    searchIssues: async (term) => {
+      deps.calls.searchIssues.push(term);
+      return term === "ENG-7"
+        ? [
+            {
+              id: "0b6e7f7e-6f3a-4b8e-9a4e-2d1c3b4a5f6e",
+              identifier: "ENG-7",
+              url: "https://linear.app/eng/issue/ENG-7",
+            },
+          ]
+        : [];
+    },
+  });
+
+  const ticket = await deliverLinearTicketWithDeps(BASE_ARGS, RESULT, deps);
+
+  assert.equal(ticket?.ticketId, "0b6e7f7e-6f3a-4b8e-9a4e-2d1c3b4a5f6e");
+  assert.deepEqual(deps.calls.searchIssues, ["ENG-7"]);
+});
+
 test("dedupes a retried completion against its investigation marker", async () => {
   const deps = makeDeps({
     searchIssues: async (term) =>

--- a/apps/worker/src/agent-runs/linear-delivery.test.ts
+++ b/apps/worker/src/agent-runs/linear-delivery.test.ts
@@ -5,7 +5,7 @@ import type { AgentRunResult } from "@superlog/db";
 import {
   type LinearDeliveryDeps,
   deliverLinearTicketWithDeps,
-  incidentMarker,
+  investigationMarker,
   isRevokedTokenError,
   linearDeliveryAllowed,
   ticketDescription,
@@ -22,7 +22,6 @@ const RESULT: AgentRunResult = {
 type DepCalls = {
   searchIssues: unknown[];
   createIssue: unknown[];
-  createComment: unknown[];
   listTeams: unknown[];
   markNeedsReauth: unknown[];
 };
@@ -33,7 +32,6 @@ function makeDeps(overrides: Partial<LinearDeliveryDeps> = {}): LinearDeliveryDe
   const calls: DepCalls = {
     searchIssues: [],
     createIssue: [],
-    createComment: [],
     listTeams: [],
     markNeedsReauth: [],
   };
@@ -47,9 +45,6 @@ function makeDeps(overrides: Partial<LinearDeliveryDeps> = {}): LinearDeliveryDe
     createIssue: async (args) => {
       calls.createIssue.push(args);
       return { id: "issue-uuid", identifier: "ENG-42", url: "https://linear.app/eng/issue/ENG-42" };
-    },
-    createComment: async (args) => {
-      calls.createComment.push(args);
     },
     listTeams: async () => {
       calls.listTeams.push(null);
@@ -65,28 +60,19 @@ function makeDeps(overrides: Partial<LinearDeliveryDeps> = {}): LinearDeliveryDe
 
 const BASE_ARGS = {
   incidentId: "inc-1",
+  agentRunId: "run-1",
   incidentTitle: "Checkout requests fail under load",
-  policy: "always" as const,
   hasInstall: true,
   defaultTeamId: null,
-  prUrl: null,
+  prUrls: [],
 };
 
-test("policy matrix gates delivery", () => {
-  assert.equal(linearDeliveryAllowed({ hasInstall: false, policy: "always", prUrl: null }), false);
-  assert.equal(linearDeliveryAllowed({ hasInstall: true, policy: "never", prUrl: "x" }), false);
-  assert.equal(
-    linearDeliveryAllowed({ hasInstall: true, policy: "on_ready_to_pr", prUrl: null }),
-    false,
-  );
-  assert.equal(
-    linearDeliveryAllowed({ hasInstall: true, policy: "on_ready_to_pr", prUrl: "x" }),
-    true,
-  );
-  assert.equal(linearDeliveryAllowed({ hasInstall: true, policy: "always", prUrl: null }), true);
+test("a connected Linear integration always enables delivery", () => {
+  assert.equal(linearDeliveryAllowed({ hasInstall: false }), false);
+  assert.equal(linearDeliveryAllowed({ hasInstall: true }), true);
 });
 
-test("creates a ticket with the incident marker when nothing exists", async () => {
+test("creates a ticket with a completed-investigation marker when nothing exists", async () => {
   const deps = makeDeps();
   const ticket = await deliverLinearTicketWithDeps(BASE_ARGS, RESULT, deps);
   assert.deepEqual(ticket, {
@@ -95,10 +81,14 @@ test("creates a ticket with the incident marker when nothing exists", async () =
     url: "https://linear.app/eng/issue/ENG-42",
     created: true,
   });
-  const created = deps.calls.createIssue[0] as { teamId: string; description: string; title: string };
+  const created = deps.calls.createIssue[0] as {
+    teamId: string;
+    description: string;
+    title: string;
+  };
   assert.equal(created.teamId, "team-1");
   assert.equal(created.title, BASE_ARGS.incidentTitle);
-  assert.ok(created.description.includes(incidentMarker("inc-1")));
+  assert.ok(created.description.includes(investigationMarker("inc-1", "run-1")));
   assert.ok(created.description.includes("## Root cause"));
 });
 
@@ -109,7 +99,7 @@ test("uses the configured default team without listing teams", async () => {
   assert.equal((deps.calls.createIssue[0] as { teamId: string }).teamId, "team-9");
 });
 
-test("comments directly on a known UUID ticket without searching", async () => {
+test("reuses the ticket already recorded for the same completed investigation", async () => {
   const deps = makeDeps({
     findKnownTicket: async () => ({
       ticketId: "0b6e7f7e-6f3a-4b8e-9a4e-2d1c3b4a5f6e",
@@ -126,35 +116,12 @@ test("comments directly on a known UUID ticket without searching", async () => {
   });
   assert.equal(deps.calls.searchIssues.length, 0);
   assert.equal(deps.calls.createIssue.length, 0);
-  assert.equal(deps.calls.createComment.length, 1);
 });
 
-test("resolves a legacy identifier-keyed known ticket via search", async () => {
-  const deps = makeDeps({
-    findKnownTicket: async () => ({
-      ticketId: "ENG-7",
-      identifier: null,
-      url: "https://linear.app/eng/issue/ENG-7",
-    }),
-    searchIssues: async () => [
-      { id: "issue-7", identifier: "ENG-7", url: "https://linear.app/eng/issue/ENG-7" },
-    ],
-  });
-  const ticket = await deliverLinearTicketWithDeps(BASE_ARGS, RESULT, deps);
-  assert.deepEqual(ticket, {
-    ticketId: "issue-7",
-    identifier: "ENG-7",
-    url: "https://linear.app/eng/issue/ENG-7",
-    created: false,
-  });
-  assert.equal(deps.calls.createIssue.length, 0);
-  assert.equal(deps.calls.createComment.length, 1);
-});
-
-test("dedupes against a marker-matching ticket found via search", async () => {
+test("dedupes a retried completion against its investigation marker", async () => {
   const deps = makeDeps({
     searchIssues: async (term) =>
-      term === incidentMarker("inc-1")
+      term === investigationMarker("inc-1", "run-1")
         ? [{ id: "issue-3", identifier: "OPS-3", url: "https://linear.app/ops/issue/OPS-3" }]
         : [],
   });
@@ -197,14 +164,30 @@ test("skips delivery when the workspace has no teams", async () => {
   assert.equal(deps.calls.createIssue.length, 0);
 });
 
-test("ticket description includes PR link when present", () => {
+test("ticket description includes every open PR link", () => {
   const desc = ticketDescription(
-    { incidentId: "inc-1", incidentTitle: "t" },
+    { incidentId: "inc-1", agentRunId: "run-1", incidentTitle: "t" },
     RESULT,
-    "https://github.com/acme/shop/pull/12",
+    ["https://github.com/acme/shop/pull/12", "https://github.com/acme/api/pull/15"],
   );
-  assert.ok(desc.includes("Proposed fix: https://github.com/acme/shop/pull/12"));
-  assert.ok(desc.includes(incidentMarker("inc-1")));
+  assert.ok(desc.includes("Proposed fixes:"));
+  assert.ok(desc.includes("- https://github.com/acme/shop/pull/12"));
+  assert.ok(desc.includes("- https://github.com/acme/api/pull/15"));
+  assert.ok(desc.includes(investigationMarker("inc-1", "run-1")));
+});
+
+test("disconnected Linear skips all provider calls", async () => {
+  const deps = makeDeps();
+  const ticket = await deliverLinearTicketWithDeps(
+    { ...BASE_ARGS, hasInstall: false },
+    RESULT,
+    deps,
+  );
+
+  assert.equal(ticket, null);
+  assert.equal(deps.calls.searchIssues.length, 0);
+  assert.equal(deps.calls.createIssue.length, 0);
+  assert.equal(deps.calls.listTeams.length, 0);
 });
 
 test("isRevokedTokenError matches auth failures only", () => {

--- a/apps/worker/src/agent-runs/linear-delivery.ts
+++ b/apps/worker/src/agent-runs/linear-delivery.ts
@@ -1,8 +1,8 @@
 // Deterministic Linear ticket delivery. The platform — not the agent — files
-// or updates the incident's Linear ticket from the completed run's findings,
-// so the recorded ticket id/url always refer to a ticket that actually
-// exists. Delivery is best-effort: any failure is logged and returns null,
-// never blocking run completion.
+// exactly one ticket for each investigation handoff. A retry of the same
+// terminal or first-PR boundary reuses that run's ticket, while a later
+// run always creates a new one. Delivery is best-effort: any failure is logged
+// and returns null, never blocking the investigation state transition.
 
 import {
   type AgentRunResult,
@@ -23,11 +23,11 @@ import { logger } from "../logger.js";
 
 const WEB_ORIGIN = process.env.WEB_ORIGIN ?? "http://localhost:5173";
 
-// Marker line embedded in every ticket description; dedupe searches for it.
-// Kept identical to the convention agent-filed tickets used, so historical
-// tickets keep deduping.
-export function incidentMarker(incidentId: string): string {
-  return `superlog_incident_id=${incidentId}`;
+// Marker line embedded in every ticket description. It is scoped to the run,
+// rather than only the incident, so a delivery retry dedupes while a separate
+// completed investigation receives a new ticket.
+export function investigationMarker(incidentId: string, agentRunId: string): string {
+  return `superlog_incident_id=${incidentId} superlog_agent_run_id=${agentRunId}`;
 }
 
 export type DeliveredLinearTicket = {
@@ -37,14 +37,14 @@ export type DeliveredLinearTicket = {
   // Human identifier for display, e.g. ENG-42.
   identifier: string;
   url: string | null;
-  // True when this delivery created the ticket (vs commented on an existing one).
+  // True when this delivery created the ticket (vs reusing an existing one).
   created: boolean;
 };
 
 export function ticketDescription(
-  args: { incidentId: string; incidentTitle: string },
+  args: { incidentId: string; agentRunId: string; incidentTitle: string },
   result: AgentRunResult,
-  prUrl: string | null,
+  prUrls: string[],
 ): string {
   const lines: string[] = [result.summary];
   if (result.rootCause?.text) {
@@ -54,20 +54,14 @@ export function ticketDescription(
     lines.push("", "## Impact", result.estimatedImpact.text);
   }
   if (result.severity) lines.push("", `Severity: ${result.severity}`);
-  if (prUrl) lines.push("", `Proposed fix: ${prUrl}`);
+  if (prUrls.length > 0) {
+    lines.push("", prUrls.length === 1 ? "Proposed fix:" : "Proposed fixes:");
+    lines.push(...prUrls.map((url) => `- ${url}`));
+  }
   lines.push("", `[Incident on Superlog](${WEB_ORIGIN}/incidents/${args.incidentId})`);
-  lines.push("", incidentMarker(args.incidentId));
+  lines.push("", investigationMarker(args.incidentId, args.agentRunId));
   return lines.join("\n");
 }
-
-function followUpComment(result: AgentRunResult, prUrl: string | null): string {
-  const lines: string[] = ["New findings from the latest investigation run:", "", result.summary];
-  if (result.rootCause?.text) lines.push("", result.rootCause.text);
-  if (prUrl) lines.push("", `Proposed fix: ${prUrl}`);
-  return lines.join("\n");
-}
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export function isRevokedTokenError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
@@ -75,17 +69,8 @@ export function isRevokedTokenError(err: unknown): boolean {
 }
 
 // Should this completion produce/refresh a ticket at all?
-export function linearDeliveryAllowed(
-  args: {
-    hasInstall: boolean;
-    policy: schema.LinearTicketPolicy;
-    prUrl: string | null;
-  },
-): boolean {
-  if (!args.hasInstall) return false;
-  if (args.policy === "never") return false;
-  if (args.policy === "on_ready_to_pr" && !args.prUrl) return false;
-  return true;
+export function linearDeliveryAllowed(args: { hasInstall: boolean }): boolean {
+  return args.hasInstall;
 }
 
 export type LinearDeliveryDeps = {
@@ -95,63 +80,48 @@ export type LinearDeliveryDeps = {
     url: string | null;
   } | null>;
   searchIssues(term: string): Promise<LinearIssueRef[]>;
-  createIssue(args: { teamId: string; title: string; description: string }): Promise<LinearIssueRef>;
-  createComment(args: { issueId: string; body: string }): Promise<void>;
+  createIssue(args: {
+    teamId: string;
+    title: string;
+    description: string;
+  }): Promise<LinearIssueRef>;
   listTeams(): Promise<LinearTeam[]>;
   markNeedsReauth(reason: string): Promise<void>;
   log(level: "info" | "warn", fields: Record<string, unknown>, msg: string): void;
 };
 
-// Core delivery: comment on the incident's known ticket, else dedupe by
-// marker search, else create under the configured (or first) team.
+// Core delivery: reuse a ticket already recorded/found for this exact run,
+// otherwise create under the configured (or first) team.
 export async function deliverLinearTicketWithDeps(
   args: {
     incidentId: string;
+    agentRunId: string;
     incidentTitle: string;
-    policy: schema.LinearTicketPolicy;
     hasInstall: boolean;
     defaultTeamId: string | null;
-    prUrl: string | null;
+    prUrls: string[];
   },
   result: AgentRunResult,
   deps: LinearDeliveryDeps,
 ): Promise<DeliveredLinearTicket | null> {
-  if (!linearDeliveryAllowed({ hasInstall: args.hasInstall, policy: args.policy, prUrl: args.prUrl })) {
+  if (!linearDeliveryAllowed({ hasInstall: args.hasInstall })) {
     return null;
   }
   try {
     const known = await deps.findKnownTicket();
     if (known) {
-      // New rows store the Linear issue UUID and can be commented directly;
-      // legacy agent-filed rows may hold the human identifier instead, which
-      // needs a search to resolve to the UUID.
-      if (UUID_RE.test(known.ticketId)) {
-        await deps.createComment({
-          issueId: known.ticketId,
-          body: followUpComment(result, args.prUrl),
-        });
-        return {
-          ticketId: known.ticketId,
-          identifier: known.identifier ?? known.ticketId,
-          url: known.url,
-          created: false,
-        };
-      }
-      const [found] = await deps.searchIssues(known.ticketId);
-      if (found) {
-        await deps.createComment({ issueId: found.id, body: followUpComment(result, args.prUrl) });
-        return {
-          ticketId: found.id,
-          identifier: found.identifier,
-          url: known.url ?? found.url,
-          created: false,
-        };
-      }
+      return {
+        ticketId: known.ticketId,
+        identifier: known.identifier ?? known.ticketId,
+        url: known.url,
+        created: false,
+      };
     }
 
-    const [existing] = await deps.searchIssues(incidentMarker(args.incidentId));
+    const [existing] = await deps.searchIssues(
+      investigationMarker(args.incidentId, args.agentRunId),
+    );
     if (existing) {
-      await deps.createComment({ issueId: existing.id, body: followUpComment(result, args.prUrl) });
       return {
         ticketId: existing.id,
         identifier: existing.identifier,
@@ -178,9 +148,13 @@ export async function deliverLinearTicketWithDeps(
       teamId,
       title: args.incidentTitle,
       description: ticketDescription(
-        { incidentId: args.incidentId, incidentTitle: args.incidentTitle },
+        {
+          incidentId: args.incidentId,
+          agentRunId: args.agentRunId,
+          incidentTitle: args.incidentTitle,
+        },
         result,
-        args.prUrl,
+        args.prUrls,
       ),
     });
     return { ticketId: issue.id, identifier: issue.identifier, url: issue.url, created: true };
@@ -219,10 +193,35 @@ async function resolveAccessToken(ctx: AgentRunContext): Promise<string> {
   return install.accessToken;
 }
 
+export async function postLinearTicketComment(
+  ctx: AgentRunContext,
+  ticketId: string,
+  body: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const install = ctx.linearInstall;
+  if (!install) return { ok: false, error: "Linear is not connected" };
+  try {
+    await createLinearComment({
+      accessToken: await resolveAccessToken(ctx),
+      issueId: ticketId,
+      body,
+    });
+    return { ok: true };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    if (isRevokedTokenError(err)) {
+      await markLinearInstallationNeedsReauth(install.id, `agent PR linking: ${error}`).catch(
+        () => undefined,
+      );
+    }
+    return { ok: false, error };
+  }
+}
+
 export async function deliverLinearTicket(
   ctx: AgentRunContext,
   result: AgentRunResult,
-  opts: { prUrl: string | null },
+  opts: { prUrls: string[] },
 ): Promise<DeliveredLinearTicket | null> {
   // The run may have retitled the incident (applyAgentRunResult) after ctx
   // was loaded; reload so the ticket carries the current title in every
@@ -255,25 +254,25 @@ export async function deliverLinearTicket(
   return deliverLinearTicketWithDeps(
     {
       incidentId: ctx.incident.id,
+      agentRunId: ctx.agentRun.id,
       incidentTitle: ctx.incident.title,
-      policy: ctx.linearTicketPolicy,
       hasInstall: !!install,
       defaultTeamId: ctx.linearDefaultTeamId,
-      prUrl: opts.prUrl,
+      prUrls: opts.prUrls,
     },
     result,
     {
       async findKnownTicket() {
         const row = await db.query.agentLinearTickets.findFirst({
-          where: eq(schema.agentLinearTickets.incidentId, ctx.incident.id),
+          where: eq(schema.agentLinearTickets.agentRunId, ctx.agentRun.id),
         });
         return row
           ? { ticketId: row.ticketId, identifier: row.ticketIdentifier, url: row.url }
           : null;
       },
       searchIssues: async (term) => searchLinearIssues(await resolveTokenOnce(), term),
-      createIssue: async (args) => createLinearIssue({ accessToken: await resolveTokenOnce(), ...args }),
-      createComment: async (args) => createLinearComment({ accessToken: await resolveTokenOnce(), ...args }),
+      createIssue: async (args) =>
+        createLinearIssue({ accessToken: await resolveTokenOnce(), ...args }),
       listTeams: async () => listLinearTeams(await resolveTokenOnce()),
       markNeedsReauth: async (reason) => {
         if (install) await markLinearInstallationNeedsReauth(install.id, reason);

--- a/apps/worker/src/agent-runs/linear-delivery.ts
+++ b/apps/worker/src/agent-runs/linear-delivery.ts
@@ -68,6 +68,10 @@ export function isRevokedTokenError(err: unknown): boolean {
   return /invalid_grant|revoked|unauthorized|401/i.test(msg);
 }
 
+function isLinearIssueUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
 // Should this completion produce/refresh a ticket at all?
 export function linearDeliveryAllowed(args: { hasInstall: boolean }): boolean {
   return args.hasInstall;
@@ -110,6 +114,17 @@ export async function deliverLinearTicketWithDeps(
   try {
     const known = await deps.findKnownTicket();
     if (known) {
+      if (!isLinearIssueUuid(known.ticketId)) {
+        const [resolved] = await deps.searchIssues(known.identifier ?? known.ticketId);
+        if (resolved) {
+          return {
+            ticketId: resolved.id,
+            identifier: resolved.identifier,
+            url: resolved.url ?? known.url,
+            created: false,
+          };
+        }
+      }
       return {
         ticketId: known.ticketId,
         identifier: known.identifier ?? known.ticketId,

--- a/apps/worker/src/agent-runs/linear-handoff.test.ts
+++ b/apps/worker/src/agent-runs/linear-handoff.test.ts
@@ -1,0 +1,112 @@
+import "../agent-run.test-env.js";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { AgentRunResult } from "@superlog/db";
+import {
+  type LinearHandoffReconciliationDeps,
+  reconcileLinearHandoffWithDeps,
+} from "./linear-handoff.js";
+
+const RESULT: AgentRunResult = { state: "complete", summary: "Investigation complete." };
+const TICKET = {
+  ticketId: "linear-uuid",
+  identifier: "ENG-42",
+  url: "https://linear.app/acme/issue/ENG-42",
+  created: false,
+};
+
+function makeDeps(overrides: Partial<LinearHandoffReconciliationDeps> = {}) {
+  const calls = { deliveredPrUrls: [] as string[][], processed: [] as string[][] };
+  return {
+    calls,
+    deps: {
+      deliverTicket: async (_result: AgentRunResult, prUrls: string[]) => {
+        calls.deliveredPrUrls.push(prUrls);
+        return TICKET;
+      },
+      recordTicket: async () => {},
+      linkPullRequests: async () => ({ linkedPullRequests: 2, complete: true }),
+      markProcessed: async (ids: string[]) => {
+        calls.processed.push(ids);
+      },
+      ...overrides,
+    } satisfies LinearHandoffReconciliationDeps,
+  };
+}
+
+test("reconciliation keeps durable work pending when ticket delivery fails", async () => {
+  const { deps, calls } = makeDeps({ deliverTicket: async () => null });
+
+  const ticket = await reconcileLinearHandoffWithDeps(
+    {
+      hasInstall: true,
+      pendingEventIds: ["event-1"],
+      result: RESULT,
+      prUrls: ["https://github.com/acme/api/pull/1"],
+    },
+    deps,
+  );
+
+  assert.equal(ticket, null);
+  assert.deepEqual(calls.processed, []);
+});
+
+test("reconciliation keeps durable work pending when either link direction fails", async () => {
+  const { deps, calls } = makeDeps({
+    linkPullRequests: async () => ({ linkedPullRequests: 0, complete: false }),
+  });
+
+  await reconcileLinearHandoffWithDeps(
+    {
+      hasInstall: true,
+      pendingEventIds: ["event-1"],
+      result: RESULT,
+      prUrls: ["https://github.com/acme/api/pull/1"],
+    },
+    deps,
+  );
+
+  assert.deepEqual(calls.processed, []);
+});
+
+test("reconciliation links every PR and completes the durable work item", async () => {
+  const { deps, calls } = makeDeps();
+  const prUrls = ["https://github.com/acme/api/pull/1", "https://github.com/acme/web/pull/2"];
+
+  const ticket = await reconcileLinearHandoffWithDeps(
+    {
+      hasInstall: true,
+      pendingEventIds: ["event-1", "event-2"],
+      result: RESULT,
+      prUrls,
+    },
+    deps,
+  );
+
+  assert.equal(ticket, TICKET);
+  assert.deepEqual(calls.deliveredPrUrls, [prUrls]);
+  assert.deepEqual(calls.processed, [["event-1", "event-2"]]);
+});
+
+test("disconnected Linear marks the handoff as reconciled without provider calls", async () => {
+  let delivered = false;
+  const { deps, calls } = makeDeps({
+    deliverTicket: async () => {
+      delivered = true;
+      return TICKET;
+    },
+  });
+
+  await reconcileLinearHandoffWithDeps(
+    {
+      hasInstall: false,
+      pendingEventIds: ["event-1"],
+      result: RESULT,
+      prUrls: [],
+    },
+    deps,
+  );
+
+  assert.equal(delivered, false);
+  assert.deepEqual(calls.processed, [["event-1"]]);
+});

--- a/apps/worker/src/agent-runs/linear-handoff.ts
+++ b/apps/worker/src/agent-runs/linear-handoff.ts
@@ -1,0 +1,161 @@
+import { type AgentRunResult, db, schema } from "@superlog/db";
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
+import type { AgentRunContext } from "../agent-run-context.js";
+import { logger } from "../logger.js";
+import { recordFiledLinearTicket } from "./deliverable-records.js";
+import { dispatchAgentRunJob } from "./enqueue.js";
+import { type DeliveredLinearTicket, deliverLinearTicket } from "./linear-delivery.js";
+import { linkLinearTicketToPullRequests } from "./linear-pr-linking.js";
+
+export const LINEAR_HANDOFF_PENDING_EVENT = "linear_handoff_pending";
+
+export type LinearHandoffReconciliationDeps = {
+  deliverTicket(result: AgentRunResult, prUrls: string[]): Promise<DeliveredLinearTicket | null>;
+  recordTicket(ticket: DeliveredLinearTicket): Promise<void>;
+  linkPullRequests(
+    ticket: DeliveredLinearTicket,
+    prUrls: string[],
+  ): Promise<{ linkedPullRequests: number; complete: boolean }>;
+  markProcessed(ids: string[]): Promise<void>;
+};
+
+export async function reconcileLinearHandoffWithDeps(
+  input: {
+    hasInstall: boolean;
+    pendingEventIds: string[];
+    result: AgentRunResult;
+    prUrls: string[];
+  },
+  deps: LinearHandoffReconciliationDeps,
+): Promise<DeliveredLinearTicket | null> {
+  if (input.pendingEventIds.length === 0) return null;
+  if (!input.hasInstall) {
+    await deps.markProcessed(input.pendingEventIds);
+    return null;
+  }
+
+  const ticket = await deps.deliverTicket(input.result, input.prUrls);
+  if (!ticket) return null;
+  await deps.recordTicket(ticket);
+  const linking = await deps.linkPullRequests(ticket, input.prUrls);
+  if (!linking.complete) return ticket;
+  await deps.markProcessed(input.pendingEventIds);
+  return ticket;
+}
+
+function resultFromPendingEvent(
+  events: Array<Pick<schema.IncidentEvent, "detail">>,
+  fallback: AgentRunResult | null,
+  incident: Pick<schema.Incident, "agentSummary" | "title">,
+): AgentRunResult {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const result = events[index]?.detail?.result;
+    if (
+      result &&
+      typeof result === "object" &&
+      typeof (result as AgentRunResult).summary === "string"
+    ) {
+      return result as AgentRunResult;
+    }
+  }
+  return fallback ?? { state: "complete", summary: incident.agentSummary ?? incident.title };
+}
+
+export async function reconcilePendingLinearHandoff(
+  ctx: AgentRunContext,
+): Promise<DeliveredLinearTicket | null> {
+  const pending = await db.query.incidentEvents.findMany({
+    where: and(
+      eq(schema.incidentEvents.agentRunId, ctx.agentRun.id),
+      eq(schema.incidentEvents.kind, LINEAR_HANDOFF_PENDING_EVENT),
+      isNull(schema.incidentEvents.processedAt),
+    ),
+    orderBy: [asc(schema.incidentEvents.createdAt)],
+    columns: { id: true, detail: true },
+  });
+  if (pending.length === 0) return null;
+
+  const pullRequests = await db.query.agentPullRequests.findMany({
+    where: eq(schema.agentPullRequests.incidentId, ctx.incident.id),
+    columns: { url: true },
+  });
+  const prUrls = [...new Set(pullRequests.map((pr) => pr.url).filter(Boolean))];
+  const result = resultFromPendingEvent(pending, ctx.agentRun.result, ctx.incident);
+
+  try {
+    return await reconcileLinearHandoffWithDeps(
+      {
+        hasInstall: !!ctx.linearInstall,
+        pendingEventIds: pending.map((event) => event.id),
+        result,
+        prUrls,
+      },
+      {
+        deliverTicket: (handoffResult, urls) =>
+          deliverLinearTicket(ctx, handoffResult, { prUrls: urls }),
+        recordTicket: (ticket) =>
+          recordFiledLinearTicket(
+            ctx,
+            {
+              id: ticket.ticketId,
+              url: ticket.url,
+              createdByAgent: ticket.created,
+            },
+            { identifier: ticket.identifier },
+          ),
+        linkPullRequests: (ticket, urls) => linkLinearTicketToPullRequests(ctx, ticket, urls),
+        markProcessed: async (ids) => {
+          await db
+            .update(schema.incidentEvents)
+            .set({ processedAt: new Date() })
+            .where(inArray(schema.incidentEvents.id, ids));
+        },
+      },
+    );
+  } catch (err) {
+    logger.warn(
+      {
+        scope: "agent_run.linear_handoff",
+        agent_run_id: ctx.agentRun.id,
+        incident_id: ctx.incident.id,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "Linear handoff reconciliation failed; leaving durable work pending",
+    );
+    return null;
+  }
+}
+
+export async function scheduleLinearHandoff(
+  ctx: AgentRunContext,
+  result: AgentRunResult,
+  boundary: string,
+): Promise<DeliveredLinearTicket | null> {
+  await db
+    .insert(schema.incidentEvents)
+    .values({
+      agentRunId: ctx.agentRun.id,
+      incidentId: ctx.incident.id,
+      kind: LINEAR_HANDOFF_PENDING_EVENT,
+      summary: "Linear handoff pending reconciliation.",
+      detail: { result },
+      providerEventId: `linear_handoff:${boundary}`,
+    })
+    .onConflictDoNothing();
+  await dispatchAgentRunJob(ctx.agentRun.id).catch(() => undefined);
+  return reconcilePendingLinearHandoff(ctx);
+}
+
+export async function listPendingLinearHandoffRunIds(limit = 500): Promise<string[]> {
+  const rows = await db
+    .selectDistinct({ agentRunId: schema.incidentEvents.agentRunId })
+    .from(schema.incidentEvents)
+    .where(
+      and(
+        eq(schema.incidentEvents.kind, LINEAR_HANDOFF_PENDING_EVENT),
+        isNull(schema.incidentEvents.processedAt),
+      ),
+    )
+    .limit(limit);
+  return rows.map((row) => row.agentRunId).filter((id): id is string => typeof id === "string");
+}

--- a/apps/worker/src/agent-runs/linear-pr-linking.test.ts
+++ b/apps/worker/src/agent-runs/linear-pr-linking.test.ts
@@ -73,7 +73,7 @@ test("cross-links each pull request and the Linear ticket", async () => {
     log: () => {},
   });
 
-  assert.equal(linked, 2);
+  assert.deepEqual(linked, { linkedPullRequests: 2, complete: true });
   assert.deepEqual(postedToGithub, PRS);
   assert.deepEqual(postedToLinear, PRS);
 });
@@ -96,7 +96,7 @@ test("does not post again when a pull request already has the ticket link", asyn
     log: () => {},
   });
 
-  assert.equal(linked, 0);
+  assert.deepEqual(linked, { linkedPullRequests: 0, complete: true });
   assert.equal(posted, false);
 });
 
@@ -114,6 +114,6 @@ test("releases a failed claim so a later sync can retry the comment", async () =
     log: () => {},
   });
 
-  assert.equal(linked, 0);
+  assert.deepEqual(linked, { linkedPullRequests: 0, complete: false });
   assert.deepEqual(released, ["pr-row-1:linear-uuid"]);
 });

--- a/apps/worker/src/agent-runs/linear-pr-linking.test.ts
+++ b/apps/worker/src/agent-runs/linear-pr-linking.test.ts
@@ -1,0 +1,119 @@
+import "../agent-run.test-env.js";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  type PullRequestTicketLinkTarget,
+  linearTicketPrComment,
+  linearTicketSlackReference,
+  linkLinearTicketToPullRequestsWithDeps,
+  pullRequestLinearComment,
+} from "./linear-pr-linking.js";
+
+const TICKET = {
+  ticketId: "linear-uuid",
+  identifier: "ENG-42",
+  url: "https://linear.app/acme/issue/ENG-42",
+  created: true,
+};
+
+const PRS: PullRequestTicketLinkTarget[] = [
+  {
+    id: "pr-row-1",
+    installationId: 123,
+    repoFullName: "acme/api",
+    prNumber: 10,
+    url: "https://github.com/acme/api/pull/10",
+  },
+  {
+    id: "pr-row-2",
+    installationId: 456,
+    repoFullName: "acme/web",
+    prNumber: 20,
+    url: "https://github.com/acme/web/pull/20",
+  },
+];
+
+test("Linear ticket PR comment contains a clickable ticket link", () => {
+  assert.equal(
+    linearTicketPrComment(TICKET),
+    "Tracking this investigation in Linear: [ENG-42](https://linear.app/acme/issue/ENG-42)",
+  );
+});
+
+test("Linear ticket Slack reference is clickable", () => {
+  assert.equal(
+    linearTicketSlackReference(TICKET),
+    "Linear: <https://linear.app/acme/issue/ENG-42|ENG-42>",
+  );
+});
+
+test("Linear receives a clickable pull request reference", () => {
+  assert.equal(
+    pullRequestLinearComment(PRS[0]!),
+    "Pull request: [acme/api#10](https://github.com/acme/api/pull/10)",
+  );
+});
+
+test("cross-links each pull request and the Linear ticket", async () => {
+  const postedToGithub: PullRequestTicketLinkTarget[] = [];
+  const postedToLinear: PullRequestTicketLinkTarget[] = [];
+  const linked = await linkLinearTicketToPullRequestsWithDeps(TICKET, PRS, {
+    claimGithub: async () => true,
+    releaseGithub: async () => assert.fail("successful links must retain their claims"),
+    postGithubComment: async (pr) => {
+      postedToGithub.push(pr);
+      return { ok: true };
+    },
+    claimLinear: async () => true,
+    releaseLinear: async () => assert.fail("successful links must retain their claims"),
+    postLinearComment: async (pr) => {
+      postedToLinear.push(pr);
+      return { ok: true };
+    },
+    log: () => {},
+  });
+
+  assert.equal(linked, 2);
+  assert.deepEqual(postedToGithub, PRS);
+  assert.deepEqual(postedToLinear, PRS);
+});
+
+test("does not post again when a pull request already has the ticket link", async () => {
+  let posted = false;
+  const linked = await linkLinearTicketToPullRequestsWithDeps(TICKET, PRS.slice(0, 1), {
+    claimGithub: async () => false,
+    releaseGithub: async () => {},
+    postGithubComment: async () => {
+      posted = true;
+      return { ok: true };
+    },
+    claimLinear: async () => false,
+    releaseLinear: async () => {},
+    postLinearComment: async () => {
+      posted = true;
+      return { ok: true };
+    },
+    log: () => {},
+  });
+
+  assert.equal(linked, 0);
+  assert.equal(posted, false);
+});
+
+test("releases a failed claim so a later sync can retry the comment", async () => {
+  const released: string[] = [];
+  const linked = await linkLinearTicketToPullRequestsWithDeps(TICKET, PRS.slice(0, 1), {
+    claimGithub: async () => true,
+    releaseGithub: async (pr, ticket) => {
+      released.push(`${pr.id}:${ticket.ticketId}`);
+    },
+    postGithubComment: async () => ({ ok: false, error: "GitHub unavailable" }),
+    claimLinear: async () => false,
+    releaseLinear: async () => {},
+    postLinearComment: async () => ({ ok: true }),
+    log: () => {},
+  });
+
+  assert.equal(linked, 0);
+  assert.deepEqual(released, ["pr-row-1:linear-uuid"]);
+});

--- a/apps/worker/src/agent-runs/linear-pr-linking.ts
+++ b/apps/worker/src/agent-runs/linear-pr-linking.ts
@@ -53,14 +53,16 @@ export async function linkLinearTicketToPullRequestsWithDeps(
   ticket: DeliveredLinearTicket,
   pullRequests: PullRequestTicketLinkTarget[],
   deps: LinearPrLinkingDeps,
-): Promise<number> {
+): Promise<{ linkedPullRequests: number; complete: boolean }> {
   let linked = 0;
+  let complete = true;
   for (const pr of pullRequests) {
     if (await deps.claimGithub(pr, ticket)) {
       const result = await deps.postGithubComment(pr, linearTicketPrComment(ticket));
       if (result.ok) {
         linked += 1;
       } else {
+        complete = false;
         await deps.releaseGithub(pr, ticket);
         deps.log(
           {
@@ -78,6 +80,7 @@ export async function linkLinearTicketToPullRequestsWithDeps(
     if (await deps.claimLinear(pr, ticket)) {
       const result = await deps.postLinearComment(pr, pullRequestLinearComment(pr));
       if (!result.ok) {
+        complete = false;
         await deps.releaseLinear(pr, ticket);
         deps.log(
           {
@@ -93,7 +96,7 @@ export async function linkLinearTicketToPullRequestsWithDeps(
       }
     }
   }
-  return linked;
+  return { linkedPullRequests: linked, complete };
 }
 
 function providerEventId(direction: "github" | "linear", ticket: DeliveredLinearTicket): string {
@@ -104,8 +107,8 @@ export async function linkLinearTicketToPullRequests(
   ctx: AgentRunContext,
   ticket: DeliveredLinearTicket,
   prUrls: string[],
-): Promise<number> {
-  if (prUrls.length === 0) return 0;
+): Promise<{ linkedPullRequests: number; complete: boolean }> {
+  if (prUrls.length === 0) return { linkedPullRequests: 0, complete: true };
   const pullRequests = await db
     .select({
       id: schema.agentPullRequests.id,

--- a/apps/worker/src/agent-runs/linear-pr-linking.ts
+++ b/apps/worker/src/agent-runs/linear-pr-linking.ts
@@ -1,0 +1,200 @@
+import { db, schema } from "@superlog/db";
+import { and, eq, inArray } from "drizzle-orm";
+import type { AgentRunContext } from "../agent-run-context.js";
+import { postAgentPrComment } from "../github-app.js";
+import { logger } from "../logger.js";
+import { type DeliveredLinearTicket, postLinearTicketComment } from "./linear-delivery.js";
+
+export type PullRequestTicketLinkTarget = {
+  id: string;
+  installationId: number;
+  repoFullName: string;
+  prNumber: number;
+  url: string;
+};
+
+export type LinearPrLinkingDeps = {
+  claimGithub(pr: PullRequestTicketLinkTarget, ticket: DeliveredLinearTicket): Promise<boolean>;
+  releaseGithub(pr: PullRequestTicketLinkTarget, ticket: DeliveredLinearTicket): Promise<void>;
+  postGithubComment(
+    pr: PullRequestTicketLinkTarget,
+    body: string,
+  ): Promise<{ ok: true } | { ok: false; error: string }>;
+  claimLinear(pr: PullRequestTicketLinkTarget, ticket: DeliveredLinearTicket): Promise<boolean>;
+  releaseLinear(pr: PullRequestTicketLinkTarget, ticket: DeliveredLinearTicket): Promise<void>;
+  postLinearComment(
+    pr: PullRequestTicketLinkTarget,
+    body: string,
+  ): Promise<{ ok: true } | { ok: false; error: string }>;
+  log(fields: Record<string, unknown>, message: string): void;
+};
+
+export function linearTicketPrComment(ticket: DeliveredLinearTicket): string {
+  const ticketRef = ticket.url ? `[${ticket.identifier}](${ticket.url})` : ticket.identifier;
+  return `Tracking this investigation in Linear: ${ticketRef}`;
+}
+
+export function pullRequestLinearComment(pr: PullRequestTicketLinkTarget): string {
+  return `Pull request: [${pr.repoFullName}#${pr.prNumber}](${pr.url})`;
+}
+
+export function linearTicketSlackReference(ticket: {
+  identifier: string;
+  url: string | null;
+}): string {
+  return ticket.url
+    ? `Linear: <${ticket.url}|${ticket.identifier}>`
+    : `Linear: ${ticket.identifier}`;
+}
+
+// The event claim gives each (PR, ticket) pair a durable idempotency key. A
+// failed provider call releases its claim so a later sync can retry it.
+export async function linkLinearTicketToPullRequestsWithDeps(
+  ticket: DeliveredLinearTicket,
+  pullRequests: PullRequestTicketLinkTarget[],
+  deps: LinearPrLinkingDeps,
+): Promise<number> {
+  let linked = 0;
+  for (const pr of pullRequests) {
+    if (await deps.claimGithub(pr, ticket)) {
+      const result = await deps.postGithubComment(pr, linearTicketPrComment(ticket));
+      if (result.ok) {
+        linked += 1;
+      } else {
+        await deps.releaseGithub(pr, ticket);
+        deps.log(
+          {
+            direction: "linear_to_github",
+            agent_pr_id: pr.id,
+            repo: pr.repoFullName,
+            pr_number: pr.prNumber,
+            linear_ticket_id: ticket.ticketId,
+            error: result.error,
+          },
+          "failed to link Linear ticket from PR; released claim for retry",
+        );
+      }
+    }
+    if (await deps.claimLinear(pr, ticket)) {
+      const result = await deps.postLinearComment(pr, pullRequestLinearComment(pr));
+      if (!result.ok) {
+        await deps.releaseLinear(pr, ticket);
+        deps.log(
+          {
+            direction: "github_to_linear",
+            agent_pr_id: pr.id,
+            repo: pr.repoFullName,
+            pr_number: pr.prNumber,
+            linear_ticket_id: ticket.ticketId,
+            error: result.error,
+          },
+          "failed to link PR from Linear ticket; released claim for retry",
+        );
+      }
+    }
+  }
+  return linked;
+}
+
+function providerEventId(direction: "github" | "linear", ticket: DeliveredLinearTicket): string {
+  return `${direction}_ticket_linked:${ticket.ticketId}`;
+}
+
+export async function linkLinearTicketToPullRequests(
+  ctx: AgentRunContext,
+  ticket: DeliveredLinearTicket,
+  prUrls: string[],
+): Promise<number> {
+  if (prUrls.length === 0) return 0;
+  const pullRequests = await db
+    .select({
+      id: schema.agentPullRequests.id,
+      installationId: schema.githubInstallations.installationId,
+      repoFullName: schema.agentPullRequests.repoFullName,
+      prNumber: schema.agentPullRequests.prNumber,
+      url: schema.agentPullRequests.url,
+    })
+    .from(schema.agentPullRequests)
+    .innerJoin(
+      schema.githubInstallations,
+      eq(schema.githubInstallations.id, schema.agentPullRequests.installationId),
+    )
+    .where(
+      and(
+        eq(schema.agentPullRequests.incidentId, ctx.incident.id),
+        inArray(schema.agentPullRequests.url, prUrls),
+      ),
+    );
+
+  return linkLinearTicketToPullRequestsWithDeps(ticket, pullRequests, {
+    async claimGithub(pr, deliveredTicket) {
+      const inserted = await db
+        .insert(schema.agentPrEvents)
+        .values({
+          agentPrId: pr.id,
+          kind: "linear_ticket_linked",
+          summary: `Linked Linear ticket ${deliveredTicket.identifier}`,
+          payload: {
+            ticketId: deliveredTicket.ticketId,
+            identifier: deliveredTicket.identifier,
+            url: deliveredTicket.url,
+          },
+          providerEventId: providerEventId("github", deliveredTicket),
+          occurredAt: new Date(),
+        })
+        .onConflictDoNothing()
+        .returning({ id: schema.agentPrEvents.id });
+      return inserted.length > 0;
+    },
+    async releaseGithub(pr, deliveredTicket) {
+      await db
+        .delete(schema.agentPrEvents)
+        .where(
+          and(
+            eq(schema.agentPrEvents.agentPrId, pr.id),
+            eq(schema.agentPrEvents.providerEventId, providerEventId("github", deliveredTicket)),
+          ),
+        );
+    },
+    postGithubComment: (pr, body) =>
+      postAgentPrComment({
+        installationId: pr.installationId,
+        repoFullName: pr.repoFullName,
+        prNumber: pr.prNumber,
+        body,
+      }),
+    async claimLinear(pr, deliveredTicket) {
+      const inserted = await db
+        .insert(schema.agentPrEvents)
+        .values({
+          agentPrId: pr.id,
+          kind: "pr_linked_to_linear",
+          summary: `Linked PR #${pr.prNumber} from Linear ticket ${deliveredTicket.identifier}`,
+          payload: {
+            ticketId: deliveredTicket.ticketId,
+            identifier: deliveredTicket.identifier,
+            ticketUrl: deliveredTicket.url,
+            prUrl: pr.url,
+          },
+          providerEventId: providerEventId("linear", deliveredTicket),
+          occurredAt: new Date(),
+        })
+        .onConflictDoNothing()
+        .returning({ id: schema.agentPrEvents.id });
+      return inserted.length > 0;
+    },
+    async releaseLinear(pr, deliveredTicket) {
+      await db
+        .delete(schema.agentPrEvents)
+        .where(
+          and(
+            eq(schema.agentPrEvents.agentPrId, pr.id),
+            eq(schema.agentPrEvents.providerEventId, providerEventId("linear", deliveredTicket)),
+          ),
+        );
+    },
+    postLinearComment: (_pr, body) => postLinearTicketComment(ctx, ticket.ticketId, body),
+    log: (fields, message) =>
+      logger.warn({ scope: "agent_run.linear_pr_link", ...fields }, message),
+  });
+}

--- a/apps/worker/src/agent-runs/outcome-actions.ts
+++ b/apps/worker/src/agent-runs/outcome-actions.ts
@@ -77,7 +77,7 @@ export function createOutcomeActionExecutor(
     // unacked (the backend's dispatch loop also guards this, but the contract
     // shouldn't depend on it).
     try {
-      return await executeValidatedCall(ctx, sessionId, validated);
+      return await executeValidatedCall(ctx, sessionId, validated, call.findings);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logger.error(
@@ -93,6 +93,7 @@ async function executeValidatedCall(
   ctx: AgentRunContext,
   sessionId: string,
   validated: Extract<ReturnType<typeof validateOutcomeToolInput>, { ok: true }>,
+  findings: OutcomeActionCall["findings"],
 ): Promise<OutcomeActionExecution> {
   switch (validated.tool) {
     case "propose_pr": {
@@ -109,7 +110,7 @@ async function executeValidatedCall(
           },
         };
       }
-      const delivery = await deliverProposedPullRequest(ctx, payload, sessionId);
+      const delivery = await deliverProposedPullRequest(ctx, payload, sessionId, findings);
       if (!delivery.ok) {
         return { handled: true, ok: false, payload: { ok: false, errors: [delivery.error] } };
       }

--- a/apps/worker/src/agent-runs/pr-delivery.ts
+++ b/apps/worker/src/agent-runs/pr-delivery.ts
@@ -24,8 +24,9 @@ import {
 import { logger } from "../logger.js";
 import { enqueueAgentRunCompleted } from "../webhooks.js";
 import { recordFiledLinearTicket, recordOpenedAgentPullRequest } from "./deliverable-records.js";
-import { type DeliveredLinearTicket, deliverLinearTicket } from "./linear-delivery.js";
-import { linearTicketSlackReference, linkLinearTicketToPullRequests } from "./linear-pr-linking.js";
+import type { DeliveredLinearTicket } from "./linear-delivery.js";
+import { scheduleLinearHandoff } from "./linear-handoff.js";
+import { linearTicketSlackReference } from "./linear-pr-linking.js";
 import { buildPrBody, buildPrTitle } from "./pr-copy.js";
 import { summarizePrOpenFailure } from "./pr-open-failure.js";
 import { failAgentRun } from "./status.js";
@@ -63,20 +64,8 @@ async function deliverAndRecordLinearTicket(
   prUrl: string,
 ): Promise<DeliveredLinearTicket | null> {
   try {
-    const ticket = await deliverLinearTicket(ctx, result, { prUrls: [] });
-    if (ticket) {
-      await recordFiledLinearTicket(
-        ctx,
-        {
-          id: ticket.ticketId,
-          url: ticket.url,
-          createdByAgent: ticket.created,
-        },
-        { identifier: ticket.identifier },
-      );
-      await linkLinearTicketToPullRequests(ctx, ticket, [prUrl]);
-      return ticket;
-    }
+    const ticket = await scheduleLinearHandoff(ctx, result, `pr:${prUrl}`);
+    if (ticket) return ticket;
     if (result.linearTicket) {
       // Legacy in-flight run finishing on the old contract: preserve its
       // self-reported ticket link.

--- a/apps/worker/src/agent-runs/pr-delivery.ts
+++ b/apps/worker/src/agent-runs/pr-delivery.ts
@@ -6,6 +6,7 @@ import {
   schema,
 } from "@superlog/db";
 import { and, desc, eq } from "drizzle-orm";
+import { type AgentRunFindings, assembleAgentRunResult } from "../agent-outcome-tools.js";
 import {
   type AgentRunContext,
   type InstalledGithubRepo,
@@ -23,7 +24,8 @@ import {
 import { logger } from "../logger.js";
 import { enqueueAgentRunCompleted } from "../webhooks.js";
 import { recordFiledLinearTicket, recordOpenedAgentPullRequest } from "./deliverable-records.js";
-import { deliverLinearTicket } from "./linear-delivery.js";
+import { type DeliveredLinearTicket, deliverLinearTicket } from "./linear-delivery.js";
+import { linearTicketSlackReference, linkLinearTicketToPullRequests } from "./linear-pr-linking.js";
 import { buildPrBody, buildPrTitle } from "./pr-copy.js";
 import { summarizePrOpenFailure } from "./pr-open-failure.js";
 import { failAgentRun } from "./status.js";
@@ -52,16 +54,16 @@ function buildFollowUpPrComment(ctx: AgentRunContext, result: AgentRunResult): s
   return lines.join("\n");
 }
 
-// Files/updates the incident's Linear ticket from the run result (platform-
-// side, deterministic) and records it. Best-effort: PR delivery never fails
-// on ticket problems.
+// Files/reuses this run's Linear ticket from the result (platform-side,
+// deterministic) and records it. Best-effort: PR delivery never fails on
+// ticket problems.
 async function deliverAndRecordLinearTicket(
   ctx: AgentRunContext,
   result: AgentRunResult,
   prUrl: string,
-): Promise<void> {
+): Promise<DeliveredLinearTicket | null> {
   try {
-    const ticket = await deliverLinearTicket(ctx, result, { prUrl });
+    const ticket = await deliverLinearTicket(ctx, result, { prUrls: [] });
     if (ticket) {
       await recordFiledLinearTicket(
         ctx,
@@ -72,7 +74,10 @@ async function deliverAndRecordLinearTicket(
         },
         { identifier: ticket.identifier },
       );
-    } else if (result.linearTicket) {
+      await linkLinearTicketToPullRequests(ctx, ticket, [prUrl]);
+      return ticket;
+    }
+    if (result.linearTicket) {
       // Legacy in-flight run finishing on the old contract: preserve its
       // self-reported ticket link.
       await recordFiledLinearTicket(ctx, result.linearTicket);
@@ -88,12 +93,18 @@ async function deliverAndRecordLinearTicket(
       "failed to deliver/record Linear ticket",
     );
   }
+  return null;
 }
 
-async function notifyFollowUpPrUpdated(ctx: AgentRunContext, prUrl: string): Promise<void> {
+async function notifyFollowUpPrUpdated(
+  ctx: AgentRunContext,
+  prUrl: string,
+  ticket: DeliveredLinearTicket | null,
+): Promise<void> {
+  const ticketLine = ticket ? `\n${linearTicketSlackReference(ticket)}` : "";
   await postIncidentThreadMessage(
     ctx.incident.id,
-    `:arrows_counterclockwise: Follow-up investigation pushed an update to the existing PR: ${prUrl}`,
+    `:arrows_counterclockwise: Follow-up investigation pushed an update to the existing PR: ${prUrl}${ticketLine}`,
   );
 }
 
@@ -287,8 +298,8 @@ export async function completeWithPullRequest(
           "failed to enqueue agent run.completed webhook",
         ),
       );
-      await deliverAndRecordLinearTicket(ctx, result, existingPr.url);
-      await notifyFollowUpPrUpdated(ctx, existingPr.url).catch((err) =>
+      const linearTicket = await deliverAndRecordLinearTicket(ctx, result, existingPr.url);
+      await notifyFollowUpPrUpdated(ctx, existingPr.url, linearTicket).catch((err) =>
         logger.warn(
           {
             scope: "agent_run.pr_delivery",
@@ -468,7 +479,7 @@ export async function completeWithPullRequest(
       ).catch(() => {});
     }
   }
-  await deliverAndRecordLinearTicket(ctx, result, opened.prUrl);
+  const linearTicket = await deliverAndRecordLinearTicket(ctx, result, opened.prUrl);
   logger.info(
     {
       scope: "agent_run",
@@ -481,18 +492,21 @@ export async function completeWithPullRequest(
     },
     "agent run complete (pr opened)",
   );
-  await postIncidentThreadMessage(ctx.incident.id, `:bulb: Opened PR ${opened.prUrl}`).catch(
-    (err) =>
-      logger.error(
-        {
-          scope: "agent_run.pr_delivery",
-          agent_run_id: ctx.agentRun.id,
-          incident_id: ctx.incident.id,
-          pr_url: opened.prUrl,
-          err: err instanceof Error ? err.message : String(err),
-        },
-        "failed to post PR-ready Slack thread message",
-      ),
+  const ticketLine = linearTicket ? `\n${linearTicketSlackReference(linearTicket)}` : "";
+  await postIncidentThreadMessage(
+    ctx.incident.id,
+    `:bulb: Opened PR ${opened.prUrl}${ticketLine}`,
+  ).catch((err) =>
+    logger.error(
+      {
+        scope: "agent_run.pr_delivery",
+        agent_run_id: ctx.agentRun.id,
+        incident_id: ctx.incident.id,
+        pr_url: opened.prUrl,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "failed to post PR-ready Slack thread message",
+    ),
   );
   const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
   await updateIncidentMainMessage(
@@ -507,7 +521,10 @@ export async function completeWithPullRequest(
       projectName: ctx.project.name,
       service: ctx.incident.service,
       buttons: [],
-      links: [{ text: "View PR", url: opened.prUrl }],
+      links: [
+        { text: "View PR", url: opened.prUrl },
+        ...(linearTicket?.url ? [{ text: "View ticket", url: linearTicket.url }] : []),
+      ],
       incidentId: ctx.incident.id,
       showResolveButton: true,
       showMergePrButton: true,
@@ -560,6 +577,7 @@ export async function deliverProposedPullRequest(
     patchFilePath: string;
   },
   sessionId: string,
+  findings: AgentRunFindings | null,
 ): Promise<MidRunPrDeliveryResult> {
   if (ctx.prPolicy === "never") {
     return {
@@ -617,6 +635,11 @@ export async function deliverProposedPullRequest(
     result: { summary: pr.body },
     pr,
   });
+  const ticketResult = assembleAgentRunResult({
+    findings: findings ?? { summary: pr.title },
+    terminal: null,
+    actions: [],
+  });
 
   // Same branch on the same repo for this incident → push a follow-up commit
   // to the existing open PR instead of opening a duplicate.
@@ -651,9 +674,11 @@ export async function deliverProposedPullRequest(
       .update(schema.agentPullRequests)
       .set({ headSha: pushed.headSha, lastSyncedAt: now, updatedAt: now })
       .where(eq(schema.agentPullRequests.id, existingPr.id));
+    const linearTicket = await deliverAndRecordLinearTicket(ctx, ticketResult, existingPr.url);
+    const ticketLine = linearTicket ? `\n${linearTicketSlackReference(linearTicket)}` : "";
     await postIncidentThreadMessage(
       ctx.incident.id,
-      `:arrows_counterclockwise: Pushed an update to PR ${existingPr.url}`,
+      `:arrows_counterclockwise: Pushed an update to PR ${existingPr.url}${ticketLine}`,
     ).catch(() => {});
     return {
       ok: true,
@@ -726,6 +751,11 @@ export async function deliverProposedPullRequest(
     detail: { url: opened.prUrl },
   });
 
+  // The first successfully-recorded PR is the ticket creation boundary.
+  // Later PRs reuse the run-scoped ticket, then independently cross-link in
+  // both directions.
+  const linearTicket = await deliverAndRecordLinearTicket(ctx, ticketResult, opened.prUrl);
+
   if (ctx.autoMergeFixPrs !== "never") {
     try {
       const outcome = await mergeAgentPullRequest({
@@ -744,7 +774,8 @@ export async function deliverProposedPullRequest(
             ? `:hourglass_flowing_sand: Auto-merge enabled — will land once checks pass (${ctx.autoMergeMethod})`
             : null;
       if (note) {
-        await postIncidentThreadMessage(ctx.incident.id, note).catch(() => {});
+        const ticketLine = linearTicket ? `\n${linearTicketSlackReference(linearTicket)}` : "";
+        await postIncidentThreadMessage(ctx.incident.id, `${note}${ticketLine}`).catch(() => {});
       }
     } catch (err) {
       logger.warn(
@@ -760,9 +791,11 @@ export async function deliverProposedPullRequest(
     }
   }
 
-  await postIncidentThreadMessage(ctx.incident.id, `:bulb: Opened PR ${opened.prUrl}`).catch(
-    () => {},
-  );
+  const ticketLine = linearTicket ? `\n${linearTicketSlackReference(linearTicket)}` : "";
+  await postIncidentThreadMessage(
+    ctx.incident.id,
+    `:bulb: Opened PR ${opened.prUrl}${ticketLine}`,
+  ).catch(() => {});
   const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
   await updateIncidentMainMessage(
     ctx.incident.id,
@@ -777,6 +810,15 @@ export async function deliverProposedPullRequest(
       buttons: [
         { text: "Open in Superlog", url: incidentUrl, actionId: "open_superlog" },
         { text: "View PR", url: opened.prUrl, actionId: "view_pr" },
+        ...(linearTicket?.url
+          ? [
+              {
+                text: `View ${linearTicket.identifier}`,
+                url: linearTicket.url,
+                actionId: "view_linear",
+              },
+            ]
+          : []),
       ],
       incidentId: ctx.incident.id,
       showResolveButton: true,

--- a/apps/worker/src/agent-runs/queue-wiring.ts
+++ b/apps/worker/src/agent-runs/queue-wiring.ts
@@ -5,6 +5,7 @@ import { asc, inArray } from "drizzle-orm";
 import { loadAgentRunContext } from "../agent-run-context.js";
 import { ACTIVE_STATES, createAgentRunLifecycle } from "../agent-run.js";
 import { setAgentRunJobDispatch } from "./enqueue.js";
+import { listPendingLinearHandoffRunIds, reconcilePendingLinearHandoff } from "./linear-handoff.js";
 import { retryQueuedPullRequestDelivery } from "./pr-delivery.js";
 import { type AgentRunQueueBoss, createAgentRunJobSender, registerAgentRunQueue } from "./queue.js";
 import { resumeAgentRunFromHumanInput } from "./resume.js";
@@ -36,14 +37,20 @@ export async function startAgentRunQueue(boss: AgentRunQueueBoss): Promise<void>
       });
     },
     listActiveRunIds: async () => {
-      const rows = await db
-        .select({ id: schema.agentRuns.id })
-        .from(schema.agentRuns)
-        .where(inArray(schema.agentRuns.state, [...ACTIVE_STATES]))
-        .orderBy(asc(schema.agentRuns.updatedAt));
-      return rows.map((row) => row.id);
+      const [rows, pendingHandoffs] = await Promise.all([
+        db
+          .select({ id: schema.agentRuns.id })
+          .from(schema.agentRuns)
+          .where(inArray(schema.agentRuns.state, [...ACTIVE_STATES]))
+          .orderBy(asc(schema.agentRuns.updatedAt)),
+        listPendingLinearHandoffRunIds(),
+      ]);
+      return [...new Set([...rows.map((row) => row.id), ...pendingHandoffs])];
     },
     handlers: {
+      reconcileHandoff: async (ctx) => {
+        await reconcilePendingLinearHandoff(ctx);
+      },
       start: startQueuedAgentRun,
       sync: syncRunningAgentRun,
       resume: resumeAgentRunFromHumanInput,

--- a/apps/worker/src/agent-runs/queue.test.ts
+++ b/apps/worker/src/agent-runs/queue.test.ts
@@ -78,6 +78,7 @@ function makeDeps(overrides: DepsOverrides = {}) {
       }),
     listActiveRunIds: overrides.listActiveRunIds ?? (async () => []),
     handlers: {
+      reconcileHandoff: overrides.handlers?.reconcileHandoff ?? handler("reconcile_handoff"),
       start: overrides.handlers?.start ?? handler("start"),
       sync: overrides.handlers?.sync ?? handler("sync"),
       resume: overrides.handlers?.resume ?? handler("resume"),
@@ -135,11 +136,15 @@ test("advance worker dispatches by run state", async () => {
     const worker = fb.workers.get(AGENT_RUN_ADVANCE_QUEUE);
     assert.ok(worker);
     await worker([{ id: "job-1", data: { agentRunId: "run-1" } }]);
-    assert.deepEqual(calls, [expected], `state ${state} must dispatch ${expected}`);
+    assert.deepEqual(
+      calls,
+      ["reconcile_handoff", expected],
+      `state ${state} must reconcile before dispatching ${expected}`,
+    );
   }
 });
 
-test("advance worker skips missing runs, terminal states, and malformed jobs", async () => {
+test("advance worker reconciles terminal handoffs and skips missing or malformed jobs", async () => {
   const fb = fakeBoss();
   const { deps, calls } = makeDeps({
     loadRun: async (id) =>
@@ -155,7 +160,7 @@ test("advance worker skips missing runs, terminal states, and malformed jobs", a
     { id: "job-3", data: { nonsense: true } },
   ]);
 
-  assert.deepEqual(calls, [], "no handler may run for missing/terminal/malformed jobs");
+  assert.deepEqual(calls, ["reconcile_handoff"]);
 });
 
 test("a run whose incident or project is gone is failed as context_unavailable", async () => {
@@ -196,7 +201,11 @@ test("one job's failure is swallowed and the rest of the batch still runs", asyn
     { id: "job-2", data: { agentRunId: "run-2" } },
   ]);
 
-  assert.deepEqual(calls, ["sync"], "the healthy job must still be processed");
+  assert.deepEqual(
+    calls,
+    ["reconcile_handoff", "reconcile_handoff", "sync"],
+    "the healthy job must still be processed",
+  );
 });
 
 test("a job exceeding the per-job timeout is abandoned and the handler resolves", async () => {
@@ -258,7 +267,11 @@ test("a run with an abandoned in-flight attempt is not advanced concurrently", a
   await worker([{ id: "job-2", data: { agentRunId: "hung-run" } }]);
   assert.equal(startCalls, 1, "the hung run must not be advanced concurrently");
   await worker([{ id: "job-3", data: { agentRunId: "other-run" } }]);
-  assert.deepEqual(calls, ["start"], "other runs must be unaffected");
+  assert.deepEqual(
+    calls,
+    ["reconcile_handoff", "reconcile_handoff", "start"],
+    "other runs must be unaffected",
+  );
 
   // Once the abandoned attempt finally settles, the run may be advanced again.
   releaseHung?.();

--- a/apps/worker/src/agent-runs/queue.ts
+++ b/apps/worker/src/agent-runs/queue.ts
@@ -72,6 +72,7 @@ export type AgentRunQueueDeps = {
   failContextUnavailable(run: schema.AgentRun): Promise<void>;
   listActiveRunIds(): Promise<string[]>;
   handlers: {
+    reconcileHandoff(ctx: AgentRunContext): Promise<void>;
     start(ctx: AgentRunContext): Promise<void>;
     sync(ctx: AgentRunContext): Promise<void>;
     resume(ctx: AgentRunContext): Promise<void>;
@@ -104,6 +105,7 @@ async function advanceRun(deps: AgentRunQueueDeps, data: AgentRunJobData): Promi
     await deps.failContextUnavailable(agentRun);
     return;
   }
+  await deps.handlers.reconcileHandoff(ctx);
   const state = ctx.agentRun.state;
   if (state === "queued" || state === "repo_discovery") {
     await deps.handlers.start(ctx);

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -325,6 +325,8 @@ function makeContext(opts: { githubInstalled?: boolean } = {}): AgentRunContext 
     linearTicketInstructions: [],
     linearDefaultTeamId: null,
     prPolicy: "on_ready_to_pr",
+    approvalPromptsEnabled: true,
+    createLinearTicketOnResolve: true,
     prBaseBranch: "development",
     autoMergeFixPrs: "never",
     autoMergeMethod: "squash",

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -60,6 +60,24 @@ test("startQueuedAgentRunWorkflow starts runner with capped repo candidates", as
   ]);
 });
 
+test("startQueuedAgentRunWorkflow exposes ask_human as an approval boundary", async () => {
+  const calls: string[] = [];
+  const ctx = makeContext();
+  let approvalPromptsEnabled: boolean | null = null;
+  let approvalPromptToolsAvailable: boolean | null = null;
+
+  await startQueuedAgentRunWorkflow(
+    ctx,
+    makeDeps(calls, {}, (input) => {
+      approvalPromptsEnabled = input.approvalPromptsEnabled;
+      approvalPromptToolsAvailable = input.approvalPromptToolsAvailable;
+    }),
+  );
+
+  assert.equal(approvalPromptsEnabled, true);
+  assert.equal(approvalPromptToolsAvailable, true);
+});
+
 test("startQueuedAgentRunWorkflow passes agent memories to the runner", async () => {
   const calls: string[] = [];
   const ctx = makeContext();
@@ -326,7 +344,7 @@ function makeContext(opts: { githubInstalled?: boolean } = {}): AgentRunContext 
     linearDefaultTeamId: null,
     prPolicy: "on_ready_to_pr",
     approvalPromptsEnabled: true,
-    createLinearTicketOnResolve: true,
+    createLinearTicketOnResolve: false,
     prBaseBranch: "development",
     autoMergeFixPrs: "never",
     autoMergeMethod: "squash",

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -262,10 +262,10 @@ async function startRunnerSession(
         mcpResource: `${(process.env.API_BASE_URL ?? "https://api.superlog.sh").replace(/\/$/, "")}/mcp`,
         prPolicy: ctx.prPolicy,
         approvalPromptsEnabled: ctx.approvalPromptsEnabled,
-        // Approval-gated integration actions are not registered yet. Keep
-        // this as an explicit capability so adding one cannot silently leave
-        // complete_investigation exposed.
-        approvalPromptToolsAvailable: false,
+        // ask_human is the approval boundary exposed by every runner. The
+        // project setting decides whether it counts as an available
+        // intervention when terminal tools are registered.
+        approvalPromptToolsAvailable: true,
         prBaseBranch: ctx.prBaseBranch,
         githubConnected: ctx.githubInstalls.length > 0,
         telemetryInvestigationHint: TELEMETRY_INVESTIGATION_HINT,

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -261,6 +261,11 @@ async function startRunnerSession(
         repoCandidates,
         mcpResource: `${(process.env.API_BASE_URL ?? "https://api.superlog.sh").replace(/\/$/, "")}/mcp`,
         prPolicy: ctx.prPolicy,
+        approvalPromptsEnabled: ctx.approvalPromptsEnabled,
+        // Approval-gated integration actions are not registered yet. Keep
+        // this as an explicit capability so adding one cannot silently leave
+        // complete_investigation exposed.
+        approvalPromptToolsAvailable: false,
         prBaseBranch: ctx.prBaseBranch,
         githubConnected: ctx.githubInstalls.length > 0,
         telemetryInvestigationHint: TELEMETRY_INVESTIGATION_HINT,

--- a/apps/worker/src/agent-runs/status.test.ts
+++ b/apps/worker/src/agent-runs/status.test.ts
@@ -2,12 +2,23 @@ import "../agent-run.test-env.js";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  WALL_CLOCK_MULTIPLIER,
   agentRunErrorLogMeta,
+  awaitingEventsSlackMessage,
   awaitingHumanSecondsFromEvents,
   exceededWallClockBudget,
   isTransientError,
-  WALL_CLOCK_MULTIPLIER,
 } from "./status.js";
+
+test("awaiting PR review Slack copy includes PRs and the Linear ticket", () => {
+  assert.equal(
+    awaitingEventsSlackMessage(["https://github.com/acme/api/pull/10"], {
+      identifier: "ENG-42",
+      url: "https://linear.app/acme/issue/ENG-42",
+    }),
+    ":hourglass_flowing_sand: Investigation is waiting on PR review. Open PRs: https://github.com/acme/api/pull/10 Linear ticket: ENG-42 (https://linear.app/acme/issue/ENG-42)",
+  );
+});
 
 test("isTransientError handles cyclic cause chains", () => {
   const err = { code: "NOPE" } as { code: string; cause?: unknown };
@@ -65,14 +76,8 @@ test("exceededWallClockBudget fires when wall-clock age exceeds maxRuntimeMinute
     startedAt.getTime() + WALL_CLOCK_MULTIPLIER * maxRuntimeMinutes * 60_000 - 1_000,
   );
 
-  assert.equal(
-    exceededWallClockBudget({ startedAt, now: justUnder, maxRuntimeMinutes }),
-    false,
-  );
-  assert.equal(
-    exceededWallClockBudget({ startedAt, now: justOver, maxRuntimeMinutes }),
-    true,
-  );
+  assert.equal(exceededWallClockBudget({ startedAt, now: justUnder, maxRuntimeMinutes }), false);
+  assert.equal(exceededWallClockBudget({ startedAt, now: justOver, maxRuntimeMinutes }), true);
 });
 
 test("exceededWallClockBudget excludes time parked awaiting a human", () => {
@@ -210,7 +215,11 @@ test("awaitingHumanSecondsFromEvents is 0 with no startedAt", () => {
   ];
 
   assert.equal(
-    awaitingHumanSecondsFromEvents({ events, startedAt: null, now: new Date("2026-07-09T02:00:00Z") }),
+    awaitingHumanSecondsFromEvents({
+      events,
+      startedAt: null,
+      now: new Date("2026-07-09T02:00:00Z"),
+    }),
     0,
   );
 });
@@ -235,10 +244,7 @@ test("exceededWallClockBudget is independent of provider-reported activeSeconds"
   const startedAt = new Date("2026-05-01T00:00:00Z");
   const now = new Date("2026-05-28T00:00:00Z"); // 27 days later
 
-  assert.equal(
-    exceededWallClockBudget({ startedAt, now, maxRuntimeMinutes: 90 }),
-    true,
-  );
+  assert.equal(exceededWallClockBudget({ startedAt, now, maxRuntimeMinutes: 90 }), true);
 });
 
 test("failure log messages split log fingerprints per failure reason", async () => {

--- a/apps/worker/src/agent-runs/status.ts
+++ b/apps/worker/src/agent-runs/status.ts
@@ -255,6 +255,8 @@ export async function moveAgentRunToAwaitingEvents(
   ctx: AgentRunContext,
   result: AgentRunResult,
   openPrUrls: string[],
+  loadLinearTicket: () => Promise<{ identifier: string; url: string | null } | null> = async () =>
+    null,
 ): Promise<boolean> {
   const parked = await agentRunLifecycle.pauseForEvents({
     id: ctx.agentRun.id,
@@ -268,10 +270,13 @@ export async function moveAgentRunToAwaitingEvents(
     );
     return false;
   }
-  const prList = openPrUrls.length > 0 ? ` Open PRs: ${openPrUrls.join(", ")}` : "";
+  // Cross-provider side effects happen only after this sync pass wins the
+  // conditional state transition. A concurrent terminal outcome must not
+  // accidentally file a waiting ticket from the losing pass.
+  const linearTicket = await loadLinearTicket();
   await postIncidentThreadMessage(
     ctx.incident.id,
-    `:hourglass_flowing_sand: Investigation is waiting on PR review.${prList}`,
+    awaitingEventsSlackMessage(openPrUrls, linearTicket),
   );
   const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
   await updateIncidentMainMessage(
@@ -287,6 +292,15 @@ export async function moveAgentRunToAwaitingEvents(
       buttons: [
         { text: "Open in Superlog", url: incidentUrl, actionId: "open_superlog" },
         ...(openPrUrls[0] ? [{ text: "View PR", url: openPrUrls[0], actionId: "view_pr" }] : []),
+        ...(linearTicket?.url
+          ? [
+              {
+                text: `View ${linearTicket.identifier}`,
+                url: linearTicket.url,
+                actionId: "view_linear",
+              },
+            ]
+          : []),
       ],
       incidentId: ctx.incident.id,
       showResolveButton: true,
@@ -297,6 +311,17 @@ export async function moveAgentRunToAwaitingEvents(
     }),
   );
   return true;
+}
+
+export function awaitingEventsSlackMessage(
+  openPrUrls: string[],
+  linearTicket: { identifier: string; url: string | null } | null,
+): string {
+  const prList = openPrUrls.length > 0 ? ` Open PRs: ${openPrUrls.join(", ")}` : "";
+  const ticket = linearTicket
+    ? ` Linear ticket: ${linearTicket.identifier}${linearTicket.url ? ` (${linearTicket.url})` : ""}`
+    : "";
+  return `:hourglass_flowing_sand: Investigation is waiting on PR review.${prList}${ticket}`;
 }
 
 export async function moveAgentRunToBlockedNoGithub(

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { TERMINAL_OUTCOME_NUDGE_MARKER } from "../agent-outcome-tools.js";
 import {
+  isCompleteInvestigationAllowed,
   isSessionBusyError,
   mobileRegressionGateState,
   mobileRegressionGateTerminatedSummary,
@@ -12,6 +13,32 @@ import {
   steerIdleRunnerWithPendingContext,
   terminalOutcomeNudgePrompt,
 } from "./sync.js";
+
+test("complete_investigation is rejected when an intervention is available", () => {
+  const result = {
+    state: "complete" as const,
+    summary: "Findings ready.",
+    completionKind: "investigation_complete" as const,
+  };
+  assert.equal(
+    isCompleteInvestigationAllowed(result, {
+      prPolicy: "always",
+      githubConnected: true,
+      approvalPromptsEnabled: false,
+      approvalPromptToolsAvailable: false,
+    }),
+    false,
+  );
+  assert.equal(
+    isCompleteInvestigationAllowed(result, {
+      prPolicy: "never",
+      githubConnected: true,
+      approvalPromptsEnabled: true,
+      approvalPromptToolsAvailable: false,
+    }),
+    true,
+  );
+});
 
 test("steerIdleRunnerWithPendingContext steers idle sessions with joined context deltas", async () => {
   const steered: Array<{ sessionId: string; message: string }> = [];
@@ -362,6 +389,12 @@ test("terminalOutcomeNudgePrompt names every outcome tool", () => {
   ]) {
     assert.ok(prompt.includes(name), `missing ${name}`);
   }
+});
+
+test("terminalOutcomeNudgePrompt uses complete_investigation when interventions are disabled", () => {
+  const prompt = terminalOutcomeNudgePrompt({ completeInvestigationAvailable: true });
+  assert.match(prompt, /complete_investigation/);
+  assert.doesNotMatch(prompt, /propose_pr/);
 });
 
 test("isSessionBusyError matches the mid-flight steer rejection only", () => {

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -34,7 +34,16 @@ test("complete_investigation is rejected when an intervention is available", () 
       prPolicy: "never",
       githubConnected: true,
       approvalPromptsEnabled: true,
-      approvalPromptToolsAvailable: false,
+      approvalPromptToolsAvailable: true,
+    }),
+    false,
+  );
+  assert.equal(
+    isCompleteInvestigationAllowed(result, {
+      prPolicy: "on_ready_to_pr",
+      githubConnected: false,
+      approvalPromptsEnabled: false,
+      approvalPromptToolsAvailable: true,
     }),
     true,
   );
@@ -363,7 +372,10 @@ test("shouldDeferSteering does not defer settled or concluded snapshots", () => 
     false,
   );
   assert.equal(
-    shouldDeferSteering({ result: { state: "complete", summary: "x" }, dispatchedToolCallCount: 1 }),
+    shouldDeferSteering({
+      result: { state: "complete", summary: "x" },
+      dispatchedToolCallCount: 1,
+    }),
     false,
   );
 });

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -1,9 +1,6 @@
 import { type AgentRunResult, db, schema } from "@superlog/db";
 import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
-import {
-  TERMINAL_OUTCOME_NUDGE_MARKER,
-  assembleAgentRunResult,
-} from "../agent-outcome-tools.js";
+import { TERMINAL_OUTCOME_NUDGE_MARKER, assembleAgentRunResult } from "../agent-outcome-tools.js";
 import type { AgentRunContext } from "../agent-run-context.js";
 import { createAgentRunLifecycle } from "../agent-run.js";
 import { type AgentRunOutcome, recordAgentRunCompletion } from "../ai-usage.js";
@@ -14,9 +11,7 @@ import { postIncidentThreadMessage } from "../infra/slack/incident-messages.js";
 import { type ResolvedIntegration, loadEnabledIntegrationsForOrg } from "../integrations.js";
 import { logger } from "../logger.js";
 import { completeWithIncidentResolution, completeWithoutPullRequest } from "./completion.js";
-import { recordFiledLinearTicket } from "./deliverable-records.js";
-import { deliverLinearTicket } from "./linear-delivery.js";
-import { linkLinearTicketToPullRequests } from "./linear-pr-linking.js";
+import { scheduleLinearHandoff } from "./linear-handoff.js";
 import { tryMergeAfterAgentRun } from "./merge.js";
 import { hasRevylCreateTestIntegration, looksLikeMobileChange } from "./mobile-regression.js";
 import { createOutcomeActionExecutor } from "./outcome-actions.js";
@@ -43,6 +38,15 @@ export function isCompleteInvestigationAllowed(
   },
 ): boolean {
   if (result.completionKind !== "investigation_complete") return true;
+  return completeInvestigationAvailable(capabilities);
+}
+
+export function completeInvestigationAvailable(capabilities: {
+  prPolicy: schema.PrPolicy;
+  githubConnected: boolean;
+  approvalPromptsEnabled: boolean;
+  approvalPromptToolsAvailable: boolean;
+}): boolean {
   const prCreation = capabilities.githubConnected && capabilities.prPolicy !== "never";
   const approvalPrompts =
     capabilities.approvalPromptsEnabled && capabilities.approvalPromptToolsAvailable;
@@ -565,8 +569,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
           prPolicy: ctx.prPolicy,
           githubConnected: ctx.githubInstalls.length > 0,
           approvalPromptsEnabled: ctx.approvalPromptsEnabled,
-          // No approval-prompt action is registered in the current runtime.
-          approvalPromptToolsAvailable: false,
+          approvalPromptToolsAvailable: true,
         })
       ) {
         await failAgentRun(
@@ -694,20 +697,12 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
           openPrUrls,
           async () => {
             try {
-              const linearTicket = await deliverLinearTicket(ctx, parkedResult, {
-                prUrls: [],
-              });
-              if (!linearTicket) return null;
-              await recordFiledLinearTicket(
+              const linearTicket = await scheduleLinearHandoff(
                 ctx,
-                {
-                  id: linearTicket.ticketId,
-                  url: linearTicket.url,
-                  createdByAgent: linearTicket.created,
-                },
-                { identifier: linearTicket.identifier },
+                parkedResult,
+                `awaiting_events:${openPrUrls.join(",")}`,
               );
-              await linkLinearTicketToPullRequests(ctx, linearTicket, openPrUrls);
+              if (!linearTicket) return null;
               return { identifier: linearTicket.identifier, url: linearTicket.url };
             } catch (err) {
               logger.warn(
@@ -770,8 +765,14 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         // landed. The delivered nudge is visible in the session's own event
         // stream, so a retry can detect it and keep the claim without
         // steering a duplicate.
-        const completeInvestigationAvailable = ctx.prPolicy === "never";
-        const nudgePrompt = terminalOutcomeNudgePrompt({ completeInvestigationAvailable });
+        const nudgePrompt = terminalOutcomeNudgePrompt({
+          completeInvestigationAvailable: completeInvestigationAvailable({
+            prPolicy: ctx.prPolicy,
+            githubConnected: ctx.githubInstalls.length > 0,
+            approvalPromptsEnabled: ctx.approvalPromptsEnabled,
+            approvalPromptToolsAvailable: true,
+          }),
+        });
         const nudgeAlreadyDelivered = snapshot.events.some(
           (event) =>
             event.type === "user.message" &&

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -1,5 +1,9 @@
 import { type AgentRunResult, db, schema } from "@superlog/db";
 import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
+import {
+  TERMINAL_OUTCOME_NUDGE_MARKER,
+  assembleAgentRunResult,
+} from "../agent-outcome-tools.js";
 import type { AgentRunContext } from "../agent-run-context.js";
 import { createAgentRunLifecycle } from "../agent-run.js";
 import { type AgentRunOutcome, recordAgentRunCompletion } from "../ai-usage.js";
@@ -9,11 +13,10 @@ import { getAgentRunnerBackend } from "../infra/agent-runner/backend.js";
 import { postIncidentThreadMessage } from "../infra/slack/incident-messages.js";
 import { type ResolvedIntegration, loadEnabledIntegrationsForOrg } from "../integrations.js";
 import { logger } from "../logger.js";
-import {
-  TERMINAL_OUTCOME_NUDGE_MARKER,
-  assembleAgentRunResult,
-} from "../agent-outcome-tools.js";
 import { completeWithIncidentResolution, completeWithoutPullRequest } from "./completion.js";
+import { recordFiledLinearTicket } from "./deliverable-records.js";
+import { deliverLinearTicket } from "./linear-delivery.js";
+import { linkLinearTicketToPullRequests } from "./linear-pr-linking.js";
 import { tryMergeAfterAgentRun } from "./merge.js";
 import { hasRevylCreateTestIntegration, looksLikeMobileChange } from "./mobile-regression.js";
 import { createOutcomeActionExecutor } from "./outcome-actions.js";
@@ -29,6 +32,22 @@ import {
 } from "./status.js";
 
 export { hasRevylCreateTestIntegration } from "./mobile-regression.js";
+
+export function isCompleteInvestigationAllowed(
+  result: AgentRunResult,
+  capabilities: {
+    prPolicy: schema.PrPolicy;
+    githubConnected: boolean;
+    approvalPromptsEnabled: boolean;
+    approvalPromptToolsAvailable: boolean;
+  },
+): boolean {
+  if (result.completionKind !== "investigation_complete") return true;
+  const prCreation = capabilities.githubConnected && capabilities.prPolicy !== "never";
+  const approvalPrompts =
+    capabilities.approvalPromptsEnabled && capabilities.approvalPromptToolsAvailable;
+  return !prCreation && !approvalPrompts;
+}
 
 const agentRunLifecycle = createAgentRunLifecycle(db);
 
@@ -217,10 +236,16 @@ export function shouldDeferSteering(snapshot: {
 // substring-matching that line (a test pins it as the prompt's exact first
 // line). Reword it only via the exported constant, never here — live
 // sessions can carry an already-delivered nudge across a deploy.
-export function terminalOutcomeNudgePrompt(): string {
+export function terminalOutcomeNudgePrompt(
+  args: {
+    completeInvestigationAvailable?: boolean;
+  } = {},
+): string {
   return [
     TERMINAL_OUTCOME_NUDGE_MARKER,
-    "Call `report_findings` now if you have findings to record, classify each linked issue (`silence_as_noise`, `place_under_observation`, or `resolve_issue`), open any needed PR with `propose_pr`, and then end your turn by calling `resolve_incident` — or `ask_human` if a human must act or answer first.",
+    args.completeInvestigationAvailable
+      ? "Call `report_findings` now, then explicitly end your turn with `complete_investigation`. Use `resolve_incident` only if impact has ceased and every linked issue is classified, or `ask_human` if a concrete human answer is required first."
+      : "Call `report_findings` now if you have findings to record, classify each linked issue (`silence_as_noise`, `place_under_observation`, or `resolve_issue`), open any needed PR with `propose_pr`, and then end your turn by calling `resolve_incident` — or `ask_human` if a human must act or answer first.",
   ].join("\n");
 }
 
@@ -535,6 +560,25 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         return;
       }
 
+      if (
+        !isCompleteInvestigationAllowed(snapshot.result, {
+          prPolicy: ctx.prPolicy,
+          githubConnected: ctx.githubInstalls.length > 0,
+          approvalPromptsEnabled: ctx.approvalPromptsEnabled,
+          // No approval-prompt action is registered in the current runtime.
+          approvalPromptToolsAvailable: false,
+        })
+      ) {
+        await failAgentRun(
+          ctx,
+          "sync_failed",
+          "Investigation tried to finish while a remediation intervention was still available.",
+          { existingResult: snapshot.result },
+        );
+        await meterAgentRun("failed");
+        return;
+      }
+
       if (snapshot.result.state === "complete" && snapshot.result.incidentResolution) {
         // Terminal resolve_incident (multi-PR contract): issues were
         // classified and PRs delivered mid-run; this resolves the incident.
@@ -643,10 +687,41 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         if (snapshot.pendingOutcome?.findings) {
           await applyIncidentMetadataFromResult(ctx, parkedResult);
         }
+        const openPrUrls = openPrs.map((pr) => pr.url);
         const parked = await moveAgentRunToAwaitingEvents(
           ctx,
           parkedResult,
-          openPrs.map((pr) => pr.url),
+          openPrUrls,
+          async () => {
+            try {
+              const linearTicket = await deliverLinearTicket(ctx, parkedResult, {
+                prUrls: [],
+              });
+              if (!linearTicket) return null;
+              await recordFiledLinearTicket(
+                ctx,
+                {
+                  id: linearTicket.ticketId,
+                  url: linearTicket.url,
+                  createdByAgent: linearTicket.created,
+                },
+                { identifier: linearTicket.identifier },
+              );
+              await linkLinearTicketToPullRequests(ctx, linearTicket, openPrUrls);
+              return { identifier: linearTicket.identifier, url: linearTicket.url };
+            } catch (err) {
+              logger.warn(
+                {
+                  scope: "agent_run.awaiting_events",
+                  agent_run_id: ctx.agentRun.id,
+                  incident_id: ctx.incident.id,
+                  err: err instanceof Error ? err.message : String(err),
+                },
+                "failed to record or cross-link Linear ticket after parking; continuing",
+              );
+              return null;
+            }
+          },
         );
         // A lost park means a concurrent pass owns this turn's conclusion —
         // it also records the usage, so a duplicate here would double-meter.
@@ -695,6 +770,8 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         // landed. The delivered nudge is visible in the session's own event
         // stream, so a retry can detect it and keep the claim without
         // steering a duplicate.
+        const completeInvestigationAvailable = ctx.prPolicy === "never";
+        const nudgePrompt = terminalOutcomeNudgePrompt({ completeInvestigationAvailable });
         const nudgeAlreadyDelivered = snapshot.events.some(
           (event) =>
             event.type === "user.message" &&
@@ -703,7 +780,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         );
         if (!nudgeAlreadyDelivered) {
           try {
-            await runner.steer(sessionId, terminalOutcomeNudgePrompt());
+            await runner.steer(sessionId, nudgePrompt);
           } catch (err) {
             // Release the claim so a later tick can retry the nudge — a
             // transient steer failure must not permanently spend the one-shot.

--- a/apps/worker/src/agent-runs/tick.ts
+++ b/apps/worker/src/agent-runs/tick.ts
@@ -2,10 +2,8 @@ import { SpanStatusCode, trace } from "@opentelemetry/api";
 import { db, schema } from "@superlog/db";
 import { asc, eq, inArray } from "drizzle-orm";
 import { loadAgentRunContext } from "../agent-run-context.js";
-import {
-  ACTIVE_STATES as AGENT_RUN_ACTIVE_STATES,
-  createAgentRunLifecycle,
-} from "../agent-run.js";
+import { ACTIVE_STATES as AGENT_RUN_ACTIVE_STATES, createAgentRunLifecycle } from "../agent-run.js";
+import { listPendingLinearHandoffRunIds, reconcilePendingLinearHandoff } from "./linear-handoff.js";
 import { retryQueuedPullRequestDelivery } from "./pr-delivery.js";
 import { resumeAgentRunFromHumanInput } from "./resume.js";
 import { startQueuedAgentRun } from "./start-run.js";
@@ -34,8 +32,13 @@ export async function tickAgentRuns(): Promise<number> {
       // monopolised every tick — a run that fell out of the top 20 once
       // (because newer incidents arrived) would never be re-synced and got
       // stuck in 'running' forever. asc(updatedAt) drains the queue instead.
+      const pendingHandoffIds = await listPendingLinearHandoffRunIds(AGENT_RUN_BATCH_SIZE);
       const rows = await db.query.agentRuns.findMany({
-        where: inArray(schema.agentRuns.state, [...AGENT_RUN_ACTIVE_STATES]),
+        where: (runs, { or }) =>
+          or(
+            inArray(runs.state, [...AGENT_RUN_ACTIVE_STATES]),
+            ...(pendingHandoffIds.length > 0 ? [inArray(runs.id, pendingHandoffIds)] : []),
+          ),
         orderBy: [asc(schema.agentRuns.updatedAt)],
         limit: AGENT_RUN_BATCH_SIZE,
       });
@@ -72,6 +75,7 @@ export async function tickAgentRuns(): Promise<number> {
           continue;
         }
         processed += 1;
+        await reconcilePendingLinearHandoff(ctx);
         if (ctx.agentRun.state === "queued" || ctx.agentRun.state === "repo_discovery") {
           await startQueuedAgentRun(ctx);
           continue;

--- a/apps/worker/src/infra/agent-runner/backend.test.ts
+++ b/apps/worker/src/infra/agent-runner/backend.test.ts
@@ -54,6 +54,8 @@ test("getAgentRunnerBackend returns the default community backend", async () => 
       repoCandidates: [],
       mcpResource: null,
       prPolicy: "never",
+      approvalPromptsEnabled: false,
+      approvalPromptToolsAvailable: false,
       prBaseBranch: null,
       githubConnected: false,
       telemetryInvestigationHint:
@@ -86,7 +88,12 @@ test("getAgentRunnerBackend returns a built-in disabled backend for community in
   assert.equal(backend.name, "disabled");
   assert.equal(backend.maxRepoResources, 0);
   assert.equal(
-    await backend.dispatchIntegrationToolCalls({ sessionId: "s", orgId: "o", projectId: "p", incidentId: "i" }),
+    await backend.dispatchIntegrationToolCalls({
+      sessionId: "s",
+      orgId: "o",
+      projectId: "p",
+      incidentId: "i",
+    }),
     0,
   );
   await assert.rejects(
@@ -101,6 +108,8 @@ test("getAgentRunnerBackend returns a built-in disabled backend for community in
         repoCandidates: [],
         mcpResource: null,
         prPolicy: "never",
+        approvalPromptsEnabled: false,
+        approvalPromptToolsAvailable: false,
         prBaseBranch: null,
         githubConnected: false,
         telemetryInvestigationHint:
@@ -127,7 +136,12 @@ test("getAgentRunnerBackend loads the closed-overlay anthropic backend from conf
     sessionId: "s",
   });
   assert.equal(
-    await backend.dispatchIntegrationToolCalls({ sessionId: "s", orgId: "o", projectId: "p", incidentId: "i" }),
+    await backend.dispatchIntegrationToolCalls({
+      sessionId: "s",
+      orgId: "o",
+      projectId: "p",
+      incidentId: "i",
+    }),
     2,
   );
 });

--- a/packages/db/migrations/0100_soft_magik.sql
+++ b/packages/db/migrations/0100_soft_magik.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "project_automation_settings" ADD COLUMN "approval_prompts_enabled" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "project_automation_settings" ADD COLUMN "create_linear_ticket_on_resolve" boolean DEFAULT true NOT NULL;

--- a/packages/db/migrations/0100_tidy_young_avengers.sql
+++ b/packages/db/migrations/0100_tidy_young_avengers.sql
@@ -1,2 +1,2 @@
 ALTER TABLE "project_automation_settings" ADD COLUMN "approval_prompts_enabled" boolean DEFAULT true NOT NULL;--> statement-breakpoint
-ALTER TABLE "project_automation_settings" ADD COLUMN "create_linear_ticket_on_resolve" boolean DEFAULT true NOT NULL;
+ALTER TABLE "project_automation_settings" ADD COLUMN "create_linear_ticket_on_resolve" boolean DEFAULT false NOT NULL;

--- a/packages/db/migrations/meta/0100_snapshot.json
+++ b/packages/db/migrations/meta/0100_snapshot.json
@@ -1,0 +1,9472 @@
+{
+  "id": "3ca7bfef-848a-410d-9a9d-2e1cc463248e",
+  "prevId": "67b8ce8a-9211-4864-a2ec-5021d76efb80",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_provider_account_idx": {
+          "name": "accounts_provider_account_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_idx": {
+          "name": "accounts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_chat_messages": {
+      "name": "agent_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_slack_user_id": {
+          "name": "author_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_chat_messages_dedupe_idx": {
+          "name": "agent_chat_messages_dedupe_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chat_messages_pending_idx": {
+          "name": "agent_chat_messages_pending_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "processed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_chat_messages_chat_id_agent_chats_id_fk": {
+          "name": "agent_chat_messages_chat_id_agent_chats_id_fk",
+          "tableFrom": "agent_chat_messages",
+          "tableTo": "agent_chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_chats": {
+      "name": "agent_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_slack_user_id": {
+          "name": "created_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_status": {
+          "name": "provider_session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cumulative_active_seconds": {
+          "name": "cumulative_active_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "session_base_active_seconds": {
+          "name": "session_base_active_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_chats_thread_idx": {
+          "name": "agent_chats_thread_idx",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_thread_ts IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_dm_channel_idx": {
+          "name": "agent_chats_dm_channel_idx",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_thread_ts IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_provider_session_idx": {
+          "name": "agent_chats_provider_session_idx",
+          "columns": [
+            {
+              "expression": "provider_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_chats_state_idx": {
+          "name": "agent_chats_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_chats_project_id_projects_id_fk": {
+          "name": "agent_chats_project_id_projects_id_fk",
+          "tableFrom": "agent_chats",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_chats_slack_installation_id_slack_installations_id_fk": {
+          "name": "agent_chats_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "agent_chats",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_ticket_events": {
+      "name": "agent_linear_ticket_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_linear_ticket_id": {
+          "name": "agent_linear_ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_linear_id": {
+          "name": "actor_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_ticket_events_ticket_idx": {
+          "name": "agent_linear_ticket_events_ticket_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_ticket_events_provider_event_idx": {
+          "name": "agent_linear_ticket_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_linear_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk": {
+          "name": "agent_linear_ticket_events_agent_linear_ticket_id_agent_linear_tickets_id_fk",
+          "tableFrom": "agent_linear_ticket_events",
+          "tableTo": "agent_linear_tickets",
+          "columnsFrom": [
+            "agent_linear_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_linear_tickets": {
+      "name": "agent_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_identifier": {
+          "name": "ticket_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_name": {
+          "name": "assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_linear_id": {
+          "name": "assignee_linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_linear_tickets_incident_idx": {
+          "name": "agent_linear_tickets_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_agent_run_idx": {
+          "name": "agent_linear_tickets_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_linear_tickets_workspace_ticket_idx": {
+          "name": "agent_linear_tickets_workspace_ticket_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_linear_tickets_incident_id_incidents_id_fk": {
+          "name": "agent_linear_tickets_incident_id_incidents_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_linear_tickets_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_linear_tickets_installation_id_linear_installations_id_fk": {
+          "name": "agent_linear_tickets_installation_id_linear_installations_id_fk",
+          "tableFrom": "agent_linear_tickets",
+          "tableTo": "linear_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memories": {
+      "name": "agent_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source_agent_run_id": {
+          "name": "source_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memories_org_status_idx": {
+          "name": "agent_memories_org_status_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_memories_org_id_orgs_id_fk": {
+          "name": "agent_memories_org_id_orgs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_id_projects_id_fk": {
+          "name": "agent_memories_project_id_projects_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_memories_source_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "source_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_source_user_id_users_id_fk": {
+          "name": "agent_memories_source_user_id_users_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "source_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_project_org_fk": {
+          "name": "agent_memories_project_org_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_memories_single_source_check": {
+          "name": "agent_memories_single_source_check",
+          "value": "NOT (source_agent_run_id IS NOT NULL AND source_user_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_pr_events": {
+      "name": "agent_pr_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_pr_id": {
+          "name": "agent_pr_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_login": {
+          "name": "actor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_github_id": {
+          "name": "actor_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_avatar_url": {
+          "name": "actor_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pr_events_pr_idx": {
+          "name": "agent_pr_events_pr_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pr_events_provider_event_idx": {
+          "name": "agent_pr_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_pr_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk": {
+          "name": "agent_pr_events_agent_pr_id_agent_pull_requests_id_fk",
+          "tableFrom": "agent_pr_events",
+          "tableTo": "agent_pull_requests",
+          "columnsFrom": [
+            "agent_pr_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_pull_requests": {
+      "name": "agent_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_node_id": {
+          "name": "pr_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_login": {
+          "name": "merged_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by_github_id": {
+          "name": "merged_by_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "negative_reaction_at": {
+          "name": "negative_reaction_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_pull_requests_incident_idx": {
+          "name": "agent_pull_requests_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_agent_run_idx": {
+          "name": "agent_pull_requests_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_pull_requests_repo_pr_idx": {
+          "name": "agent_pull_requests_repo_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_pull_requests_incident_id_incidents_id_fk": {
+          "name": "agent_pull_requests_incident_id_incidents_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_agent_run_id_agent_runs_id_fk": {
+          "name": "agent_pull_requests_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_pull_requests_installation_id_github_installations_id_fk": {
+          "name": "agent_pull_requests_installation_id_github_installations_id_fk",
+          "tableFrom": "agent_pull_requests",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'incident'"
+        },
+        "trigger_detail": {
+          "name": "trigger_detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_status": {
+          "name": "provider_session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_full_name": {
+          "name": "selected_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_url": {
+          "name": "selected_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_base_branch": {
+          "name": "selected_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_repo_score": {
+          "name": "selected_repo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cumulative_runtime_minutes": {
+          "name": "cumulative_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resume_count": {
+          "name": "resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_runs_incident_idx": {
+          "name": "agent_runs_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_provider_session_idx": {
+          "name": "agent_runs_provider_session_idx",
+          "columns": [
+            {
+              "expression": "provider_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_incident_id_incidents_id_fk": {
+          "name": "agent_runs_incident_id_incidents_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_episodes": {
+      "name": "alert_episodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'firing'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_observed_value": {
+          "name": "open_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_observed_value": {
+          "name": "peak_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_value": {
+          "name": "last_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_firing_at": {
+          "name": "last_firing_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alert_episodes_alert_started_idx": {
+          "name": "alert_episodes_alert_started_idx",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_episodes_incident_idx": {
+          "name": "alert_episodes_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_episodes_open_uniq": {
+          "name": "alert_episodes_open_uniq",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "state = 'firing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_episodes_issue_uniq": {
+          "name": "alert_episodes_issue_uniq",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "issue_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_episodes_alert_id_alerts_id_fk": {
+          "name": "alert_episodes_alert_id_alerts_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_project_id_projects_id_fk": {
+          "name": "alert_episodes_project_id_projects_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_issue_id_issues_id_fk": {
+          "name": "alert_episodes_issue_id_issues_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "alert_episodes_incident_id_incidents_id_fk": {
+          "name": "alert_episodes_incident_id_incidents_id_fk",
+          "tableFrom": "alert_episodes",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_firings": {
+      "name": "alert_firings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_value": {
+          "name": "observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluated_at": {
+          "name": "evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_firings_alert_group_idx": {
+          "name": "alert_firings_alert_group_idx",
+          "columns": [
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_firings_alert_id_alerts_id_fk": {
+          "name": "alert_firings_alert_id_alerts_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_firings_issue_id_issues_id_fk": {
+          "name": "alert_firings_issue_id_issues_id_fk",
+          "tableFrom": "alert_firings",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_name": {
+          "name": "metric_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "group_by": {
+          "name": "group_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_mode": {
+          "name": "group_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single'"
+        },
+        "aggregation": {
+          "name": "aggregation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparator": {
+          "name": "comparator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "evaluation_interval_seconds": {
+          "name": "evaluation_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alerts_project_idx": {
+          "name": "alerts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alerts_enabled_idx": {
+          "name": "alerts_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alerts_project_id_projects_id_fk": {
+          "name": "alerts_project_id_projects_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alerts_created_by_users_id_fk": {
+          "name": "alerts_created_by_users_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions": {
+      "name": "cli_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cli_sessions_user_id_users_id_fk": {
+          "name": "cli_sessions_user_id_users_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_org_id_orgs_id_fk": {
+          "name": "cli_sessions_org_id_orgs_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_sessions_token_hash_unique": {
+          "name": "cli_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_connections": {
+      "name": "cloud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scrape_role_arn": {
+          "name": "scrape_role_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id_ciphertext": {
+          "name": "external_id_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_nonce": {
+          "name": "external_id_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id_key_version": {
+          "name": "external_id_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cloud_connections_project_idx": {
+          "name": "cloud_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_connections_active_role_idx": {
+          "name": "cloud_connections_active_role_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scrape_role_arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_connections_project_id_projects_id_fk": {
+          "name": "cloud_connections_project_id_projects_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_connections_created_by_users_id_fk": {
+          "name": "cloud_connections_created_by_users_id_fk",
+          "tableFrom": "cloud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_resources": {
+      "name": "cloud_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arn": {
+          "name": "arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_fetched_at": {
+          "name": "config_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_resources_project_arn_idx": {
+          "name": "cloud_resources_project_arn_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "arn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_project_idx": {
+          "name": "cloud_resources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloud_resources_connection_idx": {
+          "name": "cloud_resources_connection_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_resources_project_id_projects_id_fk": {
+          "name": "cloud_resources_project_id_projects_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_resources_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_resources_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_resources",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_stream_keys": {
+      "name": "cloud_stream_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_ciphertext": {
+          "name": "key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_nonce": {
+          "name": "key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_key_version": {
+          "name": "key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_stream_keys_connection_kind_idx": {
+          "name": "cloud_stream_keys_connection_kind_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_stream_keys_connection_id_cloud_connections_id_fk": {
+          "name": "cloud_stream_keys_connection_id_cloud_connections_id_fk",
+          "tableFrom": "cloud_stream_keys",
+          "tableTo": "cloud_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_stream_keys_api_key_id_api_keys_id_fk": {
+          "name": "cloud_stream_keys_api_key_id_api_keys_id_fk",
+          "tableFrom": "cloud_stream_keys",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_installations": {
+      "name": "cloudflare_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_token_ciphertext": {
+          "name": "refresh_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_nonce": {
+          "name": "refresh_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_key_version": {
+          "name": "refresh_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destinations": {
+          "name": "destinations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_wire": {
+          "name": "auto_wire",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloudflare_installations_project_account_idx": {
+          "name": "cloudflare_installations_project_account_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_installations_project_id_projects_id_fk": {
+          "name": "cloudflare_installations_project_id_projects_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloudflare_installations_api_key_id_api_keys_id_fk": {
+          "name": "cloudflare_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cloudflare_installations_installed_by_user_id_users_id_fk": {
+          "name": "cloudflare_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "cloudflare_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_widgets": {
+      "name": "dashboard_widgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboard_widgets_dashboard_idx": {
+          "name": "dashboard_widgets_dashboard_idx",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_widgets_dashboard_id_dashboards_id_fk": {
+          "name": "dashboard_widgets_dashboard_id_dashboards_id_fk",
+          "tableFrom": "dashboard_widgets",
+          "tableTo": "dashboards",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboards": {
+      "name": "dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboards_project_slug_idx": {
+          "name": "dashboards_project_slug_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboards_project_idx": {
+          "name": "dashboards_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboards_project_id_projects_id_fk": {
+          "name": "dashboards_project_id_projects_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dashboards_created_by_users_id_fk": {
+          "name": "dashboards_created_by_users_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_repo": {
+          "name": "ref_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_external": {
+          "name": "author_external",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "triaged_by_user_id": {
+          "name": "triaged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_status_created_idx": {
+          "name": "feedback_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_kind_ref_idx": {
+          "name": "feedback_kind_ref_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_author_user_id_users_id_fk": {
+          "name": "feedback_author_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_org_id_orgs_id_fk": {
+          "name": "feedback_org_id_orgs_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_project_id_projects_id_fk": {
+          "name": "feedback_project_id_projects_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "feedback_triaged_by_user_id_users_id_fk": {
+          "name": "feedback_triaged_by_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triaged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repos": {
+          "name": "repos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_enabled": {
+          "name": "agent_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "repo_access": {
+          "name": "repo_access",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_name": {
+          "name": "commit_author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_email": {
+          "name": "commit_author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_login": {
+          "name": "commit_author_github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_github_id": {
+          "name": "commit_author_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_avatar_url": {
+          "name": "commit_author_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_by_user_id": {
+          "name": "commit_author_set_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_author_set_at": {
+          "name": "commit_author_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_project_installation_idx": {
+          "name": "github_installations_project_installation_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NOT NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_installation_idx": {
+          "name": "github_installations_org_installation_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "project_id IS NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_idx": {
+          "name": "github_installations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_org_id_orgs_id_fk": {
+          "name": "github_installations_org_id_orgs_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_project_id_projects_id_fk": {
+          "name": "github_installations_project_id_projects_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installations_commit_author_set_by_user_id_users_id_fk": {
+          "name": "github_installations_commit_author_set_by_user_id_users_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "commit_author_set_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_events": {
+      "name": "incident_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_posted_at": {
+          "name": "slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_events_agent_run_idx": {
+          "name": "incident_events_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_idx": {
+          "name": "incident_events_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_provider_event_idx": {
+          "name": "incident_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_provider_event_idx": {
+          "name": "incident_events_incident_provider_event_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_dedupe_idx": {
+          "name": "incident_events_dedupe_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_events_incident_dedupe_idx": {
+          "name": "incident_events_incident_dedupe_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_run_id IS NULL AND incident_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_events_agent_run_id_agent_runs_id_fk": {
+          "name": "incident_events_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_events_incident_id_incidents_id_fk": {
+          "name": "incident_events_incident_id_incidents_id_fk",
+          "tableFrom": "incident_events",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "incident_events_parentage_check": {
+          "name": "incident_events_parentage_check",
+          "value": "agent_run_id IS NOT NULL OR incident_id IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.incident_issues": {
+      "name": "incident_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_issues_pair_idx": {
+          "name": "incident_issues_pair_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_issues_incident_idx": {
+          "name": "incident_issues_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_issues_issue_lookup_idx": {
+          "name": "incident_issues_issue_lookup_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_issues_incident_id_incidents_id_fk": {
+          "name": "incident_issues_incident_id_incidents_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_issues_issue_id_issues_id_fk": {
+          "name": "incident_issues_issue_id_issues_id_fk",
+          "tableFrom": "incident_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_resolution_proposals": {
+      "name": "incident_resolution_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sweep'"
+        },
+        "proposed_reason_code": {
+          "name": "proposed_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_reason_text": {
+          "name": "proposed_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_at": {
+          "name": "proposed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_slack_user_id": {
+          "name": "decided_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incident_resolution_proposals_incident_idx": {
+          "name": "incident_resolution_proposals_incident_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proposed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incident_resolution_proposals_slack_msg_idx": {
+          "name": "incident_resolution_proposals_slack_msg_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_message_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "slack_channel_id IS NOT NULL AND slack_message_ts IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_resolution_proposals_incident_id_incidents_id_fk": {
+          "name": "incident_resolution_proposals_incident_id_incidents_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk": {
+          "name": "incident_resolution_proposals_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incident_resolution_proposals_decided_by_user_id_users_id_fk": {
+          "name": "incident_resolution_proposals_decided_by_user_id_users_id_fk",
+          "tableFrom": "incident_resolution_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codename": {
+          "name": "codename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "noise_reason": {
+          "name": "noise_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_resolved_at": {
+          "name": "noise_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_into_id": {
+          "name": "merged_into_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_incident_id": {
+          "name": "previous_incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_slack_posted_at": {
+          "name": "last_slack_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_investigate_suppressed_until": {
+          "name": "auto_investigate_suppressed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_investigate_blocked_reason": {
+          "name": "auto_investigate_blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autorecovery_last_evaluated_at": {
+          "name": "autorecovery_last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_summary": {
+          "name": "agent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_text": {
+          "name": "root_cause_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause_confidence": {
+          "name": "root_cause_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_text": {
+          "name": "estimated_impact_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_impact_confidence": {
+          "name": "estimated_impact_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_severity": {
+          "name": "suggested_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise_classification": {
+          "name": "noise_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_classification": {
+          "name": "resolution_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_agent_run_id": {
+          "name": "findings_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_kind": {
+          "name": "resolved_by_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_slack_user_id": {
+          "name": "resolved_by_slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_code": {
+          "name": "resolved_reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_reason_text": {
+          "name": "resolved_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incidents_project_status_seen_idx": {
+          "name": "incidents_project_status_seen_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_autorecovery_eval_idx": {
+          "name": "incidents_autorecovery_eval_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "autorecovery_last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_slack_thread_idx": {
+          "name": "incidents_slack_thread_idx",
+          "columns": [
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incidents_project_codename_idx": {
+          "name": "incidents_project_codename_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "codename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "codename <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_project_id_projects_id_fk": {
+          "name": "incidents_project_id_projects_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incidents_merged_into_id_incidents_id_fk": {
+          "name": "incidents_merged_into_id_incidents_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "merged_into_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_previous_incident_id_incidents_id_fk": {
+          "name": "incidents_previous_incident_id_incidents_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "incidents",
+          "columnsFrom": [
+            "previous_incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_slack_installation_id_slack_installations_id_fk": {
+          "name": "incidents_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_findings_agent_run_id_agent_runs_id_fk": {
+          "name": "incidents_findings_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "findings_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incidents_resolved_by_user_id_users_id_fk": {
+          "name": "incidents_resolved_by_user_id_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_org_idx": {
+          "name": "invitations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_org_id_orgs_id_fk": {
+          "name": "invitations_org_id_orgs_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'span'"
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_type": {
+          "name": "exception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_frame": {
+          "name": "top_frame",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_frames": {
+          "name": "normalized_frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_sample": {
+          "name": "last_sample",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "silenced_at": {
+          "name": "silenced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalation_trigger": {
+          "name": "escalation_trigger",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_started_at": {
+          "name": "observation_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_baseline_event_count": {
+          "name": "observation_baseline_event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_last_evaluated_at": {
+          "name": "observation_last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_last_event_count": {
+          "name": "observation_last_event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_alerted_at": {
+          "name": "last_alerted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "grouping_state": {
+          "name": "grouping_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'grouped'"
+        },
+        "grouping_source": {
+          "name": "grouping_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_reason": {
+          "name": "grouping_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempted_at": {
+          "name": "grouping_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grouping_attempt_count": {
+          "name": "grouping_attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_project_fingerprint_idx": {
+          "name": "issues_project_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_grouping_state_idx": {
+          "name": "issues_grouping_state_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grouping_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grouping_state IN ('pending', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_observation_idx": {
+          "name": "issues_observation_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observation_started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'under_observation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_project_status_idx": {
+          "name": "issues_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.linear_installations": {
+      "name": "linear_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_url_key": {
+          "name": "workspace_url_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_vault_id": {
+          "name": "anthropic_vault_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_credential_id": {
+          "name": "anthropic_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_required_at": {
+          "name": "reauth_required_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_reason": {
+          "name": "reauth_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "linear_installations_project_active_idx": {
+          "name": "linear_installations_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "linear_installations_project_id_projects_id_fk": {
+          "name": "linear_installations_project_id_projects_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "linear_installations_actor_user_id_users_id_fk": {
+          "name": "linear_installations_actor_user_id_users_id_fk",
+          "tableFrom": "linear_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_codes": {
+      "name": "mcp_oauth_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_codes_client_idx": {
+          "name": "mcp_oauth_codes_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_user_id_users_id_fk": {
+          "name": "mcp_oauth_codes_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_project_id_projects_id_fk": {
+          "name": "mcp_oauth_codes_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_tokens": {
+      "name": "mcp_oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "access_hash": {
+          "name": "access_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_hash": {
+          "name": "refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_tokens_client_idx": {
+          "name": "mcp_oauth_tokens_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_tokens_user_idx": {
+          "name": "mcp_oauth_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_user_id_users_id_fk": {
+          "name": "mcp_oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_project_id_projects_id_fk": {
+          "name": "mcp_oauth_tokens_project_id_projects_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_tokens_access_hash_unique": {
+          "name": "mcp_oauth_tokens_access_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_hash"
+          ]
+        },
+        "mcp_oauth_tokens_refresh_hash_unique": {
+          "name": "mcp_oauth_tokens_refresh_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notion_installations": {
+      "name": "notion_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_icon": {
+          "name": "workspace_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_required_at": {
+          "name": "reauth_required_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reauth_reason": {
+          "name": "reauth_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notion_installations_project_active_idx": {
+          "name": "notion_installations_project_active_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notion_installations_project_id_projects_id_fk": {
+          "name": "notion_installations_project_id_projects_id_fk",
+          "tableFrom": "notion_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notion_installations_actor_user_id_users_id_fk": {
+          "name": "notion_installations_actor_user_id_users_id_fk",
+          "tableFrom": "notion_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_agent_settings": {
+      "name": "org_agent_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "digest_enabled": {
+          "name": "digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "digest_slack_installation_id": {
+          "name": "digest_slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_id": {
+          "name": "digest_slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_slack_channel_name": {
+          "name": "digest_slack_channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_last_run_at": {
+          "name": "digest_last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_agent_settings_org_idx": {
+          "name": "org_agent_settings_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_agent_settings_org_id_orgs_id_fk": {
+          "name": "org_agent_settings_org_id_orgs_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk": {
+          "name": "org_agent_settings_digest_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "org_agent_settings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "digest_slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_api_keys": {
+      "name": "org_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_api_keys_org_idx": {
+          "name": "org_api_keys_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_api_keys_org_id_orgs_id_fk": {
+          "name": "org_api_keys_org_id_orgs_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_api_keys_created_by_user_id_users_id_fk": {
+          "name": "org_api_keys_created_by_user_id_users_id_fk",
+          "tableFrom": "org_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_api_keys_key_hash_unique": {
+          "name": "org_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integration_secrets": {
+      "name": "org_integration_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_integration_id": {
+          "name": "org_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_name": {
+          "name": "secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integration_secrets_unique_idx": {
+          "name": "org_integration_secrets_unique_idx",
+          "columns": [
+            {
+              "expression": "org_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integration_secrets_org_integration_id_org_integrations_id_fk": {
+          "name": "org_integration_secrets_org_integration_id_org_integrations_id_fk",
+          "tableFrom": "org_integration_secrets",
+          "tableTo": "org_integrations",
+          "columnsFrom": [
+            "org_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_integrations": {
+      "name": "org_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_integrations_org_slug_idx": {
+          "name": "org_integrations_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_integrations_org_enabled_idx": {
+          "name": "org_integrations_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_integrations_org_id_orgs_id_fk": {
+          "name": "org_integrations_org_id_orgs_id_fk",
+          "tableFrom": "org_integrations",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_members_org_user_idx": {
+          "name": "org_members_org_user_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_org_id_orgs_id_fk": {
+          "name": "org_members_org_id_orgs_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_members_user_id_users_id_fk": {
+          "name": "org_members_user_id_users_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_setup_skipped_at": {
+          "name": "github_setup_skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_source": {
+          "name": "signup_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_return_url_hosts": {
+          "name": "allowed_return_url_hosts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_slug_unique": {
+          "name": "orgs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "orgs_clerk_org_id_unique": {
+          "name": "orgs_clerk_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personal_access_tokens_user_idx": {
+          "name": "personal_access_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personal_access_tokens_project_idx": {
+          "name": "personal_access_tokens_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_access_tokens_user_id_users_id_fk": {
+          "name": "personal_access_tokens_user_id_users_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personal_access_tokens_project_id_projects_id_fk": {
+          "name": "personal_access_tokens_project_id_projects_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_automation_settings": {
+      "name": "project_automation_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_investigate_issues_enabled": {
+          "name": "auto_investigate_issues_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "agent_run_provider": {
+          "name": "agent_run_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "max_runtime_minutes": {
+          "name": "max_runtime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "max_human_resume_count": {
+          "name": "max_human_resume_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "agent_run_enabled": {
+          "name": "agent_run_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_follow_up_enabled": {
+          "name": "auto_follow_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "chat_enabled": {
+          "name": "chat_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "linear_ticket_policy": {
+          "name": "linear_ticket_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "linear_ticket_instructions": {
+          "name": "linear_ticket_instructions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "linear_default_team_id": {
+          "name": "linear_default_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_policy": {
+          "name": "pr_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_ready_to_pr'"
+        },
+        "approval_prompts_enabled": {
+          "name": "approval_prompts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "create_linear_ticket_on_resolve": {
+          "name": "create_linear_ticket_on_resolve",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "pr_base_branch": {
+          "name": "pr_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_merge_fix_prs": {
+          "name": "auto_merge_fix_prs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'never'"
+        },
+        "auto_merge_method": {
+          "name": "auto_merge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'squash'"
+        },
+        "issue_filter": {
+          "name": "issue_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "issue_filter_config": {
+          "name": "issue_filter_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"includeLogs\":[],\"includeSpans\":[],\"excludeLogs\":[],\"excludeSpans\":[]}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_automation_settings_project_idx": {
+          "name": "project_automation_settings_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_automation_settings_project_id_projects_id_fk": {
+          "name": "project_automation_settings_project_id_projects_id_fk",
+          "tableFrom": "project_automation_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_github_repos": {
+      "name": "project_github_repos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_full_name": {
+          "name": "github_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_github_repos_project_repo_idx": {
+          "name": "project_github_repos_project_repo_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_github_repos_installation_idx": {
+          "name": "project_github_repos_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_github_repos_project_id_projects_id_fk": {
+          "name": "project_github_repos_project_id_projects_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_github_repos_installation_id_github_installations_id_fk": {
+          "name": "project_github_repos_installation_id_github_installations_id_fk",
+          "tableFrom": "project_github_repos",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_ingest_filters": {
+      "name": "project_ingest_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal": {
+          "name": "signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_ingest_filters_project_source_signal_idx": {
+          "name": "project_ingest_filters_project_source_signal_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_ingest_filters_project_id_projects_id_fk": {
+          "name": "project_ingest_filters_project_id_projects_id_fk",
+          "tableFrom": "project_ingest_filters",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_mcp_oauth_attempts": {
+      "name": "project_mcp_oauth_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_ciphertext": {
+          "name": "payload_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_nonce": {
+          "name": "payload_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_key_version": {
+          "name": "payload_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_mcp_oauth_attempts_server_idx": {
+          "name": "project_mcp_oauth_attempts_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_mcp_oauth_attempts_expiry_idx": {
+          "name": "project_mcp_oauth_attempts_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_mcp_oauth_attempts_server_id_project_mcp_servers_id_fk": {
+          "name": "project_mcp_oauth_attempts_server_id_project_mcp_servers_id_fk",
+          "tableFrom": "project_mcp_oauth_attempts",
+          "tableTo": "project_mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_mcp_oauth_attempts_state_hash_unique": {
+          "name": "project_mcp_oauth_attempts_state_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_mcp_servers": {
+      "name": "project_mcp_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "auth_ciphertext": {
+          "name": "auth_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_nonce": {
+          "name": "auth_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_key_version": {
+          "name": "auth_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trusted_at": {
+          "name": "trusted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trusted_by_user_id": {
+          "name": "trusted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_mcp_servers_project_name_idx": {
+          "name": "project_mcp_servers_project_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_mcp_servers_project_url_idx": {
+          "name": "project_mcp_servers_project_url_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_mcp_servers_project_enabled_idx": {
+          "name": "project_mcp_servers_project_enabled_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_mcp_servers_project_id_projects_id_fk": {
+          "name": "project_mcp_servers_project_id_projects_id_fk",
+          "tableFrom": "project_mcp_servers",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_mcp_servers_trusted_by_user_id_users_id_fk": {
+          "name": "project_mcp_servers_trusted_by_user_id_users_id_fk",
+          "tableFrom": "project_mcp_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "trusted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_mcp_servers_created_by_user_id_users_id_fk": {
+          "name": "project_mcp_servers_created_by_user_id_users_id_fk",
+          "tableFrom": "project_mcp_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_mcp_servers_updated_by_user_id_users_id_fk": {
+          "name": "project_mcp_servers_updated_by_user_id_users_id_fk",
+          "tableFrom": "project_mcp_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_mcp_servers_auth_fields_check": {
+          "name": "project_mcp_servers_auth_fields_check",
+          "value": "(\n        auth_type = 'none'\n        AND auth_ciphertext IS NULL\n        AND auth_nonce IS NULL\n        AND auth_key_version IS NULL\n      ) OR (\n        auth_type IN ('bearer', 'api_key', 'oauth')\n        AND auth_ciphertext IS NOT NULL\n        AND auth_nonce IS NOT NULL\n        AND auth_key_version IS NOT NULL\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_topologies": {
+      "name": "project_topologies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment": {
+          "name": "enrichment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_requested_at": {
+          "name": "refresh_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_topologies_project_idx": {
+          "name": "project_topologies_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_topologies_project_id_projects_id_fk": {
+          "name": "project_topologies_project_id_projects_id_fk",
+          "tableFrom": "project_topologies",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_context": {
+          "name": "project_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "first_telemetry_at": {
+          "name": "first_telemetry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_org_slug_idx": {
+          "name": "projects_org_slug_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_org_id_orgs_id_fk": {
+          "name": "projects_org_id_orgs_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_id_org_uniq": {
+          "name": "projects_id_org_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.railway_installations": {
+      "name": "railway_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "railway_user_id": {
+          "name": "railway_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_projects": {
+          "name": "granted_projects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_token_ciphertext": {
+          "name": "refresh_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_nonce": {
+          "name": "refresh_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_key_version": {
+          "name": "refresh_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_cursor": {
+          "name": "log_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_cursor": {
+          "name": "metrics_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "railway_installations_project_user_idx": {
+          "name": "railway_installations_project_user_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "railway_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "railway_installations_project_id_projects_id_fk": {
+          "name": "railway_installations_project_id_projects_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "railway_installations_api_key_id_api_keys_id_fk": {
+          "name": "railway_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "railway_installations_installed_by_user_id_users_id_fk": {
+          "name": "railway_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "railway_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.render_installations": {
+      "name": "render_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_owner_id": {
+          "name": "render_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_owner_name": {
+          "name": "render_owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "render_api_key_ciphertext": {
+          "name": "render_api_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_api_key_nonce": {
+          "name": "render_api_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_api_key_key_version": {
+          "name": "render_api_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_cursor": {
+          "name": "log_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_cursor": {
+          "name": "metrics_cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_stream_state": {
+          "name": "log_stream_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_stream_state": {
+          "name": "metrics_stream_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "render_installations_project_owner_idx": {
+          "name": "render_installations_project_owner_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "render_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "render_installations_project_id_projects_id_fk": {
+          "name": "render_installations_project_id_projects_id_fk",
+          "tableFrom": "render_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "render_installations_api_key_id_api_keys_id_fk": {
+          "name": "render_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "render_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "render_installations_installed_by_user_id_users_id_fk": {
+          "name": "render_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "render_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_orgs_id_fk": {
+          "name": "sessions_active_organization_id_orgs_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signup_intents": {
+      "name": "signup_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_project_id": {
+          "name": "claimed_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signup_intents_claimed_project_id_projects_id_fk": {
+          "name": "signup_intents_claimed_project_id_projects_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "claimed_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "signup_intents_claimed_by_user_id_users_id_fk": {
+          "name": "signup_intents_claimed_by_user_id_users_id_fk",
+          "tableFrom": "signup_intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signup_intents_key_hash_unique": {
+          "name": "signup_intents_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default_chat_project": {
+          "name": "is_default_chat_project",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "slack_installations_project_team_idx": {
+          "name": "slack_installations_project_team_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_default_chat_idx": {
+          "name": "slack_installations_default_chat_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default_chat_project",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_project_id_projects_id_fk": {
+          "name": "slack_installations_project_id_projects_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_installations_installed_by_user_id_users_id_fk": {
+          "name": "slack_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_map_artifacts": {
+      "name": "source_map_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dist": {
+          "name": "dist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug_id": {
+          "name": "debug_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_file": {
+          "name": "bundle_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_file": {
+          "name": "map_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_hash": {
+          "name": "source_map_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_map_bytes": {
+          "name": "source_map_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_bucket": {
+          "name": "storage_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_encoding": {
+          "name": "content_encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gzip'"
+        },
+        "uploaded_by_org_api_key_id": {
+          "name": "uploaded_by_org_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_map_artifacts_project_debug_id_idx": {
+          "name": "source_map_artifacts_project_debug_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "debug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "debug_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_map_artifacts_project_release_idx": {
+          "name": "source_map_artifacts_project_release_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "release",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_map_artifacts_project_id_projects_id_fk": {
+          "name": "source_map_artifacts_project_id_projects_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk": {
+          "name": "source_map_artifacts_uploaded_by_org_api_key_id_org_api_keys_id_fk",
+          "tableFrom": "source_map_artifacts",
+          "tableTo": "org_api_keys",
+          "columnsFrom": [
+            "uploaded_by_org_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_notifications": {
+      "name": "usage_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_notifications_org_period_threshold_idx": {
+          "name": "usage_notifications_org_period_threshold_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "threshold",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_notifications_org_id_orgs_id_fk": {
+          "name": "usage_notifications_org_id_orgs_id_fk",
+          "tableFrom": "usage_notifications",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_project_id": {
+          "name": "active_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_org_id": {
+          "name": "active_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_org_id": {
+          "name": "favorite_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_project_id": {
+          "name": "favorite_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_active_project_id_projects_id_fk": {
+          "name": "users_active_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "active_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_active_org_id_orgs_id_fk": {
+          "name": "users_active_org_id_orgs_id_fk",
+          "tableFrom": "users",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "active_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_favorite_org_id_orgs_id_fk": {
+          "name": "users_favorite_org_id_orgs_id_fk",
+          "tableFrom": "users",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "favorite_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_favorite_project_id_projects_id_fk": {
+          "name": "users_favorite_project_id_projects_id_fk",
+          "tableFrom": "users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "favorite_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_installations": {
+      "name": "vercel_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_id": {
+          "name": "configuration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_nonce": {
+          "name": "access_token_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_key_version": {
+          "name": "access_token_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_ciphertext": {
+          "name": "ingest_key_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_nonce": {
+          "name": "ingest_key_nonce",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_key_version": {
+          "name": "ingest_key_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drains": {
+          "name": "drains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vercel_installations_project_configuration_idx": {
+          "name": "vercel_installations_project_configuration_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "configuration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_installations_project_id_projects_id_fk": {
+          "name": "vercel_installations_project_id_projects_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vercel_installations_api_key_id_api_keys_id_fk": {
+          "name": "vercel_installations_api_key_id_api_keys_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vercel_installations_installed_by_user_id_users_id_fk": {
+          "name": "vercel_installations_installed_by_user_id_users_id_fk",
+          "tableFrom": "vercel_installations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_status": {
+          "name": "last_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_endpoint_idx": {
+          "name": "webhook_deliveries_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_events": {
+          "name": "enabled_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"incident.created\",\"incident.updated\"]'::jsonb"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_endpoints_project_idx": {
+          "name": "webhook_endpoints_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_endpoints_project_id_projects_id_fk": {
+          "name": "webhook_endpoints_project_id_projects_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_state": {
+      "name": "worker_state",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0100_snapshot.json
+++ b/packages/db/migrations/meta/0100_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "3ca7bfef-848a-410d-9a9d-2e1cc463248e",
+  "id": "bf418b0e-3a73-4271-8ecd-3e5f461a932a",
   "prevId": "67b8ce8a-9211-4864-a2ec-5021d76efb80",
   "version": "7",
   "dialect": "postgresql",
@@ -6769,7 +6769,7 @@
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
-          "default": true
+          "default": false
         },
         "pr_base_branch": {
           "name": "pr_base_branch",

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -701,6 +701,13 @@
       "when": 1784021018932,
       "tag": "0099_tired_beast",
       "breakpoints": true
+    },
+    {
+      "idx": 100,
+      "version": "7",
+      "when": 1784031052730,
+      "tag": "0100_soft_magik",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -705,8 +705,8 @@
     {
       "idx": 100,
       "version": "7",
-      "when": 1784031052730,
-      "tag": "0100_soft_magik",
+      "when": 1784031696429,
+      "tag": "0100_tidy_young_avengers",
       "breakpoints": true
     }
   ]

--- a/packages/db/src/automation-settings.test.ts
+++ b/packages/db/src/automation-settings.test.ts
@@ -1,0 +1,7 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { projectAutomationSettings } from "./schema.js";
+
+test("resolve-time Linear ticket creation is opt-in", () => {
+  assert.equal(projectAutomationSettings.createLinearTicketOnResolve.default, false);
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -23,6 +23,7 @@ export {
   captureAgentPrLifecycleEvent,
   daysBetween,
 } from "./pr-analytics.js";
+export { linearTicketAcceptanceUnit } from "./linear-acceptance.js";
 export * as schema from "./schema.js";
 export {
   generateApiKey,

--- a/packages/db/src/linear-acceptance.test.ts
+++ b/packages/db/src/linear-acceptance.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { linearTicketAcceptanceUnit } from "./linear-acceptance.js";
+
+test("a findings-only run has a stable synthetic PR acceptance unit", () => {
+  assert.deepEqual(
+    linearTicketAcceptanceUnit({
+      id: "ticket-row-1",
+      incidentId: "incident-1",
+      agentRunId: "run-1",
+      url: "https://linear.app/acme/issue/ENG-42",
+    }),
+    {
+      id: "linear:ticket-row-1",
+      incidentId: "incident-1",
+      agentRunId: "run-1",
+      repoFullName: "linear",
+      prNumber: 0,
+      url: "https://linear.app/acme/issue/ENG-42",
+    },
+  );
+});

--- a/packages/db/src/linear-acceptance.ts
+++ b/packages/db/src/linear-acceptance.ts
@@ -1,0 +1,17 @@
+import type { AgentPrAnalyticsPr } from "./pr-analytics.js";
+
+export function linearTicketAcceptanceUnit(ticket: {
+  id: string;
+  incidentId: string;
+  agentRunId: string;
+  url: string | null;
+}): AgentPrAnalyticsPr {
+  return {
+    id: `linear:${ticket.id}`,
+    incidentId: ticket.incidentId,
+    agentRunId: ticket.agentRunId,
+    repoFullName: "linear",
+    prNumber: 0,
+    url: ticket.url ?? "",
+  };
+}

--- a/packages/db/src/pr-analytics.test.ts
+++ b/packages/db/src/pr-analytics.test.ts
@@ -71,6 +71,21 @@ test("accepted event includes days_to_accept and merged_by", () => {
   assert.equal(ev.properties?.merged_by, "octocat");
 });
 
+test("accepted event records Linear as an acceptance source", () => {
+  const rec = recorder();
+  setAnalyticsClientForTests(rec);
+
+  captureAgentPrLifecycleEvent({
+    kind: "accepted",
+    pr,
+    org,
+    daysToOutcome: 1,
+    acceptanceSource: "linear",
+  });
+
+  assert.equal(rec.events[0]?.properties?.acceptance_source, "linear");
+});
+
 test("rejected event includes the reason and days_to_reject", () => {
   const rec = recorder();
   setAnalyticsClientForTests(rec);

--- a/packages/db/src/pr-analytics.ts
+++ b/packages/db/src/pr-analytics.ts
@@ -35,6 +35,7 @@ export type AgentPrLifecycleEventInput =
       org: AgentPrAnalyticsOrg;
       daysToOutcome: number | null;
       mergedByLogin?: string | null;
+      acceptanceSource?: "github_merge" | "linear";
     }
   | {
       kind: "rejected";
@@ -82,6 +83,7 @@ export function captureAgentPrLifecycleEvent(input: AgentPrLifecycleEventInput):
   if (input.kind === "accepted") {
     properties.days_to_accept = input.daysToOutcome;
     properties.merged_by = input.mergedByLogin ?? null;
+    properties.acceptance_source = input.acceptanceSource ?? "github_merge";
   } else if (input.kind === "rejected") {
     properties.reason = input.reason;
     properties.days_to_reject = input.daysToOutcome;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -969,7 +969,7 @@ export const projectAutomationSettings = pgTable(
     // ticket for this terminal path as well.
     createLinearTicketOnResolve: boolean("create_linear_ticket_on_resolve")
       .notNull()
-      .default(true),
+      .default(false),
     prBaseBranch: text("pr_base_branch"),
     autoMergeFixPrs: text("auto_merge_fix_prs")
       .$type<"never" | "when_checks_pass" | "immediately">()

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -185,6 +185,7 @@ export type IncidentResolutionClassification = {
 // status path.
 export type IncidentResolvedByKind =
   | "agent_pr_merged" // our agent opened a PR, GitHub said it merged
+  | "linear_ticket_completed" // the run's Linear handoff entered a completed state
   | "agent_classification" // agent run completed with resolutionClassification.reason set
   | "slack_manual" // human clicked the Resolve button in Slack
   | "autorecovery_confirmed" // autorecovery agent proposed, human clicked Confirm
@@ -277,6 +278,9 @@ export type AgentRunIncidentResolution = {
 export type AgentRunResult = {
   state: "complete" | "awaiting_human" | "awaiting_events" | "failed";
   summary: string;
+  // Explicit terminal signal for runs that finish their investigation while
+  // deliberately leaving the incident open for an external ticket workflow.
+  completionKind?: "investigation_complete" | null;
   question?: string | null;
   failureReason?: AgentRunFailureReason | null;
   // Legacy single-PR record (pre multi-PR contract). New runs record opened
@@ -956,6 +960,16 @@ export const projectAutomationSettings = pgTable(
       .$type<"never" | "on_ready_to_pr" | "always">()
       .notNull()
       .default("on_ready_to_pr"),
+    // Master switch for remediation actions that require a human approval
+    // before the worker executes them. Availability is still determined by
+    // the installed integrations' actual tool set.
+    approvalPromptsEnabled: boolean("approval_prompts_enabled").notNull().default(true),
+    // Resolving an incident is normally terminal without an extra handoff.
+    // Projects that use Linear as their audit trail can opt into filing a
+    // ticket for this terminal path as well.
+    createLinearTicketOnResolve: boolean("create_linear_ticket_on_resolve")
+      .notNull()
+      .default(true),
     prBaseBranch: text("pr_base_branch"),
     autoMergeFixPrs: text("auto_merge_fix_prs")
       .$type<"never" | "when_checks_pass" | "immediately">()

--- a/scripts/portless-stack.sh
+++ b/scripts/portless-stack.sh
@@ -112,11 +112,11 @@ checksum="$(printf '%s' "$STACK_NAME" | cksum | awk '{print $1}')"
 offset=$(( checksum % 1000 ))
 if [[ -n "${SUPERLOG_PORTLESS_OFFSET:-}" ]]; then
   if [[ ! "$SUPERLOG_PORTLESS_OFFSET" =~ ^[0-9]+$ ]] ||
-    (( SUPERLOG_PORTLESS_OFFSET < 0 || SUPERLOG_PORTLESS_OFFSET > 999 )); then
+    (( 10#$SUPERLOG_PORTLESS_OFFSET < 0 || 10#$SUPERLOG_PORTLESS_OFFSET > 999 )); then
     echo "SUPERLOG_PORTLESS_OFFSET must be an integer from 0 to 999" >&2
     exit 1
   fi
-  offset="$SUPERLOG_PORTLESS_OFFSET"
+  offset=$(( 10#$SUPERLOG_PORTLESS_OFFSET ))
 fi
 
 POSTGRES_HOST_PORT=$(( 15432 + offset ))

--- a/scripts/portless-stack.sh
+++ b/scripts/portless-stack.sh
@@ -97,6 +97,7 @@ fi
 
 STACK_DIR="$REPO_ROOT/tmp/portless-stacks/$STACK_NAME"
 ENV_FILE="$STACK_DIR/env"
+OVERMIND_ENV_CHECKSUM_FILE="$STACK_DIR/overmind-env.checksum"
 LOG_DIR="$STACK_DIR/logs"
 OVERMIND_SOCKET="$STACK_DIR/overmind.sock"
 # macOS limits unix-socket paths to ~104 bytes. When the worktree path makes
@@ -109,6 +110,14 @@ COMPOSE_PROJECT="superlog-portless-$STACK_NAME"
 
 checksum="$(printf '%s' "$STACK_NAME" | cksum | awk '{print $1}')"
 offset=$(( checksum % 1000 ))
+if [[ -n "${SUPERLOG_PORTLESS_OFFSET:-}" ]]; then
+  if [[ ! "$SUPERLOG_PORTLESS_OFFSET" =~ ^[0-9]+$ ]] ||
+    (( SUPERLOG_PORTLESS_OFFSET < 0 || SUPERLOG_PORTLESS_OFFSET > 999 )); then
+    echo "SUPERLOG_PORTLESS_OFFSET must be an integer from 0 to 999" >&2
+    exit 1
+  fi
+  offset="$SUPERLOG_PORTLESS_OFFSET"
+fi
 
 POSTGRES_HOST_PORT=$(( 15432 + offset ))
 CLICKHOUSE_HTTP_HOST_PORT=$(( 18123 + offset ))
@@ -217,6 +226,18 @@ run_with_env() {
   "$@"
 }
 
+wait_for_overmind_stop() {
+  local attempt
+  for attempt in {1..50}; do
+    if ! overmind status --socket "$OVERMIND_SOCKET" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "overmind did not stop at $OVERMIND_SOCKET" >&2
+  return 1
+}
+
 print_summary() {
   printf 'stack:      %s\n' "$STACK_NAME"
   printf 'web:        %s\n' "$WEB_URL"
@@ -297,13 +318,31 @@ start_stack() {
 
   run_with_env pnpm --filter @superlog/db db:migrate
 
+  local desired_env_checksum running_env_checksum=""
+  desired_env_checksum="$(cksum "$ENV_FILE" | awk '{print $1 ":" $2}')"
+  if [[ -f "$OVERMIND_ENV_CHECKSUM_FILE" ]]; then
+    running_env_checksum="$(tr -d '[:space:]' < "$OVERMIND_ENV_CHECKSUM_FILE")"
+  fi
+
+  local overmind_running=0
   if overmind status --socket "$OVERMIND_SOCKET" >/dev/null 2>&1; then
-    echo "==> overmind already running at $OVERMIND_SOCKET"
-  else
+    overmind_running=1
+    if [[ "$running_env_checksum" != "$desired_env_checksum" ]]; then
+      echo "==> overmind environment changed; restarting services"
+      overmind quit --socket "$OVERMIND_SOCKET" >/dev/null 2>&1 || true
+      wait_for_overmind_stop
+      overmind_running=0
+    else
+      echo "==> overmind already running at $OVERMIND_SOCKET"
+    fi
+  fi
+
+  if [[ "$overmind_running" -eq 0 ]]; then
     SUPERLOG_STACK_ENV_FILE="$ENV_FILE" \
       SUPERLOG_LOG_DIR="$LOG_DIR" \
       overmind start -D --procfile Procfile.portless --socket "$OVERMIND_SOCKET" --no-port
   fi
+  printf '%s\n' "$desired_env_checksum" > "$OVERMIND_ENV_CHECKSUM_FILE"
 
   print_summary
 }
@@ -312,6 +351,7 @@ stop_stack() {
   write_env_file
 
   overmind quit --socket "$OVERMIND_SOCKET" >/dev/null 2>&1 || true
+  rm -f "$OVERMIND_ENV_CHECKSUM_FILE"
   compose down
 }
 

--- a/scripts/portless-stack.test.sh
+++ b/scripts/portless-stack.test.sh
@@ -39,4 +39,21 @@ if [[ "$(tr -d '[:space:]' < "$TMP_HOME/.portless/proxy.port")" != "2443" ]]; th
   exit 1
 fi
 
+output="$(
+  HOME="$TMP_HOME" SUPERLOG_PORTLESS_OFFSET=999 \
+    "$REPO_ROOT/scripts/portless-stack.sh" env --name "$STACK_NAME"
+)"
+
+if ! grep -Fqx "postgres:   localhost:16431" <<< "$output"; then
+  echo "expected an explicit stack offset to avoid a hashed host-port collision" >&2
+  printf '%s\n' "$output" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'overmind environment changed; restarting services' \
+  "$REPO_ROOT/scripts/portless-stack.sh"; then
+  echo "expected stack startup to restart overmind after a generated env change" >&2
+  exit 1
+fi
+
 echo "portless-stack proxy port: ok"

--- a/scripts/portless-stack.test.sh
+++ b/scripts/portless-stack.test.sh
@@ -50,9 +50,47 @@ if ! grep -Fqx "postgres:   localhost:16431" <<< "$output"; then
   exit 1
 fi
 
-if ! grep -Fq 'overmind environment changed; restarting services' \
-  "$REPO_ROOT/scripts/portless-stack.sh"; then
+output="$(
+  HOME="$TMP_HOME" SUPERLOG_PORTLESS_OFFSET=008 \
+    "$REPO_ROOT/scripts/portless-stack.sh" env --name "$STACK_NAME"
+)"
+if ! grep -Fqx "postgres:   localhost:15440" <<< "$output"; then
+  echo "expected zero-padded offsets to be parsed as decimal" >&2
+  printf '%s\n' "$output" >&2
+  exit 1
+fi
+
+FAKE_BIN="$TMP_HOME/bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$FAKE_BIN/pnpm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$FAKE_BIN/overmind" <<'EOF'
+#!/usr/bin/env bash
+state="$HOME/.fake-overmind-running"
+case "$1" in
+  status) [[ -f "$state" ]] ;;
+  quit) rm -f "$state" ;;
+  start) touch "$state" ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/docker" "$FAKE_BIN/pnpm" "$FAKE_BIN/overmind"
+
+HOME="$TMP_HOME" PATH="$FAKE_BIN:$PATH" SUPERLOG_PORTLESS_OFFSET=7 \
+  "$REPO_ROOT/scripts/portless-stack.sh" start --name "$STACK_NAME" >/dev/null
+output="$(
+  HOME="$TMP_HOME" PATH="$FAKE_BIN:$PATH" SUPERLOG_PORTLESS_OFFSET=8 \
+    "$REPO_ROOT/scripts/portless-stack.sh" start --name "$STACK_NAME"
+)"
+if ! grep -Fq 'overmind environment changed; restarting services' <<< "$output"; then
   echo "expected stack startup to restart overmind after a generated env change" >&2
+  printf '%s\n' "$output" >&2
   exit 1
 fi
 

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -96,9 +96,11 @@ If the issue is not noise, that is to say:
 - end users are impacted in any way
 - performance is significantly degraded
 - a system that used to be running is inoperative without reason
-- internal users are impacted in a meaningful way
+- internal users are impacted in a meaningful way,
 
-the Superlog agent must attempt to resolve the issue. The resolution is a multi-step process that can involve the following actions:
+the Superlog agent must attempt to resolve the issue.
+
+The resolution is a multi-step process that can involve the following actions:
 
 - Modifying the source code of the observed system and opening Pull Requests 
     - Responding to comments on these PRs to adjust them
@@ -109,14 +111,12 @@ the Superlog agent must attempt to resolve the issue. The resolution is a multi-
 
 Opening PRs and Approval prompts continues in a loop until the issue is Resolved.
 
+Both the source code modification and approval prompts can be disabled in the settings. If no resolution tools are available, the agent must submit its findings.
+
 ### Approval prompt
 
 An Approval prompt is a way for our agent to make changes in the client's infrastructure, databases and other systems with the user's approval. When Superlog has access to the customer's infrastructure, for example, their AWS account, Superlog must always send Approval Prompts before taking action. 
 
-
-### Non-noise Incident states 
-
-An Incident can be `open` (during the execution of the Agent Run).
 
 #### Resolution by the agent
 
@@ -132,25 +132,6 @@ The users of Superlog can also resolve Incidents by clicking the corresponding b
 If the interface allows so, we should provide two buttons:
 - **Problem resolved** -> Incident goes to 'resolved', issues go to 'resolved'
 - **Not an issue** -> Incident goes to 'resolved', issues go to 'silenced'
-
-# Memory 
-
-Humans and agents can add notes on various Superlog entities in order to:
-- personalize Superlog for clients
-- improve investigation quality.
-
-There are two ways to store memory in Superlog: comments and project memory
-
-## Comments
-Issues have associated Comments. Humans and Agents can add Comments that are visible to the Agent Run investigating the Incident.
-
-## Project memory
-Every Project has a list of Memories that can be added by humans and Agents. A Memory is a dated free-form text. All Project memories are visible to the Agent Run investigating the Incident. Agents can add new Memories during investigations and in response to PR comments, Slack messages and other interactions with users.
-
-# Weekly update
-
-Once per week, Superlog must send to the connected Slack channel an update containing a global review of all issues, including the number of issues counted as noise. 
-
 
 # Agent
 
@@ -172,15 +153,15 @@ Manage issues:
 - Put an issue under observation. If the Issue is a one-off event and needs observation (see above), the Issues needs to be placed under observation with an Escalation trigger.
 - Resolve an issue. If the impact of an issue has ceased due to other factors, and no more action can be taken, the issue needs to be Resolved. 
 
-Take actions to resolve the root cause of the incident (multiple times, iterating and responding to external triggers):
+Take actions to resolve the root cause of the incident (multiple times, iterating and responding to external triggers). These tools might or might not be available in a given project:
 
 - Modify the source code and open a PR. The agent never holds push credentials: it produces a patch, and the platform applies the patch and opens the PR on its behalf.
 - Produce an Approval prompt for an action that is available to it:
     - an infra fix via AWS CLI
     - other tools available to the agent (to be extended)
 When a human approves an Approval prompt, the platform executes the approved command verbatim under the customer-owned action role and reports the result back to the agent's session. The agent does not execute approved commands itself.
-
 - Require a prompt for human input and ask for clarification.
+- If no action tools are available, the agent can 'complete_investigation'.
 
 And then, finally,
 
@@ -226,13 +207,13 @@ The tool contract (source of truth: `apps/worker/src/agent-outcome-tools.ts`) ha
 
 1. **`report_findings`** (non-terminal) — shared metadata, callable repeatedly.
 2. **Action tools** (non-terminal, executed server-side mid-run): `propose_pr`, `silence_as_noise`, `place_under_observation`, `resolve_issue`. The platform executes each call while the session is live and returns the result to the agent — a PR call returns the PR URL (or the apply failure, which the agent can fix and retry); a classification call applies to the issue immediately.
-3. **Terminal tools**: `resolve_incident` ends the investigation; `ask_human` pauses it on a human.
+3. **Terminal tools**: `resolve_incident` ends the investigation and resolves the incident; `complete_investigation` ends the investigation while leaving the incident open, and is only exposed when no PR or approval-prompt action is actually available; `ask_human` pauses it on a human.
 
-A turn may also legitimately end with **no** terminal call when the agent is waiting on external events — open PRs out for review. The run then parks (`awaiting_events`) with its session intact and is resumed by a PR comment, merge, or close (or any human message). Ending a turn with no terminal call *and* nothing pending gets one nudge, then the budget backstops fail the run: a diagnosis that ends with nothing happening is not an outcome.
+A turn may also legitimately end with **no** terminal call when the agent is waiting on external events — open PRs out for review. If Linear is connected, the platform creates this run's ticket as soon as the first PR is successfully recorded. It then cross-links every PR independently: the PR gets the ticket link and the ticket gets the PR link. Later PRs reuse the same run-scoped ticket, and the Slack PR/waiting updates include it. The run then parks (`awaiting_events`) with its session intact and is resumed by a PR comment, merge, or close (or any human message). Ending a turn with no terminal call *and* nothing pending gets one nudge, then the budget backstops fail the run: a diagnosis that ends with nothing happening is not an outcome.
 
 ### report_findings (non-terminal)
 
-Records shared metadata before any acting tool. Callable repeatedly; fields are last-write-wins. All action tools and `resolve_incident` refuse to run until it has been called.
+Records shared metadata before any acting tool. Callable repeatedly; fields are last-write-wins. All action tools, `complete_investigation`, and `resolve_incident` refuse to run until it has been called.
 
 - `summary` (required) — 1-2 sentences, operator's view, symptom before mechanism
 - `proposedTitle` — replacement incident title, symptom-first, never the fix
@@ -257,6 +238,8 @@ Only error issues can be silenced or observed; alert-episode issues can only be 
 
 **`resolve_incident`** — the global resolution of the incident: impact has ceased (or never was), or the agent's actions resolved the root cause. Rejected (with the list) while any linked issue is still unclassified. Params: `reason` (full-text), `evidence` (before/after signal + window).
 
+**`complete_investigation`** — finish a findings-only investigation, create the external ticket handoff when Linear is connected, and leave the incident open. It is available only when PR creation is disabled or unavailable and no approval-prompt action is available. Requires `report_findings`; does not require issue classification. No params.
+
 **`ask_human`** — a human must act or answer first; the run pauses and resumes with session intact on reply (waiting indefinitely is by design). Param: `question`. Covers: missing context; a code artifact absent from every mounted repo; a diagnosis whose remediation is not the agent's to make (third-party defect, provider quota, customer-owned config, a decision between fix paths); a failing code path the agent could not locate. In each case the agent states what it found and asks the concrete question that unblocks action.
 
 The Approval-prompt outcome (infra fix via AWS CLI etc.) is not yet a tool; when built it joins this contract as an action-or-waiting tool.
@@ -269,7 +252,25 @@ When an agent PR is merged or closed, the platform resumes the incident's sessio
 
 - Tool schemas are flat (`type`/`properties`/`required` only) — runner APIs reject top-level composition keywords at agent-create time.
 - Runner APIs don't enforce custom-tool schemas server-side, so the worker re-validates every call and error-acks invalid input with a model-readable message; the model corrects the call within the same session. Identical-tool error acks are capped per turn, then the budget backstops own the runaway session.
-- Retired tools (`complete_investigation`, `report_failure` — removed 2026-07-08 because they let a run end without anything happening; `mark_already_resolved` — replaced 2026-07-10 by the per-issue `resolve_issue` + `resolve_incident`) are still recognized by the validator: old sessions that resume and call one get an error ack redirecting to the live outcomes, not an unknown-tool hard failure.
+- Retired tools (`report_failure` — removed 2026-07-08 because it let a run end without findings; `mark_already_resolved` — replaced 2026-07-10 by the per-issue `resolve_issue` + `resolve_incident`) are still recognized by the validator: old sessions that resume and call one get an error ack redirecting to the live outcomes, not an unknown-tool hard failure.
+
+# Memory
+
+Humans and agents can add notes on various Superlog entities in order to:
+- personalize Superlog for clients
+- improve investigation quality.
+
+There are two ways to store memory in Superlog: comments and project memory
+
+## Comments
+Issues have associated Comments. Humans and Agents can add Comments that are visible to the Agent Run investigating the Incident.
+
+## Project memory
+Every Project has a list of Memories that can be added by humans and Agents. A Memory is a dated free-form text. All Project memories are visible to the Agent Run investigating the Incident. Agents can add new Memories during investigations and in response to PR comments, Slack messages and other interactions with users.
+
+# Weekly update
+
+Once per week, Superlog must send to the connected Slack channel an update containing a global review of all issues, including the number of issues counted as noise.
 
 
 # Changelog
@@ -278,3 +279,4 @@ July 6, 2026 - initial commit
 July 9, 2026 - Issues are either errors or alert episodes. An alert-episode Issue is one breach period (new breach = new Issue), only uses `open`/`resolved`, and groups into Incidents like errors do.
 July 9, 2026 - merged the managed-agent spec into this document
 July 10, 2026 - agent loop rework: full-text reasons, non-terminal propose_pr (multiple PRs, keyed by branch), per-issue classification tools, terminal resolve_incident, awaiting_events parking, PR merge/close resumes the session
+July 14, 2026 - deterministic Linear handoff: when Linear is connected, each explicitly completed investigation gets its own ticket, while PR-producing runs create/reuse their run-scoped ticket on the first recorded PR and cross-link every later PR; resolve-time filing is configurable; completed Linear tickets resolve incidents and count as accepted remediation. Projects without PR or approval actions finish through complete_investigation.


### PR DESCRIPTION
## What changed

- create one run-scoped Linear ticket at explicit investigation completion or when the first pull request is successfully recorded
- cross-link every pull request and its Linear ticket in both directions with independently retryable delivery
- surface the Linear ticket in incident details and Slack investigation updates
- resolve the incident and record acceptance when the tracked Linear issue enters a completed state
- add project controls for pull-request creation, approval prompts, and resolve-time ticket creation
- expose `complete_investigation` only when no pull-request or approval intervention is available
- restart portless services when their generated stack environment changes

## Why

Linear delivery was tied to non-deterministic investigation behavior and could be skipped or duplicated. The application now owns explicit creation boundaries and durable idempotency, while projects that only need findings and a Linear handoff have a first-class completion path.

## Validation

- affected worker, database, and API tests pass
- worker and web TypeScript checks pass
- full seeded worktree verification passes
- settings route responds successfully in the local worktree
- generated Drizzle migration is included unchanged

Provider boundaries are covered with fakes; the local worktree did not have connected Linear, GitHub, or Slack installations for live-provider delivery.
