### PR TITLE
Add activity breakdown to weekly digests

### DIFF
--- a/apps/worker/src/digest/domain.test.ts
+++ b/apps/worker/src/digest/domain.test.ts
@@ -125,7 +125,10 @@ test("buildDigestBlocks: leads with the weekly incident and issue breakdown", ()
     issues: { open: 4, underObservation: 3, silenced: 2, resolved: 8 },
   });
 
-  assert.equal(text, "Weekly project recap: 12 incidents opened, 9 resolved, 3 remain open.");
+  assert.equal(
+    text,
+    "Weekly project recap: 12 incidents opened, 9 resolved, 3 remain open. Issues reviewed: 4 open, 3 under observation, 2 silenced, 8 resolved.",
+  );
   assert.deepEqual(blocks.slice(0, 3), [
     {
       type: "section",
@@ -152,6 +155,24 @@ test("buildDigestBlocks: leads with the weekly incident and issue breakdown", ()
     },
     { type: "divider" },
   ]);
+});
+
+test("buildDigestBlocks: plain-text fallback includes ranked PRs alongside the summary", () => {
+  const candidate = makeCandidate();
+  const { text } = buildDigestBlocks(
+    [{ pick: { agentRunId: candidate.agentRunId, rationale: "Review first" }, candidate }],
+    {
+      from: new Date("2026-07-07T10:00:00Z"),
+      to: new Date("2026-07-14T10:00:00Z"),
+      incidents: { opened: 1, resolved: 0, remainOpen: 1 },
+      issues: { open: 1, underObservation: 0, silenced: 0, resolved: 0 },
+    },
+  );
+
+  assert.match(
+    text,
+    /Top 1 fixes to merge: purple-otter \(https:\/\/github.com\/acme\/api\/pull\/42\)/,
+  );
 });
 
 test("attachCandidatesToPicks: filters out picks whose id has no candidate, caps at TOP_N", () => {

--- a/apps/worker/src/digest/domain.test.ts
+++ b/apps/worker/src/digest/domain.test.ts
@@ -1,13 +1,13 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  type DigestCandidate,
+  TOP_N,
   attachCandidatesToPicks,
   buildDigestBlocks,
   buildRankingUserMessage,
-  type DigestCandidate,
   parsePicks,
   severityEmoji,
-  TOP_N,
   trivialPicks,
 } from "./domain.js";
 
@@ -49,10 +49,10 @@ test("severityEmoji distinguishes SEV-1/2/3 and unset", () => {
 test("buildRankingUserMessage serialises candidates as JSON with the fields the prompt expects", () => {
   const msg = buildRankingUserMessage([makeCandidate()]);
   assert.ok(msg.includes("Open bug-fix PRs to rank"));
-  assert.ok(msg.includes("\"agentRunId\": \"run-1\""));
-  assert.ok(msg.includes("\"severity\": \"SEV-2\""));
+  assert.ok(msg.includes('"agentRunId": "run-1"'));
+  assert.ok(msg.includes('"severity": "SEV-2"'));
   // Dates serialised as ISO strings.
-  assert.ok(msg.includes("\"completedAt\": \"2026-05-22T10:00:00.000Z\""));
+  assert.ok(msg.includes('"completedAt": "2026-05-22T10:00:00.000Z"'));
 });
 
 test("parsePicks: valid JSON yields ordered picks (capped at TOP_N, dedup)", () => {
@@ -92,13 +92,11 @@ test("parsePicks: invalid JSON or wrong shape yields empty array", () => {
 });
 
 test("buildDigestBlocks: header reflects pick count and includes PR url + codename per pick", () => {
-  const candidates = [
-    makeCandidate({ agentRunId: "a" }),
-    makeCandidate({ agentRunId: "b", incidentCodename: "blue-eel" }),
-  ];
+  const firstCandidate = makeCandidate({ agentRunId: "a" });
+  const secondCandidate = makeCandidate({ agentRunId: "b", incidentCodename: "blue-eel" });
   const { text, blocks } = buildDigestBlocks([
-    { pick: { agentRunId: "a", rationale: "first reason" }, candidate: candidates[0]! },
-    { pick: { agentRunId: "b", rationale: "second reason" }, candidate: candidates[1]! },
+    { pick: { agentRunId: "a", rationale: "first reason" }, candidate: firstCandidate },
+    { pick: { agentRunId: "b", rationale: "second reason" }, candidate: secondCandidate },
   ]);
   assert.ok(text.includes("purple-otter"));
   assert.ok(text.includes("blue-eel"));
@@ -117,6 +115,43 @@ test("buildDigestBlocks: singular subline when exactly one pick", () => {
   ]);
   const json = JSON.stringify(blocks);
   assert.ok(json.includes("One pending bug-fix PR is ready"));
+});
+
+test("buildDigestBlocks: leads with the weekly incident and issue breakdown", () => {
+  const { text, blocks } = buildDigestBlocks([], {
+    from: new Date("2026-07-07T10:00:00Z"),
+    to: new Date("2026-07-14T10:00:00Z"),
+    incidents: { opened: 12, resolved: 9, remainOpen: 3 },
+    issues: { open: 4, underObservation: 3, silenced: 2, resolved: 8 },
+  });
+
+  assert.equal(text, "Weekly project recap: 12 incidents opened, 9 resolved, 3 remain open.");
+  assert.deepEqual(blocks.slice(0, 3), [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: ":sparkles: *Weekly project recap · Jul 7–14*",
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: [
+          "*Incidents*",
+          "*12 opened* · *9 resolved* · *3 remain open*",
+          "",
+          "*Issues reviewed*",
+          ":red_circle: Open: *4*",
+          ":eyes: Under observation: *3*",
+          ":mute: Silenced: *2*",
+          ":white_check_mark: Resolved: *8*",
+        ].join("\n"),
+      },
+    },
+    { type: "divider" },
+  ]);
 });
 
 test("attachCandidatesToPicks: filters out picks whose id has no candidate, caps at TOP_N", () => {

--- a/apps/worker/src/digest/domain.ts
+++ b/apps/worker/src/digest/domain.ts
@@ -219,11 +219,20 @@ export function buildDigestBlocks(
     ];
     blocks.push({ type: "section", text: { type: "mrkdwn", text: lines.join("\n") } });
   });
-  const fallbackText = summary
-    ? `Weekly project recap: ${summary.incidents.opened} incidents opened, ${summary.incidents.resolved} resolved, ${summary.incidents.remainOpen} remain open.`
-    : `Top ${picks.length} fixes to merge: ${picks
+  const fallbackParts: string[] = [];
+  if (summary) {
+    fallbackParts.push(
+      `Weekly project recap: ${summary.incidents.opened} incidents opened, ${summary.incidents.resolved} resolved, ${summary.incidents.remainOpen} remain open. Issues reviewed: ${summary.issues.open} open, ${summary.issues.underObservation} under observation, ${summary.issues.silenced} silenced, ${summary.issues.resolved} resolved.`,
+    );
+  }
+  if (picks.length > 0) {
+    fallbackParts.push(
+      `Top ${picks.length} fixes to merge: ${picks
         .map(({ candidate }) => `${candidate.incidentCodename} (${candidate.pr.url})`)
-        .join(", ")}`;
+        .join(", ")}`,
+    );
+  }
+  const fallbackText = fallbackParts.join(" ");
   return { text: fallbackText, blocks };
 }
 

