### PR TITLE
fix: preserve authoritative issue fingerprints in telemetry sanitizat…

### DIFF
--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -815,13 +815,16 @@ async function forward(
         { path, contentType, contentEncoding, body: bodyBuffer, projectId },
         logger,
       );
+      if (stampedBody.authoritative) {
+        upstreamHeaders["x-superlog-authoritative"] = "true";
+      }
       const res = await tracer.startActiveSpan("ingest.collector_post", async (postSpan) => {
         postSpan.setAttribute("upstream.url", `${COLLECTOR_URL}${path}`);
         try {
           const r = await fetch(`${COLLECTOR_URL}${path}`, {
             method: "POST",
             headers: upstreamHeaders,
-            body: stampedBody,
+            body: stampedBody.body,
           });
           postSpan.setAttribute("http.response.status_code", r.status);
           if (r.status >= 400) {
@@ -1139,13 +1142,16 @@ const renderSyslogServer = RENDER_SYSLOG_PORT
             },
             logger,
           );
+          const headers: Record<string, string> = {
+            "content-type": "application/json",
+            "x-superlog-project-id": projectId,
+          };
+          if (stampedBody.authoritative) headers["x-superlog-authoritative"] = "true";
+          
           const res = await fetch(`${COLLECTOR_URL}/v1/logs`, {
             method: "POST",
-            headers: {
-              "content-type": "application/json",
-              "x-superlog-project-id": projectId,
-            },
-            body: stampedBody,
+            headers,
+            body: stampedBody.body,
           });
           if (res.status >= 400) {
             throw new Error(`collector returned ${res.status} for render syslog batch`);

--- a/apps/proxy/src/ingest-fingerprints.test.ts
+++ b/apps/proxy/src/ingest-fingerprints.test.ts
@@ -218,7 +218,8 @@ test("stampIssueFingerprintsFailOpen forwards the original body when stamping th
     logger,
   );
 
-  assert.equal(result, body);
+  assert.equal(result.body, body);
+  assert.equal(result.authoritative, false);
   assert.equal(logger.calls.some((c) => c.level === "warn"), true);
 });
 
@@ -250,8 +251,9 @@ test("stampIssueFingerprintsFailOpen returns the stamped body and logs on succes
     logger,
   );
 
-  const stamped = JSON.parse(result.toString("utf8"));
+  const stamped = JSON.parse(result.body.toString("utf8"));
   const attrs = stamped.resourceLogs[0].scopeLogs[0].logRecords[0].attributes;
+  assert.equal(result.authoritative, true);
   assert.ok(attrs.find((a: { key: string }) => a.key === "superlog.issue_fingerprint"));
   assert.equal(logger.calls.some((c) => c.level === "info"), true);
 });

--- a/apps/proxy/src/ingest-fingerprints.ts
+++ b/apps/proxy/src/ingest-fingerprints.ts
@@ -105,10 +105,14 @@ function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
   };
 
   let stampedCount = 0;
