### PR TITLE
Improve initial Slack incident message

### DIFF
--- a/apps/worker/src/agent-runs/start-run.ts
+++ b/apps/worker/src/agent-runs/start-run.ts
@@ -68,6 +68,7 @@ async function notifyAgentRunStarted(
       emoji: "rotating_light",
       status: "Investigation ongoing",
       title: ctx.incident.title,
+      incidentCodename: ctx.incident.codename,
       projectName: ctx.project.name,
       service: ctx.incident.service,
       buttons: [{ text: "View incident", url: incidentUrl, actionId: "view_incident" }],

--- a/apps/worker/src/infra/slack/incident-messages.test.ts
+++ b/apps/worker/src/infra/slack/incident-messages.test.ts
@@ -39,6 +39,33 @@ test("incidentBlocks omits environment when absent", () => {
   assert.equal(line, "`Acme` · `api`");
 });
 
+test("incidentBlocks labels an ongoing investigation by codename and formats its error as code", () => {
+  const blocks = incidentBlocks({
+    emoji: "rotating_light",
+    status: "Investigation ongoing",
+    title:
+      "*ERROR: START RequestId: b19ab794-1b70-4261-a23e-acf19135aee6\n[POST] /api/plants/nullingia status=500\nEND RequestId: b19ab794-1b*",
+    incidentCodename: "code_name",
+    projectName: "demo-project",
+    service: "superlog-sample",
+    buttons: [],
+  });
+  const section = blocks[0] as { text: { text: string } };
+
+  assert.equal(
+    section.text.text,
+    ":rotating_light: *Investigation ongoing*\n" +
+      "*Incident* `code_name`\n" +
+      "*Error*:\n" +
+      "```\n" +
+      "*ERROR: START RequestId: b19ab794-1b70-4261-a23e-acf19135aee6\n" +
+      "[POST] /api/plants/nullingia status=500\n" +
+      "END RequestId: b19ab794-1b*\n" +
+      "```\n" +
+      "`demo-project` · `superlog-sample`",
+  );
+});
+
 test("incidentBlocks renders the title as a link when titleUrl is set", () => {
   const blocks = incidentBlocks({
     emoji: "rotating_light",

--- a/apps/worker/src/infra/slack/incident-messages.ts
+++ b/apps/worker/src/infra/slack/incident-messages.ts
@@ -145,6 +145,7 @@ export function incidentBlocks(opts: {
   emoji: string;
   status: string;
   title: string;
+  incidentCodename?: string | null;
   // When set, the title renders as a link to the incident. Preferred over a
   // standalone "Open in Superlog" button — it frees an actions-row slot.
   titleUrl?: string | null;
@@ -168,7 +169,13 @@ export function incidentBlocks(opts: {
   const titleText = opts.titleUrl
     ? `*<${escapeSlackLinkUrl(opts.titleUrl)}|${escapeSlackLinkText(opts.title)}>*`
     : `*${opts.title}*`;
-  const lines = [`:${opts.emoji}: *${opts.status}*`, titleText];
+  const lines = opts.incidentCodename
+    ? [
+        `:${opts.emoji}: *${opts.status}*`,
+        `*Incident* \`${opts.incidentCodename}\``,
+        `*Error*:\n\`\`\`\n${opts.title}\n\`\`\``,
+      ]
+    : [`:${opts.emoji}: *${opts.status}*`, titleText];
   if (opts.tagline) lines.push(`_${opts.tagline}_`);
   // `project · service · environment`, each a code chip; service/environment
   // only appear when present on the triggering error.


### PR DESCRIPTION
## Summary

- label the incident with its codename when an investigation starts
- render the triggering error in a multiline code block
- preserve project, service, environment, and incident actions

## Why

The initial investigation update currently presents the raw error as an unlabeled bold title. The new layout makes the incident identity and triggering error immediately distinguishable in Slack.

## Validation

- `pnpm --filter @superlog/worker exec tsx --test src/infra/slack/incident-messages.test.ts`
- `pnpm --filter @superlog/worker typecheck`
- formatter checks on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve the initial Slack incident message for ongoing investigations by labeling the incident with its codename and rendering the triggering error in a fenced code block. Project, service, environment chips, and incident actions remain unchanged.

<sup>Written for commit 640f144e102b3fcda6b525b1f4d09282e6f79733. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

