### PR TITLE
Emit a PostHog event per MCP tool call

### DIFF
--- a/apps/api/src/mcp/analytics.test.ts
+++ b/apps/api/src/mcp/analytics.test.ts
@@ -1,0 +1,145 @@
+import "dotenv/config";
+import { strict as assert } from "node:assert";
+import { after, before, test } from "node:test";
+import type { ClickHouseClient } from "@clickhouse/client";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { closeDb, db, runMigrations, schema, setAnalyticsClientForTests } from "@superlog/db";
+import { eq } from "drizzle-orm";
+import { createMcpServerForSession } from "./server.js";
+
+type CapturedEvent = { distinctId: string; event: string; properties?: Record<string, unknown> };
+
+const captured: CapturedEvent[] = [];
+const orgIds: string[] = [];
+const userIds: string[] = [];
+
+before(async () => {
+  await runMigrations();
+  setAnalyticsClientForTests({ capture: (e) => captured.push(e) });
+});
+after(async () => {
+  setAnalyticsClientForTests(undefined);
+  try {
+    for (const orgId of orgIds.reverse()) {
+      await db.delete(schema.orgs).where(eq(schema.orgs.id, orgId));
+    }
+    for (const userId of userIds.reverse()) {
+      await db.delete(schema.users).where(eq(schema.users.id, userId));
+    }
+  } finally {
+    await closeDb();
+  }
+});
+
+function uniq(prefix: string) {
+  return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+}
+
+async function seedUserWithProject() {
+  const tag = uniq("mcpan");
+  const [user] = await db
+    .insert(schema.users)
+    .values({ email: `${tag}@example.com`, name: "MCP Analytics Tester" })
+    .returning();
+  if (!user) throw new Error("seed user failed");
+  userIds.push(user.id);
+  const [org] = await db.insert(schema.orgs).values({ name: `Org ${tag}`, slug: tag }).returning();
+  if (!org) throw new Error("seed org failed");
+  orgIds.push(org.id);
+  await db.insert(schema.orgMembers).values({ orgId: org.id, userId: user.id, role: "owner" });
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ orgId: org.id, name: "Default", slug: "default" })
+    .returning();
+  if (!project) throw new Error("seed project failed");
+  return { user, org, project };
+}
+
+// list_projects / get_active_project never touch ClickHouse, so a throwing stub
+// both satisfies the type and proves analytics never rides on a CH query.
+const fakeCh = {
+  query: () => {
+    throw new Error("clickhouse should not be reached by this test");
+  },
+} as unknown as ClickHouseClient;
+
+async function connectedClient(session: Parameters<typeof createMcpServerForSession>[0]) {
+  const server = createMcpServerForSession(session);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+async function waitForEvent(
+  predicate: (e: CapturedEvent) => boolean,
+  timeoutMs = 3000,
+): Promise<CapturedEvent> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const hit = captured.find(predicate);
+    if (hit) return hit;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`timed out waiting for analytics event; captured=${JSON.stringify(captured)}`);
+}
+
+test("tool calls emit mcp_tool_called with user + org context", async () => {
+  const { user, org, project } = await seedUserWithProject();
+  const client = await connectedClient({
+    ch: fakeCh,
+    userId: user.id,
+    tokenId: "tok-analytics-1",
+    tokenKind: "pat",
+    activeProjectId: project.id,
+  });
+
+  const result = await client.callTool({ name: "list_projects", arguments: {} });
+  assert.equal(result.isError ?? false, false);
+
+  const event = await waitForEvent(
+    (e) => e.event === "mcp_tool_called" && e.properties?.tool === "list_projects",
+  );
+  assert.equal(event.distinctId, user.id);
+  assert.equal(event.properties?.project_id, project.id);
+  assert.equal(event.properties?.org_id, org.id);
+  assert.equal(event.properties?.org_name, org.name);
+  assert.equal(event.properties?.org_slug, org.slug);
+  assert.equal(event.properties?.user_email, user.email);
+  assert.equal(event.properties?.token_kind, "pat");
+  assert.equal(event.properties?.success, true);
+  assert.equal(typeof event.properties?.duration_ms, "number");
+});
+
+test("failed tool calls emit mcp_tool_called with success=false and the error", async () => {
+  const { user } = await seedUserWithProject();
+  const outsideProject = "00000000-0000-4000-8000-000000000000";
+  const client = await connectedClient({
+    ch: fakeCh,
+    userId: user.id,
+    tokenId: "tok-analytics-2",
+    tokenKind: "oauth",
+    activeProjectId: outsideProject,
+  });
+
+  const result = await client.callTool({ name: "get_active_project", arguments: {} });
+  // get_active_project succeeds even when the active project is unknown; use a
+  // tool that enforces access instead.
+  assert.equal(result.isError ?? false, false);
+
+  const failed = await client.callTool({
+    name: "query_logs",
+    arguments: { project_id: outsideProject },
+  });
+  assert.equal(failed.isError, true);
+
+  const event = await waitForEvent(
+    (e) => e.event === "mcp_tool_called" && e.properties?.tool === "query_logs",
+  );
+  assert.equal(event.distinctId, user.id);
+  assert.equal(event.properties?.success, false);
+  assert.equal(event.properties?.token_kind, "oauth");
+  assert.match(String(event.properties?.error), /project/i);
+  assert.equal(event.properties?.project_id, outsideProject);
+});

