### PR TITLE
Fix truncated telemetry transcript results

### DIFF
--- a/apps/web/src/incidents/IncidentTranscript.test.ts
+++ b/apps/web/src/incidents/IncidentTranscript.test.ts
@@ -164,6 +164,44 @@ test("custom MCP calls and failures identify their server in the investigation t
   ]);
 });
 
+test("buildActivityFeed carries truncated telemetry metadata with the stored rows", () => {
+  const feed = buildActivityFeed([
+    event({
+      id: "trace-use-1",
+      providerEventId: "trace-provider-use-1",
+      kind: "agent.mcp_tool_use",
+      detail: { toolUse: { name: "query_traces", input: { service: "api" } } },
+    }),
+    event({
+      id: "trace-result-1",
+      kind: "agent.mcp_tool_result",
+      summary: '[{"trace_id":"abc"}]',
+      detail: {
+        toolResult: {
+          toolUseId: "trace-provider-use-1",
+          isError: false,
+          truncated: true,
+          originalRowCount: 50,
+          storedRowCount: 1,
+        },
+      },
+    }),
+  ]);
+
+  assert.deepEqual(feed, [
+    {
+      type: "telemetry",
+      id: "trace-use-1",
+      kind: "traces",
+      input: { service: "api" },
+      rows: [{ trace_id: "abc" }],
+      resultState: "truncated",
+      originalRowCount: 50,
+      isError: false,
+    },
+  ]);
+});
+
 test("markAwaitingQuestion marks the latest repeated ask_human prompt", () => {
   const feed = buildActivityFeed([
     event({

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -14,8 +14,10 @@ import {
 } from "./incident-activity-feed.ts";
 import {
   type TelemetryKind,
+  type TelemetryResultState,
   exploreHref,
   formatRangeLabel,
+  telemetryResultNotice,
   toLogRows,
   toMetricRows,
   toTraceRows,
@@ -513,6 +515,8 @@ function TelemetryEntry({
         kind={item.kind}
         input={item.input}
         rows={item.rows}
+        resultState={item.resultState}
+        originalRowCount={item.originalRowCount}
         isError={item.isError}
       />
     </div>
@@ -553,17 +557,22 @@ export function TelemetryQueryWidget({
   kind,
   input,
   rows,
+  resultState = "complete",
+  originalRowCount = null,
   isError,
 }: {
   kind: TelemetryKind;
   input: Record<string, unknown>;
   rows: Record<string, unknown>[];
+  resultState?: TelemetryResultState;
+  originalRowCount?: number | null;
   isError?: boolean;
 }) {
   const range = (input.range as { since?: string; until?: string } | undefined) ?? undefined;
   const windowLabel = formatRangeLabel(range);
   const count = rows.length;
   const empty = count === 0;
+  const resultNotice = telemetryResultNotice(resultState, count, originalRowCount);
 
   return (
     <div className="mt-3 overflow-hidden rounded-lg border border-border bg-surface">
@@ -580,24 +589,35 @@ export function TelemetryQueryWidget({
       <div className="px-3.5 py-3">
         {isError ? (
           <div className="py-6 text-center font-mono text-[11px] text-danger">query failed</div>
-        ) : empty ? (
-          <div className="py-6 text-center font-mono text-[11px] text-subtle">
-            no rows in this window
-          </div>
-        ) : kind === "metrics" ? (
-          <MetricWidget
-            rows={rows}
-            range={range}
-            metricName={String(input.metric_name ?? "value")}
-          />
-        ) : kind === "logs" ? (
-          <div className="overflow-x-auto">
-            <LogsTable rows={toLogRows(rows)} />
-          </div>
         ) : (
-          <div className="overflow-x-auto">
-            <TracesTable rows={toTraceRows(rows)} />
-          </div>
+          <>
+            {resultNotice && (
+              <div className="mb-3 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 font-mono text-[11px] text-warning">
+                {resultNotice}
+              </div>
+            )}
+            {empty ? (
+              !resultNotice && (
+                <div className="py-6 text-center font-mono text-[11px] text-subtle">
+                  no rows in this window
+                </div>
+              )
+            ) : kind === "metrics" ? (
+              <MetricWidget
+                rows={rows}
+                range={range}
+                metricName={String(input.metric_name ?? "value")}
+              />
+            ) : kind === "logs" ? (
+              <div className="overflow-x-auto">
+                <LogsTable rows={toLogRows(rows)} />
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <TracesTable rows={toTraceRows(rows)} />
+              </div>
+            )}
+          </>
         )}
       </div>
 

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -557,15 +557,15 @@ export function TelemetryQueryWidget({
   kind,
   input,
   rows,
-  resultState = "complete",
-  originalRowCount = null,
+  resultState,
+  originalRowCount,
   isError,
 }: {
   kind: TelemetryKind;
   input: Record<string, unknown>;
   rows: Record<string, unknown>[];
-  resultState?: TelemetryResultState;
-  originalRowCount?: number | null;
+  resultState: TelemetryResultState;
+  originalRowCount: number | null;
   isError?: boolean;
 }) {
   const range = (input.range as { since?: string; until?: string } | undefined) ?? undefined;
@@ -1112,7 +1112,13 @@ export function IncidentSummaryTelemetry({ events }: { events: IncidentEvent[] }
   return (
     <div className="mt-4">
       <div className="mb-2 text-[12px] font-medium text-muted">Cited telemetry</div>
-      <TelemetryQueryWidget kind={metric.kind} input={metric.input} rows={metric.rows} />
+      <TelemetryQueryWidget
+        kind={metric.kind}
+        input={metric.input}
+        rows={metric.rows}
+        resultState={metric.resultState}
+        originalRowCount={metric.originalRowCount}
+      />
     </div>
   );
 }

--- a/apps/web/src/incidents/incident-activity-feed.ts
+++ b/apps/web/src/incidents/incident-activity-feed.ts
@@ -1,9 +1,20 @@
 import type { IncidentEvent } from "../api.ts";
 import { type MemoryActivity, memoryActivityFromTool } from "./memory-tool-activity.ts";
-import { type TelemetryKind, parseResultRows, telemetryToolKind } from "./telemetry-result.ts";
+import {
+  type TelemetryKind,
+  type TelemetryResultState,
+  parseTelemetryResult,
+  telemetryToolKind,
+} from "./telemetry-result.ts";
 
 type ToolUseDetail = { name?: string; input?: Record<string, unknown>; mcpServerName?: string };
-type ToolResultDetail = { toolUseId?: string; isError?: boolean };
+type ToolResultDetail = {
+  toolUseId?: string;
+  isError?: boolean;
+  truncated?: boolean;
+  originalRowCount?: number;
+  storedRowCount?: number;
+};
 
 function readToolUse(e: IncidentEvent): ToolUseDetail | null {
   const detail = e.detail as { toolUse?: ToolUseDetail } | null;
@@ -23,6 +34,8 @@ export type TranscriptItem =
       kind: TelemetryKind;
       input: Record<string, unknown>;
       rows: Record<string, unknown>[];
+      resultState: TelemetryResultState;
+      originalRowCount: number | null;
       isError: boolean;
     }
   | {
@@ -184,12 +197,19 @@ export function buildActivityFeed(
         isError,
       );
       if (kind) {
+        const resultDetail = result ? readToolResult(result) : null;
+        const parsedResult = parseTelemetryResult(result?.summary, {
+          truncated: resultDetail?.truncated,
+          originalRowCount: resultDetail?.originalRowCount,
+        });
         items.push({
           type: "telemetry",
           id: event.id,
           kind,
           input: use?.input ?? {},
-          rows: parseResultRows(result?.summary),
+          rows: parsedResult.rows,
+          resultState: parsedResult.state,
+          originalRowCount: parsedResult.originalRowCount,
           isError,
         });
       } else if (memory) {

--- a/apps/web/src/incidents/telemetry-result.test.ts
+++ b/apps/web/src/incidents/telemetry-result.test.ts
@@ -4,8 +4,10 @@ import {
   exploreHref,
   formatRangeLabel,
   normalizeBucket,
+  parseTelemetryResult,
   parseResultRows,
   telemetryToolKind,
+  telemetryResultNotice,
   toMetricRows,
   toTraceRows,
 } from "./telemetry-result.ts";
@@ -47,6 +49,34 @@ test("parseResultRows is null-safe and rejects non-arrays / scalars / bad JSON",
   assert.deepEqual(parseResultRows("not json"), []);
   assert.deepEqual(parseResultRows('{"a":1}'), []); // object, not array
   assert.deepEqual(parseResultRows("[1,2,3]"), []); // scalars filtered out
+});
+
+test("parseTelemetryResult distinguishes an empty query from a legacy truncated result", () => {
+  assert.deepEqual(parseTelemetryResult("[]"), {
+    rows: [],
+    state: "complete",
+    originalRowCount: 0,
+  });
+  assert.deepEqual(parseTelemetryResult('[{"trace_id":"abc","span_name":"fetch...'), {
+    rows: [],
+    state: "truncated",
+    originalRowCount: null,
+  });
+});
+
+test("telemetryResultNotice describes partial and unavailable recorded results", () => {
+  assert.equal(
+    telemetryResultNotice("truncated", 3, 50),
+    "Showing 3 of 50 recorded rows; the stored result was truncated.",
+  );
+  assert.equal(
+    telemetryResultNotice("truncated", 0, null),
+    "The recorded result was truncated before it could be displayed.",
+  );
+  assert.equal(
+    telemetryResultNotice("invalid", 0, null),
+    "The recorded result could not be displayed.",
+  );
 });
 
 test("normalizeBucket trims ClickHouse nanos and T separator to second precision", () => {

--- a/apps/web/src/incidents/telemetry-result.test.ts
+++ b/apps/web/src/incidents/telemetry-result.test.ts
@@ -64,6 +64,14 @@ test("parseTelemetryResult distinguishes an empty query from a legacy truncated 
   });
 });
 
+test("parseTelemetryResult keeps an omitted truncated total unknown", () => {
+  assert.deepEqual(parseTelemetryResult('[{"trace_id":"abc"}]', { truncated: true }), {
+    rows: [{ trace_id: "abc" }],
+    state: "truncated",
+    originalRowCount: null,
+  });
+});
+
 test("telemetryResultNotice describes partial and unavailable recorded results", () => {
   assert.equal(
     telemetryResultNotice("truncated", 3, 50),

--- a/apps/web/src/incidents/telemetry-result.ts
+++ b/apps/web/src/incidents/telemetry-result.ts
@@ -2,12 +2,12 @@
 // `agent.mcp_tool_use` of query_metrics/query_logs/query_traces, paired with its
 // `agent.mcp_tool_result`) into widget-ready data.
 //
-// The agent's MCP query tools return a JSON array of rows; the worker persists
-// that array verbatim in `incident_events.summary` of the result event. We render
-// the agent's *recorded* result rather than re-running the query — it's faithful
-// to what the agent saw, survives ClickHouse retention, and avoids cross-project
-// scope issues (the explore endpoints also can't express span_attrs/log_attrs
-// filters the MCP tools accept, so a live re-run would be lossy).
+// The agent's MCP query tools return a JSON array of rows. The recorded event
+// stores that array, or a valid row-bounded prefix plus truncation metadata when
+// the response is too large. We render the recorded result rather than re-running
+// the query — it survives ClickHouse retention and avoids cross-project scope
+// issues (the explore endpoints also can't express span_attrs/log_attrs filters
+// the MCP tools accept, so a live re-run would be lossy).
 
 import type { LogRow, MetricSeriesRow } from "../api.ts";
 import { parseAbsoluteRange } from "../design/range-url.ts";
@@ -25,6 +25,19 @@ export type TraceTableRow = {
 
 export type ToolRange = { since?: string; until?: string } | undefined;
 
+export type TelemetryResultState = "complete" | "truncated" | "missing" | "invalid";
+
+export type ParsedTelemetryResult = {
+  rows: Record<string, unknown>[];
+  state: TelemetryResultState;
+  originalRowCount: number | null;
+};
+
+export type TelemetryResultMetadata = {
+  truncated?: boolean;
+  originalRowCount?: number;
+};
+
 export function telemetryToolKind(name: string | undefined): TelemetryKind | null {
   switch (name) {
     case "query_metrics":
@@ -41,16 +54,53 @@ export function telemetryToolKind(name: string | undefined): TelemetryKind | nul
 /** Parse the JSON array of result rows the agent recorded. Null-safe; returns []
  *  for empty results, scalars, objects, or unparseable text. */
 export function parseResultRows(text: string | null | undefined): Record<string, unknown>[] {
-  if (!text) return [];
+  return parseTelemetryResult(text).rows;
+}
+
+export function parseTelemetryResult(
+  text: string | null | undefined,
+  metadata: TelemetryResultMetadata = {},
+): ParsedTelemetryResult {
+  if (!text) return { rows: [], state: "missing", originalRowCount: null };
   const trimmed = text.trim();
-  if (!trimmed.startsWith("[")) return [];
+  if (!trimmed.startsWith("[")) {
+    return { rows: [], state: "invalid", originalRowCount: null };
+  }
   try {
     const parsed = JSON.parse(trimmed);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter((r): r is Record<string, unknown> => !!r && typeof r === "object");
+    if (!Array.isArray(parsed)) {
+      return { rows: [], state: "invalid", originalRowCount: null };
+    }
+    const rows = parsed.filter(
+      (row): row is Record<string, unknown> => !!row && typeof row === "object",
+    );
+    return {
+      rows,
+      state: metadata.truncated ? "truncated" : "complete",
+      originalRowCount: metadata.originalRowCount ?? rows.length,
+    };
   } catch {
-    return [];
+    return {
+      rows: [],
+      state: trimmed.endsWith("...") ? "truncated" : "invalid",
+      originalRowCount: null,
+    };
   }
+}
+
+export function telemetryResultNotice(
+  state: TelemetryResultState,
+  storedRowCount: number,
+  originalRowCount: number | null,
+): string | null {
+  if (state === "complete") return null;
+  if (state === "missing") return "The query result was not recorded.";
+  if (state === "invalid") return "The recorded result could not be displayed.";
+  if (storedRowCount === 0) {
+    return "The recorded result was truncated before it could be displayed.";
+  }
+  const total = originalRowCount === null ? "more" : String(originalRowCount);
+  return `Showing ${storedRowCount} of ${total} recorded rows; the stored result was truncated.`;
 }
 
 /** ClickHouse "YYYY-MM-DD HH:MM:SS.nanos" (or ISO) → "YYYY-MM-DD HH:MM:SS",

--- a/apps/web/src/incidents/telemetry-result.ts
+++ b/apps/web/src/incidents/telemetry-result.ts
@@ -77,7 +77,7 @@ export function parseTelemetryResult(
     return {
       rows,
       state: metadata.truncated ? "truncated" : "complete",
-      originalRowCount: metadata.originalRowCount ?? rows.length,
+      originalRowCount: metadata.originalRowCount ?? (metadata.truncated ? null : rows.length),
     };
   } catch {
     return {


### PR DESCRIPTION
## Summary

- distinguish genuinely empty telemetry queries from missing, invalid, or truncated recorded results
- render stored row prefixes with an explicit partial-result notice
- recognize legacy mid-JSON truncation instead of presenting it as zero rows

## Validation

- `pnpm exec tsx --test apps/web/src/incidents/telemetry-result.test.ts apps/web/src/incidents/IncidentTranscript.test.ts`
- `pnpm --filter @superlog/web typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes telemetry transcript and cited telemetry showing as empty when recorded output was truncated, missing, or invalid. The UI now shows clear notices and renders stored row prefixes while preserving truncation details and unknown totals.

- **Bug Fixes**
  - Added `parseTelemetryResult` to classify results as `complete`, `truncated`, `missing`, or `invalid` (including legacy mid-JSON `...`) and capture `originalRowCount`; keeps totals unknown when not provided.
  - Propagate `resultState` and `originalRowCount` through the activity feed into both transcript and “Cited telemetry” widgets.
  - Widgets use `telemetryResultNotice` to show concise notices for partial/unavailable results and suppress the misleading “no rows” message when those notices apply.
  - Updated tests for parsing, feed metadata, and notices.

<sup>Written for commit 416f5a2ab90979c81656c3ff40e140a042a235d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

