### PR TITLE
Allow read-only incident views to load PR diffs

### DIFF
--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -75,6 +75,7 @@ import {
 } from "./incidents/IncidentTranscript.tsx";
 import {
   getIncidentDetailAccess,
+  resolveIncidentPullRequestDiff,
   shouldUsePreloadedPullRequests,
 } from "./incidents/incident-detail-access.ts";
 import {
@@ -1572,6 +1573,7 @@ export function IncidentDetailContent({
   summaryTelemetry,
   occurrenceBuckets,
   pullRequests,
+  pullRequestDiffBasePath,
   readOnly = false,
 }: {
   incident: Incident;
@@ -1603,6 +1605,8 @@ export function IncidentDetailContent({
    * that cannot call product APIs also render the PR panel from this.
    */
   pullRequests?: IncidentPullRequest[];
+  /** Base API path used to load live diffs for supplied PRs with no recorded patch. */
+  pullRequestDiffBasePath?: string;
   /** Render the canonical incident UI without controls that mutate customer data. */
   readOnly?: boolean;
 }) {
@@ -1875,6 +1879,7 @@ export function IncidentDetailContent({
                 projectId={incident.projectId}
                 incidentId={incident.id}
                 pullRequests={pullRequests}
+                pullRequestDiffBasePath={pullRequestDiffBasePath}
                 readOnly={!access.canMergePullRequest}
               />
             )}
@@ -2181,15 +2186,23 @@ export function IncidentPullRequestPanel({
   projectId,
   incidentId,
   pullRequests,
+  pullRequestDiffBasePath,
   readOnly,
 }: {
   projectId: string;
   incidentId: string;
   pullRequests?: IncidentPullRequest[];
+  pullRequestDiffBasePath?: string;
   readOnly: boolean;
 }) {
   if (shouldUsePreloadedPullRequests({ readOnly })) {
-    return <IncidentPullRequestView pullRequests={pullRequests ?? []} readOnly={readOnly} />;
+    return (
+      <IncidentPullRequestView
+        pullRequests={pullRequests ?? []}
+        readOnly={readOnly}
+        diffBasePath={pullRequestDiffBasePath}
+      />
+    );
   }
   return <ProductIncidentPullRequestPanel projectId={projectId} incidentId={incidentId} />;
 }
@@ -2217,7 +2230,7 @@ function ProductIncidentPullRequestPanel({
       merging={mergePr.isPending}
       mergeError={mergePr.error}
       onMerge={(prId) => mergePr.mutate({ prId })}
-      diffSource={{ projectId, incidentId }}
+      diffBasePath={`/api/projects/${projectId}/incidents/${incidentId}/pull-requests`}
     />
   );
 }
@@ -2228,19 +2241,15 @@ export function IncidentPullRequestView({
   merging = false,
   mergeError = null,
   onMerge,
-  diffSource,
+  diffBasePath,
 }: {
   pullRequests: IncidentPullRequest[];
   readOnly: boolean;
   merging?: boolean;
   mergeError?: Error | null;
   onMerge?: (prId: string) => void;
-  /**
-   * Where to fetch the live diff when a PR has no recorded patch body.
-   * Omitted by read-only consumers that cannot call product APIs — they fall
-   * back to a GitHub link.
-   */
-  diffSource?: { projectId: string; incidentId: string };
+  /** Where to fetch the live diff when a PR has no recorded patch body. */
+  diffBasePath?: string;
 }) {
   const [selectedPrId, setSelectedPrId] = useState<string | null>(null);
 
@@ -2264,6 +2273,11 @@ export function IncidentPullRequestView({
     );
   }
   if (!selectedPr) return null;
+  const diffSource = resolveIncidentPullRequestDiff({
+    patch: selectedPr.patch,
+    diffBasePath,
+    pullRequestId: selectedPr.id,
+  });
 
   return (
     <div className="space-y-4">
@@ -2323,7 +2337,7 @@ export function IncidentPullRequestView({
         </p>
       )}
 
-      {selectedPr.patch ? (
+      {diffSource.kind === "recorded" ? (
         <Suspense
           fallback={
             <div className="min-h-[520px] rounded-md border border-border bg-surface p-4 text-[12px] text-muted">
@@ -2331,15 +2345,10 @@ export function IncidentPullRequestView({
             </div>
           }
         >
-          <IncidentPrDiffView patch={selectedPr.patch} patchKey={selectedPr.id} />
+          <IncidentPrDiffView patch={diffSource.patch} patchKey={selectedPr.id} />
         </Suspense>
-      ) : diffSource ? (
-        <IncidentPrRemoteDiff
-          key={selectedPr.id}
-          projectId={diffSource.projectId}
-          incidentId={diffSource.incidentId}
-          pr={selectedPr}
-        />
+      ) : diffSource.kind === "remote" ? (
+        <IncidentPrRemoteDiff key={selectedPr.id} path={diffSource.path} pr={selectedPr} />
       ) : (
         <IncidentPrDiffUnavailable pr={selectedPr} />
       )}
@@ -2350,15 +2359,13 @@ export function IncidentPullRequestView({
 // Loads the diff from GitHub through the API when the PR view carries no
 // recorded patch body (the normal case for PRs opened mid-run).
 function IncidentPrRemoteDiff({
-  projectId,
-  incidentId,
+  path,
   pr,
 }: {
-  projectId: string;
-  incidentId: string;
+  path: string;
   pr: IncidentPullRequest;
 }) {
-  const diff = useIncidentPullRequestDiff(projectId, incidentId, pr.id, pr.headSha);
+  const diff = useIncidentPullRequestDiff(path, pr.headSha);
   if (diff.isLoading) {
     return (
       <div className="min-h-[520px] rounded-md border border-border bg-surface p-4 text-[12px] text-muted">

--- a/apps/web/src/api-request-url.test.ts
+++ b/apps/web/src/api-request-url.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { apiRequestUrl } from "./api.ts";
+
+test("API requests preserve an absolute endpoint supplied by an embedding surface", () => {
+	assert.equal(
+		apiRequestUrl(
+			"https://staff-api.example/api/incidents/incident-1/pull-requests/pr-1/diff",
+			"https://product-api.example",
+		),
+		"https://staff-api.example/api/incidents/incident-1/pull-requests/pr-1/diff",
+	);
+});
+
+test("API requests still resolve product-relative paths against the product API", () => {
+	assert.equal(
+		apiRequestUrl("/api/incidents/incident-1", "https://product-api.example"),
+		"https://product-api.example/api/incidents/incident-1",
+	);
+});

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -4,6 +4,11 @@ import { incidentPollIntervalMs } from "./incidents/agent-run-polling.ts";
 
 const API_URL = import.meta.env?.VITE_API_URL ?? "http://localhost:4100";
 
+export function apiRequestUrl(path: string, apiUrl = API_URL): string {
+	if (/^https?:\/\//i.test(path)) return path;
+	return `${apiUrl.replace(/\/$/, "")}/${path.replace(/^\//, "")}`;
+}
+
 export type Me = {
   user: { id: string; email: string; name: string; isStaff: boolean; impersonating: boolean };
   // Both null when the user signed up but hasn't created their first org yet.
@@ -86,7 +91,7 @@ export function useFetcher() {
       const source = readPendingSignupSource();
       if (source) headers["x-superlog-signup-source"] = source;
     }
-    const res = await fetch(`${API_URL}${path}`, {
+    const res = await fetch(apiRequestUrl(path), {
       ...init,
       credentials: "include",
       headers,
@@ -2673,19 +2678,11 @@ export function useIncidentPullRequests(
 // `headSha` is part of the key: the PR list polls while a run is active and a
 // follow-up push moves the head, so the diff refetches exactly when a new
 // commit lands — without polling GitHub on a timer.
-export function useIncidentPullRequestDiff(
-  projectId: string,
-  incidentId: string,
-  prId: string,
-  headSha: string | null,
-) {
+export function useIncidentPullRequestDiff(path: string, headSha: string | null) {
   const fetcher = useFetcher();
   return useQuery({
-    queryKey: ["incident-pr-diff", projectId, incidentId, prId, headSha],
-    queryFn: () =>
-      fetcher<{ patch: string }>(
-        `/api/projects/${projectId}/incidents/${incidentId}/pull-requests/${prId}/diff`,
-      ),
+    queryKey: ["incident-pr-diff", path, headSha],
+    queryFn: () => fetcher<{ patch: string }>(path),
     // Keep showing the previous commit's diff while the new head's loads.
     placeholderData: (prev) => prev,
     staleTime: 60_000,

--- a/apps/web/src/incident-detail-read-only.test.ts
+++ b/apps/web/src/incident-detail-read-only.test.ts
@@ -2,6 +2,8 @@ import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import {
   getIncidentDetailAccess,
+  incidentPullRequestDiffPath,
+  resolveIncidentPullRequestDiff,
   shouldUsePreloadedPullRequests,
 } from "./incidents/incident-detail-access.ts";
 
@@ -30,4 +32,25 @@ test("only read-only consumers render PRs straight from supplied data", () => {
   // The product detail preloads PRs for tab visibility, but its panel must
   // stay on the connected loader so merge keeps working.
   assert.equal(shouldUsePreloadedPullRequests({ readOnly: false }), false);
+});
+
+test("a read-only consumer can provide its own live PR diff endpoint", () => {
+  assert.equal(
+    incidentPullRequestDiffPath("/api/staff/incidents/incident-1/pull-requests", "pr-1"),
+    "/api/staff/incidents/incident-1/pull-requests/pr-1/diff",
+  );
+});
+
+test("a PR without a stored patch uses the supplied live diff endpoint", () => {
+  assert.deepEqual(
+    resolveIncidentPullRequestDiff({
+      patch: null,
+      diffBasePath: "/api/staff/incidents/incident-1/pull-requests",
+      pullRequestId: "pr-1",
+    }),
+    {
+      kind: "remote",
+      path: "/api/staff/incidents/incident-1/pull-requests/pr-1/diff",
+    },
+  );
 });

--- a/apps/web/src/incidents/incident-detail-access.ts
+++ b/apps/web/src/incidents/incident-detail-access.ts
@@ -24,3 +24,27 @@ export function getIncidentDetailAccess(readOnly: boolean): IncidentDetailAccess
 export function shouldUsePreloadedPullRequests({ readOnly }: { readOnly: boolean }): boolean {
   return readOnly;
 }
+
+export function incidentPullRequestDiffPath(diffBasePath: string, pullRequestId: string): string {
+  return `${diffBasePath.replace(/\/$/, "")}/${encodeURIComponent(pullRequestId)}/diff`;
+}
+
+export type IncidentPullRequestDiffSource =
+  | { kind: "recorded"; patch: string }
+  | { kind: "remote"; path: string }
+  | { kind: "unavailable" };
+
+export function resolveIncidentPullRequestDiff(input: {
+  patch: string | null;
+  diffBasePath?: string;
+  pullRequestId: string;
+}): IncidentPullRequestDiffSource {
+  if (input.patch) return { kind: "recorded", patch: input.patch };
+  if (input.diffBasePath) {
+    return {
+      kind: "remote",
+      path: incidentPullRequestDiffPath(input.diffBasePath, input.pullRequestId),
+    };
+  }
+  return { kind: "unavailable" };
+}


### PR DESCRIPTION
## What changed

- let read-only incident consumers provide a live pull-request diff endpoint
- preserve absolute API request URLs supplied by an embedding surface
- retain recorded patches and the product API path as the existing defaults

## Why

Pull requests opened during an investigation do not always carry a recorded patch. Read-only incident views need a safe way to load that diff from their own backend instead of falling back to an unavailable state.

## Validation

- web test suite: 157 passing
- web typecheck
- production web build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable read-only incident views to load PR diffs from a supplied backend when no recorded patch is available. Also preserve absolute API request URLs from embedding surfaces while keeping product-relative paths as the default.

- **New Features**
  - Added `pullRequestDiffBasePath` to read-only incident views; diff source is chosen via `resolveIncidentPullRequestDiff` and fetched with `useIncidentPullRequestDiff(path, headSha)`.
  - Wired the default product diff path in the product-connected view; still uses recorded patches when present and falls back to “unavailable” if no endpoint exists.
  - Introduced `apiRequestUrl` to pass through absolute URLs and resolve relative paths against the product API; tests added for URL handling and read-only diff routing.

<sup>Written for commit 4d885ac5fe1cfec3fd9b664b4d4c3052c16e835d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

