### PR TITLE
Group same-trace recurrences into one incident

### DIFF
--- a/apps/worker/src/incidents/intake.test.ts
+++ b/apps/worker/src/incidents/intake.test.ts
@@ -265,6 +265,38 @@ test("intake: recurred same-trace sibling joins the incident instead of opening 
   assert.ok(!calls.some((c) => c.startsWith("openRecurrence")));
 });
 
+test("intake: recurred no-trace issue re-lands on a recurrence a racer opened inside the lock", async () => {
+  // No trace id, so the lock is keyed by issue id. Outside the lock the previous
+  // incident is still resolved; by the time we hold the lock a concurrent
+  // recurrence job has opened it. We must re-read and re-land, not open a second.
+  const calls: string[] = [];
+  const resolved = makeIncident({ id: "inc-prev", status: "resolved" });
+  const openedByRacer = makeIncident({ id: "inc-prev", status: "open" });
+  let findIncidentCalls = 0;
+  const base = makeRepo({
+    calls,
+    existingLink: { issueId: "iss-new", incidentId: "inc-prev" },
+  });
+  const repo: IntakeRepository = {
+    ...base,
+    async findIncident(incidentId) {
+      calls.push(`findIncident:${incidentId}`);
+      findIncidentCalls += 1;
+      return findIncidentCalls === 1 ? resolved : openedByRacer;
+    },
+  };
+  const result = await ensureIncidentForIssueWorkflow(
+    makeIssue({ status: "resolved" } as Partial<schema.Issue>),
+    "recurred",
+    makeDeps({ repo, lifecycle: makeLifecycle({ calls }), calls }),
+  );
+
+  assert.equal(result.createdIncident, false);
+  assert.equal(result.recurrenceIncident, false);
+  assert.equal(result.incident.id, "inc-prev");
+  assert.ok(!calls.some((c) => c.startsWith("openRecurrence")));
+});
+
 test("intake: recurred issue whose latest link is already open reuses it (retry idempotency)", async () => {
   const calls: string[] = [];
   const alreadyOpen = makeIncident({ id: "inc-open", status: "open" });

--- a/apps/worker/src/incidents/intake.test.ts
+++ b/apps/worker/src/incidents/intake.test.ts
@@ -212,6 +212,59 @@ test("intake: recurred issue opens a new incident chained to its previous one", 
   );
 });
 
