### PR TITLE
Pin the seeded run's createdAt in the PR retry tests

### DIFF
--- a/packages/db/src/agent-pr-retry.test.ts
+++ b/packages/db/src/agent-pr-retry.test.ts
@@ -58,6 +58,11 @@ async function seedRetryableRun(db: DB, incidentStatus: schema.IncidentStatus = 
       runtime: "test",
       state: "failed",
       failureReason: "pr_open_failed",
+      // Pin createdAt: the "latest run" ordering compares it against
+      // successors the tests create at NOW + ε, so leaving the column on its
+      // wall-clock default made those successors stop being "newer" the
+      // moment real time passed the fixture NOW.
+      createdAt: NOW,
       completedAt: NOW,
       result: {
         state: "failed",


### PR DESCRIPTION
`Run tests` is currently red on every branch: `PR delivery retry rejects a failed predecessor once a newer run exists` started failing at exactly 2026-07-15T10:00Z.

The fixture `NOW` (`2026-07-15T10:00:00Z`) was in the future when the test was written. The seeded predecessor run leaves `createdAt` on its wall-clock column default, while the "newer" successor is pinned to `NOW + 1s`. `queueAgentPullRequestRetry` picks the latest run by `createdAt desc` — so once real time passed the fixture `NOW`, the wall-clock predecessor became the latest run, the retry queued instead of being rejected, and the test failed. It passes before the deadline and fails after, which is why main's push CI was green yesterday and every run today is red.

Fix: pin the predecessor's `createdAt: NOW` so the ordering is deterministic regardless of wall clock. Full `@superlog/db` suite green locally (209 pass). I checked the other test files using near-future date fixtures (`github-pull-request-state`, `pr-merge-service`, `github-pr-provider`, `agent-incident-resolution-race`) — they pin timestamps on both sides of their comparisons and pass at the current wall clock.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the seeded predecessor run’s createdAt to the fixture NOW in the PR retry tests to make “latest run” ordering deterministic regardless of wall clock. This stops the failure that began when real time passed the fixture time and keeps the `@superlog/db` suite green.

<sup>Written for commit eca5075e7834389d93b1506e742f0927122dd9d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