--- a/apps/worker/src/digest/domain.ts
+++ b/apps/worker/src/digest/domain.ts
@@ -45,6 +45,34 @@ export type RankedDigestPick = {
   candidate: DigestCandidate;
 };
 
+export type WeeklyDigestSummary = {
+  from: Date;
+  to: Date;
+  incidents: {
+    opened: number;
+    resolved: number;
+    remainOpen: number;
+  };
+  issues: {
+    open: number;
+    underObservation: number;
+    silenced: number;
+    resolved: number;
+  };
+};
+
+export function hasWeeklyDigestActivity(summary: WeeklyDigestSummary): boolean {
+  return (
+    summary.incidents.opened +
+      summary.incidents.resolved +
+      summary.issues.open +
+      summary.issues.underObservation +
+      summary.issues.silenced +
+      summary.issues.resolved >
+    0
+  );
+}
+
 export const DIGEST_SYSTEM_PROMPT = [
   "You rank pending bug-fix pull requests for a weekly Slack digest.",
   "You will receive a list of completed agent_runs whose proposed fix PR is still open (not merged).",
@@ -127,16 +155,60 @@ export function severityEmoji(severity: string | null): string {
   }
 }
 
-export function buildDigestBlocks(picks: RankedDigestPick[]): { text: string; blocks: unknown[] } {
+function formatDigestDateRange(from: Date, to: Date): string {
+  const month = new Intl.DateTimeFormat("en-US", { month: "short", timeZone: "UTC" });
+  const day = new Intl.DateTimeFormat("en-US", { day: "numeric", timeZone: "UTC" });
+  const fromMonth = month.format(from);
+  const toMonth = month.format(to);
+  const fromLabel = `${fromMonth} ${day.format(from)}`;
+  const toLabel = fromMonth === toMonth ? day.format(to) : `${toMonth} ${day.format(to)}`;
+  return `${fromLabel}–${toLabel}`;
+}
+
+export function buildDigestBlocks(
+  picks: RankedDigestPick[],
+  summary?: WeeklyDigestSummary,
+): { text: string; blocks: unknown[] } {
   const headerLine = `:sparkles: *Top ${picks.length} fixes to merge this week*`;
   const subline =
     picks.length === 1
       ? "_One pending bug-fix PR is ready for review._"
       : `_${picks.length} pending bug-fix PRs are ready for review, ranked by impact._`;
-  const blocks: unknown[] = [
-    { type: "section", text: { type: "mrkdwn", text: `${headerLine}\n${subline}` } },
-    { type: "divider" },
-  ];
+  const blocks: unknown[] = [];
+  if (summary) {
+    blocks.push(
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `:sparkles: *Weekly project recap · ${formatDigestDateRange(summary.from, summary.to)}*`,
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: [
+            "*Incidents*",
+            `*${summary.incidents.opened} opened* · *${summary.incidents.resolved} resolved* · *${summary.incidents.remainOpen} remain open*`,
+            "",
+            "*Issues reviewed*",
+            `:red_circle: Open: *${summary.issues.open}*`,
+            `:eyes: Under observation: *${summary.issues.underObservation}*`,
+            `:mute: Silenced: *${summary.issues.silenced}*`,
+            `:white_check_mark: Resolved: *${summary.issues.resolved}*`,
+          ].join("\n"),
+        },
+      },
+      { type: "divider" },
+    );
+  }
+  if (picks.length > 0) {
+    blocks.push(
+      { type: "section", text: { type: "mrkdwn", text: `${headerLine}\n${subline}` } },
+      { type: "divider" },
+    );
+  }
   picks.forEach(({ pick, candidate }, idx) => {
     const severity = candidate.severity ? `*${candidate.severity}* · ` : "";
     const lines = [
@@ -147,9 +219,11 @@ export function buildDigestBlocks(picks: RankedDigestPick[]): { text: string; bl
     ];
     blocks.push({ type: "section", text: { type: "mrkdwn", text: lines.join("\n") } });
   });
-  const fallbackText = `Top ${picks.length} fixes to merge: ${picks
-    .map(({ candidate }) => `${candidate.incidentCodename} (${candidate.pr.url})`)
-    .join(", ")}`;
+  const fallbackText = summary
+    ? `Weekly project recap: ${summary.incidents.opened} incidents opened, ${summary.incidents.resolved} resolved, ${summary.incidents.remainOpen} remain open.`
+    : `Top ${picks.length} fixes to merge: ${picks
+        .map(({ candidate }) => `${candidate.incidentCodename} (${candidate.pr.url})`)
+        .join(", ")}`;
   return { text: fallbackText, blocks };
 }
 

