### PR TITLE
Group volatile psycopg error logs

### DIFF
--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -311,6 +311,58 @@ test("fingerprintLog preserves application output inside a runtime invocation", 
   assert.notEqual(timeout.hash, invalidResponse.hash);
 });
 
+test("fingerprintLog groups SQLAlchemy integrity errors with different row values", () => {
+  const tracebackBodyFor = (input: { productName: string; productId: string }) =>
+    [
+      "Traceback (most recent call last):",
+      '  File "/srv/app/importer.py", line 42, in import_product',
+      "    session.flush()",
+      'sqlalchemy.exc.IntegrityError: (psycopg2.errors.NotNullViolation) null value in column "vendor_product_id" of relation "product_variants" violates not-null constraint',
+      `DETAIL:  Failing row contains (${input.productId}, ${input.productName}, null).`,
+      "[SQL: INSERT INTO product_variants (id, name, vendor_product_id) VALUES (%(id)s, %(name)s, %(vendor_product_id)s)]",
+      `[parameters: {'id': '${input.productId}', 'name': '${input.productName}', 'vendor_product_id': None}]`,
+      "(Background on this error at: https://sqlalche.me/e/20/gkpj)",
+    ].join("\n");
+  const handledBodyFor = (input: { orderNumber: string; productName: string }) =>
+    [
+      `Failed to store order ${input.orderNumber}: (psycopg2.errors.NotNullViolation) null value in column \"vendor_product_id\" of relation \"product_variants\" violates not-null constraint`,
+      `DETAIL:  Failing row contains (product-c, ${input.productName}, null).`,
+      "[SQL: INSERT INTO product_variants (id, name, vendor_product_id) VALUES (%(id)s, %(name)s, %(vendor_product_id)s)]",
+      `[parameters: {'id': 'product-c', 'name': '${input.productName}', 'vendor_product_id': None}]`,
+      "(Background on this error at: https://sqlalche.me/e/20/gkpj)",
+    ].join("\n");
+
+  const first = fingerprintLog({
+    service: "catalog-worker",
+    severity: "ERROR",
+    body: tracebackBodyFor({ productName: "Blue Fluoride Varnish", productId: "product-a" }),
+    exceptionType: "IntegrityError",
+    stacktrace: null,
+  });
+  const second = fingerprintLog({
+    service: "catalog-worker",
+    severity: "ERROR",
+    body: handledBodyFor({ orderNumber: "order-200", productName: "Mint Prophy Paste" }),
+    exceptionType: "IntegrityError",
+    stacktrace: null,
+  });
+
+  assert.equal(first.hash, second.hash);
+});
+
+test("fingerprintLog keeps different Postgres constraints separate", () => {
+  const fingerprintFor = (column: string) =>
+    fingerprintLog({
+      service: "catalog-worker",
+      severity: "ERROR",
+      body: `psycopg2.errors.NotNullViolation: null value in column "${column}" of relation "product_variants" violates not-null constraint`,
+      exceptionType: "IntegrityError",
+      stacktrace: null,
+    });
+
+  assert.notEqual(fingerprintFor("vendor_product_id").hash, fingerprintFor("vendor_item_id").hash);
+});
+
 // Postgres text and jsonb columns reject the NUL byte (0x00) — it raises
 // `22021 invalid byte sequence for encoding "UTF8": 0x00`. Telemetry can carry
 // a raw NUL in a message or stack frame; the fingerprint outputs feed straight

--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -402,6 +402,22 @@ test("fingerprintLog ignores flattened SQLAlchemy metadata after a psycopg headl
   assert.equal(fingerprintFor("order-a").hash, fingerprintFor("order-b").hash);
 });
 
+test("fingerprintLog ignores flattened Postgres diagnostic fields", () => {
+  const fingerprintFor = (diagnostic: string) =>
+    fingerprintLog({
+      service: "catalog-worker",
+      severity: "ERROR",
+      body: `(psycopg.errors.NotNullViolation) null value in column "vendor_product_id" of relation "product_variants" violates not-null constraint ${diagnostic}`,
+      exceptionType: "IntegrityError",
+      stacktrace: null,
+    });
+
+  assert.equal(
+    fingerprintFor("LINE 1: INSERT INTO product_variants VALUES ('order-a')").hash,
+    fingerprintFor("HINT: Retry without value 'order-b'").hash,
+  );
+});
+
 // Postgres text and jsonb columns reject the NUL byte (0x00) — it raises
 // `22021 invalid byte sequence for encoding "UTF8": 0x00`. Telemetry can carry
 // a raw NUL in a message or stack frame; the fingerprint outputs feed straight