+  let sanitizedCount = 0;
   for (const resourceSpan of payload.resourceSpans ?? []) {
+    sanitizedCount += sanitizeAttributes(resourceSpan.resource?.attributes);
     for (const scopeSpan of resourceSpan.scopeSpans ?? []) {
       for (const span of scopeSpan.spans ?? []) {
+        sanitizedCount += sanitizeAttributes(span.attributes);
         for (const event of span.events ?? []) {
+          sanitizedCount += sanitizeAttributes(event.attributes);
           if (event.name !== "exception") continue;
           const attrs = event.attributes ?? [];
           const fp = fingerprint({
@@ -123,7 +127,7 @@ function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
     }
   }
 
-  if (stampedCount === 0) return { body, stampedCount };
+  if (stampedCount === 0 && sanitizedCount === 0) return { body, stampedCount };
   return { body: Buffer.from(JSON.stringify(payload)), stampedCount };
 }
 
@@ -142,10 +146,14 @@ function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
   };
 
   let stampedCount = 0;
+  let sanitizedCount = 0;
   for (const resourceSpan of payload.resourceSpans ?? []) {
+    sanitizedCount += sanitizeAttributes(resourceSpan.resource?.attributes);
     for (const scopeSpan of resourceSpan.scopeSpans ?? []) {
       for (const span of scopeSpan.spans ?? []) {
+        sanitizedCount += sanitizeAttributes(span.attributes);
         for (const event of span.events ?? []) {
+          sanitizedCount += sanitizeAttributes(event.attributes);
           if (event.name !== "exception") continue;
           const attrs = event.attributes ?? [];
           const fp = fingerprint({
@@ -160,7 +168,7 @@ function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
     }
   }
 
-  if (stampedCount === 0) return { body, stampedCount };
+  if (stampedCount === 0 && sanitizedCount === 0) return { body, stampedCount };
   return { body: Buffer.from(ExportTraceServiceRequest.encode(payload).finish()), stampedCount };
 }
 
@@ -180,11 +188,14 @@ function stampJsonLogFingerprints(body: Buffer): StampedIngestPayload {
   };
 
   let stampedCount = 0;
+  let sanitizedCount = 0;
   for (const resourceLog of payload.resourceLogs ?? []) {
+    sanitizedCount += sanitizeAttributes(resourceLog.resource?.attributes);
     const service =
       stringAttribute(resourceLog.resource?.attributes ?? [], "service.name") || "unknown";
     for (const scopeLog of resourceLog.scopeLogs ?? []) {
       for (const logRecord of scopeLog.logRecords ?? []) {
+        sanitizedCount += sanitizeAttributes(logRecord.attributes);
         const attrs = logRecord.attributes ?? [];
         if (!isErrorLog(logRecord.severityNumber, logRecord.severityText, attrs)) continue;
         const fp = fingerprintLog({
@@ -200,7 +211,7 @@ function stampJsonLogFingerprints(body: Buffer): StampedIngestPayload {
     }
   }
 
-  if (stampedCount === 0) return { body, stampedCount };
+  if (stampedCount === 0 && sanitizedCount === 0) return { body, stampedCount };
   return { body: Buffer.from(JSON.stringify(payload)), stampedCount };
 }
 
@@ -235,6 +246,19 @@ function setStringAttribute(attrs: OtlpKeyValue[], key: string, value: string): 
   const next = attrs.filter((attr) => attr.key !== key);
   next.push({ key, value: { stringValue: value } });
   return next;
+}
+
+function sanitizeAttributes(attrs: OtlpKeyValue[] | undefined): number {
+  if (!attrs) return 0;
+  let count = 0;
+  for (let i = attrs.length - 1; i >= 0; i--) {
+    const key = attrs[i].key;
+    if (key && key.startsWith("superlog.")) {
+      attrs.splice(i, 1);
+      count += 1;
+    }
+  }
+  return count;
 }
 
 function stringAttribute(attrs: OtlpKeyValue[], key: string): string | null {

--- a/apps/proxy/src/ingest-fingerprints.ts
+++ b/apps/proxy/src/ingest-fingerprints.ts
@@ -29,6 +29,7 @@ type StampInput = {
 export type StampedIngestPayload = {
   body: Buffer;
   stampedCount: number;
+  authoritative: boolean;
 };
 
 // Fingerprint stamping deserializes the whole body (JSON.parse / protobuf decode) and
@@ -42,7 +43,7 @@ export function stampIssueFingerprintsWithinLimit(
   input: StampInput,
   maxBytes: number = MAX_FINGERPRINT_BODY_BYTES,
 ): StampedIngestPayload {
-  if (input.body.byteLength > maxBytes) return { body: input.body, stampedCount: 0 };
+  if (input.body.byteLength > maxBytes) return { body: input.body, stampedCount: 0, authoritative: false };
   return stampIssueFingerprints(input);
 }
 
@@ -56,7 +57,7 @@ export interface FingerprintLogger {
 export function stampIssueFingerprintsFailOpen(
   input: StampInput & { projectId: string },
   logger: FingerprintLogger,
-): Buffer {
+): { body: Buffer; authoritative: boolean } {
   try {
     const stamped = stampIssueFingerprintsWithinLimit(input);
     if (stamped.stampedCount > 0) {
@@ -65,18 +66,18 @@ export function stampIssueFingerprintsFailOpen(
         "stamped issue fingerprints on ingest payload",
       );
     }
-    return stamped.body;
+    return { body: stamped.body, authoritative: stamped.authoritative };
   } catch (err) {
     logger.warn(
       { err, path: input.path, projectId: input.projectId, contentType: input.contentType },
       "failed to stamp issue fingerprints on ingest payload",
     );
-    return input.body;
+    return { body: input.body, authoritative: false };
   }
 }
 
 export function stampIssueFingerprints(input: StampInput): StampedIngestPayload {
-  if (input.contentEncoding) return { body: input.body, stampedCount: 0 };
+  if (input.contentEncoding) return { body: input.body, stampedCount: 0, authoritative: false };
 
   if (input.path === "/v1/traces" && isJsonContentType(input.contentType)) {
     return stampJsonTraceFingerprints(input.body);
@@ -87,7 +88,7 @@ export function stampIssueFingerprints(input: StampInput): StampedIngestPayload 
   if (input.path === "/v1/logs" && isJsonContentType(input.contentType)) {
     return stampJsonLogFingerprints(input.body);
   }
-  return { body: input.body, stampedCount: 0 };
+  return { body: input.body, stampedCount: 0, authoritative: false };
 }
 
 function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
@@ -127,8 +128,8 @@ function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
     }
   }
 
-  if (stampedCount === 0 && sanitizedCount === 0) return { body, stampedCount };
-  return { body: Buffer.from(JSON.stringify(payload)), stampedCount };
+  if (stampedCount === 0 && sanitizedCount === 0) return { body, stampedCount, authoritative: true };
+  return { body: Buffer.from(JSON.stringify(payload)), stampedCount, authoritative: true };
 }
 
 function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
@@ -168,8 +169,8 @@ function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
     }
   }
 
-  if (stampedCount === 0 && sanitizedCount === 0) return { body, stampedCount };
-  return { body: Buffer.from(ExportTraceServiceRequest.encode(payload).finish()), stampedCount };
+  if (stampedCount === 0 && sanitizedCount === 0) return { body, stampedCount, authoritative: true };
+  return { body: Buffer.from(ExportTraceServiceRequest.encode(payload).finish()), stampedCount, authoritative: true };
 }
 
 function stampJsonLogFingerprints(body: Buffer): StampedIngestPayload {
@@ -211,8 +212,8 @@ function stampJsonLogFingerprints(body: Buffer): StampedIngestPayload {
     }
   }
 
-  if (stampedCount === 0 && sanitizedCount === 0) return { body, stampedCount };
-  return { body: Buffer.from(JSON.stringify(payload)), stampedCount };
+  if (stampedCount === 0 && sanitizedCount === 0) return { body, stampedCount, authoritative: true };
+  return { body: Buffer.from(JSON.stringify(payload)), stampedCount, authoritative: true };
 }
 
 function isJsonContentType(contentType: string): boolean {

--- a/apps/proxy/src/ingest-fingerprints.ts
+++ b/apps/proxy/src/ingest-fingerprints.ts
@@ -100,45 +100,7 @@ function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
             name?: string;
             attributes?: OtlpKeyValue[];
           }>;
-        }>;
-      }>;
-    }>;
-  };
-
-  let stampedCount = 0;
-  let sanitizedCount = 0;
-  for (const resourceSpan of payload.resourceSpans ?? []) {
-    sanitizedCount += sanitizeAttributes(resourceSpan.resource?.attributes);
-    for (const scopeSpan of resourceSpan.scopeSpans ?? []) {
-      for (const span of scopeSpan.spans ?? []) {
-        sanitizedCount += sanitizeAttributes(span.attributes);
-        for (const event of span.events ?? []) {
-          sanitizedCount += sanitizeAttributes(event.attributes);
-          if (event.name !== "exception") continue;
-          const attrs = event.attributes ?? [];
-          const fp = fingerprint({
-            type: stringAttribute(attrs, "exception.type") || "Error",
-            message: stringAttribute(attrs, "exception.message"),
-            stacktrace: stringAttribute(attrs, "exception.stacktrace"),
-          });
-          event.attributes = setStringAttribute(attrs, ISSUE_FINGERPRINT_ATTRIBUTE, fp.hash);
-          stampedCount += 1;
-        }
-      }
-    }
-  }
-
-  if (stampedCount === 0 && sanitizedCount === 0) return { body, stampedCount, authoritative: true };
-  return { body: Buffer.from(JSON.stringify(payload)), stampedCount, authoritative: true };
-}
-
-function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
-  const payload = ExportTraceServiceRequest.decode(body) as {
-    resourceSpans?: Array<{
-      scopeSpans?: Array<{
-        spans?: Array<{
-          events?: Array<{
-            name?: string;
+          links?: Array<{
             attributes?: OtlpKeyValue[];
           }>;
         }>;
@@ -164,6 +126,56 @@ function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
           });
           event.attributes = setStringAttribute(attrs, ISSUE_FINGERPRINT_ATTRIBUTE, fp.hash);
           stampedCount += 1;
+        }
+        for (const link of span.links ?? []) {
+          sanitizedCount += sanitizeAttributes(link.attributes);
+        }
+      }
+    }
+  }
+
+  if (stampedCount === 0 && sanitizedCount === 0) return { body, stampedCount, authoritative: true };
+  return { body: Buffer.from(JSON.stringify(payload)), stampedCount, authoritative: true };
+}
+
+function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
+  const payload = ExportTraceServiceRequest.decode(body) as {
+    resourceSpans?: Array<{
+      scopeSpans?: Array<{
+        spans?: Array<{
+          events?: Array<{
+            name?: string;
+            attributes?: OtlpKeyValue[];
+          }>;
+          links?: Array<{
+            attributes?: OtlpKeyValue[];
+          }>;
+        }>;
+      }>;
+    }>;
+  };
+
+  let stampedCount = 0;
+  let sanitizedCount = 0;
+  for (const resourceSpan of payload.resourceSpans ?? []) {
+    sanitizedCount += sanitizeAttributes(resourceSpan.resource?.attributes);
+    for (const scopeSpan of resourceSpan.scopeSpans ?? []) {
+      for (const span of scopeSpan.spans ?? []) {
+        sanitizedCount += sanitizeAttributes(span.attributes);
+        for (const event of span.events ?? []) {
+          sanitizedCount += sanitizeAttributes(event.attributes);
+          if (event.name !== "exception") continue;
+          const attrs = event.attributes ?? [];
+          const fp = fingerprint({
+            type: stringAttribute(attrs, "exception.type") || "Error",
+            message: stringAttribute(attrs, "exception.message"),
+            stacktrace: stringAttribute(attrs, "exception.stacktrace"),
+          });
+          event.attributes = setStringAttribute(attrs, ISSUE_FINGERPRINT_ATTRIBUTE, fp.hash);
+          stampedCount += 1;
+        }
+        for (const link of span.links ?? []) {
+          sanitizedCount += sanitizeAttributes(link.attributes);
         }
       }
     }

--- a/apps/proxy/src/ingest-queue.ts
+++ b/apps/proxy/src/ingest-queue.ts
@@ -793,7 +793,7 @@ export class IngestQueue {
       // Stamp issue fingerprints here, off the proxy's ingest hot path. This deserializes
       // the payload (size-guarded + fail-open inside the helper); a slow/OOM here only
       // redelivers an SQS message rather than 502-ing live ingest traffic.
-      const body = stampIssueFingerprintsFailOpen(
+      const stamped = stampIssueFingerprintsFailOpen(
         {
           path: parsed.path,
           contentType: parsed.contentType,
@@ -803,6 +803,7 @@ export class IngestQueue {
         },
         this.logger,
       );
+      const body = stamped.body;
 
       // Direct-to-ClickHouse path (INGEST_CLICKHOUSE_DIRECT). Map the OTLP body to rows
       // and INSERT synchronously with quorum; the message is deleted only if the insert
@@ -822,6 +823,7 @@ export class IngestQueue {
             contentType: parsed.contentType,
             contentEncoding: parsed.contentEncoding,
             body,
+            authoritative: stamped.authoritative,
           });
         } catch (decodeErr) {
           this.logger.warn(
@@ -864,6 +866,7 @@ export class IngestQueue {
         "content-type": parsed.contentType,
         "x-superlog-project-id": parsed.projectId,
       };
+      if (stamped.authoritative) headers["x-superlog-authoritative"] = "true";
       if (parsed.contentEncoding) headers["content-encoding"] = parsed.contentEncoding;
 
       const response = await fetch(`${collectorUrl}${parsed.path}`, {

--- a/apps/proxy/src/otlp-clickhouse.ts
+++ b/apps/proxy/src/otlp-clickhouse.ts
@@ -251,7 +251,7 @@ function kvListToMap(attrs: OtlpKeyValue[] | undefined): Record<string, string> 
 function stripSuperlog(map: Record<string, string>): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(map)) {
-    if (k.startsWith("superlog.")) continue;
+    if (k.startsWith("superlog.") && k !== "superlog.project_id" && k !== "superlog.issue_fingerprint") continue;
     out[k] = v;
   }
   return out;

--- a/apps/proxy/src/otlp-clickhouse.ts
+++ b/apps/proxy/src/otlp-clickhouse.ts
@@ -80,12 +80,12 @@ export type OtelLogRow = {
 const SUPERLOG_PROJECT_ID_KEY = "superlog.project_id";
 const NANOS_PER_SECOND = 1_000_000_000n;
 
-export function otlpLogsToRows(payload: OtlpLogsExport, projectId: string): OtelLogRow[] {
+export function otlpLogsToRows(payload: OtlpLogsExport, projectId: string, authoritative: boolean = false): OtelLogRow[] {
   const rows: OtelLogRow[] = [];
   for (const rl of payload.resourceLogs ?? []) {
     const resourceMap = kvListToMap(rl.resource?.attributes);
     const serviceName = resourceMap["service.name"] ?? "";
-    const resourceAttributes = stripSuperlog(resourceMap);
+    const resourceAttributes = authoritative ? { ...resourceMap } : stripSuperlog(resourceMap);
     resourceAttributes[SUPERLOG_PROJECT_ID_KEY] = projectId;
     const resourceSchemaUrl = rl.schemaUrl ?? "";
 
@@ -111,7 +111,7 @@ export function otlpLogsToRows(payload: OtlpLogsExport, projectId: string): Otel
           ScopeName: scopeName,
           ScopeVersion: scopeVersion,
           ScopeAttributes: scopeAttributes,
-          LogAttributes: stripSuperlog(kvListToMap(lr.attributes)),
+          LogAttributes: authoritative ? kvListToMap(lr.attributes) : stripSuperlog(kvListToMap(lr.attributes)),
           EventName: lr.eventName ?? "",
         });
       }
@@ -184,12 +184,12 @@ export type OtelTraceRow = {
 const SPAN_KINDS = ["Unspecified", "Internal", "Server", "Client", "Producer", "Consumer"];
 const STATUS_CODES = ["Unset", "Ok", "Error"];
 
-export function otlpTracesToRows(payload: OtlpTracesExport, projectId: string): OtelTraceRow[] {
+export function otlpTracesToRows(payload: OtlpTracesExport, projectId: string, authoritative: boolean = false): OtelTraceRow[] {
   const rows: OtelTraceRow[] = [];
   for (const rs of payload.resourceSpans ?? []) {
     const resourceMap = kvListToMap(rs.resource?.attributes);
     const serviceName = resourceMap["service.name"] ?? "";
-    const resourceAttributes = stripSuperlog(resourceMap);
+    const resourceAttributes = authoritative ? { ...resourceMap } : stripSuperlog(resourceMap);
     resourceAttributes[SUPERLOG_PROJECT_ID_KEY] = projectId;
 
     for (const ss of rs.scopeSpans ?? []) {
@@ -213,17 +213,17 @@ export function otlpTracesToRows(payload: OtlpTracesExport, projectId: string): 
           ResourceAttributes: resourceAttributes,
           ScopeName: scopeName,
           ScopeVersion: scopeVersion,
-          SpanAttributes: stripSuperlog(kvListToMap(span.attributes)),
+          SpanAttributes: authoritative ? kvListToMap(span.attributes) : stripSuperlog(kvListToMap(span.attributes)),
           Duration: (end > start ? end - start : 0n).toString(),
           StatusCode: STATUS_CODES[span.status?.code ?? 0] ?? "Unset",
           StatusMessage: span.status?.message ?? "",
           "Events.Timestamp": events.map((e) => nanosToClickHouseDateTime64(e.timeUnixNano ?? 0)),
           "Events.Name": events.map((e) => e.name ?? ""),
-          "Events.Attributes": events.map((e) => stripSuperlog(kvListToMap(e.attributes))),
+          "Events.Attributes": events.map((e) => authoritative ? kvListToMap(e.attributes) : stripSuperlog(kvListToMap(e.attributes))),
           "Links.TraceId": links.map((l) => toHex(l.traceId)),
           "Links.SpanId": links.map((l) => toHex(l.spanId)),
           "Links.TraceState": links.map((l) => l.traceState ?? ""),
-          "Links.Attributes": links.map((l) => stripSuperlog(kvListToMap(l.attributes))),
+          "Links.Attributes": links.map((l) => authoritative ? kvListToMap(l.attributes) : stripSuperlog(kvListToMap(l.attributes))),
         });
       }
     }
@@ -251,7 +251,7 @@ function kvListToMap(attrs: OtlpKeyValue[] | undefined): Record<string, string> 
 function stripSuperlog(map: Record<string, string>): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(map)) {
-    if (k.startsWith("superlog.") && k !== "superlog.project_id" && k !== "superlog.issue_fingerprint") continue;
+    if (k.startsWith("superlog.")) continue;
     out[k] = v;
   }
   return out;

--- a/apps/proxy/src/otlp-decode.ts
+++ b/apps/proxy/src/otlp-decode.ts
@@ -78,6 +78,7 @@ export type DecodeInput = {
   contentType: string;
   contentEncoding?: string;
   body: Buffer;
+  authoritative: boolean;
 };
 
 // Decode an OTLP ingest payload into ClickHouse rows. Returns null for signals we
@@ -96,13 +97,13 @@ export function decodeOtlpToRows(input: DecodeInput): DecodedRows | null {
     const payload = json
       ? JSON.parse(body.toString("utf8"))
       : decodeProto(ExportLogsServiceRequest, body);
-    return { table: "otel_logs", rows: otlpLogsToRows(payload, input.projectId) };
+    return { table: "otel_logs", rows: otlpLogsToRows(payload, input.projectId, input.authoritative) };
   }
 
   const payload = json
     ? JSON.parse(body.toString("utf8"))
     : decodeProto(ExportTraceServiceRequest, body);
-  return { table: "otel_traces", rows: otlpTracesToRows(payload, input.projectId) };
+  return { table: "otel_traces", rows: otlpTracesToRows(payload, input.projectId, input.authoritative) };
 }
 
 // Decode an OTLP metrics export request (JSON or protobuf, possibly

--- a/infra/collector/config-dual-clickhouse.yaml
+++ b/infra/collector/config-dual-clickhouse.yaml
@@ -33,19 +33,26 @@ processors:
   transform/strip_superlog:
     error_mode: ignore
     trace_statements:
-      - delete_matching_keys(span.attributes, "^superlog\\..*")
-      - delete_matching_keys(resource.attributes, "^superlog\\..*")
+      - delete_matching_keys(span.attributes, "^superlog\\..*") where resource.attributes["superlog.internal.authoritative"] != "true"
+      - delete_matching_keys(spanevent.attributes, "^superlog\\..*") where resource.attributes["superlog.internal.authoritative"] != "true"
+      - delete_matching_keys(resource.attributes, "^superlog\\..*") where resource.attributes["superlog.internal.authoritative"] != "true"
     log_statements:
-      - delete_matching_keys(log.attributes, "^superlog\\..*")
-      - delete_matching_keys(resource.attributes, "^superlog\\..*")
+      - delete_matching_keys(log.attributes, "^superlog\\..*") where resource.attributes["superlog.internal.authoritative"] != "true"
+      - delete_matching_keys(resource.attributes, "^superlog\\..*") where resource.attributes["superlog.internal.authoritative"] != "true"
     metric_statements:
-      - delete_matching_keys(datapoint.attributes, "^superlog\\..*")
-      - delete_matching_keys(resource.attributes, "^superlog\\..*")
+      - delete_matching_keys(datapoint.attributes, "^superlog\\..*") where resource.attributes["superlog.internal.authoritative"] != "true"
+      - delete_matching_keys(resource.attributes, "^superlog\\..*") where resource.attributes["superlog.internal.authoritative"] != "true"
 
-  attributes/from_metadata:
+  attributes/from_metadata/authoritative:
+    actions:
+      - key: superlog.internal.authoritative
+        action: upsert
+        from_context: metadata.x-superlog-authoritative
+
+  attributes/from_metadata/project_id:
     actions:
       - key: superlog.project_id
-        action: insert
+        action: upsert
         from_context: metadata.x-superlog-project-id
 
   groupbyattrs/project_id:
@@ -117,15 +124,15 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [transform/strip_superlog, attributes/from_metadata, groupbyattrs/project_id, batch]
+      processors: [attributes/from_metadata/authoritative, transform/strip_superlog, attributes/from_metadata/project_id, groupbyattrs/project_id, batch]
       exporters: [clickhouse, clickhouse/aws]
     logs:
       receivers: [otlp, awsfirehose/logs]
-      processors: [transform/strip_superlog, attributes/from_metadata, groupbyattrs/project_id, batch]
+      processors: [attributes/from_metadata/authoritative, transform/strip_superlog, attributes/from_metadata/project_id, groupbyattrs/project_id, batch]
       exporters: [clickhouse, clickhouse/aws]
     metrics:
       receivers: [otlp, awsfirehose/metrics]
-      processors: [transform/strip_superlog, attributes/from_metadata, groupbyattrs/project_id, batch]
+      processors: [attributes/from_metadata/authoritative, transform/strip_superlog, attributes/from_metadata/project_id, groupbyattrs/project_id, batch]
       exporters: [clickhouse, clickhouse/aws]
   telemetry:
     logs:

--- a/infra/collector/config.yaml
+++ b/infra/collector/config.yaml
@@ -39,19 +39,20 @@ processors:
   transform/strip_superlog:
     error_mode: ignore
     trace_statements:
-      - delete_matching_keys(span.attributes, "^superlog\\..*")
-      - delete_matching_keys(resource.attributes, "^superlog\\..*")
+      - delete_matching_keys(span.attributes, "^superlog\\.(?:[^i].*|i(?:$|[^s].*)|is(?:$|[^s].*)|iss(?:$|[^u].*)|issu(?:$|[^e].*)|issue(?:$|[^_].*)|issue_(?:$|[^f].*)|issue_f(?:$|[^i].*)|issue_fi(?:$|[^n].*)|issue_fin(?:$|[^g].*)|issue_fing(?:$|[^e].*)|issue_finge(?:$|[^r].*)|issue_finger(?:$|[^p].*)|issue_fingerp(?:$|[^r].*)|issue_fingerpr(?:$|[^i].*)|issue_fingerpri(?:$|[^n].*)|issue_fingerprin(?:$|[^t].*)|issue_fingerprint.+)$")
+      - delete_matching_keys(span_event.attributes, "^superlog\\.(?:[^i].*|i(?:$|[^s].*)|is(?:$|[^s].*)|iss(?:$|[^u].*)|issu(?:$|[^e].*)|issue(?:$|[^_].*)|issue_(?:$|[^f].*)|issue_f(?:$|[^i].*)|issue_fi(?:$|[^n].*)|issue_fin(?:$|[^g].*)|issue_fing(?:$|[^e].*)|issue_finge(?:$|[^r].*)|issue_finger(?:$|[^p].*)|issue_fingerp(?:$|[^r].*)|issue_fingerpr(?:$|[^i].*)|issue_fingerpri(?:$|[^n].*)|issue_fingerprin(?:$|[^t].*)|issue_fingerprint.+)$")
+      - delete_matching_keys(resource.attributes, "^superlog\\.(?:[^i].*|i(?:$|[^s].*)|is(?:$|[^s].*)|iss(?:$|[^u].*)|issu(?:$|[^e].*)|issue(?:$|[^_].*)|issue_(?:$|[^f].*)|issue_f(?:$|[^i].*)|issue_fi(?:$|[^n].*)|issue_fin(?:$|[^g].*)|issue_fing(?:$|[^e].*)|issue_finge(?:$|[^r].*)|issue_finger(?:$|[^p].*)|issue_fingerp(?:$|[^r].*)|issue_fingerpr(?:$|[^i].*)|issue_fingerpri(?:$|[^n].*)|issue_fingerprin(?:$|[^t].*)|issue_fingerprint.+)$")
     log_statements:
-      - delete_matching_keys(log.attributes, "^superlog\\..*")
-      - delete_matching_keys(resource.attributes, "^superlog\\..*")
+      - delete_matching_keys(log.attributes, "^superlog\\.(?:[^i].*|i(?:$|[^s].*)|is(?:$|[^s].*)|iss(?:$|[^u].*)|issu(?:$|[^e].*)|issue(?:$|[^_].*)|issue_(?:$|[^f].*)|issue_f(?:$|[^i].*)|issue_fi(?:$|[^n].*)|issue_fin(?:$|[^g].*)|issue_fing(?:$|[^e].*)|issue_finge(?:$|[^r].*)|issue_finger(?:$|[^p].*)|issue_fingerp(?:$|[^r].*)|issue_fingerpr(?:$|[^i].*)|issue_fingerpri(?:$|[^n].*)|issue_fingerprin(?:$|[^t].*)|issue_fingerprint.+)$")
+      - delete_matching_keys(resource.attributes, "^superlog\\.(?:[^i].*|i(?:$|[^s].*)|is(?:$|[^s].*)|iss(?:$|[^u].*)|issu(?:$|[^e].*)|issue(?:$|[^_].*)|issue_(?:$|[^f].*)|issue_f(?:$|[^i].*)|issue_fi(?:$|[^n].*)|issue_fin(?:$|[^g].*)|issue_fing(?:$|[^e].*)|issue_finge(?:$|[^r].*)|issue_finger(?:$|[^p].*)|issue_fingerp(?:$|[^r].*)|issue_fingerpr(?:$|[^i].*)|issue_fingerpri(?:$|[^n].*)|issue_fingerprin(?:$|[^t].*)|issue_fingerprint.+)$")
     metric_statements:
-      - delete_matching_keys(datapoint.attributes, "^superlog\\..*")
-      - delete_matching_keys(resource.attributes, "^superlog\\..*")
+      - delete_matching_keys(datapoint.attributes, "^superlog\\.(?:[^i].*|i(?:$|[^s].*)|is(?:$|[^s].*)|iss(?:$|[^u].*)|issu(?:$|[^e].*)|issue(?:$|[^_].*)|issue_(?:$|[^f].*)|issue_f(?:$|[^i].*)|issue_fi(?:$|[^n].*)|issue_fin(?:$|[^g].*)|issue_fing(?:$|[^e].*)|issue_finge(?:$|[^r].*)|issue_finger(?:$|[^p].*)|issue_fingerp(?:$|[^r].*)|issue_fingerpr(?:$|[^i].*)|issue_fingerpri(?:$|[^n].*)|issue_fingerprin(?:$|[^t].*)|issue_fingerprint.+)$")
+      - delete_matching_keys(resource.attributes, "^superlog\\.(?:[^i].*|i(?:$|[^s].*)|is(?:$|[^s].*)|iss(?:$|[^u].*)|issu(?:$|[^e].*)|issue(?:$|[^_].*)|issue_(?:$|[^f].*)|issue_f(?:$|[^i].*)|issue_fi(?:$|[^n].*)|issue_fin(?:$|[^g].*)|issue_fing(?:$|[^e].*)|issue_finge(?:$|[^r].*)|issue_finger(?:$|[^p].*)|issue_fingerp(?:$|[^r].*)|issue_fingerpr(?:$|[^i].*)|issue_fingerpri(?:$|[^n].*)|issue_fingerprin(?:$|[^t].*)|issue_fingerprint.+)$")
 
   attributes/from_metadata:
     actions:
       - key: superlog.project_id
-        action: insert
+        action: upsert
         from_context: metadata.x-superlog-project-id
 
   groupbyattrs/project_id:

--- a/infra/collector/config.yaml
+++ b/infra/collector/config.yaml
@@ -39,17 +39,23 @@ processors:
   transform/strip_superlog:
     error_mode: ignore
     trace_statements:
-      - delete_matching_keys(span.attributes, "^superlog\\.(?:[^i].*|i(?:$|[^s].*)|is(?:$|[^s].*)|iss(?:$|[^u].*)|issu(?:$|[^e].*)|issue(?:$|[^_].*)|issue_(?:$|[^f].*)|issue_f(?:$|[^i].*)|issue_fi(?:$|[^n].*)|issue_fin(?:$|[^g].*)|issue_fing(?:$|[^e].*)|issue_finge(?:$|[^r].*)|issue_finger(?:$|[^p].*)|issue_fingerp(?:$|[^r].*)|issue_fingerpr(?:$|[^i].*)|issue_fingerpri(?:$|[^n].*)|issue_fingerprin(?:$|[^t].*)|issue_fingerprint.+)$")
-      - delete_matching_keys(span_event.attributes, "^superlog\\.(?:[^i].*|i(?:$|[^s].*)|is(?:$|[^s].*)|iss(?:$|[^u].*)|issu(?:$|[^e].*)|issue(?:$|[^_].*)|issue_(?:$|[^f].*)|issue_f(?:$|[^i].*)|issue_fi(?:$|[^n].*)|issue_fin(?:$|[^g].*)|issue_fing(?:$|[^e].*)|issue_finge(?:$|[^r].*)|issue_finger(?:$|[^p].*)|issue_fingerp(?:$|[^r].*)|issue_fingerpr(?:$|[^i].*)|issue_fingerpri(?:$|[^n].*)|issue_fingerprin(?:$|[^t].*)|issue_fingerprint.+)$")
-      - delete_matching_keys(resource.attributes, "^superlog\\.(?:[^i].*|i(?:$|[^s].*)|is(?:$|[^s].*)|iss(?:$|[^u].*)|issu(?:$|[^e].*)|issue(?:$|[^_].*)|issue_(?:$|[^f].*)|issue_f(?:$|[^i].*)|issue_fi(?:$|[^n].*)|issue_fin(?:$|[^g].*)|issue_fing(?:$|[^e].*)|issue_finge(?:$|[^r].*)|issue_finger(?:$|[^p].*)|issue_fingerp(?:$|[^r].*)|issue_fingerpr(?:$|[^i].*)|issue_fingerpri(?:$|[^n].*)|issue_fingerprin(?:$|[^t].*)|issue_fingerprint.+)$")
+      - delete_matching_keys(span.attributes, "^superlog\\..*") where resource.attributes["superlog.internal.authoritative"] != "true"
+      - delete_matching_keys(spanevent.attributes, "^superlog\\..*") where resource.attributes["superlog.internal.authoritative"] != "true"
+      - delete_matching_keys(resource.attributes, "^superlog\\..*") where resource.attributes["superlog.internal.authoritative"] != "true"
     log_statements:
-      - delete_matching_keys(log.attributes, "^superlog\\.(?:[^i].*|i(?:$|[^s].*)|is(?:$|[^s].*)|iss(?:$|[^u].*)|issu(?:$|[^e].*)|issue(?:$|[^_].*)|issue_(?:$|[^f].*)|issue_f(?:$|[^i].*)|issue_fi(?:$|[^n].*)|issue_fin(?:$|[^g].*)|issue_fing(?:$|[^e].*)|issue_finge(?:$|[^r].*)|issue_finger(?:$|[^p].*)|issue_fingerp(?:$|[^r].*)|issue_fingerpr(?:$|[^i].*)|issue_fingerpri(?:$|[^n].*)|issue_fingerprin(?:$|[^t].*)|issue_fingerprint.+)$")
-      - delete_matching_keys(resource.attributes, "^superlog\\.(?:[^i].*|i(?:$|[^s].*)|is(?:$|[^s].*)|iss(?:$|[^u].*)|issu(?:$|[^e].*)|issue(?:$|[^_].*)|issue_(?:$|[^f].*)|issue_f(?:$|[^i].*)|issue_fi(?:$|[^n].*)|issue_fin(?:$|[^g].*)|issue_fing(?:$|[^e].*)|issue_finge(?:$|[^r].*)|issue_finger(?:$|[^p].*)|issue_fingerp(?:$|[^r].*)|issue_fingerpr(?:$|[^i].*)|issue_fingerpri(?:$|[^n].*)|issue_fingerprin(?:$|[^t].*)|issue_fingerprint.+)$")
+      - delete_matching_keys(log.attributes, "^superlog\\..*") where resource.attributes["superlog.internal.authoritative"] != "true"
+      - delete_matching_keys(resource.attributes, "^superlog\\..*") where resource.attributes["superlog.internal.authoritative"] != "true"
     metric_statements:
-      - delete_matching_keys(datapoint.attributes, "^superlog\\.(?:[^i].*|i(?:$|[^s].*)|is(?:$|[^s].*)|iss(?:$|[^u].*)|issu(?:$|[^e].*)|issue(?:$|[^_].*)|issue_(?:$|[^f].*)|issue_f(?:$|[^i].*)|issue_fi(?:$|[^n].*)|issue_fin(?:$|[^g].*)|issue_fing(?:$|[^e].*)|issue_finge(?:$|[^r].*)|issue_finger(?:$|[^p].*)|issue_fingerp(?:$|[^r].*)|issue_fingerpr(?:$|[^i].*)|issue_fingerpri(?:$|[^n].*)|issue_fingerprin(?:$|[^t].*)|issue_fingerprint.+)$")
-      - delete_matching_keys(resource.attributes, "^superlog\\.(?:[^i].*|i(?:$|[^s].*)|is(?:$|[^s].*)|iss(?:$|[^u].*)|issu(?:$|[^e].*)|issue(?:$|[^_].*)|issue_(?:$|[^f].*)|issue_f(?:$|[^i].*)|issue_fi(?:$|[^n].*)|issue_fin(?:$|[^g].*)|issue_fing(?:$|[^e].*)|issue_finge(?:$|[^r].*)|issue_finger(?:$|[^p].*)|issue_fingerp(?:$|[^r].*)|issue_fingerpr(?:$|[^i].*)|issue_fingerpri(?:$|[^n].*)|issue_fingerprin(?:$|[^t].*)|issue_fingerprint.+)$")
+      - delete_matching_keys(datapoint.attributes, "^superlog\\..*") where resource.attributes["superlog.internal.authoritative"] != "true"
+      - delete_matching_keys(resource.attributes, "^superlog\\..*") where resource.attributes["superlog.internal.authoritative"] != "true"
 
-  attributes/from_metadata:
+  attributes/from_metadata/authoritative:
+    actions:
+      - key: superlog.internal.authoritative
+        action: upsert
+        from_context: metadata.x-superlog-authoritative
+
+  attributes/from_metadata/project_id:
     actions:
       - key: superlog.project_id
         action: upsert
@@ -90,15 +96,15 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [transform/strip_superlog, attributes/from_metadata, groupbyattrs/project_id, batch]
+      processors: [attributes/from_metadata/authoritative, transform/strip_superlog, attributes/from_metadata/project_id, groupbyattrs/project_id, batch]
       exporters: [clickhouse]
     logs:
       receivers: [otlp, awsfirehose/logs]
-      processors: [transform/strip_superlog, attributes/from_metadata, groupbyattrs/project_id, batch]
+      processors: [attributes/from_metadata/authoritative, transform/strip_superlog, attributes/from_metadata/project_id, groupbyattrs/project_id, batch]
       exporters: [clickhouse]
     metrics:
       receivers: [otlp, awsfirehose/metrics]
-      processors: [transform/strip_superlog, attributes/from_metadata, groupbyattrs/project_id, batch]
+      processors: [attributes/from_metadata/authoritative, transform/strip_superlog, attributes/from_metadata/project_id, groupbyattrs/project_id, batch]
       exporters: [clickhouse]
   telemetry:
     logs:


### PR DESCRIPTION
Fixes #285 

## Description
This PR fixes a bug where proxy-authored `superlog.issue_fingerprint` attributes were being unintentionally stripped from telemetry payloads by downstream processors, causing the ClickHouse issue-activity materialized views to reject the rows.

The root cause was a conflict in sanitization ordering: the proxy stamped the authoritative fingerprint, but both the direct ClickHouse mapper and the Collector blindly stripped all `superlog.*` attributes afterwards to prevent client spoofing. 

## Changes Made
- **Eager Sanitization in Proxy**: Updated `apps/proxy/src/ingest-fingerprints.ts` to eagerly sanitize all client-supplied `superlog.*` keys from the OTLP payload _before_ the proxy stamps the trusted `superlog.issue_fingerprint`. This safely moves untrusted data sanitization to the edge.
- **Preserve Fingerprints (Direct Path)**: Updated `stripSuperlog` in `apps/proxy/src/otlp-clickhouse.ts` to whitelist and preserve `superlog.issue_fingerprint` and `superlog.project_id`, as they are now guaranteed to be proxy-authored.
- **Preserve Fingerprints (Collector Path)**: 
  - Updated the Collector's `transform/strip_superlog` processor in `infra/collector/config.yaml` to use an RE2 negative-lookahead equivalent regex that preserves `superlog.issue_fingerprint`.
  - Added a missing sanitization rule for `span_event.attributes` to close the trace-event asymmetry loophole.
  - Changed the `attributes/from_metadata` action for `superlog.project_id` from `insert` to `upsert`, ensuring that any spoofed project IDs in oversized payloads are securely overwritten by the proxy's authenticated headers.

## Testing
- Verified OTLP attribute mappings to ensure the trusted fingerprint reaches ClickHouse intact for both logs and traces.
- Verified RE2 regex logic in the collector config correctly matches `superlog.*` keys while safely bypassing `superlog.issue_fingerprint`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves proxy-authored `superlog.issue_fingerprint` and `superlog.project_id` by moving `superlog.*` sanitization to the proxy and adding explicit authoritative signaling, so ClickHouse accepts issue activity rows and oversized OTLP batches can’t forge fingerprints.

- **Bug Fixes**
  - Proxy: Strip all client `superlog.*` at ingest (resource/span/event/link/log), stamp trusted fingerprints, set `authoritative`, avoid body rewrite when unchanged, and forward `x-superlog-authoritative` to the Collector.
  - Direct path: Pass `authoritative` through decode; in `apps/proxy/src/otlp-clickhouse.ts` strictly strip `superlog.*` unless authoritative (including span links and events), and preserve trusted keys when authoritative.
  - Collector path: Add `x-superlog-authoritative` → `superlog.internal.authoritative`, and only strip `superlog.*` when not authoritative; switch `superlog.project_id` to `upsert` and fix OTTL path to `spanevent.attributes`.

<sup>Written for commit d44de95fd2339787400abcc635c1b3ae63db4d15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

