### PR TITLE
Prevent maintenance jobs from starving the worker

### DIFF
--- a/apps/worker/scripts/materialize-metric-usage-projections.ts
+++ b/apps/worker/scripts/materialize-metric-usage-projections.ts
@@ -1,0 +1,130 @@
+import "../src/env.js";
+import { createClient } from "@clickhouse/client";
+import { METRIC_TABLES } from "../src/billing/metric-usage-schema.js";
+
+// Materialize the metric usage projection for existing data after applying
+// infra/clickhouse/migrations/008_metric_usage_projection.sql.
+//
+// The script is dry-run by default and processes one table/date partition at a
+// time. With --apply it waits for every replica before moving on, preventing
+// five large projection mutations from competing for disk bandwidth.
+//
+// Example:
+//   pnpm --filter @superlog/worker exec tsx scripts/materialize-metric-usage-projections.ts \
+//     --from 2026-07-13 --to 2026-07-14 --apply
+
+type Args = { from: string; to: string; apply: boolean };
+
+const args = parseArgs(process.argv.slice(2));
+const clickhouse = createClient({
+  url: process.env.CLICKHOUSE_URL ?? "http://localhost:8123",
+  username: process.env.CLICKHOUSE_USER ?? "default",
+  password: process.env.CLICKHOUSE_PASSWORD ?? "",
+  database: process.env.CLICKHOUSE_DB ?? "superlog",
+  // This is an explicit maintenance command that waits for replicated
+  // mutations. The normal worker query deadline remains 30 seconds.
+  request_timeout: 6 * 60 * 60 * 1000,
+});
+
+type PartitionStatus = {
+  parts: number | string;
+  totalRows: number | string;
+  projectedParts: number | string;
+  unprojectedRows: number | string;
+  unprojectedBytes: number | string;
+};
+
+async function partitionStatus(table: string, partition: string): Promise<PartitionStatus> {
+  const result = await clickhouse.query({
+    query: `SELECT
+              count() AS parts,
+              sum(rows) AS totalRows,
+              countIf(has(projections, 'usage_by_time')) AS projectedParts,
+              sumIf(rows, NOT has(projections, 'usage_by_time')) AS unprojectedRows,
+              sumIf(bytes_on_disk, NOT has(projections, 'usage_by_time')) AS unprojectedBytes
+            FROM system.parts
+            WHERE active
+              AND database = currentDatabase()
+              AND table = {table:String}
+              AND partition = {partition:String}`,
+    query_params: { table, partition },
+    format: "JSONEachRow",
+  });
+  const rows = (await result.json()) as PartitionStatus[];
+  return (
+    rows[0] ?? {
+      parts: 0,
+      totalRows: 0,
+      projectedParts: 0,
+      unprojectedRows: 0,
+      unprojectedBytes: 0,
+    }
+  );
+}
+
+try {
+  console.log(JSON.stringify({ ...args, note: args.apply ? "materializing" : "dry run" }));
+  for (const partition of datePartitions(args.from, args.to)) {
+    for (const table of METRIC_TABLES) {
+      const before = await partitionStatus(table, partition);
+      const unprojectedRows = Number(before.unprojectedRows);
+      console.log(JSON.stringify({ table, partition, phase: "before", ...before }));
+      if (!args.apply || !Number.isFinite(unprojectedRows) || unprojectedRows <= 0) continue;
+
+      // Dates are strictly validated by parseArgs before interpolation.
+      await clickhouse.command({
+        query: `ALTER TABLE ${table}
+                MATERIALIZE PROJECTION usage_by_time IN PARTITION '${partition}'
+                SETTINGS mutations_sync = 2`,
+      });
+      const after = await partitionStatus(table, partition);
+      console.log(JSON.stringify({ table, partition, phase: "after", ...after }));
+    }
+  }
+} finally {
+  await clickhouse.close();
+}
+
+function parseArgs(argv: string[]): Args {
+  const values = new Map<string, string | true>();
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--") continue;
+    if (!arg.startsWith("--")) throw new Error(`unexpected argument: ${arg}`);
+    const key = arg.slice(2);
+    if (key === "apply") {
+      values.set(key, true);
+      continue;
+    }
+    if (key !== "from" && key !== "to") throw new Error(`unknown argument: --${key}`);
+    const value = argv[i + 1];
+    if (!value || value.startsWith("--")) throw new Error(`missing value for --${key}`);
+    values.set(key, value);
+    i += 1;
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+  const from = stringValue(values.get("from")) ?? today;
+  const to = stringValue(values.get("to")) ?? from;
+  if (!isIsoDate(from) || !isIsoDate(to)) throw new Error("--from/--to must be YYYY-MM-DD");
+  if (from > to) throw new Error("--from must not be after --to");
+  return { from, to, apply: values.get("apply") === true };
+}
+
+function stringValue(value: string | true | undefined): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function isIsoDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  return new Date(`${value}T00:00:00.000Z`).toISOString().slice(0, 10) === value;
+}
+
+function* datePartitions(from: string, to: string): Generator<string> {
+  const cursor = new Date(`${from}T00:00:00.000Z`);
+  const end = new Date(`${to}T00:00:00.000Z`);
+  while (cursor <= end) {
+    yield cursor.toISOString().slice(0, 10);
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+}

--- a/apps/worker/src/agent-runs/queue.test.ts
+++ b/apps/worker/src/agent-runs/queue.test.ts
@@ -98,7 +98,7 @@ test("registration creates both queues, workers, and the sweep schedule", async 
   // `stately` allows one queued + one active job per run id, so an
   // event-driven enqueue during processing is preserved while duplicates
   // still collapse.
-  assert.deepEqual(advance?.options, { policy: "stately" });
+  assert.deepEqual(advance?.options, { policy: "stately", expireInSeconds: 120 });
   const sweep = fb.queues.find((q) => q.name === AGENT_RUN_SWEEP_QUEUE);
   assert.deepEqual(sweep?.options, { policy: "exclusive" });
   assert.ok(fb.workers.get(AGENT_RUN_ADVANCE_QUEUE));

--- a/apps/worker/src/agent-runs/queue.test.ts
+++ b/apps/worker/src/agent-runs/queue.test.ts
@@ -19,6 +19,7 @@ function fakeBoss() {
   const sent: SentJob[] = [];
   const inserted: InsertedJob[] = [];
   const queues: Array<{ name: string; options: unknown }> = [];
+  const queueUpdates: Array<{ name: string; options: unknown }> = [];
   const schedules: Array<{ name: string; cron: string }> = [];
   const workers = new Map<string, WorkHandler>();
   const workOptions = new Map<string, WorkOptions>();
@@ -27,6 +28,10 @@ function fakeBoss() {
     async createQueue(name, options) {
       ops.push(`createQueue:${name}`);
       queues.push({ name, options });
+    },
+    async updateQueue(name, options) {
+      ops.push(`updateQueue:${name}`);
+      queueUpdates.push({ name, options });
     },
     async work(name, options, handler) {
       ops.push(`work:${name}`);
@@ -46,7 +51,7 @@ function fakeBoss() {
       schedules.push({ name, cron });
     },
   };
-  return { boss, sent, inserted, queues, schedules, workers, workOptions, ops };
+  return { boss, sent, inserted, queues, queueUpdates, schedules, workers, workOptions, ops };
 }
 
 function runOf(id: string, state: string): schema.AgentRun {
@@ -84,6 +89,8 @@ function makeDeps(overrides: DepsOverrides = {}) {
       resume: overrides.handlers?.resume ?? handler("resume"),
       retryPrDelivery: overrides.handlers?.retryPrDelivery ?? handler("retry_pr_delivery"),
     },
+    concurrency: overrides.concurrency,
+    jobTimeoutMs: overrides.jobTimeoutMs,
     logger: { warn: () => {}, error: () => {} },
   };
   return { deps, calls };
@@ -99,6 +106,9 @@ test("registration creates both queues, workers, and the sweep schedule", async 
   // event-driven enqueue during processing is preserved while duplicates
   // still collapse.
   assert.deepEqual(advance?.options, { policy: "stately", expireInSeconds: 120 });
+  assert.deepEqual(fb.queueUpdates, [
+    { name: AGENT_RUN_ADVANCE_QUEUE, options: { expireInSeconds: 120 } },
+  ]);
   const sweep = fb.queues.find((q) => q.name === AGENT_RUN_SWEEP_QUEUE);
   assert.deepEqual(sweep?.options, { policy: "exclusive" });
   assert.ok(fb.workers.get(AGENT_RUN_ADVANCE_QUEUE));
@@ -117,6 +127,17 @@ test("registration creates both queues, workers, and the sweep schedule", async 
   // failure must never leave a live advance consumer behind — that would
   // advance the same run from two places at once.
   assert.equal(fb.ops.at(-1), `work:${AGENT_RUN_ADVANCE_QUEUE}`);
+});
+
+test("a custom attempt timeout keeps the durable lease beyond the application deadline", async () => {
+  const fb = fakeBoss();
+  const { deps } = makeDeps({ jobTimeoutMs: 180_000 });
+
+  await registerAgentRunQueue(fb.boss, deps);
+
+  assert.deepEqual(fb.queueUpdates, [
+    { name: AGENT_RUN_ADVANCE_QUEUE, options: { expireInSeconds: 210 } },
+  ]);
 });
 
 test("advance worker dispatches by run state", async () => {

--- a/apps/worker/src/agent-runs/queue.ts
+++ b/apps/worker/src/agent-runs/queue.ts
@@ -53,6 +53,7 @@ const JOB_EXPIRY_GRACE_SECONDS = 30;
 
 export type AgentRunQueueBoss = {
   createQueue(name: string, options?: unknown): Promise<unknown>;
+  updateQueue(name: string, options?: unknown): Promise<unknown>;
   work(
     name: string,
     options: { batchSize: number; localConcurrency?: number },
@@ -143,13 +144,21 @@ export async function registerAgentRunQueue(
 ): Promise<void> {
   const logger = deps.logger ?? defaultLogger;
   const concurrency = clampConcurrency(deps.concurrency);
+  const jobTimeoutMs = deps.jobTimeoutMs ?? DEFAULT_JOB_TIMEOUT_MS;
+  const expireInSeconds = Math.ceil(jobTimeoutMs / 1000) + JOB_EXPIRY_GRACE_SECONDS;
 
   await boss.createQueue(AGENT_RUN_ADVANCE_QUEUE, {
     policy: "stately",
     // Keep pg-boss's durable active-job lease just beyond the application's
     // own deadline. A task killed during deploy can then block a run for at
     // most two minutes instead of pg-boss's 15-minute default.
-    expireInSeconds: Math.ceil(DEFAULT_JOB_TIMEOUT_MS / 1000) + JOB_EXPIRY_GRACE_SECONDS,
+    expireInSeconds,
+  });
+  // createQueue is insert-only in pg-boss. Update the mutable lease explicitly
+  // so queues created by an older deployment do not retain the 15-minute
+  // default indefinitely.
+  await boss.updateQueue(AGENT_RUN_ADVANCE_QUEUE, {
+    expireInSeconds,
   });
   await boss.createQueue(AGENT_RUN_SWEEP_QUEUE, { policy: "exclusive" });
 
@@ -163,7 +172,6 @@ export async function registerAgentRunQueue(
   });
   await boss.schedule(AGENT_RUN_SWEEP_QUEUE, SWEEP_SCHEDULE);
 
-  const jobTimeoutMs = deps.jobTimeoutMs ?? DEFAULT_JOB_TIMEOUT_MS;
   // Runs with an attempt still executing — including attempts whose JOB was
   // completed by the timeout below while the underlying promise keeps
   // running. A new job for such a run is skipped so two attempts never

--- a/apps/worker/src/agent-runs/queue.ts
+++ b/apps/worker/src/agent-runs/queue.ts
@@ -48,7 +48,8 @@ const MAX_CONCURRENCY = 50;
 // attempt is abandoned (logged, including a late-failure hook so an eventual
 // rejection can't become an unhandled rejection) and the minute sweep
 // re-enqueues the run.
-const DEFAULT_JOB_TIMEOUT_MS = 180_000;
+const DEFAULT_JOB_TIMEOUT_MS = 90_000;
+const JOB_EXPIRY_GRACE_SECONDS = 30;
 
 export type AgentRunQueueBoss = {
   createQueue(name: string, options?: unknown): Promise<unknown>;
@@ -143,7 +144,13 @@ export async function registerAgentRunQueue(
   const logger = deps.logger ?? defaultLogger;
   const concurrency = clampConcurrency(deps.concurrency);
 
-  await boss.createQueue(AGENT_RUN_ADVANCE_QUEUE, { policy: "stately" });
+  await boss.createQueue(AGENT_RUN_ADVANCE_QUEUE, {
+    policy: "stately",
+    // Keep pg-boss's durable active-job lease just beyond the application's
+    // own deadline. A task killed during deploy can then block a run for at
+    // most two minutes instead of pg-boss's 15-minute default.
+    expireInSeconds: Math.ceil(DEFAULT_JOB_TIMEOUT_MS / 1000) + JOB_EXPIRY_GRACE_SECONDS,
+  });
   await boss.createQueue(AGENT_RUN_SWEEP_QUEUE, { policy: "exclusive" });
 
   await boss.work(AGENT_RUN_SWEEP_QUEUE, { batchSize: 1 }, async () => {

--- a/apps/worker/src/autorecovery.ts
+++ b/apps/worker/src/autorecovery.ts
@@ -20,30 +20,27 @@
 //   - autorecovery/tick.ts is the application service
 //
 // This file is now a thin facade that wires real deps and re-exports the
-// two public entry points the worker tick calls.
+// scheduled-job and manual entry points.
 import Anthropic from "@anthropic-ai/sdk";
 import { db } from "@superlog/db";
 import { recordTokenUsage } from "./ai-usage.js";
 import {
-  asLLMClient,
   type AutorecoveryTokenAccountant,
+  asLLMClient,
   runAutorecoveryAgent,
 } from "./autorecovery/agent.js";
 import type { CandidateIncident } from "./autorecovery/domain.js";
 import {
-  type AutorecoveryPolicy,
-  autorecoveryPolicyFromEnv,
-} from "./autorecovery/policy.js";
-import {
   createAutorecoveryMetricsRepository,
   defaultClickhouseClient,
 } from "./autorecovery/metrics-repository.js";
+import { type AutorecoveryPolicy, autorecoveryPolicyFromEnv } from "./autorecovery/policy.js";
 import { createAutorecoveryRepository } from "./autorecovery/repository.js";
 import { createSlackPoster } from "./autorecovery/slack.js";
 import {
+  type TickDeps,
   runAutorecoveryNow as runAutorecoveryNowApp,
   runAutorecoveryTick as runAutorecoveryTickApp,
-  type TickDeps,
 } from "./autorecovery/tick.js";
 import { logger } from "./logger.js";
 
@@ -90,9 +87,8 @@ function makeDeps(apiKey: string, policy: AutorecoveryPolicy): TickDeps {
   };
 }
 
-// Entry point called from the main worker tick loop. Throttled by
-// `worker_state.cursor` — every worker tick checks the cursor and
-// short-circuits if the last autorecovery pass was recent.
+// Entry point called from jobs/autorecovery.ts. Throttled by
+// `worker_state.cursor` so a delayed or duplicate cron fire remains harmless.
 export async function tickAutorecovery(): Promise<number> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) return 0;

--- a/apps/worker/src/autorecovery/policy.ts
+++ b/apps/worker/src/autorecovery/policy.ts
@@ -53,13 +53,9 @@ export const DEFAULT_AUTORECOVERY_POLICY: AutorecoveryPolicy = {
   skipRecentlyCreatedMs: 2 * 60 * 60 * 1000,
   dismissalCooldownMs: 24 * 60 * 60 * 1000,
   reevaluationCooldownMs: 24 * 60 * 60 * 1000,
-  // Per-tick cap on incidents evaluated. The sweep runs inline in the worker's
-  // sequential tick and processes candidates one LLM call at a time, so this
-  // value also bounds how long a single pass blocks telemetry ingest /
-  // investigations. 50 drains the typical backlog in well under a day while
-  // keeping the worst-case pass duration bounded. Crank `AUTORECOVERY_MAX_PER_TICK`
-  // higher to blast through a large backlog faster — but mind that the pass
-  // blocks the rest of the tick until it finishes.
+  // Per-pass cap on incidents evaluated. The sweep processes candidates one
+  // LLM call at a time on its own exclusive background queue; 50 drains the
+  // typical backlog in well under a day without competing passes overlapping.
   maxCandidatesPerTick: 50,
   proposeMinConfidence: "medium",
   maxAgentIterations: 6,

--- a/apps/worker/src/billing/metric-usage-schema.ts
+++ b/apps/worker/src/billing/metric-usage-schema.ts
@@ -26,7 +26,7 @@ export async function findMetricUsageProjectionTables(
               FROM system.columns
               WHERE database = currentDatabase()
                 AND name = {column:String}
-                AND table IN ({tables:Array(String)})`,
+                AND table IN {tables:Array(String)}`,
       query_params: {
         column: METRIC_USAGE_PROJECT_ID_COLUMN,
         tables: [...METRIC_TABLES],

--- a/apps/worker/src/billing/metric-usage-schema.ts
+++ b/apps/worker/src/billing/metric-usage-schema.ts
@@ -1,0 +1,40 @@
+import type { ClickHouseClient } from "@clickhouse/client";
+
+// OpenTelemetry's ClickHouse exporter stores metric kinds separately. The HA
+// schema adds the same exact-count usage projection to each physical table.
+export const METRIC_TABLES = [
+  "otel_metrics_sum",
+  "otel_metrics_gauge",
+  "otel_metrics_histogram",
+  "otel_metrics_summary",
+  "otel_metrics_exp_histogram",
+] as const;
+
+export const METRIC_USAGE_PROJECT_ID_COLUMN = "SuperlogProjectId";
+
+// The optimized column is intentionally optional: collector-created schemas
+// and installations that have not applied the projection migration still use
+// the ResourceAttributes expression. Return tables individually so a partially
+// applied migration remains correct while it finishes.
+export async function findMetricUsageProjectionTables(
+  clickhouse: Pick<ClickHouseClient, "query">,
+): Promise<ReadonlySet<string>> {
+  try {
+    const result = await clickhouse.query({
+      query: `SELECT table
+              FROM system.columns
+              WHERE database = currentDatabase()
+                AND name = {column:String}
+                AND table IN ({tables:Array(String)})`,
+      query_params: {
+        column: METRIC_USAGE_PROJECT_ID_COLUMN,
+        tables: [...METRIC_TABLES],
+      },
+      format: "JSONEachRow",
+    });
+    const rows = (await result.json()) as Array<{ table: string }>;
+    return new Set(rows.map(({ table }) => table));
+  } catch {
+    return new Set();
+  }
+}

--- a/apps/worker/src/billing/metric-usage-schema.ts
+++ b/apps/worker/src/billing/metric-usage-schema.ts
@@ -18,6 +18,7 @@ export const METRIC_USAGE_PROJECT_ID_COLUMN = "SuperlogProjectId";
 // applied migration remains correct while it finishes.
 export async function findMetricUsageProjectionTables(
   clickhouse: Pick<ClickHouseClient, "query">,
+  abortSignal?: AbortSignal,
 ): Promise<ReadonlySet<string>> {
   try {
     const result = await clickhouse.query({
@@ -31,6 +32,7 @@ export async function findMetricUsageProjectionTables(
         tables: [...METRIC_TABLES],
       },
       format: "JSONEachRow",
+      abort_signal: abortSignal,
     });
     const rows = (await result.json()) as Array<{ table: string }>;
     return new Set(rows.map(({ table }) => table));

--- a/apps/worker/src/billing/usage-count-query.test.ts
+++ b/apps/worker/src/billing/usage-count-query.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { buildUsageCountQuery } from "./usage-count-query.js";
+import {
+  METRIC_TABLES,
+  buildUsageCountQueries,
+  buildUsageCountQuery,
+} from "./usage-count-query.js";
 
 test("log usage counts preserve precise bounds while pruning by TimestampTime", () => {
   const query = buildUsageCountQuery("logs");
@@ -9,4 +13,29 @@ test("log usage counts preserve precise bounds while pruning by TimestampTime", 
   assert.match(query, /Timestamp <= \{until:DateTime64\(9\)\}/);
   assert.match(query, /TimestampTime >= \{after:DateTime64\(9\)\} - INTERVAL 1 SECOND/);
   assert.match(query, /TimestampTime <= \{until:DateTime64\(9\)\}/);
+});
+
+test("metric usage falls back to resource attributes when optimized columns are unavailable", () => {
+  const queries = buildUsageCountQueries("metric_points");
+
+  assert.equal(queries.length, 5);
+  assert.ok(queries.every((query) => !query.includes("UNION ALL")));
+  assert.ok(queries.every((query) => query.includes("PREWHERE TimeUnix")));
+  assert.ok(queries.every((query) => query.includes("TimeUnix > {after:DateTime64(9)}")));
+  assert.ok(queries.every((query) => query.includes("TimeUnix <= {until:DateTime64(9)}")));
+  assert.ok(
+    queries.every((query) => query.includes("ResourceAttributes['superlog.project_id'] AS pid")),
+  );
+  for (const table of METRIC_TABLES) {
+    assert.ok(queries.some((query) => query.includes(`FROM ${table}`)));
+  }
+});
+
+test("metric usage reads the exact-count time projection when its project column exists", () => {
+  const queries = buildUsageCountQueries("metric_points", new Set(METRIC_TABLES));
+
+  assert.equal(queries.length, METRIC_TABLES.length);
+  assert.ok(queries.every((query) => query.includes("SuperlogProjectId AS pid")));
+  assert.ok(queries.every((query) => !query.includes("ResourceAttributes[")));
+  assert.ok(queries.every((query) => query.includes("PREWHERE TimeUnix")));
 });

--- a/apps/worker/src/billing/usage-count-query.ts
+++ b/apps/worker/src/billing/usage-count-query.ts
@@ -1,35 +1,43 @@
+import { METRIC_TABLES, METRIC_USAGE_PROJECT_ID_COLUMN } from "./metric-usage-schema.js";
 import type { UsageSignal } from "./usage-metering.js";
 
+export { METRIC_TABLES } from "./metric-usage-schema.js";
+
+const RESOURCE_PROJECT_ID = "ResourceAttributes['superlog.project_id']";
+const NO_OPTIMIZED_METRIC_TABLES: ReadonlySet<string> = new Set();
+
+function metricCountQuery(table: string, optimizedTables: ReadonlySet<string>): string {
+  const projectId = optimizedTables.has(table)
+    ? METRIC_USAGE_PROJECT_ID_COLUMN
+    : RESOURCE_PROJECT_ID;
+  return `SELECT ${projectId} AS pid, count() AS c FROM ${table}
+          PREWHERE TimeUnix > {after:DateTime64(9)} AND TimeUnix <= {until:DateTime64(9)}
+          WHERE ${projectId} != '' GROUP BY pid`;
+}
+
+export function buildUsageCountQueries(
+  signal: UsageSignal,
+  optimizedMetricTables: ReadonlySet<string> = NO_OPTIMIZED_METRIC_TABLES,
+): string[] {
+  if (signal === "metric_points") {
+    return METRIC_TABLES.map((table) => metricCountQuery(table, optimizedMetricTables));
+  }
+  return [buildUsageCountQuery(signal)];
+}
+
 // One bounded-window count query per signal. Metrics span five OTel tables.
-export function buildUsageCountQuery(signal: UsageSignal): string {
+export function buildUsageCountQuery(signal: Exclude<UsageSignal, "metric_points">): string {
   if (signal === "spans") {
     return `SELECT ResourceAttributes['superlog.project_id'] AS pid, count() AS c
             FROM otel_traces
             WHERE Timestamp > {after:DateTime64(9)} AND Timestamp <= {until:DateTime64(9)} AND pid != ''
             GROUP BY pid`;
   }
-  if (signal === "logs") {
-    return `SELECT ResourceAttributes['superlog.project_id'] AS pid, count() AS c
-            FROM otel_logs
-            WHERE Timestamp > {after:DateTime64(9)} AND Timestamp <= {until:DateTime64(9)}
-              AND TimestampTime >= {after:DateTime64(9)} - INTERVAL 1 SECOND
-              AND TimestampTime <= {until:DateTime64(9)}
-              AND pid != ''
-            GROUP BY pid`;
-  }
-  const metricTables = [
-    "otel_metrics_sum",
-    "otel_metrics_gauge",
-    "otel_metrics_histogram",
-    "otel_metrics_summary",
-    "otel_metrics_exp_histogram",
-  ];
-  const union = metricTables
-    .map(
-      (t) =>
-        `SELECT ResourceAttributes['superlog.project_id'] AS pid, count() AS c FROM ${t}
-         WHERE TimeUnix > {after:DateTime64(9)} AND TimeUnix <= {until:DateTime64(9)} AND pid != '' GROUP BY pid`,
-    )
-    .join(" UNION ALL ");
-  return `SELECT pid, sum(c) AS c FROM (${union}) GROUP BY pid`;
+  return `SELECT ResourceAttributes['superlog.project_id'] AS pid, count() AS c
+          FROM otel_logs
+          WHERE Timestamp > {after:DateTime64(9)} AND Timestamp <= {until:DateTime64(9)}
+            AND TimestampTime >= {after:DateTime64(9)} - INTERVAL 1 SECOND
+            AND TimestampTime <= {until:DateTime64(9)}
+            AND pid != ''
+          GROUP BY pid`;
 }

--- a/apps/worker/src/billing/usage-meter-ticker.test.ts
+++ b/apps/worker/src/billing/usage-meter-ticker.test.ts
@@ -3,15 +3,18 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { ClickHouseClient } from "@clickhouse/client";
 import { METRIC_TABLES } from "./usage-count-query.js";
-import { createCountByProject } from "./usage-meter-ticker.js";
+import { createAutumnTrack, createCountByProject } from "./usage-meter-ticker.js";
 
 test("metric counts probe optimized columns, scan projections sequentially, and merge totals", async () => {
   const queries: string[] = [];
+  const querySignals: Array<AbortSignal | undefined> = [];
+  const deadline = new AbortController();
   let inFlight = 0;
   let maxInFlight = 0;
   const clickhouse = {
-    async query({ query }: { query: string }) {
+    async query({ query, abort_signal }: { query: string; abort_signal?: AbortSignal }) {
       queries.push(query);
+      querySignals.push(abort_signal);
       inFlight += 1;
       maxInFlight = Math.max(maxInFlight, inFlight);
       return {
@@ -32,7 +35,7 @@ test("metric counts probe optimized columns, scan projections sequentially, and 
     },
   } as unknown as Pick<ClickHouseClient, "query">;
 
-  const count = createCountByProject(clickhouse);
+  const count = createCountByProject(clickhouse, deadline.signal);
   const result = await count(
     "metric_points",
     "2026-07-14T10:00:00.000Z",
@@ -40,6 +43,7 @@ test("metric counts probe optimized columns, scan projections sequentially, and 
   );
 
   assert.equal(queries.length, 6);
+  assert.ok(querySignals.every((signal) => signal === deadline.signal));
   assert.equal(maxInFlight, 1);
   assert.match(queries[0] ?? "", /FROM system\.columns/);
   assert.ok(queries.slice(1).every((query) => query.includes("SuperlogProjectId AS pid")));
@@ -78,4 +82,22 @@ test("metric counts retain a resource-attribute fallback for unmodified ClickHou
       .slice(1)
       .every((query) => query.includes("ResourceAttributes['superlog.project_id'] AS pid")),
   );
+});
+
+test("Autumn requests share the usage job deadline across create-and-retry", async () => {
+  const deadline = new AbortController();
+  const requestSignals: AbortSignal[] = [];
+  const statuses = [404, 200, 200];
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    requestSignals.push(init?.signal as AbortSignal);
+    return new Response(null, { status: statuses.shift() ?? 500 });
+  };
+
+  const track = createAutumnTrack("secret", fetchImpl, deadline.signal);
+  await track("org-1", "metric_points", 10);
+
+  assert.equal(requestSignals.length, 3);
+  assert.ok(requestSignals.every((signal) => !signal.aborted));
+  deadline.abort();
+  assert.ok(requestSignals.every((signal) => signal.aborted));
 });

--- a/apps/worker/src/billing/usage-meter-ticker.test.ts
+++ b/apps/worker/src/billing/usage-meter-ticker.test.ts
@@ -1,0 +1,81 @@
+import "../agent-run.test-env.js";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ClickHouseClient } from "@clickhouse/client";
+import { METRIC_TABLES } from "./usage-count-query.js";
+import { createCountByProject } from "./usage-meter-ticker.js";
+
+test("metric counts probe optimized columns, scan projections sequentially, and merge totals", async () => {
+  const queries: string[] = [];
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const clickhouse = {
+    async query({ query }: { query: string }) {
+      queries.push(query);
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      return {
+        async json() {
+          await new Promise((resolve) => setImmediate(resolve));
+          inFlight -= 1;
+          if (/FROM system\.columns/.test(query)) {
+            return METRIC_TABLES.map((table) => ({ table }));
+          }
+          return /FROM otel_metrics_sum(?:\s|$)/.test(query)
+            ? [
+                { pid: "p1", c: 2 },
+                { pid: "p2", c: 3 },
+              ]
+            : [{ pid: "p1", c: 2 }];
+        },
+      };
+    },
+  } as unknown as Pick<ClickHouseClient, "query">;
+
+  const count = createCountByProject(clickhouse);
+  const result = await count(
+    "metric_points",
+    "2026-07-14T10:00:00.000Z",
+    "2026-07-14T10:05:00.000Z",
+  );
+
+  assert.equal(queries.length, 6);
+  assert.equal(maxInFlight, 1);
+  assert.match(queries[0] ?? "", /FROM system\.columns/);
+  assert.ok(queries.slice(1).every((query) => query.includes("SuperlogProjectId AS pid")));
+  assert.deepEqual(
+    [...result],
+    [
+      ["p1", 10],
+      ["p2", 3],
+    ],
+  );
+});
+
+test("metric counts retain a resource-attribute fallback for unmodified ClickHouse schemas", async () => {
+  const queries: string[] = [];
+  const clickhouse = {
+    async query({ query }: { query: string }) {
+      queries.push(query);
+      return {
+        async json() {
+          if (/FROM system\.columns/.test(query)) return [];
+          return [{ pid: "p1", c: 1 }];
+        },
+      };
+    },
+  } as unknown as Pick<ClickHouseClient, "query">;
+
+  const result = await createCountByProject(clickhouse)(
+    "metric_points",
+    "2026-07-14T10:00:00.000Z",
+    "2026-07-14T10:05:00.000Z",
+  );
+
+  assert.equal(result.get("p1"), 5);
+  assert.ok(
+    queries
+      .slice(1)
+      .every((query) => query.includes("ResourceAttributes['superlog.project_id'] AS pid")),
+  );
+});

--- a/apps/worker/src/billing/usage-meter-ticker.test.ts
+++ b/apps/worker/src/billing/usage-meter-ticker.test.ts
@@ -46,6 +46,7 @@ test("metric counts probe optimized columns, scan projections sequentially, and 
   assert.ok(querySignals.every((signal) => signal === deadline.signal));
   assert.equal(maxInFlight, 1);
   assert.match(queries[0] ?? "", /FROM system\.columns/);
+  assert.match(queries[0] ?? "", /table IN \{tables:Array\(String\)\}/);
   assert.ok(queries.slice(1).every((query) => query.includes("SuperlogProjectId AS pid")));
   assert.deepEqual(
     [...result],

--- a/apps/worker/src/billing/usage-meter-ticker.ts
+++ b/apps/worker/src/billing/usage-meter-ticker.ts
@@ -21,7 +21,10 @@ function chTime(iso: string): string {
   return iso.replace("T", " ").replace("Z", "");
 }
 
-export function createCountByProject(clickhouse: Pick<ClickHouseClient, "query">) {
+export function createCountByProject(
+  clickhouse: Pick<ClickHouseClient, "query">,
+  abortSignal?: AbortSignal,
+) {
   let optimizedMetricTables: Promise<ReadonlySet<string>> | undefined;
   return async (signal: UsageSignal, afterIso: string, untilIso: string) => {
     const out = new Map<string, number>();
@@ -32,7 +35,7 @@ export function createCountByProject(clickhouse: Pick<ClickHouseClient, "query">
     let optimizedTables: ReadonlySet<string> | undefined;
     if (signal === "metric_points") {
       if (!optimizedMetricTables) {
-        optimizedMetricTables = findMetricUsageProjectionTables(clickhouse);
+        optimizedMetricTables = findMetricUsageProjectionTables(clickhouse, abortSignal);
       }
       optimizedTables = await optimizedMetricTables;
     }
@@ -41,6 +44,7 @@ export function createCountByProject(clickhouse: Pick<ClickHouseClient, "query">
         query,
         query_params: { after: chTime(afterIso), until: chTime(untilIso) },
         format: "JSONEachRow",
+        abort_signal: abortSignal,
       });
       const rows = (await result.json()) as Array<{ pid: string; c: number | string }>;
       for (const row of rows) {
@@ -89,6 +93,11 @@ function createCursorStore(database: DB, windowMs: number) {
 
 const TRACK_TIMEOUT_MS = 10_000;
 
+function autumnRequestSignal(jobSignal?: AbortSignal): AbortSignal {
+  const requestTimeout = AbortSignal.timeout(TRACK_TIMEOUT_MS);
+  return jobSignal ? AbortSignal.any([jobSignal, requestTimeout]) : requestTimeout;
+}
+
 // Attempt to create an Autumn customer for the given org so that a subsequent
 // track() call can succeed. Autumn auto-enables the Free plan on customer
 // creation (autoEnable:true in autumn.config.ts), so this is sufficient to
@@ -97,19 +106,24 @@ async function createAutumnCustomer(
   secretKey: string,
   orgId: string,
   fetchImpl: typeof fetch,
+  jobSignal?: AbortSignal,
 ): Promise<void> {
   const res = await fetchImpl("https://api.useautumn.com/v1/customers", {
     method: "POST",
     headers: { Authorization: `Bearer ${secretKey}`, "Content-Type": "application/json" },
     body: JSON.stringify({ id: orgId }),
-    signal: AbortSignal.timeout(TRACK_TIMEOUT_MS),
+    signal: autumnRequestSignal(jobSignal),
   });
   // 200 = created; 409 = already exists (race with another tick or auth plugin).
   // Both are safe to treat as success — the customer exists either way.
   if (!res.ok && res.status !== 409) throw new Error(`autumn /customers -> ${res.status}`);
 }
 
-function createAutumnTrack(secretKey: string, fetchImpl: typeof fetch = fetch) {
+export function createAutumnTrack(
+  secretKey: string,
+  fetchImpl: typeof fetch = fetch,
+  jobSignal?: AbortSignal,
+) {
   return async (orgId: string, featureId: string, value: number): Promise<void> => {
     // Bound the request so a hung Autumn connection can't stall the worker tick
     // loop indefinitely. On timeout the fetch rejects → the caller logs + skips
@@ -118,19 +132,19 @@ function createAutumnTrack(secretKey: string, fetchImpl: typeof fetch = fetch) {
       method: "POST",
       headers: { Authorization: `Bearer ${secretKey}`, "Content-Type": "application/json" },
       body: JSON.stringify({ customer_id: orgId, feature_id: featureId, value }),
-      signal: AbortSignal.timeout(TRACK_TIMEOUT_MS),
+      signal: autumnRequestSignal(jobSignal),
     });
     if (res.status === 404) {
       // The org is not yet provisioned in Autumn (e.g. a legacy org created
       // before the Autumn integration, or a sign-up that bypassed the auth
       // plugin). Auto-create the customer — Autumn attaches the Free plan via
       // autoEnable — then retry the track so usage is not dropped.
-      await createAutumnCustomer(secretKey, orgId, fetchImpl);
+      await createAutumnCustomer(secretKey, orgId, fetchImpl, jobSignal);
       const retry = await fetchImpl("https://api.useautumn.com/v1/track", {
         method: "POST",
         headers: { Authorization: `Bearer ${secretKey}`, "Content-Type": "application/json" },
         body: JSON.stringify({ customer_id: orgId, feature_id: featureId, value }),
-        signal: AbortSignal.timeout(TRACK_TIMEOUT_MS),
+        signal: autumnRequestSignal(jobSignal),
       });
       if (!retry.ok) throw new Error(`autumn /track -> ${retry.status} (after customer create)`);
       return;
@@ -151,6 +165,7 @@ export function createUsageMeterTicker(options: {
   intervalMs?: number;
   windowMs?: number;
   now?: () => number;
+  signal?: AbortSignal;
 }): UsageMeterTicker | null {
   const secretKey = (options.secretKey ?? process.env.AUTUMN_SECRET_KEY)?.trim();
   if (!secretKey) return null;
@@ -161,13 +176,14 @@ export function createUsageMeterTicker(options: {
   const nowMs = options.now ?? Date.now;
   const cursors = createCursorStore(database, windowMs);
   const deps: UsageMeterDeps = {
-    countByProject: createCountByProject(options.clickhouse),
+    countByProject: createCountByProject(options.clickhouse, options.signal),
     resolveOrgIds: createResolveOrgIds(database),
-    track: createAutumnTrack(secretKey),
+    track: createAutumnTrack(secretKey, fetch, options.signal),
     getCursor: cursors.getCursor,
     setCursor: cursors.setCursor,
     now: () => new Date(nowMs()),
     windowMs,
+    isCancelled: () => options.signal?.aborted ?? false,
   };
 
   let nextRunAt = 0;

--- a/apps/worker/src/billing/usage-meter-ticker.ts
+++ b/apps/worker/src/billing/usage-meter-ticker.ts
@@ -5,7 +5,8 @@
 import type { ClickHouseClient } from "@clickhouse/client";
 import { type DB, db as defaultDb, schema } from "@superlog/db";
 import { inArray } from "drizzle-orm";
-import { buildUsageCountQuery } from "./usage-count-query.js";
+import { findMetricUsageProjectionTables } from "./metric-usage-schema.js";
+import { buildUsageCountQueries } from "./usage-count-query.js";
 import {
   type UsageMeterDeps,
   type UsageSignal,
@@ -20,18 +21,34 @@ function chTime(iso: string): string {
   return iso.replace("T", " ").replace("Z", "");
 }
 
-function createCountByProject(clickhouse: Pick<ClickHouseClient, "query">) {
+export function createCountByProject(clickhouse: Pick<ClickHouseClient, "query">) {
+  let optimizedMetricTables: Promise<ReadonlySet<string>> | undefined;
   return async (signal: UsageSignal, afterIso: string, untilIso: string) => {
-    const result = await clickhouse.query({
-      query: buildUsageCountQuery(signal),
-      query_params: { after: chTime(afterIso), until: chTime(untilIso) },
-      format: "JSONEachRow",
-    });
-    const rows = (await result.json()) as Array<{ pid: string; c: number | string }>;
     const out = new Map<string, number>();
-    for (const row of rows) {
-      const n = Number(row.c);
-      if (row.pid && Number.isFinite(n) && n > 0) out.set(row.pid, n);
+    // Metrics live in five physical tables. Query them one at a time so a
+    // single metering pass never fans five full-partition scans out in
+    // parallel under write load. Each request also gets its own client
+    // deadline instead of sharing one deadline across a UNION ALL query.
+    let optimizedTables: ReadonlySet<string> | undefined;
+    if (signal === "metric_points") {
+      if (!optimizedMetricTables) {
+        optimizedMetricTables = findMetricUsageProjectionTables(clickhouse);
+      }
+      optimizedTables = await optimizedMetricTables;
+    }
+    for (const query of buildUsageCountQueries(signal, optimizedTables)) {
+      const result = await clickhouse.query({
+        query,
+        query_params: { after: chTime(afterIso), until: chTime(untilIso) },
+        format: "JSONEachRow",
+      });
+      const rows = (await result.json()) as Array<{ pid: string; c: number | string }>;
+      for (const row of rows) {
+        const n = Number(row.c);
+        if (row.pid && Number.isFinite(n) && n > 0) {
+          out.set(row.pid, (out.get(row.pid) ?? 0) + n);
+        }
+      }
     }
     return out;
   };

--- a/apps/worker/src/billing/usage-metering.test.ts
+++ b/apps/worker/src/billing/usage-metering.test.ts
@@ -96,6 +96,30 @@ test("a signal count failure preserves its cursor and does not block later signa
   assert.ok(cursors.get("usage-meter-metric_points") instanceof Date);
 });
 
+test("cancellation after counting preserves the cursor and skips delivery", async () => {
+  let cancelled = false;
+  let countCalls = 0;
+  const {
+    deps: d,
+    tracks,
+    cursors,
+  } = deps({
+    countByProject: async () => {
+      countCalls += 1;
+      cancelled = true;
+      return new Map([["p1", 10]]);
+    },
+    isCancelled: () => cancelled,
+  });
+
+  const reported = await meterTelemetryUsageTick(d);
+
+  assert.equal(reported, 0);
+  assert.equal(countCalls, 1);
+  assert.equal(tracks.length, 0);
+  assert.equal(cursors.size, 0);
+});
+
 test("an org lookup failure preserves its cursor and does not block later signals", async () => {
   const {
     deps: d,

--- a/apps/worker/src/billing/usage-metering.ts
+++ b/apps/worker/src/billing/usage-metering.ts
@@ -49,6 +49,7 @@ export type UsageMeterDeps = {
   setCursor: (name: string, at: Date) => Promise<void>;
   now: () => Date;
   windowMs: number;
+  isCancelled?: () => boolean;
 };
 
 // One metering pass over all three signals. Returns the number of (org, signal)
@@ -56,6 +57,7 @@ export type UsageMeterDeps = {
 export async function meterTelemetryUsageTick(deps: UsageMeterDeps): Promise<number> {
   let reported = 0;
   for (const signal of Object.keys(SIGNAL_FEATURE_IDS) as UsageSignal[]) {
+    if (deps.isCancelled?.()) return reported;
     try {
       const cursorName = `${CURSOR_PREFIX}${signal}`;
       const cursor = await deps.getCursor(cursorName);
@@ -67,7 +69,9 @@ export async function meterTelemetryUsageTick(deps: UsageMeterDeps): Promise<num
         cursor.toISOString(),
         until.toISOString(),
       );
+      if (deps.isCancelled?.()) return reported;
       const orgMap = perProject.size > 0 ? await deps.resolveOrgIds([...perProject.keys()]) : null;
+      if (deps.isCancelled?.()) return reported;
       // Complete the idempotent reads before advancing, then persist the cursor
       // BEFORE issuing the non-idempotent track() calls. track() is additive, so
       // a setCursor failure AFTER tracking would replay this window next tick and
@@ -76,10 +80,12 @@ export async function meterTelemetryUsageTick(deps: UsageMeterDeps): Promise<num
       await deps.setCursor(cursorName, until);
       if (orgMap) {
         for (const [orgId, value] of aggregateByOrg(perProject, orgMap)) {
+          if (deps.isCancelled?.()) return reported;
           try {
             await deps.track(orgId, SIGNAL_FEATURE_IDS[signal], value);
             reported += 1;
           } catch (err) {
+            if (deps.isCancelled?.()) return reported;
             logger.error(
               {
                 scope: "billing.usage",
@@ -94,6 +100,7 @@ export async function meterTelemetryUsageTick(deps: UsageMeterDeps): Promise<num
         }
       }
     } catch (err) {
+      if (deps.isCancelled?.()) return reported;
       logger.error(
         {
           scope: "billing.usage",

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -4,7 +4,6 @@ import { db, shutdownAnalytics } from "@superlog/db";
 import { registerAgentRunHealthMetrics } from "./agent-run-health-metrics.js";
 import { startAgentRunQueue } from "./agent-runs/queue-wiring.js";
 import { initAiUsageSink } from "./ai-usage.js";
-import { createUsageMeterTicker } from "./billing/usage-meter-ticker.js";
 import { handleIssueTransition } from "./incidents/workflow.js";
 import {
   createIssueTransitionDispatcher,
@@ -116,14 +115,9 @@ registerTelemetryIngestMetrics({
   discoveryWindowMs: TELEMETRY_DISCOVERY_WINDOW_MS,
 });
 
-// Telemetry usage metering runs in the tick; the usage-limit notifier runs
-// out-of-band as the `usage-notify` pg-boss job (jobs/usage-notify.ts), which
-// derives active orgs from ClickHouse itself — no coupling to the tick.
-const usageMeter = createUsageMeterTicker({ db, clickhouse: ch });
 const tick = createWorkerTick({
   clickhouse: ch,
   telemetryIngestor,
-  usageMeter,
   handleIssueTransition: dispatchIssueTransition,
   includeAgentRuns: !agentRunQueueReady,
 });

--- a/apps/worker/src/jobs.ts
+++ b/apps/worker/src/jobs.ts
@@ -34,6 +34,10 @@ export type JobDefinition = {
   name: string;
   // 5-field cron expression (minute precision); pg-boss checks every 30s.
   schedule: string;
+  // Durable active-job lease. Set this above the handler's legitimate worst
+  // case so pg-boss never starts an overlapping successor while a slow run is
+  // still alive.
+  expireInSeconds?: number;
   // create() receives the shared deps and returns the handler — or null to opt
   // out (e.g. a required env var / API key is absent), in which case the job is
   // skipped entirely.
@@ -44,6 +48,7 @@ export type JobDefinition = {
 export type LoadedJob = {
   name: string;
   schedule: string;
+  expireInSeconds?: number;
   handler: JobHandler;
 };
 
@@ -64,6 +69,8 @@ function isJobDefinition(value: unknown): value is JobDefinition {
     typeof def.name === "string" &&
     typeof def.schedule === "string" &&
     def.schedule.length > 0 &&
+    (def.expireInSeconds === undefined ||
+      (Number.isFinite(def.expireInSeconds) && def.expireInSeconds > 0)) &&
     typeof def.create === "function"
   );
 }
@@ -101,7 +108,12 @@ export async function loadJobs(deps: JobDeps, options: { dir?: URL } = {}): Prom
         logger.info({ scope: "jobs.load", job: def.name }, "job opted out at create(); skipping");
         continue;
       }
-      jobs.push({ name: def.name, schedule: def.schedule, handler });
+      jobs.push({
+        name: def.name,
+        schedule: def.schedule,
+        expireInSeconds: def.expireInSeconds,
+        handler,
+      });
       logger.info(
         { scope: "jobs.load", job: def.name, schedule: def.schedule },
         "discovered background job",

--- a/apps/worker/src/jobs/README.md
+++ b/apps/worker/src/jobs/README.md
@@ -41,8 +41,11 @@ its next schedule.
 
 Telemetry usage metering follows this rule deliberately: `usage-meter.ts` owns
 an isolated ClickHouse client with a 30-second client deadline and a 25-second
-server execution cap. Metric counts use the exact-timestamp `usage_by_time`
-projection when available and retain a raw-schema fallback. Apply
+server execution cap. Its 90-second whole-job deadline cancels in-flight
+ClickHouse and billing HTTP requests, leaving time for the worker's 110-second
+shutdown drain before the 120-second durable lease expires. Metric counts use
+the exact-timestamp `usage_by_time` projection when available and retain a
+raw-schema fallback. Apply
 `infra/clickhouse/migrations/008_metric_usage_projection.sql`, then materialize
 existing partitions sequentially with
 `scripts/materialize-metric-usage-projections.ts`; do not compensate for an

--- a/apps/worker/src/jobs/README.md
+++ b/apps/worker/src/jobs/README.md
@@ -14,6 +14,9 @@ export const job: JobDefinition = {
   name: "my-thing.sync",
   // 5-field cron (minute precision; pg-boss checks schedules every 30s).
   schedule: "0 */6 * * *",
+  // Optional: keep the durable active-job lease above this handler's
+  // legitimate worst case so a very slow run cannot overlap its successor.
+  expireInSeconds: 30 * 60,
   // Receives shared deps; return a handler that does ONE pass, or null to opt
   // out (e.g. a required env var is missing). pg-boss owns scheduling, retries,
   // and single-active semantics — handlers do not loop or self-gate.
@@ -32,7 +35,18 @@ Rules the loader enforces:
 - Files load in filename-sorted order.
 
 Each job gets an `exclusive` pg-boss queue (at most one queued-or-active at a
-time), so a slow run never overlaps its next schedule.
+time). Jobs that can legitimately run near pg-boss's default 15-minute lease
+must set `expireInSeconds` above their worst case so a slow run never overlaps
+its next schedule.
+
+Telemetry usage metering follows this rule deliberately: `usage-meter.ts` owns
+an isolated ClickHouse client with a 30-second client deadline and a 25-second
+server execution cap. Metric counts use the exact-timestamp `usage_by_time`
+projection when available and retain a raw-schema fallback. Apply
+`infra/clickhouse/migrations/008_metric_usage_projection.sql`, then materialize
+existing partitions sequentially with
+`scripts/materialize-metric-usage-projections.ts`; do not compensate for an
+unmaterialized projection by extending the request timeout.
 
 This is a build seam as much as a convention: a deployment can overlay
 additional job files into this directory at image-build time without this

--- a/apps/worker/src/jobs/autorecovery.test.ts
+++ b/apps/worker/src/jobs/autorecovery.test.ts
@@ -1,0 +1,24 @@
+import "../agent-run.test-env.js";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { JobDeps } from "../jobs.js";
+import { createAutorecoveryJob } from "./autorecovery.js";
+
+test("autorecovery runs from the background-job queue when configured", async () => {
+  let runs = 0;
+  const definition = createAutorecoveryJob({
+    apiKey: "configured",
+    run: async () => {
+      runs += 1;
+      return 0;
+    },
+  });
+
+  assert.equal(definition.name, "autorecovery");
+  assert.equal(definition.schedule, "*/5 * * * *");
+  const handler = await definition.create({} as JobDeps);
+  assert.ok(handler);
+
+  await handler();
+  assert.equal(runs, 1);
+});

--- a/apps/worker/src/jobs/autorecovery.ts
+++ b/apps/worker/src/jobs/autorecovery.ts
@@ -1,0 +1,29 @@
+// Autorecovery can spend minutes waiting on one LLM call per incident. Keep it
+// on an exclusive pg-boss queue so it never delays telemetry ingest, alert
+// evaluation, or the worker-loop heartbeat. The five-minute schedule is only a
+// wake-up cadence: tickAutorecovery's durable cursor retains the hourly policy.
+import { tickAutorecovery } from "../autorecovery.js";
+import type { JobDefinition } from "../jobs.js";
+
+export function createAutorecoveryJob(
+  options: {
+    apiKey?: string | null;
+    run?: () => Promise<number>;
+  } = {},
+): JobDefinition {
+  const apiKey = options.apiKey ?? process.env.ANTHROPIC_API_KEY;
+  const run = options.run ?? tickAutorecovery;
+  return {
+    name: "autorecovery",
+    schedule: "*/5 * * * *",
+    expireInSeconds: 3_600,
+    create: () => {
+      if (!apiKey?.trim()) return null;
+      return async () => {
+        await run();
+      };
+    },
+  };
+}
+
+export const job = createAutorecoveryJob();

--- a/apps/worker/src/jobs/runner.test.ts
+++ b/apps/worker/src/jobs/runner.test.ts
@@ -8,6 +8,7 @@ type WorkHandler = (jobs: unknown[]) => Promise<unknown>;
 function fakeBoss() {
   const calls: string[] = [];
   const queues: string[] = [];
+  const queueUpdates: Array<{ name: string; options: unknown }> = [];
   const schedules: Array<{ name: string; cron: string }> = [];
   const workers = new Map<string, WorkHandler>();
   const boss: JobBoss = {
@@ -18,6 +19,10 @@ function fakeBoss() {
       queues.push(name);
       calls.push(`createQueue:${name}:${JSON.stringify(options)}`);
     },
+    async updateQueue(name, options) {
+      queueUpdates.push({ name, options });
+      calls.push(`updateQueue:${name}:${JSON.stringify(options)}`);
+    },
     async work(name, handler) {
       workers.set(name, handler);
       calls.push(`work:${name}`);
@@ -27,7 +32,7 @@ function fakeBoss() {
       calls.push(`schedule:${name}:${cron}`);
     },
   };
-  return { boss, calls, queues, schedules, workers };
+  return { boss, calls, queues, queueUpdates, schedules, workers };
 }
 
 test("registerJobs starts the boss and registers a queue, worker, and cron schedule per job", async () => {
@@ -52,6 +57,7 @@ test("registerJobs starts the boss and registers a queue, worker, and cron sched
   ]);
   // Each queue is created exclusive (at most one queued-or-active).
   assert.ok(fb.calls.includes('createQueue:a.sync:{"policy":"exclusive","expireInSeconds":3600}'));
+  assert.deepEqual(fb.queueUpdates, [{ name: "a.sync", options: { expireInSeconds: 3_600 } }]);
 });
 
 test("the registered worker invokes the job handler", async () => {

--- a/apps/worker/src/jobs/runner.test.ts
+++ b/apps/worker/src/jobs/runner.test.ts
@@ -33,7 +33,12 @@ function fakeBoss() {
 test("registerJobs starts the boss and registers a queue, worker, and cron schedule per job", async () => {
   const fb = fakeBoss();
   const jobs: LoadedJob[] = [
-    { name: "a.sync", schedule: "0 */6 * * *", handler: async () => {} },
+    {
+      name: "a.sync",
+      schedule: "0 */6 * * *",
+      expireInSeconds: 3_600,
+      handler: async () => {},
+    },
     { name: "b.sync", schedule: "*/5 * * * *", handler: async () => {} },
   ];
 
@@ -46,7 +51,7 @@ test("registerJobs starts the boss and registers a queue, worker, and cron sched
     { name: "b.sync", cron: "*/5 * * * *" },
   ]);
   // Each queue is created exclusive (at most one queued-or-active).
-  assert.ok(fb.calls.includes('createQueue:a.sync:{"policy":"exclusive"}'));
+  assert.ok(fb.calls.includes('createQueue:a.sync:{"policy":"exclusive","expireInSeconds":3600}'));
 });
 
 test("the registered worker invokes the job handler", async () => {

--- a/apps/worker/src/jobs/runner.ts
+++ b/apps/worker/src/jobs/runner.ts
@@ -28,7 +28,10 @@ export async function registerJobs(boss: JobBoss, jobs: LoadedJob[]): Promise<vo
   await boss.start();
   for (const job of jobs) {
     try {
-      await boss.createQueue(job.name, { policy: "exclusive" });
+      await boss.createQueue(job.name, {
+        policy: "exclusive",
+        ...(job.expireInSeconds ? { expireInSeconds: job.expireInSeconds } : {}),
+      });
       await boss.work(job.name, async () => {
         await job.handler();
       });

--- a/apps/worker/src/jobs/runner.ts
+++ b/apps/worker/src/jobs/runner.ts
@@ -17,6 +17,7 @@ import { logger } from "../logger.js";
 export interface JobBoss {
   start(): Promise<unknown>;
   createQueue(name: string, options?: unknown): Promise<unknown>;
+  updateQueue(name: string, options?: unknown): Promise<unknown>;
   work(name: string, handler: (jobs: unknown[]) => Promise<unknown>): Promise<unknown>;
   schedule(name: string, cron: string, data?: unknown, options?: unknown): Promise<unknown>;
 }
@@ -32,6 +33,12 @@ export async function registerJobs(boss: JobBoss, jobs: LoadedJob[]): Promise<vo
         policy: "exclusive",
         ...(job.expireInSeconds ? { expireInSeconds: job.expireInSeconds } : {}),
       });
+      // pg-boss createQueue does not update an existing queue. Keep mutable
+      // lease settings in sync across deploys while leaving the immutable
+      // policy on the create path.
+      if (job.expireInSeconds) {
+        await boss.updateQueue(job.name, { expireInSeconds: job.expireInSeconds });
+      }
       await boss.work(job.name, async () => {
         await job.handler();
       });

--- a/apps/worker/src/jobs/usage-meter.test.ts
+++ b/apps/worker/src/jobs/usage-meter.test.ts
@@ -1,0 +1,47 @@
+import "../agent-run.test-env.js";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ClickHouseClient } from "@clickhouse/client";
+import type { JobDeps } from "../jobs.js";
+import { createUsageMeterJob } from "./usage-meter.js";
+
+test("usage metering uses an isolated client with bounded server and client execution", async () => {
+  let requestTimeout: number | undefined;
+  let maxExecutionTime: unknown;
+  let meterRuns = 0;
+  let closes = 0;
+  const clickhouse = {
+    query: async () => {
+      throw new Error("not used");
+    },
+    close: async () => {
+      closes += 1;
+    },
+  } as unknown as Pick<ClickHouseClient, "query" | "close">;
+  const definition = createUsageMeterJob({
+    env: { AUTUMN_SECRET_KEY: "configured" },
+    createClient: (config) => {
+      requestTimeout = config.request_timeout;
+      maxExecutionTime = config.clickhouse_settings?.max_execution_time;
+      return clickhouse;
+    },
+    createMeter: (options) => {
+      assert.equal(options.clickhouse, clickhouse);
+      assert.equal(options.intervalMs, 0);
+      return async () => {
+        meterRuns += 1;
+        return 1;
+      };
+    },
+  });
+
+  assert.equal(definition.schedule, "* * * * *");
+  const handler = await definition.create({ db: {} } as JobDeps);
+  assert.ok(handler);
+  await handler();
+
+  assert.equal(requestTimeout, 30_000);
+  assert.equal(maxExecutionTime, 25);
+  assert.equal(meterRuns, 1);
+  assert.equal(closes, 1);
+});

--- a/apps/worker/src/jobs/usage-meter.test.ts
+++ b/apps/worker/src/jobs/usage-meter.test.ts
@@ -10,6 +10,7 @@ test("usage metering uses an isolated client with bounded server and client exec
   let maxExecutionTime: unknown;
   let meterRuns = 0;
   let closes = 0;
+  let jobSignal: AbortSignal | undefined;
   const clickhouse = {
     query: async () => {
       throw new Error("not used");
@@ -28,6 +29,7 @@ test("usage metering uses an isolated client with bounded server and client exec
     createMeter: (options) => {
       assert.equal(options.clickhouse, clickhouse);
       assert.equal(options.intervalMs, 0);
+      jobSignal = (options as typeof options & { signal?: AbortSignal }).signal;
       return async () => {
         meterRuns += 1;
         return 1;
@@ -36,12 +38,64 @@ test("usage metering uses an isolated client with bounded server and client exec
   });
 
   assert.equal(definition.schedule, "* * * * *");
+  assert.equal(definition.expireInSeconds, 120);
   const handler = await definition.create({ db: {} } as JobDeps);
   assert.ok(handler);
   await handler();
 
   assert.equal(requestTimeout, 30_000);
   assert.equal(maxExecutionTime, 25);
+  assert.ok(jobSignal);
   assert.equal(meterRuns, 1);
+  assert.equal(closes, 1);
+});
+
+test("usage metering aborts in-flight work before its durable lease expires", async () => {
+  let aborted = false;
+  let closes = 0;
+  const definition = createUsageMeterJob({
+    env: { AUTUMN_SECRET_KEY: "configured" },
+    jobTimeoutMs: 5,
+    createClient: () => ({
+      query: async () => {
+        throw new Error("not used");
+      },
+      close: async () => {
+        closes += 1;
+      },
+    }),
+    createMeter:
+      ({ signal }) =>
+      async () => {
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) {
+            aborted = true;
+            resolve();
+            return;
+          }
+          signal?.addEventListener(
+            "abort",
+            () => {
+              aborted = true;
+              resolve();
+            },
+            { once: true },
+          );
+        });
+        return 0;
+      },
+  });
+
+  assert.equal(definition.expireInSeconds, 31);
+  const handler = await definition.create({ db: {} } as JobDeps);
+  assert.ok(handler);
+  const keepEventLoopAlive = setTimeout(() => {}, 100);
+  try {
+    await handler();
+  } finally {
+    clearTimeout(keepEventLoopAlive);
+  }
+
+  assert.equal(aborted, true);
   assert.equal(closes, 1);
 });

--- a/apps/worker/src/jobs/usage-meter.ts
+++ b/apps/worker/src/jobs/usage-meter.ts
@@ -1,0 +1,71 @@
+// Billing scans can be much slower than interactive ClickHouse reads when a
+// metric partition is busy. Run them on an exclusive pg-boss queue with their
+// own client deadline so they cannot extend or block the core worker tick.
+import { type ClickHouseClient, createClient } from "@clickhouse/client";
+import { type UsageMeterTicker, createUsageMeterTicker } from "../billing/usage-meter-ticker.js";
+import type { JobDefinition } from "../jobs.js";
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_EXECUTION_TIME_SECONDS = 25;
+
+type UsageClickHouseClient = Pick<ClickHouseClient, "query" | "close">;
+type ClientConfig = NonNullable<Parameters<typeof createClient>[0]>;
+type MeterOptions = Parameters<typeof createUsageMeterTicker>[0];
+
+function positiveNumber(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function createUsageMeterJob(
+  options: {
+    env?: Record<string, string | undefined>;
+    createClient?: (config: ClientConfig) => UsageClickHouseClient;
+    createMeter?: (options: MeterOptions) => UsageMeterTicker | null;
+  } = {},
+): JobDefinition {
+  const env = options.env ?? process.env;
+  const secretKey = env.AUTUMN_SECRET_KEY?.trim();
+  const createClickHouse = options.createClient ?? ((config: ClientConfig) => createClient(config));
+  const createMeter = options.createMeter ?? createUsageMeterTicker;
+
+  return {
+    name: "usage-meter",
+    schedule: "* * * * *",
+    expireInSeconds: 1_800,
+    create: ({ db }) => {
+      if (!secretKey) return null;
+      return async () => {
+        const clickhouse = createClickHouse({
+          url: env.CLICKHOUSE_URL ?? "http://localhost:8123",
+          username: env.CLICKHOUSE_USER ?? "default",
+          password: env.CLICKHOUSE_PASSWORD ?? "",
+          database: env.CLICKHOUSE_DB ?? "superlog",
+          request_timeout: positiveNumber(
+            env.BILLING_CLICKHOUSE_REQUEST_TIMEOUT_MS,
+            DEFAULT_REQUEST_TIMEOUT_MS,
+          ),
+          // Stop work on the server before the HTTP client gives up. Without
+          // this, an expired client socket can leave ClickHouse scanning until
+          // it tries to write the response and hits a broken pipe.
+          clickhouse_settings: {
+            max_execution_time: positiveNumber(
+              env.BILLING_CLICKHOUSE_MAX_EXECUTION_TIME_SECONDS,
+              DEFAULT_MAX_EXECUTION_TIME_SECONDS,
+            ),
+          },
+        });
+        try {
+          // pg-boss owns the minute cadence and exclusive execution; disable
+          // the old process-local interval gate for this one-shot handler.
+          const meter = createMeter({ db, clickhouse, secretKey, intervalMs: 0 });
+          await meter?.();
+        } finally {
+          await clickhouse.close();
+        }
+      };
+    },
+  };
+}
+
+export const job = createUsageMeterJob();

--- a/apps/worker/src/jobs/usage-meter.ts
+++ b/apps/worker/src/jobs/usage-meter.ts
@@ -7,6 +7,8 @@ import type { JobDefinition } from "../jobs.js";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_EXECUTION_TIME_SECONDS = 25;
+const DEFAULT_JOB_TIMEOUT_MS = 90_000;
+const JOB_EXPIRY_GRACE_SECONDS = 30;
 
 type UsageClickHouseClient = Pick<ClickHouseClient, "query" | "close">;
 type ClientConfig = NonNullable<Parameters<typeof createClient>[0]>;
@@ -22,20 +24,26 @@ export function createUsageMeterJob(
     env?: Record<string, string | undefined>;
     createClient?: (config: ClientConfig) => UsageClickHouseClient;
     createMeter?: (options: MeterOptions) => UsageMeterTicker | null;
+    jobTimeoutMs?: number;
   } = {},
 ): JobDefinition {
   const env = options.env ?? process.env;
   const secretKey = env.AUTUMN_SECRET_KEY?.trim();
   const createClickHouse = options.createClient ?? ((config: ClientConfig) => createClient(config));
   const createMeter = options.createMeter ?? createUsageMeterTicker;
+  const jobTimeoutMs = options.jobTimeoutMs ?? DEFAULT_JOB_TIMEOUT_MS;
 
   return {
     name: "usage-meter",
     schedule: "* * * * *",
-    expireInSeconds: 1_800,
+    // The handler stops active ClickHouse and billing requests after 90 seconds,
+    // leaving the worker's 110-second shutdown drain time to close cleanly. The
+    // durable lease has a small grace period beyond that application deadline.
+    expireInSeconds: Math.ceil(jobTimeoutMs / 1000) + JOB_EXPIRY_GRACE_SECONDS,
     create: ({ db }) => {
       if (!secretKey) return null;
       return async () => {
+        const signal = AbortSignal.timeout(jobTimeoutMs);
         const clickhouse = createClickHouse({
           url: env.CLICKHOUSE_URL ?? "http://localhost:8123",
           username: env.CLICKHOUSE_USER ?? "default",
@@ -58,7 +66,7 @@ export function createUsageMeterJob(
         try {
           // pg-boss owns the minute cadence and exclusive execution; disable
           // the old process-local interval gate for this one-shot handler.
-          const meter = createMeter({ db, clickhouse, secretKey, intervalMs: 0 });
+          const meter = createMeter({ db, clickhouse, secretKey, intervalMs: 0, signal });
           await meter?.();
         } finally {
           await clickhouse.close();

--- a/apps/worker/src/jobs/usage-notify.test.ts
+++ b/apps/worker/src/jobs/usage-notify.test.ts
@@ -1,0 +1,68 @@
+import "../agent-run.test-env.js";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ClickHouseClient } from "@clickhouse/client";
+import { METRIC_TABLES } from "../billing/usage-count-query.js";
+import { activeProjectIds } from "./usage-notify.js";
+
+test("active projects use narrow rollups and metric projections without a wide union scan", async () => {
+  const queries: string[] = [];
+  const clickhouse = {
+    async query({ query }: { query: string }) {
+      queries.push(query);
+      return {
+        async json() {
+          if (/^EXISTS TABLE events_per_minute/.test(query.trim())) return [{ result: 1 }];
+          if (/FROM system\.columns/.test(query)) {
+            return METRIC_TABLES.map((table) => ({ table }));
+          }
+          if (/FROM events_per_minute/.test(query)) {
+            return [{ pid: "11111111-1111-4111-8111-111111111111" }, { pid: "not-a-project" }];
+          }
+          return [{ pid: "22222222-2222-4222-8222-222222222222" }];
+        },
+      };
+    },
+  } as unknown as Pick<ClickHouseClient, "query">;
+
+  const result = await activeProjectIds(clickhouse);
+
+  assert.deepEqual(result, [
+    "11111111-1111-4111-8111-111111111111",
+    "22222222-2222-4222-8222-222222222222",
+  ]);
+  assert.ok(queries.some((query) => query.includes("FROM events_per_minute")));
+  assert.ok(queries.every((query) => !query.includes("UNION")));
+  assert.ok(
+    queries
+      .filter((query) => /FROM otel_metrics_/.test(query))
+      .every((query) => query.includes("SuperlogProjectId AS pid")),
+  );
+});
+
+test("active projects retain bounded raw-table fallbacks when rollups are unavailable", async () => {
+  const queries: string[] = [];
+  const clickhouse = {
+    async query({ query }: { query: string }) {
+      queries.push(query);
+      return {
+        async json() {
+          if (/^EXISTS TABLE events_per_minute/.test(query.trim())) return [{ result: 0 }];
+          if (/FROM system\.columns/.test(query)) return [];
+          return [];
+        },
+      };
+    },
+  } as unknown as Pick<ClickHouseClient, "query">;
+
+  await activeProjectIds(clickhouse);
+
+  const logQuery = queries.find((query) => query.includes("FROM otel_logs"));
+  assert.match(logQuery ?? "", /TimestampTime > now\(\) - INTERVAL 30 MINUTE - INTERVAL 1 SECOND/);
+  assert.match(logQuery ?? "", /Timestamp <= now64\(9\)/);
+  assert.ok(
+    queries
+      .filter((query) => /FROM otel_metrics_/.test(query))
+      .every((query) => query.includes("ResourceAttributes['superlog.project_id'] AS pid")),
+  );
+});

--- a/apps/worker/src/jobs/usage-notify.ts
+++ b/apps/worker/src/jobs/usage-notify.ts
@@ -1,3 +1,4 @@
+import type { ClickHouseClient } from "@clickhouse/client";
 // Scheduled job: fire usage-limit notifications for recently-active orgs, out of
 // band from the worker tick loop. Each run derives the candidate set itself by
 // asking ClickHouse which projects produced telemetry in the last window, maps
@@ -9,6 +10,11 @@
 // (USAGE_NOTIFICATIONS_ENABLED / AUTUMN_SECRET_KEY unset).
 import { schema } from "@superlog/db";
 import { inArray } from "drizzle-orm";
+import {
+  METRIC_TABLES,
+  METRIC_USAGE_PROJECT_ID_COLUMN,
+  findMetricUsageProjectionTables,
+} from "../billing/metric-usage-schema.js";
 import { usageNotifier } from "../billing/usage-notifier-infra.js";
 import type { JobDefinition, JobDeps } from "../jobs.js";
 import { logger } from "../logger.js";
@@ -21,27 +27,83 @@ const LOOKBACK = "30 MINUTE";
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 // Bound the per-query IN list under high project cardinality.
 const ID_CHUNK = 500;
-const METRIC_TABLES = [
-  "otel_metrics_sum",
-  "otel_metrics_gauge",
-  "otel_metrics_histogram",
-  "otel_metrics_summary",
-  "otel_metrics_exp_histogram",
-];
+type QueryClient = Pick<ClickHouseClient, "query">;
 
-async function activeProjectIds(clickhouse: JobDeps["clickhouse"]): Promise<string[]> {
-  const traceLog = ["otel_traces", "otel_logs"].map(
-    (t) =>
-      `SELECT ResourceAttributes['superlog.project_id'] AS pid FROM ${t} WHERE Timestamp > now() - INTERVAL ${LOOKBACK} AND pid != ''`,
-  );
-  const metrics = METRIC_TABLES.map(
-    (t) =>
-      `SELECT ResourceAttributes['superlog.project_id'] AS pid FROM ${t} WHERE TimeUnix > now() - INTERVAL ${LOOKBACK} AND pid != ''`,
-  );
-  const query = `SELECT DISTINCT pid FROM (${[...traceLog, ...metrics].join(" UNION DISTINCT ")})`;
+async function queryProjectIds(clickhouse: QueryClient, query: string): Promise<string[]> {
   const result = await clickhouse.query({ query, format: "JSONEachRow" });
   const rows = (await result.json()) as Array<{ pid: string }>;
-  return rows.map((r) => r.pid).filter((pid) => UUID_RE.test(pid));
+  return rows.map(({ pid }) => pid);
+}
+
+async function eventsRollupAvailable(clickhouse: QueryClient): Promise<boolean> {
+  try {
+    const result = await clickhouse.query({
+      query: "EXISTS TABLE events_per_minute",
+      format: "JSONEachRow",
+    });
+    const rows = (await result.json()) as Array<{ result: number | string }>;
+    return Number(rows[0]?.result) === 1;
+  } catch {
+    return false;
+  }
+}
+
+export async function activeProjectIds(clickhouse: QueryClient): Promise<string[]> {
+  const projectIds = new Set<string>();
+  const add = (ids: string[]) => {
+    for (const id of ids) if (UUID_RE.test(id)) projectIds.add(id);
+  };
+
+  if (await eventsRollupAvailable(clickhouse)) {
+    add(
+      await queryProjectIds(
+        clickhouse,
+        `SELECT DISTINCT project_id AS pid
+         FROM events_per_minute
+         PREWHERE minute > now() - INTERVAL ${LOOKBACK} AND minute <= now()
+         WHERE project_id != ''`,
+      ),
+    );
+  } else {
+    add(
+      await queryProjectIds(
+        clickhouse,
+        `SELECT DISTINCT ResourceAttributes['superlog.project_id'] AS pid
+         FROM otel_traces
+         PREWHERE Timestamp > now64(9) - INTERVAL ${LOOKBACK} AND Timestamp <= now64(9)
+         WHERE pid != ''`,
+      ),
+    );
+    add(
+      await queryProjectIds(
+        clickhouse,
+        `SELECT DISTINCT ResourceAttributes['superlog.project_id'] AS pid
+         FROM otel_logs
+         PREWHERE TimestampTime > now() - INTERVAL ${LOOKBACK} - INTERVAL 1 SECOND
+           AND TimestampTime <= now()
+         WHERE Timestamp > now64(9) - INTERVAL ${LOOKBACK}
+           AND Timestamp <= now64(9) AND pid != ''`,
+      ),
+    );
+  }
+
+  const optimizedTables = await findMetricUsageProjectionTables(clickhouse);
+  for (const table of METRIC_TABLES) {
+    const projectId = optimizedTables.has(table)
+      ? METRIC_USAGE_PROJECT_ID_COLUMN
+      : "ResourceAttributes['superlog.project_id']";
+    add(
+      await queryProjectIds(
+        clickhouse,
+        `SELECT DISTINCT ${projectId} AS pid
+         FROM ${table}
+         PREWHERE TimeUnix > now64(9) - INTERVAL ${LOOKBACK} AND TimeUnix <= now64(9)
+         WHERE ${projectId} != ''`,
+      ),
+    );
+  }
+
+  return [...projectIds];
 }
 
 export const job: JobDefinition = {

--- a/apps/worker/src/worker/runtime.ts
+++ b/apps/worker/src/worker/runtime.ts
@@ -27,21 +27,12 @@ export async function runWorker(opts: {
   logger.info({ pollMs: opts.pollIntervalMs, batchSize: opts.batchSize }, "worker up");
   while (!opts.signal?.aborted) {
     try {
-      const { spans, logs, agentRuns, alerts, digests, webhooks, autorecoveryProposals } =
-        await opts.tick();
+      const { spans, logs, agentRuns, alerts, digests, webhooks } = await opts.tick();
       // Heartbeat for the tick-lateness gauge/alarm: recorded only on a
       // completed cycle, so a wedged step shows up as a climbing age even
       // while the process stays alive.
       recordTickHeartbeat();
-      if (
-        spans > 0 ||
-        logs > 0 ||
-        agentRuns > 0 ||
-        alerts > 0 ||
-        digests > 0 ||
-        webhooks > 0 ||
-        autorecoveryProposals > 0
-      ) {
+      if (spans > 0 || logs > 0 || agentRuns > 0 || alerts > 0 || digests > 0 || webhooks > 0) {
         logger.info(
           {
             spans,
@@ -50,7 +41,6 @@ export async function runWorker(opts: {
             alerts,
             digests,
             webhooks,
-            autorecoveryProposals,
           },
           "processed",
         );

--- a/apps/worker/src/worker/shutdown.test.ts
+++ b/apps/worker/src/worker/shutdown.test.ts
@@ -35,7 +35,7 @@ test("shutdown drains the tick loop and active jobs before closing shared client
 
   await Promise.resolve();
   assert.equal(pollingStopped, true);
-  assert.deepEqual(stopOptions, { graceful: true, timeout: 90_000 });
+  assert.deepEqual(stopOptions, { graceful: true, timeout: 110_000 });
   assert.equal(clickhouseClosed, false);
 
   tick.resolve();

--- a/apps/worker/src/worker/shutdown.ts
+++ b/apps/worker/src/worker/shutdown.ts
@@ -1,4 +1,7 @@
-const DEFAULT_JOB_DRAIN_TIMEOUT_MS = 90_000;
+// Agent-run attempts abandon their pg-boss job after 90s. The deployment
+// grants 120s from SIGTERM to SIGKILL, so 110s lets the job deadline win while
+// preserving ten seconds to close clients and flush telemetry.
+const DEFAULT_JOB_DRAIN_TIMEOUT_MS = 110_000;
 
 type JobRunner = {
   stop(options: { graceful: boolean; timeout: number }): Promise<void>;

--- a/apps/worker/src/worker/tick.ts
+++ b/apps/worker/src/worker/tick.ts
@@ -2,7 +2,6 @@ import { SpanStatusCode, trace } from "@opentelemetry/api";
 import { tickAgentChats } from "../agent-chats/tick.js";
 import { tickAgentRuns } from "../agent-runs/tick.js";
 import { tickAlerts } from "../alerts.js";
-import { tickAutorecovery } from "../autorecovery.js";
 import { tickDigests } from "../digest.js";
 import { handleIssueTransition } from "../incidents/workflow.js";
 import { logger } from "../logger.js";
@@ -22,15 +21,12 @@ export type WorkerTickResult = {
   alerts: number;
   digests: number;
   webhooks: number;
-  autorecoveryProposals: number;
   observedEscalations: number;
-  usageReported: number;
 };
 
 export function createWorkerTick(opts: {
   clickhouse: ClickHouseClientLike;
   telemetryIngestor: TelemetryIngestor;
-  usageMeter?: (() => Promise<number>) | null;
   // Injected so callers can route transition side effects out-of-band (see
   // issue-transitions.ts); defaults to the direct inline workflow.
   handleIssueTransition?: typeof handleIssueTransition;
@@ -81,15 +77,11 @@ export function createWorkerTick(opts: {
         );
         const digests = await safe("digests", tickDigests, 0);
         const webhooks = await safe("webhooks", tickWebhooks, 0);
-        const autorecoveryProposals = await safe("autorecovery", tickAutorecovery, 0);
         const observedEscalations = await safe(
           "observation",
           () => tickObservedIssues(onIssueTransition),
           0,
         );
-        const usageReported = opts.usageMeter
-          ? await safe("usage_metering", opts.usageMeter, 0)
-          : 0;
         span.setAttribute("tick.spans", spans);
         span.setAttribute("tick.logs", logs);
         span.setAttribute("tick.agent_runs", agentRuns);
@@ -97,9 +89,7 @@ export function createWorkerTick(opts: {
         span.setAttribute("tick.alerts", alerts);
         span.setAttribute("tick.digests", digests);
         span.setAttribute("tick.webhooks", webhooks);
-        span.setAttribute("tick.autorecovery_proposals", autorecoveryProposals);
         span.setAttribute("tick.observed_escalations", observedEscalations);
-        span.setAttribute("tick.usage_reported", usageReported);
         return {
           spans,
           logs,
@@ -108,9 +98,7 @@ export function createWorkerTick(opts: {
           alerts,
           digests,
           webhooks,
-          autorecoveryProposals,
           observedEscalations,
-          usageReported,
         };
       } catch (err) {
         span.recordException(err as Error);

--- a/infra/clickhouse/migrations/008_metric_usage_projection.sql
+++ b/infra/clickhouse/migrations/008_metric_usage_projection.sql
@@ -1,0 +1,58 @@
+-- Exact metric-point counts are read repeatedly by billing and usage-limit
+-- notifications. The raw OTel metric tables are ordered by
+-- (ServiceName, MetricName, Attributes, TimeUnix), so a time-only window over
+-- all projects cannot efficiently prune the large active parts. At production
+-- volume, a five-minute count can otherwise read tens of millions of rows and
+-- gigabytes of ResourceAttributes maps.
+--
+-- Keep the source tables' order (it serves metric-series reads) and add a
+-- query-specific aggregate projection instead. It stores one count state per
+-- exact nanosecond timestamp and project, ordered by time. Exact timestamps
+-- preserve the billing cursor's (after, until] semantics; this is not a
+-- minute-bucket estimate. Scraped metric series generally share timestamps,
+-- so the projection is also much smaller than a second row-for-row index.
+--
+-- These replicated ALTERs intentionally do not use ON CLUSTER: Replicated
+-- MergeTree propagates the metadata change and avoids enqueuing duplicate
+-- materialization mutations through every replica.
+--
+-- Existing parts are NOT materialized by this file. New inserts get the
+-- projection immediately. Backfill existing date partitions sequentially with
+-- apps/worker/scripts/materialize-metric-usage-projections.ts; launching all
+-- five large mutations together can saturate disk I/O and defeat the purpose
+-- of the optimization.
+
+ALTER TABLE superlog.otel_metrics_gauge
+  ADD COLUMN IF NOT EXISTS SuperlogProjectId LowCardinality(String)
+  MATERIALIZED ResourceAttributes['superlog.project_id'];
+ALTER TABLE superlog.otel_metrics_gauge
+  ADD PROJECTION IF NOT EXISTS usage_by_time
+  (SELECT TimeUnix, SuperlogProjectId, count() GROUP BY TimeUnix, SuperlogProjectId);
+
+ALTER TABLE superlog.otel_metrics_sum
+  ADD COLUMN IF NOT EXISTS SuperlogProjectId LowCardinality(String)
+  MATERIALIZED ResourceAttributes['superlog.project_id'];
+ALTER TABLE superlog.otel_metrics_sum
+  ADD PROJECTION IF NOT EXISTS usage_by_time
+  (SELECT TimeUnix, SuperlogProjectId, count() GROUP BY TimeUnix, SuperlogProjectId);
+
+ALTER TABLE superlog.otel_metrics_summary
+  ADD COLUMN IF NOT EXISTS SuperlogProjectId LowCardinality(String)
+  MATERIALIZED ResourceAttributes['superlog.project_id'];
+ALTER TABLE superlog.otel_metrics_summary
+  ADD PROJECTION IF NOT EXISTS usage_by_time
+  (SELECT TimeUnix, SuperlogProjectId, count() GROUP BY TimeUnix, SuperlogProjectId);
+
+ALTER TABLE superlog.otel_metrics_histogram
+  ADD COLUMN IF NOT EXISTS SuperlogProjectId LowCardinality(String)
+  MATERIALIZED ResourceAttributes['superlog.project_id'];
+ALTER TABLE superlog.otel_metrics_histogram
+  ADD PROJECTION IF NOT EXISTS usage_by_time
+  (SELECT TimeUnix, SuperlogProjectId, count() GROUP BY TimeUnix, SuperlogProjectId);
+
+ALTER TABLE superlog.otel_metrics_exp_histogram
+  ADD COLUMN IF NOT EXISTS SuperlogProjectId LowCardinality(String)
+  MATERIALIZED ResourceAttributes['superlog.project_id'];
+ALTER TABLE superlog.otel_metrics_exp_histogram
+  ADD PROJECTION IF NOT EXISTS usage_by_time
+  (SELECT TimeUnix, SuperlogProjectId, count() GROUP BY TimeUnix, SuperlogProjectId);

--- a/infra/clickhouse/schema/ha-replicated-otel.sql
+++ b/infra/clickhouse/schema/ha-replicated-otel.sql
@@ -77,6 +77,7 @@ SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 CREATE TABLE IF NOT EXISTS superlog.otel_metrics_gauge ON CLUSTER superlog_ha
 (
     `ResourceAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `SuperlogProjectId` LowCardinality(String) MATERIALIZED ResourceAttributes['superlog.project_id'],
     `ResourceSchemaUrl` String CODEC(ZSTD(1)),
     `ScopeName` String CODEC(ZSTD(1)),
     `ScopeVersion` String CODEC(ZSTD(1)),
@@ -102,7 +103,12 @@ CREATE TABLE IF NOT EXISTS superlog.otel_metrics_gauge ON CLUSTER superlog_ha
     INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    PROJECTION usage_by_time
+    (
+        SELECT TimeUnix, SuperlogProjectId, count()
+        GROUP BY TimeUnix, SuperlogProjectId
+    )
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
 PARTITION BY toDate(TimeUnix)
@@ -113,6 +119,7 @@ SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 CREATE TABLE IF NOT EXISTS superlog.otel_metrics_sum ON CLUSTER superlog_ha
 (
     `ResourceAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `SuperlogProjectId` LowCardinality(String) MATERIALIZED ResourceAttributes['superlog.project_id'],
     `ResourceSchemaUrl` String CODEC(ZSTD(1)),
     `ScopeName` String CODEC(ZSTD(1)),
     `ScopeVersion` String CODEC(ZSTD(1)),
@@ -140,7 +147,12 @@ CREATE TABLE IF NOT EXISTS superlog.otel_metrics_sum ON CLUSTER superlog_ha
     INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    PROJECTION usage_by_time
+    (
+        SELECT TimeUnix, SuperlogProjectId, count()
+        GROUP BY TimeUnix, SuperlogProjectId
+    )
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
 PARTITION BY toDate(TimeUnix)
@@ -151,6 +163,7 @@ SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 CREATE TABLE IF NOT EXISTS superlog.otel_metrics_summary ON CLUSTER superlog_ha
 (
     `ResourceAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `SuperlogProjectId` LowCardinality(String) MATERIALIZED ResourceAttributes['superlog.project_id'],
     `ResourceSchemaUrl` String CODEC(ZSTD(1)),
     `ScopeName` String CODEC(ZSTD(1)),
     `ScopeVersion` String CODEC(ZSTD(1)),
@@ -174,7 +187,12 @@ CREATE TABLE IF NOT EXISTS superlog.otel_metrics_summary ON CLUSTER superlog_ha
     INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    PROJECTION usage_by_time
+    (
+        SELECT TimeUnix, SuperlogProjectId, count()
+        GROUP BY TimeUnix, SuperlogProjectId
+    )
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
 PARTITION BY toDate(TimeUnix)
@@ -185,6 +203,7 @@ SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 CREATE TABLE IF NOT EXISTS superlog.otel_metrics_histogram ON CLUSTER superlog_ha
 (
     `ResourceAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `SuperlogProjectId` LowCardinality(String) MATERIALIZED ResourceAttributes['superlog.project_id'],
     `ResourceSchemaUrl` String CODEC(ZSTD(1)),
     `ScopeName` String CODEC(ZSTD(1)),
     `ScopeVersion` String CODEC(ZSTD(1)),
@@ -216,7 +235,12 @@ CREATE TABLE IF NOT EXISTS superlog.otel_metrics_histogram ON CLUSTER superlog_h
     INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    PROJECTION usage_by_time
+    (
+        SELECT TimeUnix, SuperlogProjectId, count()
+        GROUP BY TimeUnix, SuperlogProjectId
+    )
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
 PARTITION BY toDate(TimeUnix)
@@ -227,6 +251,7 @@ SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 CREATE TABLE IF NOT EXISTS superlog.otel_metrics_exp_histogram ON CLUSTER superlog_ha
 (
     `ResourceAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `SuperlogProjectId` LowCardinality(String) MATERIALIZED ResourceAttributes['superlog.project_id'],
     `ResourceSchemaUrl` String CODEC(ZSTD(1)),
     `ScopeName` String CODEC(ZSTD(1)),
     `ScopeVersion` String CODEC(ZSTD(1)),
@@ -262,7 +287,12 @@ CREATE TABLE IF NOT EXISTS superlog.otel_metrics_exp_histogram ON CLUSTER superl
     INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    PROJECTION usage_by_time
+    (
+        SELECT TimeUnix, SuperlogProjectId, count()
+        GROUP BY TimeUnix, SuperlogProjectId
+    )
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
 PARTITION BY toDate(TimeUnix)


### PR DESCRIPTION
## Summary

- move autorecovery and usage metering out of the sequential worker tick and onto isolated, exclusive background queues with explicit durable leases
- bound agent-run attempts, usage-metering I/O, queue expiry, and graceful shutdown so interrupted work becomes retryable promptly
- replace wide metric billing scans with exact-timestamp ClickHouse aggregate projections, keeping a raw-schema compatibility fallback
- answer usage-notification activity checks from the narrow minute rollup and sequential metric queries instead of one wide seven-table union
- give billing queries a 25-second server deadline, 30-second client deadline, and 90-second whole-job deadline

## Root cause

The worker tick ran every step serially. Autorecovery could spend minutes on external calls, and usage metering could scan tens of millions of metric rows because the source tables are ordered for metric-series reads rather than cross-project time windows. Either step could delay telemetry processing, investigations, and the worker heartbeat.

## Rollout

Apply `infra/clickhouse/migrations/008_metric_usage_projection.sql` first, then materialize the required existing date partitions one at a time with `apps/worker/scripts/materialize-metric-usage-projections.ts`. New parts receive the projection automatically. The worker retains exact-count raw-schema fallbacks during a partial rollout.

## Validation

- 44 focused worker behavior tests
- all 13 package typechecks
- full monorepo production build
- formatting checks on every touched TypeScript and Markdown file
- local ClickHouse DDL, projection materialization, exact-result comparison, projection-selection verification, and live array-parameter execution