### PR TITLE
fix(seed-rich-telemetry): validate services count

### DIFF
--- a/scripts/demo/seed-rich-telemetry.ts
+++ b/scripts/demo/seed-rich-telemetry.ts
@@ -36,6 +36,7 @@ function usage(): string {
 function parseArgs(argv: string[]): Options {
   const map = new Map<string, string>();
   let help = false;
+
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
     if (arg === "--") continue;
@@ -44,17 +45,26 @@ function parseArgs(argv: string[]): Options {
       continue;
     }
     if (!arg.startsWith("--")) throw new Error(`unexpected: ${arg}`);
+
     const next = argv[i + 1];
     if (!next || next.startsWith("--")) throw new Error(`missing value for ${arg}`);
+
     map.set(arg.slice(2), next);
     i += 1;
   }
+
+  const services = Number(map.get("services") ?? 4);
+
+  if (!Number.isFinite(services)) {
+    throw new Error("invalid services count");
+  }
+
   return {
     projectId: map.get("project-id") ?? "",
     collectorUrl: (map.get("collector-url") ?? "http://localhost:4318").replace(/\/+$/, ""),
     minutes: Number(map.get("minutes") ?? 60),
     points: Number(map.get("points") ?? 30),
-    services: Math.min(8, Math.max(1, Number(map.get("services") ?? 4))),
+    services: Math.min(8, Math.max(1, Math.floor(services))),
     help,
   };
 }
@@ -84,18 +94,8 @@ const LOG_MESSAGES: Record<string, string[]> = {
     "session refreshed",
     "feature flag evaluated",
   ],
-  WARN: [
-    "downstream slow",
-    "cache miss",
-    "retrying request",
-    "queue backlog rising",
-  ],
-  ERROR: [
-    "upstream timeout",
-    "db connection refused",
-    "auth token rejected",
-    "panic recovered",
-  ],
+  WARN: ["downstream slow", "cache miss", "retrying request", "queue backlog rising"],
+  ERROR: ["upstream timeout", "db connection refused", "auth token rejected", "panic recovered"],
 };
 
 function stringAttr(key: string, value: string) {
@@ -209,7 +209,7 @@ function buildMetrics(opts: Options, services: typeof SERVICES) {
 function buildLogs(opts: Options, services: typeof SERVICES) {
   const now = Date.now();
   const totalLogs = opts.points * services.length * 4;
-  const records: { svcIdx: number; t: number; sev: typeof SEVERITIES[number] }[] = [];
+  const records: { svcIdx: number; t: number; sev: (typeof SEVERITIES)[number] }[] = [];
   for (let i = 0; i < totalLogs; i++) {
     records.push({
       svcIdx: Math.floor(Math.random() * services.length),
@@ -238,8 +238,14 @@ function buildLogs(opts: Options, services: typeof SERVICES) {
               severityText: rec.sev.text,
               body: { stringValue: message },
               attributes: [
-                stringAttr("http.method", ["GET", "POST", "PUT", "DELETE"][Math.floor(Math.random() * 4)]!),
-                intAttr("http.status_code", rec.sev.text === "ERROR" ? 500 : rec.sev.text === "WARN" ? 429 : 200),
+                stringAttr(
+                  "http.method",
+                  ["GET", "POST", "PUT", "DELETE"][Math.floor(Math.random() * 4)]!,
+                ),
+                intAttr(
+                  "http.status_code",
+                  rec.sev.text === "ERROR" ? 500 : rec.sev.text === "WARN" ? 429 : 200,
+                ),
               ],
             };
           }),
@@ -321,9 +327,7 @@ async function main(): Promise<void> {
   const traces = buildTraces(opts, services);
 
   console.log(`seeding project=${opts.projectId} into ${opts.collectorUrl}`);
-  console.log(
-    `  services=${services.length} window=${opts.minutes}m points/series=${opts.points}`,
-  );
+  console.log(`  services=${services.length} window=${opts.minutes}m points/series=${opts.points}`);
 
   await postOtlp(`${opts.collectorUrl}/v1/metrics`, opts.projectId, metrics);
   console.log(`  ✓ metrics`);


### PR DESCRIPTION
## What & why

Validate the `--services` CLI argument before using it.

Previously, passing a non-numeric value (for example `--services abc`) caused `Number()` to return `NaN`, which propagated through `Math.max`/`Math.min` and resulted in an invalid service count. This change validates the parsed value and throws an error for invalid input.

Addresses item #12 from Code Audit issue #68.

## How to test

- [ ] Run:
  ```bash
  pnpm tsx scripts/demo/seed-rich-telemetry.ts --services abc
  ```
  Verify the script exits with:
  ```
  Error: invalid services count
  ```

- [ ] Run:
  ```bash
  pnpm tsx scripts/demo/seed-rich-telemetry.ts --services 4
  ```
  Verify the script starts normally.

## AI assistance

<!-- If you used generative AI (Claude, Cursor, Copilot, etc.) to draft code, tests, or copy in this PR, disclose it briefly. See CONTRIBUTING.md → "Generative AI policy" for what counts. Skip this section if no AI was used. -->

- [ ] None
- [x ] Used AI for:  discussing the validation approach and reviewing the implementation.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / cleanup

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm format` has been run on changed files
- [ ] Added or updated tests where it makes sense
- [x] Branch is up to date with `main`
- [x] PR title follows the area-prefix style for the area being changed (e.g. `worker: …`, `fix(slack): …`)
- [x] Read [CONTRIBUTING.md](https://github.com/superloglabs/superlog/blob/main/CONTRIBUTING.md) (skim counts)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate the --services CLI argument in scripts/demo/seed-rich-telemetry.ts to prevent NaN-based invalid service counts (addresses Code Audit issue #68, item 12). Non-numeric or infinite values now throw "invalid services count"; valid numbers are floored and clamped to 1–8.

<sup>Written for commit 601ed3dd5748d2631b312c3c7359db59c2f15724. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

