### PR TITLE
Add an icon for the Agent memories settings nav item

### DIFF
--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -496,6 +496,16 @@ function SectionIcon({ scope, section }: { scope: SettingsScope; section: Sectio
           <circle cx="15" cy="12" r="0.5" fill="currentColor" />
         </svg>
       );
+    case "project:agent-memories":
+      return (
+        <svg {...props} aria-hidden="true">
+          <path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z" />
+          <path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z" />
+          <path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4" />
+          <path d="M6 18a4 4 0 0 1-1.967-.516" />
+          <path d="M19.967 17.484A4 4 0 0 1 18 18" />
+        </svg>
+      );
     case "mcp-server":
       return (
         <svg {...props} aria-hidden="true">


### PR DESCRIPTION
The **Agent memories** item in project settings navigation was the only entry rendering a blank icon slot: its key (`project:agent-memories`) had no `case` in `SectionIcon`, so it fell through to `default: return null` while every sibling rendered an inline SVG.

Add a `case "project:agent-memories"` returning a brain icon in the same inline-SVG style as the surrounding items (24 viewBox, 1.7 stroke, `currentColor`).

Purely presentational — no data or behaviour change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a brain icon to the Agent memories item in project settings so it matches other items and no longer shows a blank slot. Implemented by adding `case "project:agent-memories"` to `SectionIcon` with a matching inline SVG; visual-only change.

<sup>Written for commit 2c23adcceb8ad3eae2e16978820288355726ed47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

