### PR TITLE
Stabilize Vercel runtime request fingerprints

### DIFF
--- a/apps/proxy/src/vercel-log-drain.test.ts
+++ b/apps/proxy/src/vercel-log-drain.test.ts
@@ -1,11 +1,9 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
 
-import {
-  parseVercelLogDrainBody,
-  vercelLogsToOtlp,
-} from "./vercel-log-drain.js";
+import { stampIssueFingerprints } from "./ingest-fingerprints.js";
 import { otlpLogsToRows } from "./otlp-clickhouse.js";
+import { parseVercelLogDrainBody, vercelLogsToOtlp } from "./vercel-log-drain.js";
 
 const vercelLogs = [
   {
@@ -72,11 +70,56 @@ test("vercelLogsToOtlp maps Vercel logs to OTLP JSON logs", () => {
 test("mapped Vercel logs become ClickHouse log rows with service and tenant attributes", () => {
   const rows = otlpLogsToRows(vercelLogsToOtlp(vercelLogs), "superlog-project");
   assert.equal(rows.length, 1);
-  const row = rows[0]!;
+  const [row] = rows;
+  assert.ok(row);
   assert.equal(row.ServiceName, "my-app");
   assert.equal(row.Body, "API request failed");
   assert.equal(row.ResourceAttributes["superlog.project_id"], "superlog-project");
   assert.equal(row.ResourceAttributes["service.name"], "my-app");
   assert.equal(row.ResourceAttributes["vercel.project_id"], "gdufoJxB6b9b1fEqr1jUtFkyavUU");
   assert.equal(row.LogAttributes["vercel.deployment_id"], "dpl_233NRGRjVZX1caZrXWtz5g1TAksD");
+});
+
+test("Vercel runtime request envelopes receive stable fingerprints through OTLP", () => {
+  const envelope = (id: string, path: string, duration: number) =>
+    [
+      `START RequestId: ${id}`,
+      `[GET] ${path} status=503`,
+      `END RequestId: ${id}`,
+      `REPORT RequestId: ${id} Duration: ${duration} ms Billed Duration: ${duration} ms Memory Size: 2048 MB Max Memory Used: 701 MB`,
+    ].join("\n");
+  const payload = vercelLogsToOtlp([
+    {
+      ...vercelLogs[0],
+      message: envelope("sin1::request-a", "/collections/summer", 25_880),
+    },
+    {
+      ...vercelLogs[0],
+      message: envelope("gru1::request-b", "/collections/kids", 26_703),
+    },
+  ]);
+
+  const stamped = stampIssueFingerprints({
+    path: "/v1/logs",
+    contentType: "application/json",
+    body: Buffer.from(JSON.stringify(payload)),
+  });
+  const output = JSON.parse(stamped.body.toString("utf8"));
+  const fingerprints = output.resourceLogs.map(
+    (resourceLog: {
+      scopeLogs: Array<{
+        logRecords: Array<{
+          attributes: Array<{ key: string; value?: { stringValue?: string } }>;
+        }>;
+      }>;
+    }) =>
+      resourceLog.scopeLogs[0]?.logRecords[0]?.attributes.find(
+        (attribute) => attribute.key === "superlog.issue_fingerprint",
+      )?.value?.stringValue,
+  );
+
+  assert.equal(stamped.stampedCount, 2);
+  assert.equal(typeof fingerprints[0], "string");
+  assert.equal(typeof fingerprints[1], "string");
+  assert.equal(fingerprints[0], fingerprints[1]);
 });

--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -61,6 +61,7 @@ function vercelRuntimeEnvelope(input: {
   path?: string;
   status?: number;
   report?: string;
+  startMetadata?: string;
 }): string {
   const method = input.method ?? "GET";
   const path = input.path ?? "/collections/summer";
@@ -68,8 +69,9 @@ function vercelRuntimeEnvelope(input: {
   const report =
     input.report ??
     "Duration: 25880 ms Billed Duration: 25880 ms Memory Size: 2048 MB Max Memory Used: 673 MB";
+  const startMetadata = input.startMetadata ? ` ${input.startMetadata}` : "";
   return [
-    `START RequestId: ${input.id}`,
+    `START RequestId: ${input.id}${startMetadata}`,
     `[${method}] ${path} status=${status}`,
     `END RequestId: ${input.id}`,
     `REPORT RequestId: ${input.id} ${report}`,
@@ -130,6 +132,25 @@ test("fingerprintLog accepts scoped and opaque Vercel request IDs", () => {
   });
 
   assert.equal(scoped.hash, opaque.hash);
+});
+
+test("fingerprintLog ignores Vercel START-line runtime version metadata", () => {
+  const latest = fingerprintLog({
+    ...VERCEL_LOG,
+    body: vercelRuntimeEnvelope({
+      id: "sin1::request-a",
+      startMetadata: "Version: $LATEST",
+    }),
+  });
+  const numbered = fingerprintLog({
+    ...VERCEL_LOG,
+    body: vercelRuntimeEnvelope({
+      id: "gru1::request-b",
+      startMetadata: "Version: 42",
+    }),
+  });
+
+  assert.equal(latest.hash, numbered.hash);
 });
 
 test("fingerprintLog separates Vercel runtime request envelopes by method", () => {

--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -48,6 +48,125 @@ test("messageBucketFor still separates genuinely different messages", () => {
   );
 });
 
+const VERCEL_LOG = {
+  service: "storefront",
+  severity: "ERROR",
+  exceptionType: "ERROR",
+  stacktrace: null,
+};
+
+function vercelRuntimeEnvelope(input: {
+  id: string;
+  method?: string;
+  path?: string;
+  status?: number;
+  report?: string;
+}): string {
+  const method = input.method ?? "GET";
+  const path = input.path ?? "/collections/summer";
+  const status = input.status ?? 503;
+  const report =
+    input.report ??
+    "Duration: 25880 ms Billed Duration: 25880 ms Memory Size: 2048 MB Max Memory Used: 673 MB";
+  return [
+    `START RequestId: ${input.id}`,
+    `[${method}] ${path} status=${status}`,
+    `END RequestId: ${input.id}`,
+    `REPORT RequestId: ${input.id} ${report}`,
+  ].join("\n");
+}
+
+test("fingerprintLog groups equivalent Vercel runtime request envelopes", () => {
+  const first = fingerprintLog({
+    ...VERCEL_LOG,
+    body: vercelRuntimeEnvelope({
+      id: "sin1::wgjjq-1783721543178-bb29a25d147a",
+      path: "/collections/summer?direction=next&filter.p.product_type=Topical",
+    }),
+  });
+  const second = fingerprintLog({
+    ...VERCEL_LOG,
+    body: vercelRuntimeEnvelope({
+      id: "gru1::sv2np-1783721551971-8ab18e6846a0",
+      path: "/collections/kids?filter.p.product_type=Shampoo",
+      report:
+        "Duration: 26703 ms Billed Duration: 26703 ms Memory Size: 2048 MB Max Memory Used: 701 MB",
+    }),
+  });
+
+  assert.equal(first.hash, second.hash);
+});
+
+test("fingerprintLog separates Vercel runtime request envelopes by status", () => {
+  const unavailable = fingerprintLog({
+    ...VERCEL_LOG,
+    body: vercelRuntimeEnvelope({
+      id: "sin1::wgjjq-1783721543178-bb29a25d147a",
+      status: 503,
+    }),
+  });
+  const internalError = fingerprintLog({
+    ...VERCEL_LOG,
+    body: vercelRuntimeEnvelope({
+      id: "gru1::sv2np-1783721551971-8ab18e6846a0",
+      status: 500,
+    }),
+  });
+
+  assert.notEqual(unavailable.hash, internalError.hash);
+});
+
+test("fingerprintLog accepts scoped and opaque Vercel request IDs", () => {
+  const scoped = fingerprintLog({
+    ...VERCEL_LOG,
+    body: vercelRuntimeEnvelope({ id: "sin1::wgjjq-1783721543178-bb29a25d147a" }),
+  });
+  const opaque = fingerprintLog({
+    ...VERCEL_LOG,
+    body: vercelRuntimeEnvelope({ id: "3f0f7fc2-c088-4e5f-a829-14d3fd5bf8a1" }).replaceAll(
+      "\n",
+      "\r\n",
+    ),
+  });
+
+  assert.equal(scoped.hash, opaque.hash);
+});
+
+test("fingerprintLog separates Vercel runtime request envelopes by method", () => {
+  const get = fingerprintLog({
+    ...VERCEL_LOG,
+    body: vercelRuntimeEnvelope({ id: "sin1::request-a", method: "GET" }),
+  });
+  const post = fingerprintLog({
+    ...VERCEL_LOG,
+    body: vercelRuntimeEnvelope({ id: "sin1::request-b", method: "POST" }),
+  });
+
+  assert.notEqual(get.hash, post.hash);
+});
+
+test("fingerprintLog preserves application output inside a runtime invocation", () => {
+  const requestId = "sin1::request-a";
+  const withApplicationOutput = (output: string) =>
+    [
+      `START RequestId: ${requestId}`,
+      "[GET] /collections/summer status=503",
+      output,
+      `END RequestId: ${requestId}`,
+      `REPORT RequestId: ${requestId} Duration: 25880 ms`,
+    ].join("\n");
+  const timeout = fingerprintLog({
+    ...VERCEL_LOG,
+    body: withApplicationOutput("database connection timed out"),
+  });
+  const invalidResponse = fingerprintLog({
+    ...VERCEL_LOG,
+    body: withApplicationOutput("upstream returned invalid JSON"),
+  });
+
+  assert.notEqual(timeout.hash, invalidResponse.hash);
+});
+
 // Postgres text and jsonb columns reject the NUL byte (0x00) — it raises
 // `22021 invalid byte sequence for encoding "UTF8": 0x00`. Telemetry can carry
 // a raw NUL in a message or stack frame; the fingerprint outputs feed straight

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -126,10 +126,13 @@ function unwrapAnthropicErrorMessage(raw: string): string {
   // SDK errors land as `<status> <json>`; pull `error.message` if present so we
   // hash the human-readable failure, not the JSON wrapper.
   const m = raw.match(/"message"\s*:\s*"((?:[^"\\]|\\.)*)"/);
-  return m && m[1] ? m[1].replace(/\\"/g, '"').replace(/\\\\/g, "\\") : raw;
+  return m?.[1] ? m[1].replace(/\\"/g, '"').replace(/\\\\/g, "\\") : raw;
 }
 
 export function normalizeMessage(body: string): string {
+  const vercelRuntimeRequest = normalizeVercelRuntimeRequest(body);
+  if (vercelRuntimeRequest) return vercelRuntimeRequest;
+
   let s = body;
   s = s.replace(/https?:\/\/\S+/gi, "<url>");
   s = collapseRequestPaths(s);
@@ -144,6 +147,22 @@ export function normalizeMessage(body: string): string {
   s = s.replace(/\b\d+\b/g, "<n>");
   s = s.replace(/\s+/g, " ").trim().toLowerCase();
   return s;
+}
+
+// Vercel log drains can emit one four-line runtime envelope per request. Its
+// request ID, path, timings, and memory figures are occurrence metadata, not
+// error identity. Keep the match anchored and require the same request ID on
+// START/END/REPORT so application output is never mistaken for the envelope.
+const VERCEL_RUNTIME_REQUEST_ENVELOPE =
+  /^\s*START RequestId:\s*(\S+)\s*\r?\n\[([A-Z]+)\]\s+\S+\s+status=(\d{3})\s*\r?\nEND RequestId:\s*\1\s*\r?\nREPORT RequestId:\s*\1(?:\s+[^\r\n]*)?\s*$/i;
+
+function normalizeVercelRuntimeRequest(body: string): string | null {
+  const match = body.match(VERCEL_RUNTIME_REQUEST_ENVELOPE);
+  const method = match?.[2];
+  const status = match?.[3];
+  return method && status
+    ? `vercel runtime request method=${method.toLowerCase()} status=${status}`
+    : null;
 }
 
 function parseFrames(stacktrace: string): Frame[] {
@@ -162,7 +181,6 @@ function parseFrames(stacktrace: string): Frame[] {
     const bare = body.match(/^(.+?):\d+:\d+$/);
     if (bare) {
       out.push({ fn: null, path: bare[1] ?? "" });
-      continue;
     }
   }
   return out;

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -151,18 +151,102 @@ export function normalizeMessage(body: string): string {
 
 // Vercel log drains can emit one four-line runtime envelope per request. Its
 // request ID, path, timings, and memory figures are occurrence metadata, not
-// error identity. Keep the match anchored and require the same request ID on
-// START/END/REPORT so application output is never mistaken for the envelope.
-const VERCEL_RUNTIME_REQUEST_ENVELOPE =
-  /^\s*START RequestId:\s*(\S+)\s*\r?\n\[([A-Z]+)\]\s+\S+\s+status=(\d{3})\s*\r?\nEND RequestId:\s*\1\s*\r?\nREPORT RequestId:\s*\1(?:\s+[^\r\n]*)?\s*$/i;
+// error identity. Recognize exactly four lines and require the same request ID
+// on START/END/REPORT so application output is never mistaken for the envelope.
+const START_REQUEST_ID = "START RequestId:";
+const END_REQUEST_ID = "END RequestId:";
+const REPORT_REQUEST_ID = "REPORT RequestId:";
 
 function normalizeVercelRuntimeRequest(body: string): string | null {
-  const match = body.match(VERCEL_RUNTIME_REQUEST_ENVELOPE);
-  const method = match?.[2];
-  const status = match?.[3];
-  return method && status
-    ? `vercel runtime request method=${method.toLowerCase()} status=${status}`
+  const lines = body
+    .trim()
+    .split("\n")
+    .map((line) => (line.endsWith("\r") ? line.slice(0, -1) : line));
+  if (lines.length !== 4) return null;
+
+  const [startLine, requestLine, endLine, reportLine] = lines;
+  if (!startLine || !requestLine || !endLine || !reportLine) return null;
+
+  const requestId = requestIdFromLine(startLine, START_REQUEST_ID);
+  if (!requestId || requestIdFromLine(endLine, END_REQUEST_ID) !== requestId) return null;
+  if (reportRequestId(reportLine) !== requestId) return null;
+
+  const request = parseVercelRequestLine(requestLine);
+  return request
+    ? `vercel runtime request method=${request.method.toLowerCase()} status=${request.status}`
     : null;
+}
+
+function requestIdFromLine(line: string, prefix: string): string | null {
+  if (!line.startsWith(prefix)) return null;
+  const requestId = line.slice(prefix.length).trim();
+  return requestId && !hasWhitespace(requestId) ? requestId : null;
+}
+
+function reportRequestId(line: string): string | null {
+  if (!line.startsWith(REPORT_REQUEST_ID)) return null;
+  const rest = line.slice(REPORT_REQUEST_ID.length).trimStart();
+  if (!rest) return null;
+  const boundary = firstWhitespaceIndex(rest);
+  return boundary === -1 ? rest : rest.slice(0, boundary);
+}
+
+function parseVercelRequestLine(line: string): { method: string; status: string } | null {
+  if (!line.startsWith("[")) return null;
+  const methodEnd = line.indexOf("]");
+  if (methodEnd <= 1) return null;
+
+  const method = line.slice(1, methodEnd);
+  if (!isAsciiLetters(method) || !isWhitespace(line[methodEnd + 1])) return null;
+
+  let pathStart = methodEnd + 1;
+  while (isWhitespace(line[pathStart])) pathStart += 1;
+
+  const statusStart = line.lastIndexOf("status=");
+  if (statusStart <= pathStart || !isWhitespace(line[statusStart - 1])) return null;
+
+  let pathEnd = statusStart;
+  while (pathEnd > pathStart && isWhitespace(line[pathEnd - 1])) pathEnd -= 1;
+  const path = line.slice(pathStart, pathEnd);
+  const status = line.slice(statusStart + "status=".length).trim();
+  if (!path || hasWhitespace(path) || !isThreeDigits(status)) return null;
+
+  return { method, status };
+}
+
+function firstWhitespaceIndex(value: string): number {
+  for (let index = 0; index < value.length; index += 1) {
+    if (isWhitespace(value[index])) return index;
+  }
+  return -1;
+}
+
+function hasWhitespace(value: string): boolean {
+  return firstWhitespaceIndex(value) !== -1;
+}
+
+function isWhitespace(value: string | undefined): boolean {
+  return value !== undefined && value.trim() === "";
+}
+
+function isAsciiLetters(value: string): boolean {
+  if (!value) return false;
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    const isUppercase = code >= 65 && code <= 90;
+    const isLowercase = code >= 97 && code <= 122;
+    if (!isUppercase && !isLowercase) return false;
+  }
+  return true;
+}
+
+function isThreeDigits(value: string): boolean {
+  if (value.length !== 3) return false;
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if (code < 48 || code > 57) return false;
+  }
+  return true;
 }
 
 function parseFrames(stacktrace: string): Frame[] {

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -156,6 +156,7 @@ export function normalizeMessage(body: string): string {
 const START_REQUEST_ID = "START RequestId:";
 const END_REQUEST_ID = "END RequestId:";
 const REPORT_REQUEST_ID = "REPORT RequestId:";
+const VERSION_METADATA = "Version:";
 
 function normalizeVercelRuntimeRequest(body: string): string | null {
   const lines = body
@@ -167,7 +168,7 @@ function normalizeVercelRuntimeRequest(body: string): string | null {
   const [startLine, requestLine, endLine, reportLine] = lines;
   if (!startLine || !requestLine || !endLine || !reportLine) return null;
 
-  const requestId = requestIdFromLine(startLine, START_REQUEST_ID);
+  const requestId = startRequestId(startLine);
   if (!requestId || requestIdFromLine(endLine, END_REQUEST_ID) !== requestId) return null;
   if (reportRequestId(reportLine) !== requestId) return null;
 
@@ -175,6 +176,21 @@ function normalizeVercelRuntimeRequest(body: string): string | null {
   return request
     ? `vercel runtime request method=${request.method.toLowerCase()} status=${request.status}`
     : null;
+}
+
+function startRequestId(line: string): string | null {
+  if (!line.startsWith(START_REQUEST_ID)) return null;
+  const rest = line.slice(START_REQUEST_ID.length).trim();
+  if (!rest) return null;
+
+  const boundary = firstWhitespaceIndex(rest);
+  if (boundary === -1) return rest;
+
+  const requestId = rest.slice(0, boundary);
+  const metadata = rest.slice(boundary).trimStart();
+  if (!metadata.startsWith(VERSION_METADATA)) return null;
+  const version = metadata.slice(VERSION_METADATA.length).trim();
+  return version && !hasWhitespace(version) ? requestId : null;
 }
 
 function requestIdFromLine(line: string, prefix: string): string | null {


### PR DESCRIPTION
## Summary

- recognize complete Vercel runtime request envelopes before generic log-message normalization
- discard per-occurrence request IDs, paths, timing, region, and memory metadata from issue identity
- retain HTTP method and exact status as bounded semantic discriminators

## Why

Vercel log drains can emit a four-line runtime envelope for every request. Volatile fields in that envelope made equivalent failures produce different fingerprints, turning a single failure mode into many issues.

The adapter is deliberately strict: it requires the complete `START` / request / `END` / `REPORT` shape and the same request ID across the lifecycle lines. Messages containing application output continue through the existing general-purpose normalizer.

## Verification

- fingerprint package tests and typecheck
- Vercel log-drain to OTLP to issue-fingerprint integration test
- proxy, worker telemetry-ingest, and API consumer typechecks
- proxy and worker ingestion test suites

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes fingerprints for Vercel runtime request envelopes so equivalent failures group into a single issue. Adds a strict, non-backtracking parser for the 4-line START/request/END/REPORT shape that ignores volatile fields (and START-line `Version:` metadata) while keeping HTTP method and exact status.

- **Bug Fixes**
  - Recognize complete Vercel runtime envelopes before general normalization; require the same RequestId across START/END/REPORT; accept scoped/opaque IDs, CRLF line endings, and START-line `Version:`/`$LATEST` metadata; avoid false positives with strict parsing.
  - Exclude request ID, path, timing, region, and memory from the fingerprint; retain method and exact status as discriminators.
  - Added tests in `packages/fingerprint` and `apps/proxy` to verify stable grouping through OTLP, separation by method/status, handling of START-line version metadata and scoped/opaque RequestIds + CRLF, and preservation of application output.

<sup>Written for commit de6b532eff8dace046890a90d992025cb6aa0e4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

