### PR TITLE
Label incident Slack button 'View incident'

### DIFF
--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -340,7 +340,7 @@ export async function completeWithIncidentResolution(
       tagline: truncateSlackText(result.summary),
       projectName: ctx.project.name,
       service: ctx.incident.service,
-      buttons: [{ text: "View agent run", url: incidentUrl, actionId: "view_agent_run" }],
+      buttons: [{ text: "View incident", url: incidentUrl, actionId: "view_incident" }],
       incidentId: ctx.incident.id,
     }),
   );

--- a/apps/worker/src/agent-runs/start-run.ts
+++ b/apps/worker/src/agent-runs/start-run.ts
@@ -69,7 +69,7 @@ async function notifyAgentRunStarted(
       title: ctx.incident.title,
       projectName: ctx.project.name,
       service: ctx.incident.service,
-      buttons: [{ text: "View agent run", url: incidentUrl, actionId: "view_agent_run" }],
+      buttons: [{ text: "View incident", url: incidentUrl, actionId: "view_incident" }],
       incidentId: ctx.incident.id,
       showResolveButton: true,
     }),


### PR DESCRIPTION
The Slack buttons on the investigation-ongoing and incident-resolved messages linked to the incident page (`/incidents/<id>`) but were labeled **View agent run**, which didn't match where they go.

Relabel both to **View incident** and update the matching `actionId` to `view_incident`.

- `apps/worker/src/agent-runs/start-run.ts` — 'Investigation ongoing' message
- `apps/worker/src/agent-runs/completion.ts` — 'Incident resolved by the agent' message

Worker typechecks clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relabeled Slack buttons in the “Investigation ongoing” and “Incident resolved” messages to “View incident” and set the `actionId` to `view_incident` so the label and action match the incident page link.

<sup>Written for commit dc00c0171df3c4af891a04ba8841be805f0f79bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

