### PR TITLE
Fix clock range date selection

### DIFF
--- a/apps/web/src/design/range-input.ts
+++ b/apps/web/src/design/range-input.ts
@@ -75,5 +75,35 @@ export function parseRangeInputForVisibleRange(
   now: number,
 ): ParsedRangeInput | null {
   const visibleSince = new Date(visibleRange.since).getTime();
-  return parseRangeInput(input, Number.isFinite(visibleSince) ? visibleSince : now);
+  const visibleUntil = new Date(visibleRange.until).getTime();
+  const parsedNow = parseRangeInput(input, now);
+  if (
+    parsedNow?.type !== "absolute" ||
+    !Number.isFinite(visibleSince) ||
+    !Number.isFinite(visibleUntil) ||
+    visibleSince >= visibleUntil
+  ) {
+    return parsedNow;
+  }
+
+  const referenceTimes = [now, visibleUntil - 1, visibleSince];
+  for (const referenceTime of referenceTimes) {
+    const candidate = parseRangeInput(input, referenceTime);
+    if (candidate?.type !== "absolute") continue;
+    const candidateSince = new Date(candidate.range.since).getTime();
+    const candidateUntil = new Date(candidate.range.until).getTime();
+    if (candidateSince >= visibleSince && candidateUntil <= visibleUntil) {
+      return candidate;
+    }
+  }
+
+  const localDay = (timestamp: number) => {
+    const date = new Date(timestamp);
+    return date.getFullYear() * 10_000 + (date.getMonth() + 1) * 100 + date.getDate();
+  };
+  if (localDay(now) >= localDay(visibleSince) && localDay(now) <= localDay(visibleUntil)) {
+    return parsedNow;
+  }
+
+  return parseRangeInput(input, visibleSince);
 }

--- a/apps/web/src/range-input.test.ts
+++ b/apps/web/src/range-input.test.ts
@@ -42,3 +42,23 @@ test("clock ranges use the visible historical range date", () => {
     },
   );
 });
+
+test("clock ranges choose the visible day containing the interval", () => {
+  assert.deepEqual(
+    parseRangeInputForVisibleRange(
+      "09:00-10:00",
+      {
+        since: new Date(2025, 3, 3, 18).toISOString(),
+        until: new Date(2025, 3, 4, 18).toISOString(),
+      },
+      new Date(2026, 6, 16, 12).getTime(),
+    ),
+    {
+      type: "absolute",
+      range: {
+        since: new Date(2025, 3, 4, 9).toISOString(),
+        until: new Date(2025, 3, 4, 10).toISOString(),
+      },
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- choose the visible calendar day that actually contains a typed clock interval
- prefer today when today is part of the visible window
- cover historical and midnight-spanning windows with regression tests

## Validation

- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web test` (170 passing)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix clock range date selection so typed intervals land on the visible day that actually contains them. Prefer today when it’s within the visible window; otherwise use the start of the window.

- **Bug Fixes**
  - Choose an absolute range that fits inside `visibleRange` by trying `now`, `visibleUntil - 1`, and `visibleSince`.
  - Keep fallback behavior for non-absolute inputs and invalid `visibleRange`.
  - Add tests for historical windows, visible-day selection, and midnight-spanning intervals.

<sup>Written for commit be4f860400df2cafcc84f283ad909b9505d7e680. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

