### PR TITLE
Classify Linear agent sessions by source metadata, not comment thread

### DIFF
--- a/apps/api/src/linear.test.ts
+++ b/apps/api/src/linear.test.ts
@@ -33,9 +33,10 @@ test("buildLinearAuthorizeUrl requests app-actor authorization", async () => {
   assert.equal(url.searchParams.get("scope")?.includes("app:assignable"), true);
 });
 
-test("a Linear agent session created from a comment opens a chat", async () => {
+test("a Linear agent session created from an @mention comment opens a chat", async () => {
   const { classifyLinearAgentSessionEvent } = await import("./linear.js");
 
+  // A mention carries the triggering human comment: sourceMetadata.type === "comment".
   assert.deepEqual(
     classifyLinearAgentSessionEvent({
       type: "AgentSessionEvent",
@@ -45,6 +46,7 @@ test("a Linear agent session created from a comment opens a chat", async () => {
         id: "session-1",
         issueId: "issue-1",
         commentId: "comment-1",
+        sourceMetadata: { type: "comment" },
       },
     }),
     {
@@ -72,6 +74,67 @@ test("a Linear agent session created from an issue opens an incident", async () 
       issueId: "issue-2",
       prompt: "Investigate checkout failures",
     },
+  );
+});
+
+test("a delegation whose session has its own comment thread still opens an incident", async () => {
+  const { classifyLinearAgentSessionEvent } = await import("./linear.js");
+
+  // Assigning an issue to the agent (delegation) creates an AgentSession with its own
+  // auto-created comment thread — `comment`/`commentId` is set — but there is NO
+  // triggering source comment, so sourceMetadata is null. This must open an incident,
+  // not a chat. Regression guard for the ENG-327 misclassification.
+  assert.deepEqual(
+    classifyLinearAgentSessionEvent({
+      type: "AgentSessionEvent",
+      action: "created",
+      promptContext: '<issue identifier="ENG-2"><title>Block to usage over limit</title></issue>',
+      agentSession: {
+        id: "session-3",
+        issueId: "issue-3",
+        commentId: "container-comment-1",
+        sourceMetadata: null,
+      },
+    }),
+    {
+      kind: "incident",
+      agentSessionId: "session-3",
+      issueId: "issue-3",
+      prompt: '<issue identifier="ENG-2"><title>Block to usage over limit</title></issue>',
+    },
+  );
+});
+
+test("classification honours a source-metadata type resolved out of band", async () => {
+  const { classifyLinearAgentSessionEvent } = await import("./linear.js");
+
+  // When the webhook body omits sourceMetadata, the handler resolves it from Linear
+  // and passes it in. "comment" => chat regardless of the (absent) payload field.
+  assert.equal(
+    classifyLinearAgentSessionEvent(
+      {
+        type: "AgentSessionEvent",
+        action: "created",
+        promptContext: "hey @superlog",
+        agentSession: { id: "session-4", issueId: "issue-4", commentId: "c-4" },
+      },
+      { sourceMetadataType: "comment" },
+    ).kind,
+    "chat",
+  );
+
+  // Resolved null (a delegation) => incident even though a comment thread exists.
+  assert.equal(
+    classifyLinearAgentSessionEvent(
+      {
+        type: "AgentSessionEvent",
+        action: "created",
+        promptContext: "investigate",
+        agentSession: { id: "session-5", issueId: "issue-5", commentId: "c-5" },
+      },
+      { sourceMetadataType: null },
+    ).kind,
+    "incident",
   );
 });
 

--- a/apps/api/src/linear.ts
+++ b/apps/api/src/linear.ts
@@ -511,6 +511,17 @@ async function handleLinearAgentSessionEvent(
   payload: LinearWebhookPayload,
   install: schema.LinearInstallation,
 ): Promise<void> {
+  // Resolve a fresh Linear token at most once and reuse it for every Linear write in
+  // this handler (metadata fetch, acknowledgement, external URL). The stored token can
+  // be expired; refreshing only for the fetch would leave the later writes on a stale
+  // token and 500 mid-handler — after the incident/chat already exists, so the retry
+  // takes the dedupe path and skips the acknowledgement and external URL entirely.
+  let cachedAccessToken: string | undefined;
+  const accessToken = async (): Promise<string> => {
+    cachedAccessToken ??= await resolveLinearAccessToken(install);
+    return cachedAccessToken;
+  };
+
   // A created session is a mention (chat) or a delegation (incident). The reliable
   // signal is agentSession.sourceMetadata.type ("comment" for a mention). If the
   // webhook body omits sourceMetadata, resolve it from Linear rather than fall back to
@@ -525,7 +536,7 @@ async function handleLinearAgentSessionEvent(
       // This fetch gates classification and runs before any DB write, so a stale
       // access token would 500 the webhook and wedge retries. Refresh first.
       sourceMetadataType = await fetchLinearAgentSessionSourceType({
-        accessToken: await resolveLinearAccessToken(install),
+        accessToken: await accessToken(),
         agentSessionId: session.id,
       });
     }
@@ -560,7 +571,7 @@ async function handleLinearAgentSessionEvent(
       activityId: `session:${classification.agentSessionId}`,
     });
     if (recorded.outcome === "accepted") {
-      await acknowledgeLinearSession(install, classification.agentSessionId, "chat");
+      await acknowledgeLinearSession(await accessToken(), classification.agentSessionId, "chat");
     }
     return;
   }
@@ -582,11 +593,15 @@ async function handleLinearAgentSessionEvent(
           "failed to enqueue Linear incident webhook",
         ),
       );
-      await acknowledgeLinearSession(install, classification.agentSessionId, "incident");
+      await acknowledgeLinearSession(
+        await accessToken(),
+        classification.agentSessionId,
+        "incident",
+      );
       const incidentUrl = await linearIncidentUrl(result.incident);
       if (incidentUrl) {
         await updateLinearAgentSession({
-          accessToken: install.accessToken,
+          accessToken: await accessToken(),
           agentSessionId: classification.agentSessionId,
           externalUrls: [{ label: "View incident", url: incidentUrl }],
         });
@@ -616,7 +631,7 @@ async function handleLinearAgentSessionEvent(
       activityId: classification.activityId,
     });
     if (recorded.outcome === "accepted") {
-      await acknowledgeLinearSession(install, classification.agentSessionId, "chat");
+      await acknowledgeLinearSession(await accessToken(), classification.agentSessionId, "chat");
     }
     return;
   }
@@ -637,7 +652,7 @@ async function handleLinearAgentSessionEvent(
     dedupeKey: `linear_prompt:${classification.activityId}`,
   });
   if (recorded.outcome === "accepted") {
-    await acknowledgeLinearSession(install, classification.agentSessionId, "incident");
+    await acknowledgeLinearSession(await accessToken(), classification.agentSessionId, "incident");
   }
 }
 
