### PR TITLE
Avoid caching missing syslog keys

### DIFF
--- a/apps/proxy/src/render-syslog.test.ts
+++ b/apps/proxy/src/render-syslog.test.ts
@@ -3,12 +3,12 @@ import net from "node:net";
 import test from "node:test";
 
 import {
+  type RenderSyslogRecord,
   SyslogFrameSplitter,
   createRenderSyslogServer,
   extractIngestKey,
   parseRfc5424,
   renderSyslogToOtlp,
-  type RenderSyslogRecord,
 } from "./render-syslog.js";
 
 // Realistic length: real keys are the prefix + 43 chars of base64url.
@@ -209,17 +209,22 @@ test("frames that never authenticate are dropped, not delivered", async () => {
   );
 });
 
-test("invalid-key verdicts are cached across frames", async () => {
-  const calls: string[] = [];
+test("a missing key is rechecked on a following frame", async () => {
+  let calls = 0;
   await withServer(
-    async (key) => {
-      calls.push(key);
-      return null;
+    async () => {
+      calls += 1;
+      return calls === 1 ? null : "project-1";
     },
-    async (port) => {
-      await send(port, Buffer.concat([octet(FRAME), octet(FRAME), octet(FRAME)]));
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      assert.equal(calls.length, 1);
+    async (port, delivered) => {
+      await send(port, octet(FRAME));
+      await eventually(() => calls === 1);
+      assert.equal(delivered.length, 0);
+
+      await send(port, octet(FRAME));
+      await eventually(() => delivered.length === 1);
+      assert.equal(calls, 2);
+      assert.equal(delivered[0]?.projectId, "project-1");
     },
   );
 });

--- a/apps/proxy/src/render-syslog.ts
+++ b/apps/proxy/src/render-syslog.ts
@@ -245,10 +245,7 @@ export function renderSyslogToOtlp(records: RenderSyslogRecord[]): unknown {
   return {
     resourceLogs: [...byService.entries()].map(([service, group]) => ({
       resource: {
-        attributes: [
-          kv("service.name", service),
-          kv("telemetry.source", "render"),
-        ].filter(Boolean),
+        attributes: [kv("service.name", service), kv("telemetry.source", "render")].filter(Boolean),
       },
       scopeLogs: [
         {
@@ -294,17 +291,19 @@ export type RenderSyslogServerDeps = {
 };
 
 export function createRenderSyslogServer(deps: RenderSyslogServerDeps): net.Server {
-  const authCache = new Map<string, { projectId: string | null; expiresAt: number }>();
+  const authCache = new Map<string, { projectId: string; expiresAt: number }>();
 
   async function resolveKey(key: string): Promise<string | null> {
     const cached = authCache.get(key);
     if (cached && cached.expiresAt > Date.now()) return cached.projectId;
     const projectId = await deps.authenticate(key);
-    authCache.set(key, { projectId, expiresAt: Date.now() + AUTH_CACHE_TTL_MS });
-    // The cache is keyed by attacker-supplied strings; keep it bounded.
-    if (authCache.size > 10_000) {
-      const oldest = authCache.keys().next().value;
-      if (oldest !== undefined) authCache.delete(oldest);
+    if (projectId) {
+      authCache.set(key, { projectId, expiresAt: Date.now() + AUTH_CACHE_TTL_MS });
+      // The cache is keyed by attacker-supplied strings; keep it bounded.
+      if (authCache.size > 10_000) {
+        const oldest = authCache.keys().next().value;
+        if (oldest !== undefined) authCache.delete(oldest);
+      }
     }
     return projectId;
   }


### PR DESCRIPTION
## What changed

- cache only successful Render syslog ingest-key resolutions
- recheck missing keys on subsequent frames instead of retaining a one-minute negative verdict
- add a socket-level regression test covering a key that becomes valid after the first frame

## Why

The syslog server had its own authentication cache in addition to the shared ingest-key cache. Although the shared cache no longer stores missing keys, the outer syslog cache could still retain a missing verdict for one minute and delay a newly created key from taking effect.

Successful resolutions remain cached and bounded as before.

## Validation

- `pnpm --filter @superlog/proxy test` (127 tests)
- `pnpm --filter @superlog/proxy typecheck`
- `pnpm worktree:verify`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop caching missing syslog ingest keys so new keys take effect without a 1-minute delay. Missing keys are rechecked on each frame; valid keys are still cached.

- **Bug Fixes**
  - Cache only successful Render syslog ingest-key resolutions; keep TTL and size bounds.
  - Recheck missing keys on each frame instead of storing a negative result.
  - Add a socket-level regression test for a key that becomes valid after the first frame.

<sup>Written for commit 6d18953fad50d85d5431008595f11b7b60140694. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

