### PR TITLE
perf(api): cap raw telemetry scans in countSeries and surface sampled…

### DIFF
--- a/apps/api/src/alerts-service.ts
+++ b/apps/api/src/alerts-service.ts
@@ -133,7 +133,7 @@ export async function evaluateAlertQuery(
       groupCounts.set(key, (groupCounts.get(key) ?? 0) + 1);
     }
   } else {
-    const rows = await countSeries(
+    const { rows } = await countSeries(
       ch,
       alert.projectId,
       alert.source,
@@ -472,7 +472,7 @@ export async function previewAlertSeries(
       }
     }
   } else {
-    const rows = await countSeries(
+    const { rows } = await countSeries(
       ch,
       projectId,
       input.source,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -981,7 +981,7 @@ app.post("/api/projects/:projectId/explore/series", async (c) => {
   const filter = body.filter ?? {};
   const rangeSeconds = estimateRangeSeconds(filter.range);
   const step = pickStep(rangeSeconds);
-  const rows = await countSeries(
+  const { rows, sampled } = await countSeries(
     ch,
     projectId,
     source,
@@ -998,7 +998,7 @@ app.post("/api/projects/:projectId/explore/series", async (c) => {
     body.groupBy || undefined,
     step,
   );
-  return c.json({ step: `${step.n} ${step.unit}`, rows });
+  return c.json({ step: `${step.n} ${step.unit}`, rows, sampled });
 });
 
 app.get("/api/projects/:projectId/explore/metric-names", async (c) => {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -997,6 +997,7 @@ app.post("/api/projects/:projectId/explore/series", async (c) => {
     },
     body.groupBy || undefined,
     step,
+    1_000_000,
   );
   return c.json({ step: `${step.n} ${step.unit}`, rows, sampled });
 });

--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -1001,7 +1001,7 @@ test("countSeries exact scan path (no scanCap) does not use inner subquery limit
   assert.doesNotMatch(capture.query ?? "", /sum\(count\(\)\) OVER \(\)/);
 });
 
-test("countSeries capped scan path (with scanCap) uses subquery limit and window function", async () => {
+test("countSeries capped scan path (with scanCap) uses subquery limit and UNION ALL metadata count", async () => {
   const capture: { query?: string; params?: Record<string, unknown> } = {};
 
   await countSeries(
@@ -1015,5 +1015,6 @@ test("countSeries capped scan path (with scanCap) uses subquery limit and window
   );
 
   assert.match(capture.query ?? "", /FROM \(\s*SELECT [\s\S]*FROM otel_logs\s*WHERE [\s\S]*LIMIT 1000000\s*\)/);
-  assert.match(capture.query ?? "", /sum\(count\(\)\) OVER \(\)/);
+  assert.match(capture.query ?? "", /UNION ALL/);
+  assert.match(capture.query ?? "", /LIMIT 1000001/);
 });

--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -983,3 +983,37 @@ test("countSeries falls back to the raw table when the rollup table is absent", 
 
   assert.match(capture.query ?? "", /FROM otel_traces/);
 });
+
+test("countSeries exact scan path (no scanCap) does not use inner subquery limit", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await countSeries(
+    fakeClickhouse(capture),
+    "project-1",
+    "logs",
+    { range: HOUR_RANGE, search: "error" },
+    undefined,
+    { n: 15, unit: "MINUTE" },
+  );
+
+  assert.match(capture.query ?? "", /FROM otel_logs/);
+  assert.doesNotMatch(capture.query ?? "", /LIMIT 1000000/);
+  assert.doesNotMatch(capture.query ?? "", /sum\(count\(\)\) OVER \(\)/);
+});
+
+test("countSeries capped scan path (with scanCap) uses subquery limit and window function", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await countSeries(
+    fakeClickhouse(capture),
+    "project-1",
+    "logs",
+    { range: HOUR_RANGE, search: "error" },
+    undefined,
+    { n: 15, unit: "MINUTE" },
+    1_000_000,
+  );
+
+  assert.match(capture.query ?? "", /FROM \(\s*SELECT [\s\S]*FROM otel_logs\s*WHERE [\s\S]*LIMIT 1000000\s*\)/);
+  assert.match(capture.query ?? "", /sum\(count\(\)\) OVER \(\)/);
+});

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -1625,21 +1625,37 @@ export async function countSeries(
     const whereSql = filterConds.length > 0 ? `WHERE ${filterConds.join(" AND ")}` : "";
 
     const query = `
-      SELECT
-        toString(toStartOfInterval(Timestamp, INTERVAL ${step.n} ${step.unit})) AS bucket,
-        ${group.expr} AS group_key,
-        count() AS c,
-        sum(count()) OVER () AS total_count
-      FROM (
-        SELECT ${selectCols}
-        FROM ${table}
-        WHERE ${baseConds.join(" AND ")}
-        LIMIT ${scanCap}
+      (
+        SELECT
+          0 AS is_metadata,
+          toString(toStartOfInterval(Timestamp, INTERVAL ${step.n} ${step.unit})) AS bucket,
+          ${group.expr} AS group_key,
+          count() AS c
+        FROM (
+          SELECT ${selectCols}
+          FROM ${table}
+          WHERE ${baseConds.join(" AND ")}
+          LIMIT ${scanCap}
+        )
+        ${whereSql}
+        GROUP BY bucket, group_key
+        ORDER BY bucket ASC
+        LIMIT 10000
       )
-      ${whereSql}
-      GROUP BY bucket, group_key
-      ORDER BY bucket ASC
-      LIMIT 10000
+      UNION ALL
+      (
+        SELECT
+          1 AS is_metadata,
+          '' AS bucket,
+          '' AS group_key,
+          count() AS c
+        FROM (
+          SELECT 1
+          FROM ${table}
+          WHERE ${baseConds.join(" AND ")}
+          LIMIT ${scanCap + 1}
+        )
+      )
     `;
 
     const r = await ch.query({
@@ -1662,14 +1678,16 @@ export async function countSeries(
       format: "JSONEachRow",
     });
     const rows = (await r.json()) as {
+      is_metadata: string | number;
       bucket: string;
       group_key: string;
       c: string | number;
-      total_count?: string | number;
     }[];
-    const mapped = rows.map((row) => ({ bucket: row.bucket, group: row.group_key, count: Number(row.c) }));
-    const totalCount = Number(rows[0]?.total_count ?? 0);
-    return { rows: mapped, sampled: totalCount >= scanCap };
+    const dataRows = rows.filter((row) => Number(row.is_metadata) === 0);
+    const metaRow = rows.find((row) => Number(row.is_metadata) === 1);
+    const totalCount = Number(metaRow?.c ?? 0);
+    const mapped = dataRows.map((row) => ({ bucket: row.bucket, group: row.group_key, count: Number(row.c) }));
+    return { rows: mapped, sampled: totalCount > scanCap };
   }
 
   // Exact scan path (used by alerts)

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -1568,8 +1568,6 @@ async function countSeriesFromRollup(
   return rows.map((row) => ({ bucket: row.bucket, group: row.group_key, count: Number(row.c) }));
 }
 
-const SERIES_SCAN_ROW_CAP = 1_000_000;
-
 export async function countSeries(
   ch: ClickHouseClient,
   projectId: string,
@@ -1577,6 +1575,7 @@ export async function countSeries(
   filter: SeriesFilter,
   groupBy: string | undefined,
   step: Step,
+  scanCap?: number,
 ): Promise<{ rows: { bucket: string; group: string; count: number }[]; sampled: boolean }> {
   const folded = foldServiceAttrFilter(filter);
   if (folded && rollupEligible(folded, groupBy, step) && (await rollupAvailable(ch))) {
@@ -1592,39 +1591,112 @@ export async function countSeries(
       : attrConds(split.span, "SpanAttributes", "event_attr");
   const field = fieldConds(split.field, source === "logs" ? "logs" : "traces");
   const table = source === "logs" ? "otel_logs" : "otel_traces";
-  const conds: string[] = [
+
+  const baseConds: string[] = [
     "ResourceAttributes['superlog.project_id'] = {projectId:String}",
     `Timestamp >= ${sinceExpr}`,
     `Timestamp <= ${untilExpr}`,
+  ];
+  if (filter.service) baseConds.push("ServiceName = {service:String}");
+
+  const group = groupExprForAttribute(groupBy, source);
+
+  if (scanCap !== undefined && scanCap > 0) {
+    const selectCols = source === "logs"
+      ? "Timestamp, ServiceName, ResourceAttributes, LogAttributes, SeverityText, SeverityNumber, Body, TraceId, SpanId"
+      : "Timestamp, ServiceName, ResourceAttributes, SpanAttributes, SpanName, StatusCode, Duration, TraceId, SpanId";
+
+    const filterConds: string[] = [
+      ...attr.conds,
+      ...eventAttr.conds,
+      ...field.conds,
+    ];
+    if (source === "logs") {
+      if (filter.severity) filterConds.push("upper(SeverityText) = upper({severity:String})");
+      if (filter.search) filterConds.push("positionCaseInsensitive(Body, {search:String}) > 0");
+    } else {
+      if (filter.spanName) filterConds.push("SpanName = {spanName:String}");
+      if (filter.statusCode) filterConds.push("StatusCode = {statusCode:String}");
+      if (typeof filter.minDurationMs === "number") {
+        filterConds.push("Duration >= {minDurationNs:UInt64}");
+      }
+    }
+
+    const whereSql = filterConds.length > 0 ? `WHERE ${filterConds.join(" AND ")}` : "";
+
+    const query = `
+      SELECT
+        toString(toStartOfInterval(Timestamp, INTERVAL ${step.n} ${step.unit})) AS bucket,
+        ${group.expr} AS group_key,
+        count() AS c,
+        sum(count()) OVER () AS total_count
+      FROM (
+        SELECT ${selectCols}
+        FROM ${table}
+        WHERE ${baseConds.join(" AND ")}
+        LIMIT ${scanCap}
+      )
+      ${whereSql}
+      GROUP BY bucket, group_key
+      ORDER BY bucket ASC
+      LIMIT 10000
+    `;
+
+    const r = await ch.query({
+      query,
+      query_params: {
+        projectId,
+        since: sinceSql,
+        until: untilSql,
+        service: filter.service ?? "",
+        severity: filter.severity ?? "",
+        search: filter.search ?? "",
+        spanName: filter.spanName ?? "",
+        statusCode: filter.statusCode ?? "",
+        minDurationNs: Math.round((filter.minDurationMs ?? 0) * 1_000_000),
+        ...attr.params,
+        ...eventAttr.params,
+        ...field.params,
+        ...group.params,
+      },
+      format: "JSONEachRow",
+    });
+    const rows = (await r.json()) as {
+      bucket: string;
+      group_key: string;
+      c: string | number;
+      total_count?: string | number;
+    }[];
+    const mapped = rows.map((row) => ({ bucket: row.bucket, group: row.group_key, count: Number(row.c) }));
+    const totalCount = Number(rows[0]?.total_count ?? 0);
+    return { rows: mapped, sampled: totalCount >= scanCap };
+  }
+
+  // Exact scan path (used by alerts)
+  const exactConds: string[] = [
+    ...baseConds,
     ...attr.conds,
     ...eventAttr.conds,
     ...field.conds,
   ];
-  if (filter.service) conds.push("ServiceName = {service:String}");
   if (source === "logs") {
-    if (filter.severity) conds.push("upper(SeverityText) = upper({severity:String})");
-    if (filter.search) conds.push("positionCaseInsensitive(Body, {search:String}) > 0");
+    if (filter.severity) exactConds.push("upper(SeverityText) = upper({severity:String})");
+    if (filter.search) exactConds.push("positionCaseInsensitive(Body, {search:String}) > 0");
   } else {
-    if (filter.spanName) conds.push("SpanName = {spanName:String}");
-    if (filter.statusCode) conds.push("StatusCode = {statusCode:String}");
+    if (filter.spanName) exactConds.push("SpanName = {spanName:String}");
+    if (filter.statusCode) exactConds.push("StatusCode = {statusCode:String}");
     if (typeof filter.minDurationMs === "number") {
-      conds.push("Duration >= {minDurationNs:UInt64}");
+      exactConds.push("Duration >= {minDurationNs:UInt64}");
     }
   }
-
-  const group = groupExprForAttribute(groupBy, source);
 
   const query = `
     SELECT
       toString(toStartOfInterval(Timestamp, INTERVAL ${step.n} ${step.unit})) AS bucket,
       ${group.expr} AS group_key,
       count() AS c
-    FROM (
-      SELECT Timestamp, ServiceName, ResourceAttributes, ${source === "logs" ? "LogAttributes" : "SpanAttributes"}
-      FROM ${table}
-      WHERE ${conds.join(" AND ")}
-      LIMIT ${SERIES_SCAN_ROW_CAP}
-    )
+    FROM ${table}
+    WHERE ${exactConds.join(" AND ")}
     GROUP BY bucket, group_key
     ORDER BY bucket ASC
     LIMIT 10000
@@ -1651,8 +1723,7 @@ export async function countSeries(
   });
   const rows = (await r.json()) as { bucket: string; group_key: string; c: string | number }[];
   const mapped = rows.map((row) => ({ bucket: row.bucket, group: row.group_key, count: Number(row.c) }));
-  const totalCount = mapped.reduce((acc, row) => acc + row.count, 0);
-  return { rows: mapped, sampled: totalCount >= SERIES_SCAN_ROW_CAP };
+  return { rows: mapped, sampled: false };
 }
 
 // -----------------------------------------------------------------------------

--- a/apps/api/src/mcp/clickhouse.ts
+++ b/apps/api/src/mcp/clickhouse.ts
@@ -1568,6 +1568,8 @@ async function countSeriesFromRollup(
   return rows.map((row) => ({ bucket: row.bucket, group: row.group_key, count: Number(row.c) }));
 }
 
+const SERIES_SCAN_ROW_CAP = 1_000_000;
+
 export async function countSeries(
   ch: ClickHouseClient,
   projectId: string,
@@ -1575,10 +1577,11 @@ export async function countSeries(
   filter: SeriesFilter,
   groupBy: string | undefined,
   step: Step,
-): Promise<{ bucket: string; group: string; count: number }[]> {
+): Promise<{ rows: { bucket: string; group: string; count: number }[]; sampled: boolean }> {
   const folded = foldServiceAttrFilter(filter);
   if (folded && rollupEligible(folded, groupBy, step) && (await rollupAvailable(ch))) {
-    return countSeriesFromRollup(ch, projectId, source, folded, groupBy, step);
+    const rows = await countSeriesFromRollup(ch, projectId, source, folded, groupBy, step);
+    return { rows, sampled: false };
   }
   const { sinceSql, untilSql, sinceExpr, untilExpr } = resolveRange(filter.range);
   const split = splitAttrs(filter.resourceAttrs);
@@ -1616,8 +1619,12 @@ export async function countSeries(
       toString(toStartOfInterval(Timestamp, INTERVAL ${step.n} ${step.unit})) AS bucket,
       ${group.expr} AS group_key,
       count() AS c
-    FROM ${table}
-    WHERE ${conds.join(" AND ")}
+    FROM (
+      SELECT Timestamp, ServiceName, ResourceAttributes, ${source === "logs" ? "LogAttributes" : "SpanAttributes"}
+      FROM ${table}
+      WHERE ${conds.join(" AND ")}
+      LIMIT ${SERIES_SCAN_ROW_CAP}
+    )
     GROUP BY bucket, group_key
     ORDER BY bucket ASC
     LIMIT 10000
@@ -1643,7 +1650,9 @@ export async function countSeries(
     format: "JSONEachRow",
   });
   const rows = (await r.json()) as { bucket: string; group_key: string; c: string | number }[];
-  return rows.map((row) => ({ bucket: row.bucket, group: row.group_key, count: Number(row.c) }));
+  const mapped = rows.map((row) => ({ bucket: row.bucket, group: row.group_key, count: Number(row.c) }));
+  const totalCount = mapped.reduce((acc, row) => acc + row.count, 0);
+  return { rows: mapped, sampled: totalCount >= SERIES_SCAN_ROW_CAP };
 }
 
 // -----------------------------------------------------------------------------

--- a/apps/web/src/Explore.tsx
+++ b/apps/web/src/Explore.tsx
@@ -1851,7 +1851,14 @@ function ChartPanel({
     <Tile>
       {showControls && (
         <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
-          <span className="font-sans text-[12px] font-medium text-subtle">Chart</span>
+          <div className="flex items-center gap-2">
+            <span className="font-sans text-[12px] font-medium text-subtle">Chart</span>
+            {countSeries.data?.sampled && (
+              <span className="text-[10px] text-warning bg-warning/10 border border-warning/20 px-1.5 py-0.5 rounded font-medium">
+                Sampled (over 1M rows)
+              </span>
+            )}
+          </div>
           <GroupBySelect
             projectId={projectId}
             range={range}

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -3199,7 +3199,7 @@ export function useExploreSeries(
   return useQuery({
     queryKey: ["explore", "series", projectId, source, filter, groupBy ?? ""],
     queryFn: () =>
-      fetcher<{ step: string; rows: SeriesRow[] }>(`/api/projects/${projectId}/explore/series`, {
+      fetcher<{ step: string; rows: SeriesRow[]; sampled: boolean }>(`/api/projects/${projectId}/explore/series`, {
         method: "POST",
         body: JSON.stringify({ source, groupBy: groupBy ?? "", filter }),
       }),


### PR DESCRIPTION
Description
Closes #55

This pull request resolves the 500 Internal Server Errors encountered on dashboards and the explore page when querying wide time windows (e.g., 7 days) on high-volume projects.

Previously, when queries fell back to raw telemetry tables (because they weren't eligible or available in the events_per_minute rollup), the backend scanned the full time-range window in ClickHouse. On projects with millions of rows, reading map columns (like ResourceAttributes) for the entire window exceeded the ClickHouse client timeout, causing the request to abort and bubble up as a 500.

Changes

ClickHouse Subquery Optimization:
Introduced a SERIES_SCAN_ROW_CAP = 1_000_000 limit to the raw fallback scan in countSeries.
The raw scan is now performed in a nested subquery before grouping and bucket aggregation. This caps the rows processed by ClickHouse to 1M, dropping execution times under the client timeout while still surfacing a representative sample.
Sampled Detection:
Evaluated whether the results were truncated by checking if the total count of returned bucket series matches or exceeds the 1M row cap.
Updated countSeries signature to return { rows, sampled } instead of a plain array.
API & Callers Updated:
Refactored callers in alerts-service.ts and index.ts to destructure { rows } and return { rows, step, sampled } in the /api/projects/:projectId/explore/series endpoint response.
UI Warning Badge:
Updated type definitions for useExploreSeries in the web app API client.
Rendered a clean Sampled (over 1M rows) badge warning next to the chart header on the Explore page when the series is sampled.

Verification Results
TypeScript Compilation: pnpm typecheck compiles cleanly across all 13 workspace packages.
Unit Tests: Ran node test suite pnpm --filter @superlog/api test where all 20+ clickhouse query-related mock tests (asserting generated query ASTs and parameters) pass successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent 500s on wide-range queries by capping raw ClickHouse scans to 1M rows and surfacing a sampled flag. Fixes #55; cap applies to Explore only, alerts keep exact scans.

- **Bug Fixes**
  - Added optional scanCap to countSeries; Explore passes 1,000,000 to use an inner subquery LIMIT with a UNION ALL metadata count for sampling detection, while alerts use the exact (uncapped) path.
  - `/api/projects/:projectId/explore/series` now returns `{ rows, step, sampled }`; server handler and client type updated; tests added for capped vs. exact query plans (LIMIT/UNION assertions).

- **New Features**
  - Show a “Sampled (over 1M rows)” badge in Explore when series data is truncated.

<sup>Written for commit 67eb97352ba5631866c1956e18a425cf2154dc5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