@@ -671,12 +686,12 @@ async function createLinearRootIncident(args: {
 }
 
 async function acknowledgeLinearSession(
-  install: schema.LinearInstallation,
+  accessToken: string,
   agentSessionId: string,
   kind: "chat" | "incident",
 ): Promise<void> {
   await createLinearAgentActivity({
-    accessToken: install.accessToken,
+    accessToken,
     agentSessionId,
     type: "thought",
     body: kind === "incident" ? "I’m starting an investigation now." : "I’m looking into that now.",

--- a/apps/api/src/linear.ts
+++ b/apps/api/src/linear.ts
@@ -10,6 +10,7 @@ import {
   db,
   deleteLinearWebhook,
   enqueueIncidentCreated,
+  ensureFreshLinearToken,
   exchangeLinearCode,
   fetchLinearAgentSessionSourceType,
   fetchLinearViewer,
@@ -491,6 +492,21 @@ async function handleLinearWebhook(
     .onConflictDoNothing();
 }
 
+// Returns a usable Linear access token for the installation, refreshing in place when
+// the OAuth client creds are present (they are in prod). Mirrors the worker's
+// resolveAccessToken: without creds, fall back to the stored token as-is.
+async function resolveLinearAccessToken(install: schema.LinearInstallation): Promise<string> {
+  const clientId = process.env.LINEAR_CLIENT_ID;
+  const clientSecret = process.env.LINEAR_CLIENT_SECRET;
+  if (!clientId || !clientSecret) return install.accessToken;
+  const fresh = await ensureFreshLinearToken({
+    installationId: install.id,
+    clientId,
+    clientSecret,
+  });
+  return fresh.accessToken;
+}
+
 async function handleLinearAgentSessionEvent(
   payload: LinearWebhookPayload,
   install: schema.LinearInstallation,
@@ -506,8 +522,10 @@ async function handleLinearAgentSessionEvent(
     if (session && "sourceMetadata" in session) {
       sourceMetadataType = session.sourceMetadata?.type ?? null;
     } else if (session?.id) {
+      // This fetch gates classification and runs before any DB write, so a stale
+      // access token would 500 the webhook and wedge retries. Refresh first.
       sourceMetadataType = await fetchLinearAgentSessionSourceType({
-        accessToken: install.accessToken,
+        accessToken: await resolveLinearAccessToken(install),
         agentSessionId: session.id,
       });
     }

--- a/apps/api/src/linear.ts
+++ b/apps/api/src/linear.ts
@@ -11,6 +11,7 @@ import {
   deleteLinearWebhook,
   enqueueIncidentCreated,
   exchangeLinearCode,
+  fetchLinearAgentSessionSourceType,
   fetchLinearViewer,
   linearTicketAcceptanceUnit,
   recordInboundInteraction,
@@ -226,8 +227,16 @@ type LinearWebhookPayload = {
   agentSession?: {
     id?: string;
     issueId?: string;
+    // `comment` is the comment thread the session is attached to. It is present for
+    // BOTH a mention and a delegation (a delegation gets its own auto-created thread),
+    // so it must NOT be used to tell them apart.
     commentId?: string | null;
     sourceCommentId?: string | null;
+    // `sourceMetadata` records how the session was created. A mention has
+    // `{ type: "comment", ... }`; a delegation (issue assigned to the agent) has null.
+    // This is the reliable discriminator. May be omitted from the webhook body, in
+    // which case the handler resolves it from Linear.
+    sourceMetadata?: { type?: string | null } | null;
     creatorId?: string | null;
     issue?: {
       id?: string;
@@ -267,6 +276,7 @@ export type LinearAgentSessionEventClassification =
 
 export function classifyLinearAgentSessionEvent(
   payload: LinearWebhookPayload,
+  opts?: { sourceMetadataType?: string | null },
 ): LinearAgentSessionEventClassification {
   if (payload.type !== "AgentSessionEvent") return { kind: "ignore" };
   const agentSessionId = payload.agentSession?.id;
@@ -284,9 +294,16 @@ export function classifyLinearAgentSessionEvent(
   const issueId = payload.agentSession?.issueId;
   const prompt = payload.promptContext?.trim();
   if (!issueId || !prompt) return { kind: "ignore" };
-  const isMention = Boolean(
-    payload.agentSession?.commentId ?? payload.agentSession?.sourceCommentId,
-  );
+  // A mention (@superlog in a comment) is created with a triggering source comment,
+  // surfaced as sourceMetadata.type === "comment". A delegation (issue assigned to the
+  // agent) has no source comment (sourceMetadata is null) even though the session owns
+  // an auto-created comment thread. The caller may resolve sourceMetadata out of band
+  // (it can be absent from the webhook body); prefer that when provided.
+  const sourceMetadataType =
+    opts?.sourceMetadataType !== undefined
+      ? opts.sourceMetadataType
+      : (payload.agentSession?.sourceMetadata?.type ?? null);
+  const isMention = sourceMetadataType === "comment";
   return {
     kind: isMention ? "chat" : "incident",
     agentSessionId,
@@ -478,7 +495,36 @@ async function handleLinearAgentSessionEvent(
   payload: LinearWebhookPayload,
   install: schema.LinearInstallation,
 ): Promise<void> {
-  const classification = classifyLinearAgentSessionEvent(payload);
+  // A created session is a mention (chat) or a delegation (incident). The reliable
+  // signal is agentSession.sourceMetadata.type ("comment" for a mention). If the
+  // webhook body omits sourceMetadata, resolve it from Linear rather than fall back to
+  // the session's own comment thread, which is present for both and misclassifies a
+  // delegation as a chat (the ENG-327 bug).
+  let sourceMetadataType: string | null | undefined;
+  if (payload.action === "created") {
+    const session = payload.agentSession;
+    if (session && "sourceMetadata" in session) {
+      sourceMetadataType = session.sourceMetadata?.type ?? null;
+    } else if (session?.id) {
+      sourceMetadataType = await fetchLinearAgentSessionSourceType({
+        accessToken: install.accessToken,
+        agentSessionId: session.id,
+      });
+    }
+    log.info(
+      {
+        agent_session_id: payload.agentSession?.id ?? null,
+        issue: payload.agentSession?.issue?.identifier ?? null,
+        source_metadata_type: sourceMetadataType ?? null,
+        had_comment: Boolean(payload.agentSession?.commentId),
+        resolved_via:
+          payload.agentSession && "sourceMetadata" in payload.agentSession ? "webhook" : "api",
+      },
+      "linear agent session created",
+    );
+  }
+
+  const classification = classifyLinearAgentSessionEvent(payload, { sourceMetadataType });
   if (classification.kind === "ignore") return;
   const issue = payload.agentSession?.issue;
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -356,6 +356,7 @@ export {
   createLinearComment,
   createLinearAgentActivity,
   updateLinearAgentSession,
+  fetchLinearAgentSessionSourceType,
 } from "./linear.js";
 export type {
   LinearTokenResponse,

--- a/packages/db/src/linear.ts
+++ b/packages/db/src/linear.ts
@@ -207,6 +207,29 @@ export async function listLinearTeams(accessToken: string): Promise<LinearTeam[]
   return data.teams.nodes;
 }
 
+/**
+ * Reads an AgentSession's `sourceMetadata.type` from Linear. A mention has
+ * `"comment"`; a delegation (issue assigned to the agent) has no source metadata and
+ * returns null. Used to classify a created AgentSessionEvent when the webhook body
+ * doesn't include sourceMetadata — the session's own `comment` thread is present for
+ * both and can't tell them apart.
+ */
+export async function fetchLinearAgentSessionSourceType(args: {
+  accessToken: string;
+  agentSessionId: string;
+}): Promise<string | null> {
+  const data = await linearGraphql<{
+    agentSession: { sourceMetadata?: { type?: unknown } | null } | null;
+  }>(
+    args.accessToken,
+    "query($id: String!) { agentSession(id: $id) { sourceMetadata } }",
+    { id: args.agentSessionId },
+    "agentSession query",
+  );
+  const type = data.agentSession?.sourceMetadata?.type;
+  return typeof type === "string" ? type : null;
+}
+
 export type LinearIssueRef = {
   id: string;
   identifier: string;


### PR DESCRIPTION
## Problem

When you assign (delegate) an issue to the agent in Linear, it should open an incident and run an investigation. Instead it was replying as a lightweight Q&A chat.

Root cause: a delegated `AgentSession` gets its own auto-created comment thread, and the classifier (`classifyLinearAgentSessionEvent`) keyed "mention vs delegation" on the presence of that comment (`agentSession.commentId`). Since the comment thread is present for **both** a mention and a delegation, delegations were misclassified as mentions → chat instead of incident.

Verified against Linear's API for two real sessions:

| | `comment` | `sourceComment` | `sourceMetadata` |
|---|---|---|---|
| assignment/delegation | set (own thread) | null | **null** |
| @mention in a comment | set (the human's comment) | null | **`{type:"comment", …}`** |

## Fix

- Classify on `agentSession.sourceMetadata.type` — `"comment"` ⇒ mention (chat), otherwise ⇒ delegation (incident). This is the reliable discriminator; the attached `comment`/`commentId` is not.
- The webhook body may omit `sourceMetadata`, so when it's absent the handler resolves it authoritatively from Linear via a new `fetchLinearAgentSessionSourceType` query rather than guessing from the comment id.
- Log the resolved source-metadata type (and whether it came from the webhook or the API) on every created session, so this is diagnosable from logs going forward.

## Tests

- Updated the mention case to the real shape (`sourceMetadata.type: "comment"`).
- Added a regression guard: a session with its own comment thread but `sourceMetadata: null` opens an **incident**.
- Covered the out-of-band-resolved path (handler-supplied `sourceMetadataType`).

`@superlog/api` tests pass (9/9); typecheck clean for `@superlog/db`, `@superlog/api`, `@superlog/worker`; biome clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misclassification of Linear agent sessions so delegations open incidents and @mentions open chats by using source metadata instead of the comment thread. Also resolves a fresh Linear token once and reuses it for all handler writes to prevent 401/500 loops.

- **Bug Fixes**
  - Classify using `agentSession.sourceMetadata.type` ("comment" => chat; otherwise => incident) in `@superlog/api`.
  - When missing in the webhook, resolve the type via `fetchLinearAgentSessionSourceType` in `@superlog/db`; no fallback to `commentId`.
  - Resolve a fresh Linear token once via `ensureFreshLinearToken` and reuse it for the metadata fetch, acknowledgement, and external URL writes (fallback to the stored token when OAuth client creds are absent).
  - Log the resolved source type and source of truth (webhook vs API) for created sessions, and add tests covering delegation-with-comment-thread and handler-resolved paths.

<sup>Written for commit 408ef94660fd3e63a0eb99e769d758e4ed582238. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