--- a/apps/worker/src/digest/project-run.test.ts
+++ b/apps/worker/src/digest/project-run.test.ts
@@ -27,6 +27,15 @@ test("a project digest loads settings and candidates only for that project", asy
     },
     async stampLastRun() {},
     async clearRunRequest() {},
+    async gatherWeeklySummary(projectId, policy, now) {
+      calls.push(`summary:${projectId}`);
+      return {
+        from: new Date(now.getTime() - policy.intervalMs),
+        to: now,
+        incidents: { opened: 0, resolved: 0, remainOpen: 0 },
+        issues: { open: 0, underObservation: 0, silenced: 0, resolved: 0 },
+      };
+    },
     async gatherCandidates(projectId) {
       calls.push(`candidates:${projectId}`);
       return [];
@@ -46,5 +55,5 @@ test("a project digest loads settings and candidates only for that project", asy
     { force: true },
   );
 
-  assert.deepEqual(calls, ["settings:project-2", "candidates:project-2"]);
+  assert.deepEqual(calls, ["settings:project-2", "summary:project-2", "candidates:project-2"]);
 });

--- a/apps/worker/src/digest/repository.integration.test.ts
+++ b/apps/worker/src/digest/repository.integration.test.ts
@@ -74,3 +74,132 @@ test("clearing a one-shot request only consumes the request selected by the tick
   });
   assert.equal(afterMatchingClear?.digestRunRequestedAt, null);
 });