--- a/apps/api/src/mcp/analytics.test.ts
+++ b/apps/api/src/mcp/analytics.test.ts
@@ -4,8 +4,10 @@ import { after, before, test } from "node:test";
 import type { ClickHouseClient } from "@clickhouse/client";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { closeDb, db, runMigrations, schema, setAnalyticsClientForTests } from "@superlog/db";
 import { eq } from "drizzle-orm";
+import { instrumentMcpToolAnalytics } from "./analytics.js";
 import { createMcpServerForSession } from "./server.js";
 
 type CapturedEvent = { distinctId: string; event: string; properties?: Record<string, unknown> };
@@ -142,4 +144,63 @@ test("failed tool calls emit mcp_tool_called with success=false and the error", 
   assert.equal(event.properties?.token_kind, "oauth");
   assert.match(String(event.properties?.error), /project/i);
   assert.equal(event.properties?.project_id, outsideProject);
+});
+
+test("org context is omitted for projects the user is not a member of", async () => {
+  const { user } = await seedUserWithProject();
+  const other = await seedUserWithProject();
+  const client = await connectedClient({
+    ch: fakeCh,
+    userId: user.id,
+    tokenId: "tok-analytics-3",
+    tokenKind: "pat",
+    activeProjectId: other.project.id,
+  });
+
+  const failed = await client.callTool({
+    name: "query_logs",
+    arguments: { project_id: other.project.id },
+  });
+  assert.equal(failed.isError, true);
+
+  const event = await waitForEvent(
+    (e) =>
+      e.event === "mcp_tool_called" &&
+      e.properties?.tool === "query_logs" &&
+      e.properties?.project_id === other.project.id,
+  );
+  assert.equal(event.properties?.success, false);
+  // The target project belongs to another tenant — never enrich with its org.
+  assert.equal(event.properties?.org_id, undefined);
+  assert.equal(event.properties?.org_name, undefined);
+  assert.equal(event.properties?.org_slug, undefined);
+  assert.equal(event.properties?.user_email, user.email);
+});
+
+test("isError results carry the error text without a throw", async () => {
+  const { user, project } = await seedUserWithProject();
+  const server = new McpServer({ name: "test", version: "0.0.0" });
+  instrumentMcpToolAnalytics(server, {
+    ch: fakeCh,
+    userId: user.id,
+    tokenId: "tok-analytics-4",
+    tokenKind: "pat",
+    activeProjectId: project.id,
+  });
+  server.registerTool("soft_fail", { inputSchema: {} }, async () => ({
+    content: [{ type: "text" as const, text: "budget exceeded" }],
+    isError: true,
+  }));
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+  const result = await client.callTool({ name: "soft_fail", arguments: {} });
+  assert.equal(result.isError, true);
+
+  const event = await waitForEvent(
+    (e) => e.event === "mcp_tool_called" && e.properties?.tool === "soft_fail",
+  );
+  assert.equal(event.properties?.success, false);
+  assert.equal(event.properties?.error, "budget exceeded");
 });

--- a/apps/api/src/mcp/analytics.ts
+++ b/apps/api/src/mcp/analytics.ts
@@ -8,7 +8,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { captureServerEvent, db, schema } from "@superlog/db";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { logger } from "../logger.js";
 import type { McpSession } from "./server.js";
 
