### PR TITLE
Add Google Cloud to onboarding connect chooser

### DIFF
--- a/apps/web/src/onboarding/ConnectDataChooser.tsx
+++ b/apps/web/src/onboarding/ConnectDataChooser.tsx
@@ -12,6 +12,7 @@ import {
   ChevronRightIcon,
   CloudflareIcon,
   ExternalLinkIcon,
+  GcpIcon,
   RailwayIcon,
   RenderIcon,
   TerminalIcon,
@@ -32,6 +33,7 @@ function ConnectGlyph({ icon }: { icon: ConnectIcon }) {
   const map: Record<ConnectIcon, typeof AwsIcon> = {
     aws: AwsIcon,
     cloudflare: CloudflareIcon,
+    gcp: GcpIcon,
     vercel: VercelIcon,
     railway: RailwayIcon,
     render: RenderIcon,
@@ -146,6 +148,7 @@ export function ConnectDataChooser({
   const capabilities = useSystemCapabilities();
   const sections = connectSectionsFor({
     cloudflare: capabilities.data?.cloudflareConnect ?? false,
+    gcp: capabilities.data?.gcpConnect ?? false,
     vercel: capabilities.data?.vercelConnect ?? false,
     railway: capabilities.data?.railwayConnect ?? false,
     render: capabilities.data?.renderConnect ?? false,

--- a/apps/web/src/onboarding/GcpConnectFlow.tsx
+++ b/apps/web/src/onboarding/GcpConnectFlow.tsx
@@ -11,18 +11,19 @@ import {
   StepHeader,
 } from "./wizardChrome.tsx";
 
-// Open the Google Cloud consent screen in a new tab, falling back to a same-tab
-// navigation if the popup was blocked. Same opener-severing trick as the other
-// connector launch helpers. Unlike the same-tab redirect Settings uses, the new
-// tab lets this onboarding tab keep polling the connection endpoint while the
-// user authorizes and picks a project on the standalone /connect/gcp page.
+// Open the Google Cloud consent screen in a new tab, severing the opener. The
+// new tab lets this onboarding tab keep polling the connection endpoint while
+// the user authorizes and picks a project on the standalone /connect/gcp page.
+//
+// We deliberately do NOT fall back to a same-tab navigation when the popup is
+// blocked: unlike the other OAuth callbacks, which carry their outcome back to
+// `/`, the /connect/gcp result page returns to `/settings`, so a same-tab
+// round-trip would drop the user out of onboarding. When the popup is blocked
+// the connecting panel exposes a manual open link (a plain anchor, which isn't
+// popup-blocked) that keeps this tab and its polling alive.
 function openConsent(url: string) {
-  const win = window.open(url, "_blank");
-  if (win) {
-    win.opener = null;
-  } else {
-    window.location.assign(url);
-  }
+  const win = window.open(url, "_blank", "noopener,noreferrer");
+  if (win) win.opener = null;
 }
 
 export function GcpConnectFlow({
@@ -45,6 +46,10 @@ export function GcpConnectFlow({
   // from "start" to the "connecting" waiting state while the connection poll
   // catches the OAuth + project-selection round-trip landing.
   const [launched, setLaunched] = useState(false);
+  // The most recent consent URL, kept so the connecting panel can offer a
+  // manual open link (an anchor, which isn't subject to popup blocking) without
+  // re-minting a fresh authorization.
+  const [consentUrl, setConsentUrl] = useState<string | null>(null);
 
   const connection = useGcpConnection(projectId);
   const start = useStartGcpConnect(projectId);
@@ -56,6 +61,7 @@ export function GcpConnectFlow({
     if (start.isPending) return;
     try {
       const { url } = await start.mutateAsync();
+      setConsentUrl(url);
       setLaunched(true);
       openConsent(url);
     } catch {
@@ -78,11 +84,7 @@ export function GcpConnectFlow({
       )}
 
       {phase === "connecting" && (
-        <ConnectingPanel
-          statusText={gcpStatusText(phase, eventsArrived)}
-          onReopen={connect}
-          reopening={start.isPending}
-        />
+        <ConnectingPanel statusText={gcpStatusText(phase, eventsArrived)} consentUrl={consentUrl} />
       )}
 
       {phase === "failed" && (
@@ -178,12 +180,10 @@ function StartPanel({
 
 function ConnectingPanel({
   statusText,
-  onReopen,
-  reopening,
+  consentUrl,
 }: {
   statusText: string;
-  onReopen: () => void;
-  reopening: boolean;
+  consentUrl: string | null;
 }) {
   return (
     <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
@@ -201,14 +201,16 @@ function ConnectingPanel({
           <li>Pick the Google Cloud project you want to share.</li>
           <li>This panel updates on its own once the connection lands.</li>
         </ol>
-        <button
-          type="button"
-          onClick={onReopen}
-          disabled={reopening}
-          className="mt-3 inline-flex items-center gap-1.5 text-[12.5px] font-medium text-[#8C98F0] transition-colors hover:text-fg disabled:opacity-50"
-        >
-          <ExternalLinkIcon size={13} /> Reopen Google Cloud
-        </button>
+        {consentUrl && (
+          <a
+            href={consentUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-3 inline-flex items-center gap-1.5 text-[12.5px] font-medium text-[#8C98F0] transition-colors hover:text-fg"
+          >
+            <ExternalLinkIcon size={13} /> Didn't see a tab? Reopen Google Cloud
+          </a>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/onboarding/GcpConnectFlow.tsx
+++ b/apps/web/src/onboarding/GcpConnectFlow.tsx
@@ -84,7 +84,14 @@ export function GcpConnectFlow({
       )}
 
       {phase === "connecting" && (
-        <ConnectingPanel statusText={gcpStatusText(phase, eventsArrived)} consentUrl={consentUrl} />
+        <ConnectingPanel
+          statusText={gcpStatusText(phase, eventsArrived)}
+          consentUrl={consentUrl}
+          onStartOver={() => {
+            setLaunched(false);
+            setConsentUrl(null);
+          }}
+        />
       )}
 
       {phase === "failed" && (
@@ -181,9 +188,11 @@ function StartPanel({
 function ConnectingPanel({
   statusText,
   consentUrl,
+  onStartOver,
 }: {
   statusText: string;
   consentUrl: string | null;
+  onStartOver: () => void;
 }) {
   return (
     <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
@@ -201,16 +210,29 @@ function ConnectingPanel({
           <li>Pick the Google Cloud project you want to share.</li>
           <li>This panel updates on its own once the connection lands.</li>
         </ol>
-        {consentUrl && (
-          <a
-            href={consentUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="mt-3 inline-flex items-center gap-1.5 text-[12.5px] font-medium text-[#8C98F0] transition-colors hover:text-fg"
+        {/* The consent/picker steps happen in a separate tab, so a denial,
+            cancellation, or "no projects" outcome never reaches this tab and
+            can't flip the phase to failed. Reopen re-runs the flow; Start over
+            returns to the start panel so the user is never stuck waiting. */}
+        <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-1.5">
+          {consentUrl && (
+            <a
+              href={consentUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1.5 text-[12.5px] font-medium text-[#8C98F0] transition-colors hover:text-fg"
+            >
+              <ExternalLinkIcon size={13} /> Didn't see a tab? Reopen Google Cloud
+            </a>
+          )}
+          <button
+            type="button"
+            onClick={onStartOver}
+            className="text-[12.5px] font-medium text-muted transition-colors hover:text-fg"
           >
-            <ExternalLinkIcon size={13} /> Didn't see a tab? Reopen Google Cloud
-          </a>
-        )}
+            Cancelled or denied? Start over
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/onboarding/GcpConnectFlow.tsx
+++ b/apps/web/src/onboarding/GcpConnectFlow.tsx
@@ -1,0 +1,297 @@
+import { useState } from "react";
+import { useGcpConnection, useStartGcpConnect } from "../api.ts";
+import { Btn } from "../design/ui.tsx";
+import { type GcpPhase, canContinueGcp, gcpPhase, gcpStatusText } from "./gcpConnectModel.ts";
+import { CheckIcon, ExternalLinkIcon, SpinnerIcon } from "./icons.tsx";
+import {
+  ExploreDemoLink,
+  SOFT_LINE,
+  STRONG_LINE,
+  StepFooter,
+  StepHeader,
+} from "./wizardChrome.tsx";
+
+// Open the Google Cloud consent screen in a new tab, falling back to a same-tab
+// navigation if the popup was blocked. Same opener-severing trick as the other
+// connector launch helpers. Unlike the same-tab redirect Settings uses, the new
+// tab lets this onboarding tab keep polling the connection endpoint while the
+// user authorizes and picks a project on the standalone /connect/gcp page.
+function openConsent(url: string) {
+  const win = window.open(url, "_blank");
+  if (win) {
+    win.opener = null;
+  } else {
+    window.location.assign(url);
+  }
+}
+
+export function GcpConnectFlow({
+  projectId,
+  eventsArrived,
+  onBack,
+  onDone,
+  onExploreDemo,
+}: {
+  projectId: string;
+  // Whether the real project has ingested telemetry yet (from the parent's
+  // `me.project.hasIngested`). NOT derived from the stats endpoint, which is
+  // demo-overlaid for un-ingested projects and would falsely report events.
+  eventsArrived: boolean;
+  onBack: () => void;
+  onDone: () => void;
+  onExploreDemo?: () => void;
+}) {
+  // Whether we've opened the consent screen this session. Drives the transition
+  // from "start" to the "connecting" waiting state while the connection poll
+  // catches the OAuth + project-selection round-trip landing.
+  const [launched, setLaunched] = useState(false);
+
+  const connection = useGcpConnection(projectId);
+  const start = useStartGcpConnect(projectId);
+
+  const row = connection.data && "status" in connection.data ? connection.data : null;
+  const phase = gcpPhase({ status: row?.status ?? null, launched });
+
+  const connect = async () => {
+    if (start.isPending) return;
+    try {
+      const { url } = await start.mutateAsync();
+      setLaunched(true);
+      openConsent(url);
+    } catch {
+      // The mutation error surfaces via start.error below.
+    }
+  };
+
+  const header = headerForPhase(phase);
+
+  return (
+    <>
+      <StepHeader title={header.title} sub={header.sub} />
+
+      {phase === "start" && (
+        <StartPanel
+          onConnect={connect}
+          pending={start.isPending}
+          error={start.error ? String(start.error) : null}
+        />
+      )}
+
+      {phase === "connecting" && (
+        <ConnectingPanel
+          statusText={gcpStatusText(phase, eventsArrived)}
+          onReopen={connect}
+          reopening={start.isPending}
+        />
+      )}
+
+      {phase === "failed" && (
+        <FailedPanel
+          lastError={row?.lastError ?? null}
+          onReconnect={connect}
+          reconnecting={start.isPending}
+        />
+      )}
+
+      {phase === "connected" && row && (
+        <ConnectedPanel gcpProjectId={row.gcpProjectId} eventsArrived={eventsArrived} />
+      )}
+
+      <StepFooter
+        onBack={onBack}
+        onNext={onDone}
+        nextLabel={canContinueGcp(phase) ? "Continue" : "Waiting for Google Cloud…"}
+        nextDisabled={!canContinueGcp(phase)}
+      />
+      {!canContinueGcp(phase) && <ExploreDemoLink onExploreDemo={onExploreDemo} />}
+    </>
+  );
+}
+
+function headerForPhase(phase: GcpPhase): { title: string; sub: string } {
+  switch (phase) {
+    case "start":
+      return {
+        title: "Connect Google Cloud",
+        sub: "Authorize Google Cloud once and pick a project. We route Cloud Logging and read a bounded set of Cloud Monitoring metrics — no Terraform, no service-account key.",
+      };
+    case "connecting":
+      return {
+        title: "Finish in Google Cloud",
+        sub: "Approve the access request in the Google tab we opened, then choose the project you want to share — keep this tab open.",
+      };
+    case "failed":
+      return {
+        title: "Connection didn't finish",
+        sub: "Something went wrong provisioning the connection. Reconnect to try again.",
+      };
+    default:
+      return {
+        title: "You're connected",
+        sub: "We're routing Cloud Logging and reading bounded Cloud Monitoring metrics. First events typically appear within a minute.",
+      };
+  }
+}
+
+function StartPanel({
+  onConnect,
+  pending,
+  error,
+}: {
+  onConnect: () => void;
+  pending: boolean;
+  error: string | null;
+}) {
+  return (
+    <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+      <div className={`border-b px-[22px] py-[18px] ${SOFT_LINE}`}>
+        <p className="m-0 text-[13px] leading-[1.55] text-muted">
+          We never ask for a service-account key. Google's OAuth grants a scoped token; we create a
+          Cloud Logging route and read a curated set of Cloud Monitoring metrics with a hard monthly
+          series ceiling. Superlog owns and pays for Pub/Sub and Monitoring API reads — your
+          incremental GCP cost is $0. Disconnect any time from settings.
+        </p>
+      </div>
+      <div className="flex items-center justify-between gap-3 px-[22px] py-[16px]">
+        <span className="text-[12.5px] text-muted">
+          Opens the Google Cloud consent screen in a new tab.
+        </span>
+        <Btn
+          variant="primary"
+          size="md"
+          onClick={onConnect}
+          loading={pending}
+          className="!h-[36px] !rounded-[8px] !px-[14px] !text-[13px]"
+        >
+          {pending ? "Preparing…" : "Connect Google Cloud"}
+          {!pending && <ExternalLinkIcon size={13} />}
+        </Btn>
+      </div>
+      {error && (
+        <div className={`border-t px-[22px] py-[12px] ${SOFT_LINE}`}>
+          <p className="m-0 text-[12.5px] text-danger">{error}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConnectingPanel({
+  statusText,
+  onReopen,
+  reopening,
+}: {
+  statusText: string;
+  onReopen: () => void;
+  reopening: boolean;
+}) {
+  return (
+    <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+      <div
+        className={`flex items-center gap-2.5 border-b px-[18px] py-[12px] ${SOFT_LINE} text-[12px]`}
+      >
+        <span className="text-[#8C98F0]">
+          <SpinnerIcon size={13} />
+        </span>
+        <span className="text-muted">{statusText}</span>
+      </div>
+      <div className="px-[22px] py-[18px]">
+        <ol className="m-0 list-decimal space-y-1.5 pl-4 text-[13px] leading-[1.5] text-muted">
+          <li>Approve the access request in the Google tab.</li>
+          <li>Pick the Google Cloud project you want to share.</li>
+          <li>This panel updates on its own once the connection lands.</li>
+        </ol>
+        <button
+          type="button"
+          onClick={onReopen}
+          disabled={reopening}
+          className="mt-3 inline-flex items-center gap-1.5 text-[12.5px] font-medium text-[#8C98F0] transition-colors hover:text-fg disabled:opacity-50"
+        >
+          <ExternalLinkIcon size={13} /> Reopen Google Cloud
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function FailedPanel({
+  lastError,
+  onReconnect,
+  reconnecting,
+}: {
+  lastError: string | null;
+  onReconnect: () => void;
+  reconnecting: boolean;
+}) {
+  return (
+    <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+      <div className={`border-b px-[22px] py-[18px] ${SOFT_LINE}`}>
+        <p className="m-0 text-[13px] leading-[1.55] text-danger">
+          {lastError ?? "We couldn't finish connecting Google Cloud."}
+        </p>
+      </div>
+      <div className="flex items-center justify-between gap-3 px-[22px] py-[16px]">
+        <span className="text-[12.5px] text-muted">Nothing was changed on your account.</span>
+        <Btn
+          variant="primary"
+          size="md"
+          onClick={onReconnect}
+          loading={reconnecting}
+          className="!h-[36px] !rounded-[8px] !px-[14px] !text-[13px]"
+        >
+          {reconnecting ? "Preparing…" : "Reconnect Google Cloud"}
+          {!reconnecting && <ExternalLinkIcon size={13} />}
+        </Btn>
+      </div>
+    </div>
+  );
+}
+
+function ConnectedPanel({
+  gcpProjectId,
+  eventsArrived,
+}: {
+  gcpProjectId: string;
+  eventsArrived: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+        <div className={`border-b px-[18px] py-[10px] ${SOFT_LINE}`}>
+          <span className="font-mono text-[12px] text-muted">Google Cloud project shared</span>
+        </div>
+        <div className="flex items-center gap-3 px-[18px] py-[13px]">
+          <span className="text-success">
+            <CheckIcon size={14} />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-[13px] font-medium text-fg">{gcpProjectId}</span>
+            <span className="block text-[12px] text-muted">Cloud Logging + bounded metrics</span>
+          </span>
+        </div>
+      </div>
+
+      {eventsArrived ? (
+        <div className="flex items-center gap-2.5 rounded-[10px] border border-[rgba(65,209,149,0.35)] bg-[rgba(65,209,149,0.06)] px-4 py-3">
+          <span className="text-success">
+            <CheckIcon size={14} />
+          </span>
+          <div className="flex-1 text-[12.5px] text-fg">
+            First events received. <span className="text-muted">You're flowing.</span>
+          </div>
+        </div>
+      ) : (
+        <div
+          className={`flex items-center gap-2.5 rounded-[10px] border border-dashed px-4 py-3 ${STRONG_LINE}`}
+        >
+          <span className="text-[#8C98F0]">
+            <SpinnerIcon size={14} />
+          </span>
+          <div className="flex-1 text-[12.5px] text-muted">
+            The connection is live. First logs and metrics typically appear within a minute.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/onboarding/OnboardingWizard.tsx
@@ -16,6 +16,7 @@ import { getSkillOnboardingIntent } from "../skillOnboarding.ts";
 import { AwsConnectFlow } from "./AwsConnectFlow.tsx";
 import { CloudflareConnectFlow } from "./CloudflareConnectFlow.tsx";
 import { ConnectDataChooser } from "./ConnectDataChooser.tsx";
+import { GcpConnectFlow } from "./GcpConnectFlow.tsx";
 import { RailwayConnectFlow } from "./RailwayConnectFlow.tsx";
 import { RenderConnectFlow } from "./RenderConnectFlow.tsx";
 import { VercelConnectFlow } from "./VercelConnectFlow.tsx";
@@ -112,6 +113,8 @@ export function OnboardingWizard({
       setWebView("aws");
     } else if (action === "cloudflare") {
       setWebView("cloudflare");
+    } else if (action === "gcp") {
+      setWebView("gcp");
     } else if (action === "vercel") {
       setWebView("vercel");
     } else if (action === "railway") {
@@ -184,6 +187,14 @@ export function OnboardingWizard({
             />
           ) : webView === "cloudflare" ? (
             <CloudflareConnectFlow
+              projectId={projectId}
+              eventsArrived={eventsArrived}
+              onBack={() => setWebView("chooser")}
+              onDone={onComplete}
+              onExploreDemo={onExploreDemo}
+            />
+          ) : webView === "gcp" ? (
+            <GcpConnectFlow
               projectId={projectId}
               eventsArrived={eventsArrived}
               onBack={() => setWebView("chooser")}

--- a/apps/web/src/onboarding/connectChoices.test.ts
+++ b/apps/web/src/onboarding/connectChoices.test.ts
@@ -16,9 +16,9 @@ function findOption(sections: ReturnType<typeof connectSectionsFor>, id: string)
   return undefined;
 }
 
-test("the chooser offers exactly six lanes: AWS, Cloudflare, Vercel, Railway, Render, and 'I'm hosted elsewhere'", () => {
+test("the chooser offers exactly seven lanes: AWS, Cloudflare, Google Cloud, Vercel, Railway, Render, and 'I'm hosted elsewhere'", () => {
   const ids = CONNECT_SECTIONS.flatMap((s) => s.options.map((o) => o.id));
-  assert.deepEqual(ids, ["aws", "cloudflare", "vercel", "railway", "render", "elsewhere"]);
+  assert.deepEqual(ids, ["aws", "cloudflare", "gcp", "vercel", "railway", "render", "elsewhere"]);
 });
 
 test("there is no coming-soon grid", () => {
@@ -44,6 +44,7 @@ test("integration-first: the primary option is a no-code integration (AWS)", () 
 test("every lane is actionable when its connectors are configured", () => {
   const sections = connectSectionsFor({
     cloudflare: true,
+    gcp: true,
     vercel: true,
     railway: true,
     render: true,
@@ -59,6 +60,7 @@ test("every lane is actionable when its connectors are configured", () => {
 test("connectActionFor resolves known ids and returns null for unknown", () => {
   assert.equal(connectActionFor("aws"), "aws");
   assert.equal(connectActionFor("cloudflare"), "cloudflare");
+  assert.equal(connectActionFor("gcp"), "gcp");
   assert.equal(connectActionFor("vercel"), "vercel");
   assert.equal(connectActionFor("railway"), "railway");
   assert.equal(connectActionFor("render"), "render");
@@ -69,6 +71,7 @@ test("connectActionFor resolves known ids and returns null for unknown", () => {
 test("connectSectionsFor disables Cloudflare when the connector isn't configured", () => {
   const gated = connectSectionsFor({
     cloudflare: false,
+    gcp: true,
     vercel: true,
     railway: true,
     render: true,
@@ -83,9 +86,28 @@ test("connectSectionsFor disables Cloudflare when the connector isn't configured
   assert.equal(findOption(gated, "elsewhere")?.action, "code");
 });
 
+test("connectSectionsFor disables Google Cloud when the connector isn't configured", () => {
+  const gated = connectSectionsFor({
+    cloudflare: true,
+    gcp: false,
+    vercel: true,
+    railway: true,
+    render: true,
+  });
+  const gcp = findOption(gated, "gcp");
+  assert.ok(gcp);
+  assert.equal(gcp.action, null, "gcp should not be actionable when unavailable");
+  assert.equal(isComingSoon(gcp), true);
+  // Other lanes are untouched.
+  assert.equal(findOption(gated, "aws")?.action, "aws");
+  assert.equal(findOption(gated, "cloudflare")?.action, "cloudflare");
+  assert.equal(findOption(gated, "elsewhere")?.action, "code");
+});
+
 test("connectSectionsFor disables Vercel when the connector isn't configured", () => {
   const gated = connectSectionsFor({
     cloudflare: true,
+    gcp: true,
     vercel: false,
     railway: true,
     render: true,
@@ -103,6 +125,7 @@ test("connectSectionsFor disables Vercel when the connector isn't configured", (
 test("connectSectionsFor disables Railway when the connector isn't configured", () => {
   const gated = connectSectionsFor({
     cloudflare: true,
+    gcp: true,
     vercel: true,
     railway: false,
     render: true,
@@ -120,6 +143,7 @@ test("connectSectionsFor disables Railway when the connector isn't configured", 
 test("connectSectionsFor disables Render when the connector isn't configured", () => {
   const gated = connectSectionsFor({
     cloudflare: true,
+    gcp: true,
     vercel: true,
     railway: true,
     render: false,
@@ -137,11 +161,13 @@ test("connectSectionsFor disables Render when the connector isn't configured", (
 test("connectSectionsFor leaves configured connectors actionable", () => {
   const enabled = connectSectionsFor({
     cloudflare: true,
+    gcp: true,
     vercel: true,
     railway: true,
     render: true,
   });
   assert.equal(findOption(enabled, "cloudflare")?.action, "cloudflare");
+  assert.equal(findOption(enabled, "gcp")?.action, "gcp");
   assert.equal(findOption(enabled, "vercel")?.action, "vercel");
   assert.equal(findOption(enabled, "railway")?.action, "railway");
   assert.equal(findOption(enabled, "render")?.action, "render");

--- a/apps/web/src/onboarding/connectChoices.ts
+++ b/apps/web/src/onboarding/connectChoices.ts
@@ -10,11 +10,18 @@
 // What activating a row does. `null` => not yet available (coming soon), so the
 // row renders disabled and is not actionable. "code" opens the coding-agent
 // prompt (paste into Cursor / Claude Code / Codex).
-export type ConnectAction = "aws" | "cloudflare" | "vercel" | "railway" | "render" | "code";
+export type ConnectAction = "aws" | "cloudflare" | "gcp" | "vercel" | "railway" | "render" | "code";
 
 // Glyph key resolved to a neutral monochrome icon by the component. Kept as a
 // string union (not a component) so this module stays free of JSX/React.
-export type ConnectIcon = "aws" | "cloudflare" | "vercel" | "railway" | "render" | "terminal";
+export type ConnectIcon =
+  | "aws"
+  | "cloudflare"
+  | "gcp"
+  | "vercel"
+  | "railway"
+  | "render"
+  | "terminal";
 
 export type ConnectOption = {
   id: string;
@@ -55,6 +62,14 @@ export const CONNECT_SECTIONS: ConnectSection[] = [
           "Authorize Cloudflare once and we set up Workers Observability destinations that stream your Workers traces, logs, and metrics in. No agent, no code.",
         icon: "cloudflare",
         action: "cloudflare",
+      },
+      {
+        id: "gcp",
+        title: "Google Cloud",
+        description:
+          "Authorize Google Cloud once and pick a project — we route Cloud Logging and read a bounded set of Cloud Monitoring metrics. No Terraform, no service-account key.",
+        icon: "gcp",
+        action: "gcp",
       },
       {
         id: "vercel",
@@ -100,6 +115,7 @@ export const CONNECT_SECTIONS: ConnectSection[] = [
 // into the coding-agent prompt.
 export type ConnectAvailability = {
   cloudflare: boolean;
+  gcp: boolean;
   vercel: boolean;
   railway: boolean;
   render: boolean;
@@ -108,6 +124,7 @@ export type ConnectAvailability = {
 export function connectSectionsFor(availability: ConnectAvailability): ConnectSection[] {
   const unavailable = new Set<string>();
   if (!availability.cloudflare) unavailable.add("cloudflare");
+  if (!availability.gcp) unavailable.add("gcp");
   if (!availability.vercel) unavailable.add("vercel");
   if (!availability.railway) unavailable.add("railway");
   if (!availability.render) unavailable.add("render");

--- a/apps/web/src/onboarding/gcpConnectModel.test.ts
+++ b/apps/web/src/onboarding/gcpConnectModel.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { canContinueGcp, gcpPhase, gcpStatusText } from "./gcpConnectModel.ts";
+
+test("gcpPhase starts at 'start' with no connection and no launch", () => {
+  assert.equal(gcpPhase({ status: null, launched: false }), "start");
+});
+
+test("gcpPhase moves to 'connecting' once the consent screen is opened", () => {
+  assert.equal(gcpPhase({ status: null, launched: true }), "connecting");
+});
+
+test("gcpPhase treats an in-flight provisioning row as 'connecting'", () => {
+  assert.equal(gcpPhase({ status: "pending", launched: false }), "connecting");
+  assert.equal(gcpPhase({ status: "provisioning", launched: false }), "connecting");
+});
+
+test("gcpPhase reaches 'connected' once the row is connected", () => {
+  assert.equal(gcpPhase({ status: "connected", launched: true }), "connected");
+  assert.equal(gcpPhase({ status: "connected", launched: false }), "connected");
+});
+
+test("gcpPhase surfaces 'failed' regardless of launch state", () => {
+  assert.equal(gcpPhase({ status: "failed", launched: true }), "failed");
+  assert.equal(gcpPhase({ status: "failed", launched: false }), "failed");
+});
+
+test("canContinueGcp only unlocks on 'connected'", () => {
+  assert.equal(canContinueGcp("start"), false);
+  assert.equal(canContinueGcp("connecting"), false);
+  assert.equal(canContinueGcp("failed"), false);
+  assert.equal(canContinueGcp("connected"), true);
+});
+
+test("gcpStatusText reflects the phase and telemetry arrival", () => {
+  assert.match(gcpStatusText("connecting", false), /authorize Google Cloud/);
+  assert.match(gcpStatusText("connected", true), /arriving/);
+  assert.match(gcpStatusText("connected", false), /within a minute/);
+});

--- a/apps/web/src/onboarding/gcpConnectModel.ts
+++ b/apps/web/src/onboarding/gcpConnectModel.ts
@@ -1,0 +1,53 @@
+// Pure phase model for the onboarding Google Cloud connect flow, split out of
+// the component so the transitions are unit-testable (the `.tsx` can't be
+// imported by the node:test runner). Mirrors railwayConnectModel.ts.
+//
+// GCP connect is an OAuth round-trip followed by a project-selection step that
+// happens on the standalone /connect/gcp callback page (opened in a new tab).
+// Once the user picks a GCP project there, our backend provisions a Cloud
+// Logging route and begins bounded metric collection, moving the connection row
+// through `pending`/`provisioning` to `connected`. The onboarding tab polls the
+// connection endpoint; the milestone that unlocks "Continue" is `connected`.
+// Telemetry arrival is surfaced as a bonus but never blocks.
+
+export type GcpStatus = "pending" | "provisioning" | "connected" | "failed";
+
+export type GcpPhase = "start" | "connecting" | "connected" | "failed";
+
+/**
+ * Resolve the flow phase from the polled connection status and whether the user
+ * has opened the consent screen this session:
+ *  - `connected`    → the project is selected and provisioning finished.
+ *  - `failed`       → provisioning errored; offer a reconnect.
+ *  - `launched` or a `pending`/`provisioning` row → we're mid round-trip.
+ *  - otherwise      → the initial "connect" call to action.
+ */
+export function gcpPhase(input: { status: GcpStatus | null; launched: boolean }): GcpPhase {
+  if (input.status === "connected") return "connected";
+  if (input.status === "failed") return "failed";
+  if (input.launched || input.status === "pending" || input.status === "provisioning") {
+    return "connecting";
+  }
+  return "start";
+}
+
+/** Continue unlocks once the connection is live. */
+export function canContinueGcp(phase: GcpPhase): boolean {
+  return phase === "connected";
+}
+
+/** Status text for the small banner in the connecting / connected states. */
+export function gcpStatusText(phase: GcpPhase, eventsArrived: boolean): string {
+  switch (phase) {
+    case "start":
+      return "Not connected yet.";
+    case "connecting":
+      return "Waiting for you to authorize Google Cloud and pick a project in the other tab…";
+    case "failed":
+      return "The connection didn't finish. Reconnect to try again.";
+    default:
+      return eventsArrived
+        ? "Connected — telemetry from Google Cloud is arriving."
+        : "Connected — we're routing Cloud Logging and reading bounded Cloud Monitoring metrics. First events typically appear within a minute.";
+  }
+}

--- a/apps/web/src/onboarding/onboardingWebView.ts
+++ b/apps/web/src/onboarding/onboardingWebView.ts
@@ -2,6 +2,7 @@ export type WebView =
   | "chooser"
   | "aws"
   | "cloudflare"
+  | "gcp"
   | "vercel"
   | "railway"
   | "render"


### PR DESCRIPTION
## What

Google Cloud is a first-class connector everywhere in the app — the Settings integrations page, the `/connect/gcp` OAuth callback, the `gcpConnect` capability flag, DB schema, and proxy ingestion — **except** the onboarding "Connect your data" chooser, where it was never added to the catalog. New users could only reach GCP after finishing onboarding via Settings.

This adds it as a first-class lane, matching the existing OAuth connectors.

## Changes

- **`connectChoices.ts`** — add `"gcp"` to the `ConnectAction`/`ConnectIcon` unions, a **Google Cloud** entry in `CONNECT_SECTIONS`, and `gcp` gating in `connectSectionsFor` so it renders "Coming soon" when the deployment hasn't configured GCP connect (same behavior as Cloudflare/Vercel/Railway/Render).
- **`ConnectDataChooser.tsx`** — wire the `GcpIcon` glyph and the `gcpConnect` capability into the availability check.
- **`GcpConnectFlow.tsx`** (new) — inline flow that opens Google's consent screen in a new tab and polls the connection endpoint through `start → connecting → connected`, plus a `failed` state that offers a reconnect. Mirrors `RailwayConnectFlow`. The project-selection step reuses the existing standalone `/connect/gcp` page.
- **`gcpConnectModel.ts`** (new) — pure phase model for the transitions, unit-tested like `railwayConnectModel`.
- **`onboardingWebView.ts` / `OnboardingWizard.tsx`** — route the `gcp` pick to the new flow.

## Testing

- `pnpm --filter @superlog/web typecheck` — clean.
- Unit tests: extended `connectChoices.test.ts` (six→seven lanes + GCP gating) and added `gcpConnectModel.test.ts`. All pass.

Note: the live Google OAuth round-trip can't be exercised outside the primary origin (callback redirect URIs are pinned), so verification covers the typed/pure layers and the flow's rendering logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google Cloud to the onboarding "Connect your data" chooser with a new-tab OAuth flow to authorize and pick a project. The flow stays in onboarding even if the popup is blocked, and you can start over if the consent is canceled.

- **New Features**
  - Added `gcp` lane to `CONNECT_SECTIONS` with `gcpConnect` gating.
  - Introduced `GcpConnectFlow`: new-tab consent; start → connecting → connected with failed/retry; project selection reuses `/connect/gcp`; mirrors `RailwayConnectFlow`.
  - Added `gcpConnectModel` with tests; wired routing in `OnboardingWizard`/`onboardingWebView` and availability in `ConnectDataChooser`.

- **Bug Fixes**
  - Removed same-tab fallback for GCP OAuth and added a manual “Reopen Google Cloud” link so blocked popups don’t navigate away from onboarding.
  - Added a “Start over” action while waiting to recover from denied/canceled consent or “no projects” without getting stuck.

<sup>Written for commit 3bffeadc6a045797608b477b2944512569ae0f03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

