### PR TITLE
Hand recurring-step jobs back on shutdown instead of dying with them active

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -126,12 +126,20 @@ registerTelemetryIngestMetrics({
 // The tick runs the steps itself only when pg-boss is unavailable entirely.
 // Once the telemetry scan migrates too, the tick disappears.
 const skipSteps = new Set<SkippableTickStep>();
+// Aborted at drain so in-flight chain passes hand their jobs back before the
+// process exits — a job left ACTIVE by a dying process would block the chain
+// fleet-wide until expiry (up to tens of minutes for the long-lease steps).
+const recurringShutdown = new AbortController();
 if (agentRunQueueReady) skipSteps.add("agent_runs");
 if (jobBoss) {
-  await startRecurringSteps(jobBoss, {
-    clickhouse: ch,
-    onIssueTransition: dispatchIssueTransition,
-  });
+  await startRecurringSteps(
+    jobBoss,
+    {
+      clickhouse: ch,
+      onIssueTransition: dispatchIssueTransition,
+    },
+    { shutdown: recurringShutdown.signal },
+  );
   for (const step of RECURRING_TICK_STEPS) skipSteps.add(step);
 }
 
@@ -159,6 +167,7 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   shuttingDown = true;
   logger.info({ signal }, "received shutdown signal; draining");
 
+  recurringShutdown.abort();
   const exitCode = await shutdownWorkerProcess({
     drain: () =>
       drainWorker({

--- a/apps/worker/src/worker/recurring-steps.test.ts
+++ b/apps/worker/src/worker/recurring-steps.test.ts
@@ -69,7 +69,10 @@ test("a failed registration doesn't block the rest and is retried in the backgro
     async schedule() {},
   };
 
-  const migrated = await startRecurringSteps(boss, depsOf(), quietLogger, 5);
+  const migrated = await startRecurringSteps(boss, depsOf(), {
+    logger: quietLogger,
+    retryDelayMs: 5,
+  });
 
   // The failed step must not block the others — and must NOT be reported as
   // registered (the caller never runs it locally; see RECURRING_TICK_STEPS).
@@ -86,4 +89,36 @@ test("a failed registration doesn't block the rest and is retried in the backgro
     ["digest-sweep"],
     "the retried step must get exactly one consumer",
   );
+});
+
+test("registration retries stop once shutdown begins", async () => {
+  let attempts = 0;
+  const boss: RecurringBoss = {
+    async createQueue(name) {
+      if (name === "digest-sweep") {
+        attempts += 1;
+        throw new Error("createQueue refused");
+      }
+    },
+    async updateQueue() {},
+    async work() {},
+    async send() {
+      return "job-id";
+    },
+    async schedule() {},
+  };
+  const shutdown = new AbortController();
+
+  await startRecurringSteps(boss, depsOf(), {
+    logger: quietLogger,
+    retryDelayMs: 5,
+    shutdown: shutdown.signal,
+  });
+  shutdown.abort();
+  const attemptsAtShutdown = attempts;
+  await new Promise((resolve) => setTimeout(resolve, 30));
+
+  // A retry already sleeping may fire once more at most; the chain of retries
+  // must not keep hammering a draining process.
+  assert.ok(attempts <= attemptsAtShutdown + 1, "retries must stop after shutdown");
 });

--- a/apps/worker/src/worker/recurring-steps.ts
+++ b/apps/worker/src/worker/recurring-steps.ts
@@ -86,6 +86,14 @@ export function buildRecurringSteps(deps: RecurringStepsDeps): RecurringStepSpec
   ];
 }
 
+export type StartRecurringStepsOptions = {
+  logger?: LoggerLike;
+  retryDelayMs?: number;
+  // Threaded through to every step's pass (see RegisterRecurringStepOptions);
+  // also stops the background registration retry on a draining process.
+  shutdown?: AbortSignal;
+};
+
 // Register every step's chain, one failure at a time: one step's registration
 // failure must not block the others. A failed step is never run locally (see
 // RECURRING_TICK_STEPS); instead its registration keeps retrying in the
@@ -97,14 +105,15 @@ export function buildRecurringSteps(deps: RecurringStepsDeps): RecurringStepSpec
 export async function startRecurringSteps(
   boss: RecurringBoss,
   deps: RecurringStepsDeps,
-  logger: LoggerLike = defaultLogger,
-  retryDelayMs: number = REGISTRATION_RETRY_MS,
+  opts: StartRecurringStepsOptions = {},
 ): Promise<Set<SkippableTickStep>> {
+  const logger = opts.logger ?? defaultLogger;
+  const retryDelayMs = opts.retryDelayMs ?? REGISTRATION_RETRY_MS;
   const migrated = new Set<SkippableTickStep>();
   for (const step of buildRecurringSteps(deps)) {
     const attempt = async (): Promise<boolean> => {
       try {
-        await registerRecurringStep(boss, step, logger);
+        await registerRecurringStep(boss, step, { logger, shutdown: opts.shutdown });
         migrated.add(step.tickStep);
         return true;
       } catch (err) {
@@ -121,6 +130,7 @@ export async function startRecurringSteps(
     };
     const scheduleRetry = (): void => {
       const timer = setTimeout(async () => {
+        if (opts.shutdown?.aborted) return;
         if (!(await attempt())) scheduleRetry();
       }, retryDelayMs);
       timer.unref?.();

--- a/apps/worker/src/worker/recurring.test.ts
+++ b/apps/worker/src/worker/recurring.test.ts
@@ -59,7 +59,7 @@ function stepOf(overrides: Partial<RecurringStep> = {}): RecurringStep {
 
 test("registration creates a stately queue, a minute reviver, a seed job, and the consumer last", async () => {
   const fb = fakeBoss();
-  await registerRecurringStep(fb.boss, stepOf(), quietLogger);
+  await registerRecurringStep(fb.boss, stepOf(), { logger: quietLogger });
 
   // `stately` allows one queued + one active job per singleton key: the
   // running pass and its already-scheduled successor coexist, while reviver
@@ -113,7 +113,7 @@ test("a completed pass reschedules itself after the interval", async () => {
         passes += 1;
       },
     }),
-    quietLogger,
+    { logger: quietLogger },
   );
   const worker = fb.workers.get("test-step");
   assert.ok(worker);
@@ -142,9 +142,11 @@ test("a failing pass is logged and still reschedules", async () => {
       },
     }),
     {
-      ...quietLogger,
-      error: (...args: unknown[]) => {
-        errors.push(String(args[1]));
+      logger: {
+        ...quietLogger,
+        error: (...args: unknown[]) => {
+          errors.push(String(args[1]));
+        },
       },
     },
   );
@@ -166,9 +168,11 @@ test("the job stays active until the pass settles — a slow pass warns but is n
     releaseHung = resolve;
   });
   await registerRecurringStep(fb.boss, stepOf({ run: () => hung, passWarnAfterMs: 5 }), {
-    ...quietLogger,
-    warn: (...args: unknown[]) => {
-      warnings.push(String(args[1]));
+    logger: {
+      ...quietLogger,
+      warn: (...args: unknown[]) => {
+        warnings.push(String(args[1]));
+      },
     },
   });
   const worker = fb.workers.get("test-step");
@@ -205,9 +209,60 @@ test("a reschedule failure is swallowed — the reviver cron restores the chain"
     }
     throw new Error("pg down");
   };
-  await registerRecurringStep(fb.boss, stepOf(), quietLogger);
+  await registerRecurringStep(fb.boss, stepOf(), { logger: quietLogger });
   const worker = fb.workers.get("test-step");
   assert.ok(worker);
 
   await worker([{ id: "job-1", data: {} }]); // must not throw
+});
+
+test("shutdown hands an in-flight pass back so the job completes and reschedules", async () => {
+  const fb = fakeBoss();
+  const shutdown = new AbortController();
+  const never = new Promise<void>(() => {});
+  await registerRecurringStep(fb.boss, stepOf({ run: () => never }), {
+    logger: quietLogger,
+    shutdown: shutdown.signal,
+  });
+  const worker = fb.workers.get("test-step");
+  assert.ok(worker);
+  fb.sent.length = 0;
+
+  // The pass hangs; without the abort the handler would (correctly) wait
+  // forever. On shutdown it must resolve — a process dying with the job still
+  // ACTIVE would block the chain fleet-wide until job expiry.
+  let handlerSettled = false;
+  const handlerRun = worker([{ id: "job-1", data: {} }]).then(() => {
+    handlerSettled = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(handlerSettled, false);
+
+  shutdown.abort();
+  await handlerRun;
+  assert.equal(fb.sent.length, 1, "the successor must still be scheduled");
+});
+
+test("no new pass starts on a draining process, but the chain still reschedules", async () => {
+  const fb = fakeBoss();
+  const shutdown = new AbortController();
+  let passes = 0;
+  await registerRecurringStep(
+    fb.boss,
+    stepOf({
+      run: async () => {
+        passes += 1;
+      },
+    }),
+    { logger: quietLogger, shutdown: shutdown.signal },
+  );
+  const worker = fb.workers.get("test-step");
+  assert.ok(worker);
+  fb.sent.length = 0;
+
+  shutdown.abort();
+  await worker([{ id: "job-1", data: {} }]);
+
+  assert.equal(passes, 0, "a draining process must not start new work");
+  assert.equal(fb.sent.length, 1, "the successor runs on whichever process survives");
 });

--- a/apps/worker/src/worker/recurring.ts
+++ b/apps/worker/src/worker/recurring.ts
@@ -71,6 +71,19 @@ export type RecurringStep = {
   passWarnAfterMs?: number;
 };
 
+export type RegisterRecurringStepOptions = {
+  logger?: LoggerLike;
+  // Aborted when the process starts draining (SIGTERM). An in-flight pass is
+  // then handed back: the handler resolves so pg-boss completes the job and
+  // the reschedule lands, instead of the process dying with the job still
+  // ACTIVE — which would leave the stately singleton blocking every other
+  // process's chain until job expiry (up to tens of minutes for the
+  // long-lease steps). The abandoned pass keeps running only until the
+  // process exits, so the residual overlap window is bounded by the drain
+  // timeout — the same window the tick loop had on deploys.
+  shutdown?: AbortSignal;
+};
+
 // Register one step's chain. The consumer comes LAST so a partial
 // registration never leaves a live consumer on a half-configured queue;
 // everything else a partial registration can leave behind (queue, reviver
@@ -81,8 +94,10 @@ export type RecurringStep = {
 export async function registerRecurringStep(
   boss: RecurringBoss,
   step: RecurringStep,
-  logger: LoggerLike = defaultLogger,
+  opts: RegisterRecurringStepOptions = {},
 ): Promise<void> {
+  const logger = opts.logger ?? defaultLogger;
+  const shutdown = opts.shutdown;
   const warnAfterMs = step.passWarnAfterMs ?? DEFAULT_PASS_WARN_AFTER_MS;
   const lease = { retryLimit: 0, expireInSeconds: passExpireSeconds(warnAfterMs) };
 
@@ -96,7 +111,9 @@ export async function registerRecurringStep(
 
   await boss.work(step.queue, { batchSize: 1 }, async () => {
     try {
-      await runPassToSettlement();
+      // Don't start new work on a draining process; the successor scheduled
+      // below runs on whichever process is alive after the deploy.
+      if (!shutdown?.aborted) await runPassToSettlement();
     } finally {
       // Reschedule unconditionally — the chain must survive pass failures. A
       // send failure is only logged: the minute reviver restores the chain.
@@ -121,7 +138,8 @@ export async function registerRecurringStep(
 
   // Run one pass and hold the pg-boss job active until it settles — that hold
   // is what blocks the successor fleet-wide (see header). Errors are logged
-  // and swallowed: the next pass is the retry.
+  // and swallowed: the next pass is the retry. The one exception to the hold
+  // is process shutdown (see RegisterRecurringStepOptions.shutdown).
   async function runPassToSettlement(): Promise<void> {
     const warnTimer = setTimeout(() => {
       logger.warn(
@@ -129,20 +147,39 @@ export async function registerRecurringStep(
         "recurring step pass running past its deadline; the chain waits for it",
       );
     }, warnAfterMs);
+    let onAbort: (() => void) | undefined;
+    const aborted = new Promise<"aborted">((resolve) => {
+      if (!shutdown) return; // never resolves
+      onAbort = () => resolve("aborted");
+      if (shutdown.aborted) onAbort();
+      else shutdown.addEventListener("abort", onAbort, { once: true });
+    });
+    const pass = Promise.resolve()
+      .then(step.run)
+      .then(() => "done" as const)
+      .catch((err) => {
+        logger.error(
+          {
+            scope: "worker.recurring",
+            step: step.queue,
+            err: err instanceof Error ? err.message : String(err),
+            stack: err instanceof Error ? err.stack : undefined,
+          },
+          "recurring step pass failed",
+        );
+        return "done" as const;
+      });
     try {
-      await step.run();
-    } catch (err) {
-      logger.error(
-        {
-          scope: "worker.recurring",
-          step: step.queue,
-          err: err instanceof Error ? err.message : String(err),
-          stack: err instanceof Error ? err.stack : undefined,
-        },
-        "recurring step pass failed",
-      );
+      const outcome = await Promise.race([pass, aborted]);
+      if (outcome === "aborted") {
+        logger.warn(
+          { scope: "worker.recurring", step: step.queue },
+          "abandoning in-flight pass for shutdown; the successor resumes after the deploy",
+        );
+      }
     } finally {
       clearTimeout(warnTimer);
+      if (onAbort) shutdown?.removeEventListener("abort", onAbort);
     }
   }
 }


### PR DESCRIPTION
Follow-up to #241.

A recurring pass interrupted by SIGTERM could outlive the drain window, so the process exited with its pg-boss job still **active**. The stately singleton then blocked that step's chain fleet-wide until job expiry — up to 20–30 minutes for the long-lease steps (agent chats, digests) after a routine deploy. The old tick loop had no durable blocker: a replacement process resumed the step immediately.

Fix: thread an `AbortSignal` from the worker's shutdown path into every chain. When draining begins:
- an in-flight pass is handed back — the handler resolves, pg-boss completes the job, and the successor reschedules normally with `startAfter`;
- no new pass starts on the draining process (the job still completes and reschedules, so the successor runs on whichever process survives);
- the background registration retry stops.

The abandoned pass keeps running only until the process exits, so the residual overlap window is bounded by the drain timeout (~2 min) — the same window the tick loop had on deploys, and far better than a 20–30 minute chain pause.

## Testing

- `test:recurring` (8): two new tests — shutdown hands a hung pass back and still reschedules; a draining process starts no new pass but keeps the chain alive.
- `test:recurring-steps` (4): new test — registration retries stop once shutdown begins.
- `test:worker-tick` (1), `pnpm --filter @superlog/worker typecheck`, biome all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents fleet-wide stalls by handing recurring-step jobs back on shutdown so `pg-boss` jobs don’t stay ACTIVE. Draining processes stop starting new passes and stop registration retries, reducing deploy pauses to the drain window (~2 min).

- **Bug Fixes**
  - Threaded an AbortSignal from worker shutdown into all recurring chains.
  - On drain, handlers resolve so `pg-boss` completes the job and reschedules the successor.
  - Draining processes don’t start new passes.
  - Registration retries stop once shutdown begins.

- **Migration**
  - `startRecurringSteps` and `registerRecurringStep` now take an options object: `{ logger?, retryDelayMs?, shutdown? }`.

<sup>Written for commit 92bbd6ba29d8f6aecfd674a711f92445cc45cc17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