@@ -42,12 +42,13 @@ export function instrumentMcpToolAnalytics(server: McpServer, session: McpSessio
       const startedAt = performance.now();
       try {
         const result = await handler(...args);
-        const isError = (result as { isError?: unknown } | null | undefined)?.isError === true;
+        const error = resultErrorText(result);
         emitToolCalled(session, {
           tool: name,
           projectId,
-          success: !isError,
+          success: error === undefined,
           durationMs: performance.now() - startedAt,
+          error,
         });
         return result;
       } catch (err) {
@@ -66,6 +67,17 @@ export function instrumentMcpToolAnalytics(server: McpServer, session: McpSessio
 function effectiveProjectId(input: unknown, session: McpSession): string {
   const explicit = (input as { project_id?: unknown } | null | undefined)?.project_id;
   return typeof explicit === "string" ? explicit : session.activeProjectId;
+}
+
+/** Undefined when the result is a success; the error text otherwise. */
+function resultErrorText(result: unknown): string | undefined {
+  const r = result as
+    | { isError?: unknown; content?: Array<{ type?: unknown; text?: unknown }> }
+    | null
+    | undefined;
+  if (r?.isError !== true) return undefined;
+  const text = r.content?.find((c) => typeof c?.text === "string")?.text;
+  return typeof text === "string" && text ? text : "unknown error";
 }
 
 type ToolCallFacts = {
@@ -90,6 +102,9 @@ async function captureToolCalled(session: McpSession, facts: ToolCallFacts): Pro
       where: eq(schema.users.id, session.userId),
       columns: { email: true, name: true },
     }),
+    // Join through the caller's org membership: a rejected call can carry an
+    // arbitrary project_id, and enriching it would attribute another tenant's
+    // org to this event. No membership → no org fields.
     db
       .select({
         id: schema.orgs.id,
@@ -98,6 +113,13 @@ async function captureToolCalled(session: McpSession, facts: ToolCallFacts): Pro
       })
       .from(schema.projects)
       .innerJoin(schema.orgs, eq(schema.orgs.id, schema.projects.orgId))
+      .innerJoin(
+        schema.orgMembers,
+        and(
+          eq(schema.orgMembers.orgId, schema.orgs.id),
+          eq(schema.orgMembers.userId, session.userId),
+        ),
+      )
       .where(eq(schema.projects.id, facts.projectId)),
   ]);
 

