### PR TITLE
Normalize generated Next.js chunk fingerprints

### DIFF
--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -27,6 +27,28 @@ test("fingerprint groups equivalent Next.js stacks whose generated chunk hashes 
   assert.equal(first.hash, second.hash);
 });
 
+test("fingerprint groups equivalent Next.js static chunks whose content hashes differ", () => {
+  const fingerprintFor = (chunkHash: string) =>
+    fingerprint({
+      type: "TypeError",
+      message: "Failed to render account page",
+      stacktrace: `    at renderAccount (/var/task/apps/web/.next/static/chunks/webpack-${chunkHash}.js:1:200)`,
+    });
+
+  assert.equal(fingerprintFor("332dbc5711e5ed").hash, fingerprintFor("9f76a111d542c0").hash);
+});
+
+test("fingerprint groups equivalent browser Next.js chunk URLs across builds", () => {
+  const fingerprintFor = (chunkHash: string) =>
+    fingerprint({
+      type: "TypeError",
+      message: "Failed to render account page",
+      stacktrace: `    at renderAccount (https://example.com/_next/static/chunks/app/page-${chunkHash}.js:1:200)`,
+    });
+
+  assert.equal(fingerprintFor("332dbc5711e5ed").hash, fingerprintFor("9f76a111d542c0").hash);
+});
+
 function iosHermesStack(input: { applicationId: string; bundleName: string }): string {
   const bundlePath =
     `/var/mobile/Containers/Data/Application/${input.applicationId}` +

--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -2,6 +2,31 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { fingerprint, fingerprintLog, messageBucketFor, stripNullBytes } from "./index.js";
 
+test("fingerprint groups equivalent Next.js stacks whose generated chunk hashes differ", () => {
+  const stackFor = (chunkHash: string) =>
+    [
+      "api_response_error: Too Many Requests",
+      "    at a7.request (/var/task/apps/web/.next/server/chunks/ssr/node_modules__pnpm_dab6c57e._.js:17:64695)",
+      "    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)",
+      `    at async f (/var/task/apps/web/.next/server/chunks/ssr/[root-of-the-server]__${chunkHash}._.js:2:2000)`,
+      `    at async h (/var/task/apps/web/.next/server/chunks/ssr/[root-of-the-server]__${chunkHash}._.js:2:3306)`,
+      "    at async m (/var/task/apps/web/.next/server/chunks/ssr/_978abe5d._.js:2:8316)",
+    ].join("\n");
+
+  const first = fingerprint({
+    type: "api_response_error",
+    message: "Too Many Requests",
+    stacktrace: stackFor("cb666142"),
+  });
+  const second = fingerprint({
+    type: "api_response_error",
+    message: "Too Many Requests",
+    stacktrace: stackFor("9598d6e6"),
+  });
+
+  assert.equal(first.hash, second.hash);
+});
+
 // A single route-scanner error class (e.g. Phoenix NoRouteError) emits one
 // exception per probed path. The stacktrace is identical across all of them —
 // only the request path in the message differs — so without path normalization

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -303,5 +303,12 @@ function normalizePath(p: string): string {
     .replace(/^file:\/\//, "");
 
   out = out.replace(/^.*?\/((?:apps|packages|src|app|lib|pages)\/.*)$/, "$1");
+  // Next.js/Turbopack puts content hashes in generated chunk filenames. The
+  // same source stack can therefore acquire a different path identity across
+  // chunks (or builds), which must not create a fresh issue fingerprint.
+  out = out.replace(
+    /(\/\.next\/(?:server|static)\/(?:[^/]+\/)*[^/]*?)[0-9a-f]{8,}(?=\._\.js(?:$|[?#]))/gi,
+    "$1<hash>",
+  );
   return out;
 }

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -312,13 +312,13 @@ function normalizePath(p: string): string {
     // function names still identify the failing code across app releases.
     .replace(/(\/\.expo-internal\/)[^/]+\.(?:js)?bundle$/i, "$1<bundle>");
 
-  out = out.replace(/^.*?\/((?:apps|packages|src|app|lib|pages)\/.*)$/, "$1");
   // Next.js/Turbopack puts content hashes in generated chunk filenames. The
   // same source stack can therefore acquire a different path identity across
   // chunks (or builds), which must not create a fresh issue fingerprint.
   out = out.replace(
-    /(\/\.next\/(?:server|static)\/(?:[^/]+\/)*[^/]*?)[0-9a-f]{8,}(?=\._\.js(?:$|[?#]))/gi,
+    /(\/(?:\.next|_next)\/(?:server|static)\/(?:[^/]+\/)*[^/]*?)[0-9a-f]{8,}(?=(?:\._)?\.js(?:$|[?#]))/gi,
     "$1<hash>",
   );
+  out = out.replace(/^.*?\/((?:apps|packages|src|app|lib|pages)\/.*)$/, "$1");
   return out;
 }


### PR DESCRIPTION
## Summary

- canonicalize generated Next.js and Turbopack content hashes in normalized stack-frame paths
- prevent equivalent exceptions from producing separate issue fingerprints when only chunk hashes differ
- add a regression test based on production-shaped server chunk stacks

## Root cause

Fingerprint canonicalization included up to five normalized stack frames, but path normalization preserved content hashes embedded in generated `.next` chunk filenames. Equivalent exceptions could therefore receive different fingerprints across generated chunks or builds.

## Impact

Equivalent Next.js errors now fold into the same issue when their stack identity differs only by generated chunk content hashes. Function names and the remaining call-stack structure are still preserved, so genuinely different call paths remain distinct.

## Validation

- `pnpm --dir superlog --filter @superlog/fingerprint test`
- `pnpm --dir superlog --filter @superlog/fingerprint typecheck`
- proxy fingerprint and Vercel drain tests
- worker telemetry ingestion tests
- proxy and worker typechecks
- targeted formatter check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize Next.js/Turbopack stack paths by stripping content hashes from generated chunk filenames in `.next` and `/_next` so equivalent errors group under one fingerprint across builds. Covers server, static, and browser chunk URLs.

- **Bug Fixes**
  - In `@superlog/fingerprint`, extend `normalizePath` to strip hashes from `.next`/`_next` server and static chunk filenames and URLs.
  - Add tests for server `ssr` chunks, static `webpack-*`, and browser `/_next/static` URLs to ensure identical fingerprints when only the chunk hash differs.

<sup>Written for commit 2a3d1c0a85dff7167451e181971150b2664d873e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

