### PR TITLE
Bound autorecovery passes within their queue lease

### DIFF
--- a/apps/worker/src/autorecovery.ts
+++ b/apps/worker/src/autorecovery.ts
@@ -46,9 +46,9 @@ import { logger } from "./logger.js";
 
 const MODEL = process.env.ANTHROPIC_AUTORECOVERY_MODEL ?? "claude-sonnet-4-6";
 
-function makeDeps(apiKey: string, policy: AutorecoveryPolicy): TickDeps {
+function makeDeps(apiKey: string, policy: AutorecoveryPolicy, signal?: AbortSignal): TickDeps {
   const repo = createAutorecoveryRepository(db);
-  const metrics = createAutorecoveryMetricsRepository(defaultClickhouseClient);
+  const metrics = createAutorecoveryMetricsRepository(defaultClickhouseClient, signal);
   const slack = createSlackPoster();
   const anthropic = new Anthropic({ apiKey });
   const client = asLLMClient(anthropic);
@@ -59,6 +59,7 @@ function makeDeps(apiKey: string, policy: AutorecoveryPolicy): TickDeps {
     slack,
     logger,
     now: () => new Date(),
+    isCancelled: () => signal?.aborted ?? false,
     selectCandidates: (now, p, opts) => repo.selectCandidates(now, p, opts),
     async runAgent(incident: CandidateIncident) {
       const project = await repo.findProject(incident.projectId);
@@ -81,6 +82,7 @@ function makeDeps(apiKey: string, policy: AutorecoveryPolicy): TickDeps {
         accountant,
         logger,
         maxIterations: policy.maxAgentIterations,
+        signal,
         now: () => new Date(),
       });
     },
@@ -89,11 +91,11 @@ function makeDeps(apiKey: string, policy: AutorecoveryPolicy): TickDeps {
 
 // Entry point called from jobs/autorecovery.ts. Throttled by
 // `worker_state.cursor` so a delayed or duplicate cron fire remains harmless.
-export async function tickAutorecovery(): Promise<number> {
+export async function tickAutorecovery(signal?: AbortSignal): Promise<number> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) return 0;
   const policy = autorecoveryPolicyFromEnv();
-  return runAutorecoveryTickApp(makeDeps(apiKey, policy));
+  return runAutorecoveryTickApp(makeDeps(apiKey, policy, signal));
 }
 
 // Manual trigger used in tests and the end-to-end checkout — bypasses the

--- a/apps/worker/src/autorecovery/agent.test.ts
+++ b/apps/worker/src/autorecovery/agent.test.ts
@@ -87,7 +87,9 @@ function makeLogger(calls: string[]): AutorecoveryLogger {
   };
 }
 
-function makeAccountant(captured: Array<{ input: number; output: number }>): AutorecoveryTokenAccountant {
+function makeAccountant(
+  captured: Array<{ input: number; output: number }>,
+): AutorecoveryTokenAccountant {
   return {
     record(input) {
       captured.push({
@@ -146,6 +148,33 @@ test("agent: immediate propose_resolution returns parsed proposal", async () => 
   assert.equal(accountant[0]?.input, 100);
 });
 
+test("agent: forwards the pass deadline to each LLM request", async () => {
+  const calls: string[] = [];
+  const deadline = new AbortController();
+  let requestSignal: AbortSignal | undefined;
+  const client: AutorecoveryLLMClient = {
+    async send(_input, options?: { signal?: AbortSignal }) {
+      requestSignal = options?.signal;
+      return makeMessage([
+        toolUse("propose_resolution", {
+          looks_resolved: false,
+          confidence: "low",
+          reason_code: "stopped recurring unknown cause",
+          reason_text: "no signal",
+        }),
+      ]);
+    },
+  };
+  const deps = {
+    ...makeDeps({ calls, client }),
+    signal: deadline.signal,
+  } as RunAgentDeps & { signal: AbortSignal };
+
+  await runAutorecoveryAgent(makeCandidate(), deps);
+
+  assert.equal(requestSignal, deadline.signal);
+});
+
 test("agent: telemetry tool result feeds next turn, then proposal terminates", async () => {
   const calls: string[] = [];
   let turn = 0;
@@ -155,9 +184,7 @@ test("agent: telemetry tool result feeds next turn, then proposal terminates", a
       sends.push([...input.messages]);
       turn += 1;
       if (turn === 1) {
-        return makeMessage([
-          toolUse("query_service_traffic", { hours: 12 }, "tu_traffic"),
-        ]);
+        return makeMessage([toolUse("query_service_traffic", { hours: 12 }, "tu_traffic")]);
       }
       return makeMessage([
         toolUse("propose_resolution", {
@@ -269,5 +296,7 @@ test("agent: exhausts iteration budget without proposal returns null", async () 
 
   const result = await runAutorecoveryAgent(makeCandidate(), deps);
   assert.equal(result, null);
-  assert.ok(calls.includes("logger.warn:agent exhausted iteration budget without propose_resolution"));
+  assert.ok(
+    calls.includes("logger.warn:agent exhausted iteration budget without propose_resolution"),
+  );
 });

--- a/apps/worker/src/autorecovery/agent.ts
+++ b/apps/worker/src/autorecovery/agent.ts
@@ -1,28 +1,28 @@
 import type Anthropic from "@anthropic-ai/sdk";
 import {
-  buildInitialUserMessage,
   type CandidateIncident,
+  type ProposalToolInput,
+  buildInitialUserMessage,
   clampLookbackHours,
   parseProposalToolInput,
-  type ProposalToolInput,
 } from "./domain.js";
-import type {
-  IncidentActivity,
-  ServiceTraffic,
-} from "./metrics-repository.js";
+import type { IncidentActivity, ServiceTraffic } from "./metrics-repository.js";
 import { AUTORECOVERY_SYSTEM_PROMPT, AUTORECOVERY_TOOLS } from "./tools.js";
 
 // Abstraction over the Anthropic client so we can swap a fake in for tests.
 // We only need the create() shape from messages.create.
 export type AutorecoveryLLMClient = {
-  send(input: {
-    model: string;
-    system: string;
-    tools: Anthropic.Messages.Tool[];
-    messages: Anthropic.Messages.MessageParam[];
-    maxTokens: number;
-    temperature: number;
-  }): Promise<Anthropic.Messages.Message>;
+  send(
+    input: {
+      model: string;
+      system: string;
+      tools: Anthropic.Messages.Tool[];
+      messages: Anthropic.Messages.MessageParam[];
+      maxTokens: number;
+      temperature: number;
+    },
+    options?: { signal?: AbortSignal },
+  ): Promise<Anthropic.Messages.Message>;
 };
 
 export type AutorecoveryTokenAccountant = {
@@ -54,6 +54,7 @@ export type RunAgentDeps = {
   accountant: AutorecoveryTokenAccountant;
   logger: AutorecoveryLogger;
   maxIterations: number;
+  signal?: AbortSignal;
   now(): Date;
 };
 
@@ -62,15 +63,18 @@ export type RunAgentDeps = {
 // production deps.
 export function asLLMClient(client: Anthropic): AutorecoveryLLMClient {
   return {
-    async send(input) {
-      return client.messages.create({
-        model: input.model,
-        max_tokens: input.maxTokens,
-        temperature: input.temperature,
-        system: input.system,
-        tools: input.tools,
-        messages: input.messages,
-      });
+    async send(input, options) {
+      return client.messages.create(
+        {
+          model: input.model,
+          max_tokens: input.maxTokens,
+          temperature: input.temperature,
+          system: input.system,
+          tools: input.tools,
+          messages: input.messages,
+        },
+        { signal: options?.signal },
+      );
     },
   };
 }
@@ -87,14 +91,17 @@ export async function runAutorecoveryAgent(
   ];
 
   for (let iter = 0; iter < deps.maxIterations; iter++) {
-    const message = await deps.client.send({
-      model: deps.model,
-      system: AUTORECOVERY_SYSTEM_PROMPT,
-      tools: AUTORECOVERY_TOOLS,
-      messages: conversation,
-      maxTokens: 1500,
-      temperature: 0,
-    });
+    const message = await deps.client.send(
+      {
+        model: deps.model,
+        system: AUTORECOVERY_SYSTEM_PROMPT,
+        tools: AUTORECOVERY_TOOLS,
+        messages: conversation,
+        maxTokens: 1500,
+        temperature: 0,
+      },
+      { signal: deps.signal },
+    );
 
     await deps.accountant.record({
       model: deps.model,

--- a/apps/worker/src/autorecovery/metrics-repository.test.ts
+++ b/apps/worker/src/autorecovery/metrics-repository.test.ts
@@ -5,7 +5,11 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import type { CandidateIncident } from "./domain.js";
 import { createAutorecoveryMetricsRepository } from "./metrics-repository.js";
 
-type CapturedQuery = { query: string; params: Record<string, unknown> };
+type CapturedQuery = {
+  query: string;
+  params: Record<string, unknown>;
+  abortSignal?: AbortSignal;
+};
 
 function makeFakeCh(
   rows: Array<Record<string, unknown>>,
@@ -16,8 +20,16 @@ function makeFakeCh(
 } {
   const captured: CapturedQuery[] = [];
   const client = {
-    async query(input: { query: string; query_params: Record<string, unknown> }) {
-      captured.push({ query: input.query, params: input.query_params });
+    async query(input: {
+      query: string;
+      query_params: Record<string, unknown>;
+      abort_signal?: AbortSignal;
+    }) {
+      captured.push({
+        query: input.query,
+        params: input.query_params,
+        abortSignal: input.abort_signal,
+      });
       const isProbe = /EXISTS TABLE/i.test(input.query);
       return {
         async json() {
@@ -59,13 +71,15 @@ function makeCandidate(overrides: Partial<CandidateIncident> = {}): CandidateInc
 
 test("queryIncidentActivity filters by the candidate's issue exception types", async () => {
   const { client, captured } = makeFakeCh([{ hour: "2026-05-23 00:00:00", count: "2" }]);
-  const repo = createAutorecoveryMetricsRepository(async () => client);
+  const deadline = new AbortController();
+  const repo = createAutorecoveryMetricsRepository(async () => client, deadline.signal);
 
   await repo.queryIncidentActivity(makeCandidate(), 24);
 
   assert.equal(captured.length, 1);
   const q = captured[0];
   assert.ok(q, "expected a CH query to be captured");
+  assert.equal(q.abortSignal, deadline.signal);
   // The query must scope by the actual issue signatures, not just project+service.
   // Without this filter, a project-wide spike in unrelated exceptions (e.g.
   // ECONNREFUSED storm) would be attributed to this incident.
@@ -95,10 +109,10 @@ test("queryIncidentActivity collapses duplicate exception types and filters by s
 
   const q = captured[0];
   assert.ok(q);
-  assert.deepEqual(
-    [...(q.params.exception_types as string[])].sort(),
-    ["APIError", "TimeoutError"],
-  );
+  assert.deepEqual([...(q.params.exception_types as string[])].sort(), [
+    "APIError",
+    "TimeoutError",
+  ]);
   assert.equal(q.params.service, "@superlog/api");
   assert.equal(q.params.hours, 12);
 });
@@ -107,10 +121,7 @@ test("queryIncidentActivity short-circuits with zero events when there are no si
   const { client, captured } = makeFakeCh([{ hour: "x", count: "999" }]);
   const repo = createAutorecoveryMetricsRepository(async () => client);
 
-  const result = await repo.queryIncidentActivity(
-    makeCandidate({ issueSignatures: [] }),
-    24,
-  );
+  const result = await repo.queryIncidentActivity(makeCandidate({ issueSignatures: [] }), 24);
 
   // No signatures means we can't safely scope the query — fall back to "no
   // signal observed" so the agent stays conservative rather than counting

--- a/apps/worker/src/autorecovery/metrics-repository.ts
+++ b/apps/worker/src/autorecovery/metrics-repository.ts
@@ -18,7 +18,10 @@ export type ServiceTraffic = {
 
 export type AutorecoveryMetricsRepository = ReturnType<typeof createAutorecoveryMetricsRepository>;
 
-export function createAutorecoveryMetricsRepository(getCh: () => Promise<ClickHouseClient>) {
+export function createAutorecoveryMetricsRepository(
+  getCh: () => Promise<ClickHouseClient>,
+  abortSignal?: AbortSignal,
+) {
   return {
     // Counts exception events on the incident's service whose `exception.type`
     // matches one of the live issues linked to the incident. Filtering by
@@ -73,16 +76,14 @@ export function createAutorecoveryMetricsRepository(getCh: () => Promise<ClickHo
           hours,
         },
         format: "JSONEachRow",
+        abort_signal: abortSignal,
       });
       const rows = (await result.json()) as ActivityBucket[];
       const totalEvents = rows.reduce((acc, r) => acc + Number(r.count), 0);
       return { totalEvents, perHour: rows, lookbackHours: hours };
     },
 
-    async queryServiceTraffic(
-      incident: CandidateIncident,
-      hours: number,
-    ): Promise<ServiceTraffic> {
+    async queryServiceTraffic(incident: CandidateIncident, hours: number): Promise<ServiceTraffic> {
       if (!incident.service) {
         return { totalSpans: 0, perHour: [], lookbackHours: hours, service: null };
       }
@@ -99,7 +100,7 @@ export function createAutorecoveryMetricsRepository(getCh: () => Promise<ClickHo
       // milliseconds. Fall back to the raw scan only where the rollup isn't
       // deployed (it is not part of the collector's auto-created schema — see
       // infra/clickhouse/migrations/003_events_per_minute.sql).
-      if (await rollupAvailable(ch)) {
+      if (await rollupAvailable(ch, abortSignal)) {
         const result = await ch.query({
           query: `
             SELECT
@@ -125,6 +126,7 @@ export function createAutorecoveryMetricsRepository(getCh: () => Promise<ClickHo
             hours,
           },
           format: "JSONEachRow",
+          abort_signal: abortSignal,
         });
         const rows = (await result.json()) as ActivityBucket[];
         const totalSpans = rows.reduce((acc, r) => acc + Number(r.count), 0);
@@ -148,6 +150,7 @@ export function createAutorecoveryMetricsRepository(getCh: () => Promise<ClickHo
           hours,
         },
         format: "JSONEachRow",
+        abort_signal: abortSignal,
       });
       const rows = (await result.json()) as ActivityBucket[];
       const totalSpans = rows.reduce((acc, r) => acc + Number(r.count), 0);
@@ -163,7 +166,7 @@ export function createAutorecoveryMetricsRepository(getCh: () => Promise<ClickHo
 // for that call without pinning the slow path until restart.
 const rollupAvailability = new WeakMap<ClickHouseClient, Promise<boolean>>();
 
-function rollupAvailable(ch: ClickHouseClient): Promise<boolean> {
+function rollupAvailable(ch: ClickHouseClient, abortSignal?: AbortSignal): Promise<boolean> {
   let probe = rollupAvailability.get(ch);
   if (!probe) {
     probe = (async () => {
@@ -171,6 +174,7 @@ function rollupAvailable(ch: ClickHouseClient): Promise<boolean> {
         const r = await ch.query({
           query: "EXISTS TABLE events_per_minute",
           format: "JSONEachRow",
+          abort_signal: abortSignal,
         });
         const rows = (await r.json()) as { result: number | string }[];
         return Number(rows[0]?.result) === 1;
@@ -199,8 +203,7 @@ export async function defaultClickhouseClient(): Promise<ClickHouseClient> {
     password: process.env.CLICKHOUSE_PASSWORD ?? "",
     // Local portless stacks ship a `superlog` database; prod uses `olly`.
     // `CLICKHOUSE_DB` is the env name `scripts/portless-stack.sh` writes.
-    database:
-      process.env.CLICKHOUSE_DATABASE ?? process.env.CLICKHOUSE_DB ?? "olly",
+    database: process.env.CLICKHOUSE_DATABASE ?? process.env.CLICKHOUSE_DB ?? "olly",
   });
   return cachedClient;
 }

--- a/apps/worker/src/autorecovery/tick.test.ts
+++ b/apps/worker/src/autorecovery/tick.test.ts
@@ -379,6 +379,32 @@ test("runAutorecoveryTick: a failing candidate does not block the rest", async (
   assert.ok(calls.includes("logger.warn:autorecovery candidate failed"));
 });
 
+test("runAutorecoveryTick: cancellation stops before the next candidate", async () => {
+  const calls: string[] = [];
+  let cancelled = false;
+  const repo = makeRepo({
+    calls,
+    lastRun: new Date(NOW.getTime() - 2 * 60 * 60 * 1000),
+    candidates: [makeCandidate({ id: "a" }), makeCandidate({ id: "b" })],
+  });
+  const deps: TickDeps & { isCancelled: () => boolean } = {
+    ...makeDeps({ calls, repo, proposal: makeProposal() }),
+    isCancelled: () => cancelled,
+    async runAgent(incident) {
+      calls.push(`runAgent:${incident.id}`);
+      cancelled = true;
+      throw new Error("job deadline exceeded");
+    },
+  };
+
+  await runAutorecoveryTick(deps);
+
+  assert.ok(calls.includes("runAgent:a"));
+  assert.ok(!calls.includes("runAgent:b"));
+  assert.ok(!calls.includes(`markEvaluated:b:${NOW.toISOString()}`));
+  assert.ok(!calls.includes("logger.warn:autorecovery candidate failed"));
+});
+
 test("runAutorecoveryNow: bypasses throttle and filters by incidentIds", async () => {
   const calls: string[] = [];
   const candidates = [

--- a/apps/worker/src/autorecovery/tick.ts
+++ b/apps/worker/src/autorecovery/tick.ts
@@ -146,6 +146,7 @@ export type TickDeps = EvaluateIncidentDeps & {
     opts?: CandidateSelectionOptions,
   ): Promise<CandidateIncident[]>;
   now(): Date;
+  isCancelled?: () => boolean;
 };
 
 // Throttled hourly pass. Selects candidates first, then stamps the cursor
@@ -155,14 +156,18 @@ export type TickDeps = EvaluateIncidentDeps & {
 // the next poll instead of silently advancing the cursor and hiding for an
 // hour (which is exactly how the 42702 ambiguous-column bug went unnoticed).
 export async function runAutorecoveryTick(deps: TickDeps): Promise<number> {
+  if (deps.isCancelled?.()) return 0;
   const now = deps.now();
   const lastRun = await deps.repo.getLastRunAt();
+  if (deps.isCancelled?.()) return 0;
   const throttle = decideThrottle(lastRun, now, deps.policy);
   if (throttle.kind === "skip") return 0;
 
   const candidates = await deps.selectCandidates(now, deps.policy);
+  if (deps.isCancelled?.()) return 0;
 
   await deps.repo.setLastRunAt(now);
+  if (deps.isCancelled?.()) return 0;
 
   if (candidates.length === 0) {
     deps.logger.info({ scope: "autorecovery" }, "no candidates");
@@ -175,6 +180,7 @@ export async function runAutorecoveryTick(deps: TickDeps): Promise<number> {
 
   let proposalsWritten = 0;
   for (const candidate of candidates) {
+    if (deps.isCancelled?.()) break;
     try {
       // Stamp the per-incident evaluation cursor up front, before the agent
       // runs, so this incident rotates to the back of the NULLS-FIRST queue
@@ -185,9 +191,11 @@ export async function runAutorecoveryTick(deps: TickDeps): Promise<number> {
       // isolates to this incident (it'll just be re-picked next tick) instead
       // of aborting the whole pass.
       await deps.repo.markEvaluated(candidate.id, now);
+      if (deps.isCancelled?.()) break;
       const result = await evaluateIncident(candidate, deps);
       if (result.kind === "proposed") proposalsWritten += 1;
     } catch (err) {
+      if (deps.isCancelled?.()) break;
       deps.logger.warn(
         {
           scope: "autorecovery",

--- a/apps/worker/src/jobs/autorecovery.test.ts
+++ b/apps/worker/src/jobs/autorecovery.test.ts
@@ -6,19 +6,23 @@ import { createAutorecoveryJob } from "./autorecovery.js";
 
 test("autorecovery runs from the background-job queue when configured", async () => {
   let runs = 0;
+  let jobSignal: AbortSignal | undefined;
   const definition = createAutorecoveryJob({
     apiKey: "configured",
-    run: async () => {
+    run: async (signal) => {
       runs += 1;
+      jobSignal = signal;
       return 0;
     },
   });
 
   assert.equal(definition.name, "autorecovery");
   assert.equal(definition.schedule, "*/5 * * * *");
+  assert.equal(definition.expireInSeconds, 3_600);
   const handler = await definition.create({} as JobDeps);
   assert.ok(handler);
 
   await handler();
   assert.equal(runs, 1);
+  assert.ok(jobSignal);
 });

--- a/apps/worker/src/jobs/autorecovery.ts
+++ b/apps/worker/src/jobs/autorecovery.ts
@@ -5,22 +5,30 @@
 import { tickAutorecovery } from "../autorecovery.js";
 import type { JobDefinition } from "../jobs.js";
 
+const DEFAULT_JOB_TIMEOUT_MS = 45 * 60 * 1000;
+const JOB_EXPIRY_GRACE_SECONDS = 15 * 60;
+
 export function createAutorecoveryJob(
   options: {
     apiKey?: string | null;
-    run?: () => Promise<number>;
+    run?: (signal: AbortSignal) => Promise<number>;
+    jobTimeoutMs?: number;
   } = {},
 ): JobDefinition {
   const apiKey = options.apiKey ?? process.env.ANTHROPIC_API_KEY;
   const run = options.run ?? tickAutorecovery;
+  const jobTimeoutMs = options.jobTimeoutMs ?? DEFAULT_JOB_TIMEOUT_MS;
   return {
     name: "autorecovery",
     schedule: "*/5 * * * *",
-    expireInSeconds: 3_600,
+    // Cancel active external I/O before the durable lease can expire. The
+    // remaining grace covers fast DB/Slack cleanup without permitting a
+    // second exclusive pass to overlap the first one.
+    expireInSeconds: Math.ceil(jobTimeoutMs / 1000) + JOB_EXPIRY_GRACE_SECONDS,
     create: () => {
       if (!apiKey?.trim()) return null;
       return async () => {
-        await run();
+        await run(AbortSignal.timeout(jobTimeoutMs));
       };
     },
   };


### PR DESCRIPTION
## Summary

- give each autorecovery pass a 45-minute application deadline inside its one-hour durable queue lease
- stop the candidate loop quietly when that deadline is reached
- propagate cancellation into active model and ClickHouse requests so the handler can finish before its lease expires
- keep a 15-minute grace period for short database and notification cleanup

## Why

The exclusive queue prevents concurrent passes only while its active lease is valid. A worst-case 50-candidate pass could otherwise outlive the one-hour lease and overlap a later cron delivery.

## Validation

- 38 focused autorecovery, job-runner, and shutdown tests
- worker typecheck
- formatting and import checks on all touched files