### PR TITLE
Stabilize iOS Hermes error fingerprints

### DIFF
--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -2,6 +2,18 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { fingerprint, fingerprintLog, messageBucketFor, stripNullBytes } from "./index.js";
 
+function iosHermesStack(input: { applicationId: string; bundleName: string }): string {
+  const bundlePath =
+    `/var/mobile/Containers/Data/Application/${input.applicationId}` +
+    `/Library/Application Support/.expo-internal/${input.bundleName}`;
+  return [
+    "Error: fetch failed: The network connection was lost.",
+    `    at recordSpanError (address at ${bundlePath}:1:100)`,
+    `    at ?anon_0_ (address at ${bundlePath}:1:200)`,
+    "    at anonymous (address at InternalBytecode.js:1:300)",
+  ].join("\n");
+}
+
 // A single route-scanner error class (e.g. Phoenix NoRouteError) emits one
 // exception per probed path. The stacktrace is identical across all of them —
 // only the request path in the message differs — so without path normalization
@@ -30,6 +42,48 @@ test("fingerprint groups same-stack route-scanner errors that differ only by pat
     message: "no route found for GET /.env (AppWeb.Router)",
   });
   assert.equal(fp1.hash, fp2.hash);
+});
+
+test("fingerprint groups equivalent iOS Hermes stacks across app-container IDs", () => {
+  const first = fingerprint({
+    type: "Error",
+    stacktrace: iosHermesStack({
+      applicationId: "11111111-1111-4111-8111-111111111111",
+      bundleName: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bundle",
+    }),
+    message: "Could not PATCH data: The network connection was lost.",
+  });
+  const second = fingerprint({
+    type: "Error",
+    stacktrace: iosHermesStack({
+      applicationId: "22222222-2222-4222-8222-222222222222",
+      bundleName: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bundle",
+    }),
+    message: "Could not PATCH data: The network connection was lost.",
+  });
+
+  assert.equal(first.hash, second.hash);
+});
+
+test("fingerprint groups equivalent iOS Hermes stacks across Expo bundle IDs", () => {
+  const first = fingerprint({
+    type: "Error",
+    stacktrace: iosHermesStack({
+      applicationId: "11111111-1111-4111-8111-111111111111",
+      bundleName: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bundle",
+    }),
+    message: "Could not PATCH data: The network connection was lost.",
+  });
+  const second = fingerprint({
+    type: "Error",
+    stacktrace: iosHermesStack({
+      applicationId: "11111111-1111-4111-8111-111111111111",
+      bundleName: "bundle-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb.jsbundle",
+    }),
+    message: "Could not PATCH data: The network connection was lost.",
+  });
+
+  assert.equal(first.hash, second.hash);
 });
 
 test("messageBucketFor keeps a bare path token distinct from a real path", () => {

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -300,7 +300,17 @@ function normalizePath(p: string): string {
     .replace(/^webpack-internal:\/\/\/?/, "")
     .replace(/^\([^)]*\)\//, "")
     .replace(/^\.\//, "")
-    .replace(/^file:\/\//, "");
+    .replace(/^file:\/\//, "")
+    // iOS assigns each installed app a different UUID-named sandbox. Hermes
+    // includes that absolute sandbox path in frames, but it is deployment
+    // metadata rather than part of the failing code's identity.
+    .replace(
+      /\/var\/mobile\/Containers\/Data\/Application\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\//i,
+      "/var/mobile/Containers/Data/Application/<uuid>/",
+    )
+    // Expo gives the generated Hermes bundle a build-specific name. The
+    // function names still identify the failing code across app releases.
+    .replace(/(\/\.expo-internal\/)[^/]+\.(?:js)?bundle$/i, "$1<bundle>");
 
   out = out.replace(/^.*?\/((?:apps|packages|src|app|lib|pages)\/.*)$/, "$1");
   return out;


### PR DESCRIPTION
## Summary

- normalize per-install iOS application-container UUIDs in Hermes stack frames
- normalize build-specific Expo `.bundle` and `.jsbundle` identifiers
- add regression coverage proving equivalent errors group across installations and app builds

## Root cause

Hermes frames can contain absolute paths under `/var/mobile/Containers/Data/Application/<uuid>/.../.expo-internal/<bundle>`. Both the sandbox UUID and generated bundle filename vary independently of the failing code. Including them in the canonical frame list created a new fingerprint for equivalent errors.

The normalization is deliberately scoped to UUID-named iOS application sandboxes and Expo-internal bundle files. Function names, exception types, and normalized message buckets continue to distinguish errors.

## Validation

- `pnpm --filter @superlog/fingerprint test`
- `pnpm --filter @superlog/fingerprint typecheck`
- proxy ingest fingerprint tests
- worker telemetry ingestion tests
- Biome checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes error fingerprints in `@superlog/fingerprint` for iOS Hermes by stripping app-container UUIDs and Expo bundle IDs from stack frame paths. Equivalent errors now group across installs and builds, reducing duplicate issues.

- **Bug Fixes**
  - Normalize iOS sandbox UUID in Hermes paths (…/Application/<uuid>/…).
  - Normalize Expo bundle filenames to <bundle> for `.bundle`/`.jsbundle`.
  - Added regression tests to verify grouping across installations and builds.

<sup>Written for commit 7a10c398bf58302eb4f85939d0dfd23305ecfce7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