--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -363,6 +363,19 @@ test("fingerprintLog keeps different Postgres constraints separate", () => {
   assert.notEqual(fingerprintFor("vendor_product_id").hash, fingerprintFor("vendor_item_id").hash);
 });
 
+test("fingerprintLog redacts volatile quoted values in Postgres headlines", () => {
+  const fingerprintFor = (value: string) =>
+    fingerprintLog({
+      service: "catalog-worker",
+      severity: "ERROR",
+      body: `psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type integer: "${value}"`,
+      exceptionType: "DataError",
+      stacktrace: null,
+    });
+
+  assert.equal(fingerprintFor("not-a-number").hash, fingerprintFor("still-not-a-number").hash);
+});
+
 // Postgres text and jsonb columns reject the NUL byte (0x00) — it raises
 // `22021 invalid byte sequence for encoding "UTF8": 0x00`. Telemetry can carry
 // a raw NUL in a message or stack frame; the fingerprint outputs feed straight

--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -376,6 +376,19 @@ test("fingerprintLog redacts volatile quoted values in Postgres headlines", () =
   assert.equal(fingerprintFor("not-a-number").hash, fingerprintFor("still-not-a-number").hash);
 });
 
+test("fingerprintLog groups equivalent psycopg2 and psycopg3 errors", () => {
+  const fingerprintFor = (driver: "psycopg2" | "psycopg") =>
+    fingerprintLog({
+      service: "catalog-worker",
+      severity: "ERROR",
+      body: `(${driver}.errors.NotNullViolation) null value in column "vendor_product_id" of relation "product_variants" violates not-null constraint`,
+      exceptionType: "IntegrityError",
+      stacktrace: null,
+    });
+
+  assert.equal(fingerprintFor("psycopg2").hash, fingerprintFor("psycopg").hash);
+});
+
 // Postgres text and jsonb columns reject the NUL byte (0x00) — it raises
 // `22021 invalid byte sequence for encoding "UTF8": 0x00`. Telemetry can carry
 // a raw NUL in a message or stack frame; the fingerprint outputs feed straight

--- a/packages/fingerprint/src/index.test.ts
+++ b/packages/fingerprint/src/index.test.ts
@@ -389,6 +389,19 @@ test("fingerprintLog groups equivalent psycopg2 and psycopg3 errors", () => {
   assert.equal(fingerprintFor("psycopg2").hash, fingerprintFor("psycopg").hash);
 });
 
+test("fingerprintLog ignores flattened SQLAlchemy metadata after a psycopg headline", () => {
+  const fingerprintFor = (orderId: string) =>
+    fingerprintLog({
+      service: "catalog-worker",
+      severity: "ERROR",
+      body: `(psycopg2.errors.NotNullViolation) null value in column "vendor_product_id" of relation "product_variants" violates not-null constraint DETAIL: Failing row contains (${orderId}, null). [SQL: INSERT INTO product_variants ...] [parameters: {'id': '${orderId}'}]`,
+      exceptionType: "IntegrityError",
+      stacktrace: null,
+    });
+
+  assert.equal(fingerprintFor("order-a").hash, fingerprintFor("order-b").hash);
+});
+
 // Postgres text and jsonb columns reject the NUL byte (0x00) — it raises
 // `22021 invalid byte sequence for encoding "UTF8": 0x00`. Telemetry can carry
 // a raw NUL in a message or stack frame; the fingerprint outputs feed straight

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -156,10 +156,10 @@ export function normalizeMessage(body: string): string {
 // prefixes. Everything after the first driver-error line (DETAIL, rendered
 // SQL, bound parameters) is occurrence metadata, not error identity.
 function normalizePsycopgError(body: string): string | null {
-  const match = body.match(/psycopg2\.errors\.([A-Za-z_][A-Za-z0-9_]*)(?::|\))\s*([^\r\n]*)/);
+  const match = body.match(/psycopg(?:2)?\.errors\.([A-Za-z_][A-Za-z0-9_]*)(?::|\))\s*([^\r\n]*)/);
   if (!match?.[1]) return null;
 
