### PR TITLE
Include issue timestamps in grouping decisions

### DIFF
--- a/apps/worker/src/grouping/agent.test.ts
+++ b/apps/worker/src/grouping/agent.test.ts
@@ -66,6 +66,7 @@ const NEW_ISSUE: GroupingNewIssue = {
   message: "conn refused",
   topFrame: "db.query",
   normalizedFrames: ["db.query"],
+  observedAt: "2026-07-17T10:05:00.000Z",
   stacktrace: null,
   traceId: null,
   spanId: null,

--- a/apps/worker/src/grouping/domain.ts
+++ b/apps/worker/src/grouping/domain.ts
@@ -63,6 +63,7 @@ export type GroupingNewIssue = {
   message: string | null;
   topFrame: string | null;
   normalizedFrames: string[];
+  observedAt: string;
   stacktrace: string | null;
   traceId: string | null;
   spanId: string | null;

--- a/apps/worker/src/issues/domain.test.ts
+++ b/apps/worker/src/issues/domain.test.ts
@@ -86,6 +86,7 @@ test("groupingIssueInput and buildGroupingCandidate keep LLM input shape explici
     message: "boom",
     topFrame: "svc/a.ts",
     normalizedFrames: ["svc/a.ts"],
+    observedAt: "2026-07-17T10:05:00.000Z",
     stacktrace: "stack",
     traceId: "trace-1",
     spanId: "span-1",
@@ -104,6 +105,8 @@ function makeIssue(normalizedFrames: string[]): schema.Issue {
     message: "boom",
     topFrame: normalizedFrames[0] ?? null,
     normalizedFrames,
+    firstSeen: new Date("2026-07-17T10:00:00.000Z"),
+    lastSeen: new Date("2026-07-17T10:05:00.000Z"),
     lastSample: null,
   } as schema.Issue;
 }

--- a/apps/worker/src/issues/domain.ts
+++ b/apps/worker/src/issues/domain.ts
@@ -40,6 +40,7 @@ export function groupingIssueInput(issue: schema.Issue): GroupingNewIssue {
     message: issue.message,
     topFrame: issue.topFrame,
     normalizedFrames: issue.normalizedFrames ?? [],
+    observedAt: issue.lastSeen.toISOString(),
     stacktrace: sample?.stacktrace ?? null,
     traceId: sample?.traceId ?? null,
     spanId: sample?.spanId ?? null,


### PR DESCRIPTION
## Summary

- include the new issue's latest occurrence timestamp as `observedAt` in grouping input
- let burst-aware decisions compare the incoming occurrence with candidate incident timing
- avoid using a fingerprint's historical lifetime start when a resolved issue recurs
- cover the production issue-to-grouping mapping with an explicit timestamp assertion

## Validation

- `pnpm --filter @superlog/worker test:issue-domain`
- `pnpm --filter @superlog/worker test:grouping-agent`
- `pnpm --filter @superlog/worker typecheck`
- `git diff --check`