### PR TITLE
Hide service map home widget when no cloud account is connected

### DIFF
--- a/apps/web/src/home/HomeDashboard.tsx
+++ b/apps/web/src/home/HomeDashboard.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import GridLayout, { type Layout, type LayoutItem, useContainerWidth } from "react-grid-layout";
 import { verticalCompactor } from "react-grid-layout";
-import type { ExploreRange } from "../api.ts";
+import { type ExploreRange, useCloudConnections } from "../api.ts";
 import {
   RANGE_PRESETS,
   RangePicker,
@@ -46,6 +46,7 @@ export function HomeDashboard({
   slugs: ProjectRouteSlugs;
 }) {
   const home = useHomeDashboard(projectId);
+  const cloudConnections = useCloudConnections(projectId);
   const setBuiltin = useSetHomeBuiltin(projectId);
   const updateLayout = useUpdateHomeLayout(projectId);
   const remove = useDeleteHomeItem(projectId);
@@ -67,6 +68,13 @@ export function HomeDashboard({
     .map((widget) => widget.type)
     .filter((type): type is HomeBuiltinType => BUILTIN_TYPES.has(type as HomeBuiltinType));
   const { setup, grid } = splitHomeWidgets(home.data.widgets);
+  // Hide the service map tile for projects that have no cloud connection — without
+  // one there's no map and nothing to build, so the widget is pure clutter. Keep it
+  // visible while customizing so it stays draggable/removable.
+  const hasCloudConnection = (cloudConnections.data?.length ?? 0) > 0;
+  const visibleGrid = grid.filter(
+    (widget) => widget.type !== "service_map" || hasCloudConnection || customizing,
+  );
 
   return (
     <div className="flex flex-col gap-6">
@@ -99,12 +107,12 @@ export function HomeDashboard({
             Add your first widget
           </Btn>
         </div>
-      ) : grid.length > 0 ? (
+      ) : visibleGrid.length > 0 ? (
         <HomeGrid
           projectId={projectId}
           slugs={slugs}
           range={range}
-          widgets={grid}
+          widgets={visibleGrid}
           customizing={customizing}
           onRemove={(widget) => {
             if (confirm(`Remove “${widget.title}” from home?`)) remove.mutate(widget.id);

--- a/apps/web/src/home/HomeDashboard.tsx
+++ b/apps/web/src/home/HomeDashboard.tsx
@@ -69,11 +69,17 @@ export function HomeDashboard({
     .filter((type): type is HomeBuiltinType => BUILTIN_TYPES.has(type as HomeBuiltinType));
   const { setup, grid } = splitHomeWidgets(home.data.widgets);
   // Hide the service map tile for projects that have no cloud connection — without
-  // one there's no map and nothing to build, so the widget is pure clutter. Keep it
-  // visible while customizing so it stays draggable/removable.
-  const hasCloudConnection = (cloudConnections.data?.length ?? 0) > 0;
+  // one there's no map and nothing to build, so the widget is pure clutter. Only
+  // hide once the connections query has actually resolved to an empty list: while
+  // it's still loading or if it errored, keep the tile so a connected project's map
+  // doesn't flicker away (or stay hidden on a transient failure). Also keep it while
+  // customizing so it stays draggable/removable.
+  const hideServiceMap =
+    cloudConnections.isSuccess &&
+    (cloudConnections.data?.length ?? 0) === 0 &&
+    !customizing;
   const visibleGrid = grid.filter(
-    (widget) => widget.type !== "service_map" || hasCloudConnection || customizing,
+    (widget) => widget.type !== "service_map" || !hideServiceMap,
   );
 
   return (


### PR DESCRIPTION
## What

The service map only renders as the `service_map` home widget on the Overview, and the only way to build a map lives inside that widget's own empty state. For a project with no cloud connection there is no map and nothing to build — so the tile only ever showed a "Connect a cloud account to populate your service map" placeholder. That's pure clutter on the dashboard for anyone who isn't using cloud connections.

## Change

`apps/web/src/home/HomeDashboard.tsx`: filter the `service_map` widget out of the home grid when the project has no cloud connection. It stays visible while customizing home, so it remains draggable and removable.

```ts
const hasCloudConnection = (cloudConnections.data?.length ?? 0) > 0;
const visibleGrid = grid.filter(
  (widget) => widget.type !== "service_map" || hasCloudConnection || customizing,
);
```

The gate is cloud-connection presence, not "graph has nodes" — a connected-but-not-yet-built project still shows the widget with its "Generate map" CTA (the only path to create a map). Connected-and-built shows the map as before.

## Verification

Booted the app and drove it in a browser as a seeded user whose project has telemetry but no cloud connection:
- Normal Overview: service map tile absent (previously showed the connect-cloud placeholder).
- Customize home: service map tile reappears so it can be repositioned/removed.

`@superlog/web` typecheck passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the service map widget on the Overview when the project has no cloud connection to remove a dead placeholder and reduce clutter. Hide only after the cloud connections query successfully returns empty to prevent flicker or error-state hiding; the tile still appears while customizing and for connected projects (even before a map is built) so the “Generate map” CTA is available.

<sup>Written for commit eb3848076d087b52cf467ab87dc67ff9f8ea0c2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

