### PR TITLE
Keep local ClickHouse migrations non-interactive

### DIFF
--- a/scripts/clickhouse-apply-local-migrations.sh
+++ b/scripts/clickhouse-apply-local-migrations.sh
@@ -32,7 +32,10 @@ clickhouse_client() {
 }
 
 query() {
-  clickhouse_client --query "$1"
+  # clickhouse-client keeps reading INSERT data from an inherited interactive
+  # stdin even when VALUES are already present in --query. Bootstrap is often
+  # launched from a PTY, so close stdin to keep ledger inserts non-interactive.
+  clickhouse_client --query "$1" </dev/null
 }
 
 echo "==> waiting for collector ClickHouse tables"

--- a/scripts/clickhouse-apply-local-migrations.test.sh
+++ b/scripts/clickhouse-apply-local-migrations.test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/bin"
+QUERY_STDIN_LOG="$TMP_DIR/query-stdin.log"
+touch "$QUERY_STDIN_LOG"
+
+cat > "$TMP_DIR/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+args="$*"
+if [[ "$args" == *"--query"* ]]; then
+  payload="$(cat)"
+  if [[ -n "$payload" ]]; then
+    printf '%s\n' "$payload" >> "${QUERY_STDIN_LOG:?}"
+  fi
+
+  case "$args" in
+    *"FROM system.tables"*) printf '7\n' ;;
+    *"FROM superlog.local_schema_migrations"*) printf '0\n' ;;
+  esac
+else
+  cat >/dev/null
+fi
+EOF
+chmod +x "$TMP_DIR/bin/docker"
+
+printf 'inherited interactive input\n' | \
+  PATH="$TMP_DIR/bin:$PATH" \
+  QUERY_STDIN_LOG="$QUERY_STDIN_LOG" \
+  SUPERLOG_COMPOSE_PROJECT="clickhouse-stdin-test" \
+  "$REPO_ROOT/scripts/clickhouse-apply-local-migrations.sh" >/dev/null
+
+if [[ -s "$QUERY_STDIN_LOG" ]]; then
+  echo "expected ClickHouse --query calls not to consume inherited stdin" >&2
+  exit 1
+fi
+
+echo "clickhouse migration query stdin: ok"


### PR DESCRIPTION
## Summary

- close stdin for ClickHouse `--query` calls in the local migration runner
- add a regression test that pipes inherited input into the runner and verifies query calls cannot consume it

## Root cause

`clickhouse-client` can continue reading from inherited stdin for an `INSERT` even when the values are already included in `--query`. When bootstrap runs under an interactive terminal, the migration ledger insert can therefore wait indefinitely for more input.

Redirecting query stdin from `/dev/null` makes those calls deterministic while preserving file input for `--multiquery` migration execution.

## Validation

- `bash scripts/clickhouse-apply-local-migrations.test.sh`
- `bash scripts/portless-stack.test.sh`
- `bash -n scripts/clickhouse-apply-local-migrations.sh scripts/clickhouse-apply-local-migrations.test.sh`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep local ClickHouse migrations non-interactive to avoid hangs when run from a PTY. Ensures the ledger INSERT doesn’t wait for terminal input.

- **Bug Fixes**
  - Redirect `query()` stdin to `/dev/null` for `clickhouse-client --query`, preserving file input for `--multiquery`.
  - Add a regression test that pipes input into the runner and verifies `--query` calls do not consume inherited stdin.

<sup>Written for commit 7b3318e301fe0ee145c4291a6f0d424eca4fe3e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

