### PR TITLE
Group recurring issues before incident creation

### DIFF
--- a/apps/worker/src/incident-intake.ts
+++ b/apps/worker/src/incident-intake.ts
@@ -55,10 +55,10 @@ export async function ensureIncidentForIssue(
     // Serialize the workflow's read-then-create section with an advisory lock so
     // concurrent intakes (pg-boss issue-transition jobs) can't each open an
     // incident for what should be one. The workflow keys new issues by trace id
-    // when present, otherwise by issue id; recurrences key by predecessor id so
-    // all fingerprints from the prior incident converge on one successor. The
-    // LLM grouping call stays outside the hook; notifications happen in the
-    // caller after release.
+    // when present, otherwise by issue id; recurrences acquire both predecessor
+    // and trace keys when available so overlapping correlation boundaries all
+    // converge. The LLM grouping call stays outside the hook; notifications
+    // happen in the caller after release.
     serializeCreate: withIssueIntakeLock,
   });
 }

--- a/apps/worker/src/incident-intake.ts
+++ b/apps/worker/src/incident-intake.ts
@@ -12,9 +12,11 @@ import {
   findLatestIncidentIssueLink,
   findOpenIncidentCandidates,
   findOpenIncidentForAlert,
+  findOpenRecurrenceForIncident,
   findProject,
   linkIssueToIncident,
   loadLinkedIncidentIssues,
+  reopenIssue,
   touchIncidentLastSeen,
   updateIssueGrouping,
   withIssueIntakeLock,
@@ -35,6 +37,8 @@ export async function ensureIncidentForIssue(
     repo: {
       findLatestIncidentIssueLink,
       findIncident,
+      findOpenRecurrenceForIncident,
+      reopenIssue,
       findAlertEpisodeForIssue,
       findOpenIncidentForAlert,
       findLatestIncidentForAlert,
@@ -50,13 +54,11 @@ export async function ensureIncidentForIssue(
     logger,
     // Serialize the workflow's read-then-create section with an advisory lock so
     // concurrent intakes (pg-boss issue-transition jobs) can't each open an
-    // incident for what should be one. The workflow keys the lock by trace id
-    // when present — same-request symptoms (a span exception and its own log
-    // line) are DIFFERENT issues, so a per-issue lock wouldn't serialize them —
-    // and re-checks the same-trace match inside the lock so the loser re-lands on
-    // the winner's incident. Falls back to the issue id (the alert-episode case:
-    // racing evaluations fold into one episode issue). The LLM grouping call
-    // stays outside the hook; notifications happen in the caller after release.
+    // incident for what should be one. The workflow keys new issues by trace id
+    // when present, otherwise by issue id; recurrences key by predecessor id so
+    // all fingerprints from the prior incident converge on one successor. The
+    // LLM grouping call stays outside the hook; notifications happen in the
+    // caller after release.
     serializeCreate: withIssueIntakeLock,
   });
 }

--- a/apps/worker/src/incidents/intake.test.ts
+++ b/apps/worker/src/incidents/intake.test.ts
@@ -324,12 +324,21 @@ test("intake: recurred same-trace sibling joins the incident instead of opening 
       lastSample: { traceId: "trace-1", spanId: "span-log" },
     } as Partial<schema.Issue>),
     "recurred",
-    makeDeps({ repo, lifecycle: makeLifecycle({ calls }), calls }),
+    makeDeps({
+      repo,
+      lifecycle: makeLifecycle({ calls }),
+      calls,
+      serializeCreate: async (keys, fn) => {
+        calls.push(`serializeCreate:${String(keys)}`);
+        return fn();
+      },
+    }),
   );
 
   assert.equal(result.createdIncident, false);
   assert.equal(result.recurrenceIncident, false);
   assert.equal(result.incident.id, "inc-sibling");
+  assert.ok(calls.includes("serializeCreate:recurrence:inc-prev,trace:trace-1"));
   assert.ok(calls.includes("linkIssueToIncident:iss-log->inc-sibling"));
   assert.ok(!calls.some((c) => c.startsWith("openRecurrence")));
 });

