### PR TITLE
Make weekly digest channel selection the enabling action

### DIFF
--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -178,6 +178,11 @@ import {
   SettingsRow,
   SettingsSectionHeader,
 } from "./settings/rows.tsx";
+import {
+  weeklyDigestChannelSelection,
+  weeklyDigestStatusDescription,
+  weeklyDigestToggleDisabled,
+} from "./weekly-digest-controls.ts";
 
 type NavTarget = {
   scope?: SettingsScope;
@@ -2347,56 +2352,45 @@ function WeeklyDigestCard({ projectId }: { projectId: string | undefined }) {
     <SettingsCard>
       <SettingsRow
         title="Post a weekly project recap to Slack"
-        description={
-          enabled && channelId
-            ? `Posting to #${channelName ?? channelId} · ${lastRunLabel}`
-            : lastRunLabel
-        }
+        description={weeklyDigestStatusDescription({ enabled, channelId, channelName, lastRunLabel })}
         control={
           <Toggle
             checked={enabled}
-            disabled={save.isPending || (!enabled && !channelId)}
+            disabled={weeklyDigestToggleDisabled({ enabled, channelId, saving: save.isPending })}
             onChange={(v) => save.mutate({ enabled: v })}
           />
         }
       />
       <SettingsRow
         title="Channel"
-        description="Use a different channel from incident threads if it's noisy — invite the bot to private channels"
+        description="Picking a channel turns the recap on. Use a different channel from incident threads if it's noisy — invite the bot to private channels"
         control={
           <div className="w-60">
             <Dropdown
               value={channelId}
               disabled={channels.isLoading || channels.isError || save.isPending}
               onChange={(next) => {
-                if (!next) {
-                  save.mutate({ enabled: false, channelId: null, channelName: null });
-                  return;
-                }
-                const ch = channelList.find((c) => c.id === next);
-                save.mutate({ channelId: next, channelName: ch?.name ?? null });
+                const selection = weeklyDigestChannelSelection(next, channelList);
+                if (selection) save.mutate(selection);
               }}
               placeholder={
                 channels.isLoading
                   ? "Loading channels…"
                   : channels.isError
                     ? "Failed to load channels"
-                    : "No channel"
+                    : "Select a channel…"
               }
               emptyLabel="No channels found"
-              options={[
-                { value: "", searchText: "No channel", label: "No channel" },
-                ...channelList.map((ch) => ({
-                  value: ch.id,
-                  searchText: `${ch.isPrivate ? "🔒 " : "#"}${ch.name}`,
-                  label: (
-                    <span className="flex items-center gap-1.5">
-                      <span className="text-subtle">{ch.isPrivate ? "🔒" : "#"}</span>
-                      <span>{ch.name}</span>
-                    </span>
-                  ),
-                })),
-              ]}
+              options={channelList.map((ch) => ({
+                value: ch.id,
+                searchText: `${ch.isPrivate ? "🔒 " : "#"}${ch.name}`,
+                label: (
+                  <span className="flex items-center gap-1.5">
+                    <span className="text-subtle">{ch.isPrivate ? "🔒" : "#"}</span>
+                    <span>{ch.name}</span>
+                  </span>
+                ),
+              }))}
             />
           </div>
         }

--- a/apps/web/src/weekly-digest-controls.test.ts
+++ b/apps/web/src/weekly-digest-controls.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  weeklyDigestChannelSelection,
+  weeklyDigestStatusDescription,
+  weeklyDigestToggleDisabled,
+} from "./weekly-digest-controls.ts";
+
+const channels = [
+  { id: "C1", name: "superlog-prod" },
+  { id: "C2", name: "alerts" },
+];
+
+test("selecting a channel enables the digest in the same save", () => {
+  assert.deepEqual(weeklyDigestChannelSelection("C1", channels), {
+    channelId: "C1",
+    channelName: "superlog-prod",
+    enabled: true,
+  });
+});
+
+test("selecting a channel missing from the list still enables, without a name", () => {
+  assert.deepEqual(weeklyDigestChannelSelection("C9", channels), {
+    channelId: "C9",
+    channelName: null,
+    enabled: true,
+  });
+});
+
+test("an empty selection is a no-op, not a disable", () => {
+  assert.equal(weeklyDigestChannelSelection("", channels), null);
+});
+
+test("the toggle only blocks turning on without a channel", () => {
+  assert.equal(
+    weeklyDigestToggleDisabled({ enabled: false, channelId: "", saving: false }),
+    true,
+  );
+  assert.equal(
+    weeklyDigestToggleDisabled({ enabled: false, channelId: "C1", saving: false }),
+    false,
+  );
+  // an enabled digest can always be turned off, even if the channel is somehow gone
+  assert.equal(
+    weeklyDigestToggleDisabled({ enabled: true, channelId: "", saving: false }),
+    false,
+  );
+  assert.equal(
+    weeklyDigestToggleDisabled({ enabled: true, channelId: "C1", saving: true }),
+    true,
+  );
+});
+
+test("status description explains the unconfigured state instead of a bare disabled toggle", () => {
+  assert.equal(
+    weeklyDigestStatusDescription({
+      enabled: false,
+      channelId: "",
+      channelName: null,
+      lastRunLabel: "Never sent",
+    }),
+    "Pick a channel below to start posting",
+  );
+});
+
+test("status description shows the destination while enabled and a paused state while off", () => {
+  assert.equal(
+    weeklyDigestStatusDescription({
+      enabled: true,
+      channelId: "C1",
+      channelName: "superlog-prod",
+      lastRunLabel: "Never sent",
+    }),
+    "Posting to #superlog-prod · Never sent",
+  );
+  assert.equal(
+    weeklyDigestStatusDescription({
+      enabled: true,
+      channelId: "C1",
+      channelName: null,
+      lastRunLabel: "Never sent",
+    }),
+    "Posting to #C1 · Never sent",
+  );
+  assert.equal(
+    weeklyDigestStatusDescription({
+      enabled: false,
+      channelId: "C1",
+      channelName: "superlog-prod",
+      lastRunLabel: "Last sent 7/10/2026",
+    }),
+    "Paused · Last sent 7/10/2026",
+  );
+});

--- a/apps/web/src/weekly-digest-controls.ts
+++ b/apps/web/src/weekly-digest-controls.ts
@@ -1,0 +1,36 @@
+// Weekly-digest settings row logic: picking a channel is the enabling action,
+// and the toggle pauses/resumes an already-configured digest.
+
+export type WeeklyDigestChannelOption = { id: string; name: string };
+
+export function weeklyDigestChannelSelection(
+  next: string,
+  channels: readonly WeeklyDigestChannelOption[],
+): { channelId: string; channelName: string | null; enabled: true } | null {
+  if (!next) return null;
+  return {
+    channelId: next,
+    channelName: channels.find((c) => c.id === next)?.name ?? null,
+    enabled: true,
+  };
+}
+
+export function weeklyDigestToggleDisabled(state: {
+  enabled: boolean;
+  channelId: string;
+  saving: boolean;
+}): boolean {
+  return state.saving || (!state.enabled && !state.channelId);
+}
+
+export function weeklyDigestStatusDescription(state: {
+  enabled: boolean;
+  channelId: string;
+  channelName: string | null;
+  lastRunLabel: string;
+}): string {
+  if (!state.channelId) return "Pick a channel below to start posting";
+  if (state.enabled)
+    return `Posting to #${state.channelName ?? state.channelId} · ${state.lastRunLabel}`;
+  return `Paused · ${state.lastRunLabel}`;
+}


### PR DESCRIPTION
## Problem

In project Settings → Weekly recap, the enable toggle is disabled until a Slack channel is chosen, with no explanation — the channel picker below is a hidden precondition. And after picking a channel the digest is still off, so setup takes two steps. The "No channel" dropdown option was a second, hidden off-switch that also wiped the channel.

## Change

- **Picking a channel enables the digest in the same save** (`{channelId, channelName, enabled: true}` — a payload the PUT route already accepts). Setup is one action.
- **The toggle is pause/resume for a configured digest.** Turning off keeps the channel; the status line shows `Paused · <last sent>`.
- **The unconfigured state explains itself**: the status line reads "Pick a channel below to start posting" instead of a bare greyed-out toggle. (Turning on without a channel is still blocked — the API rejects it.)
- **Removed the "No channel" option**; the toggle is the only off-switch.

Row logic is extracted to `weekly-digest-controls.ts` with unit tests. No API changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make weekly recap setup a single action by enabling the digest as soon as a Slack channel is selected. The toggle now pauses/resumes an already configured digest, making the state clear.

- New Features
  - Selecting a channel saves and turns the digest on in one step.
  - The toggle pauses/resumes and keeps the selected channel; status shows “Paused · <last sent>”.
  - Clear unconfigured copy: “Pick a channel below to start posting.” Removed the “No channel” option.

- Refactors
  - Extracted row logic to weekly-digest-controls.ts with unit tests. No API changes.

<sup>Written for commit 4d99d6b79cccad28dfeaa54596374319e32c6939. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

