### PR TITLE
Cache ingest key authentication

### DIFF
--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -36,6 +36,7 @@ import {
 } from "./gcp-pubsub.js";
 import { mountGcpMetricsPullRoute } from "./gcp-pull-routes.js";
 import { stampIssueFingerprintsFailOpen } from "./ingest-fingerprints.js";
+import { createIngestKeyCache, createLastUsedRecorder } from "./ingest-key-auth.js";
 import { IngestQueue, getIngestQueueConfig } from "./ingest-queue.js";
 import {
   type IngestSource,
@@ -112,6 +113,28 @@ const ingestSourceFilter = createIngestSourceFilter({
       columns: { source: true, signal: true },
     });
     return new Set(rows.map((r) => ingestFilterKey(r.source, r.signal)));
+  },
+});
+
+// Ingest-key authentication is on every intake request. Cache the hash lookup
+// briefly and collapse concurrent misses so a hot key cannot monopolize the DB
+// connection pool. Key revocations propagate after the one-minute TTL.
+const ingestKeyCache = createIngestKeyCache({
+  lookup: async (keyHash) =>
+    (await db.query.apiKeys.findFirst({
+      where: eq(schema.apiKeys.keyHash, keyHash),
+    })) ?? null,
+});
+
+// last_used_at is operational metadata, not part of the authorization verdict.
+// Persist it at most once per key per minute per proxy instance rather than
+// taking a same-row UPDATE lock for every telemetry request.
+const lastUsedRecorder = createLastUsedRecorder({
+  write: async (keyId, usedAt) => {
+    await db.update(schema.apiKeys).set({ lastUsedAt: usedAt }).where(eq(schema.apiKeys.id, keyId));
+  },
+  onError: (err) => {
+    logger.error({ err }, "failed to update last_used_at or sync loops contact");
   },
 });
 
@@ -329,9 +352,7 @@ async function validateIngestKey(c: Context<{ Variables: Variables }>, next: () 
         );
       }
 
