### PR TITLE
Sync agent fix-started / fix-merged signals to Loops contacts

### DIFF
--- a/packages/db/src/loops-lifecycle.test.ts
+++ b/packages/db/src/loops-lifecycle.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { deriveLifecycle } from "./loops-lifecycle.js";
+
+// deriveLifecycle turns the raw per-signal timestamps (null = not happened,
+// set = happened at that time) into the boolean + timestamp pairs Loops stores
+// as contact properties. These are the properties the founder-nudge workflows
+// trigger on, so the started-vs-merged distinction has to be exact.
+const NONE = {
+  telemetrySetAt: null,
+  githubAddedAt: null,
+  slackAddedAt: null,
+  mcpInstalledAt: null,
+  fixStartedAt: null,
+  fixMergedAt: null,
+} as const;
+
+test("deriveLifecycle: a null fix timestamp is not-started, not-merged", () => {
+  const life = deriveLifecycle({ ...NONE });
+  assert.equal(life.fixStarted, false);
+  assert.equal(life.fixStartedAt, null);
+  assert.equal(life.fixMerged, false);
+  assert.equal(life.fixMergedAt, null);
+});
+
+test("deriveLifecycle: a fix opened but not merged is started, not merged", () => {
+  const life = deriveLifecycle({
+    ...NONE,
+    githubAddedAt: "2026-01-01T00:00:00.000Z",
+    fixStartedAt: "2026-02-01T00:00:00.000Z",
+  });
+  assert.equal(life.githubAdded, true);
+  assert.equal(life.fixStarted, true);
+  assert.equal(life.fixStartedAt, "2026-02-01T00:00:00.000Z");
+  assert.equal(life.fixMerged, false);
+  assert.equal(life.fixMergedAt, null);
+});
+
+test("deriveLifecycle: a merged fix is both started and merged", () => {
+  const life = deriveLifecycle({
+    ...NONE,
+    fixStartedAt: "2026-02-01T00:00:00.000Z",
+    fixMergedAt: "2026-02-03T00:00:00.000Z",
+  });
+  assert.equal(life.fixStarted, true);
+  assert.equal(life.fixMerged, true);
+  assert.equal(life.fixMergedAt, "2026-02-03T00:00:00.000Z");
+});
+
+test("deriveLifecycle: every signal maps its timestamp to a boolean pair", () => {
+  const life = deriveLifecycle({
+    telemetrySetAt: "2026-01-01T00:00:00.000Z",
+    githubAddedAt: "2026-01-02T00:00:00.000Z",
+    slackAddedAt: null,
+    mcpInstalledAt: "2026-01-04T00:00:00.000Z",
+    fixStartedAt: "2026-01-05T00:00:00.000Z",
+    fixMergedAt: "2026-01-06T00:00:00.000Z",
+  });
+  assert.deepEqual(life, {
+    telemetrySet: true,
+    telemetrySetAt: "2026-01-01T00:00:00.000Z",
+    githubAdded: true,
+    githubAddedAt: "2026-01-02T00:00:00.000Z",
+    slackAdded: false,
+    slackAddedAt: null,
+    mcpInstalled: true,
+    mcpInstalledAt: "2026-01-04T00:00:00.000Z",
+    fixStarted: true,
+    fixStartedAt: "2026-01-05T00:00:00.000Z",
+    fixMerged: true,
+    fixMergedAt: "2026-01-06T00:00:00.000Z",
+  });
+});

--- a/packages/db/src/loops-lifecycle.ts
+++ b/packages/db/src/loops-lifecycle.ts
@@ -1,0 +1,51 @@
+// Pure Loops lifecycle derivation. No DB or network imports, so the mapping is
+// unit-testable in isolation (the existing db unit tests never import the DB
+// client). The actual DB reads live in loops.ts's
+// fetchLoopsLifecycleForUserProject, which feeds the timestamps in here.
+
+export type LoopsLifecycle = {
+  telemetrySet: boolean;
+  telemetrySetAt: string | null;
+  githubAdded: boolean;
+  githubAddedAt: string | null;
+  slackAdded: boolean;
+  slackAddedAt: string | null;
+  mcpInstalled: boolean;
+  mcpInstalledAt: string | null;
+  // Whether the agent has opened at least one fix (a PR) for the org, and
+  // whether the org's first such fix has been merged. Drives re-engagement:
+  // "connected a repo but no fix yet" is githubAdded && !fixStarted.
+  fixStarted: boolean;
+  fixStartedAt: string | null;
+  fixMerged: boolean;
+  fixMergedAt: string | null;
+};
+
+/**
+ * Turn the raw per-signal "first seen" timestamps into the boolean + timestamp
+ * pairs Loops stores as contact properties. A null timestamp means the signal
+ * hasn't happened yet; a set one means it has.
+ */
+export function deriveLifecycle(ats: {
+  telemetrySetAt: string | null;
+  githubAddedAt: string | null;
+  slackAddedAt: string | null;
+  mcpInstalledAt: string | null;
+  fixStartedAt: string | null;
+  fixMergedAt: string | null;
+}): LoopsLifecycle {
+  return {
+    telemetrySet: ats.telemetrySetAt !== null,
+    telemetrySetAt: ats.telemetrySetAt,
+    githubAdded: ats.githubAddedAt !== null,
+    githubAddedAt: ats.githubAddedAt,
+    slackAdded: ats.slackAddedAt !== null,
+    slackAddedAt: ats.slackAddedAt,
+    mcpInstalled: ats.mcpInstalledAt !== null,
+    mcpInstalledAt: ats.mcpInstalledAt,
+    fixStarted: ats.fixStartedAt !== null,
+    fixStartedAt: ats.fixStartedAt,
+    fixMerged: ats.fixMergedAt !== null,
+    fixMergedAt: ats.fixMergedAt,
+  };
+}