--- a/apps/api/src/mcp/analytics.ts
+++ b/apps/api/src/mcp/analytics.ts
@@ -1,0 +1,121 @@
+// Product analytics for MCP tool usage.
+//
+// Every MCP tool invocation emits a server-side `mcp_tool_called` event so we
+// can see who uses MCP and how (by user, org, tool, outcome). Delivery rides
+// captureServerEvent, which is env-gated and best-effort — with no PostHog
+// token configured this is a no-op, and a capture failure never affects the
+// tool call it describes.
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { captureServerEvent, db, schema } from "@superlog/db";
+import { eq } from "drizzle-orm";
+import { logger } from "../logger.js";
+import type { McpSession } from "./server.js";
+
+const log = logger.child({ scope: "mcp-analytics" });
+
+const MAX_ERROR_LENGTH = 300;
+
+type AnyToolHandler = (...args: unknown[]) => unknown;
+type AnyRegisterTool = (
+  name: string,
+  config: Record<string, unknown>,
+  handler: AnyToolHandler,
+) => unknown;
+
+/**
+ * Patch `server.registerTool` so every tool registered afterwards — including
+ * by the alert/dashboard/incident/agent-config modules — emits an analytics
+ * event per invocation. Must run before any tools are registered.
+ */
+export function instrumentMcpToolAnalytics(server: McpServer, session: McpSession): void {
+  const original = (server.registerTool as AnyRegisterTool).bind(server);
+  (server as unknown as { registerTool: AnyRegisterTool }).registerTool = (
+    name,
+    config,
+    handler,
+  ) =>
+    original(name, config, async (...args: unknown[]) => {
+      // Resolve the target project before invoking: set_active_project mutates
+      // the session default, and we want the project the call was aimed at.
+      const projectId = effectiveProjectId(args[0], session);
+      const startedAt = performance.now();
+      try {
+        const result = await handler(...args);
+        const isError = (result as { isError?: unknown } | null | undefined)?.isError === true;
+        emitToolCalled(session, {
+          tool: name,
+          projectId,
+          success: !isError,
+          durationMs: performance.now() - startedAt,
+        });
+        return result;
+      } catch (err) {
+        emitToolCalled(session, {
+          tool: name,
+          projectId,
+          success: false,
+          durationMs: performance.now() - startedAt,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      }
+    });
+}
+
+function effectiveProjectId(input: unknown, session: McpSession): string {
+  const explicit = (input as { project_id?: unknown } | null | undefined)?.project_id;
+  return typeof explicit === "string" ? explicit : session.activeProjectId;
+}
+
+type ToolCallFacts = {
+  tool: string;
+  projectId: string;
+  success: boolean;
+  durationMs: number;
+  error?: string;
+};
+
+function emitToolCalled(session: McpSession, facts: ToolCallFacts): void {
+  // Fire-and-forget: the enrichment lookups must not add latency to the tool
+  // response, and an analytics failure must never surface to the MCP client.
+  void captureToolCalled(session, facts).catch((err) => {
+    log.debug({ err, tool: facts.tool }, "mcp analytics capture failed");
+  });
+}
+
+async function captureToolCalled(session: McpSession, facts: ToolCallFacts): Promise<void> {
+  const [user, [org]] = await Promise.all([
+    db.query.users.findFirst({
+      where: eq(schema.users.id, session.userId),
+      columns: { email: true, name: true },
+    }),
+    db
+      .select({
+        id: schema.orgs.id,
+        name: schema.orgs.name,
+        slug: schema.orgs.slug,
+      })
+      .from(schema.projects)
+      .innerJoin(schema.orgs, eq(schema.orgs.id, schema.projects.orgId))
+      .where(eq(schema.projects.id, facts.projectId)),
+  ]);
+
+  captureServerEvent({
+    distinctId: session.userId,
+    event: "mcp_tool_called",
+    properties: {
+      tool: facts.tool,
+      project_id: facts.projectId,
+      org_id: org?.id,
+      org_name: org?.name,
+      org_slug: org?.slug,
+      user_email: user?.email,
+      token_kind: session.tokenKind,
+      success: facts.success,
+      duration_ms: Math.round(facts.durationMs),
+      ...(facts.error === undefined ? {} : { error: facts.error.slice(0, MAX_ERROR_LENGTH) }),
+    },
+    set: user ? { email: user.email, name: user.name } : undefined,
+  });
+}

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { registerAgentConfigTools } from "./agent-config.js";
 import { registerAlertTools } from "./alerts.js";
+import { instrumentMcpToolAnalytics } from "./analytics.js";
 import { listServices, queryLogs, queryMetrics, queryTraces } from "./clickhouse.js";
 import { registerDashboardTools } from "./dashboards.js";
 import { registerIncidentTools } from "./incidents.js";
@@ -98,6 +99,10 @@ export function createMcpServerForSession(session: McpSession): McpServer {
     { name: "superlog", version: "0.1.0" },
     session.telemetryOnly ? undefined : { instructions: SERVER_INSTRUCTIONS },
   );
+
+  // Before any registerTool call so every tool below (and in the register*
+  // modules) emits a per-invocation analytics event.
+  instrumentMcpToolAnalytics(server, session);
 
   const assertTokenScope = async (projectId: string): Promise<void> => {
     if (!session.allowedOrgId) return;


### PR DESCRIPTION
## What

Every MCP tool invocation now emits a server-side `mcp_tool_called` analytics event, so MCP usage can be broken down by user, org, tool, and outcome.

Properties per event: `tool`, `project_id`, `org_id` / `org_name` / `org_slug`, `user_email`, `token_kind` (`oauth` | `pat`), `success`, `duration_ms`, and a truncated `error` message on failure. `distinctId` is the user id, and the user's email/name are set as person properties — matching the existing server-side lifecycle events.

## How

`instrumentMcpToolAnalytics` patches `registerTool` on the session's `McpServer` before any tools are registered, so all tool modules (telemetry, alerts, dashboards, incidents, agent config) are covered from one seam. The wrapper resolves the target project before invoking the handler (`set_active_project` mutates the session default), and treats both thrown errors and `isError` results as failures.

Delivery rides `captureServerEvent`: env-gated (no-op without `POSTHOG_PROJECT_TOKEN`) and best-effort. The user/org enrichment lookups run fire-and-forget after the handler returns, so analytics adds no latency to the tool response and a capture failure never surfaces to the MCP client.

## Testing

- New `analytics.test.ts` drives a real MCP client over an in-memory transport against `createMcpServerForSession`: asserts the success event's full property set and the failure event (`success=false` + error) for an out-of-scope project.
- Full `@superlog/api` suite passes (338/338); typecheck clean.
- Smoke-tested against a running dev stack: `list_projects` (success) and `query_logs` with an inaccessible project (isError) both behave unchanged through the instrumented path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit a server-side `mcp_tool_called` PostHog event on every MCP tool invocation to track usage by user, org, tool, and outcome without adding latency. Now captures error text for both thrown errors and `isError` results, and scopes org enrichment to the caller’s membership to avoid cross-tenant attribution.

- **New Features**
  - Patched the MCP server’s `registerTool` so all tools emit an event per call; resolves the target project before the handler and treats thrown errors and `isError` results as failures, capturing their error text.
  - Event properties: tool, project_id, org_id/name/slug (omitted if the user isn’t a member of that org), user_email, token_kind (`oauth` | `pat`), success, duration_ms, and a truncated error; `distinctId` is the user id with person email/name set.
  - Delivery via `captureServerEvent` (env-gated; no-op without `POSTHOG_PROJECT_TOKEN`) with fire-and-forget enrichment to avoid adding latency.

<sup>Written for commit 1f372f8e51e2418171b609c10109c08e58fd6748. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

