### PR TITLE
Fix Linear ticket delivery source of truth

### DIFF
--- a/apps/worker/src/agent-runs/deliverable-records.ts
+++ b/apps/worker/src/agent-runs/deliverable-records.ts
@@ -275,9 +275,9 @@ export async function recordFiledLinearTicket(
   ctx: AgentRunContext,
   ticket: schema.AgentRunLinearTicket | null | undefined,
   opts: { identifier?: string | null } = {},
-): Promise<void> {
-  if (!ticket?.id) return;
-  if (!ctx.linearInstall) return;
+): Promise<boolean> {
+  if (!ticket?.id) return false;
+  if (!ctx.linearInstall) return false;
   const now = new Date();
   const inserted = await db
     .insert(schema.agentLinearTickets)
@@ -296,7 +296,18 @@ export async function recordFiledLinearTicket(
     })
     .returning({ id: schema.agentLinearTickets.id });
   const row = inserted[0];
-  if (!row) return;
+  if (!row) {
+    const existing = await db.query.agentLinearTickets.findFirst({
+      where: and(
+        eq(schema.agentLinearTickets.workspaceId, ctx.linearInstall.workspaceId),
+        eq(schema.agentLinearTickets.ticketId, ticket.id),
+        eq(schema.agentLinearTickets.incidentId, ctx.incident.id),
+        eq(schema.agentLinearTickets.agentRunId, ctx.agentRun.id),
+      ),
+      columns: { id: true },
+    });
+    return !!existing;
+  }
   await db
     .insert(schema.agentLinearTicketEvents)
     .values({
@@ -329,6 +340,7 @@ export async function recordFiledLinearTicket(
       org,
     });
   }
+  return true;
 }
 
 export async function recordOpenedAgentPullRequest(

--- a/apps/worker/src/agent-runs/linear-delivery.test.ts
+++ b/apps/worker/src/agent-runs/linear-delivery.test.ts
@@ -152,15 +152,44 @@ test("resolves a legacy recorded Linear identifier to the issue UUID", async () 
   assert.deepEqual(deps.calls.searchIssues, ["ENG-7"]);
 });
 
