### PR TITLE
Resolve incidents when the last live agent PR is closed without merge

### DIFF
--- a/apps/api/src/github.test.ts
+++ b/apps/api/src/github.test.ts
@@ -910,7 +910,7 @@ test("the GitHub app's own PR comments do not resume its investigation", async (
   assert.equal(continuations.length, 0);
 });
 
-test("closed unmerged agent PR does not resolve incident or linked issue", async () => {
+test("closing the last live agent PR without merge resolves the incident and linked issue", async () => {
   const fixture = await seedAgentPrFixture("closed");
   const app = new Hono();
   mountGithubPublic(app);
@@ -937,15 +937,20 @@ test("closed unmerged agent PR does not resolve incident or linked issue", async
   });
   assert.equal(pr?.state, "closed");
 
+  // The close settled the incident's only PR: the human's decision on the
+  // delivery resolves the incident instead of parking it behind a question.
   const incident = await db.query.incidents.findFirst({
     where: eq(schema.incidents.id, fixture.incidentId),
   });
-  assert.equal(incident?.status, "open");
+  assert.equal(incident?.status, "resolved");
+  assert.equal(incident?.resolvedByKind, "agent_pr_closed");
+  assert.equal(incident?.resolvedReasonCode, "agent_pr_closed");
+  assert.match(incident?.resolvedReasonText ?? "", /closed without merge by @alice/);
 
   const issue = await db.query.issues.findFirst({
     where: eq(schema.issues.id, fixture.issueId),
   });
-  assert.equal(issue?.status, "open");
+  assert.equal(issue?.status, "resolved");
 
   const resolvedEvent = await db.query.incidentEvents.findFirst({
     where: and(
@@ -953,7 +958,7 @@ test("closed unmerged agent PR does not resolve incident or linked issue", async
       eq(schema.incidentEvents.kind, "incident_resolved"),
     ),
   });
-  assert.equal(resolvedEvent, undefined);
+  assert.match(resolvedEvent?.summary ?? "", /closed without merge/);
 });
 
 async function seedAgentPrFixture(label: string): Promise<{

--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -18,7 +18,6 @@ import {
   recordInboundInteraction,
   releaseAgentPullRequestReviewContinuationClaim,
   releaseAgentPullRequestReviewLimitNotification,
-  resolveIncidentIfAllAgentPullRequestsMerged,
   resolveIncidentIfAllAgentPullRequestsSettled,
   schema,
   syncLoopsContactsForOrg,
@@ -1049,26 +1048,33 @@ async function resolveIncidentForMergedAgentPr(opts: {
 }): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
   const { agentPr, mergedAt, mergedByLogin } = opts;
   const resolutionEventDedupeKey = `incident_resolved:agent_pr:${agentPr.id}`;
-  const resolution = await resolveIncidentIfAllAgentPullRequestsMerged({
+  // Settled guard, not all-merged: a sibling PR closed without merge must not
+  // block this merge from resolving the incident — on a mixed incident the
+  // merge can be the last settle event, with no later close to fire the
+  // policy.
+  const resolution = await resolveIncidentIfAllAgentPullRequestsSettled({
     incidentId: agentPr.incidentId,
-    kind: "agent_pr_merged",
-    reasonCode: "agent_pr_merged",
-    reasonText: `Resolved because agent PR #${agentPr.prNumber} (${agentPr.repoFullName}) was merged${
-      mergedByLogin ? ` by @${mergedByLogin}` : ""
-    }${!mergedByLogin && opts.source ? ` (${opts.source})` : ""}.`,
-    agentRunId: agentPr.agentRunId,
-    resolvingAgentRunId: null,
-    eventSummary: `Incident resolved because PR #${agentPr.prNumber} was merged.`,
-    eventDetail: {
-      agentPrId: agentPr.id,
-      repoFullName: agentPr.repoFullName,
-      prNumber: agentPr.prNumber,
-      prUrl: agentPr.url,
-      mergedByLogin,
-      ...(opts.source ? { source: opts.source } : {}),
-    },
-    eventDedupeKey: resolutionEventDedupeKey,
-    resolvedAt: mergedAt,
+    buildInput: (pullRequests) => ({
+      incidentId: agentPr.incidentId,
+      kind: "agent_pr_merged" as const,
+      reasonCode: "agent_pr_merged",
+      reasonText: `Resolved because agent PR #${agentPr.prNumber} (${agentPr.repoFullName}) was merged${
+        mergedByLogin ? ` by @${mergedByLogin}` : ""
+      }${!mergedByLogin && opts.source ? ` (${opts.source})` : ""}.`,
+      agentRunId: agentPr.agentRunId,
+      resolvingAgentRunId: null,
+      eventSummary: `Incident resolved because PR #${agentPr.prNumber} was merged.`,
+      eventDetail: {
+        agentPrId: agentPr.id,
+        repoFullName: agentPr.repoFullName,
+        prNumber: agentPr.prNumber,
+        prUrl: agentPr.url,
+        mergedByLogin,
+        ...(opts.source ? { source: opts.source } : {}),
+      },
+      eventDedupeKey: resolutionEventDedupeKey,
+      resolvedAt: latestAgentPullRequestSettlementAt(pullRequests) ?? mergedAt,
+    }),
   });
   if (resolution.disposition === "resolved") {
     await runResolvedIncidentSideEffectsWithGithub(agentPr.incidentId, {

--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -3,6 +3,7 @@ import {
   AGENT_PULL_REQUEST_REVIEW_CONTINUATION_LIMIT,
   type AgentPullRequestLifecycleContinuation,
   type AgentPullRequestProviderObservation as GithubPullRequestProviderObservation,
+  type IncidentAgentPullRequestSnapshot,
   type ResolveIncidentAfterAgentPullRequestsMergedResult,
   type ResolveIncidentInput,
   applyAgentPullRequestState,
@@ -931,10 +932,12 @@ type ClosedAgentPullRequestContinuationInput = {
 };
 
 type ClosedAgentPullRequestContinuationDependencies = {
-  listIncidentPullRequests(incidentId: string): Promise<schema.AgentPullRequest[]>;
-  resolveSettled(
-    input: ResolveIncidentInput & { kind: "agent_pr_merged" | "agent_pr_closed" },
-  ): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult>;
+  resolveSettled(opts: {
+    incidentId: string;
+    buildInput(
+      pullRequests: IncidentAgentPullRequestSnapshot[],
+    ): ResolveIncidentInput & { kind: "agent_pr_merged" | "agent_pr_closed" };
+  }): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult>;
   runResolvedSideEffects(
     incidentId: string,
     resolutionProof: { agentRunId: string | null; eventDedupeKey: string },
@@ -948,55 +951,57 @@ type ClosedAgentPullRequestContinuationDependencies = {
 export async function resolveOrResumeIncidentForClosedAgentPr(
   opts: ClosedAgentPullRequestContinuationInput,
   dependencies: ClosedAgentPullRequestContinuationDependencies = {
-    listIncidentPullRequests: (incidentId) =>
-      db.query.agentPullRequests.findMany({
-        where: eq(schema.agentPullRequests.incidentId, incidentId),
-      }),
     resolveSettled: resolveIncidentIfAllAgentPullRequestsSettled,
     runResolvedSideEffects: runResolvedIncidentSideEffectsWithGithub,
     continueInSession: resumeIncidentSessionForPrEvent,
   },
 ): Promise<ClosedAgentPullRequestContinuationDisposition> {
   const { agentPr, closedByLogin, closedAt } = opts;
-  const pullRequests = await dependencies.listIncidentPullRequests(agentPr.incidentId);
-  // Credit the landed fix when one exists: resolving a merged+closed mix as
-  // "closed" would hide that a change actually shipped.
-  const mergedSibling =
-    pullRequests
-      .filter((pullRequest) => pullRequest.state === "merged")
-      .sort((a, b) => (a.mergedAt?.getTime() ?? 0) - (b.mergedAt?.getTime() ?? 0))
-      .at(-1) ?? null;
   const closedBy = closedByLogin ? ` by @${closedByLogin}` : "";
   const eventDedupeKey = `incident_resolved:agent_pr_closed:${agentPr.id}:${closedAt.getTime()}`;
   const resolution = await dependencies.resolveSettled({
     incidentId: agentPr.incidentId,
-    ...(mergedSibling
-      ? {
-          kind: "agent_pr_merged" as const,
-          reasonCode: "agent_pr_merged",
-          reasonText: `Resolved because agent PR #${mergedSibling.prNumber} (${mergedSibling.repoFullName}) was merged and the last live agent PR #${agentPr.prNumber} was closed without merge${closedBy}.`,
-          eventSummary: `Incident resolved after PR #${agentPr.prNumber} was closed; fix PR #${mergedSibling.prNumber} is merged.`,
-        }
-      : {
-          kind: "agent_pr_closed" as const,
-          reasonCode: "agent_pr_closed",
-          reasonText: `Resolved because agent PR #${agentPr.prNumber} (${agentPr.repoFullName}) was closed without merge${closedBy} and no agent PRs remain open.`,
-          eventSummary: `Incident resolved because PR #${agentPr.prNumber} was closed without merge.`,
-        }),
-    agentRunId: agentPr.agentRunId,
-    resolvingAgentRunId: null,
-    eventDetail: {
-      agentPrId: agentPr.id,
-      repoFullName: agentPr.repoFullName,
-      prNumber: agentPr.prNumber,
-      prUrl: agentPr.url,
-      closedByLogin,
-      ...(mergedSibling
-        ? { mergedAgentPrId: mergedSibling.id, mergedPrNumber: mergedSibling.prNumber }
-        : {}),
+    // Built from the PR snapshot taken under the incident lock, so a sibling
+    // merge racing this close cannot skew the attribution: a landed fix is
+    // credited as `agent_pr_merged`, a plain close resolves as
+    // `agent_pr_closed`.
+    buildInput: (pullRequests) => {
+      const mergedSibling =
+        pullRequests
+          .filter((pullRequest) => pullRequest.state === "merged")
+          .sort((a, b) => (a.mergedAt?.getTime() ?? 0) - (b.mergedAt?.getTime() ?? 0))
+          .at(-1) ?? null;
+      return {
+        incidentId: agentPr.incidentId,
+        ...(mergedSibling
+          ? {
+              kind: "agent_pr_merged" as const,
+              reasonCode: "agent_pr_merged",
+              reasonText: `Resolved because agent PR #${mergedSibling.prNumber} (${mergedSibling.repoFullName}) was merged and the last live agent PR #${agentPr.prNumber} was closed without merge${closedBy}.`,
+              eventSummary: `Incident resolved after PR #${agentPr.prNumber} was closed; fix PR #${mergedSibling.prNumber} is merged.`,
+            }
+          : {
+              kind: "agent_pr_closed" as const,
+              reasonCode: "agent_pr_closed",
+              reasonText: `Resolved because agent PR #${agentPr.prNumber} (${agentPr.repoFullName}) was closed without merge${closedBy} and no agent PRs remain open.`,
+              eventSummary: `Incident resolved because PR #${agentPr.prNumber} was closed without merge.`,
+            }),
+        agentRunId: agentPr.agentRunId,
+        resolvingAgentRunId: null,
+        eventDetail: {
+          agentPrId: agentPr.id,
+          repoFullName: agentPr.repoFullName,
+          prNumber: agentPr.prNumber,
+          prUrl: agentPr.url,
+          closedByLogin,
+          ...(mergedSibling
+            ? { mergedAgentPrId: mergedSibling.id, mergedPrNumber: mergedSibling.prNumber }
+            : {}),
+        },
+        eventDedupeKey,
+        resolvedAt: closedAt,
+      };
     },
-    eventDedupeKey,
-    resolvedAt: closedAt,
   });
   if (resolution.disposition === "resolved") {
     await dependencies.runResolvedSideEffects(agentPr.incidentId, {

--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -934,8 +934,10 @@ type ClosedAgentPullRequestContinuationInput = {
 type ClosedAgentPullRequestContinuationDependencies = {
   resolveSettled(opts: {
     incidentId: string;
+    settlementEvidenceAt: Date;
     buildInput(
       pullRequests: IncidentAgentPullRequestSnapshot[],
+      epoch: { reopenedAt: Date | null },
     ): ResolveIncidentInput & { kind: "agent_pr_merged" | "agent_pr_closed" };
   }): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult>;
   runResolvedSideEffects(
@@ -961,14 +963,21 @@ export async function resolveOrResumeIncidentForClosedAgentPr(
   const eventDedupeKey = `incident_resolved:agent_pr_closed:${agentPr.id}:${closedAt.getTime()}`;
   const resolution = await dependencies.resolveSettled({
     incidentId: agentPr.incidentId,
+    settlementEvidenceAt: closedAt,
     // Built from the PR snapshot taken under the incident lock, so a sibling
     // merge racing this close cannot skew the attribution: a landed fix is
     // credited as `agent_pr_merged`, a plain close resolves as
-    // `agent_pr_closed`.
-    buildInput: (pullRequests) => {
+    // `agent_pr_closed`. Only current-epoch merges count — a PR merged before
+    // the incident's last manual reopen is a fix the human already overrode.
+    buildInput: (pullRequests, epoch) => {
       const mergedSibling =
         pullRequests
-          .filter((pullRequest) => pullRequest.state === "merged")
+          .filter(
+            (pullRequest) =>
+              pullRequest.state === "merged" &&
+              pullRequest.mergedAt &&
+              (!epoch.reopenedAt || pullRequest.mergedAt.getTime() > epoch.reopenedAt.getTime()),
+          )
           .sort((a, b) => (a.mergedAt?.getTime() ?? 0) - (b.mergedAt?.getTime() ?? 0))
           .at(-1) ?? null;
       return {
@@ -1054,6 +1063,7 @@ async function resolveIncidentForMergedAgentPr(opts: {
   // policy.
   const resolution = await resolveIncidentIfAllAgentPullRequestsSettled({
     incidentId: agentPr.incidentId,
+    settlementEvidenceAt: mergedAt,
     buildInput: (pullRequests) => ({
       incidentId: agentPr.incidentId,
       kind: "agent_pr_merged" as const,

--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -4,6 +4,7 @@ import {
   type AgentPullRequestLifecycleContinuation,
   type AgentPullRequestProviderObservation as GithubPullRequestProviderObservation,
   type ResolveIncidentAfterAgentPullRequestsMergedResult,
+  type ResolveIncidentInput,
   applyAgentPullRequestState,
   buildAgentPullRequestLifecycleContinuation,
   completeAgentPullRequestReviewContinuationClaim,
@@ -16,6 +17,7 @@ import {
   releaseAgentPullRequestReviewContinuationClaim,
   releaseAgentPullRequestReviewLimitNotification,
   resolveIncidentIfAllAgentPullRequestsMerged,
+  resolveIncidentIfAllAgentPullRequestsSettled,
   schema,
   syncLoopsContactsForOrg,
   unblockAgentRunsAfterGithubAccess,
@@ -741,7 +743,7 @@ async function handleAgentPrWebhook(
         mergedByLogin: canonicalPr.mergedByLogin,
       });
     } else if (appliedState === "closed" && canonicalPr.state === "closed") {
-      await maybeResumeIncidentForClosedAgentPr({
+      await resolveOrResumeIncidentForClosedAgentPr({
         agentPr: canonicalPr,
         closedByLogin: appliedObservation.providerSnapshotAuthoritative
           ? null
@@ -907,36 +909,127 @@ export async function resumeOrResolveIncidentForMergedAgentPr(
   return resolution.disposition;
 }
 
-// An agent PR was closed without merging. Resume the session so the agent can
-// react (per the spec: if the close context shows the issue is noise, silence
-// it and resolve; otherwise decide the next step). No fallback action — the
-// incident simply stays open for a human or a later run.
-async function maybeResumeIncidentForClosedAgentPr(opts: {
+// An agent PR was closed without merging. Closing the last live agent PR is
+// the human's decision on the delivery itself, so the incident resolves
+// deterministically instead of waiting for a confirmation nobody sends: as
+// `agent_pr_merged` when a sibling fix did land, as `agent_pr_closed` when
+// nothing merged. Issues cascade to resolved, so a real recurrence re-pages
+// through the ordinary resolved→recur path. While other PRs are still open
+// the close is only context — it resumes the session (when one exists) so the
+// agent keeps driving the remaining delivery.
+export type ClosedAgentPullRequestContinuationDisposition =
+  | MergedAgentPullRequestSessionContinuation
+  | Exclude<
+      ResolveIncidentAfterAgentPullRequestsMergedResult["disposition"],
+      "pull_requests_pending"
+    >;
+
+type ClosedAgentPullRequestContinuationInput = {
   agentPr: schema.AgentPullRequest;
   closedByLogin: string | null;
   closedAt: Date;
-}): Promise<void> {
-  const { agentPr, closedByLogin } = opts;
+};
+
+type ClosedAgentPullRequestContinuationDependencies = {
+  listIncidentPullRequests(incidentId: string): Promise<schema.AgentPullRequest[]>;
+  resolveSettled(
+    input: ResolveIncidentInput & { kind: "agent_pr_merged" | "agent_pr_closed" },
+  ): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult>;
+  runResolvedSideEffects(
+    incidentId: string,
+    resolutionProof: { agentRunId: string | null; eventDedupeKey: string },
+  ): Promise<void>;
+  continueInSession(opts: {
+    agentPr: schema.AgentPullRequest;
+    continuation: AgentPullRequestLifecycleContinuation;
+  }): Promise<MergedAgentPullRequestSessionContinuation>;
+};
+
+export async function resolveOrResumeIncidentForClosedAgentPr(
+  opts: ClosedAgentPullRequestContinuationInput,
+  dependencies: ClosedAgentPullRequestContinuationDependencies = {
+    listIncidentPullRequests: (incidentId) =>
+      db.query.agentPullRequests.findMany({
+        where: eq(schema.agentPullRequests.incidentId, incidentId),
+      }),
+    resolveSettled: resolveIncidentIfAllAgentPullRequestsSettled,
+    runResolvedSideEffects: runResolvedIncidentSideEffectsWithGithub,
+    continueInSession: resumeIncidentSessionForPrEvent,
+  },
+): Promise<ClosedAgentPullRequestContinuationDisposition> {
+  const { agentPr, closedByLogin, closedAt } = opts;
+  const pullRequests = await dependencies.listIncidentPullRequests(agentPr.incidentId);
+  // Credit the landed fix when one exists: resolving a merged+closed mix as
+  // "closed" would hide that a change actually shipped.
+  const mergedSibling =
+    pullRequests
+      .filter((pullRequest) => pullRequest.state === "merged")
+      .sort((a, b) => (a.mergedAt?.getTime() ?? 0) - (b.mergedAt?.getTime() ?? 0))
+      .at(-1) ?? null;
+  const closedBy = closedByLogin ? ` by @${closedByLogin}` : "";
+  const eventDedupeKey = `incident_resolved:agent_pr_closed:${agentPr.id}:${closedAt.getTime()}`;
+  const resolution = await dependencies.resolveSettled({
+    incidentId: agentPr.incidentId,
+    ...(mergedSibling
+      ? {
+          kind: "agent_pr_merged" as const,
+          reasonCode: "agent_pr_merged",
+          reasonText: `Resolved because agent PR #${mergedSibling.prNumber} (${mergedSibling.repoFullName}) was merged and the last live agent PR #${agentPr.prNumber} was closed without merge${closedBy}.`,
+          eventSummary: `Incident resolved after PR #${agentPr.prNumber} was closed; fix PR #${mergedSibling.prNumber} is merged.`,
+        }
+      : {
+          kind: "agent_pr_closed" as const,
+          reasonCode: "agent_pr_closed",
+          reasonText: `Resolved because agent PR #${agentPr.prNumber} (${agentPr.repoFullName}) was closed without merge${closedBy} and no agent PRs remain open.`,
+          eventSummary: `Incident resolved because PR #${agentPr.prNumber} was closed without merge.`,
+        }),
+    agentRunId: agentPr.agentRunId,
+    resolvingAgentRunId: null,
+    eventDetail: {
+      agentPrId: agentPr.id,
+      repoFullName: agentPr.repoFullName,
+      prNumber: agentPr.prNumber,
+      prUrl: agentPr.url,
+      closedByLogin,
+      ...(mergedSibling
+        ? { mergedAgentPrId: mergedSibling.id, mergedPrNumber: mergedSibling.prNumber }
+        : {}),
+    },
+    eventDedupeKey,
+    resolvedAt: closedAt,
+  });
+  if (resolution.disposition === "resolved") {
+    await dependencies.runResolvedSideEffects(agentPr.incidentId, {
+      agentRunId: agentPr.agentRunId,
+      eventDedupeKey,
+    });
+    return "resolved";
+  }
+  if (resolution.disposition !== "pull_requests_pending") {
+    return resolution.disposition;
+  }
   const continuation = buildAgentPullRequestLifecycleContinuation({
     pullRequest: {
       ...agentPr,
       state: "closed",
-      closedAt: opts.closedAt,
+      closedAt,
     },
     actorLogin: closedByLogin,
-    occurredAt: opts.closedAt,
+    occurredAt: closedAt,
   });
   if (!continuation) throw new Error("closed PR did not produce a lifecycle continuation");
-  await resumeIncidentSessionForPrEvent({
-    agentPr,
-    continuation,
-  }).catch((err) => {
-    log.warn(
-      { err, agent_pr_id: agentPr.id, incident_id: agentPr.incidentId },
-      "failed to resume session for closed agent PR",
-    );
-    return false;
-  });
+  return dependencies
+    .continueInSession({
+      agentPr,
+      continuation,
+    })
+    .catch((err) => {
+      log.warn(
+        { err, agent_pr_id: agentPr.id, incident_id: agentPr.incidentId },
+        "failed to resume session for closed agent PR",
+      );
+      return "no_resumable_session" as const;
+    });
 }
 
 async function resolveIncidentForMergedAgentPr(opts: {
@@ -969,31 +1062,38 @@ async function resolveIncidentForMergedAgentPr(opts: {
     resolvedAt: mergedAt,
   });
   if (resolution.disposition === "resolved") {
-    await runResolvedIncidentSideEffectsForIncident({
-      incidentId: agentPr.incidentId,
-      resolutionProof: {
-        agentRunId: agentPr.agentRunId,
-        eventDedupeKey: resolutionEventDedupeKey,
-      },
-      closePullRequest: (pr) =>
-        closeAgentPullRequestOnGithub({
-          installationId: pr.githubInstallationId,
-          fallbackInstallationIds: pr.fallbackGithubInstallationIds,
-          repoFullName: pr.repoFullName,
-          prNumber: pr.prNumber,
-          prNodeId: pr.prNodeId,
-        }),
-      reopenPullRequest: (pr) =>
-        reopenAgentPullRequestOnGithub({
-          installationId: pr.githubInstallationId,
-          fallbackInstallationIds: pr.fallbackGithubInstallationIds,
-          repoFullName: pr.repoFullName,
-          prNumber: pr.prNumber,
-          prNodeId: pr.prNodeId,
-        }),
+    await runResolvedIncidentSideEffectsWithGithub(agentPr.incidentId, {
+      agentRunId: agentPr.agentRunId,
+      eventDedupeKey: resolutionEventDedupeKey,
     });
   }
   return resolution;
+}
+
+async function runResolvedIncidentSideEffectsWithGithub(
+  incidentId: string,
+  resolutionProof: { agentRunId: string | null; eventDedupeKey: string },
+): Promise<void> {
+  await runResolvedIncidentSideEffectsForIncident({
+    incidentId,
+    resolutionProof,
+    closePullRequest: (pr) =>
+      closeAgentPullRequestOnGithub({
+        installationId: pr.githubInstallationId,
+        fallbackInstallationIds: pr.fallbackGithubInstallationIds,
+        repoFullName: pr.repoFullName,
+        prNumber: pr.prNumber,
+        prNodeId: pr.prNodeId,
+      }),
+    reopenPullRequest: (pr) =>
+      reopenAgentPullRequestOnGithub({
+        installationId: pr.githubInstallationId,
+        fallbackInstallationIds: pr.fallbackGithubInstallationIds,
+        repoFullName: pr.repoFullName,
+        prNumber: pr.prNumber,
+        prNodeId: pr.prNodeId,
+      }),
+  });
 }
 
 type EligiblePrComment = {

--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -11,6 +11,7 @@ import {
   completeAgentPullRequestReviewContinuationClaim,
   db,
   isAgentPullRequestReviewEventKind,
+  latestAgentPullRequestSettlementAt,
   listAccessibleGithubInstallsForProject,
   reconcileAgentPullRequestProviderObservation,
   recordAgentPullRequestReviewEvent,
@@ -999,7 +1000,10 @@ export async function resolveOrResumeIncidentForClosedAgentPr(
             : {}),
         },
         eventDedupeKey,
-        resolvedAt: closedAt,
+        // The delivery finished at the latest settle across the snapshot —
+        // stamping this close's time when a sibling settled later would
+        // backdate the resolution.
+        resolvedAt: latestAgentPullRequestSettlementAt(pullRequests) ?? closedAt,
       };
     },
   });

--- a/apps/api/src/pr-close-resolution.test.ts
+++ b/apps/api/src/pr-close-resolution.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import type { schema } from "@superlog/db";
+import type { IncidentAgentPullRequestSnapshot, schema } from "@superlog/db";
 
 process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
 process.env.BETTER_AUTH_SECRET ??= "test-better-auth-secret-with-enough-length";
@@ -22,19 +22,23 @@ const closedPr = {
   mergedByLogin: null,
 } as schema.AgentPullRequest;
 
-const mergedSibling = {
-  id: "agent-pr-2",
-  incidentId: "incident-1",
-  agentRunId: "agent-run-1",
+const closedSnapshot: IncidentAgentPullRequestSnapshot = {
+  id: "agent-pr-1",
+  state: "closed",
+  prNumber: 42,
   repoFullName: "acme/api",
-  prNumber: 40,
-  branchName: "fix/api-timeout-v1",
-  url: "https://github.com/acme/api/pull/40",
+  url: "https://github.com/acme/api/pull/42",
+  mergedAt: null,
+};
+
+const mergedSnapshot: IncidentAgentPullRequestSnapshot = {
+  id: "agent-pr-2",
   state: "merged",
+  prNumber: 40,
+  repoFullName: "acme/api",
+  url: "https://github.com/acme/api/pull/40",
   mergedAt: new Date("2026-07-14T10:00:00.000Z"),
-  closedAt: new Date("2026-07-14T10:00:00.000Z"),
-  mergedByLogin: "octocat",
-} as schema.AgentPullRequest;
+};
 
 test("a close that settles the last live PR resolves the incident without asking the session", async () => {
   const calls: Array<{ kind: string; value?: unknown }> = [];
@@ -42,11 +46,8 @@ test("a close that settles the last live PR resolves the incident without asking
   const disposition = await resolveOrResumeIncidentForClosedAgentPr(
     { agentPr: closedPr, closedByLogin: "hubot", closedAt },
     {
-      async listIncidentPullRequests() {
-        return [closedPr];
-      },
-      async resolveSettled(input) {
-        calls.push({ kind: "resolve", value: input });
+      async resolveSettled(opts) {
+        calls.push({ kind: "resolve", value: opts.buildInput([closedSnapshot]) });
         return { disposition: "resolved", resolved: true, resolvedIssueCount: 2 };
       },
       async runResolvedSideEffects(incidentId) {
@@ -82,18 +83,17 @@ test("a close that settles the last live PR resolves the incident without asking
     `incident_resolved:agent_pr_closed:agent-pr-1:${closedAt.getTime()}`,
   );
   assert.equal(resolveInput.resolvedAt, closedAt);
+  assert.equal(calls[1]?.value, "incident-1");
 });
 
-test("a close with a merged sibling resolves as agent_pr_merged crediting the landed fix", async () => {
+test("a close with a merged sibling in the locked snapshot resolves as agent_pr_merged", async () => {
   const resolveInputs: Array<{ kind: string; reasonText: string }> = [];
 
   const disposition = await resolveOrResumeIncidentForClosedAgentPr(
     { agentPr: closedPr, closedByLogin: "hubot", closedAt },
     {
-      async listIncidentPullRequests() {
-        return [mergedSibling, closedPr];
-      },
-      async resolveSettled(input) {
+      async resolveSettled(opts) {
+        const input = opts.buildInput([mergedSnapshot, closedSnapshot]);
         resolveInputs.push({ kind: input.kind, reasonText: input.reasonText ?? "" });
         return { disposition: "resolved", resolved: true, resolvedIssueCount: 1 };
       },
@@ -116,9 +116,6 @@ test("a close while another PR is still live falls back to the session continuat
   const disposition = await resolveOrResumeIncidentForClosedAgentPr(
     { agentPr: closedPr, closedByLogin: "hubot", closedAt },
     {
-      async listIncidentPullRequests() {
-        return [closedPr, { ...closedPr, id: "agent-pr-3", state: "open" }];
-      },
       async resolveSettled() {
         calls.push("resolve");
         return { disposition: "pull_requests_pending", resolved: false, resolvedIssueCount: 0 };
@@ -144,9 +141,6 @@ test("a close on an already-resolved incident is a no-op", async () => {
   const disposition = await resolveOrResumeIncidentForClosedAgentPr(
     { agentPr: closedPr, closedByLogin: null, closedAt },
     {
-      async listIncidentPullRequests() {
-        return [closedPr];
-      },
       async resolveSettled() {
         calls.push("resolve");
         return { disposition: "incident_not_open", resolved: false, resolvedIssueCount: 0 };

--- a/apps/api/src/pr-close-resolution.test.ts
+++ b/apps/api/src/pr-close-resolution.test.ts
@@ -29,15 +29,20 @@ const closedSnapshot: IncidentAgentPullRequestSnapshot = {
   repoFullName: "acme/api",
   url: "https://github.com/acme/api/pull/42",
   mergedAt: null,
+  closedAt,
 };
 
+// Merged after the close settled: the resolution must be stamped at the merge,
+// not backdated to the close.
+const laterMergedAt = new Date("2026-07-16T10:00:00.000Z");
 const mergedSnapshot: IncidentAgentPullRequestSnapshot = {
   id: "agent-pr-2",
   state: "merged",
   prNumber: 40,
   repoFullName: "acme/api",
   url: "https://github.com/acme/api/pull/40",
-  mergedAt: new Date("2026-07-14T10:00:00.000Z"),
+  mergedAt: laterMergedAt,
+  closedAt: laterMergedAt,
 };
 
 test("a close that settles the last live PR resolves the incident without asking the session", async () => {
@@ -87,14 +92,19 @@ test("a close that settles the last live PR resolves the incident without asking
 });
 
 test("a close with a merged sibling in the locked snapshot resolves as agent_pr_merged", async () => {
-  const resolveInputs: Array<{ kind: string; reasonText: string }> = [];
+  const resolveInputs: Array<{ kind: string; reasonText: string; resolvedAt: Date | undefined }> =
+    [];
 
   const disposition = await resolveOrResumeIncidentForClosedAgentPr(
     { agentPr: closedPr, closedByLogin: "hubot", closedAt },
     {
       async resolveSettled(opts) {
         const input = opts.buildInput([mergedSnapshot, closedSnapshot]);
-        resolveInputs.push({ kind: input.kind, reasonText: input.reasonText ?? "" });
+        resolveInputs.push({
+          kind: input.kind,
+          reasonText: input.reasonText ?? "",
+          resolvedAt: input.resolvedAt,
+        });
         return { disposition: "resolved", resolved: true, resolvedIssueCount: 1 };
       },
       async runResolvedSideEffects() {},
@@ -108,6 +118,9 @@ test("a close with a merged sibling in the locked snapshot resolves as agent_pr_
   assert.equal(resolveInputs[0]?.kind, "agent_pr_merged");
   assert.match(resolveInputs[0]?.reasonText ?? "", /#40/);
   assert.match(resolveInputs[0]?.reasonText ?? "", /#42/);
+  // The sibling merged after this close: the resolution is stamped at the
+  // merge, not backdated to the close.
+  assert.deepEqual(resolveInputs[0]?.resolvedAt, laterMergedAt);
 });
 
 test("a close while another PR is still live falls back to the session continuation", async () => {

--- a/apps/api/src/pr-close-resolution.test.ts
+++ b/apps/api/src/pr-close-resolution.test.ts
@@ -52,7 +52,10 @@ test("a close that settles the last live PR resolves the incident without asking
     { agentPr: closedPr, closedByLogin: "hubot", closedAt },
     {
       async resolveSettled(opts) {
-        calls.push({ kind: "resolve", value: opts.buildInput([closedSnapshot]) });
+        calls.push({
+          kind: "resolve",
+          value: opts.buildInput([closedSnapshot], { reopenedAt: null }),
+        });
         return { disposition: "resolved", resolved: true, resolvedIssueCount: 2 };
       },
       async runResolvedSideEffects(incidentId) {
@@ -99,7 +102,7 @@ test("a close with a merged sibling in the locked snapshot resolves as agent_pr_
     { agentPr: closedPr, closedByLogin: "hubot", closedAt },
     {
       async resolveSettled(opts) {
-        const input = opts.buildInput([mergedSnapshot, closedSnapshot]);
+        const input = opts.buildInput([mergedSnapshot, closedSnapshot], { reopenedAt: null });
         resolveInputs.push({
           kind: input.kind,
           reasonText: input.reasonText ?? "",
@@ -121,6 +124,32 @@ test("a close with a merged sibling in the locked snapshot resolves as agent_pr_
   // The sibling merged after this close: the resolution is stamped at the
   // merge, not backdated to the close.
   assert.deepEqual(resolveInputs[0]?.resolvedAt, laterMergedAt);
+});
+
+test("a merged sibling from before the incident's last reopen is not credited", async () => {
+  const resolveInputs: Array<{ kind: string }> = [];
+
+  const disposition = await resolveOrResumeIncidentForClosedAgentPr(
+    { agentPr: closedPr, closedByLogin: "hubot", closedAt },
+    {
+      async resolveSettled(opts) {
+        // The sibling merged before the human reopened the incident: that fix
+        // was already overridden, so the close resolves as agent_pr_closed.
+        const input = opts.buildInput([mergedSnapshot, closedSnapshot], {
+          reopenedAt: new Date(laterMergedAt.getTime() + 60_000),
+        });
+        resolveInputs.push({ kind: input.kind });
+        return { disposition: "resolved", resolved: true, resolvedIssueCount: 1 };
+      },
+      async runResolvedSideEffects() {},
+      async continueInSession() {
+        throw new Error("session must not be consulted");
+      },
+    },
+  );
+
+  assert.equal(disposition, "resolved");
+  assert.equal(resolveInputs[0]?.kind, "agent_pr_closed");
 });
 
 test("a close while another PR is still live falls back to the session continuation", async () => {

--- a/apps/api/src/pr-close-resolution.test.ts
+++ b/apps/api/src/pr-close-resolution.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { schema } from "@superlog/db";
+
+process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
+process.env.BETTER_AUTH_SECRET ??= "test-better-auth-secret-with-enough-length";
+
+const { resolveOrResumeIncidentForClosedAgentPr } = await import("./github.js");
+
+const closedAt = new Date("2026-07-15T10:00:00.000Z");
+const closedPr = {
+  id: "agent-pr-1",
+  incidentId: "incident-1",
+  agentRunId: "agent-run-1",
+  repoFullName: "acme/api",
+  prNumber: 42,
+  branchName: "fix/api-timeout",
+  url: "https://github.com/acme/api/pull/42",
+  state: "closed",
+  mergedAt: null,
+  closedAt,
+  mergedByLogin: null,
+} as schema.AgentPullRequest;
+
+const mergedSibling = {
+  id: "agent-pr-2",
+  incidentId: "incident-1",
+  agentRunId: "agent-run-1",
+  repoFullName: "acme/api",
+  prNumber: 40,
+  branchName: "fix/api-timeout-v1",
+  url: "https://github.com/acme/api/pull/40",
+  state: "merged",
+  mergedAt: new Date("2026-07-14T10:00:00.000Z"),
+  closedAt: new Date("2026-07-14T10:00:00.000Z"),
+  mergedByLogin: "octocat",
+} as schema.AgentPullRequest;
+
+test("a close that settles the last live PR resolves the incident without asking the session", async () => {
+  const calls: Array<{ kind: string; value?: unknown }> = [];
+
+  const disposition = await resolveOrResumeIncidentForClosedAgentPr(
+    { agentPr: closedPr, closedByLogin: "hubot", closedAt },
+    {
+      async listIncidentPullRequests() {
+        return [closedPr];
+      },
+      async resolveSettled(input) {
+        calls.push({ kind: "resolve", value: input });
+        return { disposition: "resolved", resolved: true, resolvedIssueCount: 2 };
+      },
+      async runResolvedSideEffects(incidentId) {
+        calls.push({ kind: "side_effects", value: incidentId });
+      },
+      async continueInSession() {
+        calls.push({ kind: "continue" });
+        return "continued_in_session";
+      },
+    },
+  );
+
+  assert.equal(disposition, "resolved");
+  assert.deepEqual(
+    calls.map((call) => call.kind),
+    ["resolve", "side_effects"],
+  );
+  const resolveInput = calls[0]?.value as {
+    incidentId: string;
+    kind: string;
+    reasonCode: string;
+    reasonText: string;
+    eventDedupeKey: string;
+    resolvedAt: Date;
+  };
+  assert.equal(resolveInput.incidentId, "incident-1");
+  assert.equal(resolveInput.kind, "agent_pr_closed");
+  assert.equal(resolveInput.reasonCode, "agent_pr_closed");
+  assert.match(resolveInput.reasonText, /#42/);
+  assert.match(resolveInput.reasonText, /@hubot/);
+  assert.equal(
+    resolveInput.eventDedupeKey,
+    `incident_resolved:agent_pr_closed:agent-pr-1:${closedAt.getTime()}`,
+  );
+  assert.equal(resolveInput.resolvedAt, closedAt);
+});
+
+test("a close with a merged sibling resolves as agent_pr_merged crediting the landed fix", async () => {
+  const resolveInputs: Array<{ kind: string; reasonText: string }> = [];
+
+  const disposition = await resolveOrResumeIncidentForClosedAgentPr(
+    { agentPr: closedPr, closedByLogin: "hubot", closedAt },
+    {
+      async listIncidentPullRequests() {
+        return [mergedSibling, closedPr];
+      },
+      async resolveSettled(input) {
+        resolveInputs.push({ kind: input.kind, reasonText: input.reasonText ?? "" });
+        return { disposition: "resolved", resolved: true, resolvedIssueCount: 1 };
+      },
+      async runResolvedSideEffects() {},
+      async continueInSession() {
+        throw new Error("session must not be consulted");
+      },
+    },
+  );
+
+  assert.equal(disposition, "resolved");
+  assert.equal(resolveInputs[0]?.kind, "agent_pr_merged");
+  assert.match(resolveInputs[0]?.reasonText ?? "", /#40/);
+  assert.match(resolveInputs[0]?.reasonText ?? "", /#42/);
+});
+
+test("a close while another PR is still live falls back to the session continuation", async () => {
+  const calls: string[] = [];
+
+  const disposition = await resolveOrResumeIncidentForClosedAgentPr(
+    { agentPr: closedPr, closedByLogin: "hubot", closedAt },
+    {
+      async listIncidentPullRequests() {
+        return [closedPr, { ...closedPr, id: "agent-pr-3", state: "open" }];
+      },
+      async resolveSettled() {
+        calls.push("resolve");
+        return { disposition: "pull_requests_pending", resolved: false, resolvedIssueCount: 0 };
+      },
+      async runResolvedSideEffects() {
+        calls.push("side_effects");
+      },
+      async continueInSession(opts) {
+        calls.push("continue");
+        assert.equal(opts.continuation.interaction.channel, "pr_closed");
+        return "continued_in_session";
+      },
+    },
+  );
+
+  assert.equal(disposition, "continued_in_session");
+  assert.deepEqual(calls, ["resolve", "continue"]);
+});
+
+test("a close on an already-resolved incident is a no-op", async () => {
+  const calls: string[] = [];
+
+  const disposition = await resolveOrResumeIncidentForClosedAgentPr(
+    { agentPr: closedPr, closedByLogin: null, closedAt },
+    {
+      async listIncidentPullRequests() {
+        return [closedPr];
+      },
+      async resolveSettled() {
+        calls.push("resolve");
+        return { disposition: "incident_not_open", resolved: false, resolvedIssueCount: 0 };
+      },
+      async runResolvedSideEffects() {
+        calls.push("side_effects");
+      },
+      async continueInSession() {
+        calls.push("continue");
+        return "no_resumable_session";
+      },
+    },
+  );
+
+  assert.equal(disposition, "incident_not_open");
+  assert.deepEqual(calls, ["resolve"]);
+});

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -460,9 +460,16 @@ export async function completeWithoutPullRequest(
     runCompletion?: "already_committed_by_resolution";
     incidentOutcome?:
       | {
-          kind: "all_pull_requests_merged" | "all_pull_requests_settled";
+          kind: "all_pull_requests_merged";
           prNumber: number;
           repoFullName: string;
+          resolutionProof: IncidentResolutionProof;
+        }
+      | {
+          kind: "all_pull_requests_settled";
+          prNumber: number;
+          repoFullName: string;
+          settledState: "merged" | "closed";
           resolutionProof: IncidentResolutionProof;
         }
       | { kind: "incident_already_closed" };

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -46,6 +46,7 @@ import {
   planLegacyTerminalResolutionCompletion,
   resolutionCompletionCopy,
   resolutionCompletionResult,
+  settledPullRequestResolutionCopy,
   shouldRetireProviderSession,
   shouldUpdateResolutionMainMessage,
 } from "./resolution-completion.js";
@@ -459,7 +460,7 @@ export async function completeWithoutPullRequest(
     runCompletion?: "already_committed_by_resolution";
     incidentOutcome?:
       | {
-          kind: "all_pull_requests_merged";
+          kind: "all_pull_requests_merged" | "all_pull_requests_settled";
           prNumber: number;
           repoFullName: string;
           resolutionProof: IncidentResolutionProof;
@@ -472,14 +473,17 @@ export async function completeWithoutPullRequest(
   const mergedResolutionCopy =
     opts?.incidentOutcome?.kind === "all_pull_requests_merged"
       ? mergedPullRequestResolutionCopy(opts.incidentOutcome)
-      : null;
+      : opts?.incidentOutcome?.kind === "all_pull_requests_settled"
+        ? settledPullRequestResolutionCopy(opts.incidentOutcome)
+        : null;
   const alreadyClosedCopy =
     opts?.incidentOutcome?.kind === "incident_already_closed"
       ? incidentAlreadyClosedCompletionCopy()
       : null;
   let closedElsewhereCopy = alreadyClosedCopy;
   let resolutionProof =
-    opts?.incidentOutcome?.kind === "all_pull_requests_merged"
+    opts?.incidentOutcome?.kind === "all_pull_requests_merged" ||
+    opts?.incidentOutcome?.kind === "all_pull_requests_settled"
       ? opts.incidentOutcome.resolutionProof
       : null;
   let noiseApplied = false;

--- a/apps/worker/src/agent-runs/resolution-completion.ts
+++ b/apps/worker/src/agent-runs/resolution-completion.ts
@@ -18,14 +18,18 @@ export function mergedPullRequestResolutionCopy(opts: {
 export function settledPullRequestResolutionCopy(opts: {
   prNumber: number;
   repoFullName: string;
+  settledState: "merged" | "closed";
 }): {
   threadLead: string;
   status: string;
   mainTextSuffix: string;
 } {
   return {
-    threadLead: `:white_check_mark: PR #${opts.prNumber} (${opts.repoFullName}) was closed without merging and no agent pull request remains open; incident resolved.`,
-    status: "Incident resolved - agent pull requests closed without merge",
+    threadLead:
+      opts.settledState === "merged"
+        ? `:white_check_mark: Fix PR #${opts.prNumber} (${opts.repoFullName}) is merged and the remaining agent pull requests are closed; incident resolved.`
+        : `:white_check_mark: PR #${opts.prNumber} (${opts.repoFullName}) was closed without merging and no agent pull request remains open; incident resolved.`,
+    status: "Incident resolved - all agent pull requests settled",
     mainTextSuffix: "Incident resolved",
   };
 }

--- a/apps/worker/src/agent-runs/resolution-completion.ts
+++ b/apps/worker/src/agent-runs/resolution-completion.ts
@@ -15,6 +15,21 @@ export function mergedPullRequestResolutionCopy(opts: {
   };
 }
 
+export function settledPullRequestResolutionCopy(opts: {
+  prNumber: number;
+  repoFullName: string;
+}): {
+  threadLead: string;
+  status: string;
+  mainTextSuffix: string;
+} {
+  return {
+    threadLead: `:white_check_mark: PR #${opts.prNumber} (${opts.repoFullName}) was closed without merging and no agent pull request remains open; incident resolved.`,
+    status: "Incident resolved - agent pull requests closed without merge",
+    mainTextSuffix: "Incident resolved",
+  };
+}
+
 export function agentResolveEventDedupeKey(agentRunId: string, toolUseId: string): string {
   return `incident_resolved:agent_run:${agentRunId}:resolve_incident:${toolUseId}`;
 }

--- a/apps/worker/src/agent-runs/resume.ts
+++ b/apps/worker/src/agent-runs/resume.ts
@@ -361,6 +361,7 @@ async function coldStartFallback(
       // not leave the incident open when this merge is the last settle event.
       return resolveIncidentIfAllAgentPullRequestsSettled({
         incidentId: ctx.incident.id,
+        settlementEvidenceAt: fallbackResolvedAt,
         buildInput: (lockedPullRequests) => ({
           incidentId: ctx.incident.id,
           kind: "agent_pr_merged" as const,

--- a/apps/worker/src/agent-runs/resume.ts
+++ b/apps/worker/src/agent-runs/resume.ts
@@ -8,7 +8,8 @@ import {
   isInboundInteractionEventKind,
   isIncidentResolutionProofCurrent,
   requestFollowUpAgentRun,
-  resolveIncidentIfAllAgentPullRequestsMerged,
+  latestAgentPullRequestSettlementAt,
+  resolveIncidentIfAllAgentPullRequestsSettled,
   schema,
 } from "@superlog/db";
 import { and, desc, eq, inArray, isNull } from "drizzle-orm";
@@ -354,27 +355,32 @@ async function coldStartFallback(
         };
       }
       const occurredAt = new Date(input.occurredAt);
-      const resolvedAt =
+      const fallbackResolvedAt =
         agentPr.mergedAt ?? (Number.isFinite(occurredAt.getTime()) ? occurredAt : new Date());
-      return resolveIncidentIfAllAgentPullRequestsMerged({
+      // Settled guard, not all-merged: a sibling PR closed without merge must
+      // not leave the incident open when this merge is the last settle event.
+      return resolveIncidentIfAllAgentPullRequestsSettled({
         incidentId: ctx.incident.id,
-        kind: "agent_pr_merged",
-        reasonCode: "agent_pr_merged",
-        reasonText: `Resolved because agent PR #${agentPr.prNumber} (${agentPr.repoFullName}) was merged${
-          agentPr.mergedByLogin ? ` by @${agentPr.mergedByLogin}` : ""
-        }.`,
-        agentRunId: agentPr.agentRunId,
-        resolvingAgentRunId: null,
-        eventSummary: `Incident resolved because PR #${agentPr.prNumber} was merged.`,
-        eventDetail: {
-          agentPrId: agentPr.id,
-          repoFullName: agentPr.repoFullName,
-          prNumber: agentPr.prNumber,
-          prUrl: agentPr.url,
-          mergedByLogin: agentPr.mergedByLogin,
-        },
-        eventDedupeKey: `incident_resolved:agent_pr:${agentPr.id}`,
-        resolvedAt,
+        buildInput: (lockedPullRequests) => ({
+          incidentId: ctx.incident.id,
+          kind: "agent_pr_merged" as const,
+          reasonCode: "agent_pr_merged",
+          reasonText: `Resolved because agent PR #${agentPr.prNumber} (${agentPr.repoFullName}) was merged${
+            agentPr.mergedByLogin ? ` by @${agentPr.mergedByLogin}` : ""
+          }.`,
+          agentRunId: agentPr.agentRunId,
+          resolvingAgentRunId: null,
+          eventSummary: `Incident resolved because PR #${agentPr.prNumber} was merged.`,
+          eventDetail: {
+            agentPrId: agentPr.id,
+            repoFullName: agentPr.repoFullName,
+            prNumber: agentPr.prNumber,
+            prUrl: agentPr.url,
+            mergedByLogin: agentPr.mergedByLogin,
+          },
+          eventDedupeKey: `incident_resolved:agent_pr:${agentPr.id}`,
+          resolvedAt: latestAgentPullRequestSettlementAt(lockedPullRequests) ?? fallbackResolvedAt,
+        }),
       });
     },
     async publishResolvedRun(input, disposition) {

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -374,7 +374,14 @@ test("an unavailable recovered PR lifecycle resolves only an entirely merged del
   });
   assert.deepEqual(planSettledPullRequestFallback([closed, merged], [closed, merged]), {
     kind: "resolve_settled",
-    pullRequest: closed,
+    pullRequest: merged,
+  });
+  // The merge can be the LAST settle event on a mixed incident (sibling closed
+  // earlier): no later close webhook will arrive, so the settled plan must
+  // fire from the merge itself.
+  assert.deepEqual(planSettledPullRequestFallback([merged], [closed, merged]), {
+    kind: "resolve_settled",
+    pullRequest: merged,
   });
   assert.deepEqual(planSettledPullRequestFallback([closed], [closed]), {
     kind: "resolve_settled",

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -373,9 +373,18 @@ test("an unavailable recovered PR lifecycle resolves only an entirely merged del
     kind: "follow_up",
   });
   assert.deepEqual(planSettledPullRequestFallback([closed, merged], [closed, merged]), {
+    kind: "resolve_settled",
+    pullRequest: closed,
+    mergedPullRequest: merged,
+  });
+  assert.deepEqual(planSettledPullRequestFallback([closed], [closed]), {
+    kind: "resolve_settled",
+    pullRequest: closed,
+    mergedPullRequest: null,
+  });
+  assert.deepEqual(planSettledPullRequestFallback([closed], [open, closed]), {
     kind: "follow_up",
   });
-  assert.deepEqual(planSettledPullRequestFallback([closed], [closed]), { kind: "follow_up" });
 });
 
 test("a terminal result wins when it lands at the runtime budget boundary", () => {

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -375,12 +375,10 @@ test("an unavailable recovered PR lifecycle resolves only an entirely merged del
   assert.deepEqual(planSettledPullRequestFallback([closed, merged], [closed, merged]), {
     kind: "resolve_settled",
     pullRequest: closed,
-    mergedPullRequest: merged,
   });
   assert.deepEqual(planSettledPullRequestFallback([closed], [closed]), {
     kind: "resolve_settled",
     pullRequest: closed,
-    mergedPullRequest: null,
   });
   assert.deepEqual(planSettledPullRequestFallback([closed], [open, closed]), {
     kind: "follow_up",

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -7,6 +7,7 @@ import {
   areAllIncidentPullRequestsSettled,
   buildAgentPullRequestLifecycleContinuation,
   db,
+  latestAgentPullRequestSettlementAt,
   recordInboundInteraction,
   resolveIncidentIfAllAgentPullRequestsMerged,
   resolveIncidentIfAllAgentPullRequestsSettled,
@@ -979,6 +980,11 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
                             (a, b) => (a.mergedAt?.getTime() ?? 0) - (b.mergedAt?.getTime() ?? 0),
                           )
                           .at(-1) ?? null;
+                      // The delivery finished at the latest settle across the
+                      // snapshot — stamping the closed PR's time when the fix
+                      // merged later would backdate the resolution.
+                      const resolvedAt =
+                        latestAgentPullRequestSettlementAt(lockedPullRequests) ?? settledAt;
                       return mergedSibling
                         ? {
                             incidentId: ctx.incident.id,
@@ -996,7 +1002,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
                               mergedPrNumber: mergedSibling.prNumber,
                             },
                             eventDedupeKey,
-                            resolvedAt: settledAt,
+                            resolvedAt,
                           }
                         : {
                             incidentId: ctx.incident.id,
@@ -1012,7 +1018,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
                               prUrl: fallback.pullRequest.url,
                             },
                             eventDedupeKey,
-                            resolvedAt: settledAt,
+                            resolvedAt,
                           };
                     },
                   });

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -241,11 +241,7 @@ export type PullRequestLifecycleRecordOutcome = "recorded" | "duplicate" | "unav
 
 export type SettledPullRequestFallbackPlan =
   | { kind: "resolve_merged"; pullRequest: SettledPullRequestLifecycle }
-  | {
-      kind: "resolve_settled";
-      pullRequest: SettledPullRequestLifecycle;
-      mergedPullRequest: SettledPullRequestLifecycle | null;
-    }
+  | { kind: "resolve_settled"; pullRequest: SettledPullRequestLifecycle }
   | { kind: "follow_up" };
 
 export function planSettledPullRequestFallback(
@@ -260,18 +256,13 @@ export function planSettledPullRequestFallback(
   }
   // A settled close with no delivery left in play resolves the incident (the
   // webhook applies the same policy; this is the recovery path for closes the
-  // webhook never delivered). A merged sibling means a fix landed — the
-  // resolution credits it instead of the close.
+  // webhook never delivered). Attribution — crediting a merged sibling over
+  // the close — is decided later, on the resolver's locked PR snapshot.
   const closedPullRequest = settledPullRequests.find(
     (pullRequest) => pullRequest.state === "closed",
   );
   if (closedPullRequest && areAllIncidentPullRequestsSettled(incidentPullRequests)) {
-    return {
-      kind: "resolve_settled",
-      pullRequest: closedPullRequest,
-      mergedPullRequest:
-        incidentPullRequests.find((pullRequest) => pullRequest.state === "merged") ?? null,
-    };
+    return { kind: "resolve_settled", pullRequest: closedPullRequest };
   }
   return { kind: "follow_up" };
 }
@@ -975,43 +966,56 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
                     eventDedupeKey,
                     resolvedAt: settledAt,
                   })
-                : await resolveIncidentIfAllAgentPullRequestsSettled(
-                    fallback.mergedPullRequest
-                      ? {
-                          incidentId: ctx.incident.id,
-                          kind: "agent_pr_merged",
-                          reasonCode: "agent_pr_merged",
-                          reasonText: `Resolved because agent PR #${fallback.mergedPullRequest.prNumber} (${fallback.mergedPullRequest.repoFullName}) was merged and the last live agent PR #${fallback.pullRequest.prNumber} was closed without merge.`,
-                          agentRunId: ctx.agentRun.id,
-                          eventSummary: `Incident resolved after PR #${fallback.pullRequest.prNumber} was closed; fix PR #${fallback.mergedPullRequest.prNumber} is merged.`,
-                          eventDetail: {
-                            agentPrId: fallback.pullRequest.id,
-                            repoFullName: fallback.pullRequest.repoFullName,
-                            prNumber: fallback.pullRequest.prNumber,
-                            prUrl: fallback.pullRequest.url,
-                            mergedAgentPrId: fallback.mergedPullRequest.id,
-                            mergedPrNumber: fallback.mergedPullRequest.prNumber,
-                          },
-                          eventDedupeKey,
-                          resolvedAt: settledAt,
-                        }
-                      : {
-                          incidentId: ctx.incident.id,
-                          kind: "agent_pr_closed",
-                          reasonCode: "agent_pr_closed",
-                          reasonText: `Resolved because agent PR #${fallback.pullRequest.prNumber} (${fallback.pullRequest.repoFullName}) was closed without merge and no agent PRs remain open.`,
-                          agentRunId: ctx.agentRun.id,
-                          eventSummary: `Incident resolved because PR #${fallback.pullRequest.prNumber} was closed without merge.`,
-                          eventDetail: {
-                            agentPrId: fallback.pullRequest.id,
-                            repoFullName: fallback.pullRequest.repoFullName,
-                            prNumber: fallback.pullRequest.prNumber,
-                            prUrl: fallback.pullRequest.url,
-                          },
-                          eventDedupeKey,
-                          resolvedAt: settledAt,
-                        },
-                  );
+                : await resolveIncidentIfAllAgentPullRequestsSettled({
+                    incidentId: ctx.incident.id,
+                    // Attribution comes from the locked PR snapshot: credit a
+                    // merged sibling when one landed, otherwise resolve as a
+                    // plain close.
+                    buildInput: (lockedPullRequests) => {
+                      const mergedSibling =
+                        lockedPullRequests
+                          .filter((pullRequest) => pullRequest.state === "merged")
+                          .sort(
+                            (a, b) => (a.mergedAt?.getTime() ?? 0) - (b.mergedAt?.getTime() ?? 0),
+                          )
+                          .at(-1) ?? null;
+                      return mergedSibling
+                        ? {
+                            incidentId: ctx.incident.id,
+                            kind: "agent_pr_merged" as const,
+                            reasonCode: "agent_pr_merged",
+                            reasonText: `Resolved because agent PR #${mergedSibling.prNumber} (${mergedSibling.repoFullName}) was merged and the last live agent PR #${fallback.pullRequest.prNumber} was closed without merge.`,
+                            agentRunId: ctx.agentRun.id,
+                            eventSummary: `Incident resolved after PR #${fallback.pullRequest.prNumber} was closed; fix PR #${mergedSibling.prNumber} is merged.`,
+                            eventDetail: {
+                              agentPrId: fallback.pullRequest.id,
+                              repoFullName: fallback.pullRequest.repoFullName,
+                              prNumber: fallback.pullRequest.prNumber,
+                              prUrl: fallback.pullRequest.url,
+                              mergedAgentPrId: mergedSibling.id,
+                              mergedPrNumber: mergedSibling.prNumber,
+                            },
+                            eventDedupeKey,
+                            resolvedAt: settledAt,
+                          }
+                        : {
+                            incidentId: ctx.incident.id,
+                            kind: "agent_pr_closed" as const,
+                            reasonCode: "agent_pr_closed",
+                            reasonText: `Resolved because agent PR #${fallback.pullRequest.prNumber} (${fallback.pullRequest.repoFullName}) was closed without merge and no agent PRs remain open.`,
+                            agentRunId: ctx.agentRun.id,
+                            eventSummary: `Incident resolved because PR #${fallback.pullRequest.prNumber} was closed without merge.`,
+                            eventDetail: {
+                              agentPrId: fallback.pullRequest.id,
+                              repoFullName: fallback.pullRequest.repoFullName,
+                              prNumber: fallback.pullRequest.prNumber,
+                              prUrl: fallback.pullRequest.url,
+                            },
+                            eventDedupeKey,
+                            resolvedAt: settledAt,
+                          };
+                    },
+                  });
             if (resolution.disposition === "resolved") {
               const completed = await completeWithoutPullRequest(
                 ctx,

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -967,13 +967,22 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
                   })
                 : await resolveIncidentIfAllAgentPullRequestsSettled({
                     incidentId: ctx.incident.id,
+                    settlementEvidenceAt: settledAt,
                     // Attribution comes from the locked PR snapshot: credit a
-                    // merged sibling when one landed, otherwise resolve as a
-                    // plain close.
-                    buildInput: (lockedPullRequests) => {
+                    // merged sibling when one landed in the current epoch,
+                    // otherwise resolve as a plain close — a PR merged before
+                    // the incident's last manual reopen is a fix the human
+                    // already overrode.
+                    buildInput: (lockedPullRequests, epoch) => {
                       const mergedSibling =
                         lockedPullRequests
-                          .filter((pullRequest) => pullRequest.state === "merged")
+                          .filter(
+                            (pullRequest) =>
+                              pullRequest.state === "merged" &&
+                              pullRequest.mergedAt &&
+                              (!epoch.reopenedAt ||
+                                pullRequest.mergedAt.getTime() > epoch.reopenedAt.getTime()),
+                          )
                           .sort(
                             (a, b) => (a.mergedAt?.getTime() ?? 0) - (b.mergedAt?.getTime() ?? 0),
                           )

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -4,10 +4,12 @@ import {
   type AgentRunResult,
   INBOUND_INTERACTION_EVENT_KINDS,
   areAllIncidentPullRequestsMerged,
+  areAllIncidentPullRequestsSettled,
   buildAgentPullRequestLifecycleContinuation,
   db,
   recordInboundInteraction,
   resolveIncidentIfAllAgentPullRequestsMerged,
+  resolveIncidentIfAllAgentPullRequestsSettled,
   schema,
 } from "@superlog/db";
 import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
@@ -239,6 +241,11 @@ export type PullRequestLifecycleRecordOutcome = "recorded" | "duplicate" | "unav
 
 export type SettledPullRequestFallbackPlan =
   | { kind: "resolve_merged"; pullRequest: SettledPullRequestLifecycle }
+  | {
+      kind: "resolve_settled";
+      pullRequest: SettledPullRequestLifecycle;
+      mergedPullRequest: SettledPullRequestLifecycle | null;
+    }
   | { kind: "follow_up" };
 
 export function planSettledPullRequestFallback(
@@ -250,6 +257,21 @@ export function planSettledPullRequestFallback(
   );
   if (mergedPullRequest && areAllIncidentPullRequestsMerged(incidentPullRequests)) {
     return { kind: "resolve_merged", pullRequest: mergedPullRequest };
+  }
+  // A settled close with no delivery left in play resolves the incident (the
+  // webhook applies the same policy; this is the recovery path for closes the
+  // webhook never delivered). A merged sibling means a fix landed — the
+  // resolution credits it instead of the close.
+  const closedPullRequest = settledPullRequests.find(
+    (pullRequest) => pullRequest.state === "closed",
+  );
+  if (closedPullRequest && areAllIncidentPullRequestsSettled(incidentPullRequests)) {
+    return {
+      kind: "resolve_settled",
+      pullRequest: closedPullRequest,
+      mergedPullRequest:
+        incidentPullRequests.find((pullRequest) => pullRequest.state === "merged") ?? null,
+    };
   }
   return { kind: "follow_up" };
 }
@@ -921,29 +943,75 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
             waitPlan.settledPullRequests,
             deliveredPrs,
           );
-          if (fallback.kind === "resolve_merged") {
-            const mergedAt = fallback.pullRequest.mergedAt ?? new Date();
-            const resolution = await resolveIncidentIfAllAgentPullRequestsMerged({
-              incidentId: ctx.incident.id,
-              kind: "agent_pr_merged",
-              reasonCode: "agent_pr_merged",
-              reasonText: `Resolved because agent PR #${fallback.pullRequest.prNumber} (${fallback.pullRequest.repoFullName}) was merged${
-                fallback.pullRequest.mergedByLogin
-                  ? ` by @${fallback.pullRequest.mergedByLogin}`
-                  : ""
-              }.`,
-              agentRunId: ctx.agentRun.id,
-              eventSummary: `Incident resolved because PR #${fallback.pullRequest.prNumber} was merged.`,
-              eventDetail: {
-                agentPrId: fallback.pullRequest.id,
-                repoFullName: fallback.pullRequest.repoFullName,
-                prNumber: fallback.pullRequest.prNumber,
-                prUrl: fallback.pullRequest.url,
-                mergedByLogin: fallback.pullRequest.mergedByLogin,
-              },
-              eventDedupeKey: `incident_resolved:agent_pr:${fallback.pullRequest.id}`,
-              resolvedAt: mergedAt,
-            });
+          if (fallback.kind === "resolve_merged" || fallback.kind === "resolve_settled") {
+            const settledAt =
+              fallback.kind === "resolve_merged"
+                ? (fallback.pullRequest.mergedAt ?? new Date())
+                : (fallback.pullRequest.closedAt ?? new Date());
+            const eventDedupeKey =
+              fallback.kind === "resolve_merged"
+                ? `incident_resolved:agent_pr:${fallback.pullRequest.id}`
+                : `incident_resolved:agent_pr_closed:${fallback.pullRequest.id}:${settledAt.getTime()}`;
+            const resolution =
+              fallback.kind === "resolve_merged"
+                ? await resolveIncidentIfAllAgentPullRequestsMerged({
+                    incidentId: ctx.incident.id,
+                    kind: "agent_pr_merged",
+                    reasonCode: "agent_pr_merged",
+                    reasonText: `Resolved because agent PR #${fallback.pullRequest.prNumber} (${fallback.pullRequest.repoFullName}) was merged${
+                      fallback.pullRequest.mergedByLogin
+                        ? ` by @${fallback.pullRequest.mergedByLogin}`
+                        : ""
+                    }.`,
+                    agentRunId: ctx.agentRun.id,
+                    eventSummary: `Incident resolved because PR #${fallback.pullRequest.prNumber} was merged.`,
+                    eventDetail: {
+                      agentPrId: fallback.pullRequest.id,
+                      repoFullName: fallback.pullRequest.repoFullName,
+                      prNumber: fallback.pullRequest.prNumber,
+                      prUrl: fallback.pullRequest.url,
+                      mergedByLogin: fallback.pullRequest.mergedByLogin,
+                    },
+                    eventDedupeKey,
+                    resolvedAt: settledAt,
+                  })
+                : await resolveIncidentIfAllAgentPullRequestsSettled(
+                    fallback.mergedPullRequest
+                      ? {
+                          incidentId: ctx.incident.id,
+                          kind: "agent_pr_merged",
+                          reasonCode: "agent_pr_merged",
+                          reasonText: `Resolved because agent PR #${fallback.mergedPullRequest.prNumber} (${fallback.mergedPullRequest.repoFullName}) was merged and the last live agent PR #${fallback.pullRequest.prNumber} was closed without merge.`,
+                          agentRunId: ctx.agentRun.id,
+                          eventSummary: `Incident resolved after PR #${fallback.pullRequest.prNumber} was closed; fix PR #${fallback.mergedPullRequest.prNumber} is merged.`,
+                          eventDetail: {
+                            agentPrId: fallback.pullRequest.id,
+                            repoFullName: fallback.pullRequest.repoFullName,
+                            prNumber: fallback.pullRequest.prNumber,
+                            prUrl: fallback.pullRequest.url,
+                            mergedAgentPrId: fallback.mergedPullRequest.id,
+                            mergedPrNumber: fallback.mergedPullRequest.prNumber,
+                          },
+                          eventDedupeKey,
+                          resolvedAt: settledAt,
+                        }
+                      : {
+                          incidentId: ctx.incident.id,
+                          kind: "agent_pr_closed",
+                          reasonCode: "agent_pr_closed",
+                          reasonText: `Resolved because agent PR #${fallback.pullRequest.prNumber} (${fallback.pullRequest.repoFullName}) was closed without merge and no agent PRs remain open.`,
+                          agentRunId: ctx.agentRun.id,
+                          eventSummary: `Incident resolved because PR #${fallback.pullRequest.prNumber} was closed without merge.`,
+                          eventDetail: {
+                            agentPrId: fallback.pullRequest.id,
+                            repoFullName: fallback.pullRequest.repoFullName,
+                            prNumber: fallback.pullRequest.prNumber,
+                            prUrl: fallback.pullRequest.url,
+                          },
+                          eventDedupeKey,
+                          resolvedAt: settledAt,
+                        },
+                  );
             if (resolution.disposition === "resolved") {
               const completed = await completeWithoutPullRequest(
                 ctx,
@@ -951,15 +1019,26 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
                 sessionId,
                 nextRuntimeMinutes,
                 {
-                  incidentOutcome: {
-                    kind: "all_pull_requests_merged",
-                    prNumber: fallback.pullRequest.prNumber,
-                    repoFullName: fallback.pullRequest.repoFullName,
-                    resolutionProof: {
-                      agentRunId: ctx.agentRun.id,
-                      eventDedupeKey: `incident_resolved:agent_pr:${fallback.pullRequest.id}`,
-                    },
-                  },
+                  incidentOutcome:
+                    fallback.kind === "resolve_merged"
+                      ? {
+                          kind: "all_pull_requests_merged",
+                          prNumber: fallback.pullRequest.prNumber,
+                          repoFullName: fallback.pullRequest.repoFullName,
+                          resolutionProof: {
+                            agentRunId: ctx.agentRun.id,
+                            eventDedupeKey,
+                          },
+                        }
+                      : {
+                          kind: "all_pull_requests_settled",
+                          prNumber: fallback.pullRequest.prNumber,
+                          repoFullName: fallback.pullRequest.repoFullName,
+                          resolutionProof: {
+                            agentRunId: ctx.agentRun.id,
+                            eventDedupeKey,
+                          },
+                        },
                 },
               );
               if (completed) await meterAgentRun("complete_with_pr");

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -255,15 +255,15 @@ export function planSettledPullRequestFallback(
   if (mergedPullRequest && areAllIncidentPullRequestsMerged(incidentPullRequests)) {
     return { kind: "resolve_merged", pullRequest: mergedPullRequest };
   }
-  // A settled close with no delivery left in play resolves the incident (the
-  // webhook applies the same policy; this is the recovery path for closes the
-  // webhook never delivered). Attribution — crediting a merged sibling over
-  // the close — is decided later, on the resolver's locked PR snapshot.
-  const closedPullRequest = settledPullRequests.find(
-    (pullRequest) => pullRequest.state === "closed",
-  );
-  if (closedPullRequest && areAllIncidentPullRequestsSettled(incidentPullRequests)) {
-    return { kind: "resolve_settled", pullRequest: closedPullRequest };
+  // Any settle event (merge or close) with no delivery left in play resolves
+  // the incident — on a mixed incident the merge can be the last event, and
+  // no later close will arrive to trigger the policy. Attribution — crediting
+  // a merged sibling over the close — is decided later, on the resolver's
+  // locked PR snapshot.
+  const settledPullRequest =
+    mergedPullRequest ?? settledPullRequests.find((pullRequest) => pullRequest.state === "closed");
+  if (settledPullRequest && areAllIncidentPullRequestsSettled(incidentPullRequests)) {
+    return { kind: "resolve_settled", pullRequest: settledPullRequest };
   }
   return { kind: "follow_up" };
 }
@@ -937,9 +937,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
           );
           if (fallback.kind === "resolve_merged" || fallback.kind === "resolve_settled") {
             const settledAt =
-              fallback.kind === "resolve_merged"
-                ? (fallback.pullRequest.mergedAt ?? new Date())
-                : (fallback.pullRequest.closedAt ?? new Date());
+              fallback.pullRequest.mergedAt ?? fallback.pullRequest.closedAt ?? new Date();
             const eventDedupeKey =
               fallback.kind === "resolve_merged"
                 ? `incident_resolved:agent_pr:${fallback.pullRequest.id}`
@@ -985,14 +983,16 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
                       // merged later would backdate the resolution.
                       const resolvedAt =
                         latestAgentPullRequestSettlementAt(lockedPullRequests) ?? settledAt;
+                      // Trigger-agnostic wording: the settle event that fired
+                      // this plan can itself be the merge.
                       return mergedSibling
                         ? {
                             incidentId: ctx.incident.id,
                             kind: "agent_pr_merged" as const,
                             reasonCode: "agent_pr_merged",
-                            reasonText: `Resolved because agent PR #${mergedSibling.prNumber} (${mergedSibling.repoFullName}) was merged and the last live agent PR #${fallback.pullRequest.prNumber} was closed without merge.`,
+                            reasonText: `Resolved because agent PR #${mergedSibling.prNumber} (${mergedSibling.repoFullName}) was merged and the remaining agent PRs were closed without merge.`,
                             agentRunId: ctx.agentRun.id,
-                            eventSummary: `Incident resolved after PR #${fallback.pullRequest.prNumber} was closed; fix PR #${mergedSibling.prNumber} is merged.`,
+                            eventSummary: `Incident resolved: fix PR #${mergedSibling.prNumber} is merged and the remaining agent PRs are closed.`,
                             eventDetail: {
                               agentPrId: fallback.pullRequest.id,
                               repoFullName: fallback.pullRequest.repoFullName,
@@ -1044,6 +1044,8 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
                           kind: "all_pull_requests_settled",
                           prNumber: fallback.pullRequest.prNumber,
                           repoFullName: fallback.pullRequest.repoFullName,
+                          settledState:
+                            fallback.pullRequest.state === "merged" ? "merged" : "closed",
                           resolutionProof: {
                             agentRunId: ctx.agentRun.id,
                             eventDedupeKey,

--- a/packages/db/src/agent-pr-lifecycle-continuation.test.ts
+++ b/packages/db/src/agent-pr-lifecycle-continuation.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   areAllIncidentPullRequestsMerged,
+  areAllIncidentPullRequestsSettled,
   buildAgentPullRequestLifecycleContinuation,
 } from "./agent-pr-lifecycle-continuation.js";
 
@@ -11,6 +12,14 @@ test("all Incident PRs must be merged before merge fallback may resolve", () => 
   assert.equal(areAllIncidentPullRequestsMerged([{ state: "merged" }, { state: "merged" }]), true);
   assert.equal(areAllIncidentPullRequestsMerged([{ state: "merged" }, { state: "open" }]), false);
   assert.equal(areAllIncidentPullRequestsMerged([{ state: "merged" }, { state: "closed" }]), false);
+});
+
+test("all Incident PRs must be settled before a close may resolve", () => {
+  assert.equal(areAllIncidentPullRequestsSettled([]), false);
+  assert.equal(areAllIncidentPullRequestsSettled([{ state: "closed" }]), true);
+  assert.equal(areAllIncidentPullRequestsSettled([{ state: "merged" }, { state: "closed" }]), true);
+  assert.equal(areAllIncidentPullRequestsSettled([{ state: "merged" }, { state: "merged" }]), true);
+  assert.equal(areAllIncidentPullRequestsSettled([{ state: "closed" }, { state: "open" }]), false);
 });
 
 test("buildAgentPullRequestLifecycleContinuation describes merged and closed PR events", () => {

--- a/packages/db/src/agent-pr-lifecycle-continuation.test.ts
+++ b/packages/db/src/agent-pr-lifecycle-continuation.test.ts
@@ -4,6 +4,7 @@ import {
   areAllIncidentPullRequestsMerged,
   areAllIncidentPullRequestsSettled,
   buildAgentPullRequestLifecycleContinuation,
+  latestAgentPullRequestSettlementAt,
 } from "./agent-pr-lifecycle-continuation.js";
 
 test("all Incident PRs must be merged before merge fallback may resolve", () => {
@@ -20,6 +21,23 @@ test("all Incident PRs must be settled before a close may resolve", () => {
   assert.equal(areAllIncidentPullRequestsSettled([{ state: "merged" }, { state: "closed" }]), true);
   assert.equal(areAllIncidentPullRequestsSettled([{ state: "merged" }, { state: "merged" }]), true);
   assert.equal(areAllIncidentPullRequestsSettled([{ state: "closed" }, { state: "open" }]), false);
+});
+
+test("a settled resolution is stamped at the latest merge or close across the incident's PRs", () => {
+  const earlyClose = { mergedAt: null, closedAt: new Date("2026-07-14T08:00:00.000Z") };
+  const lateMerge = { mergedAt: new Date("2026-07-15T09:00:00.000Z"), closedAt: null };
+
+  assert.equal(latestAgentPullRequestSettlementAt([]), null);
+  assert.equal(latestAgentPullRequestSettlementAt([{ mergedAt: null, closedAt: null }]), null);
+  assert.deepEqual(latestAgentPullRequestSettlementAt([earlyClose]), earlyClose.closedAt);
+  assert.deepEqual(
+    latestAgentPullRequestSettlementAt([earlyClose, lateMerge]),
+    lateMerge.mergedAt,
+  );
+  assert.deepEqual(
+    latestAgentPullRequestSettlementAt([lateMerge, earlyClose]),
+    lateMerge.mergedAt,
+  );
 });
 
 test("buildAgentPullRequestLifecycleContinuation describes merged and closed PR events", () => {

--- a/packages/db/src/agent-pr-lifecycle-continuation.ts
+++ b/packages/db/src/agent-pr-lifecycle-continuation.ts
@@ -24,6 +24,24 @@ export function areAllIncidentPullRequestsSettled(
   );
 }
 
+// The moment an incident's delivery actually finished: the latest merge or
+// close across its PRs. A settled resolution must stamp `resolvedAt` from
+// this, not from whichever settle event triggered it — crediting a merged
+// sibling with the closing PR's timestamp would backdate the resolution
+// before the fix landed.
+export function latestAgentPullRequestSettlementAt(
+  pullRequests: Array<{ mergedAt: Date | null; closedAt: Date | null }>,
+): Date | null {
+  let latest: Date | null = null;
+  for (const pullRequest of pullRequests) {
+    const settledAt = pullRequest.mergedAt ?? pullRequest.closedAt;
+    if (settledAt && (!latest || settledAt.getTime() > latest.getTime())) {
+      latest = settledAt;
+    }
+  }
+  return latest;
+}
+
 export type AgentPullRequestLifecycleRecord = {
   id: string;
   state: AgentPrState;

--- a/packages/db/src/agent-pr-lifecycle-continuation.ts
+++ b/packages/db/src/agent-pr-lifecycle-continuation.ts
@@ -11,6 +11,19 @@ export function areAllIncidentPullRequestsMerged(
   );
 }
 
+// A closed PR resolves the incident only once no delivery is still in play:
+// every incident PR must be settled (merged or closed). A human closing the
+// last live PR is their decision on the delivery itself — the incident
+// resolves rather than waiting for a confirmation nobody sends. Shared by the
+// webhook and worker recovery paths, like the merged predicate above.
+export function areAllIncidentPullRequestsSettled(
+  pullRequests: Array<{ state: AgentPrState }>,
+): boolean {
+  return (
+    pullRequests.length > 0 && pullRequests.every((pullRequest) => pullRequest.state !== "open")
+  );
+}
+
 export type AgentPullRequestLifecycleRecord = {
   id: string;
   state: AgentPrState;

--- a/packages/db/src/agent-pr-settled-resolution.test.ts
+++ b/packages/db/src/agent-pr-settled-resolution.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { DB } from "./client.js";
+import type * as schema from "./schema.js";
+
+process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
+
+const { createIncidentLifecycle } = await import("./resolve-incident.js");
+
+type RecordedCall = "transaction.begin" | "incident.lock" | "pull_requests.read";
+
+function recordingDb(opts: {
+  incidentStatus: schema.IncidentStatus;
+  pullRequestStates: schema.AgentPrState[];
+  pendingBatchReservation?: boolean;
+}): { db: DB; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const db = {
+    query: {
+      incidentEvents: {
+        async findFirst() {
+          return opts.pendingBatchReservation ? { id: "reservation-1" } : undefined;
+        },
+      },
+      agentPullRequests: {
+        async findMany() {
+          calls.push("pull_requests.read");
+          return opts.pullRequestStates.map((state) => ({ state }));
+        },
+      },
+    },
+    select() {
+      return {
+        from() {
+          return {
+            where() {
+              return {
+                orderBy() {
+                  return {
+                    async for() {
+                      calls.push("incident.lock");
+                      return [
+                        {
+                          id: "incident-1",
+                          status: opts.incidentStatus,
+                          service: "api",
+                        },
+                      ];
+                    },
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+    async transaction<T>(fn: (tx: unknown) => Promise<T>) {
+      calls.push("transaction.begin");
+      return fn(db);
+    },
+  } as unknown as DB;
+  return { db, calls };
+}
+
+const resolution = {
+  incidentId: "incident-1",
+  kind: "agent_pr_closed" as const,
+  reasonCode: "agent_pr_closed",
+  reasonText: "Last agent PR closed without merge.",
+};
+
+test("settled resolution waits while any Incident PR is still open", async () => {
+  const { db, calls } = recordingDb({
+    incidentStatus: "open",
+    pullRequestStates: ["closed", "open"],
+  });
+
+  const result = await createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled(resolution);
+
+  assert.deepEqual(result, {
+    disposition: "pull_requests_pending",
+    resolved: false,
+    resolvedIssueCount: 0,
+  });
+  assert.deepEqual(calls, ["transaction.begin", "incident.lock", "pull_requests.read"]);
+});
+
+test("settled resolution waits when the Incident has no PRs at all", async () => {
+  const { db } = recordingDb({
+    incidentStatus: "open",
+    pullRequestStates: [],
+  });
+
+  const result = await createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled(resolution);
+
+  assert.deepEqual(result, {
+    disposition: "pull_requests_pending",
+    resolved: false,
+    resolvedIssueCount: 0,
+  });
+});
+
+test("settled resolution stops after the lock when another resolver won", async () => {
+  const { db, calls } = recordingDb({
+    incidentStatus: "resolved",
+    pullRequestStates: ["closed"],
+  });
+
+  const result = await createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled(resolution);
+
+  assert.deepEqual(result, {
+    disposition: "incident_not_open",
+    resolved: false,
+    resolvedIssueCount: 0,
+  });
+  assert.deepEqual(calls, ["transaction.begin", "incident.lock"]);
+});
+
+test("settled resolution defers to an in-flight PR delivery batch", async () => {
+  const { db, calls } = recordingDb({
+    incidentStatus: "open",
+    pullRequestStates: ["closed"],
+    pendingBatchReservation: true,
+  });
+
+  const result = await createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled(resolution);
+
+  assert.deepEqual(result, {
+    disposition: "pull_requests_pending",
+    resolved: false,
+    resolvedIssueCount: 0,
+  });
+  assert.deepEqual(calls, ["transaction.begin", "incident.lock"]);
+});

--- a/packages/db/src/agent-pr-settled-resolution.test.ts
+++ b/packages/db/src/agent-pr-settled-resolution.test.ts
@@ -13,13 +13,21 @@ function recordingDb(opts: {
   incidentStatus: schema.IncidentStatus;
   pullRequestStates: schema.AgentPrState[];
   pendingBatchReservation?: boolean;
+  reopenedAfterSettlement?: boolean;
 }): { db: DB; calls: RecordedCall[] } {
   const calls: RecordedCall[] = [];
+  // The resolver's two incidentEvents.findFirst probes arrive in a fixed
+  // order: the pending-batch reservation first, then the reopened-since-
+  // settlement check.
+  const incidentEventProbes = [
+    opts.pendingBatchReservation ? { id: "reservation-1" } : undefined,
+    opts.reopenedAfterSettlement ? { id: "reopen-1" } : undefined,
+  ];
   const db = {
     query: {
       incidentEvents: {
         async findFirst() {
-          return opts.pendingBatchReservation ? { id: "reservation-1" } : undefined;
+          return incidentEventProbes.shift();
         },
       },
       agentPullRequests: {
@@ -70,6 +78,7 @@ const resolution = {
     kind: "agent_pr_closed" as const,
     reasonCode: "agent_pr_closed",
     reasonText: "Last agent PR closed without merge.",
+    resolvedAt: new Date("2026-07-15T10:00:00.000Z"),
   }),
 };
 
@@ -118,6 +127,22 @@ test("settled resolution stops after the lock when another resolver won", async 
     resolvedIssueCount: 0,
   });
   assert.deepEqual(calls, ["transaction.begin", "incident.lock"]);
+});
+
+test("settlement evidence older than the last reopen cannot resolve the new epoch", async () => {
+  const { db } = recordingDb({
+    incidentStatus: "open",
+    pullRequestStates: ["merged", "closed"],
+    reopenedAfterSettlement: true,
+  });
+
+  const result = await createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled(resolution);
+
+  assert.deepEqual(result, {
+    disposition: "resolution_event_already_consumed",
+    resolved: false,
+    resolvedIssueCount: 0,
+  });
 });
 
 test("settled resolution defers to an in-flight PR delivery batch", async () => {

--- a/packages/db/src/agent-pr-settled-resolution.test.ts
+++ b/packages/db/src/agent-pr-settled-resolution.test.ts
@@ -65,9 +65,12 @@ function recordingDb(opts: {
 
 const resolution = {
   incidentId: "incident-1",
-  kind: "agent_pr_closed" as const,
-  reasonCode: "agent_pr_closed",
-  reasonText: "Last agent PR closed without merge.",
+  buildInput: () => ({
+    incidentId: "incident-1",
+    kind: "agent_pr_closed" as const,
+    reasonCode: "agent_pr_closed",
+    reasonText: "Last agent PR closed without merge.",
+  }),
 };
 
 test("settled resolution waits while any Incident PR is still open", async () => {

--- a/packages/db/src/agent-pr-settled-resolution.test.ts
+++ b/packages/db/src/agent-pr-settled-resolution.test.ts
@@ -17,11 +17,12 @@ function recordingDb(opts: {
 }): { db: DB; calls: RecordedCall[] } {
   const calls: RecordedCall[] = [];
   // The resolver's two incidentEvents.findFirst probes arrive in a fixed
-  // order: the pending-batch reservation first, then the reopened-since-
-  // settlement check.
+  // order: the pending-batch reservation first, then the last-reopen lookup.
   const incidentEventProbes = [
     opts.pendingBatchReservation ? { id: "reservation-1" } : undefined,
-    opts.reopenedAfterSettlement ? { id: "reopen-1" } : undefined,
+    opts.reopenedAfterSettlement
+      ? { createdAt: new Date("2026-07-16T00:00:00.000Z") }
+      : undefined,
   ];
   const db = {
     query: {
@@ -73,6 +74,7 @@ function recordingDb(opts: {
 
 const resolution = {
   incidentId: "incident-1",
+  settlementEvidenceAt: new Date("2026-07-15T10:00:00.000Z"),
   buildInput: () => ({
     incidentId: "incident-1",
     kind: "agent_pr_closed" as const,

--- a/packages/db/src/incident-repository.ts
+++ b/packages/db/src/incident-repository.ts
@@ -25,7 +25,7 @@ export type LinkableIssue = Pick<schema.Issue, "id" | "lastSeen" | "service">;
 // resolution (merged sibling vs plain close) from one consistent snapshot.
 export type IncidentAgentPullRequestSnapshot = Pick<
   schema.AgentPullRequest,
-  "id" | "state" | "prNumber" | "repoFullName" | "url" | "mergedAt"
+  "id" | "state" | "prNumber" | "repoFullName" | "url" | "mergedAt" | "closedAt"
 >;
 
 async function lockIncidentsByIdInTx(tx: Tx, incidentIds: string[]): Promise<schema.Incident[]> {
@@ -130,6 +130,7 @@ export function createIncidentRepository(database: DB) {
           repoFullName: true,
           url: true,
           mergedAt: true,
+          closedAt: true,
         },
       });
     },

--- a/packages/db/src/incident-repository.ts
+++ b/packages/db/src/incident-repository.ts
@@ -20,6 +20,14 @@ export type LockedOpenIncident = schema.Incident;
 
 export type LinkableIssue = Pick<schema.Issue, "id" | "lastSeen" | "service">;
 
+// In-tx view of an incident's PRs taken under the incident lock. Rich enough
+// for a resolver to both validate the settle guard and attribute the
+// resolution (merged sibling vs plain close) from one consistent snapshot.
+export type IncidentAgentPullRequestSnapshot = Pick<
+  schema.AgentPullRequest,
+  "id" | "state" | "prNumber" | "repoFullName" | "url" | "mergedAt"
+>;
+
 async function lockIncidentsByIdInTx(tx: Tx, incidentIds: string[]): Promise<schema.Incident[]> {
   const ids = [...new Set(incidentIds)].sort();
   if (ids.length === 0) return [];
@@ -106,13 +114,23 @@ export function createIncidentRepository(database: DB) {
       return run ?? null;
     },
 
+    // Selected columns cover resolution attribution (e.g. crediting a merged
+    // sibling from the same locked snapshot the settle guard validates), not
+    // just the state predicate.
     listAgentPullRequestStatesInTx(
       tx: Tx,
       incidentId: string,
-    ): Promise<Array<{ state: schema.AgentPrState }>> {
+    ): Promise<IncidentAgentPullRequestSnapshot[]> {
       return tx.query.agentPullRequests.findMany({
         where: eq(schema.agentPullRequests.incidentId, incidentId),
-        columns: { state: true },
+        columns: {
+          id: true,
+          state: true,
+          prNumber: true,
+          repoFullName: true,
+          url: true,
+          mergedAt: true,
+        },
       });
     },
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -236,6 +236,7 @@ export {
 } from "./agent-pr-provider-reconciliation.js";
 export {
   areAllIncidentPullRequestsMerged,
+  areAllIncidentPullRequestsSettled,
   buildAgentPullRequestLifecycleContinuation,
   type AgentPullRequestLifecycleContinuation,
   type AgentPullRequestLifecycleRecord,
@@ -305,6 +306,7 @@ export {
   resolveIncident,
   resolveIncidentWithProof,
   resolveIncidentIfAllAgentPullRequestsMerged,
+  resolveIncidentIfAllAgentPullRequestsSettled,
   reconcileAgentRunCompletedByResolution,
   validateIncidentIssueOutcomes,
   reserveAgentPullRequestBatch,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -296,6 +296,7 @@ export {
   type IssueClassificationAction,
   type SynthesizeLegacyIncidentIssueOutcomesResult,
 } from "./issue-classification.js";
+export type { IncidentAgentPullRequestSnapshot } from "./incident-repository.js";
 export {
   confirmResolutionProposal,
   createIncidentLifecycle,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -237,6 +237,7 @@ export {
 export {
   areAllIncidentPullRequestsMerged,
   areAllIncidentPullRequestsSettled,
+  latestAgentPullRequestSettlementAt,
   buildAgentPullRequestLifecycleContinuation,
   type AgentPullRequestLifecycleContinuation,
   type AgentPullRequestLifecycleRecord,

--- a/packages/db/src/resolve-incident.ts
+++ b/packages/db/src/resolve-incident.ts
@@ -9,7 +9,11 @@ import {
   type IncidentResolutionProof,
   loadCurrentIncidentResolutionProof,
 } from "./incident-pr-resolution.js";
-import { type Tx, createIncidentRepository } from "./incident-repository.js";
+import {
+  type IncidentAgentPullRequestSnapshot,
+  type Tx,
+  createIncidentRepository,
+} from "./incident-repository.js";
 import {
   assertIncidentSourceState,
   buildAgentRunIncidentPatch,
@@ -509,17 +513,22 @@ export function createIncidentLifecycle(database: DB = db) {
   // current PR states is the only difference between the all-merged and
   // all-settled variants; everything else (lock ordering, batch reservation
   // guard, dedupe) must stay identical so batched PRs cannot drift
-  // semantically between the two paths.
+  // semantically between the two paths. The resolve input is built from the
+  // locked PR snapshot (not a caller pre-read) so concurrent sibling merge/
+  // close webhooks cannot skew the resolution's attribution.
   const resolveIfIncidentPullRequestsSatisfy = async (
-    input: ResolveIncidentInput,
+    incidentId: string,
     pullRequestsPermitResolution: (pullRequests: Array<{ state: schema.AgentPrState }>) => boolean,
+    inputForPullRequests: (
+      pullRequests: IncidentAgentPullRequestSnapshot[],
+    ) => ResolveIncidentInput,
   ): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> => {
     const result = await repository.transaction(async (tx) => {
       // `recordOpenedAgentPullRequest` takes this same Incident lock before
       // inserting a PR. The winner is therefore definitive: a PR inserted
       // first appears in this snapshot, while a resolution committed first
       // prevents the late PR from joining the closed Incident.
-      const incident = await repository.lockOpenIncidentInTx(tx, input.incidentId);
+      const incident = await repository.lockOpenIncidentInTx(tx, incidentId);
       if (!incident) {
         return {
           disposition: "incident_not_open" as const,
@@ -529,7 +538,7 @@ export function createIncidentLifecycle(database: DB = db) {
       }
       const pendingBatch = await tx.query.incidentEvents.findFirst({
         where: and(
-          eq(schema.incidentEvents.incidentId, input.incidentId),
+          eq(schema.incidentEvents.incidentId, incidentId),
           eq(schema.incidentEvents.kind, AGENT_PULL_REQUEST_BATCH_RESERVATION_KIND),
           isNull(schema.incidentEvents.processedAt),
         ),
@@ -542,7 +551,7 @@ export function createIncidentLifecycle(database: DB = db) {
           resolvedIssueCount: 0 as const,
         };
       }
-      const pullRequests = await repository.listAgentPullRequestStatesInTx(tx, input.incidentId);
+      const pullRequests = await repository.listAgentPullRequestStatesInTx(tx, incidentId);
       if (!pullRequestsPermitResolution(pullRequests)) {
         return {
           disposition: "pull_requests_pending" as const,
@@ -550,6 +559,7 @@ export function createIncidentLifecycle(database: DB = db) {
           resolvedIssueCount: 0 as const,
         };
       }
+      const input = inputForPullRequests(pullRequests);
       const resolution = await resolveIncidentInTx(tx, input, repository, incident);
       if (resolution.rejectionReason === "resolution_event_already_consumed") {
         return {
@@ -571,7 +581,7 @@ export function createIncidentLifecycle(database: DB = db) {
           };
     });
     if (result.disposition === "resolved") {
-      await emitIncidentResolved(database, input.incidentId);
+      await emitIncidentResolved(database, incidentId);
     }
     return result;
   };
@@ -622,18 +632,30 @@ export function createIncidentLifecycle(database: DB = db) {
     async resolveIfAllAgentPullRequestsMerged(
       input: ResolveIncidentInput & { kind: "agent_pr_merged" },
     ): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
-      return resolveIfIncidentPullRequestsSatisfy(input, areAllIncidentPullRequestsMerged);
+      return resolveIfIncidentPullRequestsSatisfy(
+        input.incidentId,
+        areAllIncidentPullRequestsMerged,
+        () => input,
+      );
     },
 
     // The settled variant backs the closed-PR policy: once every incident PR
     // is merged or closed (none open), a close is the human's final word on
     // the delivery and the incident resolves without waiting for a session or
-    // a confirmation click. Callers pick the kind: `agent_pr_merged` when a
+    // a confirmation click. `buildInput` runs on the locked PR snapshot so the
+    // caller picks the kind from consistent state: `agent_pr_merged` when a
     // sibling fix did land, `agent_pr_closed` when nothing merged.
-    async resolveIfAllAgentPullRequestsSettled(
-      input: ResolveIncidentInput & { kind: "agent_pr_merged" | "agent_pr_closed" },
-    ): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
-      return resolveIfIncidentPullRequestsSatisfy(input, areAllIncidentPullRequestsSettled);
+    async resolveIfAllAgentPullRequestsSettled(opts: {
+      incidentId: string;
+      buildInput(
+        pullRequests: IncidentAgentPullRequestSnapshot[],
+      ): ResolveIncidentInput & { kind: "agent_pr_merged" | "agent_pr_closed" };
+    }): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
+      return resolveIfIncidentPullRequestsSatisfy(
+        opts.incidentId,
+        areAllIncidentPullRequestsSettled,
+        opts.buildInput,
+      );
     },
 
     async applyAgentRunResult(opts: {
@@ -940,10 +962,13 @@ export async function resolveIncidentIfAllAgentPullRequestsMerged(
   return createIncidentLifecycle(db).resolveIfAllAgentPullRequestsMerged(input);
 }
 
-export async function resolveIncidentIfAllAgentPullRequestsSettled(
-  input: ResolveIncidentInput & { kind: "agent_pr_merged" | "agent_pr_closed" },
-): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
-  return createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled(input);
+export async function resolveIncidentIfAllAgentPullRequestsSettled(opts: {
+  incidentId: string;
+  buildInput(
+    pullRequests: IncidentAgentPullRequestSnapshot[],
+  ): ResolveIncidentInput & { kind: "agent_pr_merged" | "agent_pr_closed" };
+}): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
+  return createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled(opts);
 }
 
 // Body of the resolve operation, parameterised on a transaction handle.

--- a/packages/db/src/resolve-incident.ts
+++ b/packages/db/src/resolve-incident.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, inArray, isNull } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import {
   areAllIncidentPullRequestsMerged,
   areAllIncidentPullRequestsSettled,
@@ -515,14 +515,25 @@ export function createIncidentLifecycle(database: DB = db) {
   // guard, dedupe) must stay identical so batched PRs cannot drift
   // semantically between the two paths. The resolve input is built from the
   // locked PR snapshot (not a caller pre-read) so concurrent sibling merge/
-  // close webhooks cannot skew the resolution's attribution.
+  // close webhooks cannot skew the resolution's attribution, and receives the
+  // current epoch boundary (the last manual reopen) so it never credits a PR
+  // the human already overrode by reopening.
   const resolveIfIncidentPullRequestsSatisfy = async (
-    incidentId: string,
+    opts: {
+      incidentId: string;
+      // When the settle event driving this resolve occurred. Evidence that
+      // predates the incident's last reopen belongs to a previous epoch — a
+      // human who reopened did so knowing those PRs were settled, so a stale
+      // settle-webhook redelivery must not flip the incident closed again.
+      settlementEvidenceAt?: Date;
+    },
     pullRequestsPermitResolution: (pullRequests: Array<{ state: schema.AgentPrState }>) => boolean,
     inputForPullRequests: (
       pullRequests: IncidentAgentPullRequestSnapshot[],
+      epoch: { reopenedAt: Date | null },
     ) => ResolveIncidentInput,
   ): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> => {
+    const { incidentId } = opts;
     const result = await repository.transaction(async (tx) => {
       // `recordOpenedAgentPullRequest` takes this same Incident lock before
       // inserting a PR. The winner is therefore definitive: a PR inserted
@@ -559,29 +570,27 @@ export function createIncidentLifecycle(database: DB = db) {
           resolvedIssueCount: 0 as const,
         };
       }
-      const input = inputForPullRequests(pullRequests);
-      // Settlement evidence that predates the incident's last reopen belongs
-      // to a previous epoch: a human who reopened the incident did so knowing
-      // those PRs were settled, so a stale settle-webhook redelivery must not
-      // flip the incident closed again. Only a settle event newer than the
-      // reopen may resolve.
-      if (input.resolvedAt) {
-        const reopenedAfterSettlement = await tx.query.incidentEvents.findFirst({
-          where: and(
-            eq(schema.incidentEvents.incidentId, incidentId),
-            eq(schema.incidentEvents.kind, "incident_reopened"),
-            gt(schema.incidentEvents.createdAt, input.resolvedAt),
-          ),
-          columns: { id: true },
-        });
-        if (reopenedAfterSettlement) {
-          return {
-            disposition: "resolution_event_already_consumed" as const,
-            resolved: false as const,
-            resolvedIssueCount: 0 as const,
-          };
-        }
+      const lastReopen = await tx.query.incidentEvents.findFirst({
+        where: and(
+          eq(schema.incidentEvents.incidentId, incidentId),
+          eq(schema.incidentEvents.kind, "incident_reopened"),
+        ),
+        orderBy: [desc(schema.incidentEvents.createdAt)],
+        columns: { createdAt: true },
+      });
+      const reopenedAt = lastReopen?.createdAt ?? null;
+      if (
+        reopenedAt &&
+        opts.settlementEvidenceAt &&
+        reopenedAt.getTime() > opts.settlementEvidenceAt.getTime()
+      ) {
+        return {
+          disposition: "resolution_event_already_consumed" as const,
+          resolved: false as const,
+          resolvedIssueCount: 0 as const,
+        };
       }
+      const input = inputForPullRequests(pullRequests, { reopenedAt });
       const resolution = await resolveIncidentInTx(tx, input, repository, incident);
       if (resolution.rejectionReason === "resolution_event_already_consumed") {
         return {
@@ -655,7 +664,7 @@ export function createIncidentLifecycle(database: DB = db) {
       input: ResolveIncidentInput & { kind: "agent_pr_merged" },
     ): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
       return resolveIfIncidentPullRequestsSatisfy(
-        input.incidentId,
+        { incidentId: input.incidentId, settlementEvidenceAt: input.resolvedAt },
         areAllIncidentPullRequestsMerged,
         () => input,
       );
@@ -666,15 +675,17 @@ export function createIncidentLifecycle(database: DB = db) {
     // the delivery and the incident resolves without waiting for a session or
     // a confirmation click. `buildInput` runs on the locked PR snapshot so the
     // caller picks the kind from consistent state: `agent_pr_merged` when a
-    // sibling fix did land, `agent_pr_closed` when nothing merged.
+    // sibling fix landed in the current epoch, `agent_pr_closed` otherwise.
     async resolveIfAllAgentPullRequestsSettled(opts: {
       incidentId: string;
+      settlementEvidenceAt: Date;
       buildInput(
         pullRequests: IncidentAgentPullRequestSnapshot[],
+        epoch: { reopenedAt: Date | null },
       ): ResolveIncidentInput & { kind: "agent_pr_merged" | "agent_pr_closed" };
     }): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
       return resolveIfIncidentPullRequestsSatisfy(
-        opts.incidentId,
+        { incidentId: opts.incidentId, settlementEvidenceAt: opts.settlementEvidenceAt },
         areAllIncidentPullRequestsSettled,
         opts.buildInput,
       );
@@ -986,8 +997,10 @@ export async function resolveIncidentIfAllAgentPullRequestsMerged(
 
 export async function resolveIncidentIfAllAgentPullRequestsSettled(opts: {
   incidentId: string;
+  settlementEvidenceAt: Date;
   buildInput(
     pullRequests: IncidentAgentPullRequestSnapshot[],
+    epoch: { reopenedAt: Date | null },
   ): ResolveIncidentInput & { kind: "agent_pr_merged" | "agent_pr_closed" };
 }): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
   return createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled(opts);

--- a/packages/db/src/resolve-incident.ts
+++ b/packages/db/src/resolve-incident.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, eq, gt, inArray, isNull } from "drizzle-orm";
 import {
   areAllIncidentPullRequestsMerged,
   areAllIncidentPullRequestsSettled,
@@ -560,6 +560,28 @@ export function createIncidentLifecycle(database: DB = db) {
         };
       }
       const input = inputForPullRequests(pullRequests);
+      // Settlement evidence that predates the incident's last reopen belongs
+      // to a previous epoch: a human who reopened the incident did so knowing
+      // those PRs were settled, so a stale settle-webhook redelivery must not
+      // flip the incident closed again. Only a settle event newer than the
+      // reopen may resolve.
+      if (input.resolvedAt) {
+        const reopenedAfterSettlement = await tx.query.incidentEvents.findFirst({
+          where: and(
+            eq(schema.incidentEvents.incidentId, incidentId),
+            eq(schema.incidentEvents.kind, "incident_reopened"),
+            gt(schema.incidentEvents.createdAt, input.resolvedAt),
+          ),
+          columns: { id: true },
+        });
+        if (reopenedAfterSettlement) {
+          return {
+            disposition: "resolution_event_already_consumed" as const,
+            resolved: false as const,
+            resolvedIssueCount: 0 as const,
+          };
+        }
+      }
       const resolution = await resolveIncidentInTx(tx, input, repository, incident);
       if (resolution.rejectionReason === "resolution_event_already_consumed") {
         return {

--- a/packages/db/src/resolve-incident.ts
+++ b/packages/db/src/resolve-incident.ts
@@ -1,5 +1,8 @@
 import { and, eq, inArray, isNull } from "drizzle-orm";
-import { areAllIncidentPullRequestsMerged } from "./agent-pr-lifecycle-continuation.js";
+import {
+  areAllIncidentPullRequestsMerged,
+  areAllIncidentPullRequestsSettled,
+} from "./agent-pr-lifecycle-continuation.js";
 import { type DB, db } from "./client.js";
 import { generateCodename } from "./codename.js";
 import {
@@ -502,6 +505,77 @@ export function createIncidentLifecycle(database: DB = db) {
     return result;
   };
 
+  // Shared body of the PR-gated resolves. The predicate over the incident's
+  // current PR states is the only difference between the all-merged and
+  // all-settled variants; everything else (lock ordering, batch reservation
+  // guard, dedupe) must stay identical so batched PRs cannot drift
+  // semantically between the two paths.
+  const resolveIfIncidentPullRequestsSatisfy = async (
+    input: ResolveIncidentInput,
+    pullRequestsPermitResolution: (pullRequests: Array<{ state: schema.AgentPrState }>) => boolean,
+  ): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> => {
+    const result = await repository.transaction(async (tx) => {
+      // `recordOpenedAgentPullRequest` takes this same Incident lock before
+      // inserting a PR. The winner is therefore definitive: a PR inserted
+      // first appears in this snapshot, while a resolution committed first
+      // prevents the late PR from joining the closed Incident.
+      const incident = await repository.lockOpenIncidentInTx(tx, input.incidentId);
+      if (!incident) {
+        return {
+          disposition: "incident_not_open" as const,
+          resolved: false as const,
+          resolvedIssueCount: 0 as const,
+        };
+      }
+      const pendingBatch = await tx.query.incidentEvents.findFirst({
+        where: and(
+          eq(schema.incidentEvents.incidentId, input.incidentId),
+          eq(schema.incidentEvents.kind, AGENT_PULL_REQUEST_BATCH_RESERVATION_KIND),
+          isNull(schema.incidentEvents.processedAt),
+        ),
+        columns: { id: true },
+      });
+      if (pendingBatch) {
+        return {
+          disposition: "pull_requests_pending" as const,
+          resolved: false as const,
+          resolvedIssueCount: 0 as const,
+        };
+      }
+      const pullRequests = await repository.listAgentPullRequestStatesInTx(tx, input.incidentId);
+      if (!pullRequestsPermitResolution(pullRequests)) {
+        return {
+          disposition: "pull_requests_pending" as const,
+          resolved: false as const,
+          resolvedIssueCount: 0 as const,
+        };
+      }
+      const resolution = await resolveIncidentInTx(tx, input, repository, incident);
+      if (resolution.rejectionReason === "resolution_event_already_consumed") {
+        return {
+          disposition: "resolution_event_already_consumed" as const,
+          resolved: false as const,
+          resolvedIssueCount: 0 as const,
+        };
+      }
+      return resolution.resolved
+        ? {
+            disposition: "resolved" as const,
+            resolved: true as const,
+            resolvedIssueCount: resolution.resolvedIssueCount,
+          }
+        : {
+            disposition: "incident_not_open" as const,
+            resolved: false as const,
+            resolvedIssueCount: 0 as const,
+          };
+    });
+    if (result.disposition === "resolved") {
+      await emitIncidentResolved(database, input.incidentId);
+    }
+    return result;
+  };
+
   return {
     // Open an incident in its own transaction.
     async createOpen(opts: CreateOpenIncidentOpts): Promise<schema.Incident> {
@@ -548,66 +622,18 @@ export function createIncidentLifecycle(database: DB = db) {
     async resolveIfAllAgentPullRequestsMerged(
       input: ResolveIncidentInput & { kind: "agent_pr_merged" },
     ): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
-      const result = await repository.transaction(async (tx) => {
-        // `recordOpenedAgentPullRequest` takes this same Incident lock before
-        // inserting a PR. The winner is therefore definitive: a PR inserted
-        // first appears in this snapshot, while a resolution committed first
-        // prevents the late PR from joining the closed Incident.
-        const incident = await repository.lockOpenIncidentInTx(tx, input.incidentId);
-        if (!incident) {
-          return {
-            disposition: "incident_not_open" as const,
-            resolved: false as const,
-            resolvedIssueCount: 0 as const,
-          };
-        }
-        const pendingBatch = await tx.query.incidentEvents.findFirst({
-          where: and(
-            eq(schema.incidentEvents.incidentId, input.incidentId),
-            eq(schema.incidentEvents.kind, AGENT_PULL_REQUEST_BATCH_RESERVATION_KIND),
-            isNull(schema.incidentEvents.processedAt),
-          ),
-          columns: { id: true },
-        });
-        if (pendingBatch) {
-          return {
-            disposition: "pull_requests_pending" as const,
-            resolved: false as const,
-            resolvedIssueCount: 0 as const,
-          };
-        }
-        const pullRequests = await repository.listAgentPullRequestStatesInTx(tx, input.incidentId);
-        if (!areAllIncidentPullRequestsMerged(pullRequests)) {
-          return {
-            disposition: "pull_requests_pending" as const,
-            resolved: false as const,
-            resolvedIssueCount: 0 as const,
-          };
-        }
-        const resolution = await resolveIncidentInTx(tx, input, repository, incident);
-        if (resolution.rejectionReason === "resolution_event_already_consumed") {
-          return {
-            disposition: "resolution_event_already_consumed" as const,
-            resolved: false as const,
-            resolvedIssueCount: 0 as const,
-          };
-        }
-        return resolution.resolved
-          ? {
-              disposition: "resolved" as const,
-              resolved: true as const,
-              resolvedIssueCount: resolution.resolvedIssueCount,
-            }
-          : {
-              disposition: "incident_not_open" as const,
-              resolved: false as const,
-              resolvedIssueCount: 0 as const,
-            };
-      });
-      if (result.disposition === "resolved") {
-        await emitIncidentResolved(database, input.incidentId);
-      }
-      return result;
+      return resolveIfIncidentPullRequestsSatisfy(input, areAllIncidentPullRequestsMerged);
+    },
+
+    // The settled variant backs the closed-PR policy: once every incident PR
+    // is merged or closed (none open), a close is the human's final word on
+    // the delivery and the incident resolves without waiting for a session or
+    // a confirmation click. Callers pick the kind: `agent_pr_merged` when a
+    // sibling fix did land, `agent_pr_closed` when nothing merged.
+    async resolveIfAllAgentPullRequestsSettled(
+      input: ResolveIncidentInput & { kind: "agent_pr_merged" | "agent_pr_closed" },
+    ): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
+      return resolveIfIncidentPullRequestsSatisfy(input, areAllIncidentPullRequestsSettled);
     },
 
     async applyAgentRunResult(opts: {
@@ -912,6 +938,12 @@ export async function resolveIncidentIfAllAgentPullRequestsMerged(
   input: ResolveIncidentInput & { kind: "agent_pr_merged" },
 ): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
   return createIncidentLifecycle(db).resolveIfAllAgentPullRequestsMerged(input);
+}
+
+export async function resolveIncidentIfAllAgentPullRequestsSettled(
+  input: ResolveIncidentInput & { kind: "agent_pr_merged" | "agent_pr_closed" },
+): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
+  return createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled(input);
 }
 
 // Body of the resolve operation, parameterised on a transaction handle.

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -204,6 +204,7 @@ export type IncidentResolutionClassification = {
 // status path.
 export type IncidentResolvedByKind =
   | "agent_pr_merged" // our agent opened a PR, GitHub said it merged
+  | "agent_pr_closed" // a human closed the last live agent PR without merging — treated as their decision on the delivery
   | "linear_ticket_completed" // the run's Linear handoff entered a completed state
   | "agent_classification" // agent run completed with resolutionClassification.reason set
   | "slack_manual" // human clicked the Resolve button in Slack


### PR DESCRIPTION
## Problem

When a human closes an agent PR without merging, the incident stays open: the close resumes the investigation session (which typically asks the human what to do next), or — if no session survives — nothing happens at all. In practice those questions go unanswered, and incidents whose PRs were all closed or merged pile up as open forever. On one project we found 70+ open incidents in exactly this state, many of them quiet for weeks, most with unanswered resolution proposals.

Closing the PR *is* the human's decision on the delivery. Asking them to confirm what they already said on GitHub is a dead letter.

## Change

When a PR close settles the last live agent PR on an incident (no PR remains open), the incident now resolves deterministically:

- `agent_pr_closed` (new `IncidentResolvedByKind`) when nothing merged.
- `agent_pr_merged` crediting the landed fix when a sibling PR did merge — a merged+closed mix previously blocked the all-merged resolve forever.
- Issues cascade to resolved, so a genuine recurrence re-pages through the ordinary resolved→recur path. Auto-resolving is safe: nothing real gets lost.
- While other agent PRs are still live, a close keeps its previous behavior — it resumes the session so the agent continues driving the remaining delivery.

Paths covered:

- **Webhook** (`apps/api/src/github.ts`): `resolveOrResumeIncidentForClosedAgentPr` resolves first and only falls back to the session continuation when PRs remain open (`pull_requests_pending`).
- **Worker recovery** (`apps/worker/src/agent-runs/sync.ts`): the settled-PR fallback gains a `resolve_settled` plan for closes the webhook never delivered, completing the run with a new `all_pull_requests_settled` outcome and matching Slack copy.
- **DB** (`packages/db`): shared `areAllIncidentPullRequestsSettled` predicate and `resolveIncidentIfAllAgentPullRequestsSettled`, factored from the existing all-merged resolve so both keep identical lock ordering, PR-batch reservation guard, and event dedupe. An in-flight PR delivery batch still blocks resolution, so an agent mid-delivery can't be undercut by closing its previous PR.

## Testing

- `packages/db`: new predicate tests + settled-resolution guard tests (open PR pending / no PRs / already resolved / pending batch); full package suite green (215).
- `apps/api`: new `pr-close-resolution.test.ts` covering resolve-without-session, merged-sibling crediting, fall-back-to-session when PRs remain live, and no-op on already-resolved incidents.
- `apps/worker`: `planSettledPullRequestFallback` cases updated for the new policy (mixed settled → resolve crediting merge, all closed → resolve, open remaining → follow-up).
- Typecheck green for db/api/worker/web; api+worker suites show only pre-existing environment-dependent failures (identical to a clean checkout).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically resolve incidents when the last live agent PR is closed; if a sibling PR merged, credit it instead. Mixed incidents and reopens are handled with a locked PR snapshot and epoch-aware attribution, stamping resolution at the latest settle and rejecting stale settle redeliveries.

- **New Features**
  - `apps/api`: `resolveOrResumeIncidentForClosedAgentPr` resolves first via `resolveIncidentIfAllAgentPullRequestsSettled`; the merged-PR webhook also uses the settled resolver; `resolvedAt` comes from `latestAgentPullRequestSettlementAt`; side effects run through `runResolvedIncidentSideEffectsWithGithub`; dedupe keys include close time; attribution is computed under the incident lock and only credits merges newer than the last reopen. Added `pr-close-resolution.test.ts`; updated the closed-PR webhook e2e to assert the new behavior.
  - `apps/worker`: Added `resolve_settled` plan that fires on the last settle (close or merge) with `all_pull_requests_settled` completion and state-aware copy; cold-start/unresumable paths use the settled resolver to fix close-then-merge orderings; fallback planner updated to resolve when all PRs are settled.
  - `packages/db`: Added `resolveIncidentIfAllAgentPullRequestsSettled`, `areAllIncidentPullRequestsSettled`, and `latestAgentPullRequestSettlementAt`; `IncidentAgentPullRequestSnapshot` now includes `closedAt` and is used to attribute under the incident lock; `buildInput(pullRequests, epoch)` scopes credit to merges after the last reopen; settlement evidence older than the last reopen is rejected.

<sup>Written for commit 2291ceecd53eae616265d10d0517b3f8402fdede. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