-      const row = await db.query.apiKeys.findFirst({
-        where: eq(schema.apiKeys.keyHash, hashApiKey(key)),
-      });
+      const row = await ingestKeyCache.resolve(hashApiKey(key));
       if (!row || row.revokedAt) {
         span.setAttribute("auth.result", "invalid_key");
         span.setStatus({ code: SpanStatusCode.ERROR, message: "invalid api key" });
@@ -341,21 +362,9 @@ async function validateIngestKey(c: Context<{ Variables: Variables }>, next: () 
       span.setAttribute("auth.result", "ok");
       span.setAttribute("tenant.project_id", row.projectId);
       c.set("projectId", row.projectId);
-      const isFirstUse = row.lastUsedAt === null;
-      void db
-        .update(schema.apiKeys)
-        .set({ lastUsedAt: new Date() })
-        .where(eq(schema.apiKeys.id, row.id))
-        .then(() => {
-          // Loops only needs the lifecycle nudge when telemetrySet flips false→true, i.e. on the
-          // first ingest for this key. Firing on every request hammers the Loops rate limit.
-          // (The product-analytics activation event is fired separately, from the accept path in
-          // forward(), gated on a project-level atomic claim — see maybeCaptureProjectActivation.)
-          if (isFirstUse) return syncLoopsContactsForProject({ projectId: row.projectId });
-        })
-        .catch((err: unknown) => {
-          logger.error({ err }, "failed to update last_used_at or sync loops contact");
-        });
+      lastUsedRecorder.record(row, (identity) =>
+        syncLoopsContactsForProject({ projectId: identity.projectId }),
+      );
 
       await next();
     } catch (err) {
@@ -890,17 +899,9 @@ async function forward(
  * which the OTLP path already owns.
  */
 async function resolveProjectIdForIngestKey(key: string): Promise<string | null> {
-  const row = await db.query.apiKeys.findFirst({
-    where: eq(schema.apiKeys.keyHash, hashApiKey(key)),
-  });
+  const row = await ingestKeyCache.resolve(hashApiKey(key));
   if (!row || row.revokedAt) return null;
-  void db
-    .update(schema.apiKeys)
-    .set({ lastUsedAt: new Date() })
-    .where(eq(schema.apiKeys.id, row.id))
-    .catch((err: unknown) => {
-      logger.warn({ err }, "failed to update last_used_at for firehose key");
-    });
+  lastUsedRecorder.record(row);
   return row.projectId;
 }
 
@@ -1099,21 +1100,11 @@ const RENDER_SYSLOG_PORT = Number(process.env.RENDER_SYSLOG_PORT ?? 0);
 const renderSyslogServer = RENDER_SYSLOG_PORT
   ? createRenderSyslogServer({
       authenticate: async (key) => {
-        const row = await db.query.apiKeys.findFirst({
-          where: eq(schema.apiKeys.keyHash, hashApiKey(key)),
-        });
+        const row = await ingestKeyCache.resolve(hashApiKey(key));
         if (!row || row.revokedAt) return null;
-        const isFirstUse = row.lastUsedAt === null;
-        void db
-          .update(schema.apiKeys)
-          .set({ lastUsedAt: new Date() })
-          .where(eq(schema.apiKeys.id, row.id))
-          .then(() => {
-            if (isFirstUse) return syncLoopsContactsForProject({ projectId: row.projectId });
-          })
-          .catch((err: unknown) => {
-            logger.error({ err }, "failed to update last_used_at or sync loops contact");
-          });
+        lastUsedRecorder.record(row, (identity) =>
+          syncLoopsContactsForProject({ projectId: identity.projectId }),
+        );
         return row.projectId;
       },
       deliver: async (projectId, records) => {

--- a/apps/proxy/src/ingest-key-auth.test.ts
+++ b/apps/proxy/src/ingest-key-auth.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createIngestKeyCache, createLastUsedRecorder } from "./ingest-key-auth.js";
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+test("repeated authentication of an ingest key reuses the cached identity", async () => {
+  let lookups = 0;
+  const cache = createIngestKeyCache({
+    lookup: async () => {
+      lookups += 1;
+      return {
+        id: "key-1",
+        projectId: "project-1",
+        lastUsedAt: null,
+        revokedAt: null,
+      };
+    },
+  });
+
+  const first = await cache.resolve("hash-1");
+  const second = await cache.resolve("hash-1");
+
+  assert.deepEqual(second, first);
+  assert.equal(lookups, 1);
+});
+
+test("an expired ingest-key identity is refreshed", async () => {
+  let now = 1_000;
+  let lookups = 0;
+  const cache = createIngestKeyCache({
+    lookup: async () => {
+      lookups += 1;
+      return {
+        id: "key-1",
+        projectId: `project-${lookups}`,
+        lastUsedAt: null,
+        revokedAt: null,
+      };
+    },
+    ttlMs: 60_000,
+    now: () => now,
+  });
+
+  assert.equal((await cache.resolve("hash-1"))?.projectId, "project-1");
+  now += 60_001;
+  assert.equal((await cache.resolve("hash-1"))?.projectId, "project-2");
+  assert.equal(lookups, 2);
+});
+
+test("concurrent authentication requests share one ingest-key lookup", async () => {
+  let lookups = 0;
+  let releaseLookup: (() => void) | undefined;
+  const lookupBlocked = new Promise<void>((resolve) => {
+    releaseLookup = resolve;
+  });
+  const cache = createIngestKeyCache({
+    lookup: async () => {
+      lookups += 1;
+      await lookupBlocked;
+      return {
+        id: "key-1",
+        projectId: "project-1",
+        lastUsedAt: null,
+        revokedAt: null,
+      };
+    },
+  });
+
+  const first = cache.resolve("hash-1");
+  const second = cache.resolve("hash-1");
+  releaseLookup?.();
+
+  assert.deepEqual(await second, await first);
+  assert.equal(lookups, 1);
+});
+
+test("the ingest-key cache evicts its oldest identity at the configured bound", async () => {
+  const lookups = new Map<string, number>();
+  const cache = createIngestKeyCache({
+    lookup: async (keyHash) => {
+      lookups.set(keyHash, (lookups.get(keyHash) ?? 0) + 1);
+      return {
+        id: keyHash,
+        projectId: `project-${keyHash}`,
+        lastUsedAt: null,
+        revokedAt: null,
+      };
+    },
+    maxEntries: 2,
+  });
+
+  await cache.resolve("hash-1");
+  await cache.resolve("hash-2");
+  await cache.resolve("hash-3");
+  await cache.resolve("hash-1");
+
+  assert.equal(lookups.get("hash-1"), 2);
+  assert.equal(lookups.get("hash-2"), 1);
+  assert.equal(lookups.get("hash-3"), 1);
+});
+
+test("repeated use of one ingest key produces one last-used write per interval", () => {
+  let writes = 0;
+  const recorder = createLastUsedRecorder({
+    write: async () => {
+      writes += 1;
+    },
+  });
+  const identity = {
+    id: "key-1",
+    projectId: "project-1",
+    lastUsedAt: new Date(0),
+    revokedAt: null,
+  };
+
+  recorder.record(identity);
+  recorder.record(identity);
+
+  assert.equal(writes, 1);
+});
+
+test("last-used recording resumes after the interval", () => {
+  let now = 1_000;
+  let writes = 0;
+  const recorder = createLastUsedRecorder({
+    write: async () => {
+      writes += 1;
+    },
+    intervalMs: 60_000,
+    now: () => now,
+  });
+  const identity = {
+    id: "key-1",
+    projectId: "project-1",
+    lastUsedAt: new Date(0),
+    revokedAt: null,
+  };
+
+  recorder.record(identity);
+  now += 60_001;
+  recorder.record(identity);
+
+  assert.equal(writes, 2);
+});
+
+test("last-used throttling evicts its oldest key at the configured bound", () => {
+  const writes = new Map<string, number>();
+  const recorder = createLastUsedRecorder({
+    write: async (keyId) => {
+      writes.set(keyId, (writes.get(keyId) ?? 0) + 1);
+    },
+    maxEntries: 2,
+  });
+  const identity = (id: string) => ({
+    id,
+    projectId: `project-${id}`,
+    lastUsedAt: new Date(0),
+    revokedAt: null,
+  });
+
+  recorder.record(identity("key-1"));
+  recorder.record(identity("key-2"));
+  recorder.record(identity("key-3"));
+  recorder.record(identity("key-1"));
+
+  assert.equal(writes.get("key-1"), 2);
+  assert.equal(writes.get("key-2"), 1);
+  assert.equal(writes.get("key-3"), 1);
+});
+
+test("a failed last-used write can be retried by the next request", async () => {
+  let attempts = 0;
+  let errors = 0;
+  const recorder = createLastUsedRecorder({
+    write: async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("database unavailable");
+    },
+    onError: () => {
+      errors += 1;
+    },
+  });
+  const identity = {
+    id: "key-1",
+    projectId: "project-1",
+    lastUsedAt: new Date(0),
+    revokedAt: null,
+  };
+
+  recorder.record(identity);
+  await flush();
+  recorder.record(identity);
+  await flush();
+
+  assert.equal(attempts, 2);
+  assert.equal(errors, 1);
+});
+
+test("the first-use callback runs once after the last-used write succeeds", async () => {
+  let firstUses = 0;
+  const recorder = createLastUsedRecorder({
+    write: async () => undefined,
+  });
+  const identity = {
+    id: "key-1",
+    projectId: "project-1",
+    lastUsedAt: null,
+    revokedAt: null,
+  };
+
+  recorder.record(identity, async () => {
+    firstUses += 1;
+  });
+  await flush();
+  recorder.record(identity, async () => {
+    firstUses += 1;
+  });
+  await flush();
+
+  assert.equal(firstUses, 1);
+  assert.notEqual(identity.lastUsedAt, null);
+});

--- a/apps/proxy/src/ingest-key-auth.test.ts
+++ b/apps/proxy/src/ingest-key-auth.test.ts
@@ -48,6 +48,26 @@ test("an expired ingest-key identity is refreshed", async () => {
   assert.equal(lookups, 2);
 });
 
+test("a missing ingest key is not cached", async () => {
+  let lookups = 0;
+  const cache = createIngestKeyCache({
+    lookup: async () => {
+      lookups += 1;
+      if (lookups === 1) return null;
+      return {
+        id: "key-1",
+        projectId: "project-1",
+        lastUsedAt: null,
+        revokedAt: null,
+      };
+    },
+  });
+
+  assert.equal(await cache.resolve("hash-1"), null);
+  assert.equal((await cache.resolve("hash-1"))?.projectId, "project-1");
+  assert.equal(lookups, 2);
+});
+
 test("concurrent authentication requests share one ingest-key lookup", async () => {
   let lookups = 0;
   let releaseLookup: (() => void) | undefined;

--- a/apps/proxy/src/ingest-key-auth.ts
+++ b/apps/proxy/src/ingest-key-auth.ts
@@ -6,7 +6,7 @@ export type IngestKeyIdentity = {
 };
 
 type CacheEntry = {
-  identity: IngestKeyIdentity | null;
+  identity: IngestKeyIdentity;
   expiresAt: number;
 };
 
@@ -44,7 +44,7 @@ export function createIngestKeyCache(deps: {
       const lookup = deps
         .lookup(keyHash)
         .then((identity) => {
-          setEntry(keyHash, { identity, expiresAt: now() + ttlMs });
+          if (identity) setEntry(keyHash, { identity, expiresAt: now() + ttlMs });
           return identity;
         })
         .finally(() => inflight.delete(keyHash));

--- a/apps/proxy/src/ingest-key-auth.ts
+++ b/apps/proxy/src/ingest-key-auth.ts
@@ -1,0 +1,100 @@
+export type IngestKeyIdentity = {
+  id: string;
+  projectId: string;
+  lastUsedAt: Date | null;
+  revokedAt: Date | null;
+};
+
+type CacheEntry = {
+  identity: IngestKeyIdentity | null;
+  expiresAt: number;
+};
+
+const DEFAULT_CACHE_TTL_MS = 60_000;
+const DEFAULT_MAX_ENTRIES = 50_000;
+const DEFAULT_LAST_USED_INTERVAL_MS = 60_000;
+
+export function createIngestKeyCache(deps: {
+  lookup: (keyHash: string) => Promise<IngestKeyIdentity | null>;
+  ttlMs?: number;
+  maxEntries?: number;
+  now?: () => number;
+}) {
+  const ttlMs = deps.ttlMs ?? DEFAULT_CACHE_TTL_MS;
+  const maxEntries = Math.max(1, deps.maxEntries ?? DEFAULT_MAX_ENTRIES);
+  const now = deps.now ?? Date.now;
+  const cache = new Map<string, CacheEntry>();
+  const inflight = new Map<string, Promise<IngestKeyIdentity | null>>();
+
+  function setEntry(keyHash: string, entry: CacheEntry): void {
+    if (!cache.has(keyHash) && cache.size >= maxEntries) {
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined) cache.delete(oldest);
+    }
+    cache.set(keyHash, entry);
+  }
+
+  return {
+    async resolve(keyHash: string): Promise<IngestKeyIdentity | null> {
+      const entry = cache.get(keyHash);
+      if (entry && entry.expiresAt > now()) return entry.identity;
+      const pending = inflight.get(keyHash);
+      if (pending) return pending;
+
+      const lookup = deps
+        .lookup(keyHash)
+        .then((identity) => {
+          setEntry(keyHash, { identity, expiresAt: now() + ttlMs });
+          return identity;
+        })
+        .finally(() => inflight.delete(keyHash));
+      inflight.set(keyHash, lookup);
+      return lookup;
+    },
+  };
+}
+
+export function createLastUsedRecorder(deps: {
+  write: (keyId: string, usedAt: Date) => Promise<void>;
+  onError?: (error: unknown, identity: IngestKeyIdentity) => void;
+  intervalMs?: number;
+  maxEntries?: number;
+  now?: () => number;
+}) {
+  const intervalMs = deps.intervalMs ?? DEFAULT_LAST_USED_INTERVAL_MS;
+  const maxEntries = Math.max(1, deps.maxEntries ?? DEFAULT_MAX_ENTRIES);
+  const now = deps.now ?? Date.now;
+  const nextWriteAt = new Map<string, number>();
+
+  return {
+    record(
+      identity: IngestKeyIdentity,
+      onFirstUse?: (identity: IngestKeyIdentity) => Promise<void>,
+    ): void {
+      const usedAt = now();
+      if ((nextWriteAt.get(identity.id) ?? 0) > usedAt) return;
+      if (!nextWriteAt.has(identity.id) && nextWriteAt.size >= maxEntries) {
+        const oldest = nextWriteAt.keys().next().value;
+        if (oldest !== undefined) nextWriteAt.delete(oldest);
+      }
+      const writeAfter = usedAt + intervalMs;
+      nextWriteAt.set(identity.id, writeAfter);
+      const usedAtDate = new Date(usedAt);
+      const isFirstUse = identity.lastUsedAt === null;
+      void deps.write(identity.id, usedAtDate).then(
+        () => {
+          identity.lastUsedAt = usedAtDate;
+          if (isFirstUse && onFirstUse) {
+            void Promise.resolve()
+              .then(() => onFirstUse(identity))
+              .catch((error) => deps.onError?.(error, identity));
+          }
+        },
+        (error) => {
+          if (nextWriteAt.get(identity.id) === writeAfter) nextWriteAt.delete(identity.id);
+          deps.onError?.(error, identity);
+        },
+      );
+    },
+  };
+}


### PR DESCRIPTION
## What changed

- cache ingest-key identity lookups for one minute with a bounded in-memory cache
- coalesce concurrent misses for the same key into one database lookup
- throttle `last_used_at` persistence to once per key per minute per proxy instance
- share the behavior across HTTP ingest, Firehose, and Render syslog authentication

## Why

The proxy previously queried the API-key table and updated the same `last_used_at` row on every ingest request. A high request rate for one key could therefore create row-lock contention and consume the database connection pool, delaying unrelated authentication requests.

This change keeps authorization responsive while preserving best-effort usage metadata. It does not reject or rate-limit telemetry requests. Key revocations propagate after the cache's one-minute TTL.

## Validation

- `pnpm --filter @superlog/proxy test` (126 tests)
- `pnpm --filter @superlog/proxy typecheck`
- `pnpm worktree:verify`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache ingest-key authentication and throttle `last_used_at` writes to reduce database load and keep auth fast across HTTP ingest, Firehose, and Render syslog. Key revocations propagate within 1 minute.

- **Refactors**
  - Added bounded in-memory cache (1-minute TTL) for identity lookups; coalesces concurrent misses and does not cache missing keys.
  - Introduced last-used recorder to write at most once per key per minute; runs first-use callback once.
  - Replaced per-request queries/updates in all ingest paths with these utilities.

<sup>Written for commit 1e976c4f7fc57c1e1f9fb64a1f6944d87c9fd819. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

