### PR TITLE
Show live PR diffs and hide empty incident detail tabs

### DIFF
--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -1293,6 +1293,35 @@ async function createInstallationWriteToken(installationId: number): Promise<str
   });
 }
 
+// Fetch the current unified diff of a PR straight from GitHub. Agent PRs
+// opened mid-run don't carry a patch body on the run result (only the legacy
+// end-of-run delivery path recorded one), and the live diff is more truthful
+// anyway — it includes follow-up commits pushed to the same branch.
+export async function fetchGithubPullRequestDiff(opts: {
+  installationId: number;
+  repoFullName: string;
+  prNumber: number;
+}): Promise<string> {
+  const token = await createInstallationToken({
+    installationId: opts.installationId,
+    permissions: { contents: "read", pull_requests: "read" },
+  });
+  const pathname = `/repos/${opts.repoFullName}/pulls/${opts.prNumber}`;
+  const res = await fetch(`https://api.github.com${pathname}`, {
+    headers: {
+      accept: "application/vnd.github.diff",
+      authorization: `Bearer ${token}`,
+      "x-github-api-version": "2022-11-28",
+      "user-agent": "superlog-api",
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`github GET ${pathname} (diff) failed: ${res.status} ${text}`);
+  }
+  return await res.text();
+}
+
 export async function mergeGithubPullRequest(opts: {
   installationId: number;
   repoFullName: string;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -50,6 +50,7 @@ import { type GatewayVars, mountGateway } from "./gateway.js";
 import { prBaseBranchExists } from "./github-branches.js";
 import {
   closeAgentPullRequestOnGithub,
+  fetchGithubPullRequestDiff,
   listProjectRepoBranches,
   mountGithubAuthed,
   mountGithubAuthorOAuth,
@@ -2209,6 +2210,59 @@ app.get("/api/projects/:projectId/incidents/:incidentId/pull-requests", async (c
 
   return c.json(buildIncidentPullRequestViews(prs, agentRuns));
 });
+
+// Live diff for an agent PR, fetched from GitHub on demand. PRs opened mid-run
+// via `propose_pr` never record a patch body on the run result, so this is the
+// dashboard's only path to the diff — and it stays current with follow-up
+// commits pushed to the PR branch.
+app.get(
+  "/api/projects/:projectId/incidents/:incidentId/pull-requests/:prId/diff",
+  async (c) => {
+    const projectId = await requireProjectAccess(c, c.req.param("projectId"));
+    const incidentId = c.req.param("incidentId");
+    const prId = c.req.param("prId");
+
+    const incident = await getProjectIncident(projectId, incidentId);
+    if (!incident) throw new HTTPException(404, { message: "incident not found" });
+
+    const pr = await db.query.agentPullRequests.findFirst({
+      where: and(
+        eq(schema.agentPullRequests.id, prId),
+        eq(schema.agentPullRequests.incidentId, incidentId),
+      ),
+    });
+    if (!pr) throw new HTTPException(404, { message: "pull request not found" });
+
+    const installation = await db.query.githubInstallations.findFirst({
+      where: eq(schema.githubInstallations.id, pr.installationId),
+    });
+    if (!installation || installation.revokedAt) {
+      throw new HTTPException(409, { message: "github installation is unavailable" });
+    }
+
+    let patch: string;
+    try {
+      patch = await fetchGithubPullRequestDiff({
+        installationId: installation.installationId,
+        repoFullName: pr.repoFullName,
+        prNumber: pr.prNumber,
+      });
+    } catch (err) {
+      logger.warn(
+        {
+          scope: "incidents.pr_diff",
+          incident_id: incidentId,
+          pr_id: prId,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "failed to fetch PR diff from github",
+      );
+      throw new HTTPException(502, { message: "could not fetch the diff from github" });
+    }
+
+    return c.json({ patch });
+  },
+);
 
 app.post("/api/projects/:projectId/incidents/:incidentId/pull-requests/:prId/merge", async (c) => {
   const projectId = c.req.param("projectId");

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -2358,7 +2358,7 @@ function IncidentPrRemoteDiff({
   incidentId: string;
   pr: IncidentPullRequest;
 }) {
-  const diff = useIncidentPullRequestDiff(projectId, incidentId, pr.id);
+  const diff = useIncidentPullRequestDiff(projectId, incidentId, pr.id, pr.headSha);
   if (diff.isLoading) {
     return (
       <div className="min-h-[520px] rounded-md border border-border bg-surface p-4 text-[12px] text-muted">

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -39,6 +39,7 @@ import {
   incidentChatErrorMessage,
   useDecideResolutionProposal,
   useIncident,
+  useIncidentPullRequestDiff,
   useIncidentPullRequests,
   useIncidentStats,
   useIncidents,
@@ -76,6 +77,12 @@ import {
   getIncidentDetailAccess,
   shouldUsePreloadedPullRequests,
 } from "./incidents/incident-detail-access.ts";
+import {
+  type IncidentDetailTab,
+  incidentHasFindings,
+  resolveIncidentDetailTab,
+  visibleIncidentDetailTabs,
+} from "./incidents/incident-detail-tabs.ts";
 import {
   type IncidentMetaRow,
   buildIncidentDetailMeta,
@@ -1132,6 +1139,9 @@ function IncidentDetailBody({
 }) {
   const q = useIncident(projectId, incidentId);
   const stats = useIncidentStats(projectId, incidentId);
+  // Fetched here (not just inside the PR panel) so the PR tab can hide until a
+  // PR actually exists. Same query key as the panel's, so no duplicate fetch.
+  const prsQuery = useIncidentPullRequests(projectId, incidentId, true, q.data?.agentRun?.state);
   const updateIncident = useUpdateIncident(projectId);
   const restartAgentRun = useRestartAgentRun(projectId);
   const retryPrDelivery = useRetryPrDelivery(projectId);
@@ -1174,6 +1184,7 @@ function IncidentDetailBody({
       linearTickets={linearTickets}
       alertEpisodes={alertEpisodes}
       pendingResolutionProposal={q.data.pendingResolutionProposal ?? null}
+      pullRequests={prsQuery.data}
       events={timeline}
       eventsLoading={false}
       eventsError={null}
@@ -1587,13 +1598,25 @@ export function IncidentDetailContent({
   /** Telemetry widgets the agent quoted in its summary, rendered inside the Summary section. */
   summaryTelemetry?: ReactNode;
   occurrenceBuckets?: { day: string; count: number }[];
-  /** Preloaded PRs for read-model consumers that cannot call product APIs. */
+  /**
+   * Preloaded PRs. Drives PR-tab visibility everywhere; read-only consumers
+   * that cannot call product APIs also render the PR panel from this.
+   */
   pullRequests?: IncidentPullRequest[];
   /** Render the canonical incident UI without controls that mutate customer data. */
   readOnly?: boolean;
 }) {
   const [detailTab, setDetailTab] = useState<IncidentDetailTab>("activity");
   const access = getIncidentDetailAccess(readOnly);
+  const visibleTabs = visibleIncidentDetailTabs({
+    hasFindings: incidentHasFindings({
+      incident,
+      agentRun,
+      hasPendingResolutionProposal: !!pendingResolutionProposal,
+    }),
+    hasPullRequests: (pullRequests?.length ?? 0) > 0,
+  });
+  const activeTab = resolveIncidentDetailTab(detailTab, visibleTabs);
   // A run paused on `ask_human` stores its question on the run result, not as an
   // incident event — surface it as the closing node of the Activity timeline.
   const awaitingQuestion =
@@ -1736,10 +1759,10 @@ export function IncidentDetailContent({
         </aside>
 
         <div className="flex min-h-0 min-w-0 flex-col bg-bg">
-          <IncidentDetailTabs active={detailTab} onChange={setDetailTab} />
+          <IncidentDetailTabs active={activeTab} tabs={visibleTabs} onChange={setDetailTab} />
 
           <IncidentDetailScrollArea>
-            {detailTab === "activity" && (
+            {activeTab === "activity" && (
               <div className="space-y-8">
                 {outOfCredits && <OutOfCreditsBanner />}
                 <div className="space-y-3">
@@ -1802,7 +1825,7 @@ export function IncidentDetailContent({
               </div>
             )}
 
-            {detailTab === "findings" && (
+            {activeTab === "findings" && (
               <div className="space-y-8">
                 {alertEpisodes.length > 0 && (
                   <div className="space-y-3">
@@ -1847,7 +1870,7 @@ export function IncidentDetailContent({
               </div>
             )}
 
-            {detailTab === "pr" && (
+            {activeTab === "pr" && (
               <IncidentPullRequestPanel
                 projectId={incident.projectId}
                 incidentId={incident.id}
@@ -1857,7 +1880,7 @@ export function IncidentDetailContent({
             )}
           </IncidentDetailScrollArea>
 
-          {detailTab === "activity" && access.canChat && (
+          {activeTab === "activity" && access.canChat && (
             <IncidentChatComposer
               projectId={incident.projectId}
               incidentId={incident.id}
@@ -2126,13 +2149,19 @@ function AgentDot({ tone }: { tone?: "danger" }) {
   );
 }
 
-type IncidentDetailTab = "activity" | "findings" | "pr";
+const INCIDENT_DETAIL_TAB_LABELS: Record<IncidentDetailTab, string> = {
+  activity: "Activity",
+  findings: "Findings",
+  pr: "PR",
+};
 
 function IncidentDetailTabs({
   active,
+  tabs,
   onChange,
 }: {
   active: IncidentDetailTab;
+  tabs: IncidentDetailTab[];
   onChange: (tab: IncidentDetailTab) => void;
 }) {
   return (
@@ -2141,11 +2170,7 @@ function IncidentDetailTabs({
         <Tabs
           value={active}
           onChange={onChange}
-          options={[
-            { value: "activity", label: "Activity" },
-            { value: "findings", label: "Findings" },
-            { value: "pr", label: "PR" },
-          ]}
+          options={tabs.map((tab) => ({ value: tab, label: INCIDENT_DETAIL_TAB_LABELS[tab] }))}
         />
       </div>
     </div>
@@ -2163,12 +2188,7 @@ export function IncidentPullRequestPanel({
   pullRequests?: IncidentPullRequest[];
   readOnly: boolean;
 }) {
-  if (
-    shouldUsePreloadedPullRequests({
-      readOnly,
-      pullRequestsProvided: pullRequests !== undefined,
-    })
-  ) {
+  if (shouldUsePreloadedPullRequests({ readOnly })) {
     return <IncidentPullRequestView pullRequests={pullRequests ?? []} readOnly={readOnly} />;
   }
   return <ProductIncidentPullRequestPanel projectId={projectId} incidentId={incidentId} />;
@@ -2197,6 +2217,7 @@ function ProductIncidentPullRequestPanel({
       merging={mergePr.isPending}
       mergeError={mergePr.error}
       onMerge={(prId) => mergePr.mutate({ prId })}
+      diffSource={{ projectId, incidentId }}
     />
   );
 }
@@ -2207,12 +2228,19 @@ export function IncidentPullRequestView({
   merging = false,
   mergeError = null,
   onMerge,
+  diffSource,
 }: {
   pullRequests: IncidentPullRequest[];
   readOnly: boolean;
   merging?: boolean;
   mergeError?: Error | null;
   onMerge?: (prId: string) => void;
+  /**
+   * Where to fetch the live diff when a PR has no recorded patch body.
+   * Omitted by read-only consumers that cannot call product APIs — they fall
+   * back to a GitHub link.
+   */
+  diffSource?: { projectId: string; incidentId: string };
 }) {
   const [selectedPrId, setSelectedPrId] = useState<string | null>(null);
 
@@ -2295,11 +2323,7 @@ export function IncidentPullRequestView({
         </p>
       )}
 
-      {!selectedPr.patch ? (
-        <div className="rounded-md border border-border bg-surface p-4">
-          <p className="text-[12px] text-muted">No patch body was recorded for this PR.</p>
-        </div>
-      ) : (
+      {selectedPr.patch ? (
         <Suspense
           fallback={
             <div className="min-h-[520px] rounded-md border border-border bg-surface p-4 text-[12px] text-muted">
@@ -2309,7 +2333,70 @@ export function IncidentPullRequestView({
         >
           <IncidentPrDiffView patch={selectedPr.patch} patchKey={selectedPr.id} />
         </Suspense>
+      ) : diffSource ? (
+        <IncidentPrRemoteDiff
+          key={selectedPr.id}
+          projectId={diffSource.projectId}
+          incidentId={diffSource.incidentId}
+          pr={selectedPr}
+        />
+      ) : (
+        <IncidentPrDiffUnavailable pr={selectedPr} />
       )}
+    </div>
+  );
+}
+
+// Loads the diff from GitHub through the API when the PR view carries no
+// recorded patch body (the normal case for PRs opened mid-run).
+function IncidentPrRemoteDiff({
+  projectId,
+  incidentId,
+  pr,
+}: {
+  projectId: string;
+  incidentId: string;
+  pr: IncidentPullRequest;
+}) {
+  const diff = useIncidentPullRequestDiff(projectId, incidentId, pr.id);
+  if (diff.isLoading) {
+    return (
+      <div className="min-h-[520px] rounded-md border border-border bg-surface p-4 text-[12px] text-muted">
+        Loading diff…
+      </div>
+    );
+  }
+  if (diff.error || !diff.data?.patch) {
+    return <IncidentPrDiffUnavailable pr={pr} />;
+  }
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-[520px] rounded-md border border-border bg-surface p-4 text-[12px] text-muted">
+          Loading diff…
+        </div>
+      }
+    >
+      <IncidentPrDiffView patch={diff.data.patch} patchKey={pr.id} />
+    </Suspense>
+  );
+}
+
+function IncidentPrDiffUnavailable({ pr }: { pr: IncidentPullRequest }) {
+  return (
+    <div className="rounded-md border border-border bg-surface p-4">
+      <p className="text-[12px] text-muted">
+        The diff couldn't be loaded here.{" "}
+        <a
+          href={`${pr.url}/files`}
+          target="_blank"
+          rel="noreferrer"
+          className="text-fg underline hover:text-muted"
+        >
+          View it on GitHub
+        </a>
+        .
+      </p>
     </div>
   );
 }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -2626,18 +2626,24 @@ export function useIncidentPullRequests(
 
 // The live PR diff, fetched from GitHub by the API. Used when the PR view has
 // no recorded patch body (mid-run `propose_pr` deliveries never record one).
+// `headSha` is part of the key: the PR list polls while a run is active and a
+// follow-up push moves the head, so the diff refetches exactly when a new
+// commit lands — without polling GitHub on a timer.
 export function useIncidentPullRequestDiff(
   projectId: string,
   incidentId: string,
   prId: string,
+  headSha: string | null,
 ) {
   const fetcher = useFetcher();
   return useQuery({
-    queryKey: ["incident-pr-diff", projectId, incidentId, prId],
+    queryKey: ["incident-pr-diff", projectId, incidentId, prId, headSha],
     queryFn: () =>
       fetcher<{ patch: string }>(
         `/api/projects/${projectId}/incidents/${incidentId}/pull-requests/${prId}/diff`,
       ),
+    // Keep showing the previous commit's diff while the new head's loads.
+    placeholderData: (prev) => prev,
     staleTime: 60_000,
     retry: 1,
   });

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -2608,6 +2608,9 @@ export function useIncidentPullRequests(
   projectId: string | undefined,
   incidentId: string | undefined,
   enabled = true,
+  // When set, polls at the incident cadence while the run is active so a PR
+  // opened mid-run shows up (and surfaces the PR tab) without a refresh.
+  agentRunState?: string | null,
 ) {
   const fetcher = useFetcher();
   return useQuery({
@@ -2617,6 +2620,26 @@ export function useIncidentPullRequests(
         `/api/projects/${projectId}/incidents/${incidentId}/pull-requests`,
       ),
     enabled: !!projectId && !!incidentId && enabled,
+    refetchInterval: incidentPollIntervalMs(agentRunState),
+  });
+}
+
+// The live PR diff, fetched from GitHub by the API. Used when the PR view has
+// no recorded patch body (mid-run `propose_pr` deliveries never record one).
+export function useIncidentPullRequestDiff(
+  projectId: string,
+  incidentId: string,
+  prId: string,
+) {
+  const fetcher = useFetcher();
+  return useQuery({
+    queryKey: ["incident-pr-diff", projectId, incidentId, prId],
+    queryFn: () =>
+      fetcher<{ patch: string }>(
+        `/api/projects/${projectId}/incidents/${incidentId}/pull-requests/${prId}/diff`,
+      ),
+    staleTime: 60_000,
+    retry: 1,
   });
 }
 

--- a/apps/web/src/incident-detail-read-only.test.ts
+++ b/apps/web/src/incident-detail-read-only.test.ts
@@ -25,17 +25,9 @@ test("interactive incident detail retains every product action", () => {
   });
 });
 
-test("read-only PRs always use supplied data instead of the connected loader", () => {
-  assert.equal(
-    shouldUsePreloadedPullRequests({ readOnly: true, pullRequestsProvided: false }),
-    true,
-  );
-  assert.equal(
-    shouldUsePreloadedPullRequests({ readOnly: false, pullRequestsProvided: true }),
-    true,
-  );
-  assert.equal(
-    shouldUsePreloadedPullRequests({ readOnly: false, pullRequestsProvided: false }),
-    false,
-  );
+test("only read-only consumers render PRs straight from supplied data", () => {
+  assert.equal(shouldUsePreloadedPullRequests({ readOnly: true }), true);
+  // The product detail preloads PRs for tab visibility, but its panel must
+  // stay on the connected loader so merge keeps working.
+  assert.equal(shouldUsePreloadedPullRequests({ readOnly: false }), false);
 });

--- a/apps/web/src/incident-detail-tabs.test.ts
+++ b/apps/web/src/incident-detail-tabs.test.ts
@@ -1,0 +1,116 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import {
+  incidentHasFindings,
+  resolveIncidentDetailTab,
+  visibleIncidentDetailTabs,
+} from "./incidents/incident-detail-tabs.ts";
+
+const EMPTY_INCIDENT = {
+  agentSummary: null,
+  rootCauseText: null,
+  estimatedImpactText: null,
+  resolutionClassification: null,
+};
+
+test("an incident with no run and no findings only shows the Activity tab", () => {
+  assert.equal(
+    incidentHasFindings({
+      incident: EMPTY_INCIDENT,
+      agentRun: null,
+      hasPendingResolutionProposal: false,
+    }),
+    false,
+  );
+  assert.deepEqual(visibleIncidentDetailTabs({ hasFindings: false, hasPullRequests: false }), [
+    "activity",
+  ]);
+});
+
+test("a run that is still investigating (null result) records no findings yet", () => {
+  assert.equal(
+    incidentHasFindings({
+      incident: EMPTY_INCIDENT,
+      agentRun: { failureReason: null, result: null },
+      hasPendingResolutionProposal: false,
+    }),
+    false,
+  );
+});
+
+test("flattened incident findings surface the Findings tab", () => {
+  assert.equal(
+    incidentHasFindings({
+      incident: { ...EMPTY_INCIDENT, agentSummary: "Null deref in cart add" },
+      agentRun: null,
+      hasPendingResolutionProposal: false,
+    }),
+    true,
+  );
+  assert.deepEqual(visibleIncidentDetailTabs({ hasFindings: true, hasPullRequests: false }), [
+    "activity",
+    "findings",
+  ]);
+});
+
+test("run-result findings count before the incident columns are backfilled", () => {
+  assert.equal(
+    incidentHasFindings({
+      incident: EMPTY_INCIDENT,
+      agentRun: { failureReason: null, result: { summary: "Found the bug" } },
+      hasPendingResolutionProposal: false,
+    }),
+    true,
+  );
+});
+
+test("an ask_human question surfaces the Findings tab", () => {
+  assert.equal(
+    incidentHasFindings({
+      incident: EMPTY_INCIDENT,
+      agentRun: { failureReason: null, result: { summary: "", question: "Which env?" } },
+      hasPendingResolutionProposal: false,
+    }),
+    true,
+  );
+});
+
+test("a failed run surfaces the Findings tab so the failure reason is reachable", () => {
+  assert.equal(
+    incidentHasFindings({
+      incident: EMPTY_INCIDENT,
+      agentRun: { failureReason: "pr_open_failed", result: null },
+      hasPendingResolutionProposal: false,
+    }),
+    true,
+  );
+});
+
+test("a pending resolution proposal surfaces the Findings tab", () => {
+  assert.equal(
+    incidentHasFindings({
+      incident: EMPTY_INCIDENT,
+      agentRun: null,
+      hasPendingResolutionProposal: true,
+    }),
+    true,
+  );
+});
+
+test("the PR tab only appears once a PR exists", () => {
+  assert.deepEqual(visibleIncidentDetailTabs({ hasFindings: true, hasPullRequests: true }), [
+    "activity",
+    "findings",
+    "pr",
+  ]);
+  assert.deepEqual(visibleIncidentDetailTabs({ hasFindings: false, hasPullRequests: true }), [
+    "activity",
+    "pr",
+  ]);
+});
+
+test("a selected tab that is no longer visible falls back to Activity", () => {
+  assert.equal(resolveIncidentDetailTab("pr", ["activity", "findings"]), "activity");
+  assert.equal(resolveIncidentDetailTab("findings", ["activity", "findings"]), "findings");
+  assert.equal(resolveIncidentDetailTab("activity", ["activity"]), "activity");
+});

--- a/apps/web/src/incident-detail-tabs.test.ts
+++ b/apps/web/src/incident-detail-tabs.test.ts
@@ -64,6 +64,41 @@ test("run-result findings count before the incident columns are backfilled", () 
   );
 });
 
+test("malformed result fields do not count as findings", () => {
+  // AgentRunView renders nothing for these shapes (see isConfidenceField),
+  // so counting them would surface an empty Findings tab.
+  assert.equal(
+    incidentHasFindings({
+      incident: EMPTY_INCIDENT,
+      agentRun: {
+        failureReason: null,
+        result: {
+          summary: "",
+          rootCause: "a bare string instead of { text, confidence }",
+          estimatedImpact: { text: "missing confidence" },
+          resolutionClassification: "resolved",
+        },
+      },
+      hasPendingResolutionProposal: false,
+    }),
+    false,
+  );
+});
+
+test("well-formed result confidence fields count as findings", () => {
+  assert.equal(
+    incidentHasFindings({
+      incident: EMPTY_INCIDENT,
+      agentRun: {
+        failureReason: null,
+        result: { summary: "", rootCause: { text: "bad deploy", confidence: 0.8 } },
+      },
+      hasPendingResolutionProposal: false,
+    }),
+    true,
+  );
+});
+
 test("an ask_human question surfaces the Findings tab", () => {
   assert.equal(
     incidentHasFindings({

--- a/apps/web/src/incidents/incident-detail-access.ts
+++ b/apps/web/src/incidents/incident-detail-access.ts
@@ -17,12 +17,10 @@ export function getIncidentDetailAccess(readOnly: boolean): IncidentDetailAccess
   };
 }
 
-export function shouldUsePreloadedPullRequests({
-  readOnly,
-  pullRequestsProvided,
-}: {
-  readOnly: boolean;
-  pullRequestsProvided: boolean;
-}): boolean {
-  return readOnly || pullRequestsProvided;
+// The product detail passes preloaded PRs too (tab visibility needs them
+// before the PR panel mounts), so provision alone must not disable the
+// connected loader — only read-only consumers that cannot call product APIs
+// (and cannot merge) render straight from the supplied data.
+export function shouldUsePreloadedPullRequests({ readOnly }: { readOnly: boolean }): boolean {
+  return readOnly;
 }

--- a/apps/web/src/incidents/incident-detail-tabs.ts
+++ b/apps/web/src/incidents/incident-detail-tabs.ts
@@ -24,6 +24,19 @@ type FindingsAgentRun = {
   } | null;
 };
 
+// Same defensive shape check as AgentRunView's isConfidenceField: agent-emitted
+// result fields are sometimes malformed (e.g. a flat string in place of
+// { text, confidence }), and AgentRunView renders nothing for those — so they
+// must not count as visible findings either.
+function isConfidenceField(v: unknown): boolean {
+  return (
+    !!v &&
+    typeof v === "object" &&
+    typeof (v as { text?: unknown }).text === "string" &&
+    typeof (v as { confidence?: unknown }).confidence === "number"
+  );
+}
+
 // Mirrors what the Findings tab actually renders (AgentRunView + the
 // resolution-proposal banner): flattened incident findings, the run result's
 // fallbacks, an ask_human question, or a failure reason.
@@ -52,9 +65,9 @@ export function incidentHasFindings({
   return !!(
     result.summary ||
     result.question ||
-    result.rootCause ||
-    result.estimatedImpact ||
-    result.resolutionClassification
+    isConfidenceField(result.rootCause) ||
+    isConfidenceField(result.estimatedImpact) ||
+    (result.resolutionClassification && typeof result.resolutionClassification === "object")
   );
 }
 

--- a/apps/web/src/incidents/incident-detail-tabs.ts
+++ b/apps/web/src/incidents/incident-detail-tabs.ts
@@ -1,0 +1,79 @@
+// Which incident-detail tabs are worth showing. Activity is always there;
+// Findings and PR only appear once they have content, so a fresh incident
+// isn't a wall of empty tabs.
+
+export type IncidentDetailTab = "activity" | "findings" | "pr";
+
+// Structural subsets of the api.ts Incident / AgentRun types — keeps this
+// decidable in tests without constructing full API objects.
+type FindingsIncident = {
+  agentSummary: string | null;
+  rootCauseText: string | null;
+  estimatedImpactText: string | null;
+  resolutionClassification: unknown;
+};
+
+type FindingsAgentRun = {
+  failureReason: string | null;
+  result: {
+    summary?: string | null;
+    question?: string | null;
+    rootCause?: unknown;
+    estimatedImpact?: unknown;
+    resolutionClassification?: unknown;
+  } | null;
+};
+
+// Mirrors what the Findings tab actually renders (AgentRunView + the
+// resolution-proposal banner): flattened incident findings, the run result's
+// fallbacks, an ask_human question, or a failure reason.
+export function incidentHasFindings({
+  incident,
+  agentRun,
+  hasPendingResolutionProposal,
+}: {
+  incident: FindingsIncident;
+  agentRun: FindingsAgentRun | null;
+  hasPendingResolutionProposal: boolean;
+}): boolean {
+  if (hasPendingResolutionProposal) return true;
+  if (
+    incident.agentSummary ||
+    incident.rootCauseText ||
+    incident.estimatedImpactText ||
+    incident.resolutionClassification
+  ) {
+    return true;
+  }
+  if (!agentRun) return false;
+  if (agentRun.failureReason) return true;
+  const result = agentRun.result;
+  if (!result) return false;
+  return !!(
+    result.summary ||
+    result.question ||
+    result.rootCause ||
+    result.estimatedImpact ||
+    result.resolutionClassification
+  );
+}
+
+export function visibleIncidentDetailTabs({
+  hasFindings,
+  hasPullRequests,
+}: {
+  hasFindings: boolean;
+  hasPullRequests: boolean;
+}): IncidentDetailTab[] {
+  const tabs: IncidentDetailTab[] = ["activity"];
+  if (hasFindings) tabs.push("findings");
+  if (hasPullRequests) tabs.push("pr");
+  return tabs;
+}
+
+export function resolveIncidentDetailTab(
+  selected: IncidentDetailTab,
+  visible: IncidentDetailTab[],
+): IncidentDetailTab {
+  return visible.includes(selected) ? selected : "activity";
+}


### PR DESCRIPTION
## Problem

Two incident-detail issues:

1. **The PR tab claimed "No patch body was recorded for this PR" for real PRs.** PRs opened mid-run via the non-terminal `propose_pr` tool record an `agent_pull_requests` row but no patch on the run result — only the legacy end-of-run delivery path wrote `result.pr.patch`. `buildIncidentPullRequestViews` reads only that field, so the tab rendered the "no patch" message even though the PR exists on GitHub with a full diff.
2. **Findings and PR tabs showed even when empty.** A fresh incident rendered a Findings tab saying "No agent run queued yet" and a PR tab saying "No PR has been opened".

## Changes

**Live diff fallback**
- New endpoint `GET /api/projects/:projectId/incidents/:incidentId/pull-requests/:prId/diff` — fetches the PR's current unified diff from GitHub via an installation token (`fetchGithubPullRequestDiff`, `Accept: application/vnd.github.diff`). The live diff also reflects follow-up commits pushed to the PR branch.
- The PR view uses the recorded inline patch when present, otherwise fetches the live diff. When neither is available (e.g. consumers that can't call product APIs), it links to the PR's Files tab on GitHub instead of claiming nothing was recorded.

**Tab visibility**
- New `incidents/incident-detail-tabs.ts` model: Activity is always shown; Findings appears once findings, an `ask_human` question, a failure reason, or a pending resolution proposal exist; PR appears once a PR row exists. A selected tab that disappears falls back to Activity.
- The product incident detail preloads the PR list (same query key as the panel, so no duplicate fetch) and polls it at the incident cadence while a run is active, so a PR opened mid-run surfaces the tab without a refresh.
- `shouldUsePreloadedPullRequests` now keys on `readOnly` alone: provided PRs drive tab visibility everywhere, but only read-only consumers render the panel from supplied data — the interactive panel keeps the connected loader and merge.

## Tests

- `incident-detail-tabs.test.ts`: findings/PR visibility matrix + active-tab fallback.
- Updated `incident-detail-read-only.test.ts` for the `shouldUsePreloadedPullRequests` change.
- `@superlog/web` tests (141) pass; web + api typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show live GitHub PR diffs in incident detail and hide empty Findings/PR tabs. Fixes the “No patch body was recorded for this PR” issue and keeps diffs current when new commits land.

- Added `GET /api/projects/:projectId/incidents/:incidentId/pull-requests/:prId/diff` to return the current unified diff from GitHub.
- PR panel uses the recorded patch, else the live diff; it auto-refreshes when the PR head SHA changes and links to the PR’s Files tab on GitHub if neither is available. Read‑only consumers render PRs from supplied data; the interactive view keeps the connected loader so merge continues to work.
- Tabs: Activity is always shown; Findings and PR only appear when they have content. Findings detection ignores malformed result fields, the PR list is preloaded and polled during active runs so mid‑run PRs surface without a refresh, and if a selected tab disappears it falls back to Activity.

<sup>Written for commit aa9cbaab6b20344f00e68b8d5f506b720c11d022. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

