### PR TITLE
Improve explore time range controls

### DIFF
--- a/apps/web/src/Explore.tsx
+++ b/apps/web/src/Explore.tsx
@@ -7,6 +7,7 @@ import {
   Legend,
   Line,
   LineChart,
+  ReferenceArea,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -56,6 +57,12 @@ import {
 import { ScrollArea } from "./design/scroll-area.tsx";
 import { Btn, Chip, Input, PageHeader, ShortcutKey, Tile } from "./design/ui.tsx";
 import { addAttrFilter } from "./exploreAttrFilter.ts";
+import {
+  bucketSeriesSpansDates,
+  formatBucketAxisTick,
+  parseStepMs,
+  rangeFromBucketSelection,
+} from "./explore-timeseries.ts";
 import { sourceFromExplorePath, type ExploreSource } from "./explore-route.ts";
 import { tracer } from "./instrumentation.ts";
 import {
@@ -243,6 +250,17 @@ function ExploreInner({ projectId }: { projectId: string }) {
       updateParams((p) => (v === "spans" ? p.set("view", "spans") : p.delete("view"))),
     [updateParams],
   );
+  const applyAbsoluteRange = useCallback(
+    (nextRange: ExploreRange) => {
+      updateParams((p) => {
+        p.set("since", nextRange.since);
+        p.set("until", nextRange.until);
+        p.delete("range");
+        p.delete("rangeLabel");
+      });
+    },
+    [updateParams],
+  );
 
   // Chart/UI prefs stay local — they're per-user view state, not part of the
   // shareable query.
@@ -358,6 +376,7 @@ function ExploreInner({ projectId }: { projectId: string }) {
           <RangePicker
             value={absoluteRange ? { seconds: 0, label: CUSTOM_RANGE_LABEL } : selection}
             range={range}
+            onAbsoluteChange={applyAbsoluteRange}
             onChange={(next) => {
               const span = tracer.startSpan("explore.range_change", {
                 attributes: {
@@ -478,6 +497,7 @@ function ExploreInner({ projectId }: { projectId: string }) {
               groupBy={groupBy}
               onGroupByChange={setGroupBy}
               range={range}
+              onRangeChange={applyAbsoluteRange}
             />
             <ListPanel
               projectId={projectId}
@@ -1898,6 +1918,7 @@ function ChartPanel({
   groupBy,
   onGroupByChange,
   range,
+  onRangeChange,
   showControls = true,
 }: {
   projectId: string;
@@ -1906,6 +1927,7 @@ function ChartPanel({
   groupBy: string;
   onGroupByChange: (g: string) => void;
   range: ExploreRange;
+  onRangeChange: (range: ExploreRange) => void;
   showControls?: boolean;
 }) {
   const countSeries = useExploreSeries(
@@ -1942,6 +1964,7 @@ function ChartPanel({
             height={72}
             range={range}
             step={countSeries.data.step}
+            onRangeChange={onRangeChange}
           />
         ) : (
           <div className="flex h-14 items-center justify-center font-sans text-[11px] text-subtle">
@@ -2193,23 +2216,6 @@ function pivotRows<T extends { bucket: string }>(
 // TimeseriesChart — stacked bars via Recharts
 // ---------------------------------------------------------------------------
 
-function parseStepMs(step: string | undefined): number | undefined {
-  if (!step) return undefined;
-  const m = step.match(/^(\d+)\s+(SECOND|MINUTE|HOUR|DAY)/i);
-  if (!m) return undefined;
-  const n = Number.parseInt(m[1]!, 10);
-  const unit = m[2]!.toUpperCase();
-  const mult =
-    unit === "SECOND"
-      ? 1000
-      : unit === "MINUTE"
-        ? 60_000
-        : unit === "HOUR"
-          ? 3_600_000
-          : 86_400_000;
-  return n * mult;
-}
-
 function formatBucket(d: Date): string {
   return d.toISOString().slice(0, 19).replace("T", " ");
 }
@@ -2253,11 +2259,6 @@ function pickEvenTicks<T>(items: T[], target: number, key: (t: T) => string): st
   return [...new Set(out)];
 }
 
-function fmtBucketTime(s: string): string {
-  // s is "YYYY-MM-DD HH:MM:SS" UTC — show local "HH:MM".
-  return formatLocalHm(s);
-}
-
 const AXIS_TICK_STYLE = {
   fill: "#6b7280",
   fontSize: 9,
@@ -2278,6 +2279,7 @@ export function TimeseriesChart({
   showXAxis = true,
   showYAxis = false,
   showLegend = false,
+  onRangeChange,
 }: {
   rows: SeriesRow[];
   height?: number | `${number}%`;
@@ -2287,7 +2289,10 @@ export function TimeseriesChart({
   showXAxis?: boolean;
   showYAxis?: boolean;
   showLegend?: boolean;
+  onRangeChange?: (range: ExploreRange) => void;
 }) {
+  const [dragStart, setDragStart] = useState<string | null>(null);
+  const [dragEnd, setDragEnd] = useState<string | null>(null);
   const filled = useMemo(() => padSeriesBuckets(rows, range, step), [rows, range, step]);
   const { data, groups } = useMemo(
     () =>
@@ -2299,8 +2304,25 @@ export function TimeseriesChart({
     [filled],
   );
   const ticks = useMemo(() => pickEvenTicks(data, 5, (d) => d.bucket as string), [data]);
+  const showDates = useMemo(
+    () => bucketSeriesSpansDates(data.map((row) => String(row.bucket))),
+    [data],
+  );
 
   const Chart = chartType === "line" ? LineChart : BarChart;
+
+  const activeBucket = (label: string | number | undefined) =>
+    typeof label === "string" ? label : null;
+
+  const finishDrag = (label: string | number | undefined) => {
+    const last = activeBucket(label) ?? dragEnd ?? dragStart;
+    if (dragStart && last && range && step && onRangeChange) {
+      const nextRange = rangeFromBucketSelection(dragStart, last, step, range);
+      if (nextRange) onRangeChange(nextRange);
+    }
+    setDragStart(null);
+    setDragEnd(null);
+  };
 
   return (
     <ResponsiveContainer width="100%" height={height}>
@@ -2309,16 +2331,35 @@ export function TimeseriesChart({
         barCategoryGap={0}
         barGap={0}
         margin={{ top: 4, right: 0, bottom: showXAxis ? 6 : 0, left: 0 }}
+        style={{ cursor: onRangeChange ? "crosshair" : undefined, userSelect: "none" }}
+        onMouseDown={(state, event) => {
+          if (!onRangeChange) return;
+          const bucket = activeBucket(state.activeLabel);
+          if (!bucket) return;
+          event.preventDefault();
+          setDragStart(bucket);
+          setDragEnd(bucket);
+        }}
+        onMouseMove={(state) => {
+          if (!dragStart) return;
+          const bucket = activeBucket(state.activeLabel);
+          if (bucket) setDragEnd(bucket);
+        }}
+        onMouseUp={(state) => finishDrag(state.activeLabel)}
+        onMouseLeave={() => {
+          setDragStart(null);
+          setDragEnd(null);
+        }}
       >
         <CartesianGrid vertical={false} stroke="var(--color-border)" strokeDasharray="0" />
         {showXAxis ? (
           <XAxis
             dataKey="bucket"
             ticks={ticks}
-            tickFormatter={fmtBucketTime}
+            tickFormatter={(bucket) => formatBucketAxisTick(String(bucket), showDates)}
             axisLine={false}
             tickLine={false}
-            height={18}
+            height={showDates ? 28 : 18}
             tickMargin={4}
             tick={AXIS_TICK_STYLE}
           />
@@ -2340,6 +2381,16 @@ export function TimeseriesChart({
           {...TOOLTIP_STYLE}
           labelFormatter={(label) => formatLocalTimestamp(String(label))}
         />
+        {dragStart && dragEnd && (
+          <ReferenceArea
+            x1={dragStart}
+            x2={dragEnd}
+            fill="var(--color-accent)"
+            fillOpacity={0.16}
+            stroke="var(--color-accent)"
+            strokeOpacity={0.5}
+          />
+        )}
         {showLegend && <Legend wrapperStyle={LEGEND_STYLE} iconType="plainline" iconSize={10} />}
         {groups.map((g, gi) =>
           chartType === "line" ? (
@@ -2406,7 +2457,7 @@ export function MetricLineChart({
           <XAxis
             dataKey="bucket"
             ticks={ticks}
-            tickFormatter={fmtBucketTime}
+            tickFormatter={(bucket) => formatLocalHm(String(bucket))}
             axisLine={false}
             tickLine={false}
             height={18}

--- a/apps/web/src/design/RangePicker.tsx
+++ b/apps/web/src/design/RangePicker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ExploreRange } from "../api.ts";
-import { parseRangeInput } from "./range-input.ts";
+import { parseRangeInput, parseRangeInputForVisibleRange } from "./range-input.ts";
 import { ShortcutKey } from "./ui.tsx";
 
 export type RangeSelection = { seconds: number; label: string };
@@ -136,7 +136,10 @@ export function RangePicker({
     };
   }, [open, value.label]);
 
-  const parsed = useMemo(() => parseRangeInput(draft, Date.now()), [draft]);
+  const parsed = useMemo(
+    () => parseRangeInputForVisibleRange(draft, range, Date.now()),
+    [draft, range],
+  );
   const canApplyParsed = parsed?.type === "relative" || !!(parsed && onAbsoluteChange);
   const draftIsCurrent = draft.trim().toLowerCase() === value.label.trim().toLowerCase();
 

--- a/apps/web/src/design/RangePicker.tsx
+++ b/apps/web/src/design/RangePicker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ExploreRange } from "../api.ts";
+import { parseRangeInput } from "./range-input.ts";
 import { ShortcutKey } from "./ui.tsx";
 
 export type RangeSelection = { seconds: number; label: string };
@@ -18,14 +19,6 @@ export function rangeFromSeconds(seconds: number, now: number): ExploreRange {
     until: new Date(now).toISOString(),
   };
 }
-
-const UNIT_SECS: Record<string, number> = {
-  s: 1, sec: 1, secs: 1, second: 1, seconds: 1,
-  m: 60, min: 60, mins: 60, minute: 60, minutes: 60,
-  h: 3600, hr: 3600, hrs: 3600, hour: 3600, hours: 3600,
-  d: 86400, day: 86400, days: 86400,
-  w: 604800, week: 604800, weeks: 604800,
-};
 
 export function formatSeconds(seconds: number): string {
   if (seconds % 86400 === 0) return `${seconds / 86400}d`;
@@ -73,23 +66,20 @@ function formatSecondsVerbose(seconds: number): string {
 }
 
 export function parseDurationInput(input: string): RangeSelection | null {
-  const cleaned = input.trim().toLowerCase().replace(/^(last|past)\s+/, "");
-  const match = cleaned.match(/^(\d+(?:\.\d+)?)\s*([a-z]+)$/);
-  if (!match) return null;
-  const n = Number.parseFloat(match[1]!);
-  const mult = UNIT_SECS[match[2]!];
-  if (!mult || !Number.isFinite(n) || n <= 0) return null;
-  return { seconds: n * mult, label: `Last ${input.trim()}` };
+  const parsed = parseRangeInput(input, Date.now());
+  return parsed?.type === "relative" ? { seconds: parsed.seconds, label: parsed.label } : null;
 }
 
 export function RangePicker({
   value,
   range,
   onChange,
+  onAbsoluteChange,
 }: {
   value: RangeSelection;
   range: ExploreRange;
   onChange: (v: RangeSelection) => void;
+  onAbsoluteChange?: (range: ExploreRange) => void;
 }) {
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState("");
@@ -146,7 +136,8 @@ export function RangePicker({
     };
   }, [open, value.label]);
 
-  const parsed = useMemo(() => parseDurationInput(draft), [draft]);
+  const parsed = useMemo(() => parseRangeInput(draft, Date.now()), [draft]);
+  const canApplyParsed = parsed?.type === "relative" || !!(parsed && onAbsoluteChange);
   const draftIsCurrent = draft.trim().toLowerCase() === value.label.trim().toLowerCase();
 
   const apply = (next: RangeSelection) => {
@@ -154,8 +145,13 @@ export function RangePicker({
     setOpen(false);
   };
 
-  const submitDraft = () => {
-    if (parsed) apply(parsed);
+  const applyParsed = () => {
+    if (parsed?.type === "relative") {
+      apply({ seconds: parsed.seconds, label: parsed.label });
+    } else if (parsed?.type === "absolute" && onAbsoluteChange) {
+      onAbsoluteChange(parsed.range);
+      setOpen(false);
+    }
   };
 
   const onInputKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -170,8 +166,8 @@ export function RangePicker({
       // Prefer the parsed expression when the user typed something
       // different from the current selection; otherwise fall back to the
       // keyboard-highlighted preset row.
-      if (parsed && !draftIsCurrent) {
-        apply(parsed);
+      if (canApplyParsed && !draftIsCurrent) {
+        applyParsed();
       } else {
         const preset = RANGE_PRESETS[highlight];
         if (preset) apply(preset);
@@ -200,16 +196,24 @@ export function RangePicker({
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
               onKeyDown={onInputKey}
-              placeholder="Type a range — e.g. last 30 minutes"
+              placeholder={
+                onAbsoluteChange
+                  ? "Type a range — e.g. 17:00-19:00 or last 30 minutes"
+                  : "Type a range — e.g. last 30 minutes"
+              }
               className="h-10 flex-1 bg-transparent text-[13px] text-fg placeholder:text-subtle focus:outline-none"
             />
             {draft.trim() && !draftIsCurrent && (
               <span
                 className={`shrink-0 whitespace-nowrap font-mono text-[11px] ${
-                  parsed ? "text-success" : "text-subtle"
+                  canApplyParsed ? "text-success" : "text-subtle"
                 }`}
               >
-                {parsed ? `= ${formatSecondsVerbose(parsed.seconds)}` : "?"}
+                {parsed?.type === "relative" && canApplyParsed
+                  ? `= ${formatSecondsVerbose(parsed.seconds)}`
+                  : parsed?.type === "absolute" && canApplyParsed
+                    ? "= fixed range"
+                    : "?"}
               </span>
             )}
           </div>
@@ -264,4 +268,3 @@ function ClockIcon() {
     </svg>
   );
 }
-

--- a/apps/web/src/design/range-input.ts
+++ b/apps/web/src/design/range-input.ts
@@ -1,0 +1,70 @@
+import type { ExploreRange } from "../api.ts";
+
+export type ParsedRangeInput =
+  | { type: "absolute"; range: ExploreRange }
+  | { type: "relative"; seconds: number; label: string };
+
+const CLOCK_RANGE_RE = /^(\d{1,2}):(\d{2})\s*[-–—]\s*(\d{1,2}):(\d{2})$/;
+
+const UNIT_SECS: Record<string, number> = {
+  s: 1,
+  sec: 1,
+  secs: 1,
+  second: 1,
+  seconds: 1,
+  m: 60,
+  min: 60,
+  mins: 60,
+  minute: 60,
+  minutes: 60,
+  h: 3600,
+  hr: 3600,
+  hrs: 3600,
+  hour: 3600,
+  hours: 3600,
+  d: 86400,
+  day: 86400,
+  days: 86400,
+  w: 604800,
+  week: 604800,
+  weeks: 604800,
+};
+
+export function parseRangeInput(input: string, now: number): ParsedRangeInput | null {
+  const trimmed = input.trim();
+  const match = CLOCK_RANGE_RE.exec(trimmed);
+  if (!match) {
+    const cleaned = trimmed.toLowerCase().replace(/^(last|past)\s+/, "");
+    const duration = cleaned.match(/^(\d+(?:\.\d+)?)\s*([a-z]+)$/);
+    if (!duration) return null;
+    const [, amountInput, unit] = duration;
+    if (!amountInput || !unit) return null;
+    const amount = Number.parseFloat(amountInput);
+    const multiplier = UNIT_SECS[unit];
+    if (!multiplier || !Number.isFinite(amount) || amount <= 0) return null;
+    return {
+      type: "relative",
+      seconds: amount * multiplier,
+      label: `Last ${cleaned}`,
+    };
+  }
+
+  const sinceHour = Number(match[1]);
+  const sinceMinute = Number(match[2]);
+  const untilHour = Number(match[3]);
+  const untilMinute = Number(match[4]);
+  if (sinceHour > 23 || sinceMinute > 59 || untilHour > 23 || untilMinute > 59) {
+    return null;
+  }
+
+  const since = new Date(now);
+  since.setHours(sinceHour, sinceMinute, 0, 0);
+  const until = new Date(now);
+  until.setHours(untilHour, untilMinute, 0, 0);
+  if (since >= until) return null;
+
+  return {
+    type: "absolute",
+    range: { since: since.toISOString(), until: until.toISOString() },
+  };
+}

--- a/apps/web/src/design/range-input.ts
+++ b/apps/web/src/design/range-input.ts
@@ -68,3 +68,12 @@ export function parseRangeInput(input: string, now: number): ParsedRangeInput | 
     range: { since: since.toISOString(), until: until.toISOString() },
   };
 }
+
+export function parseRangeInputForVisibleRange(
+  input: string,
+  visibleRange: ExploreRange,
+  now: number,
+): ParsedRangeInput | null {
+  const visibleSince = new Date(visibleRange.since).getTime();
+  return parseRangeInput(input, Number.isFinite(visibleSince) ? visibleSince : now);
+}

--- a/apps/web/src/explore-timeseries.test.ts
+++ b/apps/web/src/explore-timeseries.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  bucketSeriesSpansDates,
+  formatBucketAxisTick,
+  rangeFromBucketSelection,
+} from "./explore-timeseries.ts";
+import { formatLocalTimestamp } from "./timeFormat.ts";
+
+test("rangeFromBucketSelection selects complete histogram buckets", () => {
+  assert.deepEqual(
+    rangeFromBucketSelection("2026-07-16 17:00:00", "2026-07-16 18:00:00", "1 HOUR", {
+      since: "2026-07-16T16:00:00.000Z",
+      until: "2026-07-16T20:00:00.000Z",
+    }),
+    {
+      since: "2026-07-16T17:00:00.000Z",
+      until: "2026-07-16T19:00:00.000Z",
+    },
+  );
+});
+
+test("rangeFromBucketSelection never expands beyond the current range", () => {
+  assert.deepEqual(
+    rangeFromBucketSelection("2026-07-16 17:00:00", "2026-07-16 19:00:00", "1 HOUR", {
+      since: "2026-07-16T17:15:00.000Z",
+      until: "2026-07-16T19:30:00.000Z",
+    }),
+    {
+      since: "2026-07-16T17:15:00.000Z",
+      until: "2026-07-16T19:30:00.000Z",
+    },
+  );
+});
+
+test("bucket axis ticks include dates when the series spans multiple local dates", () => {
+  const buckets = ["2026-07-15 12:00:00", "2026-07-17 12:00:00"];
+  const firstBucket = buckets[0];
+  assert.ok(firstBucket);
+
+  assert.equal(bucketSeriesSpansDates(buckets), true);
+  assert.equal(
+    formatBucketAxisTick(firstBucket, true),
+    formatLocalTimestamp(firstBucket).slice(5, 16),
+  );
+});

--- a/apps/web/src/explore-timeseries.ts
+++ b/apps/web/src/explore-timeseries.ts
@@ -1,0 +1,63 @@
+import type { ExploreRange } from "./api.ts";
+import { formatLocalHm, formatLocalTimestamp } from "./timeFormat.ts";
+
+export function parseStepMs(step: string | undefined): number | undefined {
+  if (!step) return undefined;
+  const match = step.match(/^(\d+)\s+(SECOND|MINUTE|HOUR|DAY)/i);
+  if (!match) return undefined;
+  const [, amountInput, unitInput] = match;
+  if (!amountInput || !unitInput) return undefined;
+  const amount = Number.parseInt(amountInput, 10);
+  const unit = unitInput.toUpperCase();
+  const multiplier =
+    unit === "SECOND"
+      ? 1000
+      : unit === "MINUTE"
+        ? 60_000
+        : unit === "HOUR"
+          ? 3_600_000
+          : 86_400_000;
+  return amount * multiplier;
+}
+
+function bucketTime(bucket: string): number {
+  return new Date(`${bucket.replace(" ", "T")}Z`).getTime();
+}
+
+export function rangeFromBucketSelection(
+  firstBucket: string,
+  lastBucket: string,
+  step: string | undefined,
+  currentRange: ExploreRange,
+): ExploreRange | null {
+  const stepMs = parseStepMs(step);
+  const first = bucketTime(firstBucket);
+  const last = bucketTime(lastBucket);
+  const currentSince = new Date(currentRange.since).getTime();
+  const currentUntil = new Date(currentRange.until).getTime();
+  if (
+    !stepMs ||
+    !Number.isFinite(first) ||
+    !Number.isFinite(last) ||
+    !Number.isFinite(currentSince) ||
+    !Number.isFinite(currentUntil)
+  ) {
+    return null;
+  }
+
+  const since = Math.max(Math.min(first, last), currentSince);
+  const until = Math.min(Math.max(first, last) + stepMs, currentUntil);
+  if (since >= until) return null;
+  return {
+    since: new Date(since).toISOString(),
+    until: new Date(until).toISOString(),
+  };
+}
+
+export function bucketSeriesSpansDates(buckets: string[]): boolean {
+  return new Set(buckets.map((bucket) => formatLocalTimestamp(bucket).slice(0, 10))).size > 1;
+}
+
+export function formatBucketAxisTick(bucket: string, includeDate: boolean): string {
+  return includeDate ? formatLocalTimestamp(bucket).slice(5, 16) : formatLocalHm(bucket);
+}

--- a/apps/web/src/range-input.test.ts
+++ b/apps/web/src/range-input.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { parseRangeInput } from "./design/range-input.ts";
+import { parseRangeInput, parseRangeInputForVisibleRange } from "./design/range-input.ts";
 
 test("parseRangeInput parses a local clock range on the current date", () => {
   const now = new Date(2026, 6, 16, 12, 34, 56, 789);
@@ -21,4 +21,24 @@ test("parseRangeInput preserves relative duration input", () => {
     seconds: 30 * 60,
     label: "Last 30 minutes",
   });
+});
+
+test("clock ranges use the visible historical range date", () => {
+  assert.deepEqual(
+    parseRangeInputForVisibleRange(
+      "17:00-19:00",
+      {
+        since: "2025-04-03T08:00:00.000Z",
+        until: "2025-04-03T10:00:00.000Z",
+      },
+      new Date(2026, 6, 16, 12).getTime(),
+    ),
+    {
+      type: "absolute",
+      range: {
+        since: new Date(2025, 3, 3, 17, 0).toISOString(),
+        until: new Date(2025, 3, 3, 19, 0).toISOString(),
+      },
+    },
+  );
 });

--- a/apps/web/src/range-input.test.ts
+++ b/apps/web/src/range-input.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseRangeInput } from "./design/range-input.ts";
+
+test("parseRangeInput parses a local clock range on the current date", () => {
+  const now = new Date(2026, 6, 16, 12, 34, 56, 789);
+  const result = parseRangeInput("17:00-19:00", now.getTime());
+
+  assert.deepEqual(result, {
+    type: "absolute",
+    range: {
+      since: new Date(2026, 6, 16, 17, 0).toISOString(),
+      until: new Date(2026, 6, 16, 19, 0).toISOString(),
+    },
+  });
+});
+
+test("parseRangeInput preserves relative duration input", () => {
+  assert.deepEqual(parseRangeInput("last 30 minutes", Date.now()), {
+    type: "relative",
+    seconds: 30 * 60,
+    label: "Last 30 minutes",
+  });
+});


### PR DESCRIPTION
## Summary

- parse fixed local clock ranges such as `17:00-19:00` in the logs and traces explorer
- allow dragging across occurrence-chart buckets to select an absolute time window
- include month and day in chart ticks when the visible data spans multiple local dates
- preserve existing relative duration inputs and share fixed ranges through the URL

## Validation

- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web test` (168 passing)
- seeded worktree verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users set precise windows in Explore: type a fixed local range like “17:00-19:00” anchored to the visible window’s date, or drag across chart buckets to choose an absolute time span. X-axis ticks show dates when needed; relative ranges still work and absolute ranges are shared via URL.

- **New Features**
  - Parse fixed clock ranges anchored to the current visible date (e.g., “17:00-19:00” in historical views).
  - Drag-select histogram buckets to set an absolute range with a highlighted selection.
  - Show month/day on X-axis when data spans multiple local dates.

- **Refactors**
  - Moved timeseries helpers to `explore-timeseries.ts` and range parsing to `design/range-input.ts`; wired `RangePicker` and charts to use them.
  - Added tests for range input parsing, bucket selection, and axis formatting.

<sup>Written for commit 140762170eb6cbfdebe9f1752200435ef0664f08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

