### PR TITLE
Harden telemetry discovery queries

### DIFF
--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -202,6 +202,7 @@ test("telemetry queries preserve space-separated saved-view time bounds", async 
 
 test("listServices discovers services across traces, logs, and metrics", async () => {
   const queriedTables: string[] = [];
+  const queriesByTable: Record<string, string> = {};
   const servicesByTable: Record<string, string[]> = {
     otel_traces: ["api"],
     otel_logs: ["api", "log-only-worker"],
@@ -215,6 +216,7 @@ test("listServices discovers services across traces, logs, and metrics", async (
       const table = input.query.match(/FROM\s+(otel_[a-z_]+)/i)?.[1];
       assert.ok(table);
       queriedTables.push(table);
+      queriesByTable[table] = input.query;
       if (table === "otel_metrics_summary") throw new Error("UNKNOWN_TABLE");
       return {
         async json() {
@@ -244,6 +246,10 @@ test("listServices discovers services across traces, logs, and metrics", async (
     "otel_metrics_summary",
     "otel_traces",
   ]);
+  const logQuery = queriesByTable.otel_logs;
+  assert.ok(logQuery);
+  assert.match(logQuery, /TimestampTime >= \(now\(\) - INTERVAL 1 HOUR\) - INTERVAL 1 SECOND/);
+  assert.match(logQuery, /TimestampTime <= now\(\)/);
 });
 
 test("fieldColumnExpr allowlists identifier columns per source", () => {

--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -187,6 +187,19 @@ test("telemetry queries reject malformed time bounds before querying ClickHouse"
   assert.equal(capture.query, undefined);
 });
 
+test("telemetry queries preserve space-separated saved-view time bounds", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await queryTraces(fakeClickhouse(capture), "project-1", {
+    range: { since: "2026-06-26 02:40:00", until: "2026-06-26 03:40:00" },
+    limit: 50,
+  });
+
+  assert.match(capture.query ?? "", /parseDateTime64BestEffortOrZero/);
+  assert.equal(capture.params?.since, "2026-06-26 02:40:00");
+  assert.equal(capture.params?.until, "2026-06-26 03:40:00");
+});
+
 test("listServices discovers services across traces, logs, and metrics", async () => {
   const queriedTables: string[] = [];
   const servicesByTable: Record<string, string[]> = {

--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -7,6 +7,7 @@ import {
   listAttributeKeys,
   listAttributeValues,
   listMetricNames,
+  listServices,
   metricSeries,
   queryLogs,
   queryMetrics,
@@ -170,6 +171,66 @@ test("queryTraces filters by prefixed span attributes", async () => {
   );
   assert.equal(capture.params?.sattr_k_0, "session.id");
   assert.equal(capture.params?.sattr_v_0, "s1");
+});
+
+test("telemetry queries reject malformed time bounds before querying ClickHouse", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await assert.rejects(
+    queryTraces(fakeClickhouse(capture), "project-1", {
+      range: { since: "last 24 hours", until: "now()" },
+      limit: 50,
+    }),
+    /invalid since time bound/i,
+  );
+
+  assert.equal(capture.query, undefined);
+});
+
+test("listServices discovers services across traces, logs, and metrics", async () => {
+  const queriedTables: string[] = [];
+  const servicesByTable: Record<string, string[]> = {
+    otel_traces: ["api"],
+    otel_logs: ["api", "log-only-worker"],
+    otel_metrics_gauge: ["metric-only-cron"],
+    otel_metrics_sum: [],
+    otel_metrics_histogram: ["api"],
+    otel_metrics_exp_histogram: ["exp-histogram-only"],
+  };
+  const ch = {
+    async query(input: { query: string }) {
+      const table = input.query.match(/FROM\s+(otel_[a-z_]+)/i)?.[1];
+      assert.ok(table);
+      queriedTables.push(table);
+      if (table === "otel_metrics_summary") throw new Error("UNKNOWN_TABLE");
+      return {
+        async json() {
+          return (servicesByTable[table] ?? []).map((service) => ({ service }));
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+
+  const services = await listServices(ch, "project-1", {
+    since: "now() - INTERVAL 1 HOUR",
+    until: "now()",
+  });
+
+  assert.deepEqual(services, [
+    "api",
+    "exp-histogram-only",
+    "log-only-worker",
+    "metric-only-cron",
+  ]);
+  assert.deepEqual(queriedTables.sort(), [
+    "otel_logs",
+    "otel_metrics_exp_histogram",
+    "otel_metrics_gauge",
+    "otel_metrics_histogram",
+    "otel_metrics_sum",
+    "otel_metrics_summary",
+    "otel_traces",
+  ]);
 });
 
 test("fieldColumnExpr allowlists identifier columns per source", () => {

--- a/packages/telemetry-query/src/index.ts
+++ b/packages/telemetry-query/src/index.ts
@@ -39,7 +39,7 @@ export function fieldColumnExpr(field: string, source: FieldFilterSource): strin
 const RELATIVE_TIME_EXPR_RE =
   /^now\(\)(?:\s*-\s*INTERVAL\s+(?:[1-9][0-9]*)\s+(?:SECOND|MINUTE|HOUR|DAY|WEEK|MONTH))?$/i;
 const ISO_TIME_BOUND_RE =
-  /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:Z|[+-]\d{2}:\d{2})?)?$/;
+  /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:Z|[+-]\d{2}:\d{2})?)?$/;
 
 function timeBoundExpr(value: string, paramName: "since" | "until"): string {
   const normalized = value.trim().replace(/\s+/g, " ");

--- a/packages/telemetry-query/src/index.ts
+++ b/packages/telemetry-query/src/index.ts
@@ -38,10 +38,15 @@ export function fieldColumnExpr(field: string, source: FieldFilterSource): strin
 
 const RELATIVE_TIME_EXPR_RE =
   /^now\(\)(?:\s*-\s*INTERVAL\s+(?:[1-9][0-9]*)\s+(?:SECOND|MINUTE|HOUR|DAY|WEEK|MONTH))?$/i;
+const ISO_TIME_BOUND_RE =
+  /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:Z|[+-]\d{2}:\d{2})?)?$/;
 
 function timeBoundExpr(value: string, paramName: "since" | "until"): string {
   const normalized = value.trim().replace(/\s+/g, " ");
   if (RELATIVE_TIME_EXPR_RE.test(normalized)) return normalized;
+  if (!ISO_TIME_BOUND_RE.test(normalized) || Number.isNaN(Date.parse(normalized))) {
+    throw new Error(`invalid ${paramName} time bound: ${value}`);
+  }
   return `parseDateTime64BestEffortOrZero({${paramName}:String})`;
 }
 
@@ -751,25 +756,65 @@ export async function queryMetrics(
   return results.slice(0, params.limit);
 }
 
+const SERVICE_SOURCES = [
+  { table: "otel_traces", service: "ServiceName", time: "Timestamp" },
+  { table: "otel_logs", service: "ServiceName", time: "Timestamp" },
+  {
+    table: "otel_metrics_gauge",
+    service: "ServiceName",
+    time: "TimeUnix",
+  },
+  {
+    table: "otel_metrics_sum",
+    service: "ServiceName",
+    time: "TimeUnix",
+  },
+  {
+    table: "otel_metrics_histogram",
+    service: "ServiceName",
+    time: "TimeUnix",
+  },
+  {
+    table: "otel_metrics_exp_histogram",
+    service: "ServiceName",
+    time: "TimeUnix",
+  },
+  {
+    table: "otel_metrics_summary",
+    service: "ServiceName",
+    time: "TimeUnix",
+  },
+] as const;
+
 export async function listServices(ch: ClickHouseClient, projectId: string, range?: TimeRange) {
   const { sinceSql, untilSql, sinceExpr, untilExpr } = resolveRange(range);
-  const query = `
-    SELECT DISTINCT ServiceName AS service
-    FROM otel_traces
-    WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
-      AND Timestamp >= ${sinceExpr}
-      AND Timestamp <= ${untilExpr}
-      AND ServiceName != ''
-    ORDER BY service
-    LIMIT 200
-  `;
-  const r = await ch.query({
-    query,
-    query_params: { projectId, since: sinceSql, until: untilSql },
-    format: "JSONEachRow",
-  });
-  const rows = (await r.json()) as { service: string }[];
-  return rows.map((r) => r.service);
+  const servicesBySource = await Promise.all(
+    SERVICE_SOURCES.map(async (source): Promise<string[]> => {
+      const query = `
+        SELECT DISTINCT ${source.service} AS service
+        FROM ${source.table}
+        WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+          AND ${source.time} >= ${sinceExpr}
+          AND ${source.time} <= ${untilExpr}
+          AND ${source.service} != ''
+        ORDER BY service
+        LIMIT 200
+      `;
+      try {
+        const r = await ch.query({
+          query,
+          query_params: { projectId, since: sinceSql, until: untilSql },
+          format: "JSONEachRow",
+        });
+        const rows = (await r.json()) as { service: string }[];
+        return rows.map((row) => row.service);
+      } catch (err) {
+        if (!(err instanceof Error && /UNKNOWN_TABLE|doesn't exist/i.test(err.message))) throw err;
+        return [];
+      }
+    }),
+  );
+  return [...new Set(servicesBySource.flat())].sort().slice(0, 200);
 }
 
 // Discovering which attribute keys exist only needs a representative sample of

--- a/packages/telemetry-query/src/index.ts
+++ b/packages/telemetry-query/src/index.ts
@@ -790,12 +790,21 @@ export async function listServices(ch: ClickHouseClient, projectId: string, rang
   const { sinceSql, untilSql, sinceExpr, untilExpr } = resolveRange(range);
   const servicesBySource = await Promise.all(
     SERVICE_SOURCES.map(async (source): Promise<string[]> => {
+      // Logs are partitioned by TimestampTime. Keep the canonical nanosecond
+      // Timestamp filter for exactness, and add the padded partition-key window
+      // so ClickHouse can prune retained log partitions efficiently.
+      const logPartitionWindow =
+        source.table === "otel_logs"
+          ? `
+          AND TimestampTime >= (${sinceExpr}) - INTERVAL 1 SECOND
+          AND TimestampTime <= ${untilExpr}`
+          : "";
       const query = `
         SELECT DISTINCT ${source.service} AS service
         FROM ${source.table}
         WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
           AND ${source.time} >= ${sinceExpr}
-          AND ${source.time} <= ${untilExpr}
+          AND ${source.time} <= ${untilExpr}${logPartitionWindow}
           AND ${source.service} != ''
         ORDER BY service
         LIMIT 200


### PR DESCRIPTION
## What changed

- reject malformed telemetry time bounds before ClickHouse receives a query
- discover services across traces, logs, and every metric signal table
- tolerate optional telemetry tables that have not been created yet

## Why

Invalid natural-language time bounds could fall through to ClickHouse's best-effort parser and become an epoch-wide scan. Service discovery also read only spans, hiding services that emit logs or metrics without traces.

## Validation

- 42 focused ClickHouse adapter tests
- telemetry-query typecheck
- API typecheck
- worker typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened telemetry queries by validating time bounds up front, preserving saved-view ranges, expanding service discovery across traces, logs, and metrics, and pruning log scans by partition time. This prevents wide scans and keeps services discoverable across all signals.

- **Bug Fixes**
  - Reject malformed `since`/`until` before querying ClickHouse; only `now()` +/- INTERVAL or ISO timestamps are accepted.
  - Preserve saved-view ranges with space-separated datetimes (e.g., "2026-06-26 02:40:00").

- **New Features**
  - `listServices` scans traces, logs, and all metric tables; prunes logs by `TimestampTime` (with a 1s pad) for partition pruning; results deduped/sorted and limited to 200.
  - Skips absent telemetry tables to support partial deployments.

<sup>Written for commit dd53c3e11190aba12e4cc42af62decaba1d4fdf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