-test("creates a ticket without trusting fuzzy provider search results", async () => {
+test("recovers a provider-created ticket only when its exact investigation marker is present", async () => {
+  const marker = investigationMarker("inc-1", "run-1");
   const deps = makeDeps({
     searchIssues: async () => [
       {
-        id: "unrelated-issue",
+        id: "issue-3",
         identifier: "OPS-3",
         url: "https://linear.app/ops/issue/OPS-3",
+        description: `Investigation complete.\n\n${marker}`,
       },
     ],
+  });
+
+  const ticket = await deliverLinearTicketWithDeps(BASE_ARGS, RESULT, deps);
+
+  assert.deepEqual(ticket, {
+    ticketId: "issue-3",
+    identifier: "OPS-3",
+    url: "https://linear.app/ops/issue/OPS-3",
+    created: false,
+  });
+  assert.equal(deps.calls.createIssue.length, 0);
+});
+
+test("creates a ticket without trusting fuzzy provider search results", async () => {
+  const searchTerms: string[] = [];
+  const deps = makeDeps({
+    searchIssues: async (term) => {
+      searchTerms.push(term);
+      return [
+        {
+          id: "unrelated-issue",
+          identifier: "OPS-3",
+          url: "https://linear.app/ops/issue/OPS-3",
+          description: "superlog_incident_id=someone-else superlog_agent_run_id=another-run",
+        },
+      ];
+    },
   });
   const ticket = await deliverLinearTicketWithDeps(BASE_ARGS, RESULT, deps);
   assert.deepEqual(ticket, {
@@ -169,7 +198,7 @@ test("creates a ticket without trusting fuzzy provider search results", async ()
     url: "https://linear.app/eng/issue/ENG-42",
     created: true,
   });
-  assert.equal(deps.calls.searchIssues.length, 0);
+  assert.deepEqual(searchTerms, [investigationMarker("inc-1", "run-1")]);
   assert.equal(deps.calls.createIssue.length, 1);
 });
 

--- a/apps/worker/src/agent-runs/linear-delivery.test.ts
+++ b/apps/worker/src/agent-runs/linear-delivery.test.ts
@@ -132,6 +132,11 @@ test("resolves a legacy recorded Linear identifier to the issue UUID", async () 
       return term === "ENG-7"
         ? [
             {
+              id: "unrelated-issue",
+              identifier: "OPS-3",
+              url: "https://linear.app/ops/issue/OPS-3",
+            },
+            {
               id: "0b6e7f7e-6f3a-4b8e-9a4e-2d1c3b4a5f6e",
               identifier: "ENG-7",
               url: "https://linear.app/eng/issue/ENG-7",
@@ -147,27 +152,31 @@ test("resolves a legacy recorded Linear identifier to the issue UUID", async () 
   assert.deepEqual(deps.calls.searchIssues, ["ENG-7"]);
 });
 
-test("dedupes a retried completion against its investigation marker", async () => {
+test("creates a ticket without trusting fuzzy provider search results", async () => {
   const deps = makeDeps({
-    searchIssues: async (term) =>
-      term === investigationMarker("inc-1", "run-1")
-        ? [{ id: "issue-3", identifier: "OPS-3", url: "https://linear.app/ops/issue/OPS-3" }]
-        : [],
+    searchIssues: async () => [
+      {
+        id: "unrelated-issue",
+        identifier: "OPS-3",
+        url: "https://linear.app/ops/issue/OPS-3",
+      },
+    ],
   });
   const ticket = await deliverLinearTicketWithDeps(BASE_ARGS, RESULT, deps);
   assert.deepEqual(ticket, {
-    ticketId: "issue-3",
-    identifier: "OPS-3",
-    url: "https://linear.app/ops/issue/OPS-3",
-    created: false,
+    ticketId: "issue-uuid",
+    identifier: "ENG-42",
+    url: "https://linear.app/eng/issue/ENG-42",
+    created: true,
   });
-  assert.equal(deps.calls.createIssue.length, 0);
+  assert.equal(deps.calls.searchIssues.length, 0);
+  assert.equal(deps.calls.createIssue.length, 1);
 });
 
 test("returns null and marks reauth on revoked-token errors, never throwing", async () => {
   const deps = makeDeps({
-    searchIssues: async () => {
-      throw new Error("linear searchIssues query failed: 401 invalid_grant refresh token revoked");
+    createIssue: async () => {
+      throw new Error("linear issueCreate failed: 401 invalid_grant refresh token revoked");
     },
   });
   const ticket = await deliverLinearTicketWithDeps(BASE_ARGS, RESULT, deps);

--- a/apps/worker/src/agent-runs/linear-delivery.ts
+++ b/apps/worker/src/agent-runs/linear-delivery.ts
@@ -25,8 +25,9 @@ import { logger } from "../logger.js";
 const WEB_ORIGIN = process.env.WEB_ORIGIN ?? "http://localhost:5173";
 
 // Marker line embedded in every ticket description for provider-side
-// correlation and diagnostics. Delivery retries use the locally recorded
-// ticket as their source of truth instead of fuzzy provider search.
+// correlation and recovery. Delivery retries use the locally recorded ticket
+// as their source of truth, with exact-marker provider lookup only when the
+// provider mutation succeeded before the local record committed.
 export function investigationMarker(incidentId: string, agentRunId: string): string {
   return `superlog_incident_id=${incidentId} superlog_agent_run_id=${agentRunId}`;
 }
@@ -148,6 +149,19 @@ export async function deliverLinearTicketWithDeps(
         ticketId: known.ticketId,
         identifier: known.identifier ?? known.ticketId,
         url: known.url,
+        created: false,
+      };
+    }
+
+    const marker = investigationMarker(args.incidentId, args.agentRunId);
+    const recovered = (await deps.searchIssues(marker)).find((issue) =>
+      issue.description?.includes(marker),
+    );
+    if (recovered) {
+      return {
+        ticketId: recovered.id,
+        identifier: recovered.identifier,
+        url: recovered.url,
         created: false,
       };
     }

--- a/apps/worker/src/agent-runs/linear-delivery.ts
+++ b/apps/worker/src/agent-runs/linear-delivery.ts
@@ -24,9 +24,9 @@ import { logger } from "../logger.js";
 
 const WEB_ORIGIN = process.env.WEB_ORIGIN ?? "http://localhost:5173";
 
-// Marker line embedded in every ticket description. It is scoped to the run,
-// rather than only the incident, so a delivery retry dedupes while a separate
-// completed investigation receives a new ticket.
+// Marker line embedded in every ticket description for provider-side
+// correlation and diagnostics. Delivery retries use the locally recorded
+// ticket as their source of truth instead of fuzzy provider search.
 export function investigationMarker(incidentId: string, agentRunId: string): string {
   return `superlog_incident_id=${incidentId} superlog_agent_run_id=${agentRunId}`;
 }
@@ -131,7 +131,10 @@ export async function deliverLinearTicketWithDeps(
     const known = await deps.findKnownTicket();
     if (known) {
       if (!isLinearIssueUuid(known.ticketId)) {
-        const [resolved] = await deps.searchIssues(known.identifier ?? known.ticketId);
+        const identifier = known.identifier ?? known.ticketId;
+        const resolved = (await deps.searchIssues(identifier)).find(
+          (issue) => issue.identifier === identifier,
+        );
         if (resolved) {
           return {
             ticketId: resolved.id,
@@ -145,18 +148,6 @@ export async function deliverLinearTicketWithDeps(
         ticketId: known.ticketId,
         identifier: known.identifier ?? known.ticketId,
         url: known.url,
-        created: false,
-      };
-    }
-
-    const [existing] = await deps.searchIssues(
-      investigationMarker(args.incidentId, args.agentRunId),
-    );
-    if (existing) {
-      return {
-        ticketId: existing.id,
-        identifier: existing.identifier,
-        url: existing.url,
         created: false,
       };
     }

--- a/apps/worker/src/agent-runs/linear-handoff.test.ts
+++ b/apps/worker/src/agent-runs/linear-handoff.test.ts
@@ -25,7 +25,7 @@ function makeDeps(overrides: Partial<LinearHandoffReconciliationDeps> = {}) {
         calls.deliveredPrUrls.push(prUrls);
         return TICKET;
       },
-      recordTicket: async () => {},
+      recordTicket: async () => true,
       linkPullRequests: async () => ({ linkedPullRequests: 2, complete: true }),
       markProcessed: async (ids: string[]) => {
         calls.processed.push(ids);
@@ -95,6 +95,23 @@ test("reconciliation keeps durable work pending when ticket delivery fails", asy
   );
 
   assert.equal(ticket, null);
+  assert.deepEqual(calls.processed, []);
+});
+
+test("reconciliation keeps durable work pending until the ticket is recorded locally", async () => {
+  const { deps, calls } = makeDeps({ recordTicket: async () => false });
+
+  const ticket = await reconcileLinearHandoffWithDeps(
+    {
+      hasInstall: true,
+      pendingEventIds: ["event-1"],
+      result: RESULT,
+      prUrls: [],
+    },
+    deps,
+  );
+
+  assert.equal(ticket, TICKET);
   assert.deepEqual(calls.processed, []);
 });
 

--- a/apps/worker/src/agent-runs/linear-handoff.ts
+++ b/apps/worker/src/agent-runs/linear-handoff.ts
@@ -11,7 +11,7 @@ export const LINEAR_HANDOFF_PENDING_EVENT = "linear_handoff_pending";
 
 export type LinearHandoffReconciliationDeps = {
   deliverTicket(result: AgentRunResult, prUrls: string[]): Promise<DeliveredLinearTicket | null>;
-  recordTicket(ticket: DeliveredLinearTicket): Promise<void>;
+  recordTicket(ticket: DeliveredLinearTicket): Promise<boolean>;
   linkPullRequests(
     ticket: DeliveredLinearTicket,
     prUrls: string[],
@@ -52,7 +52,8 @@ export async function reconcileLinearHandoffWithDeps(
 
   const ticket = await deps.deliverTicket(input.result, input.prUrls);
   if (!ticket) return null;
-  await deps.recordTicket(ticket);
+  const recorded = await deps.recordTicket(ticket);
+  if (!recorded) return ticket;
   const linking = await deps.linkPullRequests(ticket, input.prUrls);
   if (!linking.complete) return ticket;
   await deps.markProcessed(input.pendingEventIds);

--- a/packages/db/src/linear.ts
+++ b/packages/db/src/linear.ts
@@ -207,7 +207,12 @@ export async function listLinearTeams(accessToken: string): Promise<LinearTeam[]
   return data.teams.nodes;
 }
 
-export type LinearIssueRef = { id: string; identifier: string; url: string };
+export type LinearIssueRef = {
+  id: string;
+  identifier: string;
+  url: string;
+  description?: string | null;
+};
 
 export async function searchLinearIssues(
   accessToken: string,
@@ -215,7 +220,7 @@ export async function searchLinearIssues(
 ): Promise<LinearIssueRef[]> {
   const data = await linearGraphql<{ searchIssues: { nodes: LinearIssueRef[] } }>(
     accessToken,
-    "query($term: String!) { searchIssues(term: $term, first: 5) { nodes { id identifier url } } }",
+    "query($term: String!) { searchIssues(term: $term, first: 5) { nodes { id identifier url description } } }",
     { term },
     "searchIssues query",
   );


### PR DESCRIPTION
## Summary
- create a Linear issue for every new investigation handoff instead of trusting fuzzy provider search
- reuse the locally recorded ticket as the retry source of truth
- keep handoffs pending until the provider UUID is durably associated with the same incident and run
- require exact identifiers when resolving legacy ticket records

## Tests
- `pnpm --filter @superlog/worker test:linear-delivery`
- `pnpm --filter @superlog/worker exec tsx --test src/agent-runs/linear-handoff.test.ts`
- `pnpm --filter @superlog/worker typecheck`
- related lifecycle, linking, outcome, and completion test suites

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Linear ticket delivery deterministic by creating a new issue on each handoff and using the locally recorded ticket as the only retry source of truth. If provider creation succeeded but local recording didn’t, recover the ticket only when the exact investigation marker is present in the issue description; otherwise create a new one.

- **Bug Fixes**
  - Create for new handoffs; only recover when the issue description contains the exact investigation marker.
  - Resolve legacy records only when the search result’s `identifier` exactly matches.
  - Gate reconciliation on local recording; keep pending until the ticket is saved, then link PRs.
  - Handle 401/invalid_grant from issue creation by returning null and marking reauth (no throw).

- **Refactors**
  - `recordFiledLinearTicket` and handoff `recordTicket` now return `boolean`; `reconcileLinearHandoff` waits for a successful record before proceeding.

<sup>Written for commit 6c1ce9b55396090fffd75ea77d1ed1ba75d540c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