-  let s = `psycopg2.errors.${match[1]}: ${match[2] ?? ""}`;
+  let s = `postgres.errors.${match[1]}: ${match[2] ?? ""}`;
   s = s.replace(/"(?:[^"\\]|\\.)*"/g, (quoted, offset: number, source: string) => {
     const prefix = source.slice(0, offset);
     return /\b(?:column|relation|constraint|table|schema|database|index)\s*$/i.test(prefix)

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -160,6 +160,12 @@ function normalizePsycopgError(body: string): string | null {
   if (!match?.[1]) return null;
 
   let s = `psycopg2.errors.${match[1]}: ${match[2] ?? ""}`;
+  s = s.replace(/"(?:[^"\\]|\\.)*"/g, (quoted, offset: number, source: string) => {
+    const prefix = source.slice(0, offset);
+    return /\b(?:column|relation|constraint|table|schema|database|index)\s*$/i.test(prefix)
+      ? quoted
+      : "<str>";
+  });
   s = s.replace(/https?:\/\/\S+/gi, "<url>");
   s = s.replace(/\b[\w.+-]+@[\w.-]+\.\w+\b/g, "<email>");
   s = s.replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi, "<uuid>");

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -157,7 +157,7 @@ export function normalizeMessage(body: string): string {
 // SQL, bound parameters) is occurrence metadata, not error identity.
 function normalizePsycopgError(body: string): string | null {
   const match = body.match(
-    /psycopg(?:2)?\.errors\.([A-Za-z_][A-Za-z0-9_]*)(?::|\))[ \t]*(.*?)(?=(?:(?:[ \t]|\\[rn])+(?:DETAIL:|\[SQL:|\[parameters:|\(Background on this error at:))|[\r\n]|$)/,
+    /psycopg(?:2)?\.errors\.([A-Za-z_][A-Za-z0-9_]*)(?::|\))[ \t]*(.*?)(?=(?:(?:[ \t]|\\[rn])+(?:[A-Z][A-Z_]*(?: [A-Z][A-Z_]*)*(?: [0-9]+)?:|\[[A-Za-z]+:|\(Background on this error at:))|[\r\n]|$)/,
   );
   if (!match?.[1]) return null;
 
@@ -168,6 +168,7 @@ function normalizePsycopgError(body: string): string | null {
       ? quoted
       : "<str>";
   });
+  s = s.replace(/'(?:[^'\\]|\\.)*'/g, "<str>");
   s = s.replace(/https?:\/\/\S+/gi, "<url>");
   s = s.replace(/\b[\w.+-]+@[\w.-]+\.\w+\b/g, "<email>");
   s = s.replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi, "<uuid>");

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -133,6 +133,9 @@ export function normalizeMessage(body: string): string {
   const vercelRuntimeRequest = normalizeVercelRuntimeRequest(body);
   if (vercelRuntimeRequest) return vercelRuntimeRequest;
 
+  const psycopgError = normalizePsycopgError(body);
+  if (psycopgError) return psycopgError;
+
   let s = body;
   s = s.replace(/https?:\/\/\S+/gi, "<url>");
   s = collapseRequestPaths(s);
@@ -147,6 +150,25 @@ export function normalizeMessage(body: string): string {
   s = s.replace(/\b\d+\b/g, "<n>");
   s = s.replace(/\s+/g, " ").trim().toLowerCase();
   return s;
+}
+
+// Psycopg errors often arrive inside SQLAlchemy tracebacks or application log
+// prefixes. Everything after the first driver-error line (DETAIL, rendered
+// SQL, bound parameters) is occurrence metadata, not error identity.
+function normalizePsycopgError(body: string): string | null {
+  const match = body.match(/psycopg2\.errors\.([A-Za-z_][A-Za-z0-9_]*)(?::|\))\s*([^\r\n]*)/);
+  if (!match?.[1]) return null;
+
+  let s = `psycopg2.errors.${match[1]}: ${match[2] ?? ""}`;
+  s = s.replace(/https?:\/\/\S+/gi, "<url>");
+  s = s.replace(/\b[\w.+-]+@[\w.-]+\.\w+\b/g, "<email>");
+  s = s.replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi, "<uuid>");
+  s = s.replace(/\b\d{4}-\d{2}-\d{2}[T ][\d:.]+Z?(?:[+-]\d{2}:?\d{2})?\b/g, "<ts>");
+  s = s.replace(/\b(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?\b/g, "<ip>");
+  s = s.replace(/\b0x[0-9a-f]+\b/gi, "<hex>");
+  s = s.replace(/\b[0-9a-f]{20,}\b/gi, "<hex>");
+  s = s.replace(/\b\d+\b/g, "<n>");
+  return s.replace(/\s+/g, " ").trim().toLowerCase();
 }
 
 // Vercel log drains can emit one four-line runtime envelope per request. Its

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -156,19 +156,11 @@ export function normalizeMessage(body: string): string {
 // prefixes. Everything after the first driver-error line (DETAIL, rendered
 // SQL, bound parameters) is occurrence metadata, not error identity.
 function normalizePsycopgError(body: string): string | null {
-  const match = body.match(
-    /psycopg(?:2)?\.errors\.([A-Za-z_][A-Za-z0-9_]*)(?::|\))[ \t]*(.*?)(?=(?:(?:[ \t]|\\[rn])+(?:[A-Z][A-Z_]*(?: [A-Z][A-Z_]*)*(?: [0-9]+)?:|\[[A-Za-z]+:|\(Background on this error at:))|[\r\n]|$)/,
-  );
-  if (!match?.[1]) return null;
+  const headline = extractPsycopgHeadline(body);
+  if (!headline) return null;
 
-  let s = `postgres.errors.${match[1]}: ${match[2] ?? ""}`;
-  s = s.replace(/"(?:[^"\\]|\\.)*"/g, (quoted, offset: number, source: string) => {
-    const prefix = source.slice(0, offset);
-    return /\b(?:column|relation|constraint|table|schema|database|index)\s*$/i.test(prefix)
-      ? quoted
-      : "<str>";
-  });
-  s = s.replace(/'(?:[^'\\]|\\.)*'/g, "<str>");
+  let s = `postgres.errors.${headline.type}: ${headline.message}`;
+  s = redactPostgresHeadlineValues(s);
   s = s.replace(/https?:\/\/\S+/gi, "<url>");
   s = s.replace(/\b[\w.+-]+@[\w.-]+\.\w+\b/g, "<email>");
   s = s.replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi, "<uuid>");
