### PR TITLE
Show Linear ticket activity only after filing

### DIFF
--- a/apps/web/src/incidents/IncidentTranscript.test.ts
+++ b/apps/web/src/incidents/IncidentTranscript.test.ts
@@ -43,6 +43,25 @@ test("buildActivityFeed starts with the issue that triggered the incident", () =
   });
 });
 
+test("buildActivityFeed shows the filed Linear ticket without the internal handoff marker", () => {
+  const filed = event({
+    id: "linear-filed-1",
+    kind: "ticket_filed",
+    summary: "Filed Linear ticket ENG-42",
+    detail: { ticketUrl: "https://linear.app/acme/issue/ENG-42" },
+  });
+  const feed = buildActivityFeed([
+    event({
+      id: "linear-pending-1",
+      kind: "linear_handoff_pending",
+      summary: "Linear handoff pending reconciliation.",
+    }),
+    filed,
+  ]);
+
+  assert.deepEqual(feed, [{ type: "lifecycle", id: "linear-filed-1", event: filed }]);
+});
+
 test("buildActivityFeed turns ask_human into a question node with the exact prompt", () => {
   const feed = buildActivityFeed([
     event({

--- a/apps/web/src/incidents/incident-activity-feed.ts
+++ b/apps/web/src/incidents/incident-activity-feed.ts
@@ -67,6 +67,7 @@ const TOOL_RESULT_KINDS = new Set([
 
 function isFeedNoise(kind: string): boolean {
   if (kind === "session.error") return false;
+  if (kind === "linear_handoff_pending") return true;
   return kind.startsWith("span.") || kind.startsWith("session.");
 }
 

--- a/apps/worker/src/agent-runs/linear-handoff.test.ts
+++ b/apps/worker/src/agent-runs/linear-handoff.test.ts
@@ -5,6 +5,7 @@ import type { AgentRunResult } from "@superlog/db";
 import {
   type LinearHandoffReconciliationDeps,
   reconcileLinearHandoffWithDeps,
+  scheduleLinearHandoffWithDeps,
 } from "./linear-handoff.js";
 
 const RESULT: AgentRunResult = { state: "complete", summary: "Investigation complete." };
@@ -33,6 +34,52 @@ function makeDeps(overrides: Partial<LinearHandoffReconciliationDeps> = {}) {
     } satisfies LinearHandoffReconciliationDeps,
   };
 }
+
+test("a project without Linear connected does not schedule a handoff", async () => {
+  const calls: string[] = [];
+
+  const ticket = await scheduleLinearHandoffWithDeps(
+    { hasInstall: false },
+    {
+      recordPending: async () => {
+        calls.push("record_pending");
+      },
+      dispatch: async () => {
+        calls.push("dispatch");
+      },
+      reconcile: async () => {
+        calls.push("reconcile");
+        return TICKET;
+      },
+    },
+  );
+
+  assert.equal(ticket, null);
+  assert.deepEqual(calls, []);
+});
+
+test("a connected Linear project schedules and reconciles its handoff", async () => {
+  const calls: string[] = [];
+
+  const ticket = await scheduleLinearHandoffWithDeps(
+    { hasInstall: true },
+    {
+      recordPending: async () => {
+        calls.push("record_pending");
+      },
+      dispatch: async () => {
+        calls.push("dispatch");
+      },
+      reconcile: async () => {
+        calls.push("reconcile");
+        return TICKET;
+      },
+    },
+  );
+
+  assert.equal(ticket, TICKET);
+  assert.deepEqual(calls, ["record_pending", "dispatch", "reconcile"]);
+});
 
 test("reconciliation keeps durable work pending when ticket delivery fails", async () => {
   const { deps, calls } = makeDeps({ deliverTicket: async () => null });

--- a/apps/worker/src/agent-runs/linear-handoff.ts
+++ b/apps/worker/src/agent-runs/linear-handoff.ts
@@ -19,6 +19,22 @@ export type LinearHandoffReconciliationDeps = {
   markProcessed(ids: string[]): Promise<void>;
 };
 
+export type LinearHandoffSchedulingDeps = {
+  recordPending(): Promise<void>;
+  dispatch(): Promise<void>;
+  reconcile(): Promise<DeliveredLinearTicket | null>;
+};
+
+export async function scheduleLinearHandoffWithDeps(
+  input: { hasInstall: boolean },
+  deps: LinearHandoffSchedulingDeps,
+): Promise<DeliveredLinearTicket | null> {
+  if (!input.hasInstall) return null;
+  await deps.recordPending();
+  await deps.dispatch().catch(() => undefined);
+  return deps.reconcile();
+}
+
 export async function reconcileLinearHandoffWithDeps(
   input: {
     hasInstall: boolean;
@@ -131,19 +147,26 @@ export async function scheduleLinearHandoff(
   result: AgentRunResult,
   boundary: string,
 ): Promise<DeliveredLinearTicket | null> {
-  await db
-    .insert(schema.incidentEvents)
-    .values({
-      agentRunId: ctx.agentRun.id,
-      incidentId: ctx.incident.id,
-      kind: LINEAR_HANDOFF_PENDING_EVENT,
-      summary: "Linear handoff pending reconciliation.",
-      detail: { result },
-      providerEventId: `linear_handoff:${boundary}`,
-    })
-    .onConflictDoNothing();
-  await dispatchAgentRunJob(ctx.agentRun.id).catch(() => undefined);
-  return reconcilePendingLinearHandoff(ctx);
+  return scheduleLinearHandoffWithDeps(
+    { hasInstall: !!ctx.linearInstall },
+    {
+      recordPending: async () => {
+        await db
+          .insert(schema.incidentEvents)
+          .values({
+            agentRunId: ctx.agentRun.id,
+            incidentId: ctx.incident.id,
+            kind: LINEAR_HANDOFF_PENDING_EVENT,
+            summary: "Linear handoff pending reconciliation.",
+            detail: { result },
+            providerEventId: `linear_handoff:${boundary}`,
+          })
+          .onConflictDoNothing();
+      },
+      dispatch: () => dispatchAgentRunJob(ctx.agentRun.id),
+      reconcile: () => reconcilePendingLinearHandoff(ctx),
+    },
+  );
 }
 
 export async function listPendingLinearHandoffRunIds(limit = 500): Promise<string[]> {


### PR DESCRIPTION
## Summary

- skip Linear handoff scheduling when a project has no Linear installation
- keep the internal reconciliation marker out of the incident activity timeline
- preserve the successful filed-ticket event and link for connected projects

## Why

The durable retry marker was being presented as customer-facing activity, including for projects that had never connected Linear. Reconciliation is an internal delivery concern; the timeline should report only the successful outcome.

## Validation

- `pnpm --filter @superlog/worker exec tsx --test src/agent-runs/linear-handoff.test.ts`
- `pnpm --filter @superlog/web exec tsx --import ./src/test-setup.ts --test src/incidents/IncidentTranscript.test.ts`
- worker and web typechecks
- formatting check
- seeded worktree verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show Linear ticket activity only after filing. Hide internal reconciliation events and skip scheduling when a project has no Linear install.

- **Bug Fixes**
  - Hide `linear_handoff_pending` in the incident activity feed; only show the `ticket_filed` event with its link.
  - Do not schedule a Linear handoff when `hasInstall` is false.

- **Refactors**
  - Added `scheduleLinearHandoffWithDeps` for dependency-injected scheduling and reconciliation, and updated `scheduleLinearHandoff` to use it.
  - Expanded tests in `@superlog/worker` and `@superlog/web` to cover both cases.

<sup>Written for commit 672e3b1b9b3dfe21a86edd6211e800e8b557a759. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