+test("intake: recurred same-trace sibling joins the incident instead of opening a recurrence", async () => {
+  // Same request, resolved yesterday, recurring now: the span exception's
+  // incident is (re)opened by a racing transition; this log symptom shares the
+  // trace and must join it, not chain its own recurrence to its own predecessor.
+  const calls: string[] = [];
+  const previous = makeIncident({ id: "inc-prev", status: "resolved" });
+  const sibling = makeIncident({ id: "inc-sibling", service: "superlog-sample-nextjs" });
+  const base = makeRepo({
+    calls,
+    existingLink: { issueId: "iss-log", incidentId: "inc-prev" },
+    incidentById: new Map([
+      ["inc-prev", previous],
+      ["inc-sibling", sibling],
+    ]),
+  });
+  const repo: IntakeRepository = {
+    ...base,
+    async findOpenIncidentCandidates(_issue, queryOpts) {
+      calls.push(`findOpenIncidentCandidates:${queryOpts.filterService}`);
+      return queryOpts.filterService ? [] : [sibling];
+    },
+    async loadLinkedIncidentIssues(incidents) {
+      calls.push(`loadLinkedIncidentIssues:${incidents.length}`);
+      return incidents.map((inc) => ({
+        incidentId: inc.id,
+        title: "span exception",
+        exceptionType: "TypeError",
+        message: null,
+        topFrame: null,
+        normalizedFrames: [],
+        lastSample: { traceId: "trace-1", spanId: "span-exc" },
+        lastSeen: NOW,
+      })) as unknown as Awaited<ReturnType<IntakeRepository["loadLinkedIncidentIssues"]>>;
+    },
+  };
+  const result = await ensureIncidentForIssueWorkflow(
+    makeIssue({
+      id: "iss-log",
+      service: "superlog-sample",
+      status: "resolved",
+      lastSample: { traceId: "trace-1", spanId: "span-log" },
+    } as Partial<schema.Issue>),
+    "recurred",
+    makeDeps({ repo, lifecycle: makeLifecycle({ calls }), calls }),
+  );
+
+  assert.equal(result.createdIncident, false);
+  assert.equal(result.recurrenceIncident, false);
+  assert.equal(result.incident.id, "inc-sibling");
+  assert.ok(calls.includes("linkIssueToIncident:iss-log->inc-sibling"));
+  assert.ok(!calls.some((c) => c.startsWith("openRecurrence")));
+});
+
 test("intake: recurred issue whose latest link is already open reuses it (retry idempotency)", async () => {
   const calls: string[] = [];
   const alreadyOpen = makeIncident({ id: "inc-open", status: "open" });

--- a/apps/worker/src/incidents/intake.ts
+++ b/apps/worker/src/incidents/intake.ts
@@ -138,6 +138,15 @@ export async function ensureIncidentForIssueWorkflow(
   transition: IssueIntakeTransition,
   deps: IntakeDeps,
 ): Promise<EnsureIncidentForIssueResult> {
+  // Serialize intake by trace id when present, so same-request symptoms — a span
+  // exception and its own log line, which are DIFFERENT issues — can't each open
+  // an incident under concurrent pg-boss jobs. Falls back to the issue id (the
+  // alert-episode / same-issue case). Used by both the recurrence path below and
+  // the create path at the tail.
+  const traceId = issueSample(issue)?.traceId;
+  const serializeKey = traceId ? `trace:${traceId}` : issue.id;
+  const serialize = deps.serializeCreate ?? ((_key, fn) => fn());
+
   const existingLink = await deps.repo.findLatestIncidentIssueLink(issue.id);
 
   if ((transition === "recurred" || transition === "escalated") && existingLink) {
@@ -153,21 +162,49 @@ export async function ensureIncidentForIssueWorkflow(
           recurrenceIncident: false,
         };
       }
-      const incident = await deps.lifecycle.openRecurrence({
-        previousIncident: previous,
-        issue,
-        origin: transition === "escalated" ? "escalation_trigger" : "resolved_issue_recurred",
-        environment: environmentFromResourceAttrs(issue.lastSample?.resourceAttrs),
+      // A recurrence opens a NEW incident chained to its predecessor — but if a
+      // sibling symptom of the SAME request has already opened (or recurred)
+      // an incident, join that instead so a span exception and its own log line
+      // don't recur into separate incidents. Serialize on the trace and
+      // re-check inside the lock so concurrent sibling recurrences converge.
+      return serialize(serializeKey, async () => {
+        if (traceId) {
+          const sameTrace = await findSameTraceMatchingIncident(issue, deps);
+          if (sameTrace) {
+            const linkedIssue = await deps.repo.linkIssueToIncident({
+              incident: sameTrace.incident,
+              issue,
+            });
+            await deps.repo.updateIssueGrouping(issue.id, {
+              state: "grouped",
+              source: "heuristic",
+              reason: sameTrace.reason,
+            });
+            const fresh = (await deps.repo.findIncident(sameTrace.incident.id)) ?? sameTrace.incident;
+            return {
+              incident: fresh,
+              createdIncident: false,
+              linkedIssue,
+              recurrenceIncident: false,
+            };
+          }
+        }
+        const incident = await deps.lifecycle.openRecurrence({
+          previousIncident: previous,
+          issue,
+          origin: transition === "escalated" ? "escalation_trigger" : "resolved_issue_recurred",
+          environment: environmentFromResourceAttrs(issue.lastSample?.resourceAttrs),
+        });
+        await deps.repo.updateIssueGrouping(issue.id, {
+          state: "standalone",
+          source: "heuristic",
+          reason:
+            transition === "escalated"
+              ? "Escalation trigger fired for an observed issue; chained to its previous incident."
+              : "Recurrence of a resolved issue; chained to its previous incident.",
+        });
+        return { incident, createdIncident: true, linkedIssue: true, recurrenceIncident: true };
       });
-      await deps.repo.updateIssueGrouping(issue.id, {
-        state: "standalone",
-        source: "heuristic",
-        reason:
-          transition === "escalated"
-            ? "Escalation trigger fired for an observed issue; chained to its previous incident."
-            : "Recurrence of a resolved issue; chained to its previous incident.",
-      });
-      return { incident, createdIncident: true, linkedIssue: true, recurrenceIncident: true };
     }
   }
 
@@ -214,17 +251,10 @@ export async function ensureIncidentForIssueWorkflow(
 
   // The tail below is the workflow's one read-then-create section: everything
   // above only joins existing incidents with idempotent writes. It runs under
-  // the optional serialization hook with a link re-check inside, so a racer
-  // that created the incident first wins and the loser re-lands on it. The
-  // grouping analysis (which can call an LLM) stays outside the hook.
-  //
-  // Key the lock by trace id when present, so same-request symptoms — a span
-  // exception and its own log line, which are DIFFERENT issues — serialize on
-  // the same lock (a per-issue lock wouldn't). Fall back to the issue id for
-  // no-trace issues (e.g. alert episodes).
-  const traceId = issueSample(issue)?.traceId;
-  const serializeKey = traceId ? `trace:${traceId}` : issue.id;
-  const serialize = deps.serializeCreate ?? ((_key, fn) => fn());
+  // the trace-keyed serialization hook (computed at the top) with same-trace and
+  // link re-checks inside, so a racer that created the incident first wins and
+  // the loser re-lands on it. The grouping analysis (which can call an LLM)
+  // stays outside the hook.
   return serialize(serializeKey, async () => {
     const raceLink = await deps.repo.findLatestIncidentIssueLink(issue.id);
     if (raceLink) {

--- a/apps/worker/src/incidents/intake.ts
+++ b/apps/worker/src/incidents/intake.ts
@@ -168,6 +168,24 @@ export async function ensureIncidentForIssueWorkflow(
       // don't recur into separate incidents. Serialize on the trace and
       // re-check inside the lock so concurrent sibling recurrences converge.
       return serialize(serializeKey, async () => {
+        // Re-read the latest link now that we hold the lock: a concurrent
+        // recurrence job for this same issue may have already opened the
+        // recurrence incident (this matters for no-trace issues, where the lock
+        // is keyed by issue id) — re-land on it instead of opening a second, and
+        // don't let the same-trace lookup below match the issue's own fresh
+        // incident. Mirrors the tail create path's `raceLink` re-check.
+        const raceLink = await deps.repo.findLatestIncidentIssueLink(issue.id);
+        if (raceLink) {
+          const landed = await deps.repo.findIncident(raceLink.incidentId);
+          if (landed?.status === "open") {
+            return {
+              incident: landed,
+              createdIncident: false,
+              linkedIssue: false,
+              recurrenceIncident: false,
+            };
+          }
+        }
         if (traceId) {
           const sameTrace = await findSameTraceMatchingIncident(issue, deps);
           if (sameTrace) {


### PR DESCRIPTION
Third and final gap in the same-request grouping. #224 added the deterministic same-trace join; #228 put it under a trace-keyed lock — but both only covered the **create** path.

The **recurrence** path opens a new incident at the very top of `ensureIncidentForIssueWorkflow` (chained to the issue's own predecessor) *before* grouping, the same-trace check, or any lock. So when same-request symptoms recur together — a span exception and its own log line, resolved earlier and recurring now — each chains its own recurrence and they split into separate incidents. Confirmed in prod: three open incidents, same trace id, created within 2 ms, each with a distinct `previous_incident_id`.

Fix: hoist the trace-keyed serialize to the top of the workflow, wrap the recurrence branch in it, and — inside the lock — join an open incident sharing this trace before opening a recurrence. Now same-request symptoms converge into one incident across **new / recurred / escalated** transitions.

Test: `intake.test.ts` adds a recurred same-trace sibling that joins the existing incident (no `openRecurrence`); the existing 'recurred chains to predecessor' case (no shared trace) still passes. Worker typecheck clean; intake+domain 21/21.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate incidents by grouping same-trace recurrences into a single incident. Moves trace-keyed serialization to the top of intake, and prefers reusing/joining existing incidents before opening a recurrence.

- **Bug Fixes**
  - Serialize the recurrence path by trace id (fallback to issue id) to stop racing recurrences from creating separate incidents.
  - Inside the lock, re-read the latest link and re-land on an already-open incident; otherwise, join an open same-trace incident; only open a recurrence if neither exists.
  - Ensures same-request symptoms converge into one incident across new, recurred, and escalated transitions.
  - Tests: same-trace sibling joins existing incident; no-trace recurrence re-lands on a racer-opened incident.

<sup>Written for commit ac72776be2df3501b6962933478e1320ccb78a35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