@@ -178,6 +170,152 @@ function normalizePsycopgError(body: string): string | null {
   s = s.replace(/\b[0-9a-f]{20,}\b/gi, "<hex>");
   s = s.replace(/\b\d+\b/g, "<n>");
   return s.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+const PSYCOPG_ERROR_PREFIXES = ["psycopg2.errors.", "psycopg.errors."] as const;
+const POSTGRES_IDENTIFIER_CONTEXTS = new Set([
+  "column",
+  "relation",
+  "constraint",
+  "table",
+  "schema",
+  "database",
+  "index",
+]);
+
+function extractPsycopgHeadline(body: string): { type: string; message: string } | null {
+  let marker = -1;
+  let prefix = "";
+  for (const candidate of PSYCOPG_ERROR_PREFIXES) {
+    const index = body.indexOf(candidate);
+    if (index !== -1 && (marker === -1 || index < marker)) {
+      marker = index;
+      prefix = candidate;
+    }
+  }
+  if (marker === -1) return null;
+
+  const typeStart = marker + prefix.length;
+  let cursor = typeStart;
+  while (cursor < body.length && isIdentifierCharacter(body.charCodeAt(cursor))) cursor += 1;
+  if (cursor === typeStart || (body[cursor] !== ":" && body[cursor] !== ")")) return null;
+
+  const type = body.slice(typeStart, cursor);
+  cursor += 1;
+  while (body[cursor] === " " || body[cursor] === "\t") cursor += 1;
+  const messageEnd = findPostgresDiagnosticBoundary(body, cursor);
+  return { type, message: body.slice(cursor, messageEnd).trimEnd() };
+}
+
+function isIdentifierCharacter(code: number): boolean {
+  return (
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    (code >= 48 && code <= 57) ||
+    code === 95
+  );
+}
+
+function findPostgresDiagnosticBoundary(body: string, start: number): number {
+  for (let index = start; index < body.length; index += 1) {
+    const char = body[index];
+    if (char === "\r" || char === "\n") return index;
+    if (char === "\\" && (body[index + 1] === "r" || body[index + 1] === "n")) return index;
+    if (char !== " " && char !== "\t") continue;
+
+    let marker = index;
+    while (body[marker] === " " || body[marker] === "\t") marker += 1;
+    if (isPostgresDiagnosticMarker(body, marker)) return index;
+    index = marker - 1;
+  }
+  return body.length;
+}
+
+function isPostgresDiagnosticMarker(body: string, start: number): boolean {
+  if (body.startsWith("(Background on this error at:", start)) return true;
+
+  if (body[start] === "[") {
+    let cursor = start + 1;
+    const nameStart = cursor;
+    while (isAsciiLetterCode(body.charCodeAt(cursor))) cursor += 1;
+    return cursor > nameStart && body[cursor] === ":";
+  }
+
+  let cursor = start;
+  if (!isUppercaseWordCharacter(body.charCodeAt(cursor))) return false;
+  while (cursor < body.length) {
+    while (isUppercaseWordCharacter(body.charCodeAt(cursor))) cursor += 1;
+    if (body[cursor] === ":") return true;
+    if (body[cursor] !== " ") return false;
+    while (body[cursor] === " ") cursor += 1;
+
+    if (isDigitCode(body.charCodeAt(cursor))) {
+      while (isDigitCode(body.charCodeAt(cursor))) cursor += 1;
+      while (body[cursor] === " ") cursor += 1;
+      return body[cursor] === ":";
+    }
+    if (!isUppercaseWordCharacter(body.charCodeAt(cursor))) return false;
+  }
+  return false;
+}
+
+function isAsciiLetterCode(code: number): boolean {
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+}
+
+function isUppercaseWordCharacter(code: number): boolean {
+  return (code >= 65 && code <= 90) || code === 95;
+}
+
+function isDigitCode(code: number): boolean {
+  return code >= 48 && code <= 57;
+}
+
+function redactPostgresHeadlineValues(headline: string): string {
+  let output = "";
+  let cursor = 0;
+  while (cursor < headline.length) {
+    const quote = headline[cursor];
+    if (quote !== '"' && quote !== "'") {
+      output += quote;
+      cursor += 1;
+      continue;
+    }
+
+    const end = findClosingQuote(headline, cursor, quote);
+    if (end === -1) {
+      output += headline.slice(cursor);
+      break;
+    }
+    const preserve = quote === '"' && hasPostgresIdentifierContext(headline, cursor);
+    output += preserve ? headline.slice(cursor, end + 1) : "<str>";
+    cursor = end + 1;
+  }
+  return output;
+}
+
+function findClosingQuote(value: string, start: number, quote: string): number {
+  for (let cursor = start + 1; cursor < value.length; cursor += 1) {
+    if (value[cursor] === "\\") {
+      cursor += 1;
+      continue;
+    }
+    if (value[cursor] !== quote) continue;
+    if (value[cursor + 1] === quote) {
+      cursor += 1;
+      continue;
+    }
+    return cursor;
+  }
+  return -1;
+}
+
+function hasPostgresIdentifierContext(value: string, quoteIndex: number): boolean {
+  let end = quoteIndex;
+  while (end > 0 && (value[end - 1] === " " || value[end - 1] === "\t")) end -= 1;
+  let start = end;
+  while (start > 0 && isAsciiLetterCode(value.charCodeAt(start - 1))) start -= 1;
+  return POSTGRES_IDENTIFIER_CONTEXTS.has(value.slice(start, end).toLowerCase());
 }
 
 // Vercel log drains can emit one four-line runtime envelope per request. Its

--- a/packages/fingerprint/src/index.ts
+++ b/packages/fingerprint/src/index.ts
@@ -156,7 +156,9 @@ export function normalizeMessage(body: string): string {
 // prefixes. Everything after the first driver-error line (DETAIL, rendered
 // SQL, bound parameters) is occurrence metadata, not error identity.
 function normalizePsycopgError(body: string): string | null {
-  const match = body.match(/psycopg(?:2)?\.errors\.([A-Za-z_][A-Za-z0-9_]*)(?::|\))\s*([^\r\n]*)/);
+  const match = body.match(
+    /psycopg(?:2)?\.errors\.([A-Za-z_][A-Za-z0-9_]*)(?::|\))[ \t]*(.*?)(?=(?:(?:[ \t]|\\[rn])+(?:DETAIL:|\[SQL:|\[parameters:|\(Background on this error at:))|[\r\n]|$)/,
+  );
   if (!match?.[1]) return null;
 
   let s = `postgres.errors.${match[1]}: ${match[2] ?? ""}`;


### PR DESCRIPTION
## Summary
- derive stackless psycopg fingerprints from the stable driver-error headline
- ignore volatile DETAIL, SQL, and bound-parameter payloads
- preserve Postgres column and constraint identity

## Tests
- pnpm --filter @superlog/fingerprint test
- pnpm --filter @superlog/fingerprint typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups psycopg/SQLAlchemy error logs in `@superlog/fingerprint` using a stable fingerprint from the first driver-error line, ignoring volatile SQL/parameter metadata. Adds a linear-time headline parser for faster, safer normalization.

- **New Features**
  - Added `normalizePsycopgError` to parse driver headlines and normalize to `postgres.errors.*`.
  - Redacts URLs, emails, UUIDs, timestamps, IPs, hex, numbers, and non-identifier quoted strings; preserves quoted Postgres identifiers; lowercases and compacts whitespace.
  - Tests cover grouping across row values/log shapes, separating constraints, unifying `psycopg2`/`psycopg`, and skipping flattened diagnostic fields.

- **Refactors**
  - Rewrote headline extraction and diagnostic boundary scanning to run in linear time with a single pass.

<sup>Written for commit e77d99f998d4e694bec247b65f72e7e22131d586. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

