### PR TITLE
Alert incident cards: metric-vs-threshold graph + fix dropped markLine

### DIFF
--- a/apps/api/src/alerts-service.test.ts
+++ b/apps/api/src/alerts-service.test.ts
@@ -7,9 +7,8 @@ import { HTTPException } from "hono/http-exception";
 // (the postgres client connects lazily, so these pure-function tests never open
 // a socket). Same dynamic-import pattern as incidents/detail.test.ts.
 process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
-const { validateAlertInput, alertInputToFilter, summarizeEvaluation } = await import(
-  "./alerts-service.js"
-);
+const { validateAlertInput, alertInputToFilter, summarizeEvaluation, alertRecordToInput } =
+  await import("./alerts-service.js");
 
 type AlertInput = Parameters<typeof validateAlertInput>[0];
 
@@ -187,4 +186,59 @@ test("summarizeEvaluation falls back to single mode when groupBy is missing", ()
     total: 99,
   });
   assert.deepEqual(result, { mode: "single", value: 99, breaches: 1 });
+});
+
+test("alertRecordToInput maps a metric alert row to the preview input shape", () => {
+  const input = alertRecordToInput({
+    name: "queue depth",
+    source: "metric",
+    metricName: "pgboss.oldest_pending_ms",
+    filter: { service: "worker", resourceAttrs: [{ key: "env", value: "prod" }] },
+    groupBy: null,
+    groupMode: "single",
+    aggregation: "avg",
+    comparator: "gt",
+    threshold: 300000,
+    windowMinutes: 5,
+  });
+  assert.deepEqual(input, {
+    name: "queue depth",
+    source: "metric",
+    metricName: "pgboss.oldest_pending_ms",
+    filter: { service: "worker", resourceAttrs: [{ key: "env", value: "prod" }] },
+    groupBy: null,
+    groupMode: "single",
+    aggregation: "avg",
+    comparator: "gt",
+    threshold: 300000,
+    windowMinutes: 5,
+  });
+  // Round-trips through the filter extractor the series builder uses.
+  assert.deepEqual(alertInputToFilter(input), {
+    resourceAttrs: [{ key: "env", value: "prod" }],
+    service: "worker",
+    severity: undefined,
+    spanName: undefined,
+    statusCode: undefined,
+    minDurationMs: undefined,
+  });
+});
+
+test("alertRecordToInput passes through the stored default empty jsonb filter", () => {
+  const input = alertRecordToInput({
+    name: "error rate",
+    source: "logs",
+    metricName: null,
+    // Stored default for the `filter` column is `{}` (never null in practice).
+    filter: {},
+    groupBy: "service.name",
+    groupMode: "per_group",
+    aggregation: "count",
+    comparator: "gt",
+    threshold: 10,
+    windowMinutes: 15,
+  });
+  assert.deepEqual(input.filter, {});
+  assert.equal(input.source, "logs");
+  assert.equal(input.groupMode, "per_group");
 });

--- a/apps/api/src/alerts-service.test.ts
+++ b/apps/api/src/alerts-service.test.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
+import type { ClickHouseClient } from "@clickhouse/client";
 import { HTTPException } from "hono/http-exception";
 
 // alerts-service.ts transitively imports the db client, which throws at import
@@ -7,8 +8,13 @@ import { HTTPException } from "hono/http-exception";
 // (the postgres client connects lazily, so these pure-function tests never open
 // a socket). Same dynamic-import pattern as incidents/detail.test.ts.
 process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
-const { validateAlertInput, alertInputToFilter, summarizeEvaluation, alertRecordToInput } =
-  await import("./alerts-service.js");
+const {
+  validateAlertInput,
+  alertInputToFilter,
+  summarizeEvaluation,
+  alertRecordToInput,
+  previewAlertSeries,
+} = await import("./alerts-service.js");
 
 type AlertInput = Parameters<typeof validateAlertInput>[0];
 