--- a/apps/worker/src/incidents/intake.test.ts
+++ b/apps/worker/src/incidents/intake.test.ts
@@ -90,6 +90,13 @@ function makeRepo(opts: {
       opts.calls.push(`findIncident:${incidentId}`);
       return incidentById.get(incidentId);
     },
+    async findOpenRecurrenceForIncident(previousIncidentId) {
+      opts.calls.push(`findOpenRecurrenceForIncident:${previousIncidentId}`);
+      return undefined;
+    },
+    async reopenIssue(issueId) {
+      opts.calls.push(`reopenIssue:${issueId}`);
+    },
     async findOpenIncidentCandidates(_issue, queryOpts) {
       opts.calls.push(`findOpenIncidentCandidates:${queryOpts.filterService}`);
       return queryOpts.filterService
@@ -208,8 +215,70 @@ test("intake: recurred issue opens a new incident chained to its previous one", 
   assert.equal(result.incident.previousIncidentId, "inc-prev");
   assert.ok(calls.includes("openRecurrence:inc-prev<-iss-new:resolved_issue_recurred"));
   assert.ok(
-    calls.some((c) => c.startsWith("updateIssueGrouping:iss-new:standalone:heuristic:Recurrence")),
+    calls.some((c) =>
+      c.startsWith(
+        "updateIssueGrouping:iss-new:standalone:heuristic:No open incidents in this project.",
+      ),
+    ),
   );
+});
+
+test("intake: recurred issue goes through grouping and joins an existing incident", async () => {
+  const calls: string[] = [];
+  const previous = makeIncident({ id: "inc-prev", status: "resolved" });
+  const candidate = makeIncident({ id: "inc-current", title: "Recall credits exhausted" });
+  const repo = makeRepo({
+    calls,
+    existingLink: { issueId: "iss-new", incidentId: "inc-prev" },
+    incidentById: new Map([
+      ["inc-prev", previous],
+      ["inc-current", candidate],
+    ]),
+    openCandidates: { withService: [], withoutService: [candidate] },
+    project: { id: "proj-1", orgId: "org-1", name: "Production" } as schema.Project,
+  });
+  repo.loadLinkedIncidentIssues = async (incidents) =>
+    incidents.map((incident) => ({
+      incidentId: incident.id,
+      title: incident.title,
+      exceptionType: "ERROR",
+      message: "Recall.ai returned insufficient_credit_balance",
+      topFrame: null,
+      normalizedFrames: [],
+      lastSample: null,
+      lastSeen: NOW,
+    }));
+
+  const result = await ensureIncidentForIssueWorkflow(
+    makeIssue({
+      kind: "log",
+      status: "resolved",
+      normalizedFrames: [],
+      lastSample: null,
+    } as Partial<schema.Issue>),
+    "recurred",
+    makeDeps({
+      repo,
+      lifecycle: makeLifecycle({ calls }),
+      calls,
+      analyzeGrouping: async () => {
+        calls.push("analyzeGrouping");
+        return {
+          decision: "join",
+          incidentId: "inc-current",
+          evidence: "Both failures come from the same exhausted Recall.ai credit balance.",
+        };
+      },
+    }),
+  );
+
+  assert.equal(result.createdIncident, false);
+  assert.equal(result.recurrenceIncident, false);
+  assert.equal(result.incident.id, "inc-current");
+  assert.ok(calls.includes("analyzeGrouping"));
+  assert.ok(calls.includes("linkIssueToIncident:iss-new->inc-current"));
+  assert.ok(calls.includes("reopenIssue:iss-new"));
+  assert.ok(!calls.some((call) => call.startsWith("openRecurrence:")));
 });
 
 test("intake: recurred same-trace sibling joins the incident instead of opening a recurrence", async () => {
@@ -266,9 +335,9 @@ test("intake: recurred same-trace sibling joins the incident instead of opening 
 });
 
 test("intake: recurred no-trace issue re-lands on a recurrence a racer opened inside the lock", async () => {
-  // No trace id, so the lock is keyed by issue id. Outside the lock the previous
-  // incident is still resolved; by the time we hold the lock a concurrent
-  // recurrence job has opened it. We must re-read and re-land, not open a second.
+  // Outside the lock the previous incident is still resolved; by the time we
+  // hold the predecessor-keyed lock a concurrent recurrence job has opened it.
+  // We must re-read and re-land, not open a second.
   const calls: string[] = [];
   const resolved = makeIncident({ id: "inc-prev", status: "resolved" });
   const openedByRacer = makeIncident({ id: "inc-prev", status: "open" });
@@ -295,6 +364,56 @@ test("intake: recurred no-trace issue re-lands on a recurrence a racer opened in
   assert.equal(result.recurrenceIncident, false);
   assert.equal(result.incident.id, "inc-prev");
   assert.ok(!calls.some((c) => c.startsWith("openRecurrence")));
+});
+
+test("intake: no-trace recurrences from the same predecessor converge on one incident", async () => {
+  const calls: string[] = [];
+  const previous = makeIncident({ id: "inc-prev", status: "resolved" });
+  const siblingRecurrence = makeIncident({
+    id: "inc-sibling-recurrence",
+    previousIncidentId: "inc-prev",
+  });
+  const base = makeRepo({
+    calls,
+    existingLink: { issueId: "iss-new", incidentId: "inc-prev" },
+    incidentById: new Map([
+      ["inc-prev", previous],
+      ["inc-sibling-recurrence", siblingRecurrence],
+    ]),
+  });
+  const repo = {
+    ...base,
+    async findOpenRecurrenceForIncident(previousIncidentId: string) {
+      calls.push(`findOpenRecurrenceForIncident:${previousIncidentId}`);
+      return siblingRecurrence;
+    },
+  } as IntakeRepository;
+
+  const result = await ensureIncidentForIssueWorkflow(
+    makeIssue({
+      id: "iss-new",
+      kind: "log",
+      status: "resolved",
+      normalizedFrames: [],
+      lastSample: null,
+    } as Partial<schema.Issue>),
+    "recurred",
+    makeDeps({
+      repo,
+      lifecycle: makeLifecycle({ calls }),
+      calls,
+      serializeCreate: async (key, fn) => {
+        calls.push(`serializeCreate:${key}`);
+        return fn();
+      },
+    }),
+  );
+
+  assert.equal(result.createdIncident, false);
+  assert.equal(result.recurrenceIncident, false);
+  assert.equal(result.incident.id, "inc-sibling-recurrence");
+  assert.ok(calls.includes("linkIssueToIncident:iss-new->inc-sibling-recurrence"));
+  assert.ok(!calls.some((call) => call.startsWith("openRecurrence:")));
 });
 
 test("intake: recurred issue whose latest link is already open reuses it (retry idempotency)", async () => {
@@ -589,7 +708,9 @@ test("intake: first-ever alert episode goes through LLM grouping like an error",
   );
   assert.equal(result.createdIncident, false);
   assert.equal(result.incident.id, "inc-error");
-  assert.ok(calls.some((c) => c.startsWith("updateIssueGrouping(undecided-only):iss-new:pending:llm")));
+  assert.ok(
+    calls.some((c) => c.startsWith("updateIssueGrouping(undecided-only):iss-new:pending:llm")),
+  );
   assert.ok(calls.includes("linkIssueToIncident:iss-new->inc-error"));
 });
 

--- a/apps/worker/src/incidents/intake.ts
+++ b/apps/worker/src/incidents/intake.ts
@@ -114,7 +114,7 @@ export type IntakeDeps = {
   // first, so the racer that lost the lock re-lands on the winner's incident.
   // Deliberately excludes the LLM grouping call — implementations may hold a
   // database connection for fn's whole duration.
-  serializeCreate?: <T>(key: string, fn: () => Promise<T>) => Promise<T>;
+  serializeCreate?: <T>(keys: readonly string[], fn: () => Promise<T>) => Promise<T>;
 };
 
 export type IssueIntakeTransition = "new" | "recurred" | "escalated";
@@ -144,10 +144,10 @@ export async function ensureIncidentForIssueWorkflow(
   // exception and its own log line, which are DIFFERENT issues — can't each open
   // an incident under concurrent pg-boss jobs. Falls back to the issue id (the
   // alert-episode / same-issue case). Recurrences use their predecessor id
-  // instead, so concurrent fingerprints from one prior incident converge.
+  // in addition, so both same-request and same-predecessor symptoms converge.
   const traceId = issueSample(issue)?.traceId;
-  const serializeKey = traceId ? `trace:${traceId}` : issue.id;
-  const serialize = deps.serializeCreate ?? ((_key, fn) => fn());
+  const serializeKeys = traceId ? [`trace:${traceId}`] : [issue.id];
+  const serialize = deps.serializeCreate ?? ((_keys, fn) => fn());
 
   const existingLink = await deps.repo.findLatestIncidentIssueLink(issue.id);
 
@@ -171,7 +171,11 @@ export async function ensureIncidentForIssueWorkflow(
       // potentially slow LLM call stays outside the serialized section.
       let grouping = await findMatchingIncident(issue, deps);
       let matched = grouping.match?.incident ?? null;
-      return serialize(`recurrence:${previous.id}`, async () => {
+      const recurrenceKeys = [
+        `recurrence:${previous.id}`,
+        ...(traceId ? [`trace:${traceId}`] : []),
+      ];
+      return serialize(recurrenceKeys, async () => {
         // Re-read the latest link now that we hold the lock: a concurrent
         // recurrence job for this same issue may have already opened the
         // recurrence incident — re-land on it instead of opening a second, and
@@ -295,7 +299,7 @@ export async function ensureIncidentForIssueWorkflow(
   // link re-checks inside, so a racer that created the incident first wins and
   // the loser re-lands on it. The grouping analysis (which can call an LLM)
   // stays outside the hook.
-  return serialize(serializeKey, async () => {
+  return serialize(serializeKeys, async () => {
     const raceLink = await deps.repo.findLatestIncidentIssueLink(issue.id);
     if (raceLink) {
       const existing = await deps.repo.findIncident(raceLink.incidentId);

--- a/apps/worker/src/incidents/intake.ts
+++ b/apps/worker/src/incidents/intake.ts
@@ -35,6 +35,8 @@ export type IntakeRepository = {
   // driven over its life, so the latest link is its current incident.
   findLatestIncidentIssueLink(issueId: string): Promise<schema.IncidentIssue | undefined>;
   findIncident(incidentId: string): Promise<schema.Incident | undefined>;
+  findOpenRecurrenceForIncident(previousIncidentId: string): Promise<schema.Incident | undefined>;
+  reopenIssue(issueId: string): Promise<void>;
   touchIncidentLastSeen(incidentId: string, lastSeen: Date): Promise<void>;
   // The episode an alert-episode issue is 1:1 with — carries the alert
   // identity (alertId + groupKey) that fingerprints no longer encode.
@@ -105,14 +107,14 @@ export type IntakeDeps = {
   lifecycle: IntakeLifecycle;
   analyzeGrouping: GroupingDecider;
   logger: IntakeLogger;
-  // Optional mutual-exclusion hook around the workflow's one read-then-create
+  // Optional mutual-exclusion hook around the workflow's read-then-create
   // section (deciding on + creating/linking the incident, AFTER grouping
   // analysis). Wired for alert-episode issues, where concurrent duplicates of
   // the same issue can reach intake together. fn re-checks the issue's link
   // first, so the racer that lost the lock re-lands on the winner's incident.
   // Deliberately excludes the LLM grouping call — implementations may hold a
   // database connection for fn's whole duration.
-  serializeCreate?: <T>(issueId: string, fn: () => Promise<T>) => Promise<T>;
+  serializeCreate?: <T>(key: string, fn: () => Promise<T>) => Promise<T>;
 };
 
 export type IssueIntakeTransition = "new" | "recurred" | "escalated";
@@ -141,8 +143,8 @@ export async function ensureIncidentForIssueWorkflow(
   // Serialize intake by trace id when present, so same-request symptoms — a span
   // exception and its own log line, which are DIFFERENT issues — can't each open
   // an incident under concurrent pg-boss jobs. Falls back to the issue id (the
-  // alert-episode / same-issue case). Used by both the recurrence path below and
-  // the create path at the tail.
+  // alert-episode / same-issue case). Recurrences use their predecessor id
+  // instead, so concurrent fingerprints from one prior incident converge.
   const traceId = issueSample(issue)?.traceId;
   const serializeKey = traceId ? `trace:${traceId}` : issue.id;
   const serialize = deps.serializeCreate ?? ((_key, fn) => fn());
@@ -155,6 +157,7 @@ export async function ensureIncidentForIssueWorkflow(
       // Retry-idempotency: if a prior attempt already opened the recurrence
       // incident, the latest link points at an open incident — reuse it.
       if (previous.status === "open") {
+        await deps.repo.reopenIssue(issue.id);
         return {
           incident: previous,
           createdIncident: false,
@@ -163,21 +166,22 @@ export async function ensureIncidentForIssueWorkflow(
         };
       }
       // A recurrence opens a NEW incident chained to its predecessor — but if a
-      // sibling symptom of the SAME request has already opened (or recurred)
-      // an incident, join that instead so a span exception and its own log line
-      // don't recur into separate incidents. Serialize on the trace and
-      // re-check inside the lock so concurrent sibling recurrences converge.
-      return serialize(serializeKey, async () => {
+      // related issue already has an open incident, run the same grouping
+      // pipeline as a first occurrence and join that incident instead. The
+      // potentially slow LLM call stays outside the serialized section.
+      let grouping = await findMatchingIncident(issue, deps);
+      let matched = grouping.match?.incident ?? null;
+      return serialize(`recurrence:${previous.id}`, async () => {
         // Re-read the latest link now that we hold the lock: a concurrent
         // recurrence job for this same issue may have already opened the
-        // recurrence incident (this matters for no-trace issues, where the lock
-        // is keyed by issue id) — re-land on it instead of opening a second, and
+        // recurrence incident — re-land on it instead of opening a second, and
         // don't let the same-trace lookup below match the issue's own fresh
         // incident. Mirrors the tail create path's `raceLink` re-check.
         const raceLink = await deps.repo.findLatestIncidentIssueLink(issue.id);
         if (raceLink) {
           const landed = await deps.repo.findIncident(raceLink.incidentId);
           if (landed?.status === "open") {
+            await deps.repo.reopenIssue(issue.id);
             return {
               incident: landed,
               createdIncident: false,
@@ -186,26 +190,51 @@ export async function ensureIncidentForIssueWorkflow(
             };
           }
         }
-        if (traceId) {
+        // The grouping decision ran before acquiring the lock. A sibling
+        // recurrence may have opened an incident while this issue was being
+        // analysed, so converge on that successor before trusting a stale
+        // standalone verdict. Recurrences of one predecessor share the same
+        // lock key, making this deterministic even when neither log has trace
+        // context.
+        if (!matched) {
+          const openRecurrence = await deps.repo.findOpenRecurrenceForIncident(previous.id);
+          if (openRecurrence) {
+            grouping = {
+              match: {
+                incident: openRecurrence,
+                source: "heuristic",
+                reason: "Joined the open recurrence of the same previous incident.",
+              },
+              standaloneSource: null,
+              standaloneReason: null,
+              failedReason: null,
+            };
+            matched = openRecurrence;
+          }
+        }
+        if (!matched && traceId) {
           const sameTrace = await findSameTraceMatchingIncident(issue, deps);
           if (sameTrace) {
-            const linkedIssue = await deps.repo.linkIssueToIncident({
-              incident: sameTrace.incident,
-              issue,
-            });
-            await deps.repo.updateIssueGrouping(issue.id, {
-              state: "grouped",
-              source: "heuristic",
-              reason: sameTrace.reason,
-            });
-            const fresh = (await deps.repo.findIncident(sameTrace.incident.id)) ?? sameTrace.incident;
-            return {
-              incident: fresh,
-              createdIncident: false,
-              linkedIssue,
-              recurrenceIncident: false,
+            grouping = {
+              match: sameTrace,
+              standaloneSource: null,
+              standaloneReason: null,
+              failedReason: null,
             };
+            matched = sameTrace.incident;
           }
+        }
+        if (matched) {
+          const linkedIssue = await deps.repo.linkIssueToIncident({ incident: matched, issue });
+          await deps.repo.reopenIssue(issue.id);
+          await markIssueGrouping(issue.id, grouping, deps.repo);
+          const fresh = (await deps.repo.findIncident(matched.id)) ?? matched;
+          return {
+            incident: fresh,
+            createdIncident: false,
+            linkedIssue,
+            recurrenceIncident: false,
+          };
         }
         const incident = await deps.lifecycle.openRecurrence({
           previousIncident: previous,
@@ -213,14 +242,7 @@ export async function ensureIncidentForIssueWorkflow(
           origin: transition === "escalated" ? "escalation_trigger" : "resolved_issue_recurred",
           environment: environmentFromResourceAttrs(issue.lastSample?.resourceAttrs),
         });
-        await deps.repo.updateIssueGrouping(issue.id, {
-          state: "standalone",
-          source: "heuristic",
-          reason:
-            transition === "escalated"
-              ? "Escalation trigger fired for an observed issue; chained to its previous incident."
-              : "Recurrence of a resolved issue; chained to its previous incident.",
-        });
+        await markIssueGrouping(issue.id, grouping, deps.repo);
         return { incident, createdIncident: true, linkedIssue: true, recurrenceIncident: true };
       });
     }
@@ -304,7 +326,12 @@ export async function ensureIncidentForIssueWorkflow(
     if (!matched) {
       const sameTrace = await findSameTraceMatchingIncident(issue, deps);
       if (sameTrace) {
-        grouping = { match: sameTrace, standaloneSource: null, standaloneReason: null, failedReason: null };
+        grouping = {
+          match: sameTrace,
+          standaloneSource: null,
+          standaloneReason: null,
+          failedReason: null,
+        };
         matched = sameTrace.incident;
       }
     }

--- a/apps/worker/src/issues/repository.ts
+++ b/apps/worker/src/issues/repository.ts
@@ -1,4 +1,4 @@
-import { type DB, db, schema } from "@superlog/db";
+import { type DB, buildIssueReopenPatch, db, schema } from "@superlog/db";
 import { and, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import type { IssueGroupingSource, IssueGroupingState, LinkedIncidentIssue } from "./domain.js";
 
@@ -139,6 +139,25 @@ export async function findIncident(incidentId: string): Promise<schema.Incident 
   });
 }
 
+// A resolved incident can have several issue fingerprints recur at once. They
+// all belong to one successor investigation, so intake reuses the newest open
+// successor instead of opening one recurrence per fingerprint.
+export async function findOpenRecurrenceForIncident(
+  previousIncidentId: string,
+): Promise<schema.Incident | undefined> {
+  return db.query.incidents.findFirst({
+    where: and(
+      eq(schema.incidents.previousIncidentId, previousIncidentId),
+      eq(schema.incidents.status, "open"),
+    ),
+    orderBy: [desc(schema.incidents.createdAt)],
+  });
+}
+
+export async function reopenIssue(issueId: string): Promise<void> {
+  await db.update(schema.issues).set(buildIssueReopenPatch()).where(eq(schema.issues.id, issueId));
+}
+
 // The episode an alert-episode issue is 1:1 with (alert_episodes_issue_uniq
 // enforces the 1:1). Carries the alert identity used for same-alert grouping.
 export async function findAlertEpisodeForIssue(
@@ -149,17 +168,15 @@ export async function findAlertEpisodeForIssue(
   });
 }
 
-// Serialize incident intake for one issue across concurrent worker tasks.
-// Intake's existing-link check is read-then-create, so two racers processing
-// the same issue (e.g. duplicate alert evaluations folding into one episode
-// issue) could each open an incident. The advisory xact lock (released at
-// commit/rollback) makes the second racer wait until the first's intake has
-// committed its incident link, so it re-lands on that link instead. Callers
+// Serialize incident intake across concurrent worker tasks. The key represents
+// the correlation boundary chosen by the application workflow: issue, trace,
+// or predecessor incident. The advisory xact lock (released at commit/rollback)
+// makes later racers observe the incident/link created by the winner. Callers
 // keep notifications and other slow side effects OUTSIDE fn — the lock holds a
 // database connection open for fn's whole duration.
-export async function withIssueIntakeLock<T>(issueId: string, fn: () => Promise<T>): Promise<T> {
+export async function withIssueIntakeLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
   return db.transaction(async (tx) => {
-    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${issueId}, 0))`);
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0))`);
     return fn();
   });
 }

--- a/apps/worker/src/issues/repository.ts
+++ b/apps/worker/src/issues/repository.ts
@@ -168,15 +168,21 @@ export async function findAlertEpisodeForIssue(
   });
 }
 
-// Serialize incident intake across concurrent worker tasks. The key represents
-// the correlation boundary chosen by the application workflow: issue, trace,
-// or predecessor incident. The advisory xact lock (released at commit/rollback)
-// makes later racers observe the incident/link created by the winner. Callers
-// keep notifications and other slow side effects OUTSIDE fn — the lock holds a
-// database connection open for fn's whole duration.
-export async function withIssueIntakeLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+// Serialize incident intake across concurrent worker tasks. The keys represent
+// every correlation boundary chosen by the application workflow: issue, trace,
+// and/or predecessor incident. Acquiring unique keys in lexical order avoids
+// deadlocks when concurrent intakes overlap on only one boundary. The advisory
+// xact locks are released at commit/rollback. Callers keep notifications and
+// other slow side effects OUTSIDE fn — the lock holds a database connection
+// open for fn's whole duration.
+export async function withIssueIntakeLock<T>(
+  keys: readonly string[],
+  fn: () => Promise<T>,
+): Promise<T> {
   return db.transaction(async (tx) => {
-    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0))`);
+    for (const key of [...new Set(keys)].sort()) {
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0))`);
+    }
     return fn();
   });
 }


### PR DESCRIPTION
## Summary

- run recurring error issues through the same heuristic and LLM grouping pipeline as new issues
- serialize concurrent recurrences by predecessor incident so related no-trace fingerprints converge on one successor
- reopen recurring issues when they join an existing incident

## Root cause

Recurring issues returned through a dedicated lifecycle path that opened a chained incident before normal grouping could run. Multiple fingerprints from one resolved incident could therefore create separate successor incidents, especially when their telemetry had no trace context and arrived concurrently.

## Validation

- `pnpm --filter @superlog/worker test:incident-intake`
- `pnpm --filter @superlog/worker test:issue-transitions`
- `pnpm --filter @superlog/worker typecheck`
- `pnpm exec biome check apps/worker/src/incident-intake.ts apps/worker/src/incidents/intake.ts apps/worker/src/incidents/intake.test.ts apps/worker/src/issues/repository.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups recurring issues using the same heuristic/LLM pipeline before creating incidents. Adds multi-key serialization (predecessor + trace) so concurrent recurrences and same-request siblings converge on one successor, and reopens issues when they rejoin an existing incident.

- **Bug Fixes**
  - Recurrences go through grouping and join an existing incident when matched (open recurrence of the same predecessor or same-trace).
  - Serialize by predecessor and trace for recurrences; `withIssueIntakeLock` now accepts multiple keys and acquires ordered advisory locks.
  - Grouping runs before the lock; inside the lock we prefer an already-open recurrence and reopen the issue when it links to an open incident.
  - Expanded tests for multi-key locking, no-trace convergence, same-trace siblings, grouping-join flow, and retry idempotency.

<sup>Written for commit fb949e22f4ffbbe7e237c54ef2b02fc365d467d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

