### PR TITLE
Group correlated issue bursts before defaulting standalone

### DIFF
--- a/apps/worker/src/grouping/agent.test.ts
+++ b/apps/worker/src/grouping/agent.test.ts
@@ -2,18 +2,10 @@ import "../agent-run.test-env.js";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import type Anthropic from "@anthropic-ai/sdk";
-import {
-  type GroupingLLMClient,
-  runGroupingAgent,
-} from "./agent.js";
-import type {
-  GroupingCandidateIncident,
-  GroupingNewIssue,
-} from "./domain.js";
+import { type GroupingLLMClient, runGroupingAgent } from "./agent.js";
+import type { GroupingCandidateIncident, GroupingNewIssue } from "./domain.js";
 
-function makeMessage(
-  blocks: Anthropic.Messages.ContentBlock[],
-): Anthropic.Messages.Message {
+function makeMessage(blocks: Anthropic.Messages.ContentBlock[]): Anthropic.Messages.Message {
   return {
     id: "msg",
     type: "message",
@@ -42,7 +34,10 @@ function textBlock(text: string): Anthropic.Messages.ContentBlock {
   return { type: "text", text, citations: null } as unknown as Anthropic.Messages.ContentBlock;
 }
 
-function makeCandidate(id: string, overrides: Partial<GroupingCandidateIncident> = {}): GroupingCandidateIncident {
+function makeCandidate(
+  id: string,
+  overrides: Partial<GroupingCandidateIncident> = {},
+): GroupingCandidateIncident {
   return {
     id,
     title: "DB unreachable",
@@ -108,13 +103,7 @@ function makeDeps(
 
 test("runGroupingAgent: immediate decide_grouping standalone → standalone verdict", async () => {
   const deps = makeDeps([
-    [
-      toolUse(
-        "decide_grouping",
-        { decision: "standalone", evidence: "Nothing in common" },
-        "t1",
-      ),
-    ],
+    [toolUse("decide_grouping", { decision: "standalone", evidence: "Nothing in common" }, "t1")],
   ]);
   const verdict = await runGroupingAgent(
     { projectName: "p", newIssue: NEW_ISSUE, candidates: [makeCandidate("a")] },
@@ -231,10 +220,9 @@ test("runGroupingAgent: text-only with non-JSON returns standalone with explanat
 
 test("runGroupingAgent: exhausts iteration budget → standalone with budget message", async () => {
   // The agent only ever searches.
-  const deps = makeDeps(
-    [[toolUse("search_incidents", { query: "x" }, "loop")]],
-    { maxIterations: 2 },
-  );
+  const deps = makeDeps([[toolUse("search_incidents", { query: "x" }, "loop")]], {
+    maxIterations: 2,
+  });
   const verdict = await runGroupingAgent(
     { projectName: "p", newIssue: NEW_ISSUE, candidates: [makeCandidate("a")] },
     deps,
@@ -273,4 +261,39 @@ test("runGroupingAgent: metering failures do not abort the grouping decision", a
   );
 
   assert.deepEqual(verdict, { decision: "standalone", evidence: "Nothing in common" });
+});
+
+test("runGroupingAgent: tells the decision model to inspect correlated bursts before defaulting standalone", async () => {
+  let systemPrompt = "";
+  const client: GroupingLLMClient = {
+    async send(input) {
+      systemPrompt = input.system;
+      return makeMessage([
+        toolUse(
+          "decide_grouping",
+          { decision: "standalone", evidence: "No shared root cause" },
+          "t1",
+        ),
+      ]);
+    },
+  };
+
+  await runGroupingAgent(
+    { projectName: "p", newIssue: NEW_ISSUE, candidates: [makeCandidate("a")] },
+    {
+      client,
+      model: "test-model",
+      maxIterations: 1,
+      accountant: { record() {} },
+    },
+  );
+
+  assert.match(
+    systemPrompt,
+    /When several issues begin within the same short window and share a dependency or failure class, inspect them as a burst before deciding\./,
+  );
+  assert.match(
+    systemPrompt,
+    /Prefer joining when a single plausible deployment or configuration change explains all symptoms\./,
+  );
 });

--- a/apps/worker/src/grouping/agent.test.ts
+++ b/apps/worker/src/grouping/agent.test.ts
@@ -296,4 +296,8 @@ test("runGroupingAgent: tells the decision model to inspect correlated bursts be
     systemPrompt,
     /Prefer joining when a single plausible deployment or configuration change explains all symptoms\./,
   );
+  assert.match(
+    systemPrompt,
+    /Only join when inspected evidence supports that shared explanation; otherwise return standalone\./,
+  );
 });

--- a/apps/worker/src/grouping/tools.ts
+++ b/apps/worker/src/grouping/tools.ts
@@ -12,7 +12,8 @@ export const GROUPING_SYSTEM_PROMPT = [
   "inspect_incident can include linked issues, representative samples, and the latest agent investigation result. Prefer those structured details over title similarity.",
   "Do not assume an unseen incident is a join target.",
   "When you are done, call decide_grouping exactly once. Do not write a text reply.",
-  "When unsure, return 'standalone'.",
+  "When several issues begin within the same short window and share a dependency or failure class, inspect them as a burst before deciding.",
+  "Prefer joining when a single plausible deployment or configuration change explains all symptoms.",
 ].join("\n");
 
 const LIST_INCIDENT_TITLES_TOOL: Anthropic.Messages.Tool = {

--- a/apps/worker/src/grouping/tools.ts
+++ b/apps/worker/src/grouping/tools.ts
@@ -14,6 +14,7 @@ export const GROUPING_SYSTEM_PROMPT = [
   "When you are done, call decide_grouping exactly once. Do not write a text reply.",
   "When several issues begin within the same short window and share a dependency or failure class, inspect them as a burst before deciding.",
   "Prefer joining when a single plausible deployment or configuration change explains all symptoms.",
+  "Only join when inspected evidence supports that shared explanation; otherwise return standalone.",
 ].join("\n");
 
 const LIST_INCIDENT_TITLES_TOOL: Anthropic.Messages.Tool = {


### PR DESCRIPTION
## Summary

- inspect temporally clustered issues as a burst when they share a dependency or failure class
- prefer joining when one deployment or configuration change plausibly explains the symptoms
- require inspected evidence for the shared explanation and retain standalone as the fallback
- cover the grouping-agent system prompt through its public execution boundary

## Evaluation

A sanitized ten-issue authorization-error replay produced 4 incidents with the previous prompt. The initial burst-aware prompt produced 1 incident and then 2 incidents on a repeat run. After adding the inspected-evidence safeguard, a fresh replay produced 1 incident with 9 of 9 issues joined.

## Validation

- `pnpm --filter @superlog/worker test:grouping-domain`
- `pnpm --filter @superlog/worker test:grouping-candidate-search`
- `pnpm --filter @superlog/worker test:grouping-agent`
- `pnpm --filter @superlog/worker test:incident-intake`
- `pnpm --filter @superlog/worker typecheck`
- `pnpm exec biome check apps/worker/src/grouping/tools.ts apps/worker/src/grouping/agent.test.ts`