### PR TITLE
Add Google Cloud connector icon

### DIFF
--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -132,6 +132,7 @@ import { useDemoExploration } from "./onboarding/demoExploration.tsx";
 import {
   AwsIcon,
   CloudflareIcon,
+  GcpIcon,
   GithubIcon,
   InfoIcon,
   OtelIcon,
@@ -1490,6 +1491,12 @@ function IntegrationGlyph({ id }: { id: ProjectIntegrationId }) {
           <RenderIcon size={20} />
         </span>
       );
+    case "gcp":
+      return (
+        <span className={className}>
+          <GcpIcon size={20} />
+        </span>
+      );
     case "aws":
       return (
         <span className={className}>
@@ -2763,6 +2770,12 @@ function IngestSourceIcon({ source }: { source: IngestSource }) {
       return (
         <span className={className}>
           <RenderIcon size={18} />
+        </span>
+      );
+    case "gcp":
+      return (
+        <span className={className}>
+          <GcpIcon size={18} />
         </span>
       );
   }

--- a/apps/web/src/onboarding/icons.tsx
+++ b/apps/web/src/onboarding/icons.tsx
@@ -409,6 +409,22 @@ export function CloudflareIcon({ size = 18, className }: IconProps) {
   );
 }
 
+// Google Cloud — the official mark (Simple Icons, CC0), monochrome via currentColor.
+export function GcpIcon({ size = 18, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M12.19 2.38a9.344 9.344 0 0 0-9.234 6.893c.053-.02-.055.013 0 0-3.875 2.551-3.922 8.11-.247 10.941l.006-.007-.007.03a6.717 6.717 0 0 0 4.077 1.356h5.173l.03.03h5.192c6.687.053 9.376-8.605 3.835-12.35a9.365 9.365 0 0 0-2.821-4.552l-.043.043.006-.05A9.344 9.344 0 0 0 12.19 2.38zm-.358 4.146c1.244-.04 2.518.368 3.486 1.15a5.186 5.186 0 0 1 1.862 4.078v.518c3.53-.07 3.53 5.262 0 5.193h-5.193l-.008.009v-.04H6.785a2.59 2.59 0 0 1-1.067-.23h.001a2.597 2.597 0 1 1 3.437-3.437l3.013-3.012A6.747 6.747 0 0 0 8.11 8.24c.018-.01.04-.026.054-.023a5.186 5.186 0 0 1 3.67-1.69z" />
+    </svg>
+  );
+}
+
 export function GithubActionsIcon({ size = 18, className }: IconProps) {
   return (
     <svg


### PR DESCRIPTION
The integrations catalog and the ingest-sources card render a per-connector glyph through `switch` statements that have no `default` branch. Google Cloud had no matching `case`, so its integration card and ingest-source row rendered an empty bordered chip instead of a logo — every other connector (AWS, Vercel, Railway, Render, Cloudflare, …) shows its mark.

## Changes
- `apps/web/src/onboarding/icons.tsx` — new `GcpIcon`, the official Google Cloud mark rendered monochrome via `currentColor`, following the existing `RenderIcon` / `RailwayIcon` Simple Icons pattern.
- `apps/web/src/Settings.tsx` — import `GcpIcon` and add `case "gcp"` to both `IntegrationGlyph` (integration cards) and `IngestSourceIcon` (ingest-sources card).

Purely presentational. `@superlog/web` typecheck passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Google Cloud connector icon so integration cards and ingest-source rows show the GCP logo instead of an empty chip. Introduces `GcpIcon` (monochrome via currentColor) and adds a `gcp` case to `IntegrationGlyph` and `IngestSourceIcon`.

<sup>Written for commit 916ebd0a03b2edd11159eb62f3d52cd3afeb81e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

