### PR TITLE
fix(worker): Centralize ClickHouse configuration and fix Autorecovery…

### DIFF
--- a/apps/worker/src/autorecovery/metrics-repository.ts
+++ b/apps/worker/src/autorecovery/metrics-repository.ts
@@ -1,4 +1,5 @@
 import type { ClickHouseClient } from "@clickhouse/client";
+import { getClickhouseConfig } from "../infra/clickhouse/config.js";
 import type { CandidateIncident } from "./domain.js";
 
 export type ActivityBucket = { hour: string; count: number };
@@ -197,13 +198,6 @@ let cachedClient: ClickHouseClient | null = null;
 export async function defaultClickhouseClient(): Promise<ClickHouseClient> {
   if (cachedClient) return cachedClient;
   const { createClient } = await import("@clickhouse/client");
-  cachedClient = createClient({
-    url: process.env.CLICKHOUSE_URL ?? "http://localhost:8123",
-    username: process.env.CLICKHOUSE_USER ?? "default",
-    password: process.env.CLICKHOUSE_PASSWORD ?? "",
-    // Local portless stacks ship a `superlog` database; prod uses `olly`.
-    // `CLICKHOUSE_DB` is the env name `scripts/portless-stack.sh` writes.
-    database: process.env.CLICKHOUSE_DATABASE ?? process.env.CLICKHOUSE_DB ?? "olly",
-  });
+  cachedClient = createClient(getClickhouseConfig());
   return cachedClient;
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -5,6 +5,7 @@ import { registerAgentRunHealthMetrics } from "./agent-run-health-metrics.js";
 import { startAgentRunQueue } from "./agent-runs/queue-wiring.js";
 import { initAiUsageSink } from "./ai-usage.js";
 import { handleIssueTransition } from "./incidents/workflow.js";
+import { getClickhouseConfig } from "./infra/clickhouse/config.js";
 import {
   createIssueTransitionDispatcher,
   registerIssueTransitionWorker,
@@ -31,18 +32,11 @@ registerTenantMetrics();
 registerAgentRunHealthMetrics();
 registerQueueHealthMetrics();
 
-const CLICKHOUSE_URL = process.env.CLICKHOUSE_URL ?? "http://localhost:8123";
-const CLICKHOUSE_DB = process.env.CLICKHOUSE_DB ?? "superlog";
 const POLL_INTERVAL_MS = Number(process.env.POLL_INTERVAL_MS ?? 3000);
 const BATCH_SIZE = Number(process.env.BATCH_SIZE ?? 500);
 const TELEMETRY_DISCOVERY_WINDOW_MS = Number(process.env.TELEMETRY_DISCOVERY_WINDOW_MS);
 
-const ch = createClient({
-  url: CLICKHOUSE_URL,
-  username: process.env.CLICKHOUSE_USER ?? "default",
-  password: process.env.CLICKHOUSE_PASSWORD ?? "",
-  database: CLICKHOUSE_DB,
-});
+const ch = createClient(getClickhouseConfig());
 
 registerDatastoreObservability({ db, clickhouse: ch, logger });
 

--- a/apps/worker/src/infra/clickhouse/config.test.ts
+++ b/apps/worker/src/infra/clickhouse/config.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { getClickhouseConfig } from "./config.js";
+
+test("getClickhouseConfig defaults database to superlog", () => {
+  const config = getClickhouseConfig({});
+  assert.equal(config.database, "superlog");
+  assert.equal(config.url, "http://localhost:8123");
+  assert.equal(config.username, "default");
+  assert.equal(config.password, "");
+});
+
+test("getClickhouseConfig accepts CLICKHOUSE_DB", () => {
+  const config = getClickhouseConfig({
+    CLICKHOUSE_DB: "custom-db",
+  });
+  assert.equal(config.database, "custom-db");
+});
+
+test("getClickhouseConfig prioritizes CLICKHOUSE_DATABASE over CLICKHOUSE_DB", () => {
+  const config = getClickhouseConfig({
+    CLICKHOUSE_DATABASE: "db-one",
+    CLICKHOUSE_DB: "db-two",
+  });
+  assert.equal(config.database, "db-one");
+});
+
+test("getClickhouseConfig respects URL, user, and password overrides", () => {
+  const config = getClickhouseConfig({
+    CLICKHOUSE_URL: "http://clickhouse:8123",
+    CLICKHOUSE_USER: "admin",
+    CLICKHOUSE_PASSWORD: "secret-password",
+  });
+  assert.equal(config.url, "http://clickhouse:8123");
+  assert.equal(config.username, "admin");
+  assert.equal(config.password, "secret-password");
+});

--- a/apps/worker/src/infra/clickhouse/config.ts
+++ b/apps/worker/src/infra/clickhouse/config.ts
@@ -1,0 +1,14 @@
+import type { createClient } from "@clickhouse/client";
+
+export type ClickHouseConfig = NonNullable<Parameters<typeof createClient>[0]>;
+
+export function getClickhouseConfig(
+  env: Record<string, string | undefined> = process.env,
+): ClickHouseConfig {
+  return {
+    url: env.CLICKHOUSE_URL ?? "http://localhost:8123",
+    username: env.CLICKHOUSE_USER ?? "default",
+    password: env.CLICKHOUSE_PASSWORD ?? "",
+    database: env.CLICKHOUSE_DATABASE ?? env.CLICKHOUSE_DB ?? "superlog",
+  };
+}

--- a/apps/worker/src/infra/clickhouse/trace-context.ts
+++ b/apps/worker/src/infra/clickhouse/trace-context.ts
@@ -1,14 +1,8 @@
 import { createClient } from "@clickhouse/client";
 import { logger } from "../../logger.js";
+import { getClickhouseConfig } from "./config.js";
 
-const CLICKHOUSE_URL = process.env.CLICKHOUSE_URL ?? "http://localhost:8123";
-const CLICKHOUSE_DB = process.env.CLICKHOUSE_DB ?? "superlog";
-const ch = createClient({
-  url: CLICKHOUSE_URL,
-  username: process.env.CLICKHOUSE_USER ?? "default",
-  password: process.env.CLICKHOUSE_PASSWORD ?? "",
-  database: CLICKHOUSE_DB,
-});
+const ch = createClient(getClickhouseConfig());
 
 type TraceSpanRow = {
   timestamp: string;

--- a/apps/worker/src/jobs/usage-meter.ts
+++ b/apps/worker/src/jobs/usage-meter.ts
@@ -3,6 +3,7 @@
 // own client deadline so they cannot extend or block the core worker tick.
 import { type ClickHouseClient, createClient } from "@clickhouse/client";
 import { type UsageMeterTicker, createUsageMeterTicker } from "../billing/usage-meter-ticker.js";
+import { getClickhouseConfig } from "../infra/clickhouse/config.js";
 import type { JobDefinition } from "../jobs.js";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
@@ -45,10 +46,7 @@ export function createUsageMeterJob(
       return async () => {
         const signal = AbortSignal.timeout(jobTimeoutMs);
         const clickhouse = createClickHouse({
-          url: env.CLICKHOUSE_URL ?? "http://localhost:8123",
-          username: env.CLICKHOUSE_USER ?? "default",
-          password: env.CLICKHOUSE_PASSWORD ?? "",
-          database: env.CLICKHOUSE_DB ?? "superlog",
+          ...getClickhouseConfig(env),
           request_timeout: positiveNumber(
             env.BILLING_CLICKHOUSE_REQUEST_TIMEOUT_MS,
             DEFAULT_REQUEST_TIMEOUT_MS,


### PR DESCRIPTION
## Description
This pull request addresses **#286** by centralizing the ClickHouse client configuration across the `apps/worker` service. 

Previously, the worker's main ClickHouse client, trace-context reader, and billing usage-meter resolved configuration independently, falling back to `superlog` when `CLICKHOUSE_DB` was unset. However, the autorecovery module resolved its configuration separately, accepting the nonstandard `CLICKHOUSE_DATABASE` variable and falling back to `"olly"`.

This config drift caused the autorecovery process to query a different (often non-existent) database in local environments, preventing candidates from being read and causing recovery loops to fail.

### Changes
1. **Centralized Configuration Helper (`apps/worker/src/infra/clickhouse/config.ts`)**:
   - Implemented `getClickhouseConfig()`, which resolves connection parameters (`url`, `username`, `password`, `database`) consistently.
   - Restored backwards compatibility for `CLICKHOUSE_DATABASE` while standardizing the fallback database to `"superlog"`.
2. **Reconciliation of Callers**:
   - Replaced duplicate inline ClickHouse configurations with the new centralized utility in:
     - `apps/worker/src/index.ts` (Worker boot sequence)
     - `apps/worker/src/infra/clickhouse/trace-context.ts` (Trace context queries)
     - `apps/worker/src/jobs/usage-meter.ts` (Billing usage metering)
     - `apps/worker/src/autorecovery/metrics-repository.ts` (Autorecovery database queries)
3. **Tests Added**:
   - Implemented unit tests in `apps/worker/src/infra/clickhouse/config.test.ts` to cover default resolving behavior, `CLICKHOUSE_DB` integration, precedence rules, and database overrides.

---

## Verification
- Running `pnpm --filter @superlog/worker typecheck` completed successfully.
- Ran Biome formatting and lint checks exclusively on the modified files.
- Executed unit tests confirming they all pass:
  ```bash
  npx tsx --test src/infra/clickhouse/config.test.ts


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized ClickHouse config for the worker and fixed autorecovery querying the wrong database in local environments. All clients now share one helper with a "superlog" default and backward-compatible envs. Addresses Linear #286.

- **Bug Fixes**
  - Autorecovery now uses the same ClickHouse config as the rest of the worker (no more `"olly"` fallback).
  - Prevents empty candidate reads and recovery loop failures in local setups.

- **Refactors**
  - Added `getClickhouseConfig()` and routed all `@clickhouse/client` usage through it.
  - Standardized env resolution: `CLICKHOUSE_DATABASE` > `CLICKHOUSE_DB`, default to `"superlog"`.
  - Added unit tests for defaults, precedence, and overrides.

<sup>Written for commit de0e24bc6919b8085f71b494f13f80b704ffb85f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

