### PR TITLE
Fix weekly digest failing on Date params in raw SQL fragments

### DIFF
--- a/apps/worker/src/digest/repository.integration.test.ts
+++ b/apps/worker/src/digest/repository.integration.test.ts
@@ -203,3 +203,31 @@ test("weekly summary counts incident activity and the current status of issues t
     issues: { open: 2, underObservation: 1, silenced: 1, resolved: 2 },
   });
 });
+
+// The production postgres-js driver rejects Date instances bound through raw
+// sql`` fragments (ERR_INVALID_ARG_TYPE at Bind time) — only params bound via
+// column operators get mapped to ISO strings. PGlite accepts Dates, so this
+// asserts at the driver boundary instead of relying on the query to throw.
+test("weekly summary never hands raw Date params to the driver", async () => {
+  const captured: unknown[][] = [];
+  const recordingClient = Object.create(client) as PGlite;
+  recordingClient.query = ((query: string, params?: unknown[], options?: unknown) => {
+    captured.push(params ?? []);
+    return client.query(query, params, options as never);
+  }) as PGlite["query"];
+  const recordingRepo = createDigestRepository(
+    drizzle(recordingClient, { schema }) as unknown as DB,
+  );
+
+  await recordingRepo.gatherWeeklySummary(
+    projectId,
+    { intervalMs: 7 * 86_400_000 },
+    new Date("2026-07-14T10:00:00Z"),
+  );
+
+  assert.ok(captured.length > 0, "expected the summary to issue queries");
+  assert.deepEqual(
+    captured.flat().filter((param) => param instanceof Date),
+    [],
+  );
+});

--- a/apps/worker/src/digest/repository.ts
+++ b/apps/worker/src/digest/repository.ts
@@ -93,20 +93,23 @@ export function createDigestRepository(db: DB): DigestRepository {
     },
 
     async gatherWeeklySummary(projectId, policy, now) {
+      // Bind timestamps through column operators (or as ISO strings below):
+      // Date instances interpolated straight into sql`` skip the column's
+      // driver mapping and the postgres-js driver rejects them at Bind time.
       const from = new Date(now.getTime() - policy.intervalMs);
       const [incidentCounts] = await db
         .select({
           opened: sql<number>`count(*) filter (
-            where ${schema.incidents.firstSeen} >= ${from}
-              and ${schema.incidents.firstSeen} <= ${now}
+            where ${gte(schema.incidents.firstSeen, from)}
+              and ${lte(schema.incidents.firstSeen, now)}
           )`.mapWith(Number),
           resolved: sql<number>`count(*) filter (
-            where ${schema.incidents.resolvedAt} >= ${from}
-              and ${schema.incidents.resolvedAt} <= ${now}
+            where ${gte(schema.incidents.resolvedAt, from)}
+              and ${lte(schema.incidents.resolvedAt, now)}
           )`.mapWith(Number),
           remainOpen: sql<number>`count(*) filter (
-            where ${schema.incidents.firstSeen} >= ${from}
-              and ${schema.incidents.firstSeen} <= ${now}
+            where ${gte(schema.incidents.firstSeen, from)}
+              and ${lte(schema.incidents.firstSeen, now)}
               and ${schema.incidents.status} = 'open'
           )`.mapWith(Number),
         })
@@ -129,11 +132,11 @@ export function createDigestRepository(db: DB): DigestRepository {
             sql`coalesce(
               ${schema.incidentEvents.processedAt},
               ${schema.incidentEvents.createdAt}
-            ) >= ${from}`,
+            ) >= ${from.toISOString()}`,
             sql`coalesce(
               ${schema.incidentEvents.processedAt},
               ${schema.incidentEvents.createdAt}
-            ) <= ${now}`,
+            ) <= ${now.toISOString()}`,
           ),
         );
       const classifiedIssueIds = lifecycleRows.flatMap((row) => {


### PR DESCRIPTION
## Problem

Since the weekly digest activity breakdown (#262), every digest run — scheduled and the settings-page test send — fails for projects with digest configured. `gatherWeeklySummary` interpolates `Date` instances directly into raw `sql`` fragments (the `count(*) filter (...)` window bounds and the `coalesce(processedAt, createdAt)` comparisons). Params bound that way skip the column's `mapToDriverValue`, and the postgres-js driver rejects raw `Date` objects at Bind time:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string or an
instance of Buffer or ArrayBuffer. Received an instance of Date
```

The digest tick catches the error and its `finally` block still consumes the one-shot run request, so a test send appears to do nothing.

## Fix

- Bind the window bounds through `gte`/`lte` column operators (which apply the column's driver mapping) where the left side is a plain column, and as ISO strings in the `coalesce()` fragment.
- Add an integration test that asserts no `Date` instance reaches the driver. PGlite serializes `Date` params happily, so the existing summary test stayed green — the new test intercepts at the client boundary instead.

## Testing

- `tsx --test src/digest/repository.integration.test.ts` — new test red before the fix (8 leaked `Date` params), green after.
- All 29 digest tests pass; `pnpm typecheck` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes weekly digest crashes caused by raw Date params in SQL, so scheduled runs and test sends work again.

- Bug Fixes
  - Bind date bounds via `gte`/`lte` and pass ISO strings in coalesce() to avoid raw `Date` values reaching the `postgres-js` driver.
  - Add an integration test that records query params to assert no `Date` instances are sent (accounts for `pglite` accepting Dates).

<sup>Written for commit 8cfe55badb26b3495a1fbd6df46abe92c9280737. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

