### PR TITLE
Repair wedged session turns on resume instead of cold-starting

### DIFF
--- a/apps/worker/src/agent-runner-backend.ts
+++ b/apps/worker/src/agent-runner-backend.ts
@@ -260,6 +260,15 @@ export type AgentChatDispatchResult = {
   repliesThisTurn: number;
 };
 
+// Why delivering a message into a durable session failed.
+//   - "wedged_turn": the session is alive but its current turn is blocked on
+//     unanswered tool events, so the runtime rejects new messages. An
+//     `interrupt` closes the turn and makes the session deliverable again.
+//   - "session_gone": the runtime no longer has the session (expired or
+//     deleted) — only this kind justifies discarding the session's context.
+//   - "unknown": neither state is provable from the error.
+export type SessionDeliveryErrorKind = "wedged_turn" | "session_gone" | "unknown";
+
 export type AgentRunnerBackend = {
   name: string;
   maxRepoResources: number;
@@ -279,6 +288,12 @@ export type AgentRunnerBackend = {
   collect(sessionId: string): Promise<AgentRunnerSnapshot>;
   resume(sessionId: string, message: string): Promise<void>;
   steer(sessionId: string, message: string): Promise<void>;
+  // Optional: classify a resume/steer delivery failure so the caller can
+  // repair a wedged turn in place instead of discarding a live session.
+  classifyDeliveryError?(err: unknown): SessionDeliveryErrorKind;
+  // Optional: interrupt the session's open turn so a queued message becomes
+  // deliverable. Only meaningful for runtimes that report "wedged_turn".
+  interrupt?(sessionId: string): Promise<void>;
   dispatchIntegrationToolCalls(input: {
     sessionId: string;
     orgId: string;

--- a/apps/worker/src/agent-runs/resume.test.ts
+++ b/apps/worker/src/agent-runs/resume.test.ts
@@ -2,6 +2,7 @@ import "../agent-run.test-env.js";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  deliverResumeRepairingWedgedTurn,
   finalizeCurrentMergedPullRequestResolution,
   recoverUnresumableContinuation,
   resumeDurableAgentRun,
@@ -411,4 +412,124 @@ test("a human reply resumes first and leaves concurrent incident context for run
   assert.equal(outcome, "resumed");
   assert.deepEqual(delivered, [{ operation: "resume", message: "The provider is healthy again." }]);
   assert.deepEqual(processed, [["reply-1"]]);
+});
+
+test("a wedged-turn delivery interrupts the open turn and retries in place", async () => {
+  const calls: string[] = [];
+  let attempts = 0;
+
+  const delivery = await deliverResumeRepairingWedgedTurn({
+    async attempt() {
+      attempts += 1;
+      calls.push(`attempt:${attempts}`);
+      if (attempts === 1) throw new Error("waiting on responses to events [sevt_1]");
+      return "resumed";
+    },
+    classifyError() {
+      return "wedged_turn";
+    },
+    async interruptOpenTurn() {
+      calls.push("interrupt");
+    },
+  });
+
+  assert.deepEqual(delivery, { kind: "delivered", outcome: "resumed", repaired: true });
+  assert.deepEqual(calls, ["attempt:1", "interrupt", "attempt:2"]);
+});
+
+test("a wedged turn without an interrupt capability fails without a retry", async () => {
+  let attempts = 0;
+  const err = new Error("waiting on responses to events [sevt_1]");
+
+  const delivery = await deliverResumeRepairingWedgedTurn({
+    async attempt() {
+      attempts += 1;
+      throw err;
+    },
+    classifyError() {
+      return "wedged_turn";
+    },
+    interruptOpenTurn: null,
+  });
+
+  assert.deepEqual(delivery, {
+    kind: "failed",
+    err,
+    errorKind: "wedged_turn",
+    repairAttempted: false,
+  });
+  assert.equal(attempts, 1);
+});
+
+test("session-gone delivery errors are never repaired", async () => {
+  const calls: string[] = [];
+  const err = new Error("404 session not found");
+
+  const delivery = await deliverResumeRepairingWedgedTurn({
+    async attempt() {
+      calls.push("attempt");
+      throw err;
+    },
+    classifyError() {
+      return "session_gone";
+    },
+    async interruptOpenTurn() {
+      calls.push("interrupt");
+    },
+  });
+
+  assert.deepEqual(delivery, {
+    kind: "failed",
+    err,
+    errorKind: "session_gone",
+    repairAttempted: false,
+  });
+  assert.deepEqual(calls, ["attempt"]);
+});
+
+test("transient delivery errors propagate untouched for the next-tick retry", async () => {
+  const transient = Object.assign(new Error("socket reset"), { code: "ECONNRESET" });
+
+  await assert.rejects(
+    deliverResumeRepairingWedgedTurn({
+      async attempt() {
+        throw transient;
+      },
+      classifyError() {
+        return "wedged_turn";
+      },
+      async interruptOpenTurn() {
+        throw new Error("interrupt must not run for a transient error");
+      },
+    }),
+    (err: unknown) => err === transient,
+  );
+});
+
+test("a repair whose retry fails again reports the retry error without a third attempt", async () => {
+  const calls: string[] = [];
+  let attempts = 0;
+  const retryErr = new Error("410 session gone");
+
+  const delivery = await deliverResumeRepairingWedgedTurn({
+    async attempt() {
+      attempts += 1;
+      calls.push(`attempt:${attempts}`);
+      throw attempts === 1 ? new Error("waiting on responses to events [sevt_1]") : retryErr;
+    },
+    classifyError(err) {
+      return err === retryErr ? "session_gone" : "wedged_turn";
+    },
+    async interruptOpenTurn() {
+      calls.push("interrupt");
+    },
+  });
+
+  assert.deepEqual(delivery, {
+    kind: "failed",
+    err: retryErr,
+    errorKind: "session_gone",
+    repairAttempted: true,
+  });
+  assert.deepEqual(calls, ["attempt:1", "interrupt", "attempt:2"]);
 });

--- a/apps/worker/src/agent-runs/resume.ts
+++ b/apps/worker/src/agent-runs/resume.ts
@@ -15,7 +15,7 @@ import {
 import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { AgentRunContext } from "../agent-run-context.js";
 import { createAgentRunLifecycle } from "../agent-run.js";
-import type { AgentRunnerBackend } from "../agent-runner-backend.js";
+import type { AgentRunnerBackend, SessionDeliveryErrorKind } from "../agent-runner-backend.js";
 import { investigationGate } from "../billing/investigation-gate.js";
 import { usageNotifier } from "../billing/usage-notifier-infra.js";
 import { getAgentRunnerBackend } from "../infra/agent-runner/backend.js";
@@ -166,6 +166,50 @@ export async function resumeDurableAgentRun(opts: {
   return resumed ? "resumed" : "superseded";
 }
 
+export type ResumeDeliveryResult =
+  | { kind: "delivered"; outcome: "resumed" | "superseded"; repaired: boolean }
+  | {
+      kind: "failed";
+      err: unknown;
+      errorKind: SessionDeliveryErrorKind;
+      repairAttempted: boolean;
+    };
+
+// Deliver pending input into the durable session, repairing a wedged turn at
+// most once. A runtime rejects new messages while the session's turn is still
+// open on unanswered tool events (a run that parked mid-turn) — the session is
+// alive, so discarding it for a cold-start follow-up would throw away the
+// whole investigation context. When the backend can classify that state and
+// interrupt the open turn, do so and retry the delivery in place. Transient
+// errors are rethrown untouched so the caller's next-tick retry applies.
+export async function deliverResumeRepairingWedgedTurn(opts: {
+  attempt(): Promise<"resumed" | "superseded">;
+  classifyError(err: unknown): SessionDeliveryErrorKind;
+  interruptOpenTurn: (() => Promise<void>) | null;
+}): Promise<ResumeDeliveryResult> {
+  try {
+    return { kind: "delivered", outcome: await opts.attempt(), repaired: false };
+  } catch (err) {
+    if (isTransientError(err)) throw err;
+    const errorKind = opts.classifyError(err);
+    if (errorKind !== "wedged_turn" || !opts.interruptOpenTurn) {
+      return { kind: "failed", err, errorKind, repairAttempted: false };
+    }
+    try {
+      await opts.interruptOpenTurn();
+      return { kind: "delivered", outcome: await opts.attempt(), repaired: true };
+    } catch (retryErr) {
+      if (isTransientError(retryErr)) throw retryErr;
+      return {
+        kind: "failed",
+        err: retryErr,
+        errorKind: opts.classifyError(retryErr),
+        repairAttempted: true,
+      };
+    }
+  }
+}
+
 export function resumeInputEventKinds(
   agentRun: Pick<schema.AgentRun, "state" | "result">,
 ): Array<InboundInteractionEventKind | "incident_context_changed"> {
@@ -204,8 +248,11 @@ async function markProcessed(ids: string[]): Promise<void> {
 // An external-cause `awaiting_events` run additionally treats newly-arrived
 // incident context as resumable input, so fresh evidence wakes the parked
 // investigation without requiring an unrelated human reply.
-// When the provider session can't be resumed (never created, or reclaimed by
-// the provider after its TTL) we fall back to a cold-start follow-up run that
+// A session that parked mid-turn (unanswered tool events) rejects new
+// messages even though it is alive; when the backend can classify that state
+// we interrupt the open turn and deliver in place, preserving the session.
+// Only when the session truly can't be resumed (never created, or reclaimed
+// by the provider) do we fall back to a cold-start follow-up run that
 // re-seeds the prior context, so the human's message is never silently lost.
 export async function resumeAgentRunFromHumanInput(ctx: AgentRunContext): Promise<void> {
   const sessionId = ctx.agentRun.providerSessionId;
@@ -224,7 +271,7 @@ export async function resumeAgentRunFromHumanInput(ctx: AgentRunContext): Promis
     const resumeInputs = await loadUnprocessedResumeInputs(ctx.agentRun);
     if (resumeInputs.length === 0) return;
     if (isContinuation) {
-      await coldStartFallback(ctx, resumeInputs);
+      await coldStartFallback(ctx, resumeInputs, "session_gone");
       return;
     }
     const requeued = await agentRunLifecycle.requeueAfterHumanReply({
@@ -252,45 +299,28 @@ export async function resumeAgentRunFromHumanInput(ctx: AgentRunContext): Promis
   const resumeInputs = await loadUnprocessedResumeInputs(ctx.agentRun);
   if (resumeInputs.length === 0) return;
 
+  let delivery: ResumeDeliveryResult;
   try {
     const runner = await getAgentRunnerBackend(ctx.agentRun.runtime);
-    const outcome = await resumeDurableAgentRun({
-      sessionId,
-      inputs: resumeInputs,
-      runner,
-      transitionToRunning: () =>
-        agentRunLifecycle.resumeRunning({
-          id: ctx.agentRun.id,
-          currentState: ctx.agentRun.state,
-          currentResumeCount: ctx.agentRun.resumeCount,
-          continuation: isContinuation,
+    const interrupt = runner.interrupt?.bind(runner);
+    delivery = await deliverResumeRepairingWedgedTurn({
+      attempt: () =>
+        resumeDurableAgentRun({
+          sessionId,
+          inputs: resumeInputs,
+          runner,
+          transitionToRunning: () =>
+            agentRunLifecycle.resumeRunning({
+              id: ctx.agentRun.id,
+              currentState: ctx.agentRun.state,
+              currentResumeCount: ctx.agentRun.resumeCount,
+              continuation: isContinuation,
+            }),
+          markProcessed,
         }),
-      markProcessed,
+      classifyError: (err) => runner.classifyDeliveryError?.(err) ?? "unknown",
+      interruptOpenTurn: interrupt ? () => interrupt(sessionId) : null,
     });
-    if (outcome === "superseded") {
-      logger.info(
-        {
-          scope: "agent_run",
-          agent_run_id: ctx.agentRun.id,
-          incident_id: ctx.incident.id,
-          session_id: sessionId,
-        },
-        "resume input reached the durable session after the run had already transitioned",
-      );
-      return;
-    }
-    logger.info(
-      {
-        scope: "agent_run",
-        agent_run_id: ctx.agentRun.id,
-        incident_id: ctx.incident.id,
-        session_id: sessionId,
-        continuation: isContinuation,
-        resume_count: ctx.agentRun.resumeCount + 1,
-        input_count: resumeInputs.length,
-      },
-      "agent run resumed from pending input",
-    );
   } catch (err) {
     if (isTransientError(err)) {
       logger.error(
@@ -308,28 +338,65 @@ export async function resumeAgentRunFromHumanInput(ctx: AgentRunContext): Promis
       );
       return;
     }
-    // A non-transient resume error on a continuation almost always means the
-    // provider session is gone (TTL-reclaimed). Don't alarm the thread with an
-    // "Investigation failed" card — quietly fall back to a fresh follow-up that
+    delivery = { kind: "failed", err, errorKind: "unknown", repairAttempted: false };
+  }
+
+  if (delivery.kind === "failed") {
+    // Only a provably-gone session justifies discarding the durable context.
+    // Wedged turns are repaired above; whatever still fails here (repair
+    // exhausted, or an unclassifiable error) falls back so the human's input
+    // is never silently lost. Don't alarm the thread with an "Investigation
+    // failed" card on a continuation — quietly enqueue a fresh follow-up that
     // re-seeds the prior context. For the classic awaiting_human pause we keep
     // the existing hard-fail.
     if (isContinuation) {
       logger.warn(
         {
-          err,
+          err: delivery.err,
           scope: "agent_run",
           agent_run_id: ctx.agentRun.id,
           incident_id: ctx.incident.id,
           provider_session_id: sessionId,
           stage: "resume",
+          delivery_error_kind: delivery.errorKind,
+          repair_attempted: delivery.repairAttempted,
         },
         "could not resume durable session; falling back to a cold-start follow-up",
       );
-      await coldStartFallback(ctx, resumeInputs);
+      await coldStartFallback(ctx, resumeInputs, delivery.errorKind);
       return;
     }
-    await failAgentRun(ctx, "resume_failed", "Failed to resume agent run.", { err });
+    await failAgentRun(ctx, "resume_failed", "Failed to resume agent run.", { err: delivery.err });
+    return;
   }
+
+  if (delivery.outcome === "superseded") {
+    logger.info(
+      {
+        scope: "agent_run",
+        agent_run_id: ctx.agentRun.id,
+        incident_id: ctx.incident.id,
+        session_id: sessionId,
+      },
+      "resume input reached the durable session after the run had already transitioned",
+    );
+    return;
+  }
+  logger.info(
+    {
+      scope: "agent_run",
+      agent_run_id: ctx.agentRun.id,
+      incident_id: ctx.incident.id,
+      session_id: sessionId,
+      continuation: isContinuation,
+      resume_count: ctx.agentRun.resumeCount + 1,
+      input_count: resumeInputs.length,
+      turn_repaired: delivery.repaired,
+    },
+    delivery.repaired
+      ? "agent run resumed from pending input after interrupting a wedged turn"
+      : "agent run resumed from pending input",
+  );
 }
 
 // Session unresumable → resolve a completed PR delivery deterministically, or
@@ -337,6 +404,7 @@ export async function resumeAgentRunFromHumanInput(ctx: AgentRunContext): Promis
 async function coldStartFallback(
   ctx: AgentRunContext,
   resumeInputs: Awaited<ReturnType<typeof loadUnprocessedResumeInputs>>,
+  errorKind: SessionDeliveryErrorKind,
 ): Promise<void> {
   const recovery = await recoverUnresumableContinuation({
     inputs: resumeInputs,
@@ -441,7 +509,12 @@ async function coldStartFallback(
         id: ctx.agentRun.id,
         currentState: ctx.agentRun.state,
         reason: "resume_failed",
-        summary: "Provider session expired; continuing as a fresh follow-up.",
+        // Only claim expiry when the provider proved the session is gone —
+        // any other failure gets the honest, unspecific wording.
+        summary:
+          errorKind === "session_gone"
+            ? "Provider session expired; continuing as a fresh follow-up."
+            : "Provider session could not be resumed; continuing as a fresh follow-up.",
         category: "infrastructure",
         existingResult: ctx.agentRun.result ?? null,
       });


### PR DESCRIPTION
## Problem

When a run parks (`awaiting_events`/`awaiting_human`/`resuming`) while its durable session still has an open turn — an unanswered tool event — the runtime rejects any later `user.message` with:

> 400 `invalid_request_error`: "Invalid user.message event at events[0]: waiting on responses to events [sevt_…]; only `user.tool_confirmation`, `user.custom_tool_result`, `user.tool_result`, or `user.interrupt` may be sent"

The resume path (`apps/worker/src/agent-runs/resume.ts`) assumed any non-transient delivery error meant the session was TTL-reclaimed and quietly fell back to a cold-start follow-up with the summary "Provider session expired". In practice most of these sessions were 1–2 days old and very much alive — just wedged mid-turn. The cold start discards the session's entire investigation context, which leads to full re-investigations and duplicate PRs on the same incident (the fresh follow-up often wedges the same way later, cascading).

## Fix

- `AgentRunnerBackend` gains two optional methods: `classifyDeliveryError(err)` → `"wedged_turn" | "session_gone" | "unknown"`, and `interrupt(sessionId)`.
- New `deliverResumeRepairingWedgedTurn` wraps the delivery: on a wedged-turn failure it interrupts the open turn (the escape hatch the API itself names) and retries the delivery once, in place — session and context preserved. Transient errors still propagate for the next-tick retry.
- Cold-start stays as the last-resort fallback, but only a provably-gone session (404/410) is reported as "Provider session expired"; anything else now says "Provider session could not be resumed".
- The repair covers the classic `awaiting_human` resume, continuations, and context steers into a parked session; repair attempts and outcomes are logged (`delivery_error_kind`, `repair_attempted`, `turn_repaired`).

Backends that don't implement the new optional methods keep the exact previous behavior.

## Testing

- `node --test` on `apps/worker/src/agent-runs/resume.test.ts` — 16/16 pass (5 new tests covering repair, no-capability fallthrough, session-gone, transient propagation, and bounded retry).
- `pnpm --filter @superlog/worker typecheck` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes resume failures when a run is parked with a wedged turn by interrupting the open turn and retrying once in place. This preserves session context and only cold-starts when the session is provably gone.

- **Bug Fixes**
  - Repair wedged-turn failures by interrupting the open turn and retrying resume/steer once in place (applies to `awaiting_human` resumes, continuations, and context steers).
  - Transient errors propagate unchanged to the existing retry; cold-start only when the session is truly gone, with clearer messages.
  - Logs now include `delivery_error_kind`, `repair_attempted`, and `turn_repaired`.

- **Migration**
  - Backends can opt in by implementing `classifyDeliveryError(err)` → `"wedged_turn" | "session_gone" | "unknown"` and `interrupt(sessionId)`.
  - If not implemented, behavior remains unchanged.

<sup>Written for commit 1e786db4eaa254ca698b68b4fd1cbe4d1f054c73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

