### PR TITLE
Drain outstanding SQS long polls on shutdown

### DIFF
--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -1190,7 +1190,8 @@ logger.info(
 // the received-but-undeleted SQS messages stay invisible for the full visibility
 // timeout before redelivering — the sawtooth that pins ApproximateAgeOfOldestMessage
 // and trips the ingest-lag page on every deploy. ECS's stopTimeout bounds how long
-// we get; the consumer aborts its idle long-poll so the drain is fast in practice.
+// we get; the consumer lets a healthy long-poll finish and aborts only if it stalls
+// beyond its normal server-side wait plus network slack.
 let shuttingDown = false;
 async function shutdown(signal: NodeJS.Signals): Promise<void> {
   if (shuttingDown) return;

--- a/apps/proxy/src/ingest-queue.batch.test.ts
+++ b/apps/proxy/src/ingest-queue.batch.test.ts
@@ -186,8 +186,9 @@ test("cleans up the uploaded S3 object when its batched send fails", async () =>
 });
 
 /** Fake SQS for the consumer side: delivers one fixed batch on the first receive,
- *  then blocks like a real long-poll until aborted. Deletes must arrive as
- *  DeleteMessageBatch; entries whose receipt handle is in `failReceipts` fail. */
+ *  then completes later polls empty after a short delay, like a scaled-down SQS
+ *  long poll. Deletes must arrive as DeleteMessageBatch; entries whose receipt
+ *  handle is in `failReceipts` fail. */
 class FakeConsumerSqs {
   deleteBatches: string[][] = [];
   singleDeletes: string[] = [];
@@ -197,23 +198,15 @@ class FakeConsumerSqs {
   constructor(private readonly messages: Array<{ MessageId: string; ReceiptHandle: string; Body: string }>) {}
 
   // biome-ignore lint/suspicious/noExplicitAny: minimal AWS client test double
-  async send(cmd: any, opts?: { abortSignal?: AbortSignal }): Promise<unknown> {
+  async send(cmd: any): Promise<unknown> {
     const name = cmd.constructor.name;
     if (name === "ReceiveMessageCommand") {
       if (!this.delivered) {
         this.delivered = true;
         return { Messages: this.messages };
       }
-      return await new Promise((_resolve, reject) => {
-        const signal = opts?.abortSignal;
-        const abort = () => {
-          const err = new Error("Request aborted");
-          err.name = "AbortError";
-          reject(err);
-        };
-        if (signal?.aborted) return abort();
-        signal?.addEventListener("abort", abort, { once: true });
-      });
+      await delay(5);
+      return { Messages: [] };
     }
     if (name === "DeleteMessageBatchCommand") {
       const entries = cmd.input.Entries as Array<{ Id: string; ReceiptHandle: string }>;

--- a/apps/proxy/src/ingest-queue.shutdown.test.ts
+++ b/apps/proxy/src/ingest-queue.shutdown.test.ts
@@ -115,10 +115,15 @@ test("stop() drains a message assigned to an outstanding long poll during shutdo
   }
 });
 
-test("stop() aborts a stalled receive after the normal long-poll window", async () => {
+test("stop() bounds a stalled receive while a producer send is still draining", async () => {
   const queue = new IngestQueue({ ...config, waitTimeSeconds: 0 }, noopLogger);
   const sqs = new FakeLongPollSqs();
   (queue as unknown as { sqs: FakeLongPollSqs }).sqs = sqs;
+  let finishSend: (() => void) | undefined;
+  const pendingSend = new Promise<void>((resolve) => {
+    finishSend = resolve;
+  });
+  (queue as unknown as { inFlightSends: Set<Promise<void>> }).inFlightSends.add(pendingSend);
 
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async () => new Response(new Uint8Array(0), { status: 200 })) as typeof fetch;
@@ -130,6 +135,7 @@ test("stop() aborts a stalled receive after the normal long-poll window", async 
     const stopping = queue.stop();
     await delay(5_100);
     const abortedAfterDeadline = sqs.aborted;
+    finishSend?.();
 
     // Let the old implementation finish so the failing regression test does
     // not leave its consumer loop running forever.

--- a/apps/proxy/src/ingest-queue.shutdown.test.ts
+++ b/apps/proxy/src/ingest-queue.shutdown.test.ts
@@ -114,3 +114,30 @@ test("stop() drains a message assigned to an outstanding long poll during shutdo
     globalThis.fetch = originalFetch;
   }
 });
+
+test("stop() aborts a stalled receive after the normal long-poll window", async () => {
+  const queue = new IngestQueue({ ...config, waitTimeSeconds: 0 }, noopLogger);
+  const sqs = new FakeLongPollSqs();
+  (queue as unknown as { sqs: FakeLongPollSqs }).sqs = sqs;
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(new Uint8Array(0), { status: 200 })) as typeof fetch;
+
+  try {
+    queue.startConsumer("http://collector.local");
+    await waitFor(() => sqs.receiveCount === 1);
+
+    const stopping = queue.stop();
+    await delay(5_100);
+    const abortedAfterDeadline = sqs.aborted;
+
+    // Let the old implementation finish so the failing regression test does
+    // not leave its consumer loop running forever.
+    if (!abortedAfterDeadline) sqs.deliverDuringShutdown();
+    await stopping;
+
+    assert.equal(abortedAfterDeadline, true, "a stalled receive must not block shutdown forever");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/apps/proxy/src/ingest-queue.shutdown.test.ts
+++ b/apps/proxy/src/ingest-queue.shutdown.test.ts
@@ -32,36 +32,33 @@ const inlineBody = encodeIngestMessage(
 ).messageBody;
 
 /**
- * Fake SQS that delivers exactly one message on the first ReceiveMessage and
- * then blocks (like a real 20s long-poll) until the consumer's AbortController
- * fires — at which point it rejects with an AbortError, exactly as the AWS SDK
- * does when send() is aborted. Records every DeleteMessage.
+ * Models the shutdown race at the SQS boundary. A long poll may still be live
+ * server-side when a client aborts it. If SQS assigns a message after that
+ * abort, the message is invisible but the dead client never receives its
+ * receipt handle. Keeping the client request alive lets the consumer process
+ * and delete that final message before it exits.
  */
-class FakeConsumerSqs {
+class FakeLongPollSqs {
   receiveCount = 0;
   deleted: string[] = [];
-  private delivered = false;
+  aborted = false;
+  private resolveReceive: ((value: unknown) => void) | null = null;
 
   // biome-ignore lint/suspicious/noExplicitAny: minimal AWS client test double
   async send(cmd: any, opts?: { abortSignal?: AbortSignal }): Promise<unknown> {
     const name = cmd.constructor.name;
     if (name === "ReceiveMessageCommand") {
       this.receiveCount++;
-      if (!this.delivered) {
-        this.delivered = true;
-        return {
-          Messages: [{ MessageId: "m-1", ReceiptHandle: "r-1", Body: inlineBody }],
-        };
-      }
-      return await new Promise((_resolve, reject) => {
-        const signal = opts?.abortSignal;
+      return await new Promise((resolve, reject) => {
+        this.resolveReceive = resolve;
         const abort = () => {
+          this.aborted = true;
           const err = new Error("Request aborted");
           err.name = "AbortError";
           reject(err);
         };
-        if (signal?.aborted) return abort();
-        signal?.addEventListener("abort", abort, { once: true });
+        if (opts?.abortSignal?.aborted) return abort();
+        opts?.abortSignal?.addEventListener("abort", abort, { once: true });
       });
     }
     if (name === "DeleteMessageBatchCommand") {
@@ -70,6 +67,12 @@ class FakeConsumerSqs {
       return { Successful: entries.map((entry) => ({ Id: entry.Id })), Failed: [] };
     }
     throw new Error(`unexpected SQS command: ${name}`);
+  }
+
+  deliverDuringShutdown(): void {
+    this.resolveReceive?.({
+      Messages: [{ MessageId: "m-1", ReceiptHandle: "r-1", Body: inlineBody }],
+    });
   }
 }
 
@@ -81,33 +84,29 @@ async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<voi
   }
 }
 
-test("stop() drains the in-flight message and halts polling", async () => {
+test("stop() drains a message assigned to an outstanding long poll during shutdown", async () => {
   const queue = new IngestQueue(config, noopLogger);
-  const sqs = new FakeConsumerSqs();
-  (queue as unknown as { sqs: FakeConsumerSqs }).sqs = sqs;
+  const sqs = new FakeLongPollSqs();
+  (queue as unknown as { sqs: FakeLongPollSqs }).sqs = sqs;
 
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async () => new Response(new Uint8Array(0), { status: 200 })) as typeof fetch;
 
   try {
     queue.startConsumer("http://collector.local");
+    await waitFor(() => sqs.receiveCount === 1);
 
-    // The first delivered message must be forwarded to the collector and then
-    // deleted from SQS before we initiate shutdown.
-    await waitFor(() => sqs.deleted.length === 1);
-    assert.deepEqual(sqs.deleted, ["r-1"]);
+    const stopping = queue.stop();
+    sqs.deliverDuringShutdown();
+    await stopping;
 
-    const receivesBeforeStop = sqs.receiveCount;
-    await queue.stop();
-
-    // After draining, the loop must not issue any further ReceiveMessage calls.
-    await delay(50);
+    assert.equal(sqs.aborted, false, "shutdown must not abandon the outstanding SQS long poll");
+    assert.deepEqual(sqs.deleted, ["r-1"], "the final message must be delivered and deleted");
     assert.equal(
       sqs.receiveCount,
-      receivesBeforeStop,
-      "consumer must stop polling once stop() resolves",
+      1,
+      "the consumer must not start another poll while shutting down",
     );
-    assert.equal(sqs.deleted.length, 1, "the in-flight message must remain deleted exactly once");
 
     // stop() is idempotent.
     await queue.stop();

--- a/apps/proxy/src/ingest-queue.ts
+++ b/apps/proxy/src/ingest-queue.ts
@@ -653,9 +653,6 @@ export class IngestQueue {
   // Set by stop(); flips the consume loops out of their receive cycle so a
   // rolling deploy can drain cleanly instead of abandoning in-flight messages.
   private shuttingDown = false;
-  // Aborts an idle long-poll ReceiveMessage immediately on stop() so draining
-  // does not wait out the full waitTimeSeconds before the loop notices.
-  private readonly shutdownController = new AbortController();
   // Resolves once every consume loop has exited; stop() awaits it.
   private consumersDone: Promise<void> | null = null;
 
@@ -679,18 +676,16 @@ export class IngestQueue {
 
   /**
    * Drain the consumer for a graceful shutdown (e.g. SIGTERM from an ECS rolling
-   * deploy). Stops issuing new ReceiveMessage calls, aborts any idle long-poll,
-   * and waits for in-flight messages to finish processing — each delivered
-   * message is deleted before its loop exits. Without this, a deploy kills the
-   * task mid-batch and the received-but-undeleted messages stay invisible for the
-   * full visibility timeout before redelivering, which pins SQS
-   * ApproximateAgeOfOldestMessage into a sawtooth and trips the ingest-lag page.
-   * Idempotent.
+   * deploy). Stops issuing new ReceiveMessage calls and waits for outstanding
+   * long polls plus in-flight messages to finish — each delivered message is
+   * deleted before its loop exits. The long polls must not be client-aborted:
+   * SQS can assign a message to a server-side receive after the local abort,
+   * leaving it invisible without a live client to receive its receipt handle.
+   * ECS's stop timeout comfortably exceeds the long-poll wait. Idempotent.
    */
   async stop(): Promise<void> {
     if (this.shuttingDown) return;
     this.shuttingDown = true;
-    this.shutdownController.abort();
     this.logger.info(
       { queueUrl: this.config.queueUrl },
       "ingest queue consumer draining in-flight messages",
@@ -720,24 +715,14 @@ export class IngestQueue {
     );
 
     while (!this.shuttingDown) {
-      let result: ReceiveMessageCommandOutput;
-      try {
-        result = await this.sqs.send(
-          new ReceiveMessageCommand({
-            QueueUrl: this.config.queueUrl,
-            MaxNumberOfMessages: this.config.batchSize,
-            WaitTimeSeconds: this.config.waitTimeSeconds,
-            VisibilityTimeout: this.config.visibilityTimeoutSeconds,
-          }),
-          { abortSignal: this.shutdownController.signal },
-        );
-      } catch (err) {
-        // stop() aborts the in-flight long-poll; that surfaces here as an abort
-        // error. Exit cleanly when draining; otherwise preserve the previous
-        // crash-on-unexpected-failure behaviour.
-        if (this.shuttingDown) break;
-        throw err;
-      }
+      const result: ReceiveMessageCommandOutput = await this.sqs.send(
+        new ReceiveMessageCommand({
+          QueueUrl: this.config.queueUrl,
+          MaxNumberOfMessages: this.config.batchSize,
+          WaitTimeSeconds: this.config.waitTimeSeconds,
+          VisibilityTimeout: this.config.visibilityTimeoutSeconds,
+        }),
+      );
 
       // A batch received just before stop() is still drained: we finish
       // processing (and deleting) it before the while-condition exits the loop.

--- a/apps/proxy/src/ingest-queue.ts
+++ b/apps/proxy/src/ingest-queue.ts
@@ -54,6 +54,7 @@ const MAX_COLLECTOR_ERROR_BODY_CHARS = 1_000;
 // 10 entries, and (for sends) at most 256 KiB of total payload across entries.
 const SQS_BATCH_MAX_ENTRIES = 10;
 const SQS_BATCH_MAX_PAYLOAD_BYTES = 256 * 1024;
+const SHUTDOWN_RECEIVE_ABORT_SLACK_MS = 5_000;
 // How long a pending send may wait for batch-mates before it is flushed anyway.
 // Each SQS request is billed individually, so coalescing sends into
 // SendMessageBatch cuts the request bill up to 10x; the linger is the latency
@@ -653,6 +654,10 @@ export class IngestQueue {
   // Set by stop(); flips the consume loops out of their receive cycle so a
   // rolling deploy can drain cleanly instead of abandoning in-flight messages.
   private shuttingDown = false;
+  // Healthy long polls are allowed to finish during shutdown. This controller
+  // is aborted only after their configured server-side wait plus network slack,
+  // bounding the drain if an HTTP connection stalls indefinitely.
+  private readonly shutdownController = new AbortController();
   // Resolves once every consume loop has exited; stop() awaits it.
   private consumersDone: Promise<void> | null = null;
 
@@ -678,10 +683,12 @@ export class IngestQueue {
    * Drain the consumer for a graceful shutdown (e.g. SIGTERM from an ECS rolling
    * deploy). Stops issuing new ReceiveMessage calls and waits for outstanding
    * long polls plus in-flight messages to finish — each delivered message is
-   * deleted before its loop exits. The long polls must not be client-aborted:
-   * SQS can assign a message to a server-side receive after the local abort,
-   * leaving it invisible without a live client to receive its receipt handle.
-   * ECS's stop timeout comfortably exceeds the long-poll wait. Idempotent.
+   * deleted before its loop exits. Long polls must not be aborted immediately:
+   * SQS can assign a message to a server-side receive after an immediate local
+   * abort, leaving it invisible without a live client to receive its receipt
+   * handle. A delayed abort after the normal poll window bounds genuinely
+   * stalled connections. ECS's stop timeout comfortably exceeds that window.
+   * Idempotent.
    */
   async stop(): Promise<void> {
     if (this.shuttingDown) return;
@@ -697,8 +704,24 @@ export class IngestQueue {
     this.flushPendingSends();
     await Promise.allSettled([...this.inFlightSends]);
     // consumersDone never rejects (see startConsumer); a loop failure is logged
-    // and surfaced as a non-zero exit there.
-    await this.consumersDone;
+    // and surfaced as a non-zero exit there. Give healthy receives their full
+    // server-side long-poll window, then abort only a connection that is still
+    // stalled beyond an additional network grace period.
+    const abortTimer = this.consumersDone
+      ? setTimeout(() => {
+          this.logger.warn(
+            { queueUrl: this.config.queueUrl },
+            "aborting stalled SQS receive after shutdown drain deadline",
+          );
+          this.shutdownController.abort();
+        }, this.config.waitTimeSeconds * 1_000 + SHUTDOWN_RECEIVE_ABORT_SLACK_MS)
+      : null;
+    abortTimer?.unref?.();
+    try {
+      await this.consumersDone;
+    } finally {
+      if (abortTimer) clearTimeout(abortTimer);
+    }
     this.logger.info({ queueUrl: this.config.queueUrl }, "ingest queue consumer drained");
   }
 
@@ -715,14 +738,21 @@ export class IngestQueue {
     );
 
     while (!this.shuttingDown) {
-      const result: ReceiveMessageCommandOutput = await this.sqs.send(
-        new ReceiveMessageCommand({
-          QueueUrl: this.config.queueUrl,
-          MaxNumberOfMessages: this.config.batchSize,
-          WaitTimeSeconds: this.config.waitTimeSeconds,
-          VisibilityTimeout: this.config.visibilityTimeoutSeconds,
-        }),
-      );
+      let result: ReceiveMessageCommandOutput;
+      try {
+        result = await this.sqs.send(
+          new ReceiveMessageCommand({
+            QueueUrl: this.config.queueUrl,
+            MaxNumberOfMessages: this.config.batchSize,
+            WaitTimeSeconds: this.config.waitTimeSeconds,
+            VisibilityTimeout: this.config.visibilityTimeoutSeconds,
+          }),
+          { abortSignal: this.shutdownController.signal },
+        );
+      } catch (err) {
+        if (this.shuttingDown && this.shutdownController.signal.aborted) break;
+        throw err;
+      }
 
       // A batch received just before stop() is still drained: we finish
       // processing (and deleting) it before the while-condition exits the loop.

--- a/apps/proxy/src/ingest-queue.ts
+++ b/apps/proxy/src/ingest-queue.ts
@@ -697,16 +697,9 @@ export class IngestQueue {
       { queueUrl: this.config.queueUrl },
       "ingest queue consumer draining in-flight messages",
     );
-    // Flush any sends still waiting on the linger timer so a producer-only
-    // proxy doesn't drop the tail of accepted requests on SIGTERM. The entry
-    // promises are awaited by their HTTP handlers; allSettled only waits for
-    // the wire calls to finish.
-    this.flushPendingSends();
-    await Promise.allSettled([...this.inFlightSends]);
-    // consumersDone never rejects (see startConsumer); a loop failure is logged
-    // and surfaced as a non-zero exit there. Give healthy receives their full
-    // server-side long-poll window, then abort only a connection that is still
-    // stalled beyond an additional network grace period.
+    // Start the receive deadline when shutdown begins, independently of any
+    // producer sends that are also draining. Healthy receives get their full
+    // server-side long-poll window plus network slack.
     const abortTimer = this.consumersDone
       ? setTimeout(() => {
           this.logger.warn(
@@ -717,7 +710,15 @@ export class IngestQueue {
         }, this.config.waitTimeSeconds * 1_000 + SHUTDOWN_RECEIVE_ABORT_SLACK_MS)
       : null;
     abortTimer?.unref?.();
+    // Flush any sends still waiting on the linger timer so a producer-only
+    // proxy doesn't drop the tail of accepted requests on SIGTERM. The entry
+    // promises are awaited by their HTTP handlers; allSettled only waits for
+    // the wire calls to finish.
     try {
+      this.flushPendingSends();
+      await Promise.allSettled([...this.inFlightSends]);
+      // consumersDone never rejects (see startConsumer); a loop failure is
+      // logged and surfaced as a non-zero exit there.
       await this.consumersDone;
     } finally {
       if (abortTimer) clearTimeout(abortTimer);


### PR DESCRIPTION
## Summary
- let outstanding SQS long polls complete during graceful shutdown
- process and delete any message assigned before the poll returns
- abort only a genuinely stalled receive after the normal long-poll window plus network slack
- cover both the message-assignment race and bounded-drain fallback with regression tests
- model existing consumer-test polls as delayed empty responses instead of abort-only requests

## Why
Aborting a client-side long poll immediately does not guarantee the server-side receive is cancelled. SQS can assign a message to that abandoned receive, leaving the message invisible until its visibility timeout because the terminating consumer never obtains the receipt handle. Waiting forever is also unsafe if the HTTP connection stalls, so shutdown uses a delayed abort after the configured poll window plus five seconds.

## Validation
- full proxy suite under CI Node 20: 117 tests passed
- `pnpm --filter @superlog/proxy typecheck`
- `pnpm exec biome lint` on changed proxy files