--- a/packages/db/src/loops.ts
+++ b/packages/db/src/loops.ts
@@ -1,5 +1,6 @@
 import { and, eq, gt, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { db } from "./client.js";
+import { type LoopsLifecycle, deriveLifecycle } from "./loops-lifecycle.js";
 import * as schema from "./schema.js";
 
 const DEFAULT_LOOPS_API_BASE = "https://app.loops.so/api/v1";
@@ -34,16 +35,11 @@ export type LoopsWelcomeFlowInput = {
   appUrl?: string;
 };
 
-export type LoopsLifecycle = {
-  telemetrySet: boolean;
-  telemetrySetAt: string | null;
-  githubAdded: boolean;
-  githubAddedAt: string | null;
-  slackAdded: boolean;
-  slackAddedAt: string | null;
-  mcpInstalled: boolean;
-  mcpInstalledAt: string | null;
-};
+// LoopsLifecycle + deriveLifecycle live in the client-free loops-lifecycle
+// module so the pure mapping stays unit-testable; re-exported here to keep this
+// module's public surface unchanged.
+export { deriveLifecycle };
+export type { LoopsLifecycle };
 
 export type LoopsWelcomeEventPayload = {
   email: string;
@@ -185,62 +181,82 @@ export async function fetchLoopsLifecycleForUserProject(params: {
   projectId: string;
 }): Promise<LoopsLifecycle> {
   const now = new Date();
-  const [telemetryRows, githubRows, slackRows, mcpRows] = await Promise.all([
-    db
-      .select({ at: sql<Date | null>`max(${schema.apiKeys.lastUsedAt})` })
-      .from(schema.apiKeys)
-      .where(
-        and(
-          eq(schema.apiKeys.projectId, params.projectId),
-          isNull(schema.apiKeys.revokedAt),
-          isNotNull(schema.apiKeys.lastUsedAt),
-        ),
-      ),
-    db
-      .select({ at: sql<Date | null>`min(${schema.githubInstallations.createdAt})` })
-      .from(schema.githubInstallations)
-      .innerJoin(schema.projects, eq(schema.projects.id, schema.githubInstallations.projectId))
-      .where(
-        and(eq(schema.projects.orgId, params.orgId), isNull(schema.githubInstallations.revokedAt)),
-      ),
-    db
-      .select({ at: sql<Date | null>`min(${schema.slackInstallations.createdAt})` })
-      .from(schema.slackInstallations)
-      .innerJoin(schema.projects, eq(schema.projects.id, schema.slackInstallations.projectId))
-      .where(
-        and(eq(schema.projects.orgId, params.orgId), isNull(schema.slackInstallations.revokedAt)),
-      ),
-    db
-      .select({ at: sql<Date | null>`min(${schema.mcpOauthTokens.createdAt})` })
-      .from(schema.mcpOauthTokens)
-      .where(
-        and(
-          eq(schema.mcpOauthTokens.userId, params.userId),
-          eq(schema.mcpOauthTokens.projectId, params.projectId),
-          isNull(schema.mcpOauthTokens.revokedAt),
-          or(
-            isNull(schema.mcpOauthTokens.refreshExpiresAt),
-            gt(schema.mcpOauthTokens.refreshExpiresAt, now),
+  const [telemetryRows, githubRows, slackRows, mcpRows, fixStartedRows, fixMergedRows] =
+    await Promise.all([
+      db
+        .select({ at: sql<Date | null>`max(${schema.apiKeys.lastUsedAt})` })
+        .from(schema.apiKeys)
+        .where(
+          and(
+            eq(schema.apiKeys.projectId, params.projectId),
+            isNull(schema.apiKeys.revokedAt),
+            isNotNull(schema.apiKeys.lastUsedAt),
           ),
         ),
-      ),
-  ]);
+      db
+        .select({ at: sql<Date | null>`min(${schema.githubInstallations.createdAt})` })
+        .from(schema.githubInstallations)
+        .innerJoin(schema.projects, eq(schema.projects.id, schema.githubInstallations.projectId))
+        .where(
+          and(
+            eq(schema.projects.orgId, params.orgId),
+            isNull(schema.githubInstallations.revokedAt),
+          ),
+        ),
+      db
+        .select({ at: sql<Date | null>`min(${schema.slackInstallations.createdAt})` })
+        .from(schema.slackInstallations)
+        .innerJoin(schema.projects, eq(schema.projects.id, schema.slackInstallations.projectId))
+        .where(
+          and(eq(schema.projects.orgId, params.orgId), isNull(schema.slackInstallations.revokedAt)),
+        ),
+      db
+        .select({ at: sql<Date | null>`min(${schema.mcpOauthTokens.createdAt})` })
+        .from(schema.mcpOauthTokens)
+        .where(
+          and(
+            eq(schema.mcpOauthTokens.userId, params.userId),
+            eq(schema.mcpOauthTokens.projectId, params.projectId),
+            isNull(schema.mcpOauthTokens.revokedAt),
+            or(
+              isNull(schema.mcpOauthTokens.refreshExpiresAt),
+              gt(schema.mcpOauthTokens.refreshExpiresAt, now),
+            ),
+          ),
+        ),
+      // First agent fix (a PR the agent opened) for this org, and the first such
+      // PR that merged. Scoped to the org through the PR's incident, matching the
+      // github/slack signals above. min() ignores nulls, so mergedAt stays null
+      // until a fix actually merges.
+      db
+        .select({ at: sql<Date | null>`min(${schema.agentPullRequests.createdAt})` })
+        .from(schema.agentPullRequests)
+        .innerJoin(schema.incidents, eq(schema.incidents.id, schema.agentPullRequests.incidentId))
+        .innerJoin(schema.projects, eq(schema.projects.id, schema.incidents.projectId))
+        .where(eq(schema.projects.orgId, params.orgId)),
+      db
+        .select({ at: sql<Date | null>`min(${schema.agentPullRequests.mergedAt})` })
+        .from(schema.agentPullRequests)
+        .innerJoin(schema.incidents, eq(schema.incidents.id, schema.agentPullRequests.incidentId))
+        .innerJoin(schema.projects, eq(schema.projects.id, schema.incidents.projectId))
+        .where(eq(schema.projects.orgId, params.orgId)),
+    ]);
 
   const telemetrySetAt = iso(telemetryRows[0]?.at);
   const githubAddedAt = iso(githubRows[0]?.at);
   const slackAddedAt = iso(slackRows[0]?.at);
   const mcpInstalledAt = iso(mcpRows[0]?.at);
+  const fixStartedAt = iso(fixStartedRows[0]?.at);
+  const fixMergedAt = iso(fixMergedRows[0]?.at);
 
-  return {
-    telemetrySet: telemetrySetAt !== null,
+  return deriveLifecycle({
     telemetrySetAt,
-    githubAdded: githubAddedAt !== null,
     githubAddedAt,
-    slackAdded: slackAddedAt !== null,
     slackAddedAt,
-    mcpInstalled: mcpInstalledAt !== null,
     mcpInstalledAt,
-  };
+    fixStartedAt,
+    fixMergedAt,
+  });
 }
 
 export async function upsertLoopsContact(


### PR DESCRIPTION
## What

Adds two per-org lifecycle signals to the Loops contact sync:

- `fixStarted` / `fixStartedAt` — whether the agent has opened at least one fix (a pull request) for the org.
- `fixMerged` / `fixMergedAt` — whether the org's first agent pull request has merged.

They sit next to the existing `telemetrySet` / `githubAdded` / `slackAdded` / `mcpInstalled` signals so lifecycle messaging can segment on where an org is in the fix journey (for example, "connected a repo but no fix yet" is `githubAdded && !fixStarted`).

## How

- `fetchLoopsLifecycleForUserProject` gains two aggregate reads over `agent_pull_requests`, scoped to the org through each PR's incident (`agent_pull_requests → incidents → projects.org_id`), matching how the github/slack signals are org-scoped. `min(created_at)` is the first fix opened; `min(merged_at)` is the first merge (null until one merges).
- The pure timestamp → boolean/timestamp mapping moves into a new client-free `loops-lifecycle` module (`deriveLifecycle`) so it is unit-tested without a database — the rest of the db-package unit tests never import the DB client. `loops.ts` re-exports it, so the module's public surface is unchanged.
- The new properties ride the existing telemetry-driven contact sync (an org with a fix is by definition sending telemetry), so no new sync trigger is added.

## Tests

`packages/db/src/loops-lifecycle.test.ts` covers the derivation: not-started, started-not-merged, merged, and the full signal→property mapping. `pnpm --filter @superlog/db test` (222 tests) and typecheck pass; Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
