### PR TITLE
Request MCP OAuth scopes advertised for the resource

### DIFF
--- a/apps/api/src/project-mcp-auth-detection.test.ts
+++ b/apps/api/src/project-mcp-auth-detection.test.ts
@@ -13,6 +13,7 @@ test("MCP auth detection recognizes standards-based OAuth authorization code ser
       resource: "https://mcp.granola.example/mcp",
       codeChallengeMethods: ["S256"],
       grantTypes: ["authorization_code", "refresh_token"],
+      scopesSupported: ["projects:read", "database:read"],
     }),
   };
 
@@ -20,6 +21,7 @@ test("MCP auth detection recognizes standards-based OAuth authorization code ser
     type: "oauth",
     grantType: "authorization_code",
     supportsDynamicRegistration: true,
+    scopesSupported: ["projects:read", "database:read"],
   });
 });
 

--- a/apps/api/src/project-mcp-auth-detection.ts
+++ b/apps/api/src/project-mcp-auth-detection.ts
@@ -3,14 +3,21 @@ export type ProjectMcpAuthDetection =
       type: "oauth";
       grantType: "authorization_code" | "client_credentials";
       supportsDynamicRegistration: boolean;
+      // Scopes the server advertises for this resource, so the connect UI can
+      // show what will be requested and let the operator trim the set.
+      scopesSupported: string[];
     }
   | { type: "unknown" };
 
 export type ProjectMcpOAuthDiscoverer = {
-  discover(serverUrl: string, signal?: AbortSignal): Promise<{
+  discover(
+    serverUrl: string,
+    signal?: AbortSignal,
+  ): Promise<{
     codeChallengeMethods: string[];
     grantTypes: string[];
     registrationEndpoint: string | null;
+    scopesSupported?: string[];
   }>;
 };
 
@@ -42,16 +49,14 @@ export async function detectProjectMcpAuth(
       supportsClientCredentials && !supportsAuthorizationCode
         ? "client_credentials"
         : "authorization_code";
-    if (
-      grantType === "authorization_code" &&
-      !discovery.codeChallengeMethods.includes("S256")
-    ) {
+    if (grantType === "authorization_code" && !discovery.codeChallengeMethods.includes("S256")) {
       return { type: "unknown" };
     }
     return {
       type: "oauth",
       grantType,
       supportsDynamicRegistration: discovery.registrationEndpoint !== null,
+      scopesSupported: discovery.scopesSupported ?? [],
     };
   } catch {
     return { type: "unknown" };

--- a/apps/api/src/project-mcp-oauth.test.ts
+++ b/apps/api/src/project-mcp-oauth.test.ts
@@ -74,6 +74,7 @@ test("OAuth start uses discovery, dynamic registration, PKCE, and resource bindi
         resource: "https://linear.example/mcp",
         codeChallengeMethods: ["S256"],
         grantTypes: ["authorization_code", "refresh_token"],
+        scopesSupported: ["issues:read", "issues:write"],
       }),
       register: async () => ({
         clientId: "dynamic-client",
@@ -108,6 +109,8 @@ test("OAuth start uses discovery, dynamic registration, PKCE, and resource bindi
   assert.equal(url.searchParams.get("state"), "state-value");
   assert.equal(url.searchParams.get("code_challenge_method"), "S256");
   assert.equal(url.searchParams.get("resource"), "https://linear.example/mcp");
+  // Operator-configured scopes take precedence over the server's advertised set.
+  assert.equal(url.searchParams.get("scope"), "issues:read");
   assert.ok(url.searchParams.get("code_challenge"));
   assert.ok(attempt);
   assert.equal((attempt as ProjectMcpOAuthAttempt).clientSecret, null);
@@ -312,6 +315,7 @@ test("OAuth client credentials is accepted only when the authorization server ad
     auth: {
       ...server.auth,
       grantType: "client_credentials",
+      scopes: [],
       clientId: "service-client",
       clientSecret: "service-secret",
     },
@@ -335,6 +339,7 @@ test("OAuth client credentials is accepted only when the authorization server ad
         resource: server.url,
         codeChallengeMethods: ["S256"],
         grantTypes: ["client_credentials"],
+        scopesSupported: ["service:read"],
       }),
       register: async () => {
         throw new Error("not called");
@@ -348,6 +353,7 @@ test("OAuth client credentials is accepted only when the authorization server ad
       clientCredentials: async (input) => {
         assert.equal(input.clientId, "service-client");
         assert.equal(input.resource, server.url);
+        assert.deepEqual(input.scopes, ["service:read"]);
         return {
           accessToken: "service-access",
           refreshToken: null,
@@ -369,4 +375,112 @@ test("OAuth client credentials is accepted only when the authorization server ad
   if (result.auth.type !== "oauth") return;
   assert.equal(result.auth.status, "connected");
   assert.equal(result.auth.accessToken, "service-access");
+  assert.deepEqual(result.auth.scopes, ["service:read"]);
+});
+
+test("OAuth start requests the server's advertised scopes when none are configured", async () => {
+  let server = oauthServer();
+  server = {
+    ...server,
+    auth: { ...server.auth, type: "oauth", scopes: [] } as ProjectMcpServer["auth"],
+  };
+  let attempt: ProjectMcpOAuthAttempt | null = null;
+  const repository = {
+    get: async () => server,
+    update: async (next: ProjectMcpServer) => {
+      server = next;
+      return next;
+    },
+  } as unknown as ProjectMcpServerRepository;
+  const service = createProjectMcpOAuthService({
+    repository,
+    attempts: {
+      create: async (value) => {
+        attempt = value;
+      },
+      consume: async () => null,
+    },
+    http: {
+      discover: async () => ({
+        authorizationServer: "https://auth.example",
+        authorizationEndpoint: "https://auth.example/authorize",
+        tokenEndpoint: "https://auth.example/token",
+        registrationEndpoint: "https://auth.example/register",
+        resource: "https://linear.example/mcp",
+        codeChallengeMethods: ["S256"],
+        grantTypes: ["authorization_code", "refresh_token"],
+        scopesSupported: ["projects:read", "database:read"],
+      }),
+      register: async () => ({ clientId: "dynamic-client", clientSecret: null }),
+      exchange: async () => {
+        throw new Error("not called");
+      },
+      refresh: async () => {
+        throw new Error("not called");
+      },
+      clientCredentials: async () => {
+        throw new Error("not called");
+      },
+    },
+    randomToken: (() => {
+      const values = ["state-value", "verifier-value"];
+      return () => values.shift() ?? "unused";
+    })(),
+    now: () => new Date("2026-07-14T10:00:00.000Z"),
+  });
+
+  const result = await service.start({
+    projectId: "project-1",
+    serverId: "server-1",
+    actorUserId: "user-1",
+    redirectUri: "https://api.superlog.sh/api/agent-mcp-oauth/callback",
+  });
+
+  const url = new URL(result.authorizationUrl);
+  assert.equal(url.searchParams.get("scope"), "projects:read database:read");
+  // The advertised set is persisted so a token response without `scope` still
+  // records what was actually requested.
+  assert.deepEqual((attempt as unknown as ProjectMcpOAuthAttempt).scopes, [
+    "projects:read",
+    "database:read",
+  ]);
+});
+
+test("OAuth discovery prefers the protected-resource scopes_supported over the auth server's", async () => {
+  const json = (body: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      ...init,
+    });
+  const fakeFetch = (async (input: URL | string | Request) => {
+    const target = input.toString();
+    if (target === "https://mcp.example/mcp") {
+      return new Response(null, { status: 401 });
+    }
+    if (target === "https://mcp.example/.well-known/oauth-protected-resource/mcp") {
+      return json({
+        resource: "https://mcp.example/mcp?read_only=true",
+        authorization_servers: ["https://as.example"],
+        scopes_supported: ["projects:read", "database:read"],
+      });
+    }
+    if (target === "https://as.example/.well-known/oauth-authorization-server") {
+      return json({
+        authorization_endpoint: "https://as.example/authorize",
+        token_endpoint: "https://as.example/token",
+        code_challenge_methods_supported: ["S256"],
+        grant_types_supported: ["authorization_code"],
+        // The auth server advertises writes too; discovery must not pick these
+        // up when the protected resource has already narrowed the set.
+        scopes_supported: ["projects:read", "projects:write", "database:write"],
+      });
+    }
+    return new Response(null, { status: 404 });
+  }) as unknown as typeof fetch;
+
+  const discovery =
+    await createFetchProjectMcpOAuthHttp(fakeFetch).discover("https://mcp.example/mcp");
+
+  assert.deepEqual(discovery.scopesSupported, ["projects:read", "database:read"]);
 });

--- a/apps/api/src/project-mcp-oauth.test.ts
+++ b/apps/api/src/project-mcp-oauth.test.ts
@@ -484,3 +484,39 @@ test("OAuth discovery prefers the protected-resource scopes_supported over the a
 
   assert.deepEqual(discovery.scopesSupported, ["projects:read", "database:read"]);
 });
+
+test("OAuth discovery honors an explicitly empty protected-resource scope list", async () => {
+  const json = (body: unknown) =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  const fakeFetch = (async (input: URL | string | Request) => {
+    const target = input.toString();
+    if (target === "https://mcp.example/mcp") {
+      return new Response(null, { status: 401 });
+    }
+    if (target === "https://mcp.example/.well-known/oauth-protected-resource/mcp") {
+      return json({
+        resource: "https://mcp.example/mcp",
+        authorization_servers: ["https://as.example"],
+        scopes_supported: [],
+      });
+    }
+    if (target === "https://as.example/.well-known/oauth-authorization-server") {
+      return json({
+        authorization_endpoint: "https://as.example/authorize",
+        token_endpoint: "https://as.example/token",
+        code_challenge_methods_supported: ["S256"],
+        grant_types_supported: ["authorization_code"],
+        scopes_supported: ["projects:read", "projects:write"],
+      });
+    }
+    return new Response(null, { status: 404 });
+  }) as unknown as typeof fetch;
+
+  const discovery =
+    await createFetchProjectMcpOAuthHttp(fakeFetch).discover("https://mcp.example/mcp");
+
+  assert.deepEqual(discovery.scopesSupported, []);
+});

--- a/apps/api/src/project-mcp-oauth.ts
+++ b/apps/api/src/project-mcp-oauth.ts
@@ -508,6 +508,7 @@ async function discoverProjectMcpOAuth(
     authorizationMetadataUrls(authorizationServer),
     signal,
   );
+  const resourceAdvertisesScopes = Array.isArray(resourceMetadata.scopes_supported);
   const resourceScopes = readStringArray(resourceMetadata.scopes_supported);
   return {
     authorizationServer,
@@ -520,8 +521,9 @@ async function discoverProjectMcpOAuth(
         : endpoint.toString(),
     codeChallengeMethods: readStringArray(metadata.code_challenge_methods_supported),
     grantTypes: readStringArray(metadata.grant_types_supported),
-    scopesSupported:
-      resourceScopes.length > 0 ? resourceScopes : readStringArray(metadata.scopes_supported),
+    scopesSupported: resourceAdvertisesScopes
+      ? resourceScopes
+      : readStringArray(metadata.scopes_supported),
   };
 }
 

--- a/apps/api/src/project-mcp-oauth.ts
+++ b/apps/api/src/project-mcp-oauth.ts
@@ -14,6 +14,12 @@ export type ProjectMcpOAuthDiscovery = {
   resource: string;
   codeChallengeMethods: string[];
   grantTypes: string[];
+  // Scopes the server advertises for this resource (RFC 9728 protected-resource
+  // metadata, falling back to the authorization server's own list). Servers use
+  // this to narrow what a URL variant grants — e.g. a read-only URL advertises
+  // only read scopes — so a client should request exactly these unless the
+  // operator has pinned an explicit subset.
+  scopesSupported: string[];
 };
 
 export type ProjectMcpOAuthAttempt = {
@@ -116,6 +122,12 @@ export function createProjectMcpOAuthService(deps: {
         clientId = registration.clientId;
         clientSecret = registration.clientSecret;
       }
+      // An operator-pinned scope list wins; otherwise request everything the
+      // server advertises for this resource. This is what makes a read-only
+      // resource URL request only read scopes, matching other MCP clients,
+      // instead of falling through to the server's "grant everything" default.
+      const requestedScopes =
+        server.auth.scopes.length > 0 ? server.auth.scopes : discovery.scopesSupported;
       const state = randomToken();
       const codeVerifier = randomToken();
       const expiresAt = new Date(now().getTime() + OAUTH_ATTEMPT_TTL_MS);
@@ -131,7 +143,7 @@ export function createProjectMcpOAuthService(deps: {
         tokenEndpoint: discovery.tokenEndpoint,
         authorizationServer: discovery.authorizationServer,
         resource: discovery.resource,
-        scopes: server.auth.scopes,
+        scopes: requestedScopes,
         expiresAt,
       });
       await deps.repository.update({
@@ -156,8 +168,8 @@ export function createProjectMcpOAuthService(deps: {
       authorizationUrl.searchParams.set("code_challenge", pkceChallenge(codeVerifier));
       authorizationUrl.searchParams.set("code_challenge_method", "S256");
       authorizationUrl.searchParams.set("resource", discovery.resource);
-      if (server.auth.scopes.length > 0) {
-        authorizationUrl.searchParams.set("scope", server.auth.scopes.join(" "));
+      if (requestedScopes.length > 0) {
+        authorizationUrl.searchParams.set("scope", requestedScopes.join(" "));
       }
       return {
         authorizationUrl: authorizationUrl.toString(),
@@ -268,18 +280,21 @@ export function createProjectMcpOAuthService(deps: {
     if (!discovery.grantTypes.includes("client_credentials")) {
       throw new Error("OAuth server does not advertise the client credentials grant");
     }
+    const requestedScopes =
+      server.auth.scopes.length > 0 ? server.auth.scopes : discovery.scopesSupported;
     const token = await deps.http.clientCredentials({
       tokenEndpoint: discovery.tokenEndpoint,
       clientId: server.auth.clientId,
       clientSecret: server.auth.clientSecret,
       resource: discovery.resource,
-      scopes: server.auth.scopes,
+      scopes: requestedScopes,
     });
     return storeToken(server, token, {
       actorUserId,
       tokenEndpoint: discovery.tokenEndpoint,
       authorizationServer: discovery.authorizationServer,
       resource: discovery.resource,
+      scopes: requestedScopes,
     });
   }
 
@@ -294,6 +309,7 @@ export function createProjectMcpOAuthService(deps: {
       tokenEndpoint?: string;
       authorizationServer?: string;
       resource?: string;
+      scopes?: string[];
     } = {},
   ): Promise<ProjectMcpServer> {
     return deps.repository.update({
@@ -310,7 +326,9 @@ export function createProjectMcpOAuthService(deps: {
         tokenEndpoint: overrides.tokenEndpoint ?? server.auth.tokenEndpoint,
         authorizationServer: overrides.authorizationServer ?? server.auth.authorizationServer,
         resource: overrides.resource ?? server.auth.resource,
-        scopes: token.scope ? token.scope.split(/\s+/).filter(Boolean) : server.auth.scopes,
+        scopes: token.scope
+          ? token.scope.split(/\s+/).filter(Boolean)
+          : (overrides.scopes ?? server.auth.scopes),
       },
       updatedByUserId: overrides.actorUserId ?? server.updatedByUserId,
       updatedAt: now(),
@@ -485,7 +503,12 @@ async function discoverProjectMcpOAuth(
     throw new Error("MCP protected-resource metadata has no authorization server");
   }
   const authorizationServer = authorizationServers[0] as string;
-  const metadata = await firstJson(fetchImpl, authorizationMetadataUrls(authorizationServer), signal);
+  const metadata = await firstJson(
+    fetchImpl,
+    authorizationMetadataUrls(authorizationServer),
+    signal,
+  );
+  const resourceScopes = readStringArray(resourceMetadata.scopes_supported);
   return {
     authorizationServer,
     authorizationEndpoint: requiredMetadataUrl(metadata.authorization_endpoint),
@@ -497,6 +520,8 @@ async function discoverProjectMcpOAuth(
         : endpoint.toString(),
     codeChallengeMethods: readStringArray(metadata.code_challenge_methods_supported),
     grantTypes: readStringArray(metadata.grant_types_supported),
+    scopesSupported:
+      resourceScopes.length > 0 ? resourceScopes : readStringArray(metadata.scopes_supported),
   };
 }
 

--- a/apps/api/src/project-mcp-servers.test.ts
+++ b/apps/api/src/project-mcp-servers.test.ts
@@ -80,6 +80,7 @@ test("an owner can detect OAuth from an MCP server URL before saving it", async 
         type: "oauth",
         grantType: "authorization_code",
         supportsDynamicRegistration: true,
+        scopesSupported: ["projects:read"],
       };
     },
   });
@@ -98,6 +99,7 @@ test("an owner can detect OAuth from an MCP server URL before saving it", async 
     type: "oauth",
     grantType: "authorization_code",
     supportsDynamicRegistration: true,
+    scopesSupported: ["projects:read"],
   });
 });
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1780,6 +1780,7 @@ export type ProjectMcpAuthDetection =
       type: "oauth";
       grantType: "authorization_code" | "client_credentials";
       supportsDynamicRegistration: boolean;
+      scopesSupported: string[];
     }
   | { type: "unknown" };
 

--- a/apps/web/src/settings/AgentMcpServersCard.test.tsx
+++ b/apps/web/src/settings/AgentMcpServersCard.test.tsx
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { McpAuthenticationEditor } from "./AgentMcpServersCard.tsx";
 import { EMPTY_AUTH } from "./project-mcp-editor.ts";
@@ -38,4 +39,29 @@ test("manual MCP auth reveals credential choices only after the fallback is requ
   assert.match(html, /<select/);
   assert.match(html, /Bearer \/ API token/);
   assert.match(html, /Use auto/);
+});
+
+test("detected OAuth shows advertised scopes in a closed customization disclosure", () => {
+  const html = renderToStaticMarkup(
+    <McpAuthenticationEditor
+      manual={false}
+      detectionMessage="OAuth detected"
+      value={{
+        ...EMPTY_AUTH,
+        type: "oauth",
+        advertisedScopes: ["projects:read", "database:read"],
+      }}
+      onChange={() => {}}
+      onConfigureManually={() => {}}
+      onUseAutomatic={() => {}}
+    />,
+  );
+
+  assert.match(html, /<details/);
+  assert.doesNotMatch(html, /<details[^>]* open/);
+  assert.match(html, /OAuth scopes/);
+  assert.match(html, /2 selected/);
+  assert.match(html, /projects:read/);
+  assert.match(html, /database:read/);
+  assert.match(html, /type="checkbox"[^>]*checked/);
 });

--- a/apps/web/src/settings/AgentMcpServersCard.tsx
+++ b/apps/web/src/settings/AgentMcpServersCard.tsx
@@ -22,6 +22,7 @@ import {
   detectProjectMcpAuthSafely,
   projectMcpAuthDetectionIsCurrent,
   projectMcpAuthSelectionAfterUrlChange,
+  resolveProjectMcpAuthForSubmit,
   resolveSelectedScopes,
   shouldDetectProjectMcpAuth,
   toggleScopeSelection,
@@ -48,6 +49,7 @@ export function AgentMcpServersCard({ projectId }: { projectId: string | undefin
   const [authDetection, setAuthDetection] = useState<string | null>(null);
   const [manualAuth, setManualAuth] = useState(false);
   const authSelection = useRef<ProjectMcpAuthSelection>("automatic");
+  const detectedAuthUrl = useRef<string | null>(null);
 
   const servers = query.data?.servers ?? [];
   const canManage = query.data?.canManage ?? false;
@@ -73,6 +75,7 @@ export function AgentMcpServersCard({ projectId }: { projectId: string | undefin
     }
     if (authSelection.current !== "automatic") return auth;
     const nextAuth = createDetectedProjectMcpAuthDraft(detected);
+    detectedAuthUrl.current = requestedUrl;
     setAuth(nextAuth);
     if (nextAuth.requiresClientId) {
       authSelection.current = "required";
@@ -94,7 +97,13 @@ export function AgentMcpServersCard({ projectId }: { projectId: string | undefin
     event.preventDefault();
     setError(null);
     if (!trusted) return;
-    const submittedAuth = authSelection.current === "automatic" ? await detectAuthForUrl() : auth;
+    const submittedAuth = await resolveProjectMcpAuthForSubmit({
+      selection: authSelection.current,
+      draft: auth,
+      detectedUrl: detectedAuthUrl.current,
+      currentUrl: urlRef.current,
+      detect: detectAuthForUrl,
+    });
     if (!submittedAuth) return;
     create.mutate(
       {
@@ -110,6 +119,7 @@ export function AgentMcpServersCard({ projectId }: { projectId: string | undefin
           setUrl("");
           urlRef.current = "";
           setAuth(EMPTY_AUTH);
+          detectedAuthUrl.current = null;
           authSelection.current = "automatic";
           setManualAuth(false);
           setAuthDetection(null);
@@ -292,6 +302,7 @@ export function AgentMcpServersCard({ projectId }: { projectId: string | undefin
                   urlRef.current = e.target.value;
                   setUrl(e.target.value);
                   setAuthDetection(null);
+                  detectedAuthUrl.current = null;
                   const nextSelection = projectMcpAuthSelectionAfterUrlChange(
                     authSelection.current,
                   );
@@ -318,11 +329,13 @@ export function AgentMcpServersCard({ projectId }: { projectId: string | undefin
             onChange={setAuth}
             onConfigureManually={() => {
               authSelection.current = "manual";
+              detectedAuthUrl.current = null;
               setManualAuth(true);
               setAuthDetection(null);
             }}
             onUseAutomatic={() => {
               authSelection.current = "automatic";
+              detectedAuthUrl.current = null;
               setManualAuth(false);
               setAuth(EMPTY_AUTH);
               if (shouldDetectProjectMcpAuth("automatic", url, trusted)) void detectAuthForUrl();

--- a/apps/web/src/settings/AgentMcpServersCard.tsx
+++ b/apps/web/src/settings/AgentMcpServersCard.tsx
@@ -16,13 +16,15 @@ import { Btn, Chip, FieldLabel, Input } from "../design/ui.tsx";
 import {
   type AuthDraft,
   EMPTY_AUTH,
+  type ProjectMcpAuthSelection,
   createDetectedProjectMcpAuthDraft,
   createProjectMcpEditorDraft,
   detectProjectMcpAuthSafely,
   projectMcpAuthDetectionIsCurrent,
   projectMcpAuthSelectionAfterUrlChange,
+  resolveSelectedScopes,
   shouldDetectProjectMcpAuth,
-  type ProjectMcpAuthSelection,
+  toggleScopeSelection,
 } from "./project-mcp-editor.ts";
 import { SettingsCard, SettingsRow } from "./rows.tsx";
 
@@ -59,13 +61,11 @@ export function AgentMcpServersCard({ projectId }: { projectId: string | undefin
     connectClientCredentials.isPending ||
     disconnectOAuth.isPending;
 
-  const detectAuthForUrl = async (): Promise<AuthDraft | null> => {
+  const detectAuthForUrl = async (trustedValue = trusted): Promise<AuthDraft | null> => {
     const requestedUrl = urlRef.current;
-    if (!shouldDetectProjectMcpAuth(authSelection.current, requestedUrl, trusted)) return auth;
+    if (!shouldDetectProjectMcpAuth(authSelection.current, requestedUrl, trustedValue)) return auth;
     setAuthDetection("Detecting auth…");
-    const detected = await detectProjectMcpAuthSafely(() =>
-      detectAuth.mutateAsync(requestedUrl),
-    );
+    const detected = await detectProjectMcpAuthSafely(() => detectAuth.mutateAsync(requestedUrl));
     if (!projectMcpAuthDetectionIsCurrent(requestedUrl, urlRef.current)) return null;
     if (!detected) {
       setAuthDetection("Auth detection failed");
@@ -94,8 +94,7 @@ export function AgentMcpServersCard({ projectId }: { projectId: string | undefin
     event.preventDefault();
     setError(null);
     if (!trusted) return;
-    const submittedAuth =
-      authSelection.current === "automatic" ? await detectAuthForUrl() : auth;
+    const submittedAuth = authSelection.current === "automatic" ? await detectAuthForUrl() : auth;
     if (!submittedAuth) return;
     create.mutate(
       {
@@ -333,7 +332,13 @@ export function AgentMcpServersCard({ projectId }: { projectId: string | undefin
             <input
               type="checkbox"
               checked={trusted}
-              onChange={(e) => setTrusted(e.target.checked)}
+              onChange={(event) => {
+                const nextTrusted = event.target.checked;
+                setTrusted(nextTrusted);
+                if (shouldDetectProjectMcpAuth(authSelection.current, url, nextTrusted)) {
+                  void detectAuthForUrl(nextTrusted);
+                }
+              }}
               className="mt-0.5"
             />
             <span>
@@ -415,6 +420,9 @@ export function McpAuthenticationEditor({
             Set auth manually
           </Btn>
         </div>
+      )}
+      {!manual && value.type === "oauth" && value.advertisedScopes.length > 0 && (
+        <OAuthScopesDisclosure value={value} onChange={onChange} />
       )}
     </div>
   );
@@ -583,18 +591,22 @@ function AuthFields({
           <option value="client_credentials">Client credentials</option>
         </select>
       </Field>
-      <Field label="Scopes (space-separated)">
-        <Input
-          value={value.scopes}
-          onChange={(e) => onChange({ ...value, scopes: e.target.value })}
-          placeholder="issues:read"
-        />
-      </Field>
+      {value.advertisedScopes.length > 0 ? (
+        <div className="sm:col-span-2">
+          <OAuthScopesDisclosure value={value} onChange={onChange} />
+        </div>
+      ) : (
+        <Field label="Scopes (space-separated)">
+          <Input
+            value={value.scopes}
+            onChange={(e) => onChange({ ...value, scopes: e.target.value })}
+            placeholder="issues:read"
+          />
+        </Field>
+      )}
       <Field
         label={
-          value.requiresClientId
-            ? "Client ID"
-            : "Client ID (optional with dynamic registration)"
+          value.requiresClientId ? "Client ID" : "Client ID (optional with dynamic registration)"
         }
       >
         <Input
@@ -617,6 +629,50 @@ function AuthFields({
         />
       </Field>
     </div>
+  );
+}
+
+export function OAuthScopesDisclosure({
+  value,
+  onChange,
+}: {
+  value: AuthDraft;
+  onChange: (next: AuthDraft) => void;
+}) {
+  const selectedScopes = resolveSelectedScopes(value.scopes, value.advertisedScopes);
+  const selected = new Set(selectedScopes);
+
+  return (
+    <details className="mt-3 rounded-md border border-border bg-surface-2 px-3 py-2 text-[12px]">
+      <summary className="cursor-pointer select-none text-fg">
+        OAuth scopes · {selectedScopes.length} selected
+      </summary>
+      <p className="mt-2 text-muted">
+        These scopes come from this MCP URL. Clear a scope to request less access.
+      </p>
+      <div className="mt-2 grid gap-2 sm:grid-cols-2">
+        {value.advertisedScopes.map((scope) => {
+          const checked = selected.has(scope);
+          return (
+            <label key={scope} className="flex items-start gap-2 font-mono text-[11.5px] text-fg">
+              <input
+                type="checkbox"
+                checked={checked}
+                disabled={checked && selectedScopes.length === 1}
+                onChange={() =>
+                  onChange({
+                    ...value,
+                    scopes: toggleScopeSelection(value.scopes, value.advertisedScopes, scope),
+                  })
+                }
+                className="mt-0.5"
+              />
+              <span className="break-all">{scope}</span>
+            </label>
+          );
+        })}
+      </div>
+    </details>
   );
 }
 

--- a/apps/web/src/settings/AgentMcpServersCard.tsx
+++ b/apps/web/src/settings/AgentMcpServersCard.tsx
@@ -21,6 +21,7 @@ import {
   createProjectMcpEditorDraft,
   detectProjectMcpAuthSafely,
   projectMcpAuthDetectionIsCurrent,
+  projectMcpAuthDraftAfterUrlChange,
   projectMcpAuthSelectionAfterUrlChange,
   resolveProjectMcpAuthForSubmit,
   resolveSelectedScopes,
@@ -303,6 +304,7 @@ export function AgentMcpServersCard({ projectId }: { projectId: string | undefin
                   setUrl(e.target.value);
                   setAuthDetection(null);
                   detectedAuthUrl.current = null;
+                  setAuth((current) => projectMcpAuthDraftAfterUrlChange(current));
                   const nextSelection = projectMcpAuthSelectionAfterUrlChange(
                     authSelection.current,
                   );

--- a/apps/web/src/settings/project-mcp-editor.test.ts
+++ b/apps/web/src/settings/project-mcp-editor.test.ts
@@ -7,6 +7,7 @@ import {
   createProjectMcpEditorDraft,
   detectProjectMcpAuthSafely,
   projectMcpAuthDetectionIsCurrent,
+  projectMcpAuthDraftAfterUrlChange,
   projectMcpAuthSelectionAfterUrlChange,
   resolveProjectMcpAuthForSubmit,
   resolveSelectedScopes,
@@ -124,6 +125,20 @@ test("detected client-credentials OAuth requires manual credentials even with re
 test("changing the URL resets auth forced by detection but preserves an explicit manual choice", () => {
   assert.equal(projectMcpAuthSelectionAfterUrlChange("required"), "automatic");
   assert.equal(projectMcpAuthSelectionAfterUrlChange("manual"), "manual");
+});
+
+test("changing a manual OAuth URL clears scopes advertised by the old resource", () => {
+  const draft = {
+    ...EMPTY_AUTH,
+    type: "oauth" as const,
+    scopes: "projects:read",
+    advertisedScopes: ["projects:read", "database:read"],
+  };
+
+  assert.deepEqual(projectMcpAuthDraftAfterUrlChange(draft), {
+    ...draft,
+    advertisedScopes: [],
+  });
 });
 
 test("automatic auth detection requires an URL and explicit trust confirmation", () => {

--- a/apps/web/src/settings/project-mcp-editor.test.ts
+++ b/apps/web/src/settings/project-mcp-editor.test.ts
@@ -5,9 +5,11 @@ import {
   createDetectedProjectMcpAuthDraft,
   createProjectMcpEditorDraft,
   detectProjectMcpAuthSafely,
-  projectMcpAuthSelectionAfterUrlChange,
   projectMcpAuthDetectionIsCurrent,
+  projectMcpAuthSelectionAfterUrlChange,
+  resolveSelectedScopes,
   shouldDetectProjectMcpAuth,
+  toggleScopeSelection,
 } from "./project-mcp-editor.ts";
 
 test("opening an MCP editor starts from the persisted server instead of a stale draft", () => {
@@ -39,6 +41,7 @@ test("opening an MCP editor starts from the persisted server instead of a stale 
       key: "",
       grantType: "authorization_code",
       scopes: "issues:read",
+      advertisedScopes: [],
       clientId: "",
       clientSecret: "",
       requiresClientId: false,
@@ -52,6 +55,7 @@ test("detected OAuth becomes the form auth draft while unknown auth stays creden
       type: "oauth",
       grantType: "authorization_code",
       supportsDynamicRegistration: true,
+      scopesSupported: ["issues:read", "issues:write"],
     }),
     {
       type: "oauth",
@@ -60,6 +64,7 @@ test("detected OAuth becomes the form auth draft while unknown auth stays creden
       key: "",
       grantType: "authorization_code",
       scopes: "",
+      advertisedScopes: ["issues:read", "issues:write"],
       clientId: "",
       clientSecret: "",
       requiresClientId: false,
@@ -72,6 +77,7 @@ test("detected OAuth becomes the form auth draft while unknown auth stays creden
     key: "",
     grantType: "authorization_code",
     scopes: "",
+    advertisedScopes: [],
     clientId: "",
     clientSecret: "",
     requiresClientId: false,
@@ -84,6 +90,7 @@ test("detected OAuth without dynamic registration requires manual client credent
       type: "oauth",
       grantType: "authorization_code",
       supportsDynamicRegistration: false,
+      scopesSupported: [],
     }),
     {
       type: "oauth",
@@ -92,6 +99,7 @@ test("detected OAuth without dynamic registration requires manual client credent
       key: "",
       grantType: "authorization_code",
       scopes: "",
+      advertisedScopes: [],
       clientId: "",
       clientSecret: "",
       requiresClientId: true,
@@ -105,6 +113,7 @@ test("detected client-credentials OAuth requires manual credentials even with re
       type: "oauth",
       grantType: "client_credentials",
       supportsDynamicRegistration: true,
+      scopesSupported: [],
     }).requiresClientId,
     true,
   );
@@ -124,17 +133,11 @@ test("automatic auth detection requires an URL and explicit trust confirmation",
 
 test("auth detection results are current only while the requested URL is unchanged", () => {
   assert.equal(
-    projectMcpAuthDetectionIsCurrent(
-      "https://old.example/mcp",
-      "https://new.example/mcp",
-    ),
+    projectMcpAuthDetectionIsCurrent("https://old.example/mcp", "https://new.example/mcp"),
     false,
   );
   assert.equal(
-    projectMcpAuthDetectionIsCurrent(
-      "https://mcp.example/mcp",
-      "https://mcp.example/mcp",
-    ),
+    projectMcpAuthDetectionIsCurrent("https://mcp.example/mcp", "https://mcp.example/mcp"),
     true,
   );
 });
@@ -146,4 +149,30 @@ test("automatic auth detection fails closed when discovery errors", async () => 
     }),
     null,
   );
+});
+
+test("an empty scope selection resolves to every advertised scope", () => {
+  const advertised = ["projects:read", "database:read", "storage:read"];
+  assert.deepEqual(resolveSelectedScopes("", advertised), advertised);
+  assert.deepEqual(resolveSelectedScopes("   ", advertised), advertised);
+  assert.deepEqual(resolveSelectedScopes("projects:read database:read", advertised), [
+    "projects:read",
+    "database:read",
+  ]);
+});
+
+test("toggling a scope customizes the selection and keeps advertised order", () => {
+  const advertised = ["projects:read", "database:read", "storage:read"];
+  // From the "all" default, unchecking one produces an explicit remainder.
+  assert.equal(toggleScopeSelection("", advertised, "database:read"), "projects:read storage:read");
+  // Re-adding it keeps advertised order rather than append order.
+  assert.equal(toggleScopeSelection("storage:read projects:read", advertised, "database:read"), "");
+  // Reaching the full set again normalizes back to "" (request all).
+  assert.equal(toggleScopeSelection("projects:read database:read", advertised, "storage:read"), "");
+});
+
+test("toggling the last selected scope keeps a non-empty selection", () => {
+  const advertised = ["projects:read", "database:read"];
+
+  assert.equal(toggleScopeSelection("projects:read", advertised, "projects:read"), "projects:read");
 });

--- a/apps/web/src/settings/project-mcp-editor.test.ts
+++ b/apps/web/src/settings/project-mcp-editor.test.ts
@@ -2,11 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { ProjectMcpServer } from "../api.ts";
 import {
+  EMPTY_AUTH,
   createDetectedProjectMcpAuthDraft,
   createProjectMcpEditorDraft,
   detectProjectMcpAuthSafely,
   projectMcpAuthDetectionIsCurrent,
   projectMcpAuthSelectionAfterUrlChange,
+  resolveProjectMcpAuthForSubmit,
   resolveSelectedScopes,
   shouldDetectProjectMcpAuth,
   toggleScopeSelection,
@@ -175,4 +177,47 @@ test("toggling the last selected scope keeps a non-empty selection", () => {
   const advertised = ["projects:read", "database:read"];
 
   assert.equal(toggleScopeSelection("projects:read", advertised, "projects:read"), "projects:read");
+});
+
+test("submitting an unchanged detected URL keeps its customized OAuth scopes", async () => {
+  const draft = {
+    ...EMPTY_AUTH,
+    type: "oauth" as const,
+    scopes: "projects:read",
+    advertisedScopes: ["projects:read", "database:read"],
+  };
+  let detectionCalls = 0;
+
+  const result = await resolveProjectMcpAuthForSubmit({
+    selection: "automatic",
+    draft,
+    detectedUrl: "https://mcp.example/mcp",
+    currentUrl: "https://mcp.example/mcp",
+    detect: async () => {
+      detectionCalls += 1;
+      return EMPTY_AUTH;
+    },
+  });
+
+  assert.equal(result, draft);
+  assert.equal(detectionCalls, 0);
+});
+
+test("submitting a changed automatic URL discovers its authentication again", async () => {
+  const discovered = { ...EMPTY_AUTH, type: "oauth" as const };
+  let detectionCalls = 0;
+
+  const result = await resolveProjectMcpAuthForSubmit({
+    selection: "automatic",
+    draft: EMPTY_AUTH,
+    detectedUrl: "https://old.example/mcp",
+    currentUrl: "https://new.example/mcp",
+    detect: async () => {
+      detectionCalls += 1;
+      return discovered;
+    },
+  });
+
+  assert.equal(result, discovered);
+  assert.equal(detectionCalls, 1);
 });

--- a/apps/web/src/settings/project-mcp-editor.ts
+++ b/apps/web/src/settings/project-mcp-editor.ts
@@ -53,6 +53,10 @@ export function toggleScopeSelection(scopes: string, advertised: string[], scope
 
 export type ProjectMcpAuthSelection = "automatic" | "manual" | "required";
 
+export function projectMcpAuthDraftAfterUrlChange(draft: AuthDraft): AuthDraft {
+  return { ...draft, advertisedScopes: [] };
+}
+
 export function projectMcpAuthSelectionAfterUrlChange(
   selection: ProjectMcpAuthSelection,
 ): ProjectMcpAuthSelection {

--- a/apps/web/src/settings/project-mcp-editor.ts
+++ b/apps/web/src/settings/project-mcp-editor.ts
@@ -6,7 +6,13 @@ export type AuthDraft = {
   headerName: string;
   key: string;
   grantType: "authorization_code" | "client_credentials";
+  // Explicit scope selection. An empty string means "request everything the
+  // server advertises" — the server, not us, decides that set (see
+  // advertisedScopes), so a read-only resource URL is honoured without the
+  // operator having to type anything.
   scopes: string;
+  // Scopes the server advertised at detection time; drives the customize UI.
+  advertisedScopes: string[];
   clientId: string;
   clientSecret: string;
   requiresClientId: boolean;
@@ -19,10 +25,31 @@ export const EMPTY_AUTH: AuthDraft = {
   key: "",
   grantType: "authorization_code",
   scopes: "",
+  advertisedScopes: [],
   clientId: "",
   clientSecret: "",
   requiresClientId: false,
 };
+
+// Which advertised scopes are effectively requested: the operator's explicit
+// selection, or — when they haven't pinned one — the full advertised set.
+export function resolveSelectedScopes(scopes: string, advertised: string[]): string[] {
+  const explicit = scopes.split(/\s+/).filter(Boolean);
+  return explicit.length > 0 ? explicit : advertised;
+}
+
+// Toggle one advertised scope in/out of the selection, keeping advertised
+// order. Re-selecting the whole set normalizes back to "" (request all), so the
+// default stays future-proof if the server later widens what it offers.
+export function toggleScopeSelection(scopes: string, advertised: string[], scope: string): string {
+  const selected = new Set(resolveSelectedScopes(scopes, advertised));
+  if (selected.has(scope)) {
+    if (selected.size === 1) return scopes;
+    selected.delete(scope);
+  } else selected.add(scope);
+  const next = advertised.filter((candidate) => selected.has(candidate));
+  return next.length === advertised.length ? "" : next.join(" ");
+}
 
 export type ProjectMcpAuthSelection = "automatic" | "manual" | "required";
 
@@ -47,9 +74,7 @@ export function projectMcpAuthDetectionIsCurrent(
   return requestedUrl === currentUrl;
 }
 
-export async function detectProjectMcpAuthSafely<T>(
-  detect: () => Promise<T>,
-): Promise<T | null> {
+export async function detectProjectMcpAuthSafely<T>(detect: () => Promise<T>): Promise<T | null> {
   try {
     return await detect();
   } catch {
@@ -63,6 +88,7 @@ export function createDetectedProjectMcpAuthDraft(detection: ProjectMcpAuthDetec
     ...EMPTY_AUTH,
     type: "oauth",
     grantType: detection.grantType,
+    advertisedScopes: detection.scopesSupported,
     requiresClientId:
       detection.grantType === "client_credentials" || !detection.supportsDynamicRegistration,
   };

--- a/apps/web/src/settings/project-mcp-editor.ts
+++ b/apps/web/src/settings/project-mcp-editor.ts
@@ -82,6 +82,19 @@ export async function detectProjectMcpAuthSafely<T>(detect: () => Promise<T>): P
   }
 }
 
+export async function resolveProjectMcpAuthForSubmit(input: {
+  selection: ProjectMcpAuthSelection;
+  draft: AuthDraft;
+  detectedUrl: string | null;
+  currentUrl: string;
+  detect: () => Promise<AuthDraft | null>;
+}): Promise<AuthDraft | null> {
+  if (input.selection === "automatic" && input.detectedUrl !== input.currentUrl) {
+    return input.detect();
+  }
+  return input.draft;
+}
+
 export function createDetectedProjectMcpAuthDraft(detection: ProjectMcpAuthDetection): AuthDraft {
   if (detection.type === "unknown") return EMPTY_AUTH;
   return {


### PR DESCRIPTION
## Summary

- read `scopes_supported` from protected-resource metadata, with authorization-server metadata as a fallback
- request discovered scopes by default while preserving explicit scope overrides
- show the advertised scope set in a collapsed settings control so project owners can request a smaller set
- apply the same default to authorization-code and client-credentials grants

## Test plan

- `pnpm --filter @superlog/api typecheck`
- `pnpm --filter @superlog/web typecheck`
- `DATABASE_URL=<worktree-db> pnpm --filter @superlog/api test` (501 tests)
- `pnpm --filter @superlog/web test` (170 tests)
- focused settings component and scope-selection tests (14 tests)
- local worktree bootstrap and verification
- live auth detection for `https://mcp.supabase.com/mcp?read_only=true` returned eight read-only scopes and no write scopes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default MCP OAuth scope requests to the resource-advertised set, with a simple UI to trim scopes, and it preserves custom selections on submit. Discovery prefers protected-resource `scopes_supported` (including explicit empty lists) and falls back to the authorization server; applies to both `authorization_code` and `client_credentials`.

- New Features
  - Discover `scopes_supported` from protected-resource metadata; prefer it over auth-server metadata; expose as `scopesSupported` in `ProjectMcpAuthDetection`.
  - Default requested scopes to the advertised set when no explicit `scopes` are configured; explicit scopes still take precedence.
  - Persist requested scopes in OAuth attempts/tokens and retain them when the token response omits `scope`.
  - Web settings: add an “OAuth scopes” disclosure with checkboxes driven by `advertisedScopes`; empty selection means “all advertised,” preserves server order, and prevents deselecting the last scope.
  - Keep customized scope selection when submitting an unchanged detected URL; re-detect only when the URL or trust changes; clear stale advertised scopes when the URL changes.

<sup>Written for commit ad9fbc3f258ff3a1b34266bdbb1ba77ead86f6cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