+
+test("weekly summary counts incident activity and the current status of issues touched in the window", async () => {
+  const now = new Date("2026-07-14T10:00:00Z");
+  const withinWindow = new Date("2026-07-10T10:00:00Z");
+  const beforeWindow = new Date("2026-07-01T10:00:00Z");
+
+  await db.insert(schema.incidents).values([
+    {
+      projectId,
+      codename: "new-open",
+      title: "New open incident",
+      status: "open",
+      firstSeen: withinWindow,
+      lastSeen: withinWindow,
+      createdAt: withinWindow,
+    },
+    {
+      projectId,
+      codename: "new-resolved",
+      title: "New resolved incident",
+      status: "resolved",
+      firstSeen: withinWindow,
+      lastSeen: withinWindow,
+      resolvedAt: withinWindow,
+      createdAt: withinWindow,
+    },
+    {
+      projectId,
+      codename: "old-resolved",
+      title: "Older incident resolved this week",
+      status: "resolved",
+      firstSeen: beforeWindow,
+      lastSeen: withinWindow,
+      resolvedAt: withinWindow,
+      createdAt: beforeWindow,
+    },
+    {
+      projectId,
+      codename: "old-open",
+      title: "Older open incident",
+      status: "open",
+      firstSeen: beforeWindow,
+      lastSeen: withinWindow,
+      createdAt: beforeWindow,
+    },
+  ]);
+
+  await db.insert(schema.issues).values([
+    ...["open-1", "open-2"].map((fingerprint) => ({
+      projectId,
+      fingerprint,
+      exceptionType: "Error",
+      title: fingerprint,
+      status: "open" as const,
+      firstSeen: beforeWindow,
+      lastSeen: withinWindow,
+    })),
+    {
+      projectId,
+      fingerprint: "observed",
+      exceptionType: "Error",
+      title: "Observed",
+      status: "under_observation",
+      firstSeen: beforeWindow,
+      lastSeen: withinWindow,
+    },
+    {
+      projectId,
+      fingerprint: "silenced",
+      exceptionType: "Error",
+      title: "Silenced",
+      status: "silenced",
+      firstSeen: beforeWindow,
+      lastSeen: withinWindow,
+    },
+    {
+      projectId,
+      fingerprint: "resolved",
+      exceptionType: "Error",
+      title: "Resolved",
+      status: "resolved",
+      firstSeen: beforeWindow,
+      lastSeen: withinWindow,
+    },
+    {
+      projectId,
+      fingerprint: "untouched",
+      exceptionType: "Error",
+      title: "Untouched",
+      status: "open",
+      firstSeen: beforeWindow,
+      lastSeen: beforeWindow,
+    },
+  ]);
+
+  const [reviewedIssue] = await db
+    .insert(schema.issues)
+    .values({
+      projectId,
+      fingerprint: "reviewed-this-week",
+      exceptionType: "Error",
+      title: "Reviewed this week",
+      status: "resolved",
+      firstSeen: beforeWindow,
+      lastSeen: beforeWindow,
+    })
+    .returning();
+  const eventIncident = await db.query.incidents.findFirst({
+    where: eq(schema.incidents.codename, "new-open"),
+  });
+  assert.ok(reviewedIssue);
+  assert.ok(eventIncident);
+  await db.insert(schema.incidentEvents).values({
+    incidentId: eventIncident.id,
+    kind: "issue_resolved",
+    detail: { issueId: reviewedIssue.id },
+    processedAt: withinWindow,
+    createdAt: withinWindow,
+  });
+
+  const summary = await repo.gatherWeeklySummary(projectId, { intervalMs: 7 * 86_400_000 }, now);
+
+  assert.deepEqual(summary, {
+    from: new Date("2026-07-07T10:00:00Z"),
+    to: now,
+    incidents: { opened: 2, resolved: 2, remainOpen: 1 },
+    issues: { open: 2, underObservation: 1, silenced: 1, resolved: 2 },
+  });
+});

