### PR TITLE
Enforce the Linear ticket policy across delivery boundaries

### DIFF
--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -3322,11 +3322,22 @@ function AgentFlowchart({ projectId }: { projectId: string | undefined }) {
           </div>
         </FlowNode>
 
-        <FlowConnector active={downstreamEligible && linearConnected} />
+        <FlowConnector
+          active={downstreamEligible && linearConnected && data.linearTicketPolicy !== "never"}
+        />
 
         <FlowNode
           step={3}
           title="File Linear ticket"
+          headerSlot={
+            linearConnected ? (
+              <Toggle
+                checked={data.linearTicketPolicy !== "never"}
+                disabled={!downstreamEligible || save.isPending}
+                onChange={(v) => patch({ linearTicketPolicy: v ? "on_ready_to_pr" : "never" })}
+              />
+            ) : undefined
+          }
           status={
             !downstreamEligible ? (
               <Chip tone="muted" dot>
@@ -3340,14 +3351,16 @@ function AgentFlowchart({ projectId }: { projectId: string | undefined }) {
               <Chip tone="warning" dot>
                 Linear not connected
               </Chip>
-            ) : (
+            ) : data.linearTicketPolicy !== "never" ? (
               <Chip tone="success" dot>
                 On handoff
               </Chip>
-            )
+            ) : undefined
           }
-          spineActive={downstreamEligible && linearConnected}
-          off={!downstreamEligible}
+          spineActive={
+            downstreamEligible && linearConnected && data.linearTicketPolicy !== "never"
+          }
+          off={!downstreamEligible || data.linearTicketPolicy === "never"}
         >
           {!linearConnected ? (
             <div className="text-[12.5px] text-muted">
@@ -3358,9 +3371,10 @@ function AgentFlowchart({ projectId }: { projectId: string | undefined }) {
           ) : (
             <div className="space-y-4">
               <p className="text-[12.5px] text-muted">
-                Each findings-only handoff creates a new Linear ticket with a link back to the
-                incident. Paused and failed investigations do not create tickets; resolve-time
-                filing is controlled below.
+                When on, a ticket is filed as soon as the agent opens a fix PR — or when it
+                completes an investigation without one — with a link back to the incident. Paused
+                and failed investigations do not create tickets; resolve-time filing is controlled
+                below.
               </p>
               <div className="flex items-start justify-between gap-4 rounded-md border border-border px-3 py-3">
                 <div>
@@ -3374,13 +3388,17 @@ function AgentFlowchart({ projectId }: { projectId: string | undefined }) {
                 </div>
                 <Toggle
                   checked={data.createLinearTicketOnResolve}
-                  disabled={!downstreamEligible || save.isPending}
+                  disabled={
+                    !downstreamEligible || data.linearTicketPolicy === "never" || save.isPending
+                  }
                   onChange={(v) => patch({ createLinearTicketOnResolve: v })}
                 />
               </div>
               <LinearTicketInstructionsField
                 value={data.linearTicketInstructions}
-                disabled={!downstreamEligible || save.isPending}
+                disabled={
+                  !downstreamEligible || data.linearTicketPolicy === "never" || save.isPending
+                }
                 onSave={(v) => patch({ linearTicketInstructions: v })}
               />
             </div>

--- a/apps/worker/src/agent-runs/completion-policy.test.ts
+++ b/apps/worker/src/agent-runs/completion-policy.test.ts
@@ -1,12 +1,78 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { shouldCreateLinearTicketForTerminalOutcome } from "./completion-policy.js";
+import { shouldDeliverLinearTicket } from "./completion-policy.js";
 
-test("complete_investigation always attempts the connected Linear handoff", () => {
-  assert.equal(shouldCreateLinearTicketForTerminalOutcome("complete_investigation", false), true);
+test("policy never blocks every boundary, including updates to an existing ticket", () => {
+  for (const boundary of ["pr_delivered", "investigation_handoff", "incident_resolved"] as const) {
+    assert.equal(
+      shouldDeliverLinearTicket({
+        policy: "never",
+        boundary,
+        createOnResolve: true,
+        runHasTicket: true,
+      }),
+      false,
+    );
+  }
 });
 
-test("resolve_incident follows the project's create-ticket-on-resolve toggle", () => {
-  assert.equal(shouldCreateLinearTicketForTerminalOutcome("resolve_incident", true), true);
-  assert.equal(shouldCreateLinearTicketForTerminalOutcome("resolve_incident", false), false);
+test("on_ready_to_pr files at the PR boundary and on findings handoff", () => {
+  assert.equal(
+    shouldDeliverLinearTicket({
+      policy: "on_ready_to_pr",
+      boundary: "pr_delivered",
+      createOnResolve: false,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldDeliverLinearTicket({
+      policy: "on_ready_to_pr",
+      boundary: "investigation_handoff",
+      createOnResolve: false,
+    }),
+    true,
+  );
+});
+
+test("incident-resolving completions follow the create-ticket-on-resolve toggle", () => {
+  assert.equal(
+    shouldDeliverLinearTicket({
+      policy: "on_ready_to_pr",
+      boundary: "incident_resolved",
+      createOnResolve: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldDeliverLinearTicket({
+      policy: "on_ready_to_pr",
+      boundary: "incident_resolved",
+      createOnResolve: false,
+    }),
+    false,
+  );
+});
+
+test("policy always files on incident-resolving completions regardless of the toggle", () => {
+  assert.equal(
+    shouldDeliverLinearTicket({
+      policy: "always",
+      boundary: "incident_resolved",
+      createOnResolve: false,
+    }),
+    true,
+  );
+});
+
+test("a run that already filed a ticket may update it at resolution", () => {
+  assert.equal(
+    shouldDeliverLinearTicket({
+      policy: "on_ready_to_pr",
+      boundary: "incident_resolved",
+      createOnResolve: false,
+      runHasTicket: true,
+    }),
+    true,
+  );
 });

--- a/apps/worker/src/agent-runs/completion-policy.ts
+++ b/apps/worker/src/agent-runs/completion-policy.ts
@@ -1,8 +1,26 @@
-export type TicketCreatingTerminalOutcome = "complete_investigation" | "resolve_incident";
+import type { schema } from "@superlog/db";
 
-export function shouldCreateLinearTicketForTerminalOutcome(
-  outcome: TicketCreatingTerminalOutcome,
-  createOnResolve: boolean,
-): boolean {
-  return outcome === "complete_investigation" || createOnResolve;
+// The boundaries at which the platform files (or updates) a Linear ticket for
+// an investigation. Creation is deterministic and platform-side — the policy
+// decides which boundaries produce a ticket at all.
+export type LinearTicketBoundary =
+  // A fix PR was opened for the incident, or a follow-up landed on one.
+  | "pr_delivered"
+  // The run completed with findings while leaving the incident open.
+  | "investigation_handoff"
+  // The completion closes the incident (resolve_incident, noise,
+  // already-resolved, or every PR merged).
+  | "incident_resolved";
+
+export function shouldDeliverLinearTicket(args: {
+  policy: schema.LinearTicketPolicy;
+  boundary: LinearTicketBoundary;
+  createOnResolve: boolean;
+  // A ticket already filed by this run may still be updated/linked at a
+  // resolving boundary even when resolve-time creation is off.
+  runHasTicket?: boolean;
+}): boolean {
+  if (args.policy === "never") return false;
+  if (args.boundary !== "incident_resolved") return true;
+  return args.policy === "always" || args.createOnResolve || args.runHasTicket === true;
 }

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -33,8 +33,8 @@ import {
 } from "../infra/slack/incident-messages.js";
 import { logger } from "../logger.js";
 import { enqueueAgentRunCompleted } from "../webhooks.js";
-import { shouldCreateLinearTicketForTerminalOutcome } from "./completion-policy.js";
-import { recordFiledLinearTicket } from "./deliverable-records.js";
+import { shouldDeliverLinearTicket } from "./completion-policy.js";
+import { recordFiledLinearTicket, runHasFiledLinearTicket } from "./deliverable-records.js";
 import { scheduleLinearHandoff } from "./linear-handoff.js";
 import {
   closedElsewhereCopyAfterNoiseRace,
@@ -378,10 +378,12 @@ export async function completeWithIncidentResolution(
       // Linear ticket: file/update deterministically from the findings. The
       // reconciliation boundary links every PR recorded for the incident and
       // remains pending when either provider is temporarily unavailable.
-      const shouldCreateTicket = shouldCreateLinearTicketForTerminalOutcome(
-        "resolve_incident",
-        ctx.createLinearTicketOnResolve,
-      );
+      const shouldCreateTicket = shouldDeliverLinearTicket({
+        policy: ctx.linearTicketPolicy,
+        boundary: "incident_resolved",
+        createOnResolve: ctx.createLinearTicketOnResolve,
+        runHasTicket: await runHasFiledLinearTicket(ctx.agentRun.id),
+      });
       const deliveredTicket = shouldCreateTicket
         ? await scheduleLinearHandoff(ctx, completionResult, "resolve_incident")
         : null;
@@ -645,12 +647,21 @@ export async function completeWithoutPullRequest(
     // The platform files/updates the Linear ticket deterministically from the
     // run's findings. Keep this provider mutation inside the same epoch guard
     // as Slack and Linear response copy so a reopened Incident cannot receive
-    // stale terminal follow-ups from a delayed completion snapshot.
-    const deliveredTicket = await scheduleLinearHandoff(
-      ctx,
-      completionResult,
-      completionResult.completionKind ?? "complete_without_pr",
-    );
+    // stale terminal follow-ups from a delayed completion snapshot. This
+    // publish path only runs for incident-closing completions, so ticket
+    // creation follows the resolve-time policy.
+    const deliveredTicket = shouldDeliverLinearTicket({
+      policy: ctx.linearTicketPolicy,
+      boundary: "incident_resolved",
+      createOnResolve: ctx.createLinearTicketOnResolve,
+      runHasTicket: await runHasFiledLinearTicket(ctx.agentRun.id),
+    })
+      ? await scheduleLinearHandoff(
+          ctx,
+          completionResult,
+          completionResult.completionKind ?? "complete_without_pr",
+        )
+      : null;
     if (!deliveredTicket && completionResult.linearTicket) {
       await recordFiledLinearTicket(ctx, completionResult.linearTicket);
     }

--- a/apps/worker/src/agent-runs/deliverable-records.ts
+++ b/apps/worker/src/agent-runs/deliverable-records.ts
@@ -271,6 +271,17 @@ export async function resolveIncidentOrgBestEffort(
   }
 }
 
+// Whether this run has already filed a Linear ticket (e.g. at the PR
+// boundary). Resolving completions may update such a ticket even when
+// resolve-time creation is disabled.
+export async function runHasFiledLinearTicket(agentRunId: string): Promise<boolean> {
+  const row = await db.query.agentLinearTickets.findFirst({
+    where: eq(schema.agentLinearTickets.agentRunId, agentRunId),
+    columns: { id: true },
+  });
+  return Boolean(row);
+}
+
 export async function recordFiledLinearTicket(
   ctx: AgentRunContext,
   ticket: schema.AgentRunLinearTicket | null | undefined,

--- a/apps/worker/src/agent-runs/linear-delivery.test.ts
+++ b/apps/worker/src/agent-runs/linear-delivery.test.ts
@@ -65,13 +65,30 @@ const BASE_ARGS = {
   orgSlug: "acme",
   projectSlug: "shop",
   hasInstall: true,
+  policy: "on_ready_to_pr" as const,
   defaultTeamId: null,
   prUrls: [],
 };
 
-test("a connected Linear integration always enables delivery", () => {
-  assert.equal(linearDeliveryAllowed({ hasInstall: false }), false);
-  assert.equal(linearDeliveryAllowed({ hasInstall: true }), true);
+test("delivery requires a connected install and a policy other than never", () => {
+  assert.equal(linearDeliveryAllowed({ hasInstall: false, policy: "on_ready_to_pr" }), false);
+  assert.equal(linearDeliveryAllowed({ hasInstall: true, policy: "on_ready_to_pr" }), true);
+  assert.equal(linearDeliveryAllowed({ hasInstall: true, policy: "always" }), true);
+  assert.equal(linearDeliveryAllowed({ hasInstall: true, policy: "never" }), false);
+});
+
+test("policy never suppresses delivery even when a ticket could be reused", async () => {
+  const deps = makeDeps({
+    findKnownTicket: async () => ({
+      ticketId: "0b6e7f7e-6f3a-4b8e-9a4e-2d1c3b4a5f6e",
+      identifier: "ENG-7",
+      url: "https://linear.app/eng/issue/ENG-7",
+    }),
+  });
+  const ticket = await deliverLinearTicketWithDeps({ ...BASE_ARGS, policy: "never" }, RESULT, deps);
+  assert.equal(ticket, null);
+  assert.equal(deps.calls.createIssue.length, 0);
+  assert.equal(deps.calls.searchIssues.length, 0);
 });
 
 test("creates a ticket with a completed-investigation marker when nothing exists", async () => {

--- a/apps/worker/src/agent-runs/linear-delivery.ts
+++ b/apps/worker/src/agent-runs/linear-delivery.ts
@@ -87,8 +87,11 @@ function isLinearIssueUuid(value: string): boolean {
 }
 
 // Should this completion produce/refresh a ticket at all?
-export function linearDeliveryAllowed(args: { hasInstall: boolean }): boolean {
-  return args.hasInstall;
+export function linearDeliveryAllowed(args: {
+  hasInstall: boolean;
+  policy: schema.LinearTicketPolicy;
+}): boolean {
+  return args.hasInstall && args.policy !== "never";
 }
 
 export type LinearDeliveryDeps = {
@@ -118,13 +121,14 @@ export async function deliverLinearTicketWithDeps(
     orgSlug: string;
     projectSlug: string;
     hasInstall: boolean;
+    policy: schema.LinearTicketPolicy;
     defaultTeamId: string | null;
     prUrls: string[];
   },
   result: AgentRunResult,
   deps: LinearDeliveryDeps,
 ): Promise<DeliveredLinearTicket | null> {
-  if (!linearDeliveryAllowed({ hasInstall: args.hasInstall })) {
+  if (!linearDeliveryAllowed({ hasInstall: args.hasInstall, policy: args.policy })) {
     return null;
   }
   try {
@@ -292,6 +296,7 @@ export async function deliverLinearTicket(
       orgSlug: ctx.org.slug,
       projectSlug: ctx.project.slug,
       hasInstall: !!install,
+      policy: ctx.linearTicketPolicy,
       defaultTeamId: ctx.linearDefaultTeamId,
       prUrls: opts.prUrls,
     },

--- a/apps/worker/src/agent-runs/linear-handoff.test.ts
+++ b/apps/worker/src/agent-runs/linear-handoff.test.ts
@@ -35,11 +35,11 @@ function makeDeps(overrides: Partial<LinearHandoffReconciliationDeps> = {}) {
   };
 }
 
-test("a project without Linear connected does not schedule a handoff", async () => {
+test("a project with delivery disabled (no install or policy never) does not schedule a handoff", async () => {
   const calls: string[] = [];
 
   const ticket = await scheduleLinearHandoffWithDeps(
-    { hasInstall: false },
+    { deliveryEnabled: false },
     {
       recordPending: async () => {
         calls.push("record_pending");
@@ -62,7 +62,7 @@ test("a connected Linear project schedules and reconciles its handoff", async ()
   const calls: string[] = [];
 
   const ticket = await scheduleLinearHandoffWithDeps(
-    { hasInstall: true },
+    { deliveryEnabled: true },
     {
       recordPending: async () => {
         calls.push("record_pending");
@@ -86,7 +86,7 @@ test("reconciliation keeps durable work pending when ticket delivery fails", asy
 
   const ticket = await reconcileLinearHandoffWithDeps(
     {
-      hasInstall: true,
+      deliveryEnabled: true,
       pendingEventIds: ["event-1"],
       result: RESULT,
       prUrls: ["https://github.com/acme/api/pull/1"],
@@ -105,7 +105,7 @@ test("reconciliation keeps durable work pending when either link direction fails
 
   await reconcileLinearHandoffWithDeps(
     {
-      hasInstall: true,
+      deliveryEnabled: true,
       pendingEventIds: ["event-1"],
       result: RESULT,
       prUrls: ["https://github.com/acme/api/pull/1"],
@@ -122,7 +122,7 @@ test("reconciliation links every PR and completes the durable work item", async 
 
   const ticket = await reconcileLinearHandoffWithDeps(
     {
-      hasInstall: true,
+      deliveryEnabled: true,
       pendingEventIds: ["event-1", "event-2"],
       result: RESULT,
       prUrls,
@@ -135,7 +135,7 @@ test("reconciliation links every PR and completes the durable work item", async 
   assert.deepEqual(calls.processed, [["event-1", "event-2"]]);
 });
 
-test("disconnected Linear marks the handoff as reconciled without provider calls", async () => {
+test("disabled delivery marks the handoff as reconciled without provider calls", async () => {
   let delivered = false;
   const { deps, calls } = makeDeps({
     deliverTicket: async () => {
@@ -146,7 +146,7 @@ test("disconnected Linear marks the handoff as reconciled without provider calls
 
   await reconcileLinearHandoffWithDeps(
     {
-      hasInstall: false,
+      deliveryEnabled: false,
       pendingEventIds: ["event-1"],
       result: RESULT,
       prUrls: [],

--- a/apps/worker/src/agent-runs/linear-handoff.ts
+++ b/apps/worker/src/agent-runs/linear-handoff.ts
@@ -26,10 +26,10 @@ export type LinearHandoffSchedulingDeps = {
 };
 
 export async function scheduleLinearHandoffWithDeps(
-  input: { hasInstall: boolean },
+  input: { deliveryEnabled: boolean },
   deps: LinearHandoffSchedulingDeps,
 ): Promise<DeliveredLinearTicket | null> {
-  if (!input.hasInstall) return null;
+  if (!input.deliveryEnabled) return null;
   await deps.recordPending();
   await deps.dispatch().catch(() => undefined);
   return deps.reconcile();
@@ -37,7 +37,7 @@ export async function scheduleLinearHandoffWithDeps(
 
 export async function reconcileLinearHandoffWithDeps(
   input: {
-    hasInstall: boolean;
+    deliveryEnabled: boolean;
     pendingEventIds: string[];
     result: AgentRunResult;
     prUrls: string[];
@@ -45,7 +45,9 @@ export async function reconcileLinearHandoffWithDeps(
   deps: LinearHandoffReconciliationDeps,
 ): Promise<DeliveredLinearTicket | null> {
   if (input.pendingEventIds.length === 0) return null;
-  if (!input.hasInstall) {
+  // Disconnected Linear or a policy of never: retire the durable work instead
+  // of leaving it pending forever.
+  if (!input.deliveryEnabled) {
     await deps.markProcessed(input.pendingEventIds);
     return null;
   }
@@ -101,7 +103,7 @@ export async function reconcilePendingLinearHandoff(
   try {
     return await reconcileLinearHandoffWithDeps(
       {
-        hasInstall: !!ctx.linearInstall,
+        deliveryEnabled: !!ctx.linearInstall && ctx.linearTicketPolicy !== "never",
         pendingEventIds: pending.map((event) => event.id),
         result,
         prUrls,
@@ -148,7 +150,7 @@ export async function scheduleLinearHandoff(
   boundary: string,
 ): Promise<DeliveredLinearTicket | null> {
   return scheduleLinearHandoffWithDeps(
-    { hasInstall: !!ctx.linearInstall },
+    { deliveryEnabled: !!ctx.linearInstall && ctx.linearTicketPolicy !== "never" },
     {
       recordPending: async () => {
         await db


### PR DESCRIPTION
## Problem

The project automation setting `linear_ticket_policy` (`never` / `on_ready_to_pr` / `always`) was persisted by the API and loaded into the agent-run context, but nothing ever read it. `never` did not suppress ticket filing, `always` changed nothing, and the setting had no UI surface.

## Behavior

Ticket delivery boundaries are: the first fix PR opening (or a follow-up push), a findings handoff that leaves the incident open, and incident-resolving completions (`resolve_incident`, noise, already-resolved, all-PRs-merged).

- **`never`** — no Linear delivery at any boundary. Pending handoff work items are retired (marked processed) instead of retrying forever when the policy flips mid-flight, same as a disconnected install.
- **`on_ready_to_pr`** (default) — unchanged: ticket filed at the PR boundary, or at investigation completion when no PR was produced (covers projects with PRs disabled). Resolve-time filing keeps following `create_linear_ticket_on_resolve`.
- **`always`** — incident-resolving completions file a ticket regardless of the resolve toggle.

A ticket the run already filed (e.g. at the PR boundary) may still be updated and cross-linked by a resolving completion even when resolve-time creation is off — that's an update, not a creation.

One deliberate change to existing behavior: legacy noise / already-resolved completions used to file tickets unconditionally; they now go through the resolve-time gate, matching what the settings copy already promised ("resolve-time filing is controlled below").

## UI

The "File Linear ticket" step in project agent settings gets an on/off toggle (mirrors the PR step): on ⇒ `on_ready_to_pr`, off ⇒ `never`. Inner controls disable when off.

## Tests

- `completion-policy.test.ts` rewritten for the boundary matrix (never blocks everything incl. updates; resolve boundary needs `always`/toggle/existing ticket).
- `linear-delivery.test.ts`: `never` suppresses delivery even when a reusable ticket exists.
- `linear-handoff.test.ts`: disabled delivery retires pending durable work.
- Full `agent-runs` suite: 237 passing; worker + web typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the `linear_ticket_policy` across all delivery boundaries and adds a settings toggle to control when Linear tickets are filed. This stops unwanted tickets when disabled and aligns resolve-time behavior with project settings.

- **New Features**
  - `never`: no Linear delivery at PR, findings handoff, or resolve; pending handoff work is retired.
  - `on_ready_to_pr` (default): file at the first PR or findings-only handoff; resolve-time follows `createLinearTicketOnResolve`.
  - `always`: also file on incident-resolving completions regardless of `createLinearTicketOnResolve`.
  - Runs that already filed a ticket may update/cross-link it at resolution even when resolve-time creation is off.
  - UI: the “File Linear ticket” settings step now has an on/off toggle (on → `on_ready_to_pr`, off → `never`); inner controls disable when off and connectors reflect state.

<sup>Written for commit f86dd2b65d81b6587fb77e486297c43c73f147e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