@@ -241,4 +247,42 @@ test("alertRecordToInput passes through the stored default empty jsonb filter", 
   assert.deepEqual(input.filter, {});
   assert.equal(input.source, "logs");
   assert.equal(input.groupMode, "per_group");
+});
+
+test("previewAlertSeries scopes an explicitly empty per-group key", async () => {
+  let query = "";
+  let params: Record<string, unknown> | undefined;
+  const ch = {
+    async query(input: { query: string; query_params?: Record<string, unknown> }) {
+      query = input.query;
+      params = input.query_params;
+      return {
+        async json() {
+          return [
+            { bucket: "2026-07-14 10:00:00", group_key: "", c: 2 },
+            { bucket: "2026-07-14 10:00:00", group_key: "checkout", c: 7 },
+          ];
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+
+  const result = await previewAlertSeries(
+    ch,
+    "project-1",
+    baseInput({
+      source: "logs",
+      groupMode: "per_group",
+      groupBy: "attr:team",
+      windowMinutes: 5,
+    }),
+    "",
+  );
+
+  assert.match(query, /LogAttributes\[\{groupKey:String\}\]/);
+  assert.equal(params?.groupKey, "team");
+  assert.deepEqual(
+    result.rows.map((row) => row.value),
+    [2],
+  );
 });

--- a/apps/api/src/alerts-service.ts
+++ b/apps/api/src/alerts-service.ts
@@ -420,14 +420,19 @@ export type AlertPreviewSeries = {
 // The time series the alert evaluates, bucketed at the alert's own window so
 // each point is exactly one evaluation ("count over the window" / "metric agg
 // over the window"). Used by the preview graph to show the signal against the
-// threshold line over the recent past. Collapses groups to a single overview
-// series (groupBy is ignored here — per-group preview would need a series each).
+// threshold line over the recent past.
+//
+// By default it collapses all groups into a single overview series. Pass a
+// non-empty `groupKey` (for a per-group alert) to plot only that group's
+// signal — the incident card uses this so it shows the exact group that
+// breached, not the aggregate across every group.
 const PREVIEW_BUCKETS = 24;
 
 export async function previewAlertSeries(
   ch: ClickHouseClient,
   projectId: string,
   input: AlertInput,
+  groupKey?: string,
 ): Promise<AlertPreviewSeries> {
   validateAlertInput(input);
   const windowMinutes = input.windowMinutes ?? 5;
@@ -436,8 +441,15 @@ export async function previewAlertSeries(
   const range = { since, until: new Date(now).toISOString() };
   const step = { n: windowMinutes, unit: "MINUTE" as const };
   const filter = alertInputToFilter(input);
-  const label =
+  // Only scope to a single group when the alert actually groups and a group was
+  // named; otherwise fall back to the aggregate overview.
+  const scopedGroup = groupKey && input.groupBy ? groupKey : undefined;
+  const groupBy = scopedGroup ? input.groupBy || undefined : undefined;
+  const baseLabel =
     input.source === "metric" ? (input.metricName ?? "metric") : `${input.source} count`;
+  const label = scopedGroup ? `${baseLabel} · ${scopedGroup}` : baseLabel;
+  const keep = (rowGroup: string | null | undefined) =>
+    scopedGroup === undefined || (rowGroup ?? "") === scopedGroup;
 
   const byBucket = new Map<string, number>();
   if (input.source === "metric") {
@@ -447,11 +459,14 @@ export async function previewAlertSeries(
         projectId,
         input.metricName,
         { range, service: filter.service, resourceAttrs: filter.resourceAttrs },
-        undefined,
+        groupBy,
         step,
         input.aggregation as MetricAggregation,
       );
-      for (const r of rows) byBucket.set(r.bucket, (byBucket.get(r.bucket) ?? 0) + r.value);
+      for (const r of rows) {
+        if (!keep(r.group)) continue;
+        byBucket.set(r.bucket, (byBucket.get(r.bucket) ?? 0) + r.value);
+      }
     }
   } else {
     const rows = await countSeries(
@@ -467,10 +482,13 @@ export async function previewAlertSeries(
         statusCode: filter.statusCode,
         minDurationMs: filter.minDurationMs,
       },
-      undefined,
+      groupBy,
       step,
     );
-    for (const r of rows) byBucket.set(r.bucket, (byBucket.get(r.bucket) ?? 0) + r.count);
+    for (const r of rows) {
+      if (!keep(r.group)) continue;
+      byBucket.set(r.bucket, (byBucket.get(r.bucket) ?? 0) + r.count);
+    }
   }
 
   const rows: AlertSeriesRow[] = [...byBucket.entries()]
@@ -527,12 +545,13 @@ export async function previewAlertSeriesById(
   ch: ClickHouseClient,
   projectId: string,
   id: string,
+  groupKey?: string,
 ): Promise<AlertPreviewSeries | null> {
   const alert = await db.query.alerts.findFirst({
     where: and(eq(schema.alerts.id, id), eq(schema.alerts.projectId, projectId)),
   });
   if (!alert) return null;
-  return previewAlertSeries(ch, projectId, alertRecordToInput(alert));
+  return previewAlertSeries(ch, projectId, alertRecordToInput(alert), groupKey);
 }
 
 export async function listAlertEpisodes(

--- a/apps/api/src/alerts-service.ts
+++ b/apps/api/src/alerts-service.ts
@@ -423,9 +423,9 @@ export type AlertPreviewSeries = {
 // threshold line over the recent past.
 //
 // By default it collapses all groups into a single overview series. Pass a
-// non-empty `groupKey` (for a per-group alert) to plot only that group's
-// signal — the incident card uses this so it shows the exact group that
-// breached, not the aggregate across every group.
+// `groupKey` (including an explicitly empty key) for a per-group alert to plot
+// only that group's signal — the incident card uses this so it shows the exact
+// group that breached, not the aggregate across every group.
 const PREVIEW_BUCKETS = 24;
 
 export async function previewAlertSeries(
@@ -442,12 +442,15 @@ export async function previewAlertSeries(
   const step = { n: windowMinutes, unit: "MINUTE" as const };
   const filter = alertInputToFilter(input);
   // Only scope to a single group when the alert actually groups and a group was
-  // named; otherwise fall back to the aggregate overview.
-  const scopedGroup = groupKey && input.groupBy ? groupKey : undefined;
-  const groupBy = scopedGroup ? input.groupBy || undefined : undefined;
+  // supplied; an empty string is a valid evaluated group key.
+  const scopedGroup = groupKey !== undefined && input.groupBy ? groupKey : undefined;
+  const groupBy = scopedGroup !== undefined ? input.groupBy || undefined : undefined;
   const baseLabel =
     input.source === "metric" ? (input.metricName ?? "metric") : `${input.source} count`;
-  const label = scopedGroup ? `${baseLabel} · ${scopedGroup}` : baseLabel;
+  const label =
+    scopedGroup !== undefined
+      ? `${baseLabel} · ${scopedGroup === "" ? "(empty)" : scopedGroup}`
+      : baseLabel;
   const keep = (rowGroup: string | null | undefined) =>
     scopedGroup === undefined || (rowGroup ?? "") === scopedGroup;
 

--- a/apps/api/src/alerts-service.ts
+++ b/apps/api/src/alerts-service.ts
@@ -436,7 +436,8 @@ export async function previewAlertSeries(
   const range = { since, until: new Date(now).toISOString() };
   const step = { n: windowMinutes, unit: "MINUTE" as const };
   const filter = alertInputToFilter(input);
-  const label = input.source === "metric" ? (input.metricName ?? "metric") : `${input.source} count`;
+  const label =
+    input.source === "metric" ? (input.metricName ?? "metric") : `${input.source} count`;
 
   const byBucket = new Map<string, number>();
   if (input.source === "metric") {
@@ -485,6 +486,53 @@ export async function previewAlertSeries(
     windowMinutes,
     label,
   };
+}
+
+// Map a stored alert row back to the `AlertInput` shape the preview/series
+// helpers consume, so we can reuse `previewAlertSeries` for a saved alert
+// without re-deriving its config at the call site.
+export function alertRecordToInput(
+  alert: Pick<
+    schema.Alert,
+    | "name"
+    | "source"
+    | "metricName"
+    | "filter"
+    | "groupBy"
+    | "groupMode"
+    | "aggregation"
+    | "comparator"
+    | "threshold"
+    | "windowMinutes"
+  >,
+): AlertInput {
+  return {
+    name: alert.name,
+    source: alert.source,
+    metricName: alert.metricName,
+    filter: alert.filter ?? undefined,
+    groupBy: alert.groupBy,
+    groupMode: alert.groupMode,
+    aggregation: alert.aggregation,
+    comparator: alert.comparator,
+    threshold: alert.threshold,
+    windowMinutes: alert.windowMinutes,
+  };
+}
+
+// The evaluated-signal series (with threshold) for a *saved* alert, so the
+// incident detail can draw the alert's metric-vs-threshold graph. Returns null
+// when the alert doesn't belong to the project (404 at the route layer).
+export async function previewAlertSeriesById(
+  ch: ClickHouseClient,
+  projectId: string,
+  id: string,
+): Promise<AlertPreviewSeries | null> {
+  const alert = await db.query.alerts.findFirst({
+    where: and(eq(schema.alerts.id, id), eq(schema.alerts.projectId, projectId)),
+  });
+  if (!alert) return null;
+  return previewAlertSeries(ch, projectId, alertRecordToInput(alert));
 }
 
 export async function listAlertEpisodes(
@@ -547,6 +595,9 @@ export type IncidentAlertEpisodeView = {
   endedAt: string | null;
   peakObservedValue: number;
   seq: number;
+  // The issue this episode raised, so the incident timeline can match the
+  // triggering issue card to its alert (and draw the metric-vs-threshold graph).
+  issueId: string | null;
 };
 
 // The alert episodes that triggered a given incident, for the incident detail
@@ -592,6 +643,7 @@ export async function loadIncidentAlertEpisodes(
     endedAt: r.endedAt ? r.endedAt.toISOString() : null,
     peakObservedValue: r.peakObservedValue,
     seq: seqMap.get(r.id) ?? 1,
+    issueId: r.issueId,
   }));
 }
 

--- a/apps/api/src/alerts.ts
+++ b/apps/api/src/alerts.ts
@@ -73,7 +73,10 @@ export function mountAlerts(app: Hono<{ Variables: Vars }>, opts: { ch: ClickHou
     const projectId = c.req.param("projectId");
     const id = c.req.param("id");
     await requireAccess(c, projectId);
-    const series = await previewAlertSeriesById(opts.ch, projectId, id);
+    // Optional: scope the series to one group (a per-group alert episode's key)
+    // so the incident card plots the exact group that breached.
+    const groupKey = c.req.query("groupKey") || undefined;
+    const series = await previewAlertSeriesById(opts.ch, projectId, id, groupKey);
     if (series === null) throw new HTTPException(404, { message: "alert not found" });
     return c.json(series);
   });

--- a/apps/api/src/alerts.ts
+++ b/apps/api/src/alerts.ts
@@ -75,7 +75,7 @@ export function mountAlerts(app: Hono<{ Variables: Vars }>, opts: { ch: ClickHou
     await requireAccess(c, projectId);
     // Optional: scope the series to one group (a per-group alert episode's key)
     // so the incident card plots the exact group that breached.
-    const groupKey = c.req.query("groupKey") || undefined;
+    const groupKey = c.req.query("groupKey");
     const series = await previewAlertSeriesById(opts.ch, projectId, id, groupKey);
     if (series === null) throw new HTTPException(404, { message: "alert not found" });
     return c.json(series);

--- a/apps/api/src/alerts.ts
+++ b/apps/api/src/alerts.ts
@@ -12,6 +12,7 @@ import {
   listAlertsForProject,
   previewAlert,
   previewAlertSeries,
+  previewAlertSeriesById,
   testAlertById,
   updateAlertRecord,
 } from "./alerts-service.js";
@@ -66,6 +67,15 @@ export function mountAlerts(app: Hono<{ Variables: Vars }>, opts: { ch: ClickHou
     const episodes = await listAlertEpisodes(projectId, id);
     if (episodes === null) throw new HTTPException(404, { message: "alert not found" });
     return c.json(episodes);
+  });
+
+  app.get("/api/projects/:projectId/alerts/:id/series", async (c) => {
+    const projectId = c.req.param("projectId");
+    const id = c.req.param("id");
+    await requireAccess(c, projectId);
+    const series = await previewAlertSeriesById(opts.ch, projectId, id);
+    if (series === null) throw new HTTPException(404, { message: "alert not found" });
+    return c.json(series);
   });
 
   app.patch("/api/projects/:projectId/alerts/:id", async (c) => {

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -1729,9 +1729,9 @@ export function IncidentDetailContent({
                       const issue = issues.find((i) => i.id === issueId);
                       if (!issue) return null;
                       // If an alert episode raised this issue, draw the alert's
-                      // metric-vs-threshold graph instead of the occurrence graph.
-                      const alertId =
-                        alertEpisodes.find((ep) => ep.issueId === issueId)?.alertId ?? null;
+                      // metric-vs-threshold graph instead of the occurrence graph,
+                      // scoped to the group that breached for per-group alerts.
+                      const episode = alertEpisodes.find((ep) => ep.issueId === issueId) ?? null;
                       return (
                         <div className="rounded-lg border border-border bg-surface px-3 py-2">
                           <IssueCard
@@ -1741,7 +1741,8 @@ export function IncidentDetailContent({
                               options?.showOccurrences ? occurrenceBuckets : undefined
                             }
                             projectId={incident.projectId}
-                            alertId={alertId}
+                            alertId={episode?.alertId ?? null}
+                            alertGroupKey={episode?.groupKey ?? null}
                           />
                         </div>
                       );
@@ -2797,6 +2798,7 @@ function IssueCard({
   occurrenceBuckets,
   projectId,
   alertId,
+  alertGroupKey,
 }: {
   issue: Issue;
   onViewIssue: (id: string) => void;
@@ -2806,6 +2808,9 @@ function IssueCard({
   // The right-side graph then shows the alert's evaluated signal against its
   // threshold instead of raw occurrence counts.
   alertId?: string | null;
+  // For a per-group alert, the group that breached — scopes the graph to that
+  // group's signal rather than the aggregate across all groups.
+  alertGroupKey?: string | null;
 }) {
   const hasOccurrences = !!occurrenceBuckets && occurrenceBuckets.length > 0;
   const showAlertGraph = !!alertId && !!projectId;
@@ -2832,7 +2837,7 @@ function IssueCard({
           )}
         </div>
         {showAlertGraph ? (
-          <AlertThresholdGraph projectId={projectId} alertId={alertId} />
+          <AlertThresholdGraph projectId={projectId} alertId={alertId} groupKey={alertGroupKey} />
         ) : hasOccurrences ? (
           <IssueOccurrenceGraph buckets={occurrenceBuckets} />
         ) : null}
@@ -2848,8 +2853,16 @@ const alertSeriesValue = (r: AlertSeriesRow) => r.value;
 // line — shown in place of the occurrence graph on an alert-raised issue card,
 // where "occurrences" is always 0 and the metric-vs-threshold view is what
 // actually explains the firing. Same footprint as IssueOccurrenceGraph.
-function AlertThresholdGraph({ projectId, alertId }: { projectId: string; alertId: string }) {
-  const series = useAlertSeries(projectId, alertId);
+function AlertThresholdGraph({
+  projectId,
+  alertId,
+  groupKey,
+}: {
+  projectId: string;
+  alertId: string;
+  groupKey?: string | null;
+}) {
+  const series = useAlertSeries(projectId, alertId, { groupKey });
   return (
     <div className="border-t border-border pt-2.5 sm:w-44 sm:flex-none sm:border-l sm:border-t-0 sm:pl-4 sm:pt-0">
       {series.isLoading ? (

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -20,6 +20,8 @@ import { type EvidenceLinkContext, EvidenceMarkdown } from "./EvidenceMarkdown.t
 import { FeedbackTrigger } from "./FeedbackDialog.tsx";
 import { LogDrawer } from "./LogDetail.tsx";
 import { TraceDrawer } from "./TraceDetail.tsx";
+import { useAlertSeries } from "./alerts/api.ts";
+import type { AlertPreviewSeries, AlertSeriesRow } from "./alerts/types.ts";
 import {
   type AgentRun,
   type AgentRunEventActor,
@@ -54,6 +56,7 @@ import {
   useUnsilenceIssue,
   useUpdateIncident,
 } from "./api.ts";
+import { CountChart } from "./dashboards/widgets/CountChart.tsx";
 import {
   Btn,
   Chip,
@@ -63,6 +66,7 @@ import {
   Tabs,
 } from "./design/ui.tsx";
 import { type IncidentStatusAction, getIncidentStatusActions } from "./incident-status-action.ts";
+import { IncidentDetailScrollArea } from "./incidents/IncidentDetailScrollArea.tsx";
 import {
   IncidentActivityFeed,
   IncidentSummaryTelemetry,
@@ -76,7 +80,6 @@ import {
   type IncidentMetaRow,
   buildIncidentDetailMeta,
 } from "./incidents/incident-detail-view-model.ts";
-import { IncidentDetailScrollArea } from "./incidents/IncidentDetailScrollArea.tsx";
 import { getIssueIncidentLinkState } from "./issue-incident-link-state.ts";
 import { IssueDetailView } from "./issues/IssueDetailView.tsx";
 import {
@@ -1725,6 +1728,10 @@ export function IncidentDetailContent({
                     renderIssueCard={(issueId, options) => {
                       const issue = issues.find((i) => i.id === issueId);
                       if (!issue) return null;
+                      // If an alert episode raised this issue, draw the alert's
+                      // metric-vs-threshold graph instead of the occurrence graph.
+                      const alertId =
+                        alertEpisodes.find((ep) => ep.issueId === issueId)?.alertId ?? null;
                       return (
                         <div className="rounded-lg border border-border bg-surface px-3 py-2">
                           <IssueCard
@@ -1733,6 +1740,8 @@ export function IncidentDetailContent({
                             occurrenceBuckets={
                               options?.showOccurrences ? occurrenceBuckets : undefined
                             }
+                            projectId={incident.projectId}
+                            alertId={alertId}
                           />
                         </div>
                       );
@@ -2786,23 +2795,27 @@ function IssueCard({
   issue,
   onViewIssue,
   occurrenceBuckets,
+  projectId,
+  alertId,
 }: {
   issue: Issue;
   onViewIssue: (id: string) => void;
   occurrenceBuckets?: { day: string; count: number }[];
+  projectId?: string;
+  // When this issue was raised by one of the project's alerts, the alert's id.
+  // The right-side graph then shows the alert's evaluated signal against its
+  // threshold instead of raw occurrence counts.
+  alertId?: string | null;
 }) {
+  const hasOccurrences = !!occurrenceBuckets && occurrenceBuckets.length > 0;
+  const showAlertGraph = !!alertId && !!projectId;
+  const showGraph = showAlertGraph || hasOccurrences;
   return (
     <button
       onClick={() => onViewIssue(issue.id)}
       className="block w-full min-w-0 text-left transition-colors hover:text-muted"
     >
-      <div
-        className={
-          occurrenceBuckets && occurrenceBuckets.length > 0
-            ? "flex flex-col gap-3 sm:flex-row sm:gap-4"
-            : undefined
-        }
-      >
+      <div className={showGraph ? "flex flex-col gap-3 sm:flex-row sm:gap-4" : undefined}>
         <div className="min-w-0 flex-1">
           <div className="mb-0.5 flex items-center gap-2">
             <KindChip issue={issue} />
@@ -2812,24 +2825,86 @@ function IssueCard({
             </span>
           </div>
           <p className="truncate text-[12px] text-fg">{issue.message ?? issue.title}</p>
-          {occurrenceBuckets && occurrenceBuckets.length > 0 && (
+          {showGraph && (
             <p className="mt-3 text-[10px] text-subtle">
               First {fmtRelative(issue.firstSeen)} · Last {fmtRelative(issue.lastSeen)}
             </p>
           )}
         </div>
-        {occurrenceBuckets && occurrenceBuckets.length > 0 && (
+        {showAlertGraph ? (
+          <AlertThresholdGraph projectId={projectId} alertId={alertId} />
+        ) : hasOccurrences ? (
           <IssueOccurrenceGraph buckets={occurrenceBuckets} />
-        )}
+        ) : null}
       </div>
     </button>
   );
 }
 
+// Stable accessor so CountChart's series memo doesn't recompute each render.
+const alertSeriesValue = (r: AlertSeriesRow) => r.value;
+
+// The alert's evaluated signal over recent history with a dashed threshold
+// line — shown in place of the occurrence graph on an alert-raised issue card,
+// where "occurrences" is always 0 and the metric-vs-threshold view is what
+// actually explains the firing. Same footprint as IssueOccurrenceGraph.
+function AlertThresholdGraph({ projectId, alertId }: { projectId: string; alertId: string }) {
+  const series = useAlertSeries(projectId, alertId);
+  return (
+    <div className="border-t border-border pt-2.5 sm:w-44 sm:flex-none sm:border-l sm:border-t-0 sm:pl-4 sm:pt-0">
+      {series.isLoading ? (
+        <div className="h-[76px] text-[10px] text-subtle">Loading signal…</div>
+      ) : series.error || !series.data || series.data.rows.length === 0 ? (
+        <div className="h-[76px] text-[10px] text-subtle">No signal data.</div>
+      ) : (
+        <AlertThresholdGraphBody series={series.data} />
+      )}
+    </div>
+  );
+}
+
+function AlertThresholdGraphBody({ series }: { series: AlertPreviewSeries }) {
+  const cmp = series.comparator === "lt" ? "<" : ">";
+  return (
+    <>
+      <div className="flex items-center justify-between text-[10px] text-subtle">
+        <span className="truncate">{series.label}</span>
+        <span className="font-sans tabular-nums text-fg">
+          {cmp} {formatAlertNum(series.threshold)}
+        </span>
+      </div>
+      <div
+        className="mt-2 h-16 w-full"
+        role="img"
+        aria-label={`${series.label} against a threshold of ${formatAlertNum(series.threshold)}`}
+      >
+        <CountChart
+          rows={series.rows}
+          value={alertSeriesValue}
+          range={series.range}
+          step={series.step}
+          // Bars, not a line: a single evaluation (the common case on a
+          // freshly-fired alert) has one data point, which a line can't draw.
+          chartType="bar"
+          limit={1}
+          showXAxis={false}
+          showYAxis={false}
+          showLegend={false}
+          legendPosition="side"
+          threshold={series.threshold}
+          thresholdLabel={`${cmp} ${formatAlertNum(series.threshold)}`}
+        />
+      </div>
+    </>
+  );
+}
+
+function formatAlertNum(n: number): string {
+  return Number.isInteger(n) ? n.toLocaleString() : n.toFixed(2);
+}
+
 function formatOccurrenceDate(day: string) {
-  const [year = Number.NaN, month = Number.NaN, date = Number.NaN] = day
-    .split("-")
-    .map(Number);
+  const [year = Number.NaN, month = Number.NaN, date = Number.NaN] = day.split("-").map(Number);
   const parsed =
     Number.isFinite(year) && Number.isFinite(month) && Number.isFinite(date)
       ? new Date(year, month - 1, date)

--- a/apps/web/src/alerts-api.test.ts
+++ b/apps/web/src/alerts-api.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { alertSeriesPath } from "./alerts/series-path.ts";
+
+test("alertSeriesPath preserves an explicitly empty group key", () => {
+  assert.equal(
+    alertSeriesPath("project-1", "alert-1", ""),
+    "/api/projects/project-1/alerts/alert-1/series?groupKey=",
+  );
+  assert.equal(
+    alertSeriesPath("project-1", "alert-1"),
+    "/api/projects/project-1/alerts/alert-1/series",
+  );
+});

--- a/apps/web/src/alerts/api.ts
+++ b/apps/web/src/alerts/api.ts
@@ -52,6 +52,24 @@ export function useAlertEpisodes(projectId: string | undefined, id: string | und
   });
 }
 
+// The evaluated-signal series (with threshold) for a *saved* alert, keyed by
+// alert id. Used by the incident timeline to draw the alert's metric-vs-threshold
+// graph on the triggering issue card. `enabled` lets callers defer the fetch
+// until the card is actually an alert.
+export function useAlertSeries(
+  projectId: string | undefined,
+  alertId: string | undefined,
+  options: { enabled?: boolean } = {},
+) {
+  const fetcher = useFetcher();
+  return useQuery({
+    queryKey: ["alert-series", projectId, alertId],
+    queryFn: () =>
+      fetcher<AlertPreviewSeries>(`/api/projects/${projectId}/alerts/${alertId}/series`),
+    enabled: !!projectId && !!alertId && options.enabled !== false,
+  });
+}
+
 export function useCreateAlert(projectId: string) {
   const fetcher = useFetcher();
   const qc = useQueryClient();

--- a/apps/web/src/alerts/api.ts
+++ b/apps/web/src/alerts/api.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { alertSeriesPath } from "./series-path.ts";
 import type {
   Alert,
   AlertCreateBody,
@@ -62,15 +63,10 @@ export function useAlertSeries(
   options: { enabled?: boolean; groupKey?: string | null } = {},
 ) {
   const fetcher = useFetcher();
-  const groupKey = options.groupKey || undefined;
+  const groupKey = options.groupKey ?? undefined;
   return useQuery({
     queryKey: ["alert-series", projectId, alertId, groupKey ?? null],
-    queryFn: () => {
-      const qs = groupKey ? `?groupKey=${encodeURIComponent(groupKey)}` : "";
-      return fetcher<AlertPreviewSeries>(
-        `/api/projects/${projectId}/alerts/${alertId}/series${qs}`,
-      );
-    },
+    queryFn: () => fetcher<AlertPreviewSeries>(alertSeriesPath(projectId, alertId, groupKey)),
     enabled: !!projectId && !!alertId && options.enabled !== false,
   });
 }

--- a/apps/web/src/alerts/api.ts
+++ b/apps/web/src/alerts/api.ts
@@ -59,13 +59,18 @@ export function useAlertEpisodes(projectId: string | undefined, id: string | und
 export function useAlertSeries(
   projectId: string | undefined,
   alertId: string | undefined,
-  options: { enabled?: boolean } = {},
+  options: { enabled?: boolean; groupKey?: string | null } = {},
 ) {
   const fetcher = useFetcher();
+  const groupKey = options.groupKey || undefined;
   return useQuery({
-    queryKey: ["alert-series", projectId, alertId],
-    queryFn: () =>
-      fetcher<AlertPreviewSeries>(`/api/projects/${projectId}/alerts/${alertId}/series`),
+    queryKey: ["alert-series", projectId, alertId, groupKey ?? null],
+    queryFn: () => {
+      const qs = groupKey ? `?groupKey=${encodeURIComponent(groupKey)}` : "";
+      return fetcher<AlertPreviewSeries>(
+        `/api/projects/${projectId}/alerts/${alertId}/series${qs}`,
+      );
+    },
     enabled: !!projectId && !!alertId && options.enabled !== false,
   });
 }

--- a/apps/web/src/alerts/series-path.ts
+++ b/apps/web/src/alerts/series-path.ts
@@ -1,0 +1,8 @@
+export function alertSeriesPath(
+  projectId: string | undefined,
+  alertId: string | undefined,
+  groupKey?: string,
+): string {
+  const qs = groupKey !== undefined ? `?groupKey=${encodeURIComponent(groupKey)}` : "";
+  return `/api/projects/${projectId}/alerts/${alertId}/series${qs}`;
+}

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -2439,6 +2439,9 @@ export type IncidentAlertEpisode = {
   endedAt: string | null;
   peakObservedValue: number;
   seq: number;
+  // The issue this episode raised. Lets the incident timeline match the
+  // triggering issue card to its alert and draw the metric-vs-threshold graph.
+  issueId: string | null;
 };
 
 export type IncidentPullRequest = {

--- a/apps/web/src/dashboards/widgets/echarts-setup.ts
+++ b/apps/web/src/dashboards/widgets/echarts-setup.ts
@@ -5,6 +5,7 @@ import {
   AriaComponent,
   BrushComponent,
   GridComponent,
+  MarkLineComponent,
   ToolboxComponent,
   TooltipComponent,
 } from "echarts/components";
@@ -17,6 +18,9 @@ echarts.use([
   AriaComponent,
   BrushComponent,
   GridComponent,
+  // Required for `series.markLine` (the dashed threshold line on alert charts).
+  // Without it the tree-shaken core silently drops markLine — no error, no line.
+  MarkLineComponent,
   ToolboxComponent,
   TooltipComponent,
   CanvasRenderer,


### PR DESCRIPTION
## What

On the incident timeline, an alert-raised issue card (`AlertFired`) now shows the alert's **evaluated signal against its threshold** instead of the occurrence-count graph — which is always 0 for alert issues and explains nothing about why the alert fired.

The graph is a **bar** (the observed value) with a dashed **threshold line**. Bars rather than a line so a freshly-fired alert's single evaluation point is actually visible (a line can't draw one point).

## Why the threshold line was missing everywhere

The dashboard charts use a tree-shaken `echarts/core` build (`echarts-setup.ts`) that must register each component explicitly. `MarkLineComponent` was never registered, so `series.markLine` was **silently dropped — no error, no line**. That means the threshold reference line never rendered on any chart, including the alert editor's preview. Registering the component fixes it.

## Wiring

- **API** — new `GET /api/projects/:projectId/alerts/:id/series` returns the evaluated series (with threshold) for a *saved* alert, reusing the existing preview-series builder via a small pure `alertRecordToInput()` mapper (unit-tested).
- Alert episodes now expose `issueId`, so the incident card can match its triggering issue to the alert that raised it and fetch that alert's series.
- **Web** — `useAlertSeries()` query hook + `AlertThresholdGraph`, rendered inside `IssueCard` when the issue maps to an alert episode; otherwise the occurrence graph is unchanged.

## Test

- New unit tests for `alertRecordToInput` (14/14 in `alerts-service.test.ts`); api + web typecheck clean.
- Verified end-to-end against a running stack: created a logs alert, let it fire (real episode + issue), linked an incident, confirmed the `/series` endpoint (200 + correct shape, 404 on unknown id) and that the card renders the bar + dashed threshold line with its label.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Alert-raised issue cards now show the alert’s evaluated signal vs its threshold (bar + dashed line) instead of the empty occurrence graph. For per‑group alerts, the graph scopes to the breached group, including empty keys.

- **New Features**
  - Replaced occurrence graph with a metric‑vs‑threshold bar chart on alert-raised issue cards.
  - Added `GET /api/projects/:projectId/alerts/:id/series` to return the evaluated series with threshold; supports `?groupKey=` to plot the breached group; reused the preview builder via `alertRecordToInput`.
  - Episodes now include `issueId`; `IssueCard` uses `useAlertSeries` and passes the episode’s `groupKey` to render the exact group’s signal.

- **Bug Fixes**
  - Registered `MarkLineComponent` in `echarts/core` so `series.markLine` renders; the threshold line now appears across charts.
  - Preserved explicitly empty group keys end-to-end (`?groupKey=`) so per-group episodes with empty keys render the correct series.

<sup>Written for commit dead9634826aafa39c304d1a6da3a03a6dad9c9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

