### PR TITLE
Link alert-episode issues and incidents back to the alert that fired

### DIFF
--- a/apps/api/src/alerts-service.ts
+++ b/apps/api/src/alerts-service.ts
@@ -549,6 +549,24 @@ export type IncidentAlertEpisodeView = {
   seq: number;
 };
 
+// The alert whose breach opened a given issue (alert-episode issues are 1:1
+// with an episode), for the "Triggered by" link on the issue detail page.
+// Returns null for ordinary error issues, which have no episode row.
+export async function loadTriggeringAlertForIssue(
+  issueId: string,
+): Promise<{ id: string; name: string } | null> {
+  const episode = await db.query.alertEpisodes.findFirst({
+    where: eq(schema.alertEpisodes.issueId, issueId),
+    columns: { alertId: true },
+  });
+  if (!episode) return null;
+  const alert = await db.query.alerts.findFirst({
+    where: eq(schema.alerts.id, episode.alertId),
+    columns: { id: true, name: true },
+  });
+  return alert ? { id: alert.id, name: alert.name } : null;
+}
+
 // The alert episodes that triggered a given incident, for the incident detail
 // "Triggered by" back-link. Computes each episode's per-alert ordinal so the UI
 // can render "alert X · Episode #N".

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -32,7 +32,7 @@ import type { Context } from "hono";
 import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import { nanoid } from "nanoid";
-import { loadIncidentAlertEpisodes } from "./alerts-service.js";
+import { loadIncidentAlertEpisodes, loadTriggeringAlertForIssue } from "./alerts-service.js";
 import { mountAlerts } from "./alerts.js";
 import { auth } from "./auth.js";
 import { shouldRunMigrationsOnBoot } from "./boot-migrations.js";
@@ -1290,16 +1290,19 @@ app.get("/api/projects/:projectId/issues/:issueId", async (c) => {
     where: and(eq(schema.issues.id, issueId), eq(schema.issues.projectId, projectId)),
   });
   if (!issue) throw new HTTPException(404, { message: "issue not found" });
