### PR TITLE
Revive only dead recurring chains

### DIFF
--- a/apps/worker/src/worker/recurring-steps.test.ts
+++ b/apps/worker/src/worker/recurring-steps.test.ts
@@ -67,6 +67,7 @@ test("a failed registration doesn't block the rest and is retried in the backgro
       return "job-id";
     },
     async schedule() {},
+    async unschedule() {},
   };
 
   const migrated = await startRecurringSteps(boss, depsOf(), {
@@ -89,6 +90,12 @@ test("a failed registration doesn't block the rest and is retried in the backgro
     ["digest-sweep"],
     "the retried step must get exactly one consumer",
   );
+
+  // The shared dead-chain reviver rides along, once.
+  assert.deepEqual(
+    consumers.filter((name) => name === "recurring-reviver"),
+    ["recurring-reviver"],
+  );
 });
 
 test("registration retries stop once shutdown begins", async () => {
@@ -106,6 +113,7 @@ test("registration retries stop once shutdown begins", async () => {
       return "job-id";
     },
     async schedule() {},
+    async unschedule() {},
   };
   const shutdown = new AbortController();
 

--- a/apps/worker/src/worker/recurring-steps.ts
+++ b/apps/worker/src/worker/recurring-steps.ts
@@ -11,8 +11,15 @@ import { tickDigests } from "../digest.js";
 import type { handleIssueTransition } from "../incidents/workflow.js";
 import { logger as defaultLogger } from "../logger.js";
 import { tickObservedIssues } from "../observation.js";
+import { loadQueueHealthCounts } from "../queue-health.js";
 import { tickWebhooks } from "../webhooks.js";
-import { type RecurringBoss, type RecurringStep, registerRecurringStep } from "./recurring.js";
+import {
+  type ChainCounts,
+  type RecurringBoss,
+  type RecurringStep,
+  registerRecurringReviver,
+  registerRecurringStep,
+} from "./recurring.js";
 import type { SkippableTickStep } from "./tick.js";
 
 type ClickHouseClientLike = Parameters<typeof tickAlerts>[0];
@@ -92,6 +99,8 @@ export type StartRecurringStepsOptions = {
   // Threaded through to every step's pass (see RegisterRecurringStepOptions);
   // also stops the background registration retry on a draining process.
   shutdown?: AbortSignal;
+  // Test seam; defaults to the queue-health loader.
+  loadChainCounts?: () => Promise<ChainCounts[]>;
 };
 
 // Register every step's chain, one failure at a time: one step's registration
@@ -99,9 +108,9 @@ export type StartRecurringStepsOptions = {
 // RECURRING_TICK_STEPS); instead its registration keeps retrying in the
 // background — sequential attempts via a self-scheduling timeout, so two
 // attempts can't race a consumer onto the queue twice. Registration is
-// idempotent (createQueue/updateQueue/schedule upsert, the seed send dedupes
-// on the chain key), which is what makes the retry safe after a partial
-// failure. Returns the steps that registered on the first attempt.
+// idempotent (createQueue/updateQueue upsert, the seed send dedupes on the
+// chain key), which is what makes the retry safe after a partial failure.
+// Returns the steps that registered on the first attempt.
 export async function startRecurringSteps(
   boss: RecurringBoss,
   deps: RecurringStepsDeps,
@@ -136,6 +145,19 @@ export async function startRecurringSteps(
       timer.unref?.();
     };
     if (!(await attempt())) scheduleRetry();
+  }
+
+  // The shared dead-chain reviver (see recurring.ts). Its own failure is
+  // non-fatal: every healthy chain self-perpetuates without it; it only
+  // narrows the crash window between a pass and its reschedule.
+  try {
+    const loadCounts = opts.loadChainCounts ?? loadQueueHealthCounts;
+    await registerRecurringReviver(boss, buildRecurringSteps(deps), loadCounts, logger);
+  } catch (err) {
+    logger.error(
+      { scope: "worker.recurring", err: err instanceof Error ? err.message : String(err) },
+      "recurring reviver failed to register; chains rely on their own rescheduling",
+    );
   }
   return migrated;
 }

--- a/apps/worker/src/worker/recurring.test.ts
+++ b/apps/worker/src/worker/recurring.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  type ChainCounts,
   RECURRING_CHAIN_KEY,
+  RECURRING_REVIVER_QUEUE,
   type RecurringBoss,
   type RecurringStep,
   passExpireSeconds,
+  registerRecurringReviver,
   registerRecurringStep,
 } from "./recurring.js";
 
@@ -42,6 +45,9 @@ function fakeBoss() {
       ops.push(`schedule:${name}`);
       schedules.push({ name, cron, options });
     },
+    async unschedule(name) {
+      ops.push(`unschedule:${name}`);
+    },
   };
   return { boss, sent, queues, queueUpdates, schedules, workers, workOptions, ops };
 }
