### PR TITLE
Normalize hashless Next.js chunk URL suffixes

### DIFF
--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -60,6 +60,17 @@ test("fingerprint ignores cache-busting suffixes on browser Next.js chunk URLs",
   assert.equal(fingerprintFor("?dpl=first").hash, fingerprintFor("#dpl=second").hash);
 });
 
+test("fingerprint ignores cache-busting suffixes on hashless Next.js chunk URLs", () => {
+  const fingerprintFor = (suffix: string) =>
+    fingerprint({
+      type: "TypeError",
+      message: "Failed to render account page",
+      stacktrace: `    at renderAccount (https://example.com/_next/static/chunks/main-app.js${suffix}:1:200)`,
+    });
+
+  assert.equal(fingerprintFor("?dpl=first").hash, fingerprintFor("#dpl=second").hash);
+});
+
 function iosHermesStack(input: { applicationId: string; bundleName: string }): string {
   const bundlePath =
     `/var/mobile/Containers/Data/Application/${input.applicationId}` +

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -312,11 +312,19 @@ function normalizePath(p: string): string {
     // function names still identify the failing code across app releases.
     .replace(/(\/\.expo-internal\/)[^/]+\.(?:js)?bundle$/i, "$1<bundle>");
 
+  // Browser stack URLs can append deployment or cache metadata to any Next.js
+  // chunk, including stable filenames such as `main-app.js`. Strip that suffix
+  // before normalizing generated content hashes below.
+  out = out.replace(
+    /(\/(?:\.next|_next)\/(?:server|static)\/(?:[^/]+\/)*[^/?#]+(?:\._)?\.js)(?:[?#].*)$/gi,
+    "$1",
+  );
+
   // Next.js/Turbopack puts content hashes in generated chunk filenames. The
   // same source stack can therefore acquire a different path identity across
   // chunks (or builds), which must not create a fresh issue fingerprint.
   out = out.replace(
-    /(\/(?:\.next|_next)\/(?:server|static)\/(?:[^/]+\/)*[^/]*?)[0-9a-f]{8,}((?:\._)?\.js)(?:[?#].*)?$/gi,
+    /(\/(?:\.next|_next)\/(?:server|static)\/(?:[^/]+\/)*[^/]*?)[0-9a-f]{8,}((?:\._)?\.js)$/gi,
     "$1<hash>$2",
   );
   out = out.replace(/^.*?\/((?:apps|packages|src|app|lib|pages)\/.*)$/, "$1");


### PR DESCRIPTION
## Summary
- strip query and fragment metadata from hashless Next.js chunk URLs before fingerprinting
- retain generated content-hash normalization for hashed Next.js and Turbopack chunks
- cover stable chunk names with a public fingerprint regression test

## Testing
- `pnpm --filter @superlog/fingerprint test`
- `pnpm --filter @superlog/fingerprint typecheck`
- `pnpm exec biome check packages/fingerprint/src/index.ts packages/fingerprint/src/index.test.ts`
- `pnpm --filter @superlog/proxy test -- fingerprint`
- `pnpm --filter @superlog/worker test -- telemetry-ingest`
- `pnpm --filter @superlog/proxy typecheck`
- `pnpm --filter @superlog/worker typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize Next.js chunk URLs in `@superlog/fingerprint` to avoid new fingerprints when only cache-busting suffixes differ. We now strip query and fragment parts from hashless chunk filenames and keep hash normalization for hashed Next.js/Turbopack chunks.

- **Bug Fixes**
  - Ensure hashless Next.js chunk paths (e.g. main-app.js) fingerprint the same regardless of `?` or `#` suffix.
  - Preserve existing content-hash replacement for hashed chunks; added a regression test for stable chunk names.

<sup>Written for commit bfa7f472ecb5838b7856b8206897564b39bd254d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