--- a/apps/worker/src/digest/repository.ts
+++ b/apps/worker/src/digest/repository.ts
@@ -1,6 +1,6 @@
 import { type DB, adoptLegacyOrgDigestSettings, schema } from "@superlog/db";
-import { and, desc, eq, gte, isNotNull, isNull, or } from "drizzle-orm";
-import type { DigestCandidate } from "./domain.js";
+import { and, desc, eq, gte, inArray, isNotNull, isNull, lte, or, sql } from "drizzle-orm";
+import type { DigestCandidate, WeeklyDigestSummary } from "./domain.js";
 import type { DigestPolicy } from "./policy.js";
 
 export type ProjectDigestSettings = {
@@ -20,6 +20,11 @@ export type DigestRepository = {
   listRunnableProjectSettings(): Promise<ProjectDigestSettings[]>;
   stampLastRun(projectId: string, at: Date): Promise<void>;
   clearRunRequest(projectId: string, requestedAt: Date): Promise<void>;
+  gatherWeeklySummary(
+    projectId: string,
+    policy: Pick<DigestPolicy, "intervalMs">,
+    now: Date,
+  ): Promise<WeeklyDigestSummary>;
   gatherCandidates(
     projectId: string,
     policy: Pick<DigestPolicy, "candidateLookbackMs" | "candidateLimit">,
@@ -85,6 +90,84 @@ export function createDigestRepository(db: DB): DigestRepository {
             eq(schema.projectAutomationSettings.digestRunRequestedAt, requestedAt),
           ),
         );
+    },
+
+    async gatherWeeklySummary(projectId, policy, now) {
+      const from = new Date(now.getTime() - policy.intervalMs);
+      const [incidentCounts] = await db
+        .select({
+          opened: sql<number>`count(*) filter (
+            where ${schema.incidents.firstSeen} >= ${from}
+              and ${schema.incidents.firstSeen} <= ${now}
+          )`.mapWith(Number),
+          resolved: sql<number>`count(*) filter (
+            where ${schema.incidents.resolvedAt} >= ${from}
+              and ${schema.incidents.resolvedAt} <= ${now}
+          )`.mapWith(Number),
+          remainOpen: sql<number>`count(*) filter (
+            where ${schema.incidents.firstSeen} >= ${from}
+              and ${schema.incidents.firstSeen} <= ${now}
+              and ${schema.incidents.status} = 'open'
+          )`.mapWith(Number),
+        })
+        .from(schema.incidents)
+        .where(eq(schema.incidents.projectId, projectId));
+
+      const lifecycleRows = await db
+        .select({ detail: schema.incidentEvents.detail })
+        .from(schema.incidentEvents)
+        .innerJoin(schema.incidents, eq(schema.incidents.id, schema.incidentEvents.incidentId))
+        .where(
+          and(
+            eq(schema.incidents.projectId, projectId),
+            inArray(schema.incidentEvents.kind, [
+              "issue_reopened",
+              "issue_resolved",
+              "issue_silenced",
+              "issue_observed",
+            ]),
+            sql`coalesce(
+              ${schema.incidentEvents.processedAt},
+              ${schema.incidentEvents.createdAt}
+            ) >= ${from}`,
+            sql`coalesce(
+              ${schema.incidentEvents.processedAt},
+              ${schema.incidentEvents.createdAt}
+            ) <= ${now}`,
+          ),
+        );
+      const classifiedIssueIds = lifecycleRows.flatMap((row) => {
+        const issueId = row.detail?.issueId;
+        return typeof issueId === "string" ? [issueId] : [];
+      });
+      const recentlySeen = and(gte(schema.issues.lastSeen, from), lte(schema.issues.lastSeen, now));
+      const touchedThisWeek =
+        classifiedIssueIds.length > 0
+          ? or(recentlySeen, inArray(schema.issues.id, classifiedIssueIds))
+          : recentlySeen;
+
+      const issueRows = await db
+        .select({ status: schema.issues.status, count: sql<number>`count(*)`.mapWith(Number) })
+        .from(schema.issues)
+        .where(and(eq(schema.issues.projectId, projectId), touchedThisWeek))
+        .groupBy(schema.issues.status);
+      const issueCounts = new Map(issueRows.map((row) => [row.status, row.count]));
+
+      return {
+        from,
+        to: now,
+        incidents: {
+          opened: incidentCounts?.opened ?? 0,
+          resolved: incidentCounts?.resolved ?? 0,
+          remainOpen: incidentCounts?.remainOpen ?? 0,
+        },
+        issues: {
+          open: issueCounts.get("open") ?? 0,
+          underObservation: issueCounts.get("under_observation") ?? 0,
+          silenced: issueCounts.get("silenced") ?? 0,
+          resolved: issueCounts.get("resolved") ?? 0,
+        },
+      };
     },
 
     async gatherCandidates(projectId, policy, now) {

--- a/apps/worker/src/digest/run.test.ts
+++ b/apps/worker/src/digest/run.test.ts
@@ -1,7 +1,7 @@
 import "../agent-run.test-env.js";
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import type { DigestCandidate, DigestPick } from "./domain.js";
+import type { DigestCandidate, DigestPick, WeeklyDigestSummary } from "./domain.js";
 import { DEFAULT_DIGEST_POLICY, type DigestPolicy } from "./policy.js";
 import type { DigestRepository, ProjectDigestSettings } from "./repository.js";
 import {
@@ -41,11 +41,22 @@ function makeCandidate(overrides: Partial<DigestCandidate> = {}): DigestCandidat
   };
 }
 
+function makeSummary(overrides: Partial<WeeklyDigestSummary> = {}): WeeklyDigestSummary {
+  return {
+    from: new Date(NOW.getTime() - DEFAULT_DIGEST_POLICY.intervalMs),
+    to: NOW,
+    incidents: { opened: 0, resolved: 0, remainOpen: 0 },
+    issues: { open: 0, underObservation: 0, silenced: 0, resolved: 0 },
+    ...overrides,
+  };
+}
+
 function makeRepo(opts: {
   calls: string[];
   settings?: Partial<ProjectDigestSettings>;
   installation?: { id: string; botAccessToken: string };
   candidates?: DigestCandidate[];
+  summary?: WeeklyDigestSummary;
   enabledSettings?: ProjectDigestSettings[];
 }): DigestRepository {
   return {
@@ -76,6 +87,10 @@ function makeRepo(opts: {
     },
     async clearRunRequest(projectId, requestedAt) {
       opts.calls.push(`clearRunRequest:${projectId}:${requestedAt.toISOString()}`);
+    },
+    async gatherWeeklySummary(projectId) {
+      opts.calls.push(`gatherWeeklySummary:${projectId}`);
+      return opts.summary ?? makeSummary();
     },
     async gatherCandidates(projectId, _policy, _now) {
       opts.calls.push(`gatherCandidates:${projectId}`);
@@ -217,6 +232,37 @@ test("runDigestForProject: a forced test posts an empty digest when there are no
   assert.deepEqual(result, { status: "posted", pickCount: 0, ts: "1700000000.0001" });
   assert.ok(calls.includes("postDigest:C1"));
   assert.ok(calls.includes(`stampLastRun:project-1:${NOW.toISOString()}`));
+});
+
+test("runDigestForProject: posts the weekly breakdown even when there are no PR candidates", async () => {
+  const calls: string[] = [];
+  let postedBlocks: unknown[] = [];
+  const repo = makeRepo({
+    calls,
+    settings: {},
+    installation: INSTALLATION,
+    candidates: [],
+    summary: makeSummary({
+      incidents: { opened: 2, resolved: 1, remainOpen: 1 },
+      issues: { open: 1, underObservation: 1, silenced: 0, resolved: 2 },
+    }),
+  });
+  const deps = makeDeps({
+    calls,
+    repo,
+    slack: {
+      async postDigest(input) {
+        postedBlocks = input.blocks;
+        return { ok: true, ts: "1700000000.0001" };
+      },
+    },
+  });
+
+  const result = await runDigestForProjectWorkflow("project-1", deps);
+
+  assert.deepEqual(result, { status: "posted", pickCount: 0, ts: "1700000000.0001" });
+  assert.match(JSON.stringify(postedBlocks), /Weekly project recap/);
+  assert.match(JSON.stringify(postedBlocks), /2 opened/);
 });
 
 test("runDigestForProject: does NOT stamp last-run when Slack post fails", async () => {

--- a/apps/worker/src/digest/run.ts
+++ b/apps/worker/src/digest/run.ts
@@ -4,6 +4,7 @@ import {
   type DigestPick,
   attachCandidatesToPicks,
   buildDigestBlocks,
+  hasWeeklyDigestActivity,
 } from "./domain.js";
 import type { DigestPolicy } from "./policy.js";
 import type { DigestRepository } from "./repository.js";
@@ -71,32 +72,24 @@ export async function runDigestForProjectWorkflow(
     return { status: "skipped", reason: "slack installation revoked or missing" };
   }
 
-  const candidates = await deps.repo.gatherCandidates(projectId, deps.policy, deps.now());
+  const now = deps.now();
+  const summary = await deps.repo.gatherWeeklySummary(projectId, deps.policy, now);
+  const candidates = await deps.repo.gatherCandidates(projectId, deps.policy, now);
   let text: string;
   let blocks: unknown[];
   let pickCount: number;
   if (candidates.length === 0) {
-    if (!opts.force) {
+    if (!opts.force && !hasWeeklyDigestActivity(summary)) {
       // Stamp last-run so an empty scheduled week doesn't retry every tick.
-      await deps.repo.stampLastRun(projectId, deps.now());
-      return { status: "skipped", reason: "no open bug-fix PRs in lookback window" };
+      await deps.repo.stampLastRun(projectId, now);
+      return { status: "skipped", reason: "no weekly activity or open bug-fix PRs" };
     }
-    text = "Superlog weekly digest: no open bug-fix PRs in the lookback window.";
-    blocks = [
-      { type: "header", text: { type: "plain_text", text: "Weekly digest" } },
-      {
-        type: "section",
-        text: { type: "mrkdwn", text: "No open bug-fix PRs in the lookback window." },
-      },
-    ];
+    ({ text, blocks } = buildDigestBlocks([], summary));
     pickCount = 0;
   } else {
     const picks = await deps.rank(candidates);
     const ordered = attachCandidatesToPicks(picks, candidates);
-    if (ordered.length === 0) {
-      return { status: "skipped", reason: "ranking returned no valid picks" };
-    }
-    ({ text, blocks } = buildDigestBlocks(ordered));
+    ({ text, blocks } = buildDigestBlocks(ordered, summary));
     pickCount = ordered.length;
   }
 
@@ -116,7 +109,7 @@ export async function runDigestForProjectWorkflow(
     return { status: "skipped", reason: `slack error: ${result.error ?? "no response"}` };
   }
 
-  await deps.repo.stampLastRun(projectId, deps.now());
+  await deps.repo.stampLastRun(projectId, now);
   return { status: "posted", pickCount, ts: result.ts ?? null };
 }
 


### PR DESCRIPTION
## Summary

- lead the weekly Slack recap with incidents opened, resolved, and still open
- break down issues touched during the week by their current lifecycle status
- send activity-only recaps when there are no pull request candidates, while continuing to skip truly empty weeks

## Validation

- `pnpm --filter @superlog/worker test:digest-domain`
- `pnpm --filter @superlog/worker test:digest-run`
- `pnpm --filter @superlog/worker typecheck`
- targeted Biome check for all changed files

## Note

The repository-wide `pnpm lint` command remains red on pre-existing formatting and lint findings outside this diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a weekly activity breakdown to Slack digests, leading with incident counts and issue status by week. Improves the plain-text fallback and sends a recap-only message when no PR candidates exist, while still skipping truly empty weeks.

- **New Features**
  - Slack digest starts with a “Weekly project recap” (date range, incidents opened/resolved/remaining open, and issues by status).
  - Added `gatherWeeklySummary` to compute weekly counts from incidents and issues touched during the window (by `lastSeen` or incident events), and return the `from`/`to` range.
  - Digest behavior: if no PR candidates, post the recap only; if no activity and not forced, skip and stamp last run (via `hasWeeklyDigestActivity`).
  - Updated `buildDigestBlocks` to render the recap before ranked PRs and enhance the plain-text fallback to include both the recap and the PR list.
  - Expanded tests across `@superlog/worker` domain, repository, and run workflow.

<sup>Written for commit bbd6820ffb64693bcdae4a2c34814f0cc34ab130. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