-  const symbolication = await symbolicateIssueSample({
-    database: db,
-    objectReader: sourceMapObjectStore,
-    projectId,
-    sample: issue.lastSample,
-  }).catch((err) => {
-    logger.warn({ err, projectId, issueId }, "failed to symbolicate issue sample");
-    return null;
-  });
-  return c.json({ ...issue, symbolication });
+  const [symbolication, triggeringAlert] = await Promise.all([
+    symbolicateIssueSample({
+      database: db,
+      objectReader: sourceMapObjectStore,
+      projectId,
+      sample: issue.lastSample,
+    }).catch((err) => {
+      logger.warn({ err, projectId, issueId }, "failed to symbolicate issue sample");
+      return null;
+    }),
+    loadTriggeringAlertForIssue(issue.id),
+  ]);
+  return c.json({ ...issue, symbolication, triggeringAlert });
 });
 
 app.post("/api/projects/:projectId/issues/lookup", async (c) => {

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -77,6 +77,7 @@ import {
   buildIncidentDetailMeta,
 } from "./incidents/incident-detail-view-model.ts";
 import { IncidentDetailScrollArea } from "./incidents/IncidentDetailScrollArea.tsx";
+import { TriggeredByAlertMetaRow } from "./incidents/TriggeredByAlertMetaRow.tsx";
 import { getIssueIncidentLinkState } from "./issue-incident-link-state.ts";
 import { IssueDetailView } from "./issues/IssueDetailView.tsx";
 import {
@@ -1645,6 +1646,9 @@ export function IncidentDetailContent({
             <div className="mt-7 grid gap-3.5">
               {/* "Agent run" stays last; Linked issues slots in where Findings used to be. */}
               <IncidentSidebarMetaRows rows={detailMeta.slice(0, -1)} />
+              {alertEpisodes.length > 0 && (
+                <TriggeredByAlertMetaRow episodes={alertEpisodes} />
+              )}
               <LinkedIssuesMetaRow issues={issues} onViewIssue={onViewIssue} />
               <IncidentSidebarMetaRows rows={detailMeta.slice(-1)} />
             </div>

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -2102,6 +2102,10 @@ export type Issue = {
   lastSample: IssueSample | null;
   symbolication?: Symbolication | null;
   createdAt: string;
+  // Set on the issue-detail response for alert-episode issues: the alert whose
+  // breach opened this issue, for the "Triggered by" back-link. Null/absent for
+  // ordinary error issues and in list responses.
+  triggeringAlert?: { id: string; name: string } | null;
 };
 
 export function useIssues(

--- a/apps/web/src/incidents/TriggeredByAlertMetaRow.test.tsx
+++ b/apps/web/src/incidents/TriggeredByAlertMetaRow.test.tsx
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { IncidentAlertEpisode } from "../api.ts";
+import { TriggeredByAlertMetaRow } from "./TriggeredByAlertMetaRow.tsx";
+
+function episode(overrides: Partial<IncidentAlertEpisode> = {}): IncidentAlertEpisode {
+  return {
+    id: "ep-1",
+    alertId: "alert-1",
+    alertName: "p95 latency > 500ms",
+    groupKey: "",
+    state: "firing",
+    startedAt: "2026-07-14T10:00:00.000Z",
+    endedAt: null,
+    peakObservedValue: 812,
+    seq: 1,
+    ...overrides,
+  };
+}
+
+function render(episodes: IncidentAlertEpisode[]): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <TriggeredByAlertMetaRow episodes={episodes} />
+    </MemoryRouter>,
+  );
+}
+
+test("links the alert that fired straight to the alert page", () => {
+  const html = render([episode()]);
+  assert.match(html, /Triggered by/);
+  assert.match(html, /p95 latency &gt; 500ms/);
+  assert.match(html, /href="\/alerts\/alert-1"/);
+});
+
+test("renders nothing when there are no alert episodes", () => {
+  assert.equal(render([]), "");
+});
+
+test("collapses multiple episodes of the same alert to a single link", () => {
+  const html = render([
+    episode({ id: "ep-1", seq: 1 }),
+    episode({ id: "ep-2", seq: 2, state: "resolved" }),
+  ]);
+  const links = html.match(/href="\/alerts\/alert-1"/g) ?? [];
+  assert.equal(links.length, 1);
+});
+
+test("lists each distinct alert when an incident groups more than one", () => {
+  const html = render([
+    episode({ id: "ep-1", alertId: "alert-1", alertName: "latency" }),
+    episode({ id: "ep-2", alertId: "alert-2", alertName: "error rate" }),
+  ]);
+  assert.match(html, /href="\/alerts\/alert-1"/);
+  assert.match(html, /href="\/alerts\/alert-2"/);
+  assert.match(html, /latency/);
+  assert.match(html, /error rate/);
+});

--- a/apps/web/src/incidents/TriggeredByAlertMetaRow.tsx
+++ b/apps/web/src/incidents/TriggeredByAlertMetaRow.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import type { IncidentAlertEpisode } from "../api.ts";
+
+function ArrowUpRightIcon() {
+  return (
+    <svg
+      className="h-4 w-4 shrink-0 text-muted"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M7 17 17 7" />
+      <path d="M7 7h10v10" />
+    </svg>
+  );
+}
+
+// Sidebar property linking straight to the alert(s) that raised this incident.
+// For an alert-triggered incident this is the most important outbound link, so
+// it sits in the always-visible sidebar rather than only in the Findings tab.
+// One incident can group several episodes (and occasionally several alerts) —
+// collapse to one link per distinct alert.
+export function TriggeredByAlertMetaRow({ episodes }: { episodes: IncidentAlertEpisode[] }) {
+  const alerts = useMemo(() => {
+    const byId = new Map<string, { alertId: string; alertName: string }>();
+    for (const ep of episodes) {
+      if (!byId.has(ep.alertId)) {
+        byId.set(ep.alertId, { alertId: ep.alertId, alertName: ep.alertName });
+      }
+    }
+    return [...byId.values()];
+  }, [episodes]);
+
+  if (alerts.length === 0) return null;
+
+  return (
+    <div className="grid grid-cols-[132px_minmax(0,1fr)] items-start gap-3 text-[13px]">
+      <div className="text-muted">Triggered by</div>
+      <div className="flex min-w-0 flex-col gap-1.5">
+        {alerts.map((alert) => (
+          <Link
+            key={alert.alertId}
+            to={`/alerts/${alert.alertId}`}
+            className="flex min-w-0 items-center gap-[5px] text-fg transition-colors hover:text-muted"
+          >
+            <ArrowUpRightIcon />
+            <span className="min-w-0 truncate">{alert.alertName}</span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/issues/IssueDetailView.test.tsx
+++ b/apps/web/src/issues/IssueDetailView.test.tsx
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
 import type { IncidentEvent, Issue } from "../api.ts";
 import { IssueDetailView } from "./IssueDetailView.tsx";
 
@@ -149,4 +150,36 @@ test("error detail shows system-generated resolution activity without a reason",
 
   assert.match(html, /Activity/);
   assert.match(html, /Resolved/);
+});
+
+test("an alert-episode error links straight to the alert that fired", () => {
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <IssueDetailView
+        issue={{
+          ...issue,
+          kind: "alert",
+          exceptionType: "AlertFired",
+          triggeringAlert: { id: "alert-9", name: "checkout-api p95 latency > 500ms" },
+        }}
+        environment="production"
+        onBack={() => {}}
+      />
+    </MemoryRouter>,
+  );
+
+  assert.match(html, /Triggered by/);
+  assert.match(html, /checkout-api p95 latency &gt; 500ms/);
+  assert.match(html, /href="\/alerts\/alert-9"/);
+});
+
+test("a normal error shows no alert link", () => {
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <IssueDetailView issue={issue} environment="production" onBack={() => {}} />
+    </MemoryRouter>,
+  );
+
+  assert.doesNotMatch(html, /Triggered by/);
+  assert.doesNotMatch(html, /href="\/alerts\//);
 });

--- a/apps/web/src/issues/IssueDetailView.tsx
+++ b/apps/web/src/issues/IssueDetailView.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
 import type { IncidentEvent, Issue } from "../api.ts";
 import { Btn, Chip } from "../design/ui.tsx";
 
@@ -91,6 +92,22 @@ export function IssueDetailView({
               <MetaRow label="Last seen" value={formatTimestamp(issue.lastSeen)} />
               <MetaRow label="Grouping" value={groupingLabel(issue)} />
             </dl>
+
+            {issue.triggeringAlert && (
+              <section className="mt-7 border-t border-border pt-6">
+                <SectionLabel>Triggered by</SectionLabel>
+                <Link
+                  to={`/alerts/${issue.triggeringAlert.id}`}
+                  className="mt-2 flex items-center gap-2 rounded-lg border border-border bg-surface px-3 py-2.5 text-fg transition-colors hover:border-muted"
+                >
+                  <AlertIcon />
+                  <span className="min-w-0 flex-1 truncate text-[12.5px]">
+                    {issue.triggeringAlert.name}
+                  </span>
+                  <ArrowUpRightIcon />
+                </Link>
+              </section>
+            )}
 
             {linkedIncident && (
               <section className="mt-7 border-t border-border pt-6">
@@ -351,6 +368,42 @@ function CloseIcon() {
       aria-hidden="true"
     >
       <path d="M18 6 6 18M6 6l12 12" />
+    </svg>
+  );
+}
+
+function AlertIcon() {
+  return (
+    <svg
+      className="h-4 w-4 shrink-0 text-muted"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+      <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+    </svg>
+  );
+}
+
+function ArrowUpRightIcon() {
+  return (
+    <svg
+      className="h-4 w-4 shrink-0 text-muted"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M7 17 17 7" />
+      <path d="M7 7h10v10" />
     </svg>
   );
 }


### PR DESCRIPTION
An alert-episode issue — and the incident it groups into — had no path back to the alert that raised it. The only linkage was `alert_episodes.issue_id`, which the read paths never surfaced, so from the error/incident view you couldn't get to the alert.

## Changes

- **Issue detail (`IssueDetailView`)** — the issue endpoint now resolves an alert-episode issue to its alert and returns `triggeringAlert: { id, name } | null` (one indexed lookup on `alert_episodes.issue_id`; null for ordinary error issues). The sidebar renders a new **"Triggered by"** link to `/alerts/:id`, above "Linked incident".
- **Incident detail** — a **"Triggered by"** alert link in the sidebar meta rows (above "Linked errors"), collapsing multiple episodes of the same alert into one link and listing each distinct alert when an incident groups more than one.

## Tests

- `TriggeredByAlertMetaRow`: render, empty, same-alert dedup, multi-alert.
- `IssueDetailView`: alert link present for an alert-episode issue, absent for an ordinary error.

Both `@superlog/web` and `@superlog/api` typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add back-links from alert-episode issues and incidents to the alert that fired. This makes it easy to jump from an error or incident straight to its originating alert.

- **New Features**
  - Issue detail API now returns `triggeringAlert: { id, name } | null` for alert-episode issues.
  - Issue detail shows a "Triggered by" link to `/alerts/:id` above "Linked incident".
  - Incident detail sidebar adds "Triggered by" alert link(s). Deduplicates multiple episodes of the same alert and lists each distinct alert when grouped.

<sup>Written for commit 8e0670f3735dac9c48bc733ddd6f7c18235a5928. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

