### PR TITLE
Show joined issue cards in incident activity

### DIFF
--- a/apps/web/src/incidents/IncidentTranscript.test.ts
+++ b/apps/web/src/incidents/IncidentTranscript.test.ts
@@ -43,6 +43,28 @@ test("buildActivityFeed starts with the issue that triggered the incident", () =
   });
 });
 
+test("buildActivityFeed presents a joined issue as issue activity instead of its raw context summary", () => {
+  const feed = buildActivityFeed([
+    event({
+      id: "joined-issue-1",
+      kind: "incident_context_changed",
+      summary:
+        'Regressed issue joined the incident (issue id: 85cc8c48-fefb-4c99-8c99-47a83800b91c): ERROR: cart.add failed for plant "nullingia"',
+      createdAt: "2026-07-09T00:28:18.068Z",
+    }),
+  ]);
+
+  assert.deepEqual(feed, [
+    {
+      type: "issue_activity",
+      id: "joined-issue-1",
+      issueId: "85cc8c48-fefb-4c99-8c99-47a83800b91c",
+      label: "Regressed issue joined the incident",
+      createdAt: "2026-07-09T00:28:18.068Z",
+    },
+  ]);
+});
+
 test("buildActivityFeed shows the filed Linear ticket without the internal handoff marker", () => {
   const filed = event({
     id: "linear-filed-1",

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -46,8 +46,8 @@ export function IncidentActivityFeed({
   /** The issue that opened the incident. It is projected as the first feed
    *  entry without writing a fictional lifecycle row to incident_events. */
   triggeringIssue?: { issueId: string; createdAt: string } | null;
-  /** Renders the referenced issue as a card under lifecycle events whose
-   *  detail carries an `issueId` (recurrence, reopen). */
+  /** Renders the referenced issue as a card under issue activity projected
+   *  from lifecycle detail or a legacy joined-issue summary. */
   renderIssueCard?: (issueId: string, options?: { showOccurrences?: boolean }) => ReactNode;
   /** When the run paused on `ask_human`, the question is not an incident event
    *  — it lives on the run result. Render it as a terminal node so the timeline
@@ -73,7 +73,25 @@ export function IncidentActivityFeed({
   const renderItem = (item: FeedItem) => {
     if (item.type === "message") return <MessageEntry key={item.id} text={item.text} />;
     if (item.type === "triggering_issue")
-      return <TriggeringIssueEntry key={item.id} item={item} renderIssueCard={renderIssueCard} />;
+      return (
+        <IssueActivityEntry
+          key={item.id}
+          item={item}
+          label="Issue detected"
+          renderIssueCard={renderIssueCard}
+          showOccurrences
+          accent
+        />
+      );
+    if (item.type === "issue_activity")
+      return (
+        <IssueActivityEntry
+          key={item.id}
+          item={item}
+          label={item.label}
+          renderIssueCard={renderIssueCard}
+        />
+      );
     if (item.type === "human") return <HumanEntry key={item.id} item={item} />;
     if (item.type === "telemetry") return <TelemetryEntry key={item.id} item={item} />;
     if (item.type === "memory") return <MemoryEntry key={item.id} item={item} />;
@@ -273,23 +291,32 @@ function QuestionEntry({
   );
 }
 
-function TriggeringIssueEntry({
+function IssueActivityEntry({
   item,
+  label,
   renderIssueCard,
+  showOccurrences = false,
+  accent = false,
 }: {
-  item: Extract<FeedItem, { type: "triggering_issue" }>;
+  item: Extract<FeedItem, { type: "triggering_issue" | "issue_activity" }>;
+  label: string;
   renderIssueCard?: (issueId: string, options?: { showOccurrences?: boolean }) => ReactNode;
+  showOccurrences?: boolean;
+  accent?: boolean;
 }) {
-  const issueCard = renderIssueCard?.(item.issueId, { showOccurrences: true });
+  const issueCard = renderIssueCard?.(
+    item.issueId,
+    showOccurrences ? { showOccurrences: true } : undefined,
+  );
   return (
     <div className="relative mb-6">
-      <Node tone="accent">
+      <Node tone={accent ? "accent" : "muted"}>
         <path d="M12 3v9" />
         <path d="M12 17h.01" />
         <circle cx="12" cy="12" r="9" />
       </Node>
       <div className="mb-1.5 flex min-h-[22px] items-baseline gap-2">
-        <span className="text-[12px] font-semibold text-fg">Issue detected</span>
+        <span className="text-[12px] font-semibold text-fg">{label}</span>
         <span className="text-[11px] text-subtle">{fmtRelative(item.createdAt)}</span>
       </div>
       {issueCard}

--- a/apps/web/src/incidents/incident-activity-feed.ts
+++ b/apps/web/src/incidents/incident-activity-feed.ts
@@ -51,6 +51,13 @@ export type TranscriptItem =
 export type FeedItem =
   | TranscriptItem
   | { type: "triggering_issue"; id: string; issueId: string; createdAt: string }
+  | {
+      type: "issue_activity";
+      id: string;
+      issueId: string;
+      label: string;
+      createdAt: string;
+    }
   | { type: "human"; id: string; author: string | null; text: string; createdAt: string }
   | { type: "lifecycle"; id: string; event: IncidentEvent };
 
@@ -69,6 +76,26 @@ function isFeedNoise(kind: string): boolean {
   if (kind === "session.error") return false;
   if (kind === "linear_handoff_pending") return true;
   return kind.startsWith("span.") || kind.startsWith("session.");
+}
+
+function joinedIssueActivity(
+  event: IncidentEvent,
+): Extract<FeedItem, { type: "issue_activity" }> | null {
+  if (event.kind !== "incident_context_changed") return null;
+  const match = (event.summary ?? "").match(
+    /^(New|Regressed) issue joined the incident(?: \(issue id:\s*([^)]+)\))?(?::|$)/,
+  );
+  if (!match) return null;
+  const detailIssueId = event.detail?.issueId;
+  const issueId = typeof detailIssueId === "string" ? detailIssueId : match[2]?.trim();
+  if (!issueId) return null;
+  return {
+    type: "issue_activity",
+    id: event.id,
+    issueId,
+    label: `${match[1]} issue joined the incident`,
+    createdAt: event.createdAt,
+  };
 }
 
 export function buildActivityFeed(
@@ -94,6 +121,11 @@ export function buildActivityFeed(
       ]
     : [];
   for (const event of events) {
+    const issueActivity = joinedIssueActivity(event);
+    if (issueActivity) {
+      items.push(issueActivity);
+      continue;
+    }
     const mcpError = (
       event.detail as {
         mcpError?: { serverName?: string; category?: string; message?: string };
@@ -218,6 +250,9 @@ export function markAwaitingQuestion(feed: FeedItem[], question: string): FeedIt
 export function buildTranscript(events: IncidentEvent[]): TranscriptItem[] {
   return buildActivityFeed(events).filter(
     (item): item is TranscriptItem =>
-      item.type !== "lifecycle" && item.type !== "human" && item.type !== "triggering_issue",
+      item.type !== "lifecycle" &&
+      item.type !== "human" &&
+      item.type !== "triggering_issue" &&
+      item.type !== "issue_activity",
   );
 }


### PR DESCRIPTION
## Summary

- render the triggering and joined issues through one shared activity-card presentation
- replace legacy joined-issue UUID/error summaries with concise timeline labels while preserving timestamp and order
- support existing context-change events whose issue ID appears only in the legacy summary

## Why

Joined issues were rendered as raw lifecycle copy because older context-change events did not carry a structured issue ID. That made incident activity difficult to scan and omitted the linked error tile.

## Validation

- focused incident activity and outcome tests
- web typecheck
- full web test suite (149 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show joined issue cards in the incident activity timeline using a shared issue card UI. We parse legacy joined-issue summaries to extract the issue ID, render a compact label, and keep timestamp and ordering.

- **New Features**
  - Add `issue_activity` items for joined issues and render them via `renderIssueCard` with concise labels; transcripts exclude these items.
  - Parse legacy `incident_context_changed` summaries to get `issueId` when missing from event detail; unify UI by using `IssueActivityEntry` (accented for the triggering issue, supports occurrences).

<sup>Written for commit 3ffa0bec3f94fb9e42cce3ef45d72167eca7778e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