@@ -57,7 +63,7 @@ function stepOf(overrides: Partial<RecurringStep> = {}): RecurringStep {
   };
 }
 
-test("registration creates a stately queue, a minute reviver, a seed job, and the consumer last", async () => {
+test("registration creates a stately queue, a seed job, and the consumer last", async () => {
   const fb = fakeBoss();
   await registerRecurringStep(fb.boss, stepOf(), { logger: quietLogger });
 
@@ -73,12 +79,12 @@ test("registration creates a stately queue, a minute reviver, a seed job, and th
   // by earlier deploys.
   assert.deepEqual(fb.queueUpdates, [{ name: "test-step", options: lease }]);
 
-  // The reviver cron re-seeds the chain if it ever dies (crash between a pass
-  // and its reschedule). Its send must carry the chain singleton key so a
-  // healthy chain absorbs it as a no-op.
-  assert.deepEqual(fb.schedules, [
-    { name: "test-step", cron: "* * * * *", options: { singletonKey: RECURRING_CHAIN_KEY } },
-  ]);
+  // No per-queue cron: an unconditional minute seed parks a pending job
+  // behind a long-but-healthy active pass (false stuck-queue alerts) — dead
+  // chains are revived by the shared reviver instead, and the legacy
+  // per-queue schedule row is removed from earlier revisions.
+  assert.deepEqual(fb.schedules, []);
+  assert.ok(fb.ops.includes("unschedule:test-step"));
 
   // The seed starts the chain immediately at boot.
   assert.deepEqual(fb.sent, [
@@ -90,6 +96,65 @@ test("registration creates a stately queue, a minute reviver, a seed job, and th
   // The consumer is registered LAST so a partial registration never leaves a
   // live consumer on a half-configured queue.
   assert.equal(fb.ops.at(-1), "work:test-step");
+});
+
+test("the reviver seeds only dead chains", async () => {
+  const fb = fakeBoss();
+  const counts: ChainCounts[] = [
+    { queue: "busy-step", pending: 0, active: 1 }, // long pass in flight
+    { queue: "waiting-step", pending: 1, active: 0 }, // successor scheduled
+    { queue: "drained-step", pending: 0, active: 0 }, // dead
+    // "missing-step" absent entirely — also dead
+  ];
+  await registerRecurringReviver(
+    fb.boss,
+    [
+      { queue: "busy-step" },
+      { queue: "waiting-step" },
+      { queue: "drained-step" },
+      { queue: "missing-step" },
+    ],
+    async () => counts,
+    quietLogger,
+  );
+
+  assert.deepEqual(fb.queues, [
+    { name: RECURRING_REVIVER_QUEUE, options: { policy: "exclusive" } },
+  ]);
+  assert.equal(fb.schedules[0]?.name, RECURRING_REVIVER_QUEUE);
+  assert.equal(fb.schedules[0]?.cron, "* * * * *");
+  const reviver = fb.workers.get(RECURRING_REVIVER_QUEUE);
+  assert.ok(reviver);
+
+  await reviver([{ id: "revive-1", data: {} }]);
+
+  // A chain with an active pass or a queued successor must NOT get a seed —
+  // that pending job would age behind the pass and trip stuck-queue alerts.
+  assert.deepEqual(
+    fb.sent.map((s) => [s.name, s.options]),
+    [
+      ["drained-step", { singletonKey: RECURRING_CHAIN_KEY }],
+      ["missing-step", { singletonKey: RECURRING_CHAIN_KEY }],
+    ],
+  );
+});
+
+test("a reviver counts-load failure is swallowed and retried next minute", async () => {
+  const fb = fakeBoss();
+  await registerRecurringReviver(
+    fb.boss,
+    [{ queue: "some-step" }],
+    async () => {
+      throw new Error("pg down");
+    },
+    quietLogger,
+  );
+  const reviver = fb.workers.get(RECURRING_REVIVER_QUEUE);
+  assert.ok(reviver);
+
+  await reviver([{ id: "revive-1", data: {} }]); // must not throw
+
+  assert.deepEqual(fb.sent, [], "nothing may be seeded on unknown chain state");
 });
 
 test("expiry stays a comfortable multiple of the warn deadline, with a floor", () => {

--- a/apps/worker/src/worker/recurring.ts
+++ b/apps/worker/src/worker/recurring.ts
@@ -11,10 +11,13 @@
 //   - The chain itself: every pass reschedules in `finally`, so a failed pass
 //     still continues the chain (each pass is an idempotent sweep — "retrying"
 //     a failure IS the next pass, which is why the queue sets retryLimit 0).
-//   - A minute cron reviver per queue: if the chain dies anyway (process crash
-//     between a pass completing and its reschedule landing), the cron's send
-//     re-seeds it. On a healthy chain the send collapses against the queued
-//     successor via the singleton key.
+//   - A shared minute-cron reviver (registerRecurringReviver): if a chain dies
+//     anyway (process crash between a pass completing and its reschedule
+//     landing), the reviver re-seeds it. It seeds ONLY chains with no queued
+//     and no active job: an unconditional seed during a legitimately long
+//     pass would park a pending job behind the active one for the pass's
+//     whole duration — tripping stuck-queue alerting on a healthy queue — and
+//     its dedupe would swallow the successor's intended interval.
 //
 // Passes never overlap, across processes included: the `stately` policy plus
 // one fixed singleton key allows at most one ACTIVE job per queue anywhere in
@@ -30,6 +33,7 @@
 import { logger as defaultLogger } from "../logger.js";
 
 export const RECURRING_CHAIN_KEY = "chain";
+export const RECURRING_REVIVER_QUEUE = "recurring-reviver";
 const REVIVER_SCHEDULE = "* * * * *";
 
 // Soft deadline: a pass running longer than this is logged (it shows up next
@@ -55,6 +59,7 @@ export type RecurringBoss = {
   ): Promise<unknown>;
   send(name: string, data: object, options?: object): Promise<unknown>;
   schedule(name: string, cron: string, data?: unknown, options?: unknown): Promise<unknown>;
+  unschedule(name: string, key?: string): Promise<unknown>;
 };
 
 type LoggerLike = Pick<typeof defaultLogger, "info" | "warn" | "error">;
@@ -106,7 +111,10 @@ export async function registerRecurringStep(
   // keep the mutable lease settings in sync across deploys while leaving the
   // immutable policy on the create path.
   await boss.updateQueue(step.queue, lease);
-  await boss.schedule(step.queue, REVIVER_SCHEDULE, {}, { singletonKey: RECURRING_CHAIN_KEY });
+  // Earlier revisions revived via an unconditional per-queue cron; its
+  // schedule row persists in the database, so remove it or long passes keep
+  // tripping the false-pending problem the shared reviver exists to avoid.
+  await boss.unschedule(step.queue);
   await boss.send(step.queue, {}, { singletonKey: RECURRING_CHAIN_KEY });
 
   await boss.work(step.queue, { batchSize: 1 }, async () => {
@@ -130,7 +138,7 @@ export async function registerRecurringStep(
             step: step.queue,
             err: err instanceof Error ? err.message : String(err),
           },
-          "failed to reschedule recurring step; the reviver cron restores it within a minute",
+          "failed to reschedule recurring step; the reviver restores it within a minute",
         );
       }
     }
@@ -182,4 +190,57 @@ export async function registerRecurringStep(
       if (onAbort) shutdown?.removeEventListener("abort", onAbort);
     }
   }
+}
+
+// Live queued/active job counts for a chain queue; zero/zero means the chain
+// is dead. Injected so the mechanism stays free of the database dependency
+// (recurring-steps.ts wires it to the queue-health loader).
+export type ChainCounts = { queue: string; pending: number; active: number };
+
+// One shared minute cron that re-seeds DEAD chains only (see header). A
+// missing entry in the counts means the queue has no live jobs at all — the
+// loader only returns queues with queued/retry/active rows — so it is seeded.
+// Seeding is idempotent (chain singleton key), so racing a just-landed
+// reschedule is harmless; seeds for steps whose consumer never registered sit
+// inert until a healthy process picks them up.
+export async function registerRecurringReviver(
+  boss: RecurringBoss,
+  steps: ReadonlyArray<Pick<RecurringStep, "queue">>,
+  loadChainCounts: () => Promise<ChainCounts[]>,
+  logger: LoggerLike = defaultLogger,
+): Promise<void> {
+  await boss.createQueue(RECURRING_REVIVER_QUEUE, { policy: "exclusive" });
+  await boss.schedule(RECURRING_REVIVER_QUEUE, REVIVER_SCHEDULE);
+  await boss.work(RECURRING_REVIVER_QUEUE, { batchSize: 1 }, async () => {
+    let counts: Map<string, ChainCounts>;
+    try {
+      counts = new Map((await loadChainCounts()).map((c) => [c.queue, c]));
+    } catch (err) {
+      logger.error(
+        { scope: "worker.recurring", err: err instanceof Error ? err.message : String(err) },
+        "reviver failed to load chain counts; retrying next minute",
+      );
+      return;
+    }
+    for (const step of steps) {
+      const c = counts.get(step.queue);
+      if (c && (c.pending > 0 || c.active > 0)) continue;
+      try {
+        await boss.send(step.queue, {}, { singletonKey: RECURRING_CHAIN_KEY });
+        logger.warn(
+          { scope: "worker.recurring", step: step.queue },
+          "revived a dead recurring chain",
+        );
+      } catch (err) {
+        logger.error(
+          {
+            scope: "worker.recurring",
+            step: step.queue,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          "failed to revive a dead recurring chain; retrying next minute",
+        );
+      }
+    }
+  });
 }


### PR DESCRIPTION
Follow-up to #241/#281.

The per-queue minute reviver cron seeded unconditionally. During a legitimately long pass (agent chats and digests may run 10–15 minutes before their warn deadline) the stately policy accepts that seed as a *queued* job next to the active one, where it sits for the pass's whole duration — aging past the stuck-queue alert threshold on a perfectly healthy queue — and its dedupe then swallows the successor's intended `startAfter` interval, so the next pass runs immediately instead of after the pause.

Fix:
- Replace the per-queue crons with **one shared `recurring-reviver` job** (exclusive queue, minute cron) whose handler loads each chain's queued/active counts (reusing the queue-health loader) and seeds **only chains with neither** — a dead chain revives within a minute, a busy chain is left alone.
- Step registration removes the legacy per-queue schedule rows (`unschedule`) so databases that booted an earlier revision don't keep the old unconditional seeding.
- A counts-load failure logs and skips the round (never seed on unknown state); a reviver registration failure is non-fatal — healthy chains self-perpetuate without it.

## Testing

- `test:recurring` (10): reviver seeds only dead/missing chains and skips active/queued ones; counts-load failure seeds nothing; step registration creates no per-queue schedule and unschedules the legacy one.
- `test:recurring-steps` (4): the shared reviver registers exactly once alongside the steps.
- `test:worker-tick`, `test:queue-health`, worker typecheck, biome all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced per-queue minute revivers with a single shared `recurring-reviver` that only seeds dead recurring chains. This prevents false stuck-queue alerts and keeps the intended pause between passes.

- **Bug Fixes**
  - Added a shared exclusive `recurring-reviver` cron that seeds only chains with zero queued and zero active jobs (via queue-health counts).
  - Removed legacy per-queue schedules during step registration to stop unconditional minute seeds.
  - Safe failure modes: skip seeding if counts fail to load; reviver registration failure is non-fatal.
  - Tests updated to cover dead-only revival, single reviver registration, and unscheduling of legacy crons.

<sup>Written for commit a5faf5c82877b11fae1b7e9f736c26a4116cda87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

