### PR TITLE
Protect project home dashboard mutations

### DIFF
--- a/apps/api/src/dashboards-service.ts
+++ b/apps/api/src/dashboards-service.ts
@@ -118,6 +118,12 @@ export function dashboardRouteCanWriteWidget({
   );
 }
 
+export function dashboardRouteCanMutateDashboard({
+  isHome,
+}: Pick<schema.Dashboard, "isHome">): boolean {
+  return !isHome;
+}
+
 export function defaultHomeWidgets(): DashboardWidgetCreateInput[] {
   return [
     {
@@ -323,7 +329,7 @@ export async function setHomeBuiltin(
     await insertDashboardWidget(home.id, definition);
   }
   if (!enabled && existing) {
-    await deleteDashboardWidget(projectId, home.id, existing.id);
+    await removeDashboardWidget(home.id, existing.id);
   }
   return (await getDashboardWithWidgets(projectId, home.id)) ?? home;
 }
@@ -353,7 +359,7 @@ export async function addHomeDataWidget(
     throw new Error("use the dedicated home built-in or link operation");
   }
   const home = await getOrCreateHomeDashboard(projectId, userId);
-  const widget = await addDashboardWidget(projectId, home.id, input);
+  const widget = await insertDashboardWidget(home.id, input);
   if (!widget) throw new Error("failed to add home widget");
   return widget;
 }
@@ -365,7 +371,16 @@ export async function deleteHomeItem(
 ): Promise<boolean> {
   const home = await getOrCreateHomeDashboard(projectId, userId);
   if (!home.widgets.some((widget) => widget.id === itemId)) return false;
-  return deleteDashboardWidget(projectId, home.id, itemId);
+  return removeDashboardWidget(home.id, itemId);
+}
+
+export async function updateHomeLayout(
+  projectId: string,
+  userId: string,
+  widgets: { id: string; layout: z.infer<typeof dashboardWidgetLayoutSchema> }[],
+): Promise<void> {
+  const home = await getOrCreateHomeDashboard(projectId, userId);
+  await updateDashboardLayoutItems(home.id, widgets);
 }
 
 export async function getDashboardWithWidgets(
@@ -424,7 +439,13 @@ export async function updateDashboard(
       ...(input.variables !== undefined ? { variables: input.variables } : {}),
       updatedAt: new Date(),
     })
-    .where(and(eq(schema.dashboards.id, id), eq(schema.dashboards.projectId, projectId)))
+    .where(
+      and(
+        eq(schema.dashboards.id, id),
+        eq(schema.dashboards.projectId, projectId),
+        eq(schema.dashboards.isHome, false),
+      ),
+    )
     .returning();
   return updated[0] ?? null;
 }
@@ -437,7 +458,13 @@ export async function setDashboardVariables(
   const updated = await db
     .update(schema.dashboards)
     .set({ variables, updatedAt: new Date() })
-    .where(and(eq(schema.dashboards.id, id), eq(schema.dashboards.projectId, projectId)))
+    .where(
+      and(
+        eq(schema.dashboards.id, id),
+        eq(schema.dashboards.projectId, projectId),
+        eq(schema.dashboards.isHome, false),
+      ),
+    )
     .returning();
   return updated[0] ?? null;
 }
@@ -472,6 +499,7 @@ export async function addDashboardWidget(
 ): Promise<schema.DashboardWidget | null> {
   const dashboard = await ensureDashboardOwned(projectId, dashboardId);
   if (!dashboard) return null;
+  if (!dashboardRouteCanMutateDashboard(dashboard)) return null;
   if (!dashboardRouteCanWriteWidget({ requestedType: input.type })) return null;
   return insertDashboardWidget(dashboardId, input);
 }
