### PR TITLE
Limit default MCP OAuth scopes to the resource

### DIFF
--- a/apps/api/src/project-mcp-oauth.test.ts
+++ b/apps/api/src/project-mcp-oauth.test.ts
@@ -485,6 +485,41 @@ test("OAuth discovery prefers the protected-resource scopes_supported over the a
   assert.deepEqual(discovery.scopesSupported, ["projects:read", "database:read"]);
 });
 
+test("OAuth discovery does not default to authorization-server scopes", async () => {
+  const json = (body: unknown) =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  const fakeFetch = (async (input: URL | string | Request) => {
+    const target = input.toString();
+    if (target === "https://mcp.example/mcp") {
+      return new Response(null, { status: 401 });
+    }
+    if (target === "https://mcp.example/.well-known/oauth-protected-resource/mcp") {
+      return json({
+        resource: "https://mcp.example/mcp",
+        authorization_servers: ["https://as.example"],
+      });
+    }
+    if (target === "https://as.example/.well-known/oauth-authorization-server") {
+      return json({
+        authorization_endpoint: "https://as.example/authorize",
+        token_endpoint: "https://as.example/token",
+        code_challenge_methods_supported: ["S256"],
+        grant_types_supported: ["authorization_code"],
+        scopes_supported: ["projects:read", "projects:write", "admin"],
+      });
+    }
+    return new Response(null, { status: 404 });
+  }) as unknown as typeof fetch;
+
+  const discovery =
+    await createFetchProjectMcpOAuthHttp(fakeFetch).discover("https://mcp.example/mcp");
+
+  assert.deepEqual(discovery.scopesSupported, []);
+});
+
 test("OAuth discovery honors an explicitly empty protected-resource scope list", async () => {
   const json = (body: unknown) =>
     new Response(JSON.stringify(body), {

--- a/apps/api/src/project-mcp-oauth.ts
+++ b/apps/api/src/project-mcp-oauth.ts
@@ -508,7 +508,6 @@ async function discoverProjectMcpOAuth(
     authorizationMetadataUrls(authorizationServer),
     signal,
   );
-  const resourceAdvertisesScopes = Array.isArray(resourceMetadata.scopes_supported);
   const resourceScopes = readStringArray(resourceMetadata.scopes_supported);
   return {
     authorizationServer,
@@ -521,9 +520,7 @@ async function discoverProjectMcpOAuth(
         : endpoint.toString(),
     codeChallengeMethods: readStringArray(metadata.code_challenge_methods_supported),
     grantTypes: readStringArray(metadata.grant_types_supported),
-    scopesSupported: resourceAdvertisesScopes
-      ? resourceScopes
-      : readStringArray(metadata.scopes_supported),
+    scopesSupported: resourceScopes,
   };
 }
 


### PR DESCRIPTION
## Summary

- default OAuth requests only from protected-resource `scopes_supported` metadata
- do not treat the authorization server scope catalog as the resource request
- leave the default scope list empty when the protected resource does not advertise scopes

## Validation

- `pnpm --filter @superlog/api test`
- `pnpm --filter @superlog/api typecheck`
- `pnpm exec biome check apps/api/src/project-mcp-oauth.ts apps/api/src/project-mcp-oauth.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit default OAuth scope discovery to the protected resource’s `scopes_supported`. We no longer fall back to authorization server scopes; if the resource doesn’t advertise scopes, the default list is empty.

- **Bug Fixes**
  - Only read default scopes from protected-resource `scopes_supported`.
  - Do not use authorization server `scopes_supported` as a fallback.
  - Return empty `scopesSupported` when the resource doesn’t advertise scopes.

<sup>Written for commit a567a3a16bdf5d1fa8723852a658cb52c9704dcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

