### PR TITLE
Show outcome evidence in incident activity

### DIFF
--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -1755,6 +1755,10 @@ export function IncidentDetailContent({
                     !triggeringIssue && <p className="text-[12px] text-muted">No activity yet.</p>}
                   <IncidentActivityFeed
                     events={events}
+                    evidenceContext={{
+                      repoUrl: agentRun?.selectedRepoUrl ?? null,
+                      baseBranch: agentRun?.selectedBaseBranch ?? null,
+                    }}
                     triggeringIssue={
                       triggeringIssue
                         ? { issueId: triggeringIssue.id, createdAt: incident.firstSeen }

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -820,6 +820,14 @@ const OUTCOME_RECORD_PRESENTATION: Record<string, OutcomeRecordPresentation> = {
       },
     ],
   },
+  resolve_issue: {
+    title: "Resolved issue",
+    fields: [
+      { key: "issueId", label: "Issue" },
+      { key: "reason", label: "Reasoning" },
+      { key: "evidence", label: "Evidence" },
+    ],
+  },
   resolve_incident: {
     title: "Resolved incident",
     fields: [

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -674,10 +674,99 @@ function ToolEntry({
       </Node>
       {isEdit ? (
         <EditEntry item={item} />
+      ) : item.name === "list_memories" ? (
+        <ListMemoriesEntry item={item} />
       ) : outcomePresentation ? (
         <OutcomeRecordEntry item={item} ctx={ctx} presentation={outcomePresentation} />
       ) : (
         <CodeEntry item={item} />
+      )}
+    </div>
+  );
+}
+
+type ListedMemory = {
+  id: string;
+  kind: string | null;
+  title: string | null;
+  body: string | null;
+};
+
+function listedMemoriesFromResult(result: string | null): ListedMemory[] | null {
+  if (!result) return null;
+  try {
+    const payload = JSON.parse(result) as { memories?: unknown };
+    if (!Array.isArray(payload.memories)) return null;
+    return payload.memories.flatMap((value) => {
+      if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+      const memory = value as Record<string, unknown>;
+      const text = (key: string) =>
+        typeof memory[key] === "string" && memory[key] ? (memory[key] as string) : null;
+      const id = text("id");
+      if (!id) return [];
+      return [
+        {
+          id,
+          kind: text("kind"),
+          title: text("title"),
+          body: text("body"),
+        },
+      ];
+    });
+  } catch {
+    return null;
+  }
+}
+
+function ListMemoriesEntry({ item }: { item: Extract<TranscriptItem, { type: "tool" }> }) {
+  const memories = listedMemoriesFromResult(item.result);
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-surface">
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-3.5 py-2.5">
+        <span className="text-[12px] font-semibold text-fg">Listed memories</span>
+        <span className="font-mono text-[11px] text-subtle">{item.name}</span>
+        {memories && (
+          <Chip tone="muted">
+            {memories.length} {memories.length === 1 ? "memory" : "memories"}
+          </Chip>
+        )}
+        {item.isError && <Chip tone="danger">failed</Chip>}
+      </div>
+      {memories ? (
+        memories.length === 0 ? (
+          <div className="px-3.5 py-4 text-[12.5px] text-muted">No active memories.</div>
+        ) : (
+          <div className="divide-y divide-border">
+            {memories.map((memory) => (
+              <article key={memory.id} className="px-3.5 py-3">
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                  <span className="min-w-0 font-medium text-[13px] text-fg">
+                    {memory.title ?? "Untitled memory"}
+                  </span>
+                  {memory.kind && <Chip tone="muted">{memory.kind}</Chip>}
+                  <span className="min-w-0 truncate font-mono text-[10.5px] text-subtle">
+                    {memory.id}
+                  </span>
+                </div>
+                {memory.body && (
+                  <div className="mt-1.5 whitespace-pre-wrap break-words text-[12.5px] leading-relaxed text-muted">
+                    {memory.body}
+                  </div>
+                )}
+              </article>
+            ))}
+          </div>
+        )
+      ) : item.result ? (
+        <div
+          className={`whitespace-pre-wrap break-words px-3.5 py-3 font-mono text-[11.5px] leading-relaxed ${
+            item.isError ? "text-danger" : "text-muted"
+          }`}
+        >
+          {item.result}
+        </div>
+      ) : (
+        <div className="px-3.5 py-4 text-[12.5px] text-muted">No result recorded.</div>
       )}
     </div>
   );

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -40,6 +40,7 @@ export function IncidentActivityFeed({
   triggeringIssue,
   renderIssueCard,
   awaiting,
+  evidenceContext,
 }: {
   events: IncidentEvent[];
   /** The issue that opened the incident. It is projected as the first feed
@@ -52,6 +53,8 @@ export function IncidentActivityFeed({
    *  — it lives on the run result. Render it as a terminal node so the timeline
    *  ends on what the agent needs from the human. */
   awaiting?: { question: string; ctx: EvidenceLinkContext } | null;
+  /** Link context for markdown evidence recorded by outcome tools. */
+  evidenceContext?: EvidenceLinkContext;
 }) {
   const [expanded, setExpanded] = useState(false);
   const railRef = useRef<HTMLDivElement>(null);
@@ -61,7 +64,7 @@ export function IncidentActivityFeed({
   // the last node's offset depends on every entry above it.
   const [railHeight, setRailHeight] = useState<number>();
 
-  const ctx = awaiting?.ctx ?? {};
+  const ctx = evidenceContext ?? awaiting?.ctx ?? {};
   // The question is sourced only from the current run state, appended as the
   // terminal node so a paused run ends on what it needs from the human.
   const base = buildActivityFeed(events, { triggeringIssue });
@@ -74,7 +77,7 @@ export function IncidentActivityFeed({
     if (item.type === "human") return <HumanEntry key={item.id} item={item} />;
     if (item.type === "telemetry") return <TelemetryEntry key={item.id} item={item} />;
     if (item.type === "memory") return <MemoryEntry key={item.id} item={item} />;
-    if (item.type === "tool") return <ToolEntry key={item.id} item={item} />;
+    if (item.type === "tool") return <ToolEntry key={item.id} item={item} ctx={ctx} />;
     if (item.type === "mcp_error") return <McpErrorEntry key={item.id} item={item} />;
     if (item.type === "start") return <StartEntry key={item.id} />;
     if (item.type === "question")
@@ -648,8 +651,15 @@ function MetricWidget({
 
 const EDIT_TOOLS = new Set(["edit", "write", "multi_edit", "str_replace_editor"]);
 
-function ToolEntry({ item }: { item: Extract<TranscriptItem, { type: "tool" }> }) {
+function ToolEntry({
+  item,
+  ctx,
+}: {
+  item: Extract<TranscriptItem, { type: "tool" }>;
+  ctx: EvidenceLinkContext;
+}) {
   const isEdit = EDIT_TOOLS.has(item.name);
+  const outcomePresentation = OUTCOME_RECORD_PRESENTATION[item.name];
   return (
     <div className="relative mb-6">
       <Node>
@@ -662,7 +672,157 @@ function ToolEntry({ item }: { item: Extract<TranscriptItem, { type: "tool" }> }
           </>
         )}
       </Node>
-      {isEdit ? <EditEntry item={item} /> : <CodeEntry item={item} />}
+      {isEdit ? (
+        <EditEntry item={item} />
+      ) : outcomePresentation ? (
+        <OutcomeRecordEntry item={item} ctx={ctx} presentation={outcomePresentation} />
+      ) : (
+        <CodeEntry item={item} />
+      )}
+    </div>
+  );
+}
+
+type OutcomeRecordField = {
+  key: string;
+  label: string;
+  sourceKeys?: string[];
+  read?: (input: Record<string, unknown>) => unknown;
+};
+
+type OutcomeRecordPresentation = {
+  title: string;
+  fields: OutcomeRecordField[];
+};
+
+const OUTCOME_RECORD_PRESENTATION: Record<string, OutcomeRecordPresentation> = {
+  report_findings: {
+    title: "Reported findings",
+    fields: [
+      { key: "summary", label: "Summary" },
+      { key: "proposedTitle", label: "Proposed title" },
+      { key: "rootCause", label: "Root cause" },
+      { key: "rootCauseConfidence", label: "Root cause confidence" },
+      { key: "estimatedImpact", label: "Estimated impact" },
+      { key: "impactConfidence", label: "Impact confidence" },
+      { key: "severity", label: "Severity" },
+      { key: "handoffNotes", label: "Handoff notes" },
+    ],
+  },
+  silence_as_noise: {
+    title: "Silenced as noise",
+    fields: [
+      { key: "issueId", label: "Issue" },
+      { key: "reason", label: "Reasoning" },
+      { key: "evidence", label: "Evidence" },
+    ],
+  },
+  place_under_observation: {
+    title: "Placed under observation",
+    fields: [
+      { key: "issueId", label: "Issue" },
+      { key: "reason", label: "Reasoning" },
+      { key: "evidence", label: "Evidence" },
+      {
+        key: "escalationTrigger",
+        label: "Escalation trigger",
+        sourceKeys: ["escalateOn", "threshold"],
+        read: formatEscalationTrigger,
+      },
+    ],
+  },
+  resolve_incident: {
+    title: "Resolved incident",
+    fields: [
+      { key: "reason", label: "Reasoning" },
+      { key: "evidence", label: "Evidence" },
+    ],
+  },
+};
+
+function humanizeFieldName(key: string): string {
+  const words = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .toLowerCase();
+  return words ? words.charAt(0).toUpperCase() + words.slice(1) : key;
+}
+
+function formatEscalationTrigger(input: Record<string, unknown>): string | null {
+  const threshold = input.threshold;
+  if (typeof threshold !== "number" || !Number.isFinite(threshold)) return null;
+  const events = threshold === 1 ? "event" : "events";
+  if (input.escalateOn === "events_per_minute") {
+    return `${threshold} ${events} per minute (trailing 5-minute average)`;
+  }
+  if (input.escalateOn === "additional_events") {
+    return `${threshold} additional ${events}`;
+  }
+  return null;
+}
+
+function outcomeRecordFields(
+  item: Extract<TranscriptItem, { type: "tool" }>,
+  presentation: OutcomeRecordPresentation,
+) {
+  const knownKeys = new Set(
+    presentation.fields.flatMap((field) => [field.key, ...(field.sourceKeys ?? [])]),
+  );
+  const fields: OutcomeRecordField[] = [
+    ...presentation.fields,
+    ...Object.keys(item.input)
+      .filter((key) => !knownKeys.has(key))
+      .map((key) => ({ key, label: humanizeFieldName(key) })),
+  ];
+  return fields.flatMap((field) => {
+    const value = field.read?.(item.input) ?? item.input[field.key];
+    if (value == null || value === "") return [];
+    return [{ ...field, value }];
+  });
+}
+
+function OutcomeRecordEntry({
+  item,
+  ctx,
+  presentation,
+}: {
+  item: Extract<TranscriptItem, { type: "tool" }>;
+  ctx: EvidenceLinkContext;
+  presentation: OutcomeRecordPresentation;
+}) {
+  const fields = outcomeRecordFields(item, presentation);
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-surface">
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-3.5 py-2.5">
+        <span className="text-[12px] font-semibold text-fg">{presentation.title}</span>
+        <span className="font-mono text-[11px] text-subtle">{item.name}</span>
+        {item.isError && <Chip tone="danger">failed</Chip>}
+      </div>
+      <div className="divide-y divide-border">
+        {fields.map(({ key, label, value }) => (
+          <div key={key} className="grid gap-1.5 px-3.5 py-3 sm:grid-cols-[150px_minmax(0,1fr)]">
+            <div className="text-[11px] font-medium text-muted">{label}</div>
+            <div className="min-w-0">
+              {typeof value === "string" ? (
+                <EvidenceMarkdown text={value} ctx={ctx} />
+              ) : (
+                <span className="whitespace-pre-wrap break-words text-[12.5px] leading-relaxed text-fg">
+                  {typeof value === "object" ? JSON.stringify(value, null, 2) : String(value)}
+                </span>
+              )}
+            </div>
+          </div>
+        ))}
+        {item.isError && item.result && (
+          <div className="grid gap-1.5 px-3.5 py-3 sm:grid-cols-[150px_minmax(0,1fr)]">
+            <div className="text-[11px] font-medium text-muted">Result</div>
+            <div className="whitespace-pre-wrap break-words font-mono text-[11.5px] leading-relaxed text-danger">
+              {item.result}
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/incidents/IncidentTranscriptOutcome.test.tsx
+++ b/apps/web/src/incidents/IncidentTranscriptOutcome.test.tsx
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { IncidentEvent } from "../api.ts";
+import { IncidentActivityFeed } from "./IncidentTranscript.tsx";
+
+function outcomeToolEvent(id: string, name: string, input: Record<string, unknown>): IncidentEvent {
+  return {
+    id,
+    agentRunId: "run-1",
+    kind: "agent.custom_tool_use",
+    summary: null,
+    detail: { toolUse: { name, input } },
+    createdAt: "2026-07-14T16:11:22.000Z",
+  };
+}
+
+test("outcome records show every recorded finding, reason, and piece of evidence", () => {
+  const html = renderToStaticMarkup(
+    <IncidentActivityFeed
+      events={[
+        outcomeToolEvent("findings", "report_findings", {
+          summary: "SiteWatch customer creation emits a false-positive error.",
+          proposedTitle: "SiteWatch setup is reported as an error",
+          rootCause:
+            "The client returns the created organization before the error span is emitted.",
+          rootCauseConfidence: 9,
+          estimatedImpact: "Organization setup still completes successfully.",
+          impactConfidence: 8,
+          severity: "SEV-3",
+          handoffNotes: "Verified the create path and ruled out a failed write.",
+        }),
+        outcomeToolEvent("silence", "silence_as_noise", {
+          issueId: "issue-1",
+          reason: "The operation succeeds and only the diagnostic span is wrong.",
+          evidence: "The organization is returned with its persisted SiteWatch configuration.",
+        }),
+        outcomeToolEvent("resolve", "resolve_incident", {
+          reason: "Every linked issue is classified and there is no customer impact.",
+          evidence: "The successful response and persisted configuration prove setup completed.",
+        }),
+      ]}
+    />,
+  );
+
+  assert.match(html, /Reported findings/);
+  assert.match(html, /SiteWatch customer creation emits a false-positive error\./);
+  assert.match(html, /SiteWatch setup is reported as an error/);
+  assert.match(html, /The client returns the created organization/);
+  assert.match(html, /Root cause confidence/);
+  assert.match(html, />9</);
+  assert.match(html, /Organization setup still completes successfully\./);
+  assert.match(html, /Impact confidence/);
+  assert.match(html, />8</);
+  assert.match(html, /SEV-3/);
+  assert.match(html, /Verified the create path and ruled out a failed write\./);
+
+  assert.match(html, /Silenced as noise/);
+  assert.match(html, /The operation succeeds and only the diagnostic span is wrong\./);
+  assert.match(html, /The organization is returned with its persisted SiteWatch configuration\./);
+
+  assert.match(html, /Resolved incident/);
+  assert.match(html, /Every linked issue is classified and there is no customer impact\./);
+  assert.match(html, /The successful response and persisted configuration prove setup completed\./);
+});
+
+test("observation records show the escalation trigger in operator language", () => {
+  const html = renderToStaticMarkup(
+    <IncidentActivityFeed
+      events={[
+        outcomeToolEvent("observe", "place_under_observation", {
+          issueId: "issue-2",
+          reason: "The failure was isolated, but the safe baseline is not established yet.",
+          evidence: "Only one event occurred during the inspected six-hour window.",
+          escalateOn: "events_per_minute",
+          threshold: 5,
+        }),
+        outcomeToolEvent("observe-count", "place_under_observation", {
+          issueId: "issue-3",
+          reason: "Recurrence should reopen the investigation.",
+          evidence: "The issue is currently quiet after a single transient failure.",
+          escalateOn: "additional_events",
+          threshold: 20,
+        }),
+      ]}
+    />,
+  );
+
+  assert.match(html, /Placed under observation/);
+  assert.match(html, /The failure was isolated, but the safe baseline is not established yet\./);
+  assert.match(html, /Only one event occurred during the inspected six-hour window\./);
+  assert.match(html, /Escalation trigger/);
+  assert.match(html, /5 events per minute/);
+  assert.match(html, /20 additional events/);
+  assert.doesNotMatch(html, /events_per_minute/);
+});

--- a/apps/web/src/incidents/IncidentTranscriptOutcome.test.tsx
+++ b/apps/web/src/incidents/IncidentTranscriptOutcome.test.tsx
@@ -94,3 +94,49 @@ test("observation records show the escalation trigger in operator language", () 
   assert.match(html, /20 additional events/);
   assert.doesNotMatch(html, /events_per_minute/);
 });
+
+test("memory list records show every returned memory in full", () => {
+  const listEvent = {
+    ...outcomeToolEvent("list-memories", "list_memories", {}),
+    providerEventId: "provider-list-memories",
+  };
+  const resultEvent: IncidentEvent = {
+    id: "list-memories-result",
+    agentRunId: "run-1",
+    kind: "user.custom_tool_result",
+    summary: JSON.stringify({
+      memories: [
+        {
+          id: "memory-1",
+          kind: "terminology",
+          title: "SiteWatch customer",
+          body: "A SiteWatch customer is the organization-level monitoring configuration.",
+        },
+        {
+          id: "memory-2",
+          kind: "infra",
+          title: "SiteWatch verification",
+          body: "Verification retries once before falling back to the last valid configuration.",
+        },
+      ],
+    }),
+    detail: { toolResult: { toolUseId: "provider-list-memories", isError: false } },
+    createdAt: "2026-07-14T16:11:23.000Z",
+  };
+
+  const html = renderToStaticMarkup(<IncidentActivityFeed events={[listEvent, resultEvent]} />);
+
+  assert.match(html, /Listed memories/);
+  assert.match(html, /2 memories/);
+  assert.match(html, /memory-1/);
+  assert.match(html, /terminology/);
+  assert.match(html, /SiteWatch customer/);
+  assert.match(html, /A SiteWatch customer is the organization-level monitoring configuration\./);
+  assert.match(html, /memory-2/);
+  assert.match(html, /infra/);
+  assert.match(html, /SiteWatch verification/);
+  assert.match(
+    html,
+    /Verification retries once before falling back to the last valid configuration\./,
+  );
+});

--- a/apps/web/src/incidents/IncidentTranscriptOutcome.test.tsx
+++ b/apps/web/src/incidents/IncidentTranscriptOutcome.test.tsx
@@ -95,6 +95,25 @@ test("observation records show the escalation trigger in operator language", () 
   assert.doesNotMatch(html, /events_per_minute/);
 });
 
+test("resolved issue records show the recorded reasoning and evidence", () => {
+  const html = renderToStaticMarkup(
+    <IncidentActivityFeed
+      events={[
+        outcomeToolEvent("resolve-issue", "resolve_issue", {
+          issueId: "issue-4",
+          reason: "The deployed retry guard removed the failing path.",
+          evidence: "No failures occurred in 2,400 requests after deployment.",
+        }),
+      ]}
+    />,
+  );
+
+  assert.match(html, /Resolved issue/);
+  assert.match(html, /issue-4/);
+  assert.match(html, /The deployed retry guard removed the failing path\./);
+  assert.match(html, /No failures occurred in 2,400 requests after deployment\./);
+});
+
 test("memory list records show every returned memory in full", () => {
   const listEvent = {
     ...outcomeToolEvent("list-memories", "list_memories", {}),


### PR DESCRIPTION
## Summary

- render investigation outcome calls as structured activity records instead of terse tool-name rows
- show all recorded findings, reasoning, evidence, confidence, severity, and handoff fields
- show observation escalation thresholds in operator-friendly language for rate and count triggers
- render every returned project memory as an unclamped structured record
- preserve repository context so markdown evidence citations remain linkable

## Why

The incident activity feed retained full outcome and memory payloads, but its generic tool renderer displayed only terse tool names and truncated JSON previews. Operators could not inspect the reasoning or evidence behind decisions or read every memory returned to the investigation.

## Validation

- focused incident transcript and issue detail tests (21 passing)
- production web build
- diff whitespace validation