@@ -510,6 +538,7 @@ export async function updateDashboardWidget(
 ): Promise<schema.DashboardWidget | null> {
   const dashboard = await ensureDashboardOwned(projectId, dashboardId);
   if (!dashboard) return null;
+  if (!dashboardRouteCanMutateDashboard(dashboard)) return null;
   const existing = await db.query.dashboardWidgets.findFirst({
     where: and(
       eq(schema.dashboardWidgets.id, widgetId),
@@ -556,15 +585,21 @@ export async function deleteDashboardWidget(
 ): Promise<boolean> {
   const dashboard = await ensureDashboardOwned(projectId, dashboardId);
   if (!dashboard) return false;
-  await db
+  if (!dashboardRouteCanMutateDashboard(dashboard)) return false;
+  return removeDashboardWidget(dashboardId, widgetId);
+}
+
+async function removeDashboardWidget(dashboardId: string, widgetId: string): Promise<boolean> {
+  const deleted = await db
     .delete(schema.dashboardWidgets)
     .where(
       and(
         eq(schema.dashboardWidgets.id, widgetId),
         eq(schema.dashboardWidgets.dashboardId, dashboardId),
       ),
-    );
-  return true;
+    )
+    .returning({ id: schema.dashboardWidgets.id });
+  return deleted.length > 0;
 }
 
 export async function updateDashboardLayout(
@@ -574,6 +609,15 @@ export async function updateDashboardLayout(
 ): Promise<boolean> {
   const dashboard = await ensureDashboardOwned(projectId, dashboardId);
   if (!dashboard) return false;
+  if (!dashboardRouteCanMutateDashboard(dashboard)) return false;
+  await updateDashboardLayoutItems(dashboardId, widgets);
+  return true;
+}
+
+async function updateDashboardLayoutItems(
+  dashboardId: string,
+  widgets: { id: string; layout: z.infer<typeof dashboardWidgetLayoutSchema> }[],
+): Promise<void> {
   await Promise.all(
     widgets.map((w) =>
       db
@@ -591,5 +635,4 @@ export async function updateDashboardLayout(
     .update(schema.dashboards)
     .set({ updatedAt: new Date() })
     .where(eq(schema.dashboards.id, dashboardId));
-  return true;
 }

--- a/apps/api/src/dashboards.ts
+++ b/apps/api/src/dashboards.ts
@@ -25,6 +25,7 @@ import {
   updateDashboard,
   updateDashboardLayout,
   updateDashboardWidget,
+  updateHomeLayout,
   setHomeBuiltin,
 } from "./dashboards-service.js";
 import { resolveEffectiveReadProjectId } from "./demo.js";
@@ -105,8 +106,7 @@ export function mountDashboards(app: Hono<{ Variables: Vars }>) {
       })
       .safeParse(body);
     if (!parsed.success) throw new HTTPException(400, { message: "invalid home layout" });
-    const home = await getOrCreateHomeDashboard(projectId, user.id);
-    await updateDashboardLayout(projectId, home.id, parsed.data.widgets);
+    await updateHomeLayout(projectId, user.id, parsed.data.widgets);
     return c.json({ ok: true });
   });
 

--- a/apps/api/src/home-dashboard.test.ts
+++ b/apps/api/src/home-dashboard.test.ts
@@ -3,8 +3,12 @@ import { test } from "node:test";
 
 process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
 
-const { defaultHomeWidgets, homeLinkCreateSchema, dashboardRouteCanWriteWidget } =
-  await import("./dashboards-service.js");
+const {
+  defaultHomeWidgets,
+  homeLinkCreateSchema,
+  dashboardRouteCanMutateDashboard,
+  dashboardRouteCanWriteWidget,
+} = await import("./dashboards-service.js");
 
 test("a new project home preserves the three existing overview sections as widgets", () => {
   const widgets = defaultHomeWidgets();
@@ -35,4 +39,9 @@ test("generic dashboard routes cannot create or edit home-only widgets", () => {
   assert.equal(dashboardRouteCanWriteWidget({ existingType: "link" }), false);
   assert.equal(dashboardRouteCanWriteWidget({ requestedType: "active_incidents" }), false);
   assert.equal(dashboardRouteCanWriteWidget({ requestedType: "timeseries_count" }), true);
+});
+
+test("generic dashboard routes cannot mutate the home dashboard", () => {
+  assert.equal(dashboardRouteCanMutateDashboard({ isHome: true }), false);
+  assert.equal(dashboardRouteCanMutateDashboard({ isHome: false }), true);
 });

--- a/apps/api/src/mcp/dashboards.ts
+++ b/apps/api/src/mcp/dashboards.ts
@@ -21,6 +21,7 @@ import {
   updateDashboard,
   updateDashboardLayout,
   updateDashboardWidget,
+  updateHomeLayout,
   setHomeBuiltin,
 } from "../dashboards-service.js";
 import { assertProjectAccess } from "./projects.js";
@@ -161,8 +162,7 @@ export function registerDashboardTools(
     },
     async (input) => {
       const projectId = await resolve(input.project_id);
-      const home = await getOrCreateHomeDashboard(projectId, session.userId);
-      await updateDashboardLayout(projectId, home.id, input.items);
+      await updateHomeLayout(projectId, session.userId, input.items);
       return text({ ok: true });
     },
   );


### PR DESCRIPTION
## Summary
- reject generic dashboard mutations when the target is the project home
- keep home layout, removal, and widget creation behind dedicated home operations
- prevent generic metadata and variable updates from changing the home dashboard

## Validation
- node --import tsx --test src/home-dashboard.test.ts
- pnpm --filter @superlog/api typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protect the project home dashboard from generic mutations. Only dedicated home operations can change home layout or widgets, preventing accidental metadata/variable edits.

- **Bug Fixes**
  - Block generic updates to home by enforcing `isHome = false` in dashboard and variable updates.
  - Guard widget add/update/delete and layout updates with a home check so generic routes cannot modify home.
  - Add `updateHomeLayout` and route/tool usage to update home layout safely.
  - Add tests to ensure generic routes cannot mutate the home dashboard.

- **Refactors**
  - Extract `removeDashboardWidget` and `updateDashboardLayoutItems` helpers and reuse across home operations.
  - Use `insertDashboardWidget` for home widget creation to avoid generic-route checks.

<sup>Written for commit 84460e14c6c2d2887b1cabfe6197d22747e980f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

