### PR TITLE
Add project-scoped application URLs

### DIFF
--- a/apps/api/src/incidents/resolution-side-effects.test.ts
+++ b/apps/api/src/incidents/resolution-side-effects.test.ts
@@ -6,6 +6,8 @@ import {
   shouldRunResolvedIncidentSideEffects,
 } from "./resolution-side-effects.js";
 
+const PROJECT_ROUTE = { orgSlug: "acme", projectSlug: "shop" };
+
 test("shouldRunResolvedIncidentSideEffects runs cleanup for stale already-closed resolve requests", () => {
   assert.equal(
     shouldRunResolvedIncidentSideEffects({ requestedStatus: "resolved", incidentExists: true }),
@@ -34,6 +36,7 @@ test("runResolvedIncidentSideEffects closes incident PRs through the shared help
       service: "checkout-api",
     },
     projectName: "Acme",
+    projectRoute: PROJECT_ROUTE,
     deps: {
       closeIncidentPullRequests: async (incidentId) => {
         calls.push(`close-prs:${incidentId}`);
@@ -57,6 +60,7 @@ test("runResolvedIncidentSideEffects still refreshes Slack when PR closure repor
   const result = await runResolvedIncidentSideEffects({
     incident: { id: "inc-1", title: "Checkout API timeout", service: null },
     projectName: "Acme",
+    projectRoute: PROJECT_ROUTE,
     deps: {
       closeIncidentPullRequests: async () => {
         calls.push("close-prs");
@@ -77,6 +81,7 @@ test("runResolvedIncidentSideEffects still refreshes Slack when PR closure throw
   const result = await runResolvedIncidentSideEffects({
     incident: { id: "inc-1", title: "Checkout API timeout", service: null },
     projectName: "Acme",
+    projectRoute: PROJECT_ROUTE,
     deps: {
       closeIncidentPullRequests: async () => {
         calls.push("close-prs");
@@ -96,6 +101,7 @@ test("runResolvedIncidentSideEffects does not fail when Slack refresh throws", a
   const result = await runResolvedIncidentSideEffects({
     incident: { id: "inc-1", title: "Checkout API timeout", service: null },
     projectName: "Acme",
+    projectRoute: PROJECT_ROUTE,
     deps: {
       closeIncidentPullRequests: async () => ({
         closedPullRequestCount: 1,
@@ -118,6 +124,7 @@ test("buildResolvedIncidentSlackRoot removes resolve action and keeps rating act
       service: "checkout-api",
     },
     projectName: "Acme",
+    projectRoute: PROJECT_ROUTE,
   });
 
   const json = JSON.stringify(update.blocks);
@@ -125,6 +132,7 @@ test("buildResolvedIncidentSlackRoot removes resolve action and keeps rating act
   assert.equal(json.includes("resolve_incident:"), false);
   // The incident link now lives on the title, not a standalone button.
   assert.equal(json.includes("open_superlog"), false);
+  assert.equal(json.includes("/org/acme/project/shop/incidents/inc-1"), true);
   assert.equal(json.includes("rate_incident:helpful:inc-1"), true);
   assert.equal(json.includes("rate_incident:unhelpful:inc-1"), true);
 });

--- a/apps/api/src/incidents/resolution-side-effects.ts
+++ b/apps/api/src/incidents/resolution-side-effects.ts
@@ -37,6 +37,7 @@ export function shouldRunResolvedIncidentSideEffects(opts: {
 export async function runResolvedIncidentSideEffects(opts: {
   incident: ResolvedIncidentSideEffectIncident;
   projectName: string;
+  projectRoute: { orgSlug: string; projectSlug: string };
   deps: ResolvedIncidentSideEffectDeps;
 }): Promise<CloseIncidentOpenPullRequestsResult> {
   let closed: CloseIncidentOpenPullRequestsResult;
@@ -50,6 +51,7 @@ export async function runResolvedIncidentSideEffects(opts: {
   const slackRoot = buildResolvedIncidentSlackRoot({
     incident: opts.incident,
     projectName: opts.projectName,
+    projectRoute: opts.projectRoute,
   });
   try {
     await opts.deps.updateSlackRootMessage({
@@ -79,13 +81,17 @@ export async function runResolvedIncidentSideEffectsForIncident(opts: {
   const project = await db.query.projects.findFirst({
     where: eq(schema.projects.id, incident.projectId),
   });
+  if (!project) return null;
+  const org = await db.query.orgs.findFirst({ where: eq(schema.orgs.id, project.orgId) });
+  if (!org) return null;
   return runResolvedIncidentSideEffects({
     incident: {
       id: incident.id,
       title: incident.title,
       service: incident.service,
     },
-    projectName: project?.name ?? incident.projectId,
+    projectName: project.name,
+    projectRoute: { orgSlug: org.slug, projectSlug: project.slug },
     deps: createResolvedIncidentSideEffectDeps({
       closePullRequest: opts.closePullRequest,
     }),
@@ -95,8 +101,12 @@ export async function runResolvedIncidentSideEffectsForIncident(opts: {
 export function buildResolvedIncidentSlackRoot(opts: {
   incident: ResolvedIncidentSideEffectIncident;
   projectName: string;
+  projectRoute: { orgSlug: string; projectSlug: string };
 }): ResolvedIncidentSlackRoot {
-  const incidentUrl = escapeSlackLinkUrl(`${WEB_ORIGIN}/incidents/${opts.incident.id}`);
+  const origin = WEB_ORIGIN.replace(/\/$/, "");
+  const incidentUrl = escapeSlackLinkUrl(
+    `${origin}/org/${encodeURIComponent(opts.projectRoute.orgSlug)}/project/${encodeURIComponent(opts.projectRoute.projectSlug)}/incidents/${encodeURIComponent(opts.incident.id)}`,
+  );
   const titleLabel = escapeSlackLinkText(opts.incident.title);
   const lines = [
     ":white_check_mark: *Incident resolved*",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -75,7 +75,6 @@ import {
 import { mountIngestFilters } from "./ingest-filters.js";
 import { sanitizeIssueFilterConfig } from "./issue-filter-service.js";
 import { mountLinearAuthed, mountLinearPublic } from "./linear.js";
-import { mountNotionAuthed, mountNotionPublic } from "./notion.js";
 import { logger } from "./logger.js";
 import { mountManagementApi, mountOrgKeyManagementAuthed } from "./management.js";
 import {
@@ -100,6 +99,7 @@ import {
   queryTracesAggregated,
 } from "./mcp/clickhouse.js";
 import { mountMcpAuthed, mountMcpPublic } from "./mcp/index.js";
+import { mountNotionAuthed, mountNotionPublic } from "./notion.js";
 import { resolveActiveOrgContext, resolveMaybeActiveOrgContext } from "./org-context.js";
 import { ORG_NAME_MAX, createOrgWithDefaults, mountOrgCrud } from "./orgs.js";
 import { mountPersonalAccessTokens } from "./personal-access-tokens.js";
@@ -108,12 +108,13 @@ import {
   VALID_MANUAL_MERGE_METHODS,
   mergeAgentPullRequestAndResolveIncident,
 } from "./pr-merge-service.js";
+import { mountProjectMcpRelayPublic } from "./project-mcp-relay.js";
 import {
   mountProjectMcpOAuthPublic,
   mountProjectMcpServersAuthed,
   mountProjectMcpServersManagement,
 } from "./project-mcp-servers.js";
-import { mountProjectMcpRelayPublic } from "./project-mcp-relay.js";
+import { mountProjectRouteContext } from "./project-route-context.js";
 import { mountRailwayAuthed, mountRailwayPublic } from "./railway.js";
 import { mountRenderAuthed } from "./render.js";
 import { mountSettingsAuthed } from "./settings.js";
@@ -161,6 +162,7 @@ const SIGNUP_INTENT_TTL_MS = 30 * 60 * 1000;
 
 type Vars = {
   userId: string;
+  sessionId?: string;
   orgId: string | null;
   impersonating?: boolean;
   // Set by the demoOverlay middleware (apps/api/src/demo.ts): the project id
@@ -321,6 +323,7 @@ app.use("/api/*", async (c, next) => {
   const session = await auth.api.getSession({ headers: c.req.raw.headers });
   if (!session) return c.json({ error: "unauthenticated" }, 401);
   c.set("userId", session.user.id);
+  c.set("sessionId", session.session.id);
   c.set("orgId", session.session.activeOrganizationId ?? null);
   // Better Auth's admin plugin sets impersonatedBy on the session row when an
   // admin is acting as another user; surface it on `c.var` so /api/me can
@@ -338,6 +341,7 @@ app.use("/api/projects/:projectId/*", demoOverlay());
 
 mountMcpAuthed(app);
 mountPersonalAccessTokens(app);
+mountProjectRouteContext(app);
 mountGithubAuthed(app);
 mountLinearAuthed(app);
 mountNotionAuthed(app);

--- a/apps/api/src/mcp/incidents.ts
+++ b/apps/api/src/mcp/incidents.ts
@@ -48,7 +48,7 @@ export function registerIncidentTools(
     {
       title: "Get incident",
       description:
-        "Fetch one incident by its id — the uuid in a superlog.sh/incidents/<id> link — and everything needed to explain it. " +
+        "Fetch one incident by its id — the uuid at the end of a superlog.sh/org/<org>/project/<project>/incidents/<id> link — and everything needed to explain it. " +
         "No project_id is required; the project is resolved from the incident. Returns: the incident summary with the agent's findings (root_cause_text, agent_summary, estimated_impact_text) and its project_id; every linked issue with a stored telemetry `sample` (trace_id, span_id, stacktrace, span/log/resource attributes); and a pointer to the latest investigation run. " +
         "To pull live telemetry, take a sample's trace_id and call query_traces, or filter query_logs/query_traces by the issue's service + exception type — passing the returned project_id.",
       inputSchema: {

--- a/apps/api/src/project-route-context.test.ts
+++ b/apps/api/src/project-route-context.test.ts
@@ -1,0 +1,158 @@
+import "dotenv/config";
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+import { closeDb, db, runMigrations, schema } from "@superlog/db";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { mountProjectRouteContext } from "./project-route-context.js";
+
+type Vars = { userId: string; sessionId?: string; orgId: string | null };
+
+const orgIds: string[] = [];
+const userIds: string[] = [];
+
+before(async () => runMigrations());
+after(async () => {
+  try {
+    for (const orgId of orgIds.reverse()) {
+      await db.delete(schema.orgs).where(eq(schema.orgs.id, orgId));
+    }
+    for (const userId of userIds.reverse()) {
+      await db.delete(schema.users).where(eq(schema.users.id, userId));
+    }
+  } finally {
+    await closeDb();
+  }
+});
+
+function uniq(prefix: string) {
+  return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+}
+
+async function seedContext(projectSlug = "demo-project") {
+  const tag = uniq("route-context");
+  const [user] = await db
+    .insert(schema.users)
+    .values({ email: `${tag}@example.com` })
+    .returning();
+  if (!user) throw new Error("seed user failed");
+  userIds.push(user.id);
+
+  const [org] = await db.insert(schema.orgs).values({ name: tag, slug: tag }).returning();
+  if (!org) throw new Error("seed org failed");
+  orgIds.push(org.id);
+  await db.insert(schema.orgMembers).values({ orgId: org.id, userId: user.id, role: "member" });
+
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ orgId: org.id, name: "Demo project", slug: projectSlug })
+    .returning();
+  if (!project) throw new Error("seed project failed");
+
+  const [session] = await db
+    .insert(schema.sessions)
+    .values({
+      userId: user.id,
+      token: uniq("session-token"),
+      expiresAt: new Date(Date.now() + 60_000),
+    })
+    .returning();
+  if (!session) throw new Error("seed session failed");
+  return { user, org, project, session };
+}
+
+test("PUT /api/me/active-context selects an accessible org and project from route slugs", async () => {
+  const { user, org, project, session } = await seedContext();
+  const app = new Hono<{ Variables: Vars }>();
+  app.use("*", (c, next) => {
+    c.set("userId", user.id);
+    c.set("sessionId", session.id);
+    c.set("orgId", null);
+    return next();
+  });
+  mountProjectRouteContext(app);
+
+  const response = await app.request("/api/me/active-context", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ orgSlug: org.slug, projectSlug: project.slug }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    org: { id: org.id, name: org.name, slug: org.slug },
+    project: { id: project.id, name: project.name, slug: project.slug },
+  });
+  const updatedSession = await db.query.sessions.findFirst({
+    where: eq(schema.sessions.id, session.id),
+  });
+  const updatedUser = await db.query.users.findFirst({ where: eq(schema.users.id, user.id) });
+  assert.equal(updatedSession?.activeOrganizationId, org.id);
+  assert.equal(updatedUser?.activeOrgId, org.id);
+  assert.equal(updatedUser?.activeProjectId, project.id);
+});
+
+test("PUT /api/me/active-context hides inaccessible route contexts without changing selection", async () => {
+  const current = await seedContext();
+  const inaccessible = await seedContext();
+  await db
+    .update(schema.sessions)
+    .set({ activeOrganizationId: current.org.id })
+    .where(eq(schema.sessions.id, current.session.id));
+  await db
+    .update(schema.users)
+    .set({ activeOrgId: current.org.id, activeProjectId: current.project.id })
+    .where(eq(schema.users.id, current.user.id));
+
+  const app = new Hono<{ Variables: Vars }>();
+  app.use("*", (c, next) => {
+    c.set("userId", current.user.id);
+    c.set("sessionId", current.session.id);
+    c.set("orgId", null);
+    return next();
+  });
+  mountProjectRouteContext(app);
+
+  const response = await app.request("/api/me/active-context", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      orgSlug: inaccessible.org.slug,
+      projectSlug: inaccessible.project.slug,
+    }),
+  });
+
+  assert.equal(response.status, 404);
+  const session = await db.query.sessions.findFirst({
+    where: eq(schema.sessions.id, current.session.id),
+  });
+  const user = await db.query.users.findFirst({ where: eq(schema.users.id, current.user.id) });
+  assert.equal(session?.activeOrganizationId, current.org.id);
+  assert.equal(user?.activeOrgId, current.org.id);
+  assert.equal(user?.activeProjectId, current.project.id);
+});
+
+test("PUT /api/me/active-context rejects an org and project slug from different memberships", async () => {
+  const first = await seedContext();
+  const second = await seedContext("other-project");
+  await db
+    .insert(schema.orgMembers)
+    .values({ orgId: second.org.id, userId: first.user.id, role: "member" });
+
+  const app = new Hono<{ Variables: Vars }>();
+  app.use("*", (c, next) => {
+    c.set("userId", first.user.id);
+    c.set("sessionId", first.session.id);
+    c.set("orgId", null);
+    return next();
+  });
+  mountProjectRouteContext(app);
+
+  const response = await app.request("/api/me/active-context", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ orgSlug: first.org.slug, projectSlug: second.project.slug }),
+  });
+
+  assert.equal(response.status, 404);
+});

--- a/apps/api/src/project-route-context.ts
+++ b/apps/api/src/project-route-context.ts
@@ -1,0 +1,72 @@
+import { db, schema } from "@superlog/db";
+import { and, eq } from "drizzle-orm";
+import type { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+
+type Vars = { userId: string; sessionId?: string; orgId: string | null };
+
+export function mountProjectRouteContext(app: Hono<{ Variables: Vars }>) {
+  app.put("/api/me/active-context", async (c) => {
+    const sessionId = c.var.sessionId;
+    if (!sessionId) throw new HTTPException(401, { message: "authenticated session required" });
+    const body = (await c.req.json().catch(() => ({}))) as {
+      orgSlug?: unknown;
+      projectSlug?: unknown;
+    };
+    const orgSlug = typeof body.orgSlug === "string" ? body.orgSlug.trim() : "";
+    const projectSlug = typeof body.projectSlug === "string" ? body.projectSlug.trim() : "";
+    if (!orgSlug || !projectSlug) {
+      throw new HTTPException(400, { message: "orgSlug and projectSlug required" });
+    }
+
+    const selected = await db.transaction(async (tx) => {
+      const [context] = await tx
+        .select({
+          orgId: schema.orgs.id,
+          orgName: schema.orgs.name,
+          orgSlug: schema.orgs.slug,
+          projectId: schema.projects.id,
+          projectName: schema.projects.name,
+          projectSlug: schema.projects.slug,
+        })
+        .from(schema.orgMembers)
+        .innerJoin(schema.orgs, eq(schema.orgs.id, schema.orgMembers.orgId))
+        .innerJoin(schema.projects, eq(schema.projects.orgId, schema.orgs.id))
+        .where(
+          and(
+            eq(schema.orgMembers.userId, c.var.userId),
+            eq(schema.orgs.slug, orgSlug),
+            eq(schema.projects.slug, projectSlug),
+          ),
+        )
+        .limit(1);
+
+      if (!context) return null;
+
+      await tx
+        .update(schema.sessions)
+        .set({ activeOrganizationId: context.orgId })
+        .where(and(eq(schema.sessions.id, sessionId), eq(schema.sessions.userId, c.var.userId)));
+      await tx
+        .update(schema.users)
+        .set({ activeOrgId: context.orgId, activeProjectId: context.projectId })
+        .where(eq(schema.users.id, c.var.userId));
+
+      return context;
+    });
+
+    if (!selected) {
+      // A missing route and an inaccessible route deliberately look identical.
+      throw new HTTPException(404, { message: "organization or project not found" });
+    }
+
+    return c.json({
+      org: { id: selected.orgId, name: selected.orgName, slug: selected.orgSlug },
+      project: {
+        id: selected.projectId,
+        name: selected.projectName,
+        slug: selected.projectSlug,
+      },
+    });
+  });
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCustomer } from "autumn-js/react";
 import { usePostHog } from "posthog-js/react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
-import { Link, Navigate, Route, Routes, useLocation } from "react-router-dom";
+import { Link, Navigate, Route, Routes, matchPath, useLocation } from "react-router-dom";
 import { AcceptInvitation } from "./AcceptInvitation.tsx";
 import { Activate } from "./Activate.tsx";
 import { Blog } from "./Blog.tsx";
@@ -19,6 +19,8 @@ import { Overview } from "./Overview.tsx";
 import { PrFeedback } from "./PrFeedback.tsx";
 import { Pricing } from "./Pricing.tsx";
 import { PrivacyPolicy } from "./PrivacyPolicy.tsx";
+import { ProjectRouteBoundary } from "./ProjectRouteBoundary.tsx";
+import { ProjectRouteProvider, useProjectPath } from "./ProjectRouteContext.tsx";
 import { RailwayCallback } from "./RailwayCallback.tsx";
 import { ResetPassword } from "./ResetPassword.tsx";
 import { Roadmap } from "./Roadmap.tsx";
@@ -38,6 +40,11 @@ import { ThemeToggle } from "./design/ui.tsx";
 import { McpInstallPill } from "./onboarding/McpInstallPill.tsx";
 import { OnboardingGate } from "./onboarding/OnboardingGate.tsx";
 import { useDemoExploration } from "./onboarding/demoExploration.tsx";
+import {
+  appLocationFromProjectRoute,
+  appPathFromProjectRoute,
+  canonicalProjectLocation,
+} from "./project-route.ts";
 import {
   APP_FRAME_CLASS,
   PAGE_SCROLL_CONTAINER_CLASS,
@@ -202,6 +209,8 @@ function SignupRoute() {
 function AuthenticatedApp() {
   const { data, isPending } = useSession();
   const me = useMe();
+  const location = useLocation();
+  const { pathname } = location;
   useGlobalKeybinds(!!data);
   const impersonating = me.data?.user.impersonating === true;
   // Billing top bar: a Free org that has exhausted a hard-capped signal has its
@@ -221,7 +230,26 @@ function AuthenticatedApp() {
     ["spans", "logs", "metric_points"].some((f) => signalAtHardCap(check, f));
   if (isPending) return null;
   if (!data) return <Landing />;
-  return (
+  const scopedRoute = matchPath("/org/:orgSlug/project/:projectSlug/*", pathname);
+  const orgSlug = scopedRoute?.params.orgSlug;
+  const projectSlug = scopedRoute?.params.projectSlug;
+  if (!orgSlug && me.data?.org && me.data.project) {
+    return (
+      <Navigate
+        replace
+        to={canonicalProjectLocation(
+          { orgSlug: me.data.org.slug, projectSlug: me.data.project.slug },
+          { pathname, search: location.search, hash: location.hash },
+        )}
+      />
+    );
+  }
+  const appLocation = appLocationFromProjectRoute({
+    pathname,
+    search: location.search,
+    hash: location.hash,
+  });
+  const app = (
     <OnboardingGate>
       <div className={APP_FRAME_CLASS}>
         <TopRibbon
@@ -231,7 +259,7 @@ function AuthenticatedApp() {
         />
         <ProductShell toolbar={<ProductToolbar />}>
           <RouteContainer>
-            <Routes>
+            <Routes location={appLocation}>
               <Route path="/explore/*" element={<Explore />} />
               <Route path="/incidents" element={<Issues />} />
               <Route path="/incidents/:id" element={<Issues />} />
@@ -251,6 +279,18 @@ function AuthenticatedApp() {
       <CommandPalette />
       <McpInstallPill />
     </OnboardingGate>
+  );
+  const projectApp =
+    orgSlug && projectSlug ? (
+      <ProjectRouteProvider slugs={{ orgSlug, projectSlug }}>{app}</ProjectRouteProvider>
+    ) : (
+      app
+    );
+  if (!orgSlug || !projectSlug) return projectApp;
+  return (
+    <ProjectRouteBoundary me={me.data} slugs={{ orgSlug, projectSlug }}>
+      {projectApp}
+    </ProjectRouteBoundary>
   );
 }
 
@@ -340,12 +380,13 @@ function ImpersonationBar({ email }: { email: string }) {
 }
 
 function BillingLimitBar() {
+  const projectPath = useProjectPath();
   return (
     <div className="flex h-7 w-full items-center justify-center gap-2 bg-danger px-3 text-[11px] text-white">
       <span className="font-semibold">Ingest paused</span>
       <span className="opacity-90">You’ve hit your Free plan limits.</span>
       <Link
-        to="/settings?scope=org&section=billing"
+        to={projectPath("/settings?scope=org&section=billing")}
         className="font-medium underline underline-offset-2 hover:opacity-80"
       >
         Add a card to switch to pay-as-you-go →
@@ -356,8 +397,9 @@ function BillingLimitBar() {
 
 function RouteContainer({ children }: { children: ReactNode }) {
   const { pathname } = useLocation();
-  const detailWorkspace = isDetailWorkspacePath(pathname);
-  const wide = pathname.startsWith("/dashboards/");
+  const appPath = appPathFromProjectRoute(pathname);
+  const detailWorkspace = isDetailWorkspacePath(appPath);
+  const wide = appPath.startsWith("/dashboards/");
   if (detailWorkspace) {
     return <div className="flex min-h-0 flex-1 flex-col">{children}</div>;
   }

--- a/apps/web/src/CommandPalette.tsx
+++ b/apps/web/src/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useProjectPath } from "./ProjectRouteContext.tsx";
 import { type ImpersonationTarget, useImpersonationTargets, useMe } from "./api.ts";
 import { authClient } from "./auth-client.ts";
 
@@ -32,6 +33,7 @@ export function CommandPalette() {
   const listRef = useRef<HTMLDivElement | null>(null);
 
   const navigate = useNavigate();
+  const projectPath = useProjectPath();
   // Both isStaff and isImpersonating come from /api/me so they agree on the
   // current acting-as user. Reading impersonatedBy off the raw session object
   // would diverge from the staff check (which already runs against the
@@ -75,13 +77,55 @@ export function CommandPalette() {
   const items = useMemo<Item[]>(() => {
     if (mode === "root") {
       const navItems: Item[] = [
-        { id: "nav-overview", label: "Overview", group: "Navigate", haystack: "overview home", onSelect: () => navigate("/") },
-        { id: "nav-incidents", label: "Incidents", group: "Navigate", haystack: "incidents", onSelect: () => navigate("/incidents") },
-        { id: "nav-errors", label: "Errors", group: "Navigate", haystack: "errors issues", onSelect: () => navigate("/issues") },
-        { id: "nav-alerts", label: "Alerts", group: "Navigate", haystack: "alerts", onSelect: () => navigate("/alerts") },
-        { id: "nav-explore", label: "Explore", group: "Navigate", haystack: "explore traces logs metrics", onSelect: () => navigate("/explore") },
-        { id: "nav-dashboards", label: "Dashboards", group: "Navigate", haystack: "dashboards", onSelect: () => navigate("/dashboards") },
-        { id: "nav-settings", label: "Settings", group: "Navigate", haystack: "settings preferences", onSelect: () => navigate("/settings") },
+        {
+          id: "nav-overview",
+          label: "Overview",
+          group: "Navigate",
+          haystack: "overview home",
+          onSelect: () => navigate(projectPath("/")),
+        },
+        {
+          id: "nav-incidents",
+          label: "Incidents",
+          group: "Navigate",
+          haystack: "incidents",
+          onSelect: () => navigate(projectPath("/incidents")),
+        },
+        {
+          id: "nav-errors",
+          label: "Errors",
+          group: "Navigate",
+          haystack: "errors issues",
+          onSelect: () => navigate(projectPath("/issues")),
+        },
+        {
+          id: "nav-alerts",
+          label: "Alerts",
+          group: "Navigate",
+          haystack: "alerts",
+          onSelect: () => navigate(projectPath("/alerts")),
+        },
+        {
+          id: "nav-explore",
+          label: "Explore",
+          group: "Navigate",
+          haystack: "explore traces logs metrics",
+          onSelect: () => navigate(projectPath("/explore")),
+        },
+        {
+          id: "nav-dashboards",
+          label: "Dashboards",
+          group: "Navigate",
+          haystack: "dashboards",
+          onSelect: () => navigate(projectPath("/dashboards")),
+        },
+        {
+          id: "nav-settings",
+          label: "Settings",
+          group: "Navigate",
+          haystack: "settings preferences",
+          onSelect: () => navigate(projectPath("/settings")),
+        },
       ];
       const adminItems: Item[] = isStaff
         ? [
@@ -139,7 +183,8 @@ export function CommandPalette() {
         id: `imp-${info.userId}`,
         label,
         sublabel: orgNames.join(", "),
-        haystack: `${info.email} ${info.name ?? ""} ${orgNames.join(" ")} ${orgSlugs.join(" ")}`.toLowerCase(),
+        haystack:
+          `${info.email} ${info.name ?? ""} ${orgNames.join(" ")} ${orgSlugs.join(" ")}`.toLowerCase(),
         onSelect: async () => {
           // Same pattern as stopImpersonating: error lands in result.error,
           // not as a throw. Don't reload if the impersonation didn't take.
@@ -157,7 +202,7 @@ export function CommandPalette() {
     }
     out.sort((a, b) => a.label.localeCompare(b.label));
     return out;
-  }, [mode, navigate, isStaff, isImpersonating, targets.data, me.data?.user.id]);
+  }, [mode, navigate, projectPath, isStaff, isImpersonating, targets.data, me.data?.user.id]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/apps/web/src/Explore.tsx
+++ b/apps/web/src/Explore.tsx
@@ -13,6 +13,7 @@ import {
   YAxis,
 } from "recharts";
 import { LogDrawer } from "./LogDetail.tsx";
+import { useProjectPath } from "./ProjectRouteContext.tsx";
 import { TraceDrawer } from "./TraceDetail.tsx";
 import { ExploreFacets, SEVERITY_OPTIONS, STATUS_OPTIONS } from "./ExploreFacets.tsx";
 import { facetDisplayName } from "./FacetValues.tsx";
@@ -103,15 +104,16 @@ function sourceFromPath(pathname: string): Source | null {
 
 function ExploreInner({ projectId }: { projectId: string }) {
   const navigate = useNavigate();
+  const projectPath = useProjectPath();
   const { pathname } = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const sourceFromUrl = sourceFromPath(pathname);
 
   useEffect(() => {
     if (sourceFromUrl === null) {
-      navigate("/explore/logs", { replace: true });
+      navigate(projectPath("/explore/logs"), { replace: true });
     }
-  }, [sourceFromUrl, navigate]);
+  }, [sourceFromUrl, navigate, projectPath]);
 
   const source: Source = sourceFromUrl ?? "logs";
 
@@ -455,7 +457,7 @@ function ExploreInner({ projectId }: { projectId: string }) {
         }}
         onOpenIssue={(id) => {
           closeLog();
-          navigate(`/issues/${id}`);
+          navigate(projectPath(`/issues/${id}`));
         }}
         onAddFilter={addFilter}
       />
@@ -472,6 +474,7 @@ function ExploreInner({ projectId }: { projectId: string }) {
 // ResourcesPanel — inventory of AWS resources discovered for the project.
 
 function ResourcesPanel({ projectId }: { projectId: string }) {
+  const projectPath = useProjectPath();
   const resources = useCloudResources(projectId);
   const connections = useCloudConnections(projectId);
   const sync = useSyncCloudConnection(projectId);
@@ -512,7 +515,7 @@ function ResourcesPanel({ projectId }: { projectId: string }) {
             No AWS account connected yet. Connect one to inventory your resources.
           </p>
           <NavLink
-            to="/settings?scope=project&section=integrations"
+            to={projectPath("/settings?scope=project&section=integrations")}
             className="inline-block rounded-sm bg-accent px-3 py-1.5 text-[13px] font-medium text-bg"
           >
             Connect AWS
@@ -621,12 +624,13 @@ const TABS: { source: Source; label: string }[] = [
 ];
 
 export function ExploreTabs() {
+  const projectPath = useProjectPath();
   return (
     <nav className="flex items-center gap-1">
       {TABS.map((t) => (
         <NavLink
           key={t.source}
-          to={`/explore/${t.source}`}
+          to={projectPath(`/explore/${t.source}`)}
           className={({ isActive }) =>
             isActive
               ? "rounded-md bg-surface-3 px-3 py-1.5 text-[13px] font-medium tracking-tight text-fg"

--- a/apps/web/src/Explore.tsx
+++ b/apps/web/src/Explore.tsx
@@ -55,6 +55,7 @@ import {
 import { ScrollArea } from "./design/scroll-area.tsx";
 import { Btn, Chip, Input, PageHeader, ShortcutKey, Tile } from "./design/ui.tsx";
 import { addAttrFilter } from "./exploreAttrFilter.ts";
+import { sourceFromExplorePath, type ExploreSource } from "./explore-route.ts";
 import { tracer } from "./instrumentation.ts";
 import {
   ExploreSignalDetailSkeleton,
@@ -92,22 +93,16 @@ export function Explore() {
   return <ExploreInner projectId={me.data.project.id} />;
 }
 
-export type Source = "logs" | "traces" | "metrics" | "resources";
+export type Source = ExploreSource;
 type TelemetrySource = TelemetrySkeletonSource;
 export type TracesView = "spans" | "traces";
-
-function sourceFromPath(pathname: string): Source | null {
-  const seg = pathname.replace(/^\/explore\/?/, "").split("/")[0];
-  if (seg === "logs" || seg === "traces" || seg === "metrics" || seg === "resources") return seg;
-  return null;
-}
 
 function ExploreInner({ projectId }: { projectId: string }) {
   const navigate = useNavigate();
   const projectPath = useProjectPath();
   const { pathname } = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
-  const sourceFromUrl = sourceFromPath(pathname);
+  const sourceFromUrl = sourceFromExplorePath(pathname);
 
   useEffect(() => {
     if (sourceFromUrl === null) {

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -82,6 +82,12 @@ import { IncidentDetailScrollArea } from "./incidents/IncidentDetailScrollArea.t
 import { TriggeredByAlertMetaRow } from "./incidents/TriggeredByAlertMetaRow.tsx";
 import { getIssueIncidentLinkState } from "./issue-incident-link-state.ts";
 import { IssueDetailView } from "./issues/IssueDetailView.tsx";
+import { useProjectPath } from "./ProjectRouteContext.tsx";
+import {
+  appPathFromProjectRoute,
+  buildProjectPath,
+  type ProjectRouteSlugs,
+} from "./project-route.ts";
 import {
   IncidentDetailSkeleton,
   IncidentListSkeleton,
@@ -95,26 +101,26 @@ type IssueFilter = "active" | "silenced" | "all";
 type IncidentStatus = "open" | "resolved" | "autoresolved_noise" | "all";
 type Tab = "issues" | "incidents";
 
-function tabBasePath(tab: Tab) {
-  return tab === "issues" ? "/issues" : "/incidents";
+function tabBasePath(tab: Tab, slugs: ProjectRouteSlugs) {
+  return buildProjectPath(slugs, tab === "issues" ? "/issues" : "/incidents");
 }
 
 function useTab(): Tab {
   const location = useLocation();
-  return location.pathname.startsWith("/issues") ? "issues" : "incidents";
+  return appPathFromProjectRoute(location.pathname).startsWith("/issues") ? "issues" : "incidents";
 }
 
-function useNav() {
+function useNav(slugs: ProjectRouteSlugs) {
   const navigate = useNavigate();
   const params = useParams<{ id?: string }>();
   const tab = useTab();
   const id = params.id ?? null;
 
   function openItem(itemId: string, targetTab: Tab = tab) {
-    navigate(`${tabBasePath(targetTab)}/${itemId}`);
+    navigate(`${tabBasePath(targetTab, slugs)}/${itemId}`);
   }
   function closeItem() {
-    navigate(tabBasePath(tab), { replace: true });
+    navigate(tabBasePath(tab, slugs), { replace: true });
   }
   return { tab, id, openItem, closeItem };
 }
@@ -155,17 +161,23 @@ export function Issues() {
   if (me.error || !me.data || !me.data.project) {
     return <div className="text-[13px] text-danger">Error: {String(me.error ?? "no session")}</div>;
   }
-  return <IssuesShell projectId={me.data.project.id} />;
+  if (!me.data.org) return null;
+  return (
+    <IssuesShell
+      projectId={me.data.project.id}
+      slugs={{ orgSlug: me.data.org.slug, projectSlug: me.data.project.slug }}
+    />
+  );
 }
 
-function IssuesShell({ projectId }: { projectId: string }) {
+function IssuesShell({ projectId, slugs }: { projectId: string; slugs: ProjectRouteSlugs }) {
   const tab = useTab();
   const params = useParams<{ id?: string }>();
   const navigate = useNavigate();
   const labels: Record<Tab, string> = { incidents: "Incidents", issues: "Errors" };
 
   if (tab === "incidents" && params.id) {
-    return <IncidentsTab projectId={projectId} />;
+    return <IncidentsTab projectId={projectId} slugs={slugs} />;
   }
 
   if (tab === "issues" && params.id) {
@@ -173,8 +185,10 @@ function IssuesShell({ projectId }: { projectId: string }) {
       <IssueDetailPage
         projectId={projectId}
         issueId={params.id}
-        onClose={() => navigate("/issues")}
-        onViewIncident={(incidentId) => navigate(`/incidents/${incidentId}`)}
+        onClose={() => navigate(buildProjectPath(slugs, "/issues"))}
+        onViewIncident={(incidentId) =>
+          navigate(buildProjectPath(slugs, `/incidents/${incidentId}`))
+        }
       />
     );
   }
@@ -191,9 +205,9 @@ function IssuesShell({ projectId }: { projectId: string }) {
       />
       <div className="mt-6">
         {tab === "issues" ? (
-          <IssuesTab projectId={projectId} />
+          <IssuesTab projectId={projectId} slugs={slugs} />
         ) : (
-          <IncidentsTab projectId={projectId} />
+          <IncidentsTab projectId={projectId} slugs={slugs} />
         )}
       </div>
     </div>
@@ -209,10 +223,10 @@ type EventTarget =
   | { kind: "log"; log: LogRow }
   | null;
 
-function IssuesTab({ projectId }: { projectId: string }) {
+function IssuesTab({ projectId, slugs }: { projectId: string; slugs: ProjectRouteSlugs }) {
   const [filter, setFilter] = useState<IssueFilter>("active");
   const [eventTarget, setEventTarget] = useState<EventTarget>(null);
-  const { id: selectedId, openItem, closeItem } = useNav();
+  const { id: selectedId, openItem, closeItem } = useNav(slugs);
   const issues = useIssues(projectId, filter, { groupingFilter: "ungrouped" });
   const silence = useSilenceIssue(projectId);
   const unsilence = useUnsilenceIssue(projectId);
@@ -780,10 +794,10 @@ function groupIncidents(rows: IncidentListItem[]): IncidentGroup[] {
   return groups;
 }
 
-function IncidentsTab({ projectId }: { projectId: string }) {
+function IncidentsTab({ projectId, slugs }: { projectId: string; slugs: ProjectRouteSlugs }) {
   const [status, setStatus] = useState<IncidentStatus>("open");
   const [newInvestigationOpen, setNewInvestigationOpen] = useState(false);
-  const { id: selectedId, openItem, closeItem } = useNav();
+  const { id: selectedId, openItem, closeItem } = useNav(slugs);
   const incidents = useIncidents(projectId, status);
   const resolveAllRecovery = useResolveAllRecoveryDetected(projectId);
 
@@ -1485,6 +1499,7 @@ function PeakMarker({ value }: { value: number }) {
 }
 
 function TriggeredByAlertEpisodes({ episodes }: { episodes: IncidentAlertEpisode[] }) {
+  const projectPath = useProjectPath();
   return (
     <ul className="divide-y divide-border border border-border">
       {episodes.map((ep) => {
@@ -1492,7 +1507,7 @@ function TriggeredByAlertEpisodes({ episodes }: { episodes: IncidentAlertEpisode
         return (
           <li key={ep.id} className="px-3 py-2">
             <Link
-              to={`/alerts/${ep.alertId}`}
+              to={projectPath(`/alerts/${ep.alertId}`)}
               className="block w-full min-w-0 overflow-hidden text-left transition-colors hover:text-muted"
             >
               <div className="mb-0.5 flex items-center gap-2">
@@ -2858,9 +2873,7 @@ function IssueCard({
 }
 
 function formatOccurrenceDate(day: string) {
-  const [year = Number.NaN, month = Number.NaN, date = Number.NaN] = day
-    .split("-")
-    .map(Number);
+  const [year = Number.NaN, month = Number.NaN, date = Number.NaN] = day.split("-").map(Number);
   const parsed =
     Number.isFinite(year) && Number.isFinite(month) && Number.isFinite(date)
       ? new Date(year, month - 1, date)

--- a/apps/web/src/OrgProjectSwitcher.tsx
+++ b/apps/web/src/OrgProjectSwitcher.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   type Me,
   useMe,
@@ -10,6 +10,7 @@ import {
 } from "./api.ts";
 import { authClient, useActiveOrganization, useListOrganizations } from "./auth-client.ts";
 import { ScrollArea } from "./design/scroll-area.tsx";
+import { appPathFromProjectRoute, canonicalProjectLocation } from "./project-route.ts";
 
 const ON_MAC = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform || "");
 
@@ -89,6 +90,7 @@ function SwitcherDropdown({ me, onClose }: { me: MeWithOrg; onClose: () => void 
   const setFavoriteProject = useSetFavoriteProject();
   const qc = useQueryClient();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const [step, setStep] = useState<Step>("orgs");
   const [pendingOrgSwitch, setPendingOrgSwitch] = useState<{
@@ -108,6 +110,24 @@ function SwitcherDropdown({ me, onClose }: { me: MeWithOrg; onClose: () => void 
   }, [query, step]);
 
   const activeOrgId = activeOrgQuery.data?.id ?? me.org.id;
+  const activeOrgSlug = orgsQuery.data?.find((org) => org.id === activeOrgId)?.slug ?? me.org.slug;
+
+  const navigateToProject = useCallback(
+    (projectSlug: string) => {
+      navigate(
+        canonicalProjectLocation(
+          { orgSlug: activeOrgSlug, projectSlug },
+          {
+            pathname: appPathFromProjectRoute(location.pathname),
+            search: location.search,
+            hash: location.hash,
+          },
+        ),
+        { replace: true },
+      );
+    },
+    [activeOrgSlug, location.hash, location.pathname, location.search, navigate],
+  );
 
   useEffect(() => {
     if (!pendingOrgSwitch) return;
@@ -116,12 +136,21 @@ function SwitcherDropdown({ me, onClose }: { me: MeWithOrg; onClose: () => void 
     const list = projects.data.projects;
     setPendingOrgSwitch(null);
     if (list.length <= 1) {
+      const project = list[0];
+      if (project) navigateToProject(project.slug);
       onClose();
     } else {
       setStep("projects");
       setQuery("");
     }
-  }, [pendingOrgSwitch, activeOrgId, projects.isFetching, projects.data, onClose]);
+  }, [
+    pendingOrgSwitch,
+    activeOrgId,
+    projects.isFetching,
+    projects.data,
+    navigateToProject,
+    onClose,
+  ]);
 
   const switchOrgAndDrill = async (orgId: string) => {
     setPendingOrgSwitch({ targetOrgId: orgId });
@@ -146,11 +175,14 @@ function SwitcherDropdown({ me, onClose }: { me: MeWithOrg; onClose: () => void 
   };
 
   const pickProject = async (projectId: string) => {
+    const project = projects.data?.projects.find((candidate) => candidate.id === projectId);
     if (projectId === me.project.id) {
+      if (project) navigateToProject(project.slug);
       onClose();
       return;
     }
     await setActiveProject.mutateAsync(projectId);
+    if (project) navigateToProject(project.slug);
     onClose();
   };
 

--- a/apps/web/src/Overview.tsx
+++ b/apps/web/src/Overview.tsx
@@ -3,6 +3,7 @@ import { IncidentRow } from "./Issues.tsx";
 import { useCloudConnections, useIncidents, useMe } from "./api.ts";
 import { PageHeader } from "./design/ui.tsx";
 import { SetupTodos } from "./onboarding/SetupTodos.tsx";
+import { type ProjectRouteSlugs, buildProjectPath } from "./project-route.ts";
 import { ServiceMap } from "./service-map/ServiceMap.tsx";
 
 const ACTIVE_INCIDENT_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -17,7 +18,7 @@ export function Overview() {
   if (me.error) {
     return <div className="text-[12px] text-danger">Error: {String(me.error)}</div>;
   }
-  if (!me.data || !me.data.project) return null;
+  if (!me.data || !me.data.org || !me.data.project) return null;
   const projectId = me.data.project.id;
 
   return (
@@ -27,7 +28,10 @@ export function Overview() {
         description="Project health, recent critical activity, and the connections that shape your system."
       />
       <SetupTodos projectId={projectId} />
-      <ActiveIncidentsSection projectId={projectId} />
+      <ActiveIncidentsSection
+        projectId={projectId}
+        slugs={{ orgSlug: me.data.org.slug, projectSlug: me.data.project.slug }}
+      />
       <ServiceMapSection projectId={projectId} />
     </div>
   );
@@ -41,7 +45,13 @@ function ServiceMapSection({ projectId }: { projectId: string }) {
   return <ServiceMap projectId={projectId} />;
 }
 
-function ActiveIncidentsSection({ projectId }: { projectId: string }) {
+function ActiveIncidentsSection({
+  projectId,
+  slugs,
+}: {
+  projectId: string;
+  slugs: ProjectRouteSlugs;
+}) {
   const navigate = useNavigate();
   const incidents = useIncidents(projectId, "open");
 
@@ -81,7 +91,7 @@ function ActiveIncidentsSection({ projectId }: { projectId: string }) {
               key={row.incident.id}
               row={row}
               selected={false}
-              onClick={() => navigate(`/incidents/${row.incident.id}`)}
+              onClick={() => navigate(buildProjectPath(slugs, `/incidents/${row.incident.id}`))}
             />
           ))}
         </div>

--- a/apps/web/src/ProjectRouteBoundary.tsx
+++ b/apps/web/src/ProjectRouteBoundary.tsx
@@ -1,6 +1,31 @@
-import { type ReactNode, useEffect, useRef } from "react";
+import { type ReactNode, useCallback, useEffect, useRef } from "react";
 import { type Me, useSetActiveContext } from "./api.ts";
+import { Btn } from "./design/ui.tsx";
+import { projectRouteFailureKind } from "./project-route-failure.ts";
 import type { ProjectRouteSlugs } from "./project-route.ts";
+
+export function ProjectRouteFailure({ error, onRetry }: { error: unknown; onRetry: () => void }) {
+  const unavailable = projectRouteFailureKind(error) === "unavailable";
+  return (
+    <main className="grid min-h-screen place-items-center bg-bg px-6 text-fg">
+      <div className="max-w-md text-center">
+        <h1 className="text-lg font-semibold">
+          {unavailable ? "Project unavailable" : "Couldn’t open project"}
+        </h1>
+        <p className="mt-2 text-[13px] text-muted">
+          {unavailable
+            ? "This project does not exist, or you do not have access to it."
+            : "Something went wrong while switching projects. Please try again."}
+        </p>
+        {!unavailable && (
+          <Btn className="mt-4" onClick={onRetry}>
+            Retry
+          </Btn>
+        )}
+      </div>
+    </main>
+  );
+}
 
 export function ProjectRouteBoundary({
   children,
@@ -15,30 +40,26 @@ export function ProjectRouteBoundary({
   const attempted = useRef<string | null>(null);
   const selected = me?.org?.slug === slugs.orgSlug && me.project?.slug === slugs.projectSlug;
   const target = `${slugs.orgSlug}/${slugs.projectSlug}`;
+  const mutateActiveContext = setActiveContext.mutate;
 
-  useEffect(() => {
-    if (!me || selected || attempted.current === target) return;
+  const openProject = useCallback(() => {
     attempted.current = target;
-    setActiveContext.mutate(slugs, {
+    mutateActiveContext({ orgSlug: slugs.orgSlug, projectSlug: slugs.projectSlug }, {
       // Reloading is intentional: org-scoped queries and Better Auth's session
       // store may both contain the previous tenant. The scoped URL survives the
       // reload, while every query starts cleanly in the selected context.
       onSuccess: () => window.location.reload(),
     });
-  }, [me, selected, setActiveContext, slugs, target]);
+  }, [mutateActiveContext, slugs.orgSlug, slugs.projectSlug, target]);
+
+  useEffect(() => {
+    if (!me || selected || attempted.current === target) return;
+    openProject();
+  }, [me, openProject, selected, target]);
 
   if (selected) return children;
   if (setActiveContext.error) {
-    return (
-      <main className="grid min-h-screen place-items-center bg-bg px-6 text-fg">
-        <div className="max-w-md text-center">
-          <h1 className="text-lg font-semibold">Project unavailable</h1>
-          <p className="mt-2 text-[13px] text-muted">
-            This project does not exist, or you do not have access to it.
-          </p>
-        </div>
-      </main>
-    );
+    return <ProjectRouteFailure error={setActiveContext.error} onRetry={openProject} />;
   }
   return (
     <main className="grid min-h-screen place-items-center bg-bg px-6 text-[13px] text-muted">

--- a/apps/web/src/ProjectRouteBoundary.tsx
+++ b/apps/web/src/ProjectRouteBoundary.tsx
@@ -1,0 +1,48 @@
+import { type ReactNode, useEffect, useRef } from "react";
+import { type Me, useSetActiveContext } from "./api.ts";
+import type { ProjectRouteSlugs } from "./project-route.ts";
+
+export function ProjectRouteBoundary({
+  children,
+  me,
+  slugs,
+}: {
+  children: ReactNode;
+  me: Me | undefined;
+  slugs: ProjectRouteSlugs;
+}) {
+  const setActiveContext = useSetActiveContext();
+  const attempted = useRef<string | null>(null);
+  const selected = me?.org?.slug === slugs.orgSlug && me.project?.slug === slugs.projectSlug;
+  const target = `${slugs.orgSlug}/${slugs.projectSlug}`;
+
+  useEffect(() => {
+    if (!me || selected || attempted.current === target) return;
+    attempted.current = target;
+    setActiveContext.mutate(slugs, {
+      // Reloading is intentional: org-scoped queries and Better Auth's session
+      // store may both contain the previous tenant. The scoped URL survives the
+      // reload, while every query starts cleanly in the selected context.
+      onSuccess: () => window.location.reload(),
+    });
+  }, [me, selected, setActiveContext, slugs, target]);
+
+  if (selected) return children;
+  if (setActiveContext.error) {
+    return (
+      <main className="grid min-h-screen place-items-center bg-bg px-6 text-fg">
+        <div className="max-w-md text-center">
+          <h1 className="text-lg font-semibold">Project unavailable</h1>
+          <p className="mt-2 text-[13px] text-muted">
+            This project does not exist, or you do not have access to it.
+          </p>
+        </div>
+      </main>
+    );
+  }
+  return (
+    <main className="grid min-h-screen place-items-center bg-bg px-6 text-[13px] text-muted">
+      Opening project…
+    </main>
+  );
+}

--- a/apps/web/src/ProjectRouteContext.tsx
+++ b/apps/web/src/ProjectRouteContext.tsx
@@ -1,0 +1,22 @@
+import { type ReactNode, createContext, useCallback, useContext } from "react";
+import { type ProjectRouteSlugs, buildProjectPath } from "./project-route.ts";
+
+const ProjectRouteContext = createContext<ProjectRouteSlugs | null>(null);
+
+export function ProjectRouteProvider({
+  children,
+  slugs,
+}: {
+  children: ReactNode;
+  slugs: ProjectRouteSlugs;
+}) {
+  return <ProjectRouteContext.Provider value={slugs}>{children}</ProjectRouteContext.Provider>;
+}
+
+export function useProjectPath() {
+  const slugs = useContext(ProjectRouteContext);
+  return useCallback(
+    (appPath: string) => (slugs ? buildProjectPath(slugs, appPath) : appPath),
+    [slugs],
+  );
+}

--- a/apps/web/src/alerts/AlertEdit.tsx
+++ b/apps/web/src/alerts/AlertEdit.tsx
@@ -2,9 +2,10 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { AddFilter, MetricNamePicker } from "../Explore.tsx";
 import { type ExploreRange, type ResourceAttr, useExploreAttributeKeys, useMe } from "../api.ts";
+import { CountChart } from "../dashboards/widgets/CountChart.tsx";
 import { Dropdown } from "../design/Dropdown.tsx";
 import { Btn, Chip, Input, PillToggle, Tile } from "../design/ui.tsx";
-import { CountChart } from "../dashboards/widgets/CountChart.tsx";
+import { type ProjectRouteSlugs, buildProjectPath } from "../project-route.ts";
 import { SettingsCard, SettingsCardFooter, SettingsRow } from "../settings/rows.tsx";
 import {
   useAlert,
@@ -41,17 +42,31 @@ export function AlertEdit() {
       <div className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted">loading…</div>
     );
   }
-  if (me.error || !me.data || !me.data.project) {
+  if (me.error || !me.data || !me.data.org || !me.data.project) {
     return (
       <div className="font-mono text-[11px] text-danger">
         error: {String(me.error ?? "no session")}
       </div>
     );
   }
-  return <AlertEditInner projectId={me.data.project.id} alertId={id} />;
+  return (
+    <AlertEditInner
+      projectId={me.data.project.id}
+      alertId={id}
+      slugs={{ orgSlug: me.data.org.slug, projectSlug: me.data.project.slug }}
+    />
+  );
 }
 
-function AlertEditInner({ projectId, alertId }: { projectId: string; alertId?: string }) {
+function AlertEditInner({
+  projectId,
+  alertId,
+  slugs,
+}: {
+  projectId: string;
+  alertId?: string;
+  slugs: ProjectRouteSlugs;
+}) {
   const navigate = useNavigate();
   const editing = !!alertId;
   const existing = useAlert(projectId, alertId);
@@ -149,10 +164,10 @@ function AlertEditInner({ projectId, alertId }: { projectId: string; alertId?: s
       await update.mutateAsync(body);
     } else {
       const created = await create.mutateAsync(body);
-      navigate(`/alerts/${created.id}`, { replace: true });
+      navigate(buildProjectPath(slugs, `/alerts/${created.id}`), { replace: true });
       return;
     }
-    navigate("/alerts");
+    navigate(buildProjectPath(slugs, "/alerts"));
   };
 
   // Keep the preview in sync with the rule as you edit it. Debounced so typing
@@ -424,7 +439,11 @@ function AlertEditInner({ projectId, alertId }: { projectId: string; alertId?: s
               Fill in the required fields to continue
             </span>
           )}
-          <Btn variant="ghost" size="sm" onClick={() => navigate("/alerts")}>
+          <Btn
+            variant="ghost"
+            size="sm"
+            onClick={() => navigate(buildProjectPath(slugs, "/alerts"))}
+          >
             Cancel
           </Btn>
           <Btn
@@ -438,7 +457,7 @@ function AlertEditInner({ projectId, alertId }: { projectId: string; alertId?: s
         </SettingsCardFooter>
       </SettingsCard>
 
-      {editing && alertId && <EpisodesTile projectId={projectId} alertId={alertId} />}
+      {editing && alertId && <EpisodesTile projectId={projectId} alertId={alertId} slugs={slugs} />}
     </div>
   );
 }
@@ -507,7 +526,15 @@ function formatNum(n: number): string {
 // An alert's contiguous activations. Each row links to the incident it raised
 // so you can jump from "the alert fired" to "what we did about it". Styled to
 // match the settings cards (Tile header + divide-y rows, no mono/caps).
-function EpisodesTile({ projectId, alertId }: { projectId: string; alertId: string }) {
+function EpisodesTile({
+  projectId,
+  alertId,
+  slugs,
+}: {
+  projectId: string;
+  alertId: string;
+  slugs: ProjectRouteSlugs;
+}) {
   const episodes = useAlertEpisodes(projectId, alertId);
   const rows = episodes.data ?? [];
   return (
@@ -527,7 +554,7 @@ function EpisodesTile({ projectId, alertId }: { projectId: string; alertId: stri
       ) : (
         <ul className="divide-y divide-border">
           {rows.map((ep) => (
-            <EpisodeRow key={ep.id} ep={ep} />
+            <EpisodeRow key={ep.id} ep={ep} slugs={slugs} />
           ))}
         </ul>
       )}
@@ -535,7 +562,7 @@ function EpisodesTile({ projectId, alertId }: { projectId: string; alertId: stri
   );
 }
 
-function EpisodeRow({ ep }: { ep: AlertEpisode }) {
+function EpisodeRow({ ep, slugs }: { ep: AlertEpisode; slugs: ProjectRouteSlugs }) {
   const firing = ep.state === "firing";
   const body = (
     <>
@@ -578,7 +605,7 @@ function EpisodeRow({ ep }: { ep: AlertEpisode }) {
     return (
       <li>
         <Link
-          to={`/incidents/${ep.incident.id}`}
+          to={buildProjectPath(slugs, `/incidents/${ep.incident.id}`)}
           className="flex items-center justify-between gap-3 px-5 py-3 transition-colors hover:bg-surface-2"
         >
           {body}

--- a/apps/web/src/alerts/AlertsList.tsx
+++ b/apps/web/src/alerts/AlertsList.tsx
@@ -1,4 +1,5 @@
 import { Link, useNavigate } from "react-router-dom";
+import { useProjectPath } from "../ProjectRouteContext.tsx";
 import { useMe } from "../api.ts";
 import { RowMenu } from "../design/RowMenu.tsx";
 import {
@@ -33,13 +34,14 @@ function AlertsListInner({ projectId }: { projectId: string }) {
   const list = useAlerts(projectId);
   const remove = useDeleteAlert(projectId);
   const navigate = useNavigate();
+  const projectPath = useProjectPath();
 
   return (
     <div className="flex flex-col gap-6">
       <PageHeader
         title="Alerts"
         description="Turn important telemetry thresholds into focused, actionable notifications."
-        actions={<Btn onClick={() => navigate("/alerts/new")}>New alert</Btn>}
+        actions={<Btn onClick={() => navigate(projectPath("/alerts/new"))}>New alert</Btn>}
       />
 
       <DataList label="Alert rules">
@@ -58,7 +60,11 @@ function AlertsListInner({ projectId }: { projectId: string }) {
           <div className="px-5 py-12 text-center">
             <div className="text-[12px] text-subtle">No alerts yet</div>
             <div className="mt-3">
-              <Btn variant="secondary" size="sm" onClick={() => navigate("/alerts/new")}>
+              <Btn
+                variant="secondary"
+                size="sm"
+                onClick={() => navigate(projectPath("/alerts/new"))}
+              >
                 Create your first alert
               </Btn>
             </div>
@@ -71,7 +77,7 @@ function AlertsListInner({ projectId }: { projectId: string }) {
           >
             <DataListCell className="min-w-0">
               <Link
-                to={`/alerts/${a.id}`}
+                to={projectPath(`/alerts/${a.id}`)}
                 className="block truncate text-[13px] font-medium text-fg hover:underline"
               >
                 {a.name}

--- a/apps/web/src/api-error.ts
+++ b/apps/web/src/api-error.ts
@@ -1,0 +1,9 @@
+export class ApiError extends Error {
+  constructor(
+    readonly status: number,
+    body: string,
+  ) {
+    super(`${status}: ${body}`);
+    this.name = "ApiError";
+  }
+}

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ApiError } from "./api-error.ts";
 import { incidentPollIntervalMs } from "./incidents/agent-run-polling.ts";
 
 const API_URL = import.meta.env?.VITE_API_URL ?? "http://localhost:4100";
@@ -91,7 +92,7 @@ function useFetcher() {
     });
     if (!res.ok) {
       const body = await res.text();
-      throw new Error(`${res.status}: ${body}`);
+      throw new ApiError(res.status, body);
     }
     return res.json() as Promise<T>;
   };

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1520,6 +1520,20 @@ export function useSetActiveProject() {
   });
 }
 
+export function useSetActiveContext() {
+  const fetcher = useFetcher();
+  return useMutation({
+    mutationFn: (input: { orgSlug: string; projectSlug: string }) =>
+      fetcher<{
+        org: { id: string; name: string; slug: string };
+        project: { id: string; name: string; slug: string };
+      }>("/api/me/active-context", {
+        method: "PUT",
+        body: JSON.stringify(input),
+      }),
+  });
+}
+
 // Pin a project as the favorite (opens by default on a fresh session), or pass
 // null to clear the favorite. The server pins the active org alongside it.
 export function useSetFavoriteProject() {

--- a/apps/web/src/dashboards/DashboardView.tsx
+++ b/apps/web/src/dashboards/DashboardView.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } fro
 import GridLayout, { type Layout, type LayoutItem, useContainerWidth } from "react-grid-layout";
 import { verticalCompactor } from "react-grid-layout";
 import { Link, useParams } from "react-router-dom";
+import { useProjectPath } from "../ProjectRouteContext.tsx";
 import { type ExploreRange, useMe } from "../api.ts";
 import {
   RANGE_PRESETS,
@@ -81,6 +82,7 @@ function DashboardViewInner({
   projectId: string;
   dashboardId: string;
 }) {
+  const projectPath = useProjectPath();
   const dashboard = useDashboard(projectId, dashboardId);
   const [selection, setSelection] = useState<RangeSelection>(
     RANGE_PRESETS[1] ?? RANGE_PRESETS[0] ?? DEFAULT_RANGE_SELECTION,
@@ -137,7 +139,7 @@ function DashboardViewInner({
       <section className="flex items-end justify-between gap-4">
         <div className="min-w-0 flex-1">
           <Link
-            to="/dashboards"
+            to={projectPath("/dashboards")}
             className="inline-flex items-center gap-1.5 text-[13px] text-muted hover:text-fg"
           >
             <span aria-hidden>←</span>

--- a/apps/web/src/dashboards/DashboardsList.tsx
+++ b/apps/web/src/dashboards/DashboardsList.tsx
@@ -1,4 +1,5 @@
 import { Link, useNavigate } from "react-router-dom";
+import { useProjectPath } from "../ProjectRouteContext.tsx";
 import { useMe } from "../api.ts";
 import { RowMenu } from "../design/RowMenu.tsx";
 import {
@@ -39,10 +40,11 @@ function DashboardsListInner({ projectId }: { projectId: string }) {
   const create = useCreateDashboard(projectId);
   const remove = useDeleteDashboard(projectId);
   const navigate = useNavigate();
+  const projectPath = useProjectPath();
 
   const handleCreate = async () => {
     const dashboard = await create.mutateAsync(randomName());
-    navigate(`/dashboards/${dashboard.id}`);
+    navigate(projectPath(`/dashboards/${dashboard.id}`));
   };
 
   return (
@@ -83,7 +85,7 @@ function DashboardsListInner({ projectId }: { projectId: string }) {
           >
             <DataListCell className="min-w-0">
               <Link
-                to={`/dashboards/${d.id}`}
+                to={projectPath(`/dashboards/${d.id}`)}
                 className="block truncate text-[13px] font-medium text-fg hover:underline"
               >
                 {d.name}

--- a/apps/web/src/design/ProductShell.test.tsx
+++ b/apps/web/src/design/ProductShell.test.tsx
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
+import { ProjectRouteProvider } from "../ProjectRouteContext.tsx";
 import { ProductShell } from "./ProductShell.tsx";
 import { readSidebarCollapsed, writeSidebarCollapsed } from "./sidebarCollapsed.ts";
 
@@ -40,6 +41,23 @@ test("the shell renders a collapse toggle and expanded nav labels by default", (
   assert.match(html, /aria-label="Collapse sidebar"/);
   assert.match(html, /aria-pressed="false"/);
   assert.match(html, />Overview<\/span>/);
+});
+
+test("primary navigation emits canonical project URLs", () => {
+  const html = renderToStaticMarkup(
+    <MemoryRouter initialEntries={["/org/superlog/project/demo-project/explore/logs"]}>
+      <ProjectRouteProvider slugs={{ orgSlug: "superlog", projectSlug: "demo-project" }}>
+        <ProductShell>
+          <main>Explore page</main>
+        </ProductShell>
+      </ProjectRouteProvider>
+    </MemoryRouter>,
+  );
+
+  assert.match(html, /href="\/org\/superlog\/project\/demo-project"/);
+  for (const appPath of ["incidents", "issues", "alerts", "explore", "dashboards", "settings"]) {
+    assert.match(html, new RegExp(`href="/org/superlog/project/demo-project/${appPath}"`));
+  }
 });
 
 test("sidebar collapse state round-trips through localStorage", () => {
@@ -95,8 +113,8 @@ test("errors and incidents are separate primary navigation destinations", () => 
 test("the command palette mirrors the incidents and errors navigation", async () => {
   const source = await readFile(new URL("../CommandPalette.tsx", import.meta.url), "utf8");
 
-  assert.match(source, /label: "Incidents"[^\n]*navigate\("\/incidents"\)/);
-  assert.match(source, /label: "Errors"[^\n]*navigate\("\/issues"\)/);
+  assert.match(source, /label: "Incidents"[^\n]*navigate\(projectPath\("\/incidents"\)\)/);
+  assert.match(source, /label: "Errors"[^\n]*navigate\(projectPath\("\/issues"\)\)/);
   assert.doesNotMatch(source, /label: "Issues"/);
 });
 

--- a/apps/web/src/design/ProductShell.tsx
+++ b/apps/web/src/design/ProductShell.tsx
@@ -9,6 +9,8 @@ import { SirenIcon } from "@phosphor-icons/react/dist/csr/Siren";
 import { SquaresFourIcon } from "@phosphor-icons/react/dist/csr/SquaresFour";
 import { type ReactNode, useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
+import { useProjectPath } from "../ProjectRouteContext.tsx";
+import { appPathFromProjectRoute } from "../project-route.ts";
 import { readSidebarCollapsed, writeSidebarCollapsed } from "./sidebarCollapsed.ts";
 import { Wordmark } from "./ui.tsx";
 
@@ -48,12 +50,14 @@ export function ProductShell({
   children: ReactNode;
 }) {
   const { pathname } = useLocation();
+  const projectPath = useProjectPath();
+  const appPath = appPathFromProjectRoute(pathname);
   const [collapsed, setCollapsed] = useState(readSidebarCollapsed);
   useEffect(() => {
     writeSidebarCollapsed(collapsed);
   }, [collapsed]);
   const current = [...NAVIGATION_GROUPS.flatMap((group) => group.items), SETTINGS_ITEM].find(
-    (item) => isActive(item, pathname),
+    (item) => isActive(item, appPath),
   );
 
   return (
@@ -64,7 +68,9 @@ export function ProductShell({
           collapsed ? "w-16 px-2" : "w-56 px-4"
         }`}
       >
-        <div className={`flex items-center ${collapsed ? "justify-center" : "justify-between px-2"}`}>
+        <div
+          className={`flex items-center ${collapsed ? "justify-center" : "justify-between px-2"}`}
+        >
           {!collapsed && <Wordmark size="sm" />}
           <button
             type="button"
@@ -89,7 +95,8 @@ export function ProductShell({
                   <NavigationLink
                     key={item.href}
                     item={item}
-                    pathname={pathname}
+                    pathname={appPath}
+                    href={projectPath(item.href)}
                     collapsed={collapsed}
                   />
                 ))}
@@ -99,7 +106,12 @@ export function ProductShell({
         </nav>
 
         <div className="mt-auto border-t border-border pt-3">
-          <NavigationLink item={SETTINGS_ITEM} pathname={pathname} collapsed={collapsed} />
+          <NavigationLink
+            item={SETTINGS_ITEM}
+            pathname={appPath}
+            href={projectPath(SETTINGS_ITEM.href)}
+            collapsed={collapsed}
+          />
         </div>
       </aside>
 
@@ -116,7 +128,7 @@ export function ProductShell({
             </div>
             <div className="flex shrink-0 items-center gap-2">{toolbar}</div>
           </div>
-          <MobileNavigation pathname={pathname} />
+          <MobileNavigation pathname={appPath} projectPath={projectPath} />
         </header>
         <div className="flex min-h-0 flex-1 flex-col">{children}</div>
       </div>
@@ -127,17 +139,19 @@ export function ProductShell({
 function NavigationLink({
   item,
   pathname,
+  href,
   collapsed,
 }: {
   item: NavigationItem;
   pathname: string;
+  href: string;
   collapsed?: boolean;
 }) {
   const active = isActive(item, pathname);
   const Icon = item.icon;
   return (
     <Link
-      to={item.href}
+      to={href}
       aria-current={active ? "page" : undefined}
       title={collapsed ? item.label : undefined}
       className={`flex items-center rounded-md py-1.5 text-[13px] transition-colors ${
@@ -150,7 +164,13 @@ function NavigationLink({
   );
 }
 
-function MobileNavigation({ pathname }: { pathname: string }) {
+function MobileNavigation({
+  pathname,
+  projectPath,
+}: {
+  pathname: string;
+  projectPath: (appPath: string) => string;
+}) {
   const items = [...NAVIGATION_GROUPS.flatMap((group) => group.items), SETTINGS_ITEM];
   return (
     <nav
@@ -163,7 +183,7 @@ function MobileNavigation({ pathname }: { pathname: string }) {
           return (
             <Link
               key={item.href}
-              to={item.href}
+              to={projectPath(item.href)}
               aria-current={active ? "page" : undefined}
               className={`rounded-md px-2.5 py-1 text-[12px] ${
                 active ? "bg-surface-3 text-fg" : "text-muted"

--- a/apps/web/src/design/ui.tsx
+++ b/apps/web/src/design/ui.tsx
@@ -2,6 +2,7 @@ import { CreditCardIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { type CSSProperties, type ReactNode, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { useProjectPath } from "../ProjectRouteContext.tsx";
 
 // ---------------------------------------------------------------------------
 // Canonical shared primitives — used across the app and the /design sheet.
@@ -673,6 +674,7 @@ export function OutOfCreditsBadge() {
 }
 
 export function OutOfCreditsBanner() {
+  const projectPath = useProjectPath();
   return (
     <div
       className="rounded-md border p-4"
@@ -696,7 +698,7 @@ export function OutOfCreditsBanner() {
       </p>
       <div className="flex items-center justify-end">
         <Link
-          to="/settings?scope=org&section=billing"
+          to={projectPath("/settings?scope=org&section=billing")}
           className="inline-flex items-center rounded-md bg-fg px-3 py-1.5 text-[13px] font-medium text-bg transition-opacity hover:opacity-90"
         >
           Manage billing

--- a/apps/web/src/explore-route.test.ts
+++ b/apps/web/src/explore-route.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { sourceFromExplorePath } from "./explore-route.ts";
+
+test("scoped Explore URLs select their requested telemetry source", () => {
+  assert.equal(
+    sourceFromExplorePath("/org/acme/project/default/explore/traces"),
+    "traces",
+  );
+});

--- a/apps/web/src/explore-route.ts
+++ b/apps/web/src/explore-route.ts
@@ -1,0 +1,10 @@
+import { appPathFromProjectRoute } from "./project-route.ts";
+
+export type ExploreSource = "logs" | "traces" | "metrics" | "resources";
+
+export function sourceFromExplorePath(pathname: string): ExploreSource | null {
+  const appPath = appPathFromProjectRoute(pathname);
+  const seg = appPath.replace(/^\/explore\/?/, "").split("/")[0];
+  if (seg === "logs" || seg === "traces" || seg === "metrics" || seg === "resources") return seg;
+  return null;
+}

--- a/apps/web/src/project-route-failure.test.ts
+++ b/apps/web/src/project-route-failure.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ApiError } from "./api-error.ts";
+import { ProjectRouteFailure } from "./ProjectRouteBoundary.tsx";
+import { projectRouteFailureKind } from "./project-route-failure.ts";
+
+test("missing or inaccessible projects are unavailable", () => {
+  assert.equal(projectRouteFailureKind(new ApiError(404, "Not found")), "unavailable");
+});
+
+test("operational failures can be retried", () => {
+  assert.equal(projectRouteFailureKind(new ApiError(500, "Try again")), "retryable");
+  assert.equal(projectRouteFailureKind(new TypeError("Failed to fetch")), "retryable");
+});
+
+test("operational failures offer a retry without describing the project as unavailable", () => {
+  const html = renderToStaticMarkup(
+    createElement(ProjectRouteFailure, {
+      error: new ApiError(500, "Try again"),
+      onRetry: () => {},
+    }),
+  );
+
+  assert.match(html, /Couldn’t open project/);
+  assert.match(html, />Retry</);
+  assert.doesNotMatch(html, /does not exist/);
+});

--- a/apps/web/src/project-route-failure.ts
+++ b/apps/web/src/project-route-failure.ts
@@ -1,0 +1,7 @@
+import { ApiError } from "./api-error.ts";
+
+export type ProjectRouteFailureKind = "unavailable" | "retryable";
+
+export function projectRouteFailureKind(error: unknown): ProjectRouteFailureKind {
+  return error instanceof ApiError && error.status === 404 ? "unavailable" : "retryable";
+}

--- a/apps/web/src/project-route.test.ts
+++ b/apps/web/src/project-route.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  appLocationFromProjectRoute,
+  appPathFromProjectRoute,
+  buildProjectPath,
+  canonicalProjectLocation,
+} from "./project-route.ts";
+
+test("buildProjectPath creates shareable incident URLs with org and project slugs", () => {
+  assert.equal(
+    buildProjectPath(
+      { orgSlug: "superlog", projectSlug: "demo-project" },
+      "/incidents/4b44c317-0d30-4c53-8938-9e1970a50cc5",
+    ),
+    "/org/superlog/project/demo-project/incidents/4b44c317-0d30-4c53-8938-9e1970a50cc5",
+  );
+});
+
+test("appPathFromProjectRoute exposes the incident route inside a scoped URL", () => {
+  assert.equal(
+    appPathFromProjectRoute(
+      "/org/superlog/project/demo-project/incidents/4b44c317-0d30-4c53-8938-9e1970a50cc5",
+    ),
+    "/incidents/4b44c317-0d30-4c53-8938-9e1970a50cc5",
+  );
+  assert.equal(appPathFromProjectRoute("/incidents/incident-1"), "/incidents/incident-1");
+});
+
+test("all project pages have canonical org and project URLs", () => {
+  const slugs = { orgSlug: "superlog", projectSlug: "demo-project" };
+  const appPaths = [
+    "/explore/logs",
+    "/incidents/incident-1",
+    "/issues/issue-1",
+    "/alerts/alert-1",
+    "/dashboards/dashboard-1",
+    "/settings?scope=project&section=integrations",
+  ];
+
+  for (const appPath of appPaths) {
+    assert.equal(buildProjectPath(slugs, appPath), `/org/superlog/project/demo-project${appPath}`);
+  }
+});
+
+test("the project root is the canonical overview URL", () => {
+  const scopedRoot = "/org/superlog/project/demo-project";
+
+  assert.equal(
+    buildProjectPath({ orgSlug: "superlog", projectSlug: "demo-project" }, "/"),
+    scopedRoot,
+  );
+  assert.equal(appPathFromProjectRoute(scopedRoot), "/");
+  assert.equal(appPathFromProjectRoute(`${scopedRoot}/`), "/");
+});
+
+test("canonical project navigation preserves search and hash state", () => {
+  assert.deepEqual(
+    canonicalProjectLocation(
+      { orgSlug: "superlog", projectSlug: "demo-project" },
+      {
+        pathname: "/explore/logs",
+        search: "?service=api&severity=error",
+        hash: "#selected",
+      },
+    ),
+    {
+      pathname: "/org/superlog/project/demo-project/explore/logs",
+      search: "?service=api&severity=error",
+      hash: "#selected",
+    },
+  );
+});
+
+test("scoped browser locations are translated back to app routes", () => {
+  assert.deepEqual(
+    appLocationFromProjectRoute({
+      pathname: "/org/superlog/project/demo-project/dashboards/dashboard-1",
+      search: "?range=1h",
+      hash: "#latency",
+    }),
+    {
+      pathname: "/dashboards/dashboard-1",
+      search: "?range=1h",
+      hash: "#latency",
+    },
+  );
+});

--- a/apps/web/src/project-route.test.ts
+++ b/apps/web/src/project-route.test.ts
@@ -72,6 +72,24 @@ test("canonical project navigation preserves search and hash state", () => {
   );
 });
 
+test("canonical project navigation replaces an existing project scope", () => {
+  assert.deepEqual(
+    canonicalProjectLocation(
+      { orgSlug: "new-org", projectSlug: "new-project" },
+      {
+        pathname: "/org/old-org/project/old-project/incidents/incident-1",
+        search: "?tab=timeline",
+        hash: "#event-1",
+      },
+    ),
+    {
+      pathname: "/org/new-org/project/new-project/incidents/incident-1",
+      search: "?tab=timeline",
+      hash: "#event-1",
+    },
+  );
+});
+
 test("scoped browser locations are translated back to app routes", () => {
   assert.deepEqual(
     appLocationFromProjectRoute({

--- a/apps/web/src/project-route.ts
+++ b/apps/web/src/project-route.ts
@@ -1,0 +1,40 @@
+export type ProjectRouteSlugs = {
+  orgSlug: string;
+  projectSlug: string;
+};
+
+export type ProjectRouteLocation = {
+  pathname: string;
+  search: string;
+  hash: string;
+};
+
+export function buildProjectPath(slugs: ProjectRouteSlugs, appPath: string): string {
+  const root = `/org/${encodeURIComponent(slugs.orgSlug)}/project/${encodeURIComponent(slugs.projectSlug)}`;
+  if (appPath === "/" || appPath === "") return root;
+  const suffix = appPath.startsWith("/") ? appPath : `/${appPath}`;
+  return `${root}${suffix}`;
+}
+
+export function appPathFromProjectRoute(pathname: string): string {
+  const match = /^\/org\/[^/]+\/project\/[^/]+(?<appPath>\/.*)?$/.exec(pathname);
+  if (!match) return pathname;
+  return match.groups?.appPath || "/";
+}
+
+export function canonicalProjectLocation(
+  slugs: ProjectRouteSlugs,
+  location: ProjectRouteLocation,
+): ProjectRouteLocation {
+  return {
+    ...location,
+    pathname: buildProjectPath(slugs, location.pathname),
+  };
+}
+
+export function appLocationFromProjectRoute(location: ProjectRouteLocation): ProjectRouteLocation {
+  return {
+    ...location,
+    pathname: appPathFromProjectRoute(location.pathname),
+  };
+}

--- a/apps/web/src/project-route.ts
+++ b/apps/web/src/project-route.ts
@@ -28,7 +28,7 @@ export function canonicalProjectLocation(
 ): ProjectRouteLocation {
   return {
     ...location,
-    pathname: buildProjectPath(slugs, location.pathname),
+    pathname: buildProjectPath(slugs, appPathFromProjectRoute(location.pathname)),
   };
 }
 

--- a/apps/worker/src/agent-run-context.ts
+++ b/apps/worker/src/agent-run-context.ts
@@ -31,6 +31,7 @@ export type ScoredGithubRepo = InstalledGithubRepo & { score: number };
 export type AgentRunContext = {
   agentRun: schema.AgentRun;
   incident: schema.Incident;
+  org: typeof schema.orgs.$inferSelect;
   project: schema.Project;
   automation: {
     autoInvestigateIssuesEnabled: boolean;
@@ -195,6 +196,10 @@ export async function loadAgentRunContext(
     where: eq(schema.projects.id, incident.projectId),
   });
   if (!project) return null;
+  const org = await db.query.orgs.findFirst({
+    where: eq(schema.orgs.id, project.orgId),
+  });
+  if (!org) return null;
   const automation = await getProjectAutomation(project.id);
   const issueIds = await db
     .select({ issueId: schema.incidentIssues.issueId })
@@ -255,6 +260,7 @@ export async function loadAgentRunContext(
   return {
     agentRun,
     incident,
+    org,
     project,
     automation,
     githubInstalls,

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -17,6 +17,7 @@ import {
   noiseReasonLabel,
   resolutionReasonLabel,
 } from "../incident-result-policy.js";
+import { buildContextIncidentUrl } from "../incident-route.js";
 import {
   incidentBlocks,
   postIncidentThreadMessage,
@@ -322,7 +323,7 @@ export async function completeWithIncidentResolution(
     lines.push(`Linear: <${deliveredTicket.url}|${deliveredTicket.identifier}>`);
   }
   await postIncidentThreadMessage(ctx.incident.id, lines.join("\n"));
-  const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
+  const incidentUrl = buildContextIncidentUrl(WEB_ORIGIN, ctx);
   await updateIncidentMainMessage(
     ctx.incident.id,
     `:white_check_mark: ${ctx.incident.title} — Incident resolved`,
@@ -470,7 +471,7 @@ export async function completeWithoutPullRequest(
       : ":memo:";
     await postIncidentThreadMessage(ctx.incident.id, `${badge} ${result.summary}`);
   }
-  const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
+  const incidentUrl = buildContextIncidentUrl(WEB_ORIGIN, ctx);
   const status =
     noiseReason && noiseApplied
       ? `${isAlertIncident(ctx) ? "Alert" : "Incident"} marked as noise - ${noiseReasonLabel(noiseReason)}`

--- a/apps/worker/src/agent-runs/linear-delivery.test.ts
+++ b/apps/worker/src/agent-runs/linear-delivery.test.ts
@@ -62,6 +62,8 @@ const BASE_ARGS = {
   incidentId: "inc-1",
   agentRunId: "run-1",
   incidentTitle: "Checkout requests fail under load",
+  orgSlug: "acme",
+  projectSlug: "shop",
   hasInstall: true,
   defaultTeamId: null,
   prUrls: [],
@@ -193,13 +195,20 @@ test("skips delivery when the workspace has no teams", async () => {
 
 test("ticket description includes every open PR link", () => {
   const desc = ticketDescription(
-    { incidentId: "inc-1", agentRunId: "run-1", incidentTitle: "t" },
+    {
+      incidentId: "inc-1",
+      agentRunId: "run-1",
+      incidentTitle: "t",
+      orgSlug: "acme",
+      projectSlug: "shop",
+    },
     RESULT,
     ["https://github.com/acme/shop/pull/12", "https://github.com/acme/api/pull/15"],
   );
   assert.ok(desc.includes("Proposed fixes:"));
   assert.ok(desc.includes("- https://github.com/acme/shop/pull/12"));
   assert.ok(desc.includes("- https://github.com/acme/api/pull/15"));
+  assert.ok(desc.includes("/org/acme/project/shop/incidents/inc-1"));
   assert.ok(desc.includes(investigationMarker("inc-1", "run-1")));
 });
 

--- a/apps/worker/src/agent-runs/linear-delivery.ts
+++ b/apps/worker/src/agent-runs/linear-delivery.ts
@@ -19,6 +19,7 @@ import {
 } from "@superlog/db";
 import { eq } from "drizzle-orm";
 import type { AgentRunContext } from "../agent-run-context.js";
+import { buildIncidentUrl } from "../incident-route.js";
 import { logger } from "../logger.js";
 
 const WEB_ORIGIN = process.env.WEB_ORIGIN ?? "http://localhost:5173";
@@ -42,7 +43,13 @@ export type DeliveredLinearTicket = {
 };
 
 export function ticketDescription(
-  args: { incidentId: string; agentRunId: string; incidentTitle: string },
+  args: {
+    incidentId: string;
+    agentRunId: string;
+    incidentTitle: string;
+    orgSlug: string;
+    projectSlug: string;
+  },
   result: AgentRunResult,
   prUrls: string[],
 ): string {
@@ -58,7 +65,14 @@ export function ticketDescription(
     lines.push("", prUrls.length === 1 ? "Proposed fix:" : "Proposed fixes:");
     lines.push(...prUrls.map((url) => `- ${url}`));
   }
-  lines.push("", `[Incident on Superlog](${WEB_ORIGIN}/incidents/${args.incidentId})`);
+  lines.push(
+    "",
+    `[Incident on Superlog](${buildIncidentUrl(WEB_ORIGIN, {
+      orgSlug: args.orgSlug,
+      projectSlug: args.projectSlug,
+      incidentId: args.incidentId,
+    })})`,
+  );
   lines.push("", investigationMarker(args.incidentId, args.agentRunId));
   return lines.join("\n");
 }
@@ -101,6 +115,8 @@ export async function deliverLinearTicketWithDeps(
     incidentId: string;
     agentRunId: string;
     incidentTitle: string;
+    orgSlug: string;
+    projectSlug: string;
     hasInstall: boolean;
     defaultTeamId: string | null;
     prUrls: string[];
@@ -167,6 +183,8 @@ export async function deliverLinearTicketWithDeps(
           incidentId: args.incidentId,
           agentRunId: args.agentRunId,
           incidentTitle: args.incidentTitle,
+          orgSlug: args.orgSlug,
+          projectSlug: args.projectSlug,
         },
         result,
         args.prUrls,
@@ -271,6 +289,8 @@ export async function deliverLinearTicket(
       incidentId: ctx.incident.id,
       agentRunId: ctx.agentRun.id,
       incidentTitle: ctx.incident.title,
+      orgSlug: ctx.org.slug,
+      projectSlug: ctx.project.slug,
       hasInstall: !!install,
       defaultTeamId: ctx.linearDefaultTeamId,
       prUrls: opts.prUrls,

--- a/apps/worker/src/agent-runs/merge.ts
+++ b/apps/worker/src/agent-runs/merge.ts
@@ -10,6 +10,7 @@ import { and, desc, eq, inArray } from "drizzle-orm";
 import type { AgentRunContext } from "../agent-run-context.js";
 import { createAgentRunLifecycle } from "../agent-run.js";
 import { type LinkedIncidentIssue, loadLinkedIncidentIssues } from "../incident-intake.js";
+import { buildContextIncidentUrl, buildIncidentUrl } from "../incident-route.js";
 import {
   incidentBlocks,
   postIncidentThreadMessage,
@@ -329,8 +330,12 @@ async function applyMergeOutcome(opts: {
     "agent run merged into existing incident",
   );
 
-  const targetUrl = `${WEB_ORIGIN}/incidents/${target.id}`;
-  const sourceUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
+  const targetUrl = buildIncidentUrl(WEB_ORIGIN, {
+    orgSlug: ctx.org.slug,
+    projectSlug: ctx.project.slug,
+    incidentId: target.id,
+  });
+  const sourceUrl = buildContextIncidentUrl(WEB_ORIGIN, ctx);
   const targetLabel = target.codename || target.title;
   const sourceLabel = ctx.incident.codename || ctx.incident.title;
 

--- a/apps/worker/src/agent-runs/pr-delivery.ts
+++ b/apps/worker/src/agent-runs/pr-delivery.ts
@@ -14,6 +14,7 @@ import {
 } from "../agent-run-context.js";
 import { createAgentRunLifecycle } from "../agent-run.js";
 import { mergeAgentPullRequest, pushPatchToExistingAgentPr } from "../github-app.js";
+import { buildContextIncidentUrl } from "../incident-route.js";
 import { downloadAgentPatchFile } from "../infra/agent-runner/patch-files.js";
 import { openAgentRunPullRequest } from "../infra/github/pull-requests.js";
 import {
@@ -183,7 +184,7 @@ export async function completeWithPullRequest(
 
   const prTitle = buildPrTitle({ ctx, result, pr });
   const prBody = buildPrBody({
-    incidentUrl: `${WEB_ORIGIN}/incidents/${ctx.incident.id}`,
+    incidentUrl: buildContextIncidentUrl(WEB_ORIGIN, ctx),
     result,
     pr,
   });
@@ -497,7 +498,7 @@ export async function completeWithPullRequest(
       "failed to post PR-ready Slack thread message",
     ),
   );
-  const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
+  const incidentUrl = buildContextIncidentUrl(WEB_ORIGIN, ctx);
   await updateIncidentMainMessage(
     ctx.incident.id,
     `:bulb: PR Ready: ${ctx.incident.title}`,
@@ -620,7 +621,7 @@ export async function deliverProposedPullRequest(
       : DEFAULT_COMMIT_AUTHOR;
   const prTitle = buildPrTitle({ ctx, result: { summary: pr.title }, pr });
   const prBody = buildPrBody({
-    incidentUrl: `${WEB_ORIGIN}/incidents/${ctx.incident.id}`,
+    incidentUrl: buildContextIncidentUrl(WEB_ORIGIN, ctx),
     result: { summary: pr.body },
     pr,
   });
@@ -785,7 +786,7 @@ export async function deliverProposedPullRequest(
     ctx.incident.id,
     `:bulb: Opened PR ${opened.prUrl}${ticketLine}`,
   ).catch(() => {});
-  const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
+  const incidentUrl = buildContextIncidentUrl(WEB_ORIGIN, ctx);
   await updateIncidentMainMessage(
     ctx.incident.id,
     `:bulb: PR Ready: ${ctx.incident.title}`,

--- a/apps/worker/src/agent-runs/start-run.ts
+++ b/apps/worker/src/agent-runs/start-run.ts
@@ -2,6 +2,7 @@ import { db, enqueueAgentRunStarted } from "@superlog/db";
 import type { AgentRunContext } from "../agent-run-context.js";
 import { listAccessibleGithubRepositories, scoreRepos } from "../agent-run-context.js";
 import { createAgentRunLifecycle } from "../agent-run.js";
+import { buildContextIncidentUrl } from "../incident-route.js";
 import { getAgentRunnerBackend } from "../infra/agent-runner/backend.js";
 import {
   createRepositoryReadToken,
@@ -59,7 +60,7 @@ async function notifyAgentRunStarted(
     ctx.incident.id,
     `:mag: Investigation started across ${repoCandidateCount} candidate repos.`,
   );
-  const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
+  const incidentUrl = buildContextIncidentUrl(WEB_ORIGIN, ctx);
   await updateIncidentMainMessage(
     ctx.incident.id,
     `:rotating_light: ${ctx.incident.title} — Investigation ongoing`,

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -317,10 +317,16 @@ function makeContext(opts: { githubInstalled?: boolean } = {}): AgentRunContext 
       title: "Incident",
       service: "api",
     } as schema.Incident,
+    org: {
+      id: "org-1",
+      name: "Org",
+      slug: "org",
+    } as typeof schema.orgs.$inferSelect,
     project: {
       id: "project-1",
       orgId: "org-1",
       name: "Project",
+      slug: "project",
     } as schema.Project,
     automation: {
       autoInvestigateIssuesEnabled: true,

--- a/apps/worker/src/agent-runs/status.ts
+++ b/apps/worker/src/agent-runs/status.ts
@@ -7,6 +7,7 @@ import {
 } from "@superlog/db";
 import type { AgentRunContext } from "../agent-run-context.js";
 import { createAgentRunLifecycle } from "../agent-run.js";
+import { buildContextIncidentUrl } from "../incident-route.js";
 import {
   incidentBlocks,
   postIncidentThreadMessage,
@@ -178,7 +179,7 @@ export async function failAgentRun(
   const emoji =
     category === "agent" ? ":mag:" : category === "deliverable" ? ":x:" : ":rotating_light:";
   await postIncidentThreadMessage(ctx.incident.id, `${emoji} ${summary}`);
-  const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
+  const incidentUrl = buildContextIncidentUrl(WEB_ORIGIN, ctx);
   await updateIncidentMainMessage(
     ctx.incident.id,
     `:x: ${ctx.incident.title} — Investigation failed`,
@@ -226,7 +227,7 @@ export async function moveAgentRunToAwaitingHuman(
     ),
   );
   await postIncidentThreadMessage(ctx.incident.id, `:speech_balloon: ${summary}\n${question}`);
-  const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
+  const incidentUrl = buildContextIncidentUrl(WEB_ORIGIN, ctx);
   await updateIncidentMainMessage(
     ctx.incident.id,
     `:speech_balloon: ${ctx.incident.title} — Awaiting human input`,
@@ -278,7 +279,7 @@ export async function moveAgentRunToAwaitingEvents(
     ctx.incident.id,
     awaitingEventsSlackMessage(openPrUrls, linearTicket),
   );
-  const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
+  const incidentUrl = buildContextIncidentUrl(WEB_ORIGIN, ctx);
   await updateIncidentMainMessage(
     ctx.incident.id,
     `:hourglass_flowing_sand: ${ctx.incident.title} — Waiting on PR review`,
@@ -349,7 +350,7 @@ export async function moveAgentRunToBlockedNoGithub(
       "failed to enqueue incident.updated webhook (agent_awaiting_input)",
     ),
   );
-  const incidentUrl = `${WEB_ORIGIN}/incidents/${ctx.incident.id}`;
+  const incidentUrl = buildContextIncidentUrl(WEB_ORIGIN, ctx);
   const installUrl = `${WEB_ORIGIN}/settings?tab=github`;
   const tagline = "Connect a GitHub repo so we can investigate.";
   await postIncidentThreadMessage(

--- a/apps/worker/src/incident-route.test.ts
+++ b/apps/worker/src/incident-route.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildIncidentUrl } from "./incident-route.js";
+
+test("buildIncidentUrl includes the owning org and project slugs", () => {
+  assert.equal(
+    buildIncidentUrl("https://superlog.sh/", {
+      orgSlug: "superlog",
+      projectSlug: "demo-project",
+      incidentId: "4b44c317-0d30-4c53-8938-9e1970a50cc5",
+    }),
+    "https://superlog.sh/org/superlog/project/demo-project/incidents/4b44c317-0d30-4c53-8938-9e1970a50cc5",
+  );
+});

--- a/apps/worker/src/incident-route.ts
+++ b/apps/worker/src/incident-route.ts
@@ -1,0 +1,25 @@
+export type IncidentRoute = {
+  orgSlug: string;
+  projectSlug: string;
+  incidentId: string;
+};
+
+export function buildIncidentUrl(webOrigin: string, route: IncidentRoute): string {
+  const origin = webOrigin.replace(/\/$/, "");
+  return `${origin}/org/${encodeURIComponent(route.orgSlug)}/project/${encodeURIComponent(route.projectSlug)}/incidents/${encodeURIComponent(route.incidentId)}`;
+}
+
+export function buildContextIncidentUrl(
+  webOrigin: string,
+  context: {
+    org: { slug: string };
+    project: { slug: string };
+    incident: { id: string };
+  },
+): string {
+  return buildIncidentUrl(webOrigin, {
+    orgSlug: context.org.slug,
+    projectSlug: context.project.slug,
+    incidentId: context.incident.id,
+  });
+}

--- a/apps/worker/src/infra/slack/incident-messages.ts
+++ b/apps/worker/src/infra/slack/incident-messages.ts
@@ -1,5 +1,6 @@
 import { db, environmentFromResourceAttrs, schema } from "@superlog/db";
 import { and, eq, isNull, sql } from "drizzle-orm";
+import { buildIncidentUrl } from "../../incident-route.js";
 import { logger } from "../../logger.js";
 import { isStaleSlackAnchorError } from "../../slack-pinning.js";
 import {
@@ -12,6 +13,18 @@ import {
 } from "./api.js";
 
 const WEB_ORIGIN = process.env.WEB_ORIGIN ?? "http://localhost:5173";
+
+async function incidentUrlForProject(projectId: string, incidentId: string): Promise<string> {
+  const [route] = await db
+    .select({ orgSlug: schema.orgs.slug, projectSlug: schema.projects.slug })
+    .from(schema.projects)
+    .innerJoin(schema.orgs, eq(schema.orgs.id, schema.projects.orgId))
+    .where(eq(schema.projects.id, projectId))
+    .limit(1);
+  return route
+    ? buildIncidentUrl(WEB_ORIGIN, { ...route, incidentId })
+    : `${WEB_ORIGIN}/incidents/${incidentId}`;
+}
 
 async function fetchSlackTarget(projectId: string): Promise<SlackTarget | null> {
   const rows = await db.execute<{
@@ -349,7 +362,7 @@ export async function postIncidentRootMessage(opts: {
   if (opts.incident.slackThreadTs) return;
   const target = await fetchSlackTarget(opts.projectId);
   if (!target) return;
-  const incidentUrl = `${WEB_ORIGIN}/incidents/${opts.incident.id}`;
+  const incidentUrl = await incidentUrlForProject(opts.projectId, opts.incident.id);
   const text = `:rotating_light: New incident: ${opts.firstIssue.title}`;
   const blocks = incidentBlocks({
     emoji: "rotating_light",
@@ -377,7 +390,7 @@ async function createIncidentRootInCurrentRoute(
   const project = await db.query.projects.findFirst({
     where: eq(schema.projects.id, incident.projectId),
   });
-  const incidentUrl = `${WEB_ORIGIN}/incidents/${incident.id}`;
+  const incidentUrl = await incidentUrlForProject(incident.projectId, incident.id);
   const text = `:rotating_light: Incident: ${incident.title}`;
   const blocks = incidentBlocks({
     emoji: "rotating_light",


### PR DESCRIPTION
## What changed

- add canonical `/org/:orgSlug/project/:projectSlug/...` URLs for every authenticated project page
- switch the active organization and project when an authorized user opens a scoped URL
- keep legacy short URLs working by redirecting them to the canonical project URL
- update navigation, alert/dashboard/detail links, and generated incident links to preserve project context
- keep inaccessible projects behind the existing membership checks

## Why

Frontend URLs previously depended on whichever organization and project happened to be active in the session. Opening a shared link could therefore show the wrong project or fail to find the referenced resource. The scoped route now carries the tenant identity explicitly and reconciles the session before rendering.

## Validation

- API tests: 357 passed
- Web tests: 119 passed
- Worker focused tests: 56 passed
- API, web, and worker typechecks passed
- local worktree verification passed, including telemetry ingestion and authenticated project context

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds canonical project-scoped URLs (/org/:orgSlug/project/:projectSlug/...) for all project pages and hardens navigation with automatic redirects, scoped link generation, and clear error handling. Legacy short URLs still work and redirect.

- **New Features**
  - Canonical routing with helpers: `buildProjectPath`, `appPathFromProjectRoute`, `appLocationFromProjectRoute`, `canonicalProjectLocation`, `ProjectRouteProvider`, and `useProjectPath`.
  - `ProjectRouteBoundary` reconciles the session via `PUT /api/me/active-context`, auto-reloads into the selected context, and shows a friendly error with a retry for operational failures (404 renders an “unavailable” message).
  - App shell, command palette, and all internal links now emit scoped paths; unauthenticated or unscoped app routes auto-redirect to the canonical project route while preserving the current path, search, and hash.
  - Slack, PR, and Linear ticket links now use scoped incident URLs via `buildIncidentUrl`/`buildContextIncidentUrl`; API-side Slack updates include org/project slugs.

- **Migration**
  - No breaking changes; old links redirect.
  - For new links in the web app, use `useProjectPath` (or `buildProjectPath`) to generate URLs.
  - The API exposes `PUT /api/me/active-context` to align the session with scoped routes when needed.

<sup>Written for commit e7414d2f7d612a60459423679f52754557b30249. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

