### PR TITLE
fix(proxy): Secure and harmonize fingerprint sanitization pipeline with protobuf support and precise metrics

### DIFF
--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -811,7 +811,7 @@ async function forward(
       }
       requestBytes = bodyBuffer.byteLength;
 
-      const stampedBody = stampIssueFingerprintsFailOpen(
+      const { body: stampedBody } = stampIssueFingerprintsFailOpen(
         { path, contentType, contentEncoding, body: bodyBuffer, projectId },
         logger,
       );
@@ -1129,7 +1129,7 @@ const renderSyslogServer = RENDER_SYSLOG_PORT
         } else {
           // Direct mode has no consumer to stamp issue fingerprints, so stamp
           // here — same as the HTTP edge's direct branch.
-          const stampedBody = stampIssueFingerprintsFailOpen(
+          const { body: stampedBody } = stampIssueFingerprintsFailOpen(
             {
               path: "/v1/logs",
               contentType: "application/json",

--- a/apps/proxy/src/ingest-fingerprints.test.ts
+++ b/apps/proxy/src/ingest-fingerprints.test.ts
@@ -21,6 +21,8 @@ const require = createRequire(import.meta.url);
 const otlpRoot = require("@opentelemetry/otlp-transformer/build/esm/generated/root.js");
 const ExportTraceServiceRequest =
   otlpRoot.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+const ExportLogsServiceRequest =
+  otlpRoot.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
 
 test("stampIssueFingerprints adds issue fingerprint attributes to JSON trace exceptions", () => {
   const input = {
@@ -396,3 +398,61 @@ test("stampIssueFingerprintsFailOpen logs a warning when client-supplied fingerp
     "stripped client-supplied superlog.issue_fingerprint attributes on ingest payload",
   );
 });
+
+test("stampIssueFingerprints adds issue fingerprint attributes to protobuf error logs and strips from non-error logs", () => {
+  const request = ExportLogsServiceRequest.create({
+    resourceLogs: [
+      {
+        scopeLogs: [
+          {
+            logRecords: [
+              {
+                severityNumber: 17, // ERROR
+                severityText: "ERROR",
+                body: { stringValue: "request failed" },
+                attributes: [
+                  { key: "exception.type", value: { stringValue: "ForbiddenError" } },
+                  { key: "superlog.issue_fingerprint", value: { stringValue: "client-supplied-1" } },
+                ],
+              },
+              {
+                severityNumber: 9, // INFO
+                severityText: "INFO",
+                body: { stringValue: "some info" },
+                attributes: [
+                  { key: "superlog.issue_fingerprint", value: { stringValue: "client-supplied-2" } },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+  const body = Buffer.from(ExportLogsServiceRequest.encode(request).finish());
+
+  const stamped = stampIssueFingerprints({
+    path: "/v1/logs",
+    contentType: "application/x-protobuf",
+    body,
+  });
+
+  const decoded = ExportLogsServiceRequest.decode(stamped.body);
+  const logRecords = decoded.resourceLogs[0].scopeLogs[0].logRecords;
+
+  assert.equal(stamped.stampedCount, 1);
+  assert.equal(stamped.strippedCount, 2);
+
+  // Check the error log: should have stamped authoritative fingerprint (which overwrites client-supplied)
+  const errAttrs = logRecords[0].attributes;
+  const fpAttr = errAttrs.find((attr: { key: string }) => attr.key === "superlog.issue_fingerprint");
+  assert.ok(fpAttr);
+  assert.equal(fpAttr.value.stringValue.length, 16);
+  assert.notEqual(fpAttr.value.stringValue, "client-supplied-1");
+
+  // Check the info log: should have stripped fingerprint
+  const infoAttrs = logRecords[1].attributes;
+  const infoFpAttr = infoAttrs.find((attr: { key: string }) => attr.key === "superlog.issue_fingerprint");
+  assert.equal(infoFpAttr, undefined);
+});
+

--- a/apps/proxy/src/ingest-fingerprints.test.ts
+++ b/apps/proxy/src/ingest-fingerprints.test.ts
@@ -268,3 +268,90 @@ test("stampIssueFingerprints leaves compressed payloads untouched", () => {
   assert.equal(stamped.body, body);
   assert.equal(stamped.stampedCount, 0);
 });
+
+test("stampIssueFingerprints strips client-supplied fingerprint from non-error logs even if no logs stamped", () => {
+  const input = {
+    path: "/v1/logs",
+    contentType: "application/json",
+    body: Buffer.from(
+      JSON.stringify({
+        resourceLogs: [
+          {
+            scopeLogs: [
+              {
+                logRecords: [
+                  {
+                    severityText: "INFO",
+                    body: { stringValue: "info message" },
+                    attributes: [
+                      { key: "superlog.issue_fingerprint", value: { stringValue: "fakefp" } },
+                      { key: "env", value: { stringValue: "prod" } },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+  };
+
+  const stamped = stampIssueFingerprints(input);
+  assert.equal(stamped.stampedCount, 0);
+  const payload = JSON.parse(stamped.body.toString("utf8"));
+  const attributes = payload.resourceLogs[0].scopeLogs[0].logRecords[0].attributes;
+  assert.equal(
+    attributes.find((attr: { key: string }) => attr.key === "superlog.issue_fingerprint"),
+    undefined,
+  );
+  assert.equal(
+    attributes.find((attr: { key: string }) => attr.key === "env").value.stringValue,
+    "prod",
+  );
+});
+
+test("stampIssueFingerprints strips client-supplied fingerprint from non-exception trace events even if no spans stamped", () => {
+  const input = {
+    path: "/v1/traces",
+    contentType: "application/json",
+    body: Buffer.from(
+      JSON.stringify({
+        resourceSpans: [
+          {
+            scopeSpans: [
+              {
+                spans: [
+                  {
+                    events: [
+                      {
+                        name: "custom_event",
+                        attributes: [
+                          { key: "superlog.issue_fingerprint", value: { stringValue: "fakefp" } },
+                          { key: "custom.key", value: { stringValue: "value" } },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+  };
+
+  const stamped = stampIssueFingerprints(input);
+  assert.equal(stamped.stampedCount, 0);
+  const payload = JSON.parse(stamped.body.toString("utf8"));
+  const attributes = payload.resourceSpans[0].scopeSpans[0].spans[0].events[0].attributes;
+  assert.equal(
+    attributes.find((attr: { key: string }) => attr.key === "superlog.issue_fingerprint"),
+    undefined,
+  );
+  assert.equal(
+    attributes.find((attr: { key: string }) => attr.key === "custom.key").value.stringValue,
+    "value",
+  );
+});

--- a/apps/proxy/src/ingest-fingerprints.test.ts
+++ b/apps/proxy/src/ingest-fingerprints.test.ts
@@ -222,7 +222,9 @@ test("stampIssueFingerprintsFailOpen forwards the original body when stamping th
 
   assert.equal(result, body);
   assert.equal(stamped, false);
-  assert.equal(logger.calls.some((c) => c.level === "warn"), true);
+  const warnCall = logger.calls.find((c) => c.level === "warn");
+  assert.ok(warnCall);
+  assert.equal(warnCall.obj.bodyBytes, body.byteLength);
 });
 
 test("stampIssueFingerprintsFailOpen returns the stamped body and logs on success", () => {

--- a/apps/proxy/src/ingest-fingerprints.test.ts
+++ b/apps/proxy/src/ingest-fingerprints.test.ts
@@ -355,3 +355,41 @@ test("stampIssueFingerprints strips client-supplied fingerprint from non-excepti
     "value",
   );
 });
+
+test("stampIssueFingerprintsFailOpen logs a warning when client-supplied fingerprints are stripped", () => {
+  const body = Buffer.from(
+    JSON.stringify({
+      resourceLogs: [
+        {
+          scopeLogs: [
+            {
+              logRecords: [
+                {
+                  severityText: "INFO",
+                  body: { stringValue: "info" },
+                  attributes: [
+                    { key: "superlog.issue_fingerprint", value: { stringValue: "fakefp" } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
+  );
+  const logger = captureLogger();
+
+  stampIssueFingerprintsFailOpen(
+    { path: "/v1/logs", contentType: "application/json", body, projectId: "p1" },
+    logger,
+  );
+
+  const warnCall = logger.calls.find((c) => c.level === "warn");
+  assert.ok(warnCall, "should have logged a warn call");
+  assert.equal(warnCall.obj.strippedCount, 1);
+  assert.equal(
+    warnCall.msg,
+    "stripped client-supplied superlog.issue_fingerprint attributes on ingest payload",
+  );
+});

--- a/apps/proxy/src/ingest-fingerprints.test.ts
+++ b/apps/proxy/src/ingest-fingerprints.test.ts
@@ -213,12 +213,13 @@ test("stampIssueFingerprintsFailOpen forwards the original body when stamping th
   const body = Buffer.from('{"resourceLogs": broken');
   const logger = captureLogger();
 
-  const result = stampIssueFingerprintsFailOpen(
+  const { body: result, stamped } = stampIssueFingerprintsFailOpen(
     { path: "/v1/logs", contentType: "application/json", body, projectId: "p1" },
     logger,
   );
 
   assert.equal(result, body);
+  assert.equal(stamped, false);
   assert.equal(logger.calls.some((c) => c.level === "warn"), true);
 });
 
@@ -245,14 +246,15 @@ test("stampIssueFingerprintsFailOpen returns the stamped body and logs on succes
   );
   const logger = captureLogger();
 
-  const result = stampIssueFingerprintsFailOpen(
+  const { body: result, stamped } = stampIssueFingerprintsFailOpen(
     { path: "/v1/logs", contentType: "application/json", body, projectId: "p1" },
     logger,
   );
 
-  const stamped = JSON.parse(result.toString("utf8"));
-  const attrs = stamped.resourceLogs[0].scopeLogs[0].logRecords[0].attributes;
+  const stampedObj = JSON.parse(result.toString("utf8"));
+  const attrs = stampedObj.resourceLogs[0].scopeLogs[0].logRecords[0].attributes;
   assert.ok(attrs.find((a: { key: string }) => a.key === "superlog.issue_fingerprint"));
+  assert.equal(stamped, true);
   assert.equal(logger.calls.some((c) => c.level === "info"), true);
 });
 
@@ -380,7 +382,7 @@ test("stampIssueFingerprintsFailOpen logs a warning when client-supplied fingerp
   );
   const logger = captureLogger();
 
-  stampIssueFingerprintsFailOpen(
+  const { stamped } = stampIssueFingerprintsFailOpen(
     { path: "/v1/logs", contentType: "application/json", body, projectId: "p1" },
     logger,
   );
@@ -388,6 +390,7 @@ test("stampIssueFingerprintsFailOpen logs a warning when client-supplied fingerp
   const warnCall = logger.calls.find((c) => c.level === "warn");
   assert.ok(warnCall, "should have logged a warn call");
   assert.equal(warnCall.obj.strippedCount, 1);
+  assert.equal(stamped, true);
   assert.equal(
     warnCall.msg,
     "stripped client-supplied superlog.issue_fingerprint attributes on ingest payload",

--- a/apps/proxy/src/ingest-fingerprints.ts
+++ b/apps/proxy/src/ingest-fingerprints.ts
@@ -63,20 +63,33 @@ export function stampIssueFingerprintsFailOpen(
     const stamped = stampIssueFingerprintsWithinLimit(input);
     if (stamped.stampedCount > 0) {
       logger.info(
-        { path: input.path, projectId: input.projectId, stampedCount: stamped.stampedCount },
+        {
+          path: input.path,
+          projectId: input.projectId ?? "unknown",
+          stampedCount: stamped.stampedCount,
+        },
         "stamped issue fingerprints on ingest payload",
       );
     }
     if (stamped.strippedCount > 0) {
       logger.warn(
-        { path: input.path, projectId: input.projectId, strippedCount: stamped.strippedCount },
+        {
+          path: input.path,
+          projectId: input.projectId ?? "unknown",
+          strippedCount: stamped.strippedCount,
+        },
         "stripped client-supplied superlog.issue_fingerprint attributes on ingest payload",
       );
     }
     return stamped.body;
   } catch (err) {
     logger.warn(
-      { err, path: input.path, projectId: input.projectId, contentType: input.contentType },
+      {
+        err,
+        path: input.path,
+        projectId: input.projectId ?? "unknown",
+        contentType: input.contentType,
+      },
       "failed to stamp issue fingerprints on ingest payload",
     );
     return input.body;

--- a/apps/proxy/src/ingest-fingerprints.ts
+++ b/apps/proxy/src/ingest-fingerprints.ts
@@ -105,6 +105,7 @@ function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
   };
 
   let stampedCount = 0;
+  let strippedCount = 0;
   for (const resourceSpan of payload.resourceSpans ?? []) {
     for (const scopeSpan of resourceSpan.scopeSpans ?? []) {
       for (const span of scopeSpan.spans ?? []) {
@@ -113,9 +114,10 @@ function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
           // cannot inject a fake value on non-exception events that the
           // stamper skips. For exception events, setStringAttribute overwrites
           // it with the proxy-computed hash immediately after.
-          event.attributes = (event.attributes ?? []).filter(
-            (a) => a.key !== ISSUE_FINGERPRINT_ATTRIBUTE,
-          );
+          const before = event.attributes ?? [];
+          const after = before.filter((a) => a.key !== ISSUE_FINGERPRINT_ATTRIBUTE);
+          if (after.length !== before.length) strippedCount += 1;
+          event.attributes = after;
           if (event.name !== "exception") continue;
           const attrs = event.attributes;
           const fp = fingerprint({
@@ -130,7 +132,10 @@ function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
     }
   }
 
-  if (stampedCount === 0) return { body, stampedCount };
+  // Re-serialize if anything changed — stripping alone mutates the parsed
+  // object in memory but the caller receives the original Buffer unless we
+  // re-encode here.
+  if (stampedCount === 0 && strippedCount === 0) return { body, stampedCount };
   return { body: Buffer.from(JSON.stringify(payload)), stampedCount };
 }
 
@@ -149,15 +154,17 @@ function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
   };
 
   let stampedCount = 0;
+  let strippedCount = 0;
   for (const resourceSpan of payload.resourceSpans ?? []) {
     for (const scopeSpan of resourceSpan.scopeSpans ?? []) {
       for (const span of scopeSpan.spans ?? []) {
         for (const event of span.events ?? []) {
           // Strip any client-supplied fingerprint unconditionally — same
           // rationale as stampJsonTraceFingerprints.
-          event.attributes = (event.attributes ?? []).filter(
-            (a) => a.key !== ISSUE_FINGERPRINT_ATTRIBUTE,
-          );
+          const before = event.attributes ?? [];
+          const after = before.filter((a) => a.key !== ISSUE_FINGERPRINT_ATTRIBUTE);
+          if (after.length !== before.length) strippedCount += 1;
+          event.attributes = after;
           if (event.name !== "exception") continue;
           const attrs = event.attributes;
           const fp = fingerprint({
@@ -172,7 +179,10 @@ function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
     }
   }
 
-  if (stampedCount === 0) return { body, stampedCount };
+  // Re-serialize if anything changed — stripping alone mutates the parsed
+  // object in memory but the caller receives the original Buffer unless we
+  // re-encode here.
+  if (stampedCount === 0 && strippedCount === 0) return { body, stampedCount };
   return { body: Buffer.from(ExportTraceServiceRequest.encode(payload).finish()), stampedCount };
 }
 
@@ -192,6 +202,7 @@ function stampJsonLogFingerprints(body: Buffer): StampedIngestPayload {
   };
 
   let stampedCount = 0;
+  let strippedCount = 0;
   for (const resourceLog of payload.resourceLogs ?? []) {
     const service =
       stringAttribute(resourceLog.resource?.attributes ?? [], "service.name") || "unknown";
@@ -199,9 +210,10 @@ function stampJsonLogFingerprints(body: Buffer): StampedIngestPayload {
       for (const logRecord of scopeLog.logRecords ?? []) {
         // Strip any client-supplied fingerprint unconditionally so a client
         // cannot inject a fake value for non-error logs the stamper skips.
-        logRecord.attributes = (logRecord.attributes ?? []).filter(
-          (a) => a.key !== ISSUE_FINGERPRINT_ATTRIBUTE,
-        );
+        const before = logRecord.attributes ?? [];
+        const after = before.filter((a) => a.key !== ISSUE_FINGERPRINT_ATTRIBUTE);
+        if (after.length !== before.length) strippedCount += 1;
+        logRecord.attributes = after;
         const attrs = logRecord.attributes;
         if (!isErrorLog(logRecord.severityNumber, logRecord.severityText, attrs)) continue;
         const fp = fingerprintLog({
@@ -217,7 +229,10 @@ function stampJsonLogFingerprints(body: Buffer): StampedIngestPayload {
     }
   }
 
-  if (stampedCount === 0) return { body, stampedCount };
+  // Re-serialize if anything changed — stripping alone mutates the parsed
+  // object in memory but the caller receives the original Buffer unless we
+  // re-encode here.
+  if (stampedCount === 0 && strippedCount === 0) return { body, stampedCount };
   return { body: Buffer.from(JSON.stringify(payload)), stampedCount };
 }
 

--- a/apps/proxy/src/ingest-fingerprints.ts
+++ b/apps/proxy/src/ingest-fingerprints.ts
@@ -1,7 +1,13 @@
 import { createRequire } from "node:module";
 import { fingerprint, fingerprintLog } from "@superlog/fingerprint";
+import { metrics } from "@opentelemetry/api";
 
 const ISSUE_FINGERPRINT_ATTRIBUTE = "superlog.issue_fingerprint";
+
+const meter = metrics.getMeter("@superlog/proxy/operational");
+const fingerprintStrippedCounter = meter.createCounter("superlog.proxy.fingerprint_stripped_total", {
+  description: "Total number of client-supplied superlog.issue_fingerprint attributes stripped.",
+});
 const require = createRequire(import.meta.url);
 const otlpRoot = require("@opentelemetry/otlp-transformer/build/esm/generated/root.js");
 const ExportTraceServiceRequest =
@@ -72,6 +78,9 @@ export function stampIssueFingerprintsFailOpen(
       );
     }
     if (stamped.strippedCount > 0) {
+      fingerprintStrippedCounter.add(stamped.strippedCount, {
+        path: input.path,
+      });
       logger.warn(
         {
           path: input.path,

--- a/apps/proxy/src/ingest-fingerprints.ts
+++ b/apps/proxy/src/ingest-fingerprints.ts
@@ -109,8 +109,15 @@ function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
     for (const scopeSpan of resourceSpan.scopeSpans ?? []) {
       for (const span of scopeSpan.spans ?? []) {
         for (const event of span.events ?? []) {
+          // Strip any client-supplied fingerprint unconditionally so a client
+          // cannot inject a fake value on non-exception events that the
+          // stamper skips. For exception events, setStringAttribute overwrites
+          // it with the proxy-computed hash immediately after.
+          event.attributes = (event.attributes ?? []).filter(
+            (a) => a.key !== ISSUE_FINGERPRINT_ATTRIBUTE,
+          );
           if (event.name !== "exception") continue;
-          const attrs = event.attributes ?? [];
+          const attrs = event.attributes;
           const fp = fingerprint({
             type: stringAttribute(attrs, "exception.type") || "Error",
             message: stringAttribute(attrs, "exception.message"),
@@ -146,8 +153,13 @@ function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
     for (const scopeSpan of resourceSpan.scopeSpans ?? []) {
       for (const span of scopeSpan.spans ?? []) {
         for (const event of span.events ?? []) {
+          // Strip any client-supplied fingerprint unconditionally — same
+          // rationale as stampJsonTraceFingerprints.
+          event.attributes = (event.attributes ?? []).filter(
+            (a) => a.key !== ISSUE_FINGERPRINT_ATTRIBUTE,
+          );
           if (event.name !== "exception") continue;
-          const attrs = event.attributes ?? [];
+          const attrs = event.attributes;
           const fp = fingerprint({
             type: stringAttribute(attrs, "exception.type") || "Error",
             message: stringAttribute(attrs, "exception.message"),
@@ -185,7 +197,12 @@ function stampJsonLogFingerprints(body: Buffer): StampedIngestPayload {
       stringAttribute(resourceLog.resource?.attributes ?? [], "service.name") || "unknown";
     for (const scopeLog of resourceLog.scopeLogs ?? []) {
       for (const logRecord of scopeLog.logRecords ?? []) {
-        const attrs = logRecord.attributes ?? [];
+        // Strip any client-supplied fingerprint unconditionally so a client
+        // cannot inject a fake value for non-error logs the stamper skips.
+        logRecord.attributes = (logRecord.attributes ?? []).filter(
+          (a) => a.key !== ISSUE_FINGERPRINT_ATTRIBUTE,
+        );
+        const attrs = logRecord.attributes;
         if (!isErrorLog(logRecord.severityNumber, logRecord.severityText, attrs)) continue;
         const fp = fingerprintLog({
           service,

--- a/apps/proxy/src/ingest-fingerprints.ts
+++ b/apps/proxy/src/ingest-fingerprints.ts
@@ -1,13 +1,19 @@
 import { createRequire } from "node:module";
 import { fingerprint, fingerprintLog } from "@superlog/fingerprint";
-import { metrics } from "@opentelemetry/api";
+import { type Counter, metrics } from "@opentelemetry/api";
 
 const ISSUE_FINGERPRINT_ATTRIBUTE = "superlog.issue_fingerprint";
 
-const meter = metrics.getMeter("@superlog/proxy/operational");
-const fingerprintStrippedCounter = meter.createCounter("superlog.proxy.fingerprint_stripped_total", {
-  description: "Total number of client-supplied superlog.issue_fingerprint attributes stripped.",
-});
+let fingerprintStrippedCounter: Counter | null = null;
+function getFingerprintStrippedCounter(): Counter {
+  if (!fingerprintStrippedCounter) {
+    const meter = metrics.getMeter("@superlog/proxy/operational");
+    fingerprintStrippedCounter = meter.createCounter("superlog.proxy.fingerprint_stripped_total", {
+      description: "Total number of client-supplied superlog.issue_fingerprint attributes stripped.",
+    });
+  }
+  return fingerprintStrippedCounter;
+}
 const require = createRequire(import.meta.url);
 const otlpRoot = require("@opentelemetry/otlp-transformer/build/esm/generated/root.js");
 const ExportTraceServiceRequest =
@@ -78,8 +84,9 @@ export function stampIssueFingerprintsFailOpen(
       );
     }
     if (stamped.strippedCount > 0) {
-      fingerprintStrippedCounter.add(stamped.strippedCount, {
+      getFingerprintStrippedCounter().add(stamped.strippedCount, {
         path: input.path,
+        projectId: input.projectId ?? "unknown",
       });
       logger.warn(
         {

--- a/apps/proxy/src/ingest-fingerprints.ts
+++ b/apps/proxy/src/ingest-fingerprints.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 import { fingerprint, fingerprintLog } from "@superlog/fingerprint";
 import { type Counter, metrics } from "@opentelemetry/api";
+import protobuf from "protobufjs";
 
 const ISSUE_FINGERPRINT_ATTRIBUTE = "superlog.issue_fingerprint";
 
@@ -18,6 +19,49 @@ const require = createRequire(import.meta.url);
 const otlpRoot = require("@opentelemetry/otlp-transformer/build/esm/generated/root.js");
 const ExportTraceServiceRequest =
   otlpRoot.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+
+const LOGS_PROTO = `
+syntax = "proto3";
+package otlplogs;
+message ExportLogsServiceRequest { repeated ResourceLogs resource_logs = 1; }
+message ResourceLogs { Resource resource = 1; repeated ScopeLogs scope_logs = 2; string schema_url = 3; }
+message Resource { repeated KeyValue attributes = 1; uint32 dropped_attributes_count = 2; }
+message ScopeLogs { InstrumentationScope scope = 1; repeated LogRecord log_records = 2; string schema_url = 3; }
+message InstrumentationScope { string name = 1; string version = 2; repeated KeyValue attributes = 3; uint32 dropped_attributes_count = 4; }
+message LogRecord {
+  fixed64 time_unix_nano = 1;
+  uint32 severity_number = 2;
+  string severity_text = 3;
+  AnyValue body = 5;
+  repeated KeyValue attributes = 6;
+  uint32 dropped_attributes_count = 7;
+  fixed32 flags = 8;
+  bytes trace_id = 9;
+  bytes span_id = 10;
+  fixed64 observed_time_unix_nano = 11;
+  string event_name = 12;
+}
+message KeyValue { string key = 1; AnyValue value = 2; }
+message AnyValue {
+  oneof value {
+    string string_value = 1;
+    bool bool_value = 2;
+    int64 int_value = 3;
+    double double_value = 4;
+    ArrayValue array_value = 5;
+    KeyValueList kvlist_value = 6;
+    bytes bytes_value = 7;
+  }
+}
+message ArrayValue { repeated AnyValue values = 1; }
+message KeyValueList { repeated KeyValue values = 1; }
+`;
+
+const ExportLogsServiceRequest = protobuf
+  .parse(LOGS_PROTO)
+  .root.lookupType("otlplogs.ExportLogsServiceRequest");
+
+const PROTO_TO_OBJECT_OPTS = { longs: String, enums: Number, defaults: false };
 
 type OtlpAnyValue = {
   stringValue?: string;
@@ -42,6 +86,7 @@ export type StampedIngestPayload = {
   body: Buffer;
   stampedCount: number;
   strippedCount: number;
+  stamped: boolean;
 };
 
 // Fingerprint stamping deserializes the whole body (JSON.parse / protobuf decode) and
@@ -56,7 +101,7 @@ export function stampIssueFingerprintsWithinLimit(
   maxBytes: number = MAX_FINGERPRINT_BODY_BYTES,
 ): StampedIngestPayload {
   if (input.body.byteLength > maxBytes)
-    return { body: input.body, stampedCount: 0, strippedCount: 0 };
+    return { body: input.body, stampedCount: 0, strippedCount: 0, stamped: false };
   return stampIssueFingerprints(input);
 }
 
@@ -73,7 +118,6 @@ export function stampIssueFingerprintsFailOpen(
 ): { body: Buffer; stamped: boolean } {
   try {
     const stamped = stampIssueFingerprintsWithinLimit(input);
-    const isStamped = !input.contentEncoding && input.body.byteLength <= MAX_FINGERPRINT_BODY_BYTES;
     if (stamped.stampedCount > 0) {
       logger.info(
         {
@@ -98,7 +142,7 @@ export function stampIssueFingerprintsFailOpen(
         "stripped client-supplied superlog.issue_fingerprint attributes on ingest payload",
       );
     }
-    return { body: stamped.body, stamped: isStamped };
+    return { body: stamped.body, stamped: stamped.stamped };
   } catch (err) {
     logger.warn(
       {
@@ -114,18 +158,25 @@ export function stampIssueFingerprintsFailOpen(
 }
 
 export function stampIssueFingerprints(input: StampInput): StampedIngestPayload {
-  if (input.contentEncoding) return { body: input.body, stampedCount: 0, strippedCount: 0 };
+  if (input.contentEncoding) return { body: input.body, stampedCount: 0, strippedCount: 0, stamped: false };
 
   if (input.path === "/v1/traces" && isJsonContentType(input.contentType)) {
-    return stampJsonTraceFingerprints(input.body);
+    const res = stampJsonTraceFingerprints(input.body);
+    return { ...res, stamped: true };
   }
   if (input.path === "/v1/traces" && isProtobufContentType(input.contentType)) {
-    return stampProtobufTraceFingerprints(input.body);
+    const res = stampProtobufTraceFingerprints(input.body);
+    return { ...res, stamped: true };
   }
   if (input.path === "/v1/logs" && isJsonContentType(input.contentType)) {
-    return stampJsonLogFingerprints(input.body);
+    const res = stampJsonLogFingerprints(input.body);
+    return { ...res, stamped: true };
   }
-  return { body: input.body, stampedCount: 0, strippedCount: 0 };
+  if (input.path === "/v1/logs" && isProtobufContentType(input.contentType)) {
+    const res = stampProtobufLogFingerprints(input.body);
+    return { ...res, stamped: true };
+  }
+  return { body: input.body, stampedCount: 0, strippedCount: 0, stamped: false };
 }
 
 function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
@@ -279,6 +330,57 @@ function stampJsonLogFingerprints(body: Buffer): StampedIngestPayload {
   if (stampedCount === 0 && strippedCount === 0)
     return { body, stampedCount: 0, strippedCount: 0 };
   return { body: Buffer.from(JSON.stringify(payload)), stampedCount, strippedCount };
+}
+
+function stampProtobufLogFingerprints(body: Buffer): { body: Buffer; stampedCount: number; strippedCount: number } {
+  const decoded = ExportLogsServiceRequest.decode(body);
+  const payload = ExportLogsServiceRequest.toObject(decoded, PROTO_TO_OBJECT_OPTS) as {
+    resourceLogs?: Array<{
+      resource?: { attributes?: OtlpKeyValue[] };
+      scopeLogs?: Array<{
+        logRecords?: Array<{
+          severityText?: string;
+          severityNumber?: number;
+          body?: OtlpAnyValue;
+          attributes?: OtlpKeyValue[];
+        }>;
+      }>;
+    }>;
+  };
+
+  let stampedCount = 0;
+  let strippedCount = 0;
+  for (const resourceLog of payload.resourceLogs ?? []) {
+    const service =
+      stringAttribute(resourceLog.resource?.attributes ?? [], "service.name") || "unknown";
+    for (const scopeLog of resourceLog.scopeLogs ?? []) {
+      for (const logRecord of scopeLog.logRecords ?? []) {
+        const before = logRecord.attributes ?? [];
+        const after = before.filter((a) => a.key !== ISSUE_FINGERPRINT_ATTRIBUTE);
+        if (after.length !== before.length) strippedCount += 1;
+        logRecord.attributes = after;
+        const attrs = logRecord.attributes;
+        if (!isErrorLog(logRecord.severityNumber, logRecord.severityText, attrs)) continue;
+        const fp = fingerprintLog({
+          service,
+          severity: logRecord.severityText || String(logRecord.severityNumber ?? ""),
+          body: stringValue(logRecord.body) ?? "",
+          exceptionType: stringAttribute(attrs, "exception.type"),
+          stacktrace: stringAttribute(attrs, "exception.stacktrace"),
+        });
+        logRecord.attributes = setStringAttribute(attrs, ISSUE_FINGERPRINT_ATTRIBUTE, fp.hash);
+        stampedCount += 1;
+      }
+    }
+  }
+
+  if (stampedCount === 0 && strippedCount === 0)
+    return { body, stampedCount: 0, strippedCount: 0 };
+  return {
+    body: Buffer.from(ExportLogsServiceRequest.encode(payload).finish()),
+    stampedCount,
+    strippedCount,
+  };
 }
 
 function isJsonContentType(contentType: string): boolean {

--- a/apps/proxy/src/ingest-fingerprints.ts
+++ b/apps/proxy/src/ingest-fingerprints.ts
@@ -29,6 +29,7 @@ type StampInput = {
 export type StampedIngestPayload = {
   body: Buffer;
   stampedCount: number;
+  strippedCount: number;
 };
 
 // Fingerprint stamping deserializes the whole body (JSON.parse / protobuf decode) and
@@ -42,7 +43,8 @@ export function stampIssueFingerprintsWithinLimit(
   input: StampInput,
   maxBytes: number = MAX_FINGERPRINT_BODY_BYTES,
 ): StampedIngestPayload {
-  if (input.body.byteLength > maxBytes) return { body: input.body, stampedCount: 0 };
+  if (input.body.byteLength > maxBytes)
+    return { body: input.body, stampedCount: 0, strippedCount: 0 };
   return stampIssueFingerprints(input);
 }
 
@@ -65,6 +67,12 @@ export function stampIssueFingerprintsFailOpen(
         "stamped issue fingerprints on ingest payload",
       );
     }
+    if (stamped.strippedCount > 0) {
+      logger.warn(
+        { path: input.path, projectId: input.projectId, strippedCount: stamped.strippedCount },
+        "stripped client-supplied superlog.issue_fingerprint attributes on ingest payload",
+      );
+    }
     return stamped.body;
   } catch (err) {
     logger.warn(
@@ -76,7 +84,7 @@ export function stampIssueFingerprintsFailOpen(
 }
 
 export function stampIssueFingerprints(input: StampInput): StampedIngestPayload {
-  if (input.contentEncoding) return { body: input.body, stampedCount: 0 };
+  if (input.contentEncoding) return { body: input.body, stampedCount: 0, strippedCount: 0 };
 
   if (input.path === "/v1/traces" && isJsonContentType(input.contentType)) {
     return stampJsonTraceFingerprints(input.body);
@@ -87,7 +95,7 @@ export function stampIssueFingerprints(input: StampInput): StampedIngestPayload 
   if (input.path === "/v1/logs" && isJsonContentType(input.contentType)) {
     return stampJsonLogFingerprints(input.body);
   }
-  return { body: input.body, stampedCount: 0 };
+  return { body: input.body, stampedCount: 0, strippedCount: 0 };
 }
 
 function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
@@ -135,8 +143,9 @@ function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
   // Re-serialize if anything changed — stripping alone mutates the parsed
   // object in memory but the caller receives the original Buffer unless we
   // re-encode here.
-  if (stampedCount === 0 && strippedCount === 0) return { body, stampedCount };
-  return { body: Buffer.from(JSON.stringify(payload)), stampedCount };
+  if (stampedCount === 0 && strippedCount === 0)
+    return { body, stampedCount: 0, strippedCount: 0 };
+  return { body: Buffer.from(JSON.stringify(payload)), stampedCount, strippedCount };
 }
 
 function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
@@ -182,8 +191,13 @@ function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
   // Re-serialize if anything changed — stripping alone mutates the parsed
   // object in memory but the caller receives the original Buffer unless we
   // re-encode here.
-  if (stampedCount === 0 && strippedCount === 0) return { body, stampedCount };
-  return { body: Buffer.from(ExportTraceServiceRequest.encode(payload).finish()), stampedCount };
+  if (stampedCount === 0 && strippedCount === 0)
+    return { body, stampedCount: 0, strippedCount: 0 };
+  return {
+    body: Buffer.from(ExportTraceServiceRequest.encode(payload).finish()),
+    stampedCount,
+    strippedCount,
+  };
 }
 
 function stampJsonLogFingerprints(body: Buffer): StampedIngestPayload {
@@ -232,8 +246,9 @@ function stampJsonLogFingerprints(body: Buffer): StampedIngestPayload {
   // Re-serialize if anything changed — stripping alone mutates the parsed
   // object in memory but the caller receives the original Buffer unless we
   // re-encode here.
-  if (stampedCount === 0 && strippedCount === 0) return { body, stampedCount };
-  return { body: Buffer.from(JSON.stringify(payload)), stampedCount };
+  if (stampedCount === 0 && strippedCount === 0)
+    return { body, stampedCount: 0, strippedCount: 0 };
+  return { body: Buffer.from(JSON.stringify(payload)), stampedCount, strippedCount };
 }
 
 function isJsonContentType(contentType: string): boolean {

--- a/apps/proxy/src/ingest-fingerprints.ts
+++ b/apps/proxy/src/ingest-fingerprints.ts
@@ -5,14 +5,12 @@ import protobuf from "protobufjs";
 
 const ISSUE_FINGERPRINT_ATTRIBUTE = "superlog.issue_fingerprint";
 
-let fingerprintStrippedCounter: Counter | null = null;
+const meter = metrics.getMeter("@superlog/proxy/operational");
+export const fingerprintStrippedCounter = meter.createCounter("superlog.proxy.fingerprint_stripped_total", {
+  description: "Total number of client-supplied superlog.issue_fingerprint attributes stripped.",
+});
+
 export function getFingerprintStrippedCounter(): Counter {
-  if (!fingerprintStrippedCounter) {
-    const meter = metrics.getMeter("@superlog/proxy/operational");
-    fingerprintStrippedCounter = meter.createCounter("superlog.proxy.fingerprint_stripped_total", {
-      description: "Total number of client-supplied superlog.issue_fingerprint attributes stripped.",
-    });
-  }
   return fingerprintStrippedCounter;
 }
 const require = createRequire(import.meta.url);
@@ -150,6 +148,7 @@ export function stampIssueFingerprintsFailOpen(
         path: input.path,
         projectId: input.projectId ?? "unknown",
         contentType: input.contentType,
+        bodyBytes: input.body.byteLength,
       },
       "failed to stamp issue fingerprints on ingest payload",
     );

--- a/apps/proxy/src/ingest-fingerprints.ts
+++ b/apps/proxy/src/ingest-fingerprints.ts
@@ -5,7 +5,7 @@ import { type Counter, metrics } from "@opentelemetry/api";
 const ISSUE_FINGERPRINT_ATTRIBUTE = "superlog.issue_fingerprint";
 
 let fingerprintStrippedCounter: Counter | null = null;
-function getFingerprintStrippedCounter(): Counter {
+export function getFingerprintStrippedCounter(): Counter {
   if (!fingerprintStrippedCounter) {
     const meter = metrics.getMeter("@superlog/proxy/operational");
     fingerprintStrippedCounter = meter.createCounter("superlog.proxy.fingerprint_stripped_total", {
@@ -70,9 +70,10 @@ export interface FingerprintLogger {
 export function stampIssueFingerprintsFailOpen(
   input: StampInput & { projectId: string },
   logger: FingerprintLogger,
-): Buffer {
+): { body: Buffer; stamped: boolean } {
   try {
     const stamped = stampIssueFingerprintsWithinLimit(input);
+    const isStamped = !input.contentEncoding && input.body.byteLength <= MAX_FINGERPRINT_BODY_BYTES;
     if (stamped.stampedCount > 0) {
       logger.info(
         {
@@ -97,7 +98,7 @@ export function stampIssueFingerprintsFailOpen(
         "stripped client-supplied superlog.issue_fingerprint attributes on ingest payload",
       );
     }
-    return stamped.body;
+    return { body: stamped.body, stamped: isStamped };
   } catch (err) {
     logger.warn(
       {
@@ -108,7 +109,7 @@ export function stampIssueFingerprintsFailOpen(
       },
       "failed to stamp issue fingerprints on ingest payload",
     );
-    return input.body;
+    return { body: input.body, stamped: false };
   }
 }
 

--- a/apps/proxy/src/ingest-queue.ts
+++ b/apps/proxy/src/ingest-queue.ts
@@ -832,7 +832,7 @@ export class IngestQueue {
         }
         if (decoded) {
           await this.rowWriter.insert(decoded.table, decoded.rows);
-          if (decoded.strippedCount > 0) {
+          if (!stamped && decoded.strippedCount > 0) {
             getFingerprintStrippedCounter().add(decoded.strippedCount, {
               path: parsed.path,
               projectId: parsed.projectId ?? "unknown",
@@ -843,7 +843,7 @@ export class IngestQueue {
                 projectId: parsed.projectId ?? "unknown",
                 strippedCount: decoded.strippedCount,
               },
-              "stripped client-supplied superlog.* attributes on direct-write payload",
+              "stripped client-supplied superlog.issue_fingerprint attributes on direct-write payload",
             );
           }
           proxyOperationalRecorder.recordQueueDelivery({

--- a/apps/proxy/src/ingest-queue.ts
+++ b/apps/proxy/src/ingest-queue.ts
@@ -21,7 +21,7 @@ import { Upload } from "@aws-sdk/lib-storage";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
 import { type SpillSink, captureBody } from "./body-capture.js";
 import type { IngestRowWriter } from "./clickhouse-writer.js";
-import { stampIssueFingerprintsFailOpen } from "./ingest-fingerprints.js";
+import { getFingerprintStrippedCounter, stampIssueFingerprintsFailOpen } from "./ingest-fingerprints.js";
 import { proxyOperationalRecorder } from "./operational-metrics.js";
 import { type DecodedRows, decodeOtlpToRows } from "./otlp-decode.js";
 
@@ -793,7 +793,7 @@ export class IngestQueue {
       // Stamp issue fingerprints here, off the proxy's ingest hot path. This deserializes
       // the payload (size-guarded + fail-open inside the helper); a slow/OOM here only
       // redelivers an SQS message rather than 502-ing live ingest traffic.
-      const body = stampIssueFingerprintsFailOpen(
+      const { body, stamped } = stampIssueFingerprintsFailOpen(
         {
           path: parsed.path,
           contentType: parsed.contentType,
@@ -822,6 +822,7 @@ export class IngestQueue {
             contentType: parsed.contentType,
             contentEncoding: parsed.contentEncoding,
             body,
+            stamped,
           });
         } catch (decodeErr) {
           this.logger.warn(
@@ -831,6 +832,20 @@ export class IngestQueue {
         }
         if (decoded) {
           await this.rowWriter.insert(decoded.table, decoded.rows);
+          if (decoded.strippedCount > 0) {
+            getFingerprintStrippedCounter().add(decoded.strippedCount, {
+              path: parsed.path,
+              projectId: parsed.projectId ?? "unknown",
+            });
+            this.logger.warn(
+              {
+                path: parsed.path,
+                projectId: parsed.projectId ?? "unknown",
+                strippedCount: decoded.strippedCount,
+              },
+              "stripped client-supplied superlog.* attributes on direct-write payload",
+            );
+          }
           proxyOperationalRecorder.recordQueueDelivery({
             path: parsed.path,
             projectId: parsed.projectId,

--- a/apps/proxy/src/otlp-clickhouse.test.ts
+++ b/apps/proxy/src/otlp-clickhouse.test.ts
@@ -77,7 +77,7 @@ test("otlpLogsToRows maps one row per log record with collector-compatible colum
   assert.equal(r.Timestamp, "2024-06-10 06:13:20.123456789");
 });
 
-test("otlpLogsToRows strips superlog.* from resource attrs and stamps the real project id", () => {
+test("otlpLogsToRows strips untrusted superlog.* but preserves proxy-stamped issue_fingerprint", () => {
   const rows = otlpLogsToRows(logsExport, "proj-123");
   assert.equal(rows[0]!.ResourceAttributes["superlog.project_id"], "proj-123");
   assert.equal(rows[0]!.ResourceAttributes["service.name"], "checkout");
@@ -85,13 +85,11 @@ test("otlpLogsToRows strips superlog.* from resource attrs and stamps the real p
   // no stray superlog.* keys other than the stamped project id
   const superlogKeys = Object.keys(rows[0]!.ResourceAttributes).filter((k) => k.startsWith("superlog."));
   assert.deepEqual(superlogKeys, ["superlog.project_id"]);
-  // superlog.* is stripped from log record attributes too (matches the collector's
-  // transform/strip_superlog on log.attributes); project id lives only on resource attrs.
-  assert.equal(rows[0]!.LogAttributes["superlog.issue_fingerprint"], undefined);
-  assert.equal(
-    Object.keys(rows[0]!.LogAttributes).some((k) => k.startsWith("superlog.")),
-    false,
-  );
+  // superlog.issue_fingerprint is proxy-authored and MUST survive so the
+  // issue-activity materialized views can match it (regression for #285).
+  assert.equal(rows[0]!.LogAttributes["superlog.issue_fingerprint"], "deadbeef");
+  // other log attributes are unaffected
+  assert.equal(rows[0]!.LogAttributes["http.status"], "500");
 });
 
 test("otlpLogsToRows stringifies log attribute values like the collector Map(String,String)", () => {
@@ -192,13 +190,13 @@ test("otlpTracesToRows maps spans with collector-compatible columns", () => {
   assert.equal(r.Timestamp, "2024-06-10 06:13:20.000000000");
 });
 
-test("otlpTracesToRows strips superlog.* from resource and span attrs, stamps project id", () => {
+test("otlpTracesToRows strips untrusted superlog.* from resource and span attrs, preserves issue_fingerprint", () => {
   const r = otlpTracesToRows(tracesExport, "proj-xyz")[0]!;
   assert.equal(r.ResourceAttributes["superlog.project_id"], "proj-xyz");
   assert.equal(r.ResourceAttributes["service.name"], "api");
   assert.equal(r.SpanAttributes["http.method"], "GET");
-  // span-level superlog.* stripped (matches collector transform/strip_superlog)
-  assert.equal(r.SpanAttributes["superlog.issue_fingerprint"], undefined);
+  // proxy-stamped issue_fingerprint is preserved on span attrs (regression #285)
+  assert.equal(r.SpanAttributes["superlog.issue_fingerprint"], "deadbeef");
 });
 
 test("otlpTracesToRows flattens events and links into parallel arrays", () => {
@@ -212,4 +210,111 @@ test("otlpTracesToRows flattens events and links into parallel arrays", () => {
 
 test("otlpTracesToRows tolerates an empty export", () => {
   assert.deepEqual(otlpTracesToRows({}, "p"), []);
+});
+
+// ── Regression tests for #285 ────────────────────────────────────────────────
+// The proxy stamps superlog.issue_fingerprint as authoritative data before
+// selecting a delivery branch. Neither the direct-ClickHouse mapper nor the
+// collector pipeline should strip it; the issue-activity materialized views
+// require it to be present on both logs and trace events.
+
+test("regression #285: issue_fingerprint survives direct-ClickHouse mapping for logs", () => {
+  const fp = { key: "superlog.issue_fingerprint", value: { stringValue: "fp16" } };
+  const control = { key: "exception.type", value: { stringValue: "Error" } };
+  const rows = otlpLogsToRows(
+    {
+      resourceLogs: [
+        {
+          scopeLogs: [
+            {
+              logRecords: [
+                { timeUnixNano: "1000000000", severityNumber: 17, attributes: [control, fp] },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    "p",
+  );
+  // Fingerprint must reach ClickHouse so the log activity view admits the row.
+  assert.equal(
+    rows[0]!.LogAttributes["superlog.issue_fingerprint"],
+    "fp16",
+    "issue_fingerprint must be preserved in LogAttributes",
+  );
+  // Neighbouring control attribute must also survive (non-regression).
+  assert.equal(rows[0]!.LogAttributes["exception.type"], "Error");
+});
+
+test("regression #285: issue_fingerprint survives direct-ClickHouse mapping for trace events", () => {
+  const fp = { key: "superlog.issue_fingerprint", value: { stringValue: "fp16" } };
+  const control = { key: "exception.type", value: { stringValue: "Error" } };
+  const rows = otlpTracesToRows(
+    {
+      resourceSpans: [
+        {
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  startTimeUnixNano: "1000000000",
+                  endTimeUnixNano: "2000000000",
+                  events: [{ name: "exception", timeUnixNano: "1000000000", attributes: [control, fp] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    "p",
+  );
+  // Fingerprint must reach ClickHouse so the trace activity view admits the row.
+  assert.equal(
+    rows[0]!["Events.Attributes"][0]!["superlog.issue_fingerprint"],
+    "fp16",
+    "issue_fingerprint must be preserved in Events.Attributes",
+  );
+  // Neighbouring control attribute must also survive (non-regression).
+  assert.equal(rows[0]!["Events.Attributes"][0]!["exception.type"], "Error");
+});
+
+test("control #285: ordinary (non-superlog) attributes are unaffected", () => {
+  const attrs = [
+    { key: "exception.type", value: { stringValue: "Error" } },
+    { key: "user.id", value: { stringValue: "u1" } },
+  ];
+  const logRows = otlpLogsToRows(
+    {
+      resourceLogs: [
+        { scopeLogs: [{ logRecords: [{ timeUnixNano: "1000000000", severityNumber: 17, attributes: attrs }] }] },
+      ],
+    },
+    "p",
+  );
+  const traceRows = otlpTracesToRows(
+    {
+      resourceSpans: [
+        {
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  startTimeUnixNano: "1000000000",
+                  endTimeUnixNano: "2000000000",
+                  events: [{ name: "exception", timeUnixNano: "1000000000", attributes: attrs }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    "p",
+  );
+  assert.equal(logRows[0]!.LogAttributes["exception.type"], "Error");
+  assert.equal(logRows[0]!.LogAttributes["user.id"], "u1");
+  assert.equal(traceRows[0]!["Events.Attributes"][0]!["exception.type"], "Error");
+  assert.equal(traceRows[0]!["Events.Attributes"][0]!["user.id"], "u1");
 });

--- a/apps/proxy/src/otlp-clickhouse.test.ts
+++ b/apps/proxy/src/otlp-clickhouse.test.ts
@@ -195,8 +195,8 @@ test("otlpTracesToRows strips untrusted superlog.* from resource and span attrs,
   assert.equal(r.ResourceAttributes["superlog.project_id"], "proj-xyz");
   assert.equal(r.ResourceAttributes["service.name"], "api");
   assert.equal(r.SpanAttributes["http.method"], "GET");
-  // proxy-stamped issue_fingerprint is preserved on span attrs (regression #285)
-  assert.equal(r.SpanAttributes["superlog.issue_fingerprint"], "deadbeef");
+  // client-supplied issue_fingerprint on span attributes is stripped unconditionally
+  assert.equal(r.SpanAttributes["superlog.issue_fingerprint"], undefined);
 });
 
 test("otlpTracesToRows flattens events and links into parallel arrays", () => {

--- a/apps/proxy/src/otlp-clickhouse.test.ts
+++ b/apps/proxy/src/otlp-clickhouse.test.ts
@@ -78,7 +78,7 @@ test("otlpLogsToRows maps one row per log record with collector-compatible colum
 });
 
 test("otlpLogsToRows strips untrusted superlog.* but preserves proxy-stamped issue_fingerprint", () => {
-  const rows = otlpLogsToRows(logsExport, "proj-123");
+  const rows = otlpLogsToRows(logsExport, "proj-123", true);
   assert.equal(rows[0]!.ResourceAttributes["superlog.project_id"], "proj-123");
   assert.equal(rows[0]!.ResourceAttributes["service.name"], "checkout");
   assert.equal(rows[0]!.ResourceAttributes["service.version"], "1.2.3");
@@ -191,7 +191,7 @@ test("otlpTracesToRows maps spans with collector-compatible columns", () => {
 });
 
 test("otlpTracesToRows strips untrusted superlog.* from resource and span attrs, preserves issue_fingerprint", () => {
-  const r = otlpTracesToRows(tracesExport, "proj-xyz")[0]!;
+  const r = otlpTracesToRows(tracesExport, "proj-xyz", true)[0]!;
   assert.equal(r.ResourceAttributes["superlog.project_id"], "proj-xyz");
   assert.equal(r.ResourceAttributes["service.name"], "api");
   assert.equal(r.SpanAttributes["http.method"], "GET");
@@ -236,6 +236,7 @@ test("regression #285: issue_fingerprint survives direct-ClickHouse mapping for 
       ],
     },
     "p",
+    true,
   );
   // Fingerprint must reach ClickHouse so the log activity view admits the row.
   assert.equal(
@@ -269,6 +270,7 @@ test("regression #285: issue_fingerprint survives direct-ClickHouse mapping for 
       ],
     },
     "p",
+    true,
   );
   // Fingerprint must reach ClickHouse so the trace activity view admits the row.
   assert.equal(
@@ -317,4 +319,62 @@ test("control #285: ordinary (non-superlog) attributes are unaffected", () => {
   assert.equal(logRows[0]!.LogAttributes["user.id"], "u1");
   assert.equal(traceRows[0]!["Events.Attributes"][0]!["exception.type"], "Error");
   assert.equal(traceRows[0]!["Events.Attributes"][0]!["user.id"], "u1");
+});
+
+test("otlpLogsToRows strips issue_fingerprint when stamped is false", () => {
+  const fp = { key: "superlog.issue_fingerprint", value: { stringValue: "fp16" } };
+  const control = { key: "exception.type", value: { stringValue: "Error" } };
+  const tracker = { strippedCount: 0 };
+  const rows = otlpLogsToRows(
+    {
+      resourceLogs: [
+        {
+          scopeLogs: [
+            {
+              logRecords: [
+                { timeUnixNano: "1000000000", severityNumber: 17, attributes: [control, fp] },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    "p",
+    false,
+    tracker,
+  );
+  assert.equal(rows[0]!.LogAttributes["superlog.issue_fingerprint"], undefined);
+  assert.equal(rows[0]!.LogAttributes["exception.type"], "Error");
+  assert.equal(tracker.strippedCount, 1);
+});
+
+test("otlpTracesToRows strips issue_fingerprint when stamped is false", () => {
+  const fp = { key: "superlog.issue_fingerprint", value: { stringValue: "fp16" } };
+  const control = { key: "exception.type", value: { stringValue: "Error" } };
+  const tracker = { strippedCount: 0 };
+  const rows = otlpTracesToRows(
+    {
+      resourceSpans: [
+        {
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  startTimeUnixNano: "1000000000",
+                  endTimeUnixNano: "2000000000",
+                  events: [{ name: "exception", timeUnixNano: "1000000000", attributes: [control, fp] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    "p",
+    false,
+    tracker,
+  );
+  assert.equal(rows[0]!["Events.Attributes"][0]!["superlog.issue_fingerprint"], undefined);
+  assert.equal(rows[0]!["Events.Attributes"][0]!["exception.type"], "Error");
+  assert.equal(tracker.strippedCount, 1);
 });

--- a/apps/proxy/src/otlp-clickhouse.ts
+++ b/apps/proxy/src/otlp-clickhouse.ts
@@ -229,7 +229,7 @@ export function otlpTracesToRows(
           ResourceAttributes: resourceAttributes,
           ScopeName: scopeName,
           ScopeVersion: scopeVersion,
-          SpanAttributes: stripUntrustedSuperlog(kvListToMap(span.attributes), stamped, tracker),
+          SpanAttributes: stripAllSuperlog(kvListToMap(span.attributes), tracker),
           Duration: (end > start ? end - start : 0n).toString(),
           StatusCode: STATUS_CODES[span.status?.code ?? 0] ?? "Unset",
           StatusMessage: span.status?.message ?? "",
@@ -276,7 +276,9 @@ function stripAllSuperlog(
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(map)) {
     if (k.startsWith("superlog.")) {
-      if (tracker) tracker.strippedCount += 1;
+      if (k === ISSUE_FINGERPRINT_KEY && tracker) {
+        tracker.strippedCount += 1;
+      }
       continue;
     }
     out[k] = v;
@@ -299,7 +301,9 @@ function stripUntrustedSuperlog(
       if (stamped && PRESERVED_SUPERLOG_KEYS.has(k)) {
         out[k] = v;
       } else {
-        if (tracker) tracker.strippedCount += 1;
+        if (k === ISSUE_FINGERPRINT_KEY && tracker) {
+          tracker.strippedCount += 1;
+        }
       }
       continue;
     }

--- a/apps/proxy/src/otlp-clickhouse.ts
+++ b/apps/proxy/src/otlp-clickhouse.ts
@@ -78,14 +78,20 @@ export type OtelLogRow = {
 };
 
 const SUPERLOG_PROJECT_ID_KEY = "superlog.project_id";
+const ISSUE_FINGERPRINT_KEY = "superlog.issue_fingerprint";
 const NANOS_PER_SECOND = 1_000_000_000n;
+
+// Keys in the superlog.* namespace that are proxy-authored and must be
+// preserved through the ClickHouse mapper. All other superlog.* keys are
+// client-supplied and must be stripped to prevent tenant spoofing.
+const PRESERVED_SUPERLOG_KEYS = new Set([ISSUE_FINGERPRINT_KEY]);
 
 export function otlpLogsToRows(payload: OtlpLogsExport, projectId: string): OtelLogRow[] {
   const rows: OtelLogRow[] = [];
   for (const rl of payload.resourceLogs ?? []) {
     const resourceMap = kvListToMap(rl.resource?.attributes);
     const serviceName = resourceMap["service.name"] ?? "";
-    const resourceAttributes = stripSuperlog(resourceMap);
+    const resourceAttributes = stripAllSuperlog(resourceMap);
     resourceAttributes[SUPERLOG_PROJECT_ID_KEY] = projectId;
     const resourceSchemaUrl = rl.schemaUrl ?? "";
 
@@ -111,7 +117,7 @@ export function otlpLogsToRows(payload: OtlpLogsExport, projectId: string): Otel
           ScopeName: scopeName,
           ScopeVersion: scopeVersion,
           ScopeAttributes: scopeAttributes,
-          LogAttributes: stripSuperlog(kvListToMap(lr.attributes)),
+          LogAttributes: stripUntrustedSuperlog(kvListToMap(lr.attributes)),
           EventName: lr.eventName ?? "",
         });
       }
@@ -189,7 +195,7 @@ export function otlpTracesToRows(payload: OtlpTracesExport, projectId: string): 
   for (const rs of payload.resourceSpans ?? []) {
     const resourceMap = kvListToMap(rs.resource?.attributes);
     const serviceName = resourceMap["service.name"] ?? "";
-    const resourceAttributes = stripSuperlog(resourceMap);
+    const resourceAttributes = stripAllSuperlog(resourceMap);
     resourceAttributes[SUPERLOG_PROJECT_ID_KEY] = projectId;
 
     for (const ss of rs.scopeSpans ?? []) {
@@ -213,17 +219,17 @@ export function otlpTracesToRows(payload: OtlpTracesExport, projectId: string): 
           ResourceAttributes: resourceAttributes,
           ScopeName: scopeName,
           ScopeVersion: scopeVersion,
-          SpanAttributes: stripSuperlog(kvListToMap(span.attributes)),
+          SpanAttributes: stripUntrustedSuperlog(kvListToMap(span.attributes)),
           Duration: (end > start ? end - start : 0n).toString(),
           StatusCode: STATUS_CODES[span.status?.code ?? 0] ?? "Unset",
           StatusMessage: span.status?.message ?? "",
           "Events.Timestamp": events.map((e) => nanosToClickHouseDateTime64(e.timeUnixNano ?? 0)),
           "Events.Name": events.map((e) => e.name ?? ""),
-          "Events.Attributes": events.map((e) => stripSuperlog(kvListToMap(e.attributes))),
+          "Events.Attributes": events.map((e) => stripUntrustedSuperlog(kvListToMap(e.attributes))),
           "Links.TraceId": links.map((l) => toHex(l.traceId)),
           "Links.SpanId": links.map((l) => toHex(l.spanId)),
           "Links.TraceState": links.map((l) => l.traceState ?? ""),
-          "Links.Attributes": links.map((l) => stripSuperlog(kvListToMap(l.attributes))),
+          "Links.Attributes": links.map((l) => stripAllSuperlog(kvListToMap(l.attributes))),
         });
       }
     }
@@ -248,10 +254,26 @@ function kvListToMap(attrs: OtlpKeyValue[] | undefined): Record<string, string> 
   return out;
 }
 
-function stripSuperlog(map: Record<string, string>): Record<string, string> {
+// Strips ALL superlog.* attributes unconditionally. Used only for resource
+// attributes, where the proxy never stamps issue_fingerprint — only
+// superlog.project_id is re-added afterwards from the request context.
+function stripAllSuperlog(map: Record<string, string>): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(map)) {
     if (k.startsWith("superlog.")) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+// Strips client-supplied superlog.* attributes while preserving proxy-authored
+// keys (currently superlog.issue_fingerprint). Clients must not be able to
+// spoof reserved namespace attributes; the proxy is the sole authoritative
+// source and stamps its own keys after sanitisation.
+function stripUntrustedSuperlog(map: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(map)) {
+    if (k.startsWith("superlog.") && !PRESERVED_SUPERLOG_KEYS.has(k)) continue;
     out[k] = v;
   }
   return out;

--- a/apps/proxy/src/otlp-clickhouse.ts
+++ b/apps/proxy/src/otlp-clickhouse.ts
@@ -86,12 +86,17 @@ const NANOS_PER_SECOND = 1_000_000_000n;
 // client-supplied and must be stripped to prevent tenant spoofing.
 const PRESERVED_SUPERLOG_KEYS = new Set([ISSUE_FINGERPRINT_KEY]);
 
-export function otlpLogsToRows(payload: OtlpLogsExport, projectId: string): OtelLogRow[] {
+export function otlpLogsToRows(
+  payload: OtlpLogsExport,
+  projectId: string,
+  stamped = false,
+  tracker?: { strippedCount: number },
+): OtelLogRow[] {
   const rows: OtelLogRow[] = [];
   for (const rl of payload.resourceLogs ?? []) {
     const resourceMap = kvListToMap(rl.resource?.attributes);
     const serviceName = resourceMap["service.name"] ?? "";
-    const resourceAttributes = stripAllSuperlog(resourceMap);
+    const resourceAttributes = stripAllSuperlog(resourceMap, tracker);
     resourceAttributes[SUPERLOG_PROJECT_ID_KEY] = projectId;
     const resourceSchemaUrl = rl.schemaUrl ?? "";
 
@@ -117,7 +122,7 @@ export function otlpLogsToRows(payload: OtlpLogsExport, projectId: string): Otel
           ScopeName: scopeName,
           ScopeVersion: scopeVersion,
           ScopeAttributes: scopeAttributes,
-          LogAttributes: stripUntrustedSuperlog(kvListToMap(lr.attributes)),
+          LogAttributes: stripUntrustedSuperlog(kvListToMap(lr.attributes), stamped, tracker),
           EventName: lr.eventName ?? "",
         });
       }
@@ -190,12 +195,17 @@ export type OtelTraceRow = {
 const SPAN_KINDS = ["Unspecified", "Internal", "Server", "Client", "Producer", "Consumer"];
 const STATUS_CODES = ["Unset", "Ok", "Error"];
 
-export function otlpTracesToRows(payload: OtlpTracesExport, projectId: string): OtelTraceRow[] {
+export function otlpTracesToRows(
+  payload: OtlpTracesExport,
+  projectId: string,
+  stamped = false,
+  tracker?: { strippedCount: number },
+): OtelTraceRow[] {
   const rows: OtelTraceRow[] = [];
   for (const rs of payload.resourceSpans ?? []) {
     const resourceMap = kvListToMap(rs.resource?.attributes);
     const serviceName = resourceMap["service.name"] ?? "";
-    const resourceAttributes = stripAllSuperlog(resourceMap);
+    const resourceAttributes = stripAllSuperlog(resourceMap, tracker);
     resourceAttributes[SUPERLOG_PROJECT_ID_KEY] = projectId;
 
     for (const ss of rs.scopeSpans ?? []) {
@@ -219,17 +229,19 @@ export function otlpTracesToRows(payload: OtlpTracesExport, projectId: string): 
           ResourceAttributes: resourceAttributes,
           ScopeName: scopeName,
           ScopeVersion: scopeVersion,
-          SpanAttributes: stripUntrustedSuperlog(kvListToMap(span.attributes)),
+          SpanAttributes: stripUntrustedSuperlog(kvListToMap(span.attributes), stamped, tracker),
           Duration: (end > start ? end - start : 0n).toString(),
           StatusCode: STATUS_CODES[span.status?.code ?? 0] ?? "Unset",
           StatusMessage: span.status?.message ?? "",
           "Events.Timestamp": events.map((e) => nanosToClickHouseDateTime64(e.timeUnixNano ?? 0)),
           "Events.Name": events.map((e) => e.name ?? ""),
-          "Events.Attributes": events.map((e) => stripUntrustedSuperlog(kvListToMap(e.attributes))),
+          "Events.Attributes": events.map((e) =>
+            stripUntrustedSuperlog(kvListToMap(e.attributes), stamped, tracker),
+          ),
           "Links.TraceId": links.map((l) => toHex(l.traceId)),
           "Links.SpanId": links.map((l) => toHex(l.spanId)),
           "Links.TraceState": links.map((l) => l.traceState ?? ""),
-          "Links.Attributes": links.map((l) => stripAllSuperlog(kvListToMap(l.attributes))),
+          "Links.Attributes": links.map((l) => stripAllSuperlog(kvListToMap(l.attributes), tracker)),
         });
       }
     }
@@ -257,10 +269,16 @@ function kvListToMap(attrs: OtlpKeyValue[] | undefined): Record<string, string> 
 // Strips ALL superlog.* attributes unconditionally. Used only for resource
 // attributes, where the proxy never stamps issue_fingerprint — only
 // superlog.project_id is re-added afterwards from the request context.
-function stripAllSuperlog(map: Record<string, string>): Record<string, string> {
+function stripAllSuperlog(
+  map: Record<string, string>,
+  tracker?: { strippedCount: number },
+): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(map)) {
-    if (k.startsWith("superlog.")) continue;
+    if (k.startsWith("superlog.")) {
+      if (tracker) tracker.strippedCount += 1;
+      continue;
+    }
     out[k] = v;
   }
   return out;
@@ -270,10 +288,21 @@ function stripAllSuperlog(map: Record<string, string>): Record<string, string> {
 // keys (currently superlog.issue_fingerprint). Clients must not be able to
 // spoof reserved namespace attributes; the proxy is the sole authoritative
 // source and stamps its own keys after sanitisation.
-function stripUntrustedSuperlog(map: Record<string, string>): Record<string, string> {
+function stripUntrustedSuperlog(
+  map: Record<string, string>,
+  stamped: boolean,
+  tracker?: { strippedCount: number },
+): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(map)) {
-    if (k.startsWith("superlog.") && !PRESERVED_SUPERLOG_KEYS.has(k)) continue;
+    if (k.startsWith("superlog.")) {
+      if (stamped && PRESERVED_SUPERLOG_KEYS.has(k)) {
+        out[k] = v;
+      } else {
+        if (tracker) tracker.strippedCount += 1;
+      }
+      continue;
+    }
     out[k] = v;
   }
   return out;

--- a/apps/proxy/src/otlp-clickhouse.ts
+++ b/apps/proxy/src/otlp-clickhouse.ts
@@ -96,7 +96,7 @@ export function otlpLogsToRows(
   for (const rl of payload.resourceLogs ?? []) {
     const resourceMap = kvListToMap(rl.resource?.attributes);
     const serviceName = resourceMap["service.name"] ?? "";
-    const resourceAttributes = stripAllSuperlog(resourceMap, tracker);
+    const resourceAttributes = stripAllSuperlog(resourceMap);
     resourceAttributes[SUPERLOG_PROJECT_ID_KEY] = projectId;
     const resourceSchemaUrl = rl.schemaUrl ?? "";
 
@@ -205,7 +205,7 @@ export function otlpTracesToRows(
   for (const rs of payload.resourceSpans ?? []) {
     const resourceMap = kvListToMap(rs.resource?.attributes);
     const serviceName = resourceMap["service.name"] ?? "";
-    const resourceAttributes = stripAllSuperlog(resourceMap, tracker);
+    const resourceAttributes = stripAllSuperlog(resourceMap);
     resourceAttributes[SUPERLOG_PROJECT_ID_KEY] = projectId;
 
     for (const ss of rs.scopeSpans ?? []) {
@@ -229,7 +229,7 @@ export function otlpTracesToRows(
           ResourceAttributes: resourceAttributes,
           ScopeName: scopeName,
           ScopeVersion: scopeVersion,
-          SpanAttributes: stripAllSuperlog(kvListToMap(span.attributes), tracker),
+          SpanAttributes: stripAllSuperlog(kvListToMap(span.attributes)),
           Duration: (end > start ? end - start : 0n).toString(),
           StatusCode: STATUS_CODES[span.status?.code ?? 0] ?? "Unset",
           StatusMessage: span.status?.message ?? "",
@@ -241,7 +241,7 @@ export function otlpTracesToRows(
           "Links.TraceId": links.map((l) => toHex(l.traceId)),
           "Links.SpanId": links.map((l) => toHex(l.spanId)),
           "Links.TraceState": links.map((l) => l.traceState ?? ""),
-          "Links.Attributes": links.map((l) => stripAllSuperlog(kvListToMap(l.attributes), tracker)),
+          "Links.Attributes": links.map((l) => stripAllSuperlog(kvListToMap(l.attributes))),
         });
       }
     }
@@ -271,14 +271,10 @@ function kvListToMap(attrs: OtlpKeyValue[] | undefined): Record<string, string> 
 // superlog.project_id is re-added afterwards from the request context.
 function stripAllSuperlog(
   map: Record<string, string>,
-  tracker?: { strippedCount: number },
 ): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(map)) {
     if (k.startsWith("superlog.")) {
-      if (k === ISSUE_FINGERPRINT_KEY && tracker) {
-        tracker.strippedCount += 1;
-      }
       continue;
     }
     out[k] = v;

--- a/apps/proxy/src/otlp-decode.test.ts
+++ b/apps/proxy/src/otlp-decode.test.ts
@@ -152,7 +152,7 @@ test("decodeOtlpToRows handles client-supplied superlog attributes based on stam
   });
   assert.ok(resStamped);
   assert.equal(resStamped.table, "otel_logs");
-  assert.equal(resStamped.strippedCount, 1);
+  assert.equal(resStamped.strippedCount, 0);
   assert.equal(resStamped.rows[0]!.LogAttributes["superlog.issue_fingerprint"], "fake");
   assert.equal(resStamped.rows[0]!.LogAttributes["superlog.other_key"], undefined);
   assert.equal(resStamped.rows[0]!.LogAttributes["normal_key"], "ok");
@@ -167,7 +167,7 @@ test("decodeOtlpToRows handles client-supplied superlog attributes based on stam
   });
   assert.ok(resUnstamped);
   assert.equal(resUnstamped.table, "otel_logs");
-  assert.equal(resUnstamped.strippedCount, 2);
+  assert.equal(resUnstamped.strippedCount, 1);
   assert.equal(resUnstamped.rows[0]!.LogAttributes["superlog.issue_fingerprint"], undefined);
   assert.equal(resUnstamped.rows[0]!.LogAttributes["superlog.other_key"], undefined);
   assert.equal(resUnstamped.rows[0]!.LogAttributes["normal_key"], "ok");

--- a/apps/proxy/src/otlp-decode.test.ts
+++ b/apps/proxy/src/otlp-decode.test.ts
@@ -116,3 +116,59 @@ test("decodeOtlpToRows returns null for an undecodable content type", () => {
     null,
   );
 });
+
+test("decodeOtlpToRows handles client-supplied superlog attributes based on stamped status", () => {
+  const jsonLogsWithSpoofedFingerprint = JSON.stringify({
+    resourceLogs: [
+      {
+        resource: { attributes: [{ key: "service.name", value: { stringValue: "svc" } }] },
+        scopeLogs: [
+          {
+            scope: { name: "s" },
+            logRecords: [
+              {
+                timeUnixNano: "1718000000000000000",
+                body: { stringValue: "hi" },
+                attributes: [
+                  { key: "superlog.issue_fingerprint", value: { stringValue: "fake" } },
+                  { key: "superlog.other_key", value: { stringValue: "val" } },
+                  { key: "normal_key", value: { stringValue: "ok" } }
+                ]
+              }
+            ],
+          },
+        ],
+      },
+    ],
+  });
+
+  // Test Case 1: stamped = true -> preserves issue_fingerprint, strips other superlog keys
+  const resStamped = decodeOtlpToRows({
+    path: "/v1/logs",
+    projectId: "p1",
+    contentType: "application/json",
+    body: Buffer.from(jsonLogsWithSpoofedFingerprint),
+    stamped: true,
+  });
+  assert.ok(resStamped);
+  assert.equal(resStamped.table, "otel_logs");
+  assert.equal(resStamped.strippedCount, 1);
+  assert.equal(resStamped.rows[0]!.LogAttributes["superlog.issue_fingerprint"], "fake");
+  assert.equal(resStamped.rows[0]!.LogAttributes["superlog.other_key"], undefined);
+  assert.equal(resStamped.rows[0]!.LogAttributes["normal_key"], "ok");
+
+  // Test Case 2: stamped = false -> strips all superlog keys including issue_fingerprint
+  const resUnstamped = decodeOtlpToRows({
+    path: "/v1/logs",
+    projectId: "p1",
+    contentType: "application/json",
+    body: Buffer.from(jsonLogsWithSpoofedFingerprint),
+    stamped: false,
+  });
+  assert.ok(resUnstamped);
+  assert.equal(resUnstamped.table, "otel_logs");
+  assert.equal(resUnstamped.strippedCount, 2);
+  assert.equal(resUnstamped.rows[0]!.LogAttributes["superlog.issue_fingerprint"], undefined);
+  assert.equal(resUnstamped.rows[0]!.LogAttributes["superlog.other_key"], undefined);
+  assert.equal(resUnstamped.rows[0]!.LogAttributes["normal_key"], "ok");
+});

--- a/apps/proxy/src/otlp-decode.ts
+++ b/apps/proxy/src/otlp-decode.ts
@@ -69,8 +69,8 @@ const ExportLogsServiceRequest = protobuf
 const PROTO_TO_OBJECT_OPTS = { longs: String, enums: Number, defaults: false };
 
 export type DecodedRows =
-  | { table: "otel_logs"; rows: OtelLogRow[] }
-  | { table: "otel_traces"; rows: OtelTraceRow[] };
+  | { table: "otel_logs"; rows: OtelLogRow[]; strippedCount: number }
+  | { table: "otel_traces"; rows: OtelTraceRow[]; strippedCount: number };
 
 export type DecodeInput = {
   path: string;
@@ -78,6 +78,7 @@ export type DecodeInput = {
   contentType: string;
   contentEncoding?: string;
   body: Buffer;
+  stamped?: boolean;
 };
 
 // Decode an OTLP ingest payload into ClickHouse rows. Returns null for signals we
@@ -91,18 +92,28 @@ export function decodeOtlpToRows(input: DecodeInput): DecodedRows | null {
   if (!json && !protobufContent) return null;
 
   const body = decompress(input.body, input.contentEncoding);
+  const stamped = input.stamped ?? false;
+  const tracker = { strippedCount: 0 };
 
   if (input.path === "/v1/logs") {
     const payload = json
       ? JSON.parse(body.toString("utf8"))
       : decodeProto(ExportLogsServiceRequest, body);
-    return { table: "otel_logs", rows: otlpLogsToRows(payload, input.projectId) };
+    return {
+      table: "otel_logs",
+      rows: otlpLogsToRows(payload, input.projectId, stamped, tracker),
+      strippedCount: tracker.strippedCount,
+    };
   }
 
   const payload = json
     ? JSON.parse(body.toString("utf8"))
     : decodeProto(ExportTraceServiceRequest, body);
-  return { table: "otel_traces", rows: otlpTracesToRows(payload, input.projectId) };
+  return {
+    table: "otel_traces",
+    rows: otlpTracesToRows(payload, input.projectId, stamped, tracker),
+    strippedCount: tracker.strippedCount,
+  };
 }
 
 // Decode an OTLP metrics export request (JSON or protobuf, possibly

--- a/infra/collector/config-dual-clickhouse.yaml
+++ b/infra/collector/config-dual-clickhouse.yaml
@@ -30,17 +30,26 @@ processors:
   # both span/log/datapoint and resource scope. The proxy is the only
   # authoritative source of `superlog.*` keys; without this strip a customer
   # could spoof another tenant by setting `superlog.project_id` themselves.
+  #
+  # IMPORTANT: superlog.issue_fingerprint is proxy-authored and must survive
+  # to reach ClickHouse so the issue-activity materialized views can match it.
+  # The negative lookahead excludes it while stripping all other superlog.* keys.
   transform/strip_superlog:
     error_mode: ignore
     trace_statements:
-      - delete_matching_keys(span.attributes, "^superlog\\..*")
-      - delete_matching_keys(resource.attributes, "^superlog\\..*")
+      - context: span
+        statements:
+          - delete_matching_keys(attributes, "^superlog\\.(?!issue_fingerprint).*")
+          - delete_matching_keys(resource.attributes, "^superlog\\.(?!issue_fingerprint).*")
+      - context: spanevent
+        statements:
+          - delete_matching_keys(attributes, "^superlog\\.(?!issue_fingerprint).*")
     log_statements:
-      - delete_matching_keys(log.attributes, "^superlog\\..*")
-      - delete_matching_keys(resource.attributes, "^superlog\\..*")
+      - delete_matching_keys(log.attributes, "^superlog\\.(?!issue_fingerprint).*")
+      - delete_matching_keys(resource.attributes, "^superlog\\.(?!issue_fingerprint).*")
     metric_statements:
-      - delete_matching_keys(datapoint.attributes, "^superlog\\..*")
-      - delete_matching_keys(resource.attributes, "^superlog\\..*")
+      - delete_matching_keys(datapoint.attributes, "^superlog\\.(?!issue_fingerprint).*")
+      - delete_matching_keys(resource.attributes, "^superlog\\.(?!issue_fingerprint).*")
 
   attributes/from_metadata:
     actions:

--- a/infra/collector/config.yaml
+++ b/infra/collector/config.yaml
@@ -36,17 +36,27 @@ processors:
   # both span/log/datapoint and resource scope. The proxy is the only
   # authoritative source of `superlog.*` keys; without this strip a customer
   # could spoof another tenant by setting `superlog.project_id` themselves.
+  #
+  # IMPORTANT: superlog.issue_fingerprint is proxy-authored (stamped after
+  # ingest-queue dequeues the payload) and must survive to reach ClickHouse
+  # so the issue-activity materialized views can match it. The negative
+  # lookahead below excludes it from deletion while still stripping every
+  # other superlog.* key a client could inject.
   transform/strip_superlog:
     error_mode: ignore
     trace_statements:
-      - delete_matching_keys(span.attributes, "^superlog\\..*")
-      - delete_matching_keys(resource.attributes, "^superlog\\..*")
+      - delete_matching_keys(span.attributes, "^superlog\\.(?!issue_fingerprint).*")
+      - delete_matching_keys(resource.attributes, "^superlog\\.(?!issue_fingerprint).*")
+      # Symmetric with log_statements: strip spoofed superlog.* from event
+      # attrs too (excluding the proxy-stamped fingerprint which lives here
+      # for exception events on the collector delivery path).
+      - delete_matching_keys(span.attributes["Events.Attributes"], "^superlog\\.(?!issue_fingerprint).*")
     log_statements:
-      - delete_matching_keys(log.attributes, "^superlog\\..*")
-      - delete_matching_keys(resource.attributes, "^superlog\\..*")
+      - delete_matching_keys(log.attributes, "^superlog\\.(?!issue_fingerprint).*")
+      - delete_matching_keys(resource.attributes, "^superlog\\.(?!issue_fingerprint).*")
     metric_statements:
-      - delete_matching_keys(datapoint.attributes, "^superlog\\..*")
-      - delete_matching_keys(resource.attributes, "^superlog\\..*")
+      - delete_matching_keys(datapoint.attributes, "^superlog\\.(?!issue_fingerprint).*")
+      - delete_matching_keys(resource.attributes, "^superlog\\.(?!issue_fingerprint).*")
 
   attributes/from_metadata:
     actions:

--- a/infra/collector/config.yaml
+++ b/infra/collector/config.yaml
@@ -45,12 +45,17 @@ processors:
   transform/strip_superlog:
     error_mode: ignore
     trace_statements:
-      - delete_matching_keys(span.attributes, "^superlog\\.(?!issue_fingerprint).*")
-      - delete_matching_keys(resource.attributes, "^superlog\\.(?!issue_fingerprint).*")
-      # Symmetric with log_statements: strip spoofed superlog.* from event
-      # attrs too (excluding the proxy-stamped fingerprint which lives here
-      # for exception events on the collector delivery path).
-      - delete_matching_keys(span.attributes["Events.Attributes"], "^superlog\\.(?!issue_fingerprint).*")
+      - context: span
+        statements:
+          - delete_matching_keys(attributes, "^superlog\\.(?!issue_fingerprint).*")
+          - delete_matching_keys(resource.attributes, "^superlog\\.(?!issue_fingerprint).*")
+      # Span events live in the spanevent OTTL context, not in span attributes.
+      # This is symmetric with log_statements and prevents spoofed
+      # superlog.* keys in exception event attributes from passing through
+      # to ClickHouse unstripped (excluding the proxy-stamped fingerprint).
+      - context: spanevent
+        statements:
+          - delete_matching_keys(attributes, "^superlog\\.(?!issue_fingerprint).*")
     log_statements:
       - delete_matching_keys(log.attributes, "^superlog\\.(?!issue_fingerprint).*")
       - delete_matching_keys(resource.attributes, "^superlog\\.(?!issue_fingerprint).*")


### PR DESCRIPTION
Closes #285.

This pull request finalizes the security, correctness, and observability of the fingerprint sanitization pipeline.

### Key Changes
1. **Protobuf Log Sanitization**:
   - Implemented `stampProtobufLogFingerprints` in `ingest-fingerprints.ts` using the OTLP `LOGS_PROTO` descriptor.
   - The proxy now decodes, sanitizes (stripping client-supplied `superlog.issue_fingerprint`), and re-serializes OTLP protobuf log batches.

2. **Accurate Trust Signaling (`stamped`)**:
   - Re-engineered the `stamped` trust signal returned from the stamper. It now returns `true` if and only if the payload was successfully parsed, sanitized, and stamped, replacing the previous size-based eligibility check.

3. **Unconditional Span Attribute Stripping**:
   - Updated `SpanAttributes` mapping logic to unconditionally strip any client-supplied `superlog.*` keys (using `stripAllSuperlog`), ensuring the proxy-only namespace remains secure from spoofing on spans.

4. **Precise Metrics & Double-Counting Mitigation**:
   - Restricted the `strippedCount` tracking to only increment when stripping the authoritative `superlog.issue_fingerprint` key.
   - Gated the metric increment (`superlog.proxy.fingerprint_stripped_total`) and warning log in `ingest-queue.ts` behind `!stamped` to prevent double-counting payloads already processed by the stamper.

5. **Test Coverage**:
   - Added test coverage in `ingest-fingerprints.test.ts` for protobuf log sanitization (stamping of error logs and stripping of non-error logs).
   - Updated test suites in `otlp-decode.test.ts` and `otlp-clickhouse.test.ts` to assert the corrected `strippedCount` and unconditional span attribute stripping behavior.

---

### Verification
All 137 unit tests passed successfully:
```bash
pnpm --filter @superlog/proxy test
