### PR TITLE
Normalize Next.js chunk URL suffixes

### DIFF
--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -49,6 +49,17 @@ test("fingerprint groups equivalent browser Next.js chunk URLs across builds", (
   assert.equal(fingerprintFor("332dbc5711e5ed").hash, fingerprintFor("9f76a111d542c0").hash);
 });
 
+test("fingerprint ignores cache-busting suffixes on browser Next.js chunk URLs", () => {
+  const fingerprintFor = (suffix: string) =>
+    fingerprint({
+      type: "TypeError",
+      message: "Failed to render account page",
+      stacktrace: `    at renderAccount (https://example.com/_next/static/chunks/app/page-332dbc5711e5ed.js${suffix}:1:200)`,
+    });
+
+  assert.equal(fingerprintFor("?dpl=first").hash, fingerprintFor("#dpl=second").hash);
+});
+
 function iosHermesStack(input: { applicationId: string; bundleName: string }): string {
   const bundlePath =
     `/var/mobile/Containers/Data/Application/${input.applicationId}` +

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -316,8 +316,8 @@ function normalizePath(p: string): string {
   // same source stack can therefore acquire a different path identity across
   // chunks (or builds), which must not create a fresh issue fingerprint.
   out = out.replace(
-    /(\/(?:\.next|_next)\/(?:server|static)\/(?:[^/]+\/)*[^/]*?)[0-9a-f]{8,}(?=(?:\._)?\.js(?:$|[?#]))/gi,
-    "$1<hash>",
+    /(\/(?:\.next|_next)\/(?:server|static)\/(?:[^/]+\/)*[^/]*?)[0-9a-f]{8,}((?:\._)?\.js)(?:[?#].*)?$/gi,
+    "$1<hash>$2",
   );
   out = out.replace(/^.*?\/((?:apps|packages|src|app|lib|pages)\/.*)$/, "$1");
   return out;


### PR DESCRIPTION
## Summary

- remove cache-busting query strings and fragments while canonicalizing generated Next.js chunk URLs
- preserve the normalized chunk extension while replacing content hashes
- add regression coverage for browser stack frames whose chunk suffixes differ

## Root cause

The existing Next.js chunk normalization replaced generated content hashes but left trailing URL query strings and fragments intact. Deployment-specific cache-busting values could therefore continue splitting otherwise equivalent browser exceptions.

## Validation

- fingerprint package tests and typecheck
- proxy fingerprint and Vercel drain tests
- worker telemetry ingestion tests
- proxy and worker typechecks
- targeted formatting and diff checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize Next.js chunk URLs by stripping query/fragment suffixes and preserving the `.js` extension while replacing content hashes. This prevents cache-busting from splitting equivalent browser error fingerprints across deploys.

- **Bug Fixes**
  - Update `packages/fingerprint/src/index.ts` regex to replace the hash and drop `?`/`#` suffixes, keeping `.js` or `._.js`.
  - Add tests in `packages/fingerprint/src/index.test.ts` to confirm identical fingerprints across builds and cache-busting variants.

<sup>Written for commit 23b04665e13c3fb9faa8480304778b000c15ff48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

