### PR TITLE
fix(api): ensure active org and project resolution fallbacks are dete…

### DIFF
--- a/apps/api/src/org-context.ts
+++ b/apps/api/src/org-context.ts
@@ -29,6 +29,7 @@ export type MaybeActiveOrgContext =
 async function ensureProjectForOrg(orgId: string): Promise<SyncedProject> {
   const existing = await db.query.projects.findFirst({
     where: eq(schema.projects.orgId, orgId),
+    orderBy: (p, { asc }) => asc(p.createdAt),
   });
   if (existing) return existing;
 
@@ -90,6 +91,7 @@ export async function resolveMaybeActiveOrgContext(
 
   const firstMembership = await db.query.orgMembers.findFirst({
     where: eq(schema.orgMembers.userId, options.userId),
+    orderBy: (m, { asc }) => asc(m.createdAt),
   });
 
   if (!firstMembership) return { user, org: null, project: null };


### PR DESCRIPTION
Closes #38

This pull request resolves the non-deterministic fallback selection of a user's active organization and default project when a preferred context is not set or valid.

### Changes

* **Deterministic Active Org Resolution**: Added `orderBy: (m, { asc }) => asc(m.createdAt)` to the `firstMembership` query in `resolveMaybeActiveOrgContext` (`org-context.ts`), ensuring the user's first/oldest organization membership is always selected deterministically.
* **Deterministic Default Project Selection**: Added `orderBy: (p, { asc }) => asc(p.createdAt)` to `ensureProjectForOrg` (`org-context.ts`), ensuring that the oldest project in the organization is chosen as fallback when multiple exist.

---

### Verification Results

* **TypeScript Compilation**: `pnpm typecheck` compiles cleanly across all packages.
* **Unit Tests**: All existing auth and active context tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-deterministic fallback when resolving a user's active organization and default project (addresses #38). When no preferred context is set or valid, we now consistently select the oldest org membership and the oldest project.

- **Bug Fixes**
  - Order org memberships by createdAt asc in resolveMaybeActiveOrgContext.
  - Order projects by createdAt asc in ensureProjectForOrg.

<sup>Written for commit 4d4636ab7bcb591217898272ace8f37812b82ad6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

