### PR TITLE
Show active investigation progress

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "tsx --import ./src/test-setup.ts --test src/*.test.ts src/content/*.test.ts",
+    "test": "tsx --import ./src/test-setup.ts --test src/*.test.ts src/content/*.test.ts src/incidents/*.test.ts src/incidents/*.test.tsx",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -84,6 +84,7 @@ import {
   resolveIncidentDetailTab,
   visibleIncidentDetailTabs,
 } from "./incidents/incident-detail-tabs.ts";
+import { isInvestigationInProgress } from "./incidents/investigation-progress.ts";
 import {
   type IncidentMetaRow,
   buildIncidentDetailMeta,
@@ -1782,6 +1783,7 @@ export function IncidentDetailContent({
                     !triggeringIssue && <p className="text-[12px] text-muted">No activity yet.</p>}
                   <IncidentActivityFeed
                     events={events}
+                    investigating={isInvestigationInProgress(agentRun?.state)}
                     evidenceContext={{
                       repoUrl: agentRun?.selectedRepoUrl ?? null,
                       baseBranch: agentRun?.selectedBaseBranch ?? null,

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -43,6 +43,7 @@ export function IncidentActivityFeed({
   renderIssueCard,
   awaiting,
   evidenceContext,
+  investigating = false,
 }: {
   events: IncidentEvent[];
   /** The issue that opened the incident. It is projected as the first feed
@@ -57,6 +58,8 @@ export function IncidentActivityFeed({
   awaiting?: { question: string; ctx: EvidenceLinkContext } | null;
   /** Link context for markdown evidence recorded by outcome tools. */
   evidenceContext?: EvidenceLinkContext;
+  /** Appends a live terminal node while the agent is actively investigating. */
+  investigating?: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const railRef = useRef<HTMLDivElement>(null);
@@ -172,18 +175,81 @@ export function IncidentActivityFeed({
     return () => ro.disconnect();
   }, [nodes.length, expanded]);
 
-  if (nodes.length === 0) return null;
+  if (nodes.length === 0 && !investigating) return null;
 
   return (
     <div ref={railRef} className="relative pl-7">
-      {/* Start at the first entry's marker center (~12px); cut at the last node
-          so no hairline dangles past the final entry. */}
-      <div
-        className="absolute left-[10px] top-3 w-px bg-border"
-        style={railHeight != null ? { height: railHeight } : { bottom: 8 }}
-      />
-      {nodes.slice(0, -1)}
-      <div ref={lastRef}>{nodes[nodes.length - 1]}</div>
+      {nodes.length > 0 && (
+        <>
+          {/* Start at the first entry's marker center (~12px); cut at the last node
+              so no hairline dangles past the final entry. */}
+          <div
+            className="absolute left-[10px] top-3 w-px bg-border"
+            style={railHeight != null ? { height: railHeight } : { bottom: 8 }}
+          />
+          {nodes.slice(0, -1)}
+          <div ref={lastRef}>{nodes[nodes.length - 1]}</div>
+        </>
+      )}
+      {investigating && <InvestigationProgressEntry />}
+    </div>
+  );
+}
+
+const INVESTIGATION_PROGRESS_PHRASES = [
+  "Looking for evidence…",
+  "Following the signal…",
+  "Checking recent changes…",
+  "Connecting the clues…",
+  "Tracing the failure path…",
+  "Comparing related events…",
+  "Testing likely causes…",
+  "Reviewing the surrounding code…",
+  "Ruling out false leads…",
+  "Building the incident timeline…",
+] as const;
+const INVESTIGATION_PROGRESS_DOTS = [
+  "top-left",
+  "top-center",
+  "top-right",
+  "middle-left",
+  "middle-center",
+  "middle-right",
+  "bottom-left",
+  "bottom-center",
+  "bottom-right",
+] as const;
+
+function InvestigationProgressEntry() {
+  return (
+    <div className="-ml-7 -mt-3 mb-6 flex min-h-[22px] min-w-0 items-center gap-2">
+      <span aria-hidden className="grid shrink-0 grid-cols-3 gap-[2px]">
+        {INVESTIGATION_PROGRESS_DOTS.map((dot, index) => (
+          <span
+            key={dot}
+            className="investigation-progress-dot h-[2px] w-[2px] rounded-full bg-[#97a3f2]"
+            style={{ animationDelay: `${index * -0.12}s` }}
+          />
+        ))}
+      </span>
+      <output
+        aria-live="polite"
+        aria-atomic="true"
+        className="flex min-h-[22px] min-w-0 items-center"
+      >
+        <span className="sr-only">Investigation in progress</span>
+        <span aria-hidden className="relative block h-4 min-w-0 flex-1 overflow-hidden">
+          {INVESTIGATION_PROGRESS_PHRASES.map((phrase, index) => (
+            <span
+              key={phrase}
+              className="investigation-progress-phrase absolute left-0 top-0 block max-w-full truncate text-[12px] font-medium text-muted"
+              style={{ animationDelay: `${index * 3}s` }}
+            >
+              {phrase}
+            </span>
+          ))}
+        </span>
+      </output>
     </div>
   );
 }

--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -235,7 +235,7 @@ function InvestigationProgressEntry() {
       <output
         aria-live="polite"
         aria-atomic="true"
-        className="flex min-h-[22px] min-w-0 items-center"
+        className="flex min-h-[22px] min-w-0 flex-1 items-center"
       >
         <span className="sr-only">Investigation in progress</span>
         <span aria-hidden className="relative block h-4 min-w-0 flex-1 overflow-hidden">

--- a/apps/web/src/incidents/IncidentTranscriptProgress.test.tsx
+++ b/apps/web/src/incidents/IncidentTranscriptProgress.test.tsx
@@ -7,6 +7,7 @@ test("an active investigation ends the transcript with rotating progress copy", 
   const html = renderToStaticMarkup(<IncidentActivityFeed events={[]} investigating />);
 
   assert.match(html, /<output/);
+  assert.match(html, /<output[^>]*class="[^"]*flex-1/);
   assert.match(html, /Investigation in progress/);
   assert.doesNotMatch(html, /border-accent\/40|rounded-full[^>]*investigation-progress-dot/);
   assert.doesNotMatch(html, /w-px bg-border/);

--- a/apps/web/src/incidents/IncidentTranscriptProgress.test.tsx
+++ b/apps/web/src/incidents/IncidentTranscriptProgress.test.tsx
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { IncidentActivityFeed } from "./IncidentTranscript.tsx";
+
+test("an active investigation ends the transcript with rotating progress copy", () => {
+  const html = renderToStaticMarkup(<IncidentActivityFeed events={[]} investigating />);
+
+  assert.match(html, /<output/);
+  assert.match(html, /Investigation in progress/);
+  assert.doesNotMatch(html, /border-accent\/40|rounded-full[^>]*investigation-progress-dot/);
+  assert.doesNotMatch(html, /w-px bg-border/);
+  assert.match(html, /class="-ml-7 -mt-3 mb-6/);
+  for (const phrase of [
+    "Looking for evidence",
+    "Following the signal",
+    "Checking recent changes",
+    "Connecting the clues",
+    "Tracing the failure path",
+    "Comparing related events",
+    "Testing likely causes",
+    "Reviewing the surrounding code",
+    "Ruling out false leads",
+    "Building the incident timeline",
+  ]) {
+    assert.match(html, new RegExp(phrase));
+  }
+});

--- a/apps/web/src/incidents/investigation-progress.test.ts
+++ b/apps/web/src/incidents/investigation-progress.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { isInvestigationInProgress } from "./investigation-progress.ts";
+
+test("only agent states doing investigation work show progress", () => {
+  for (const state of ["queued", "repo_discovery", "running", "resuming"]) {
+    assert.equal(isInvestigationInProgress(state), true, `${state} should show progress`);
+  }
+
+  for (const state of [
+    null,
+    "awaiting_human",
+    "awaiting_events",
+    "pr_retry_queued",
+    "blocked_no_github",
+    "complete",
+    "failed",
+  ]) {
+    assert.equal(isInvestigationInProgress(state), false, `${state} should not show progress`);
+  }
+});

--- a/apps/web/src/incidents/investigation-progress.ts
+++ b/apps/web/src/incidents/investigation-progress.ts
@@ -1,0 +1,5 @@
+const INVESTIGATING_STATES = new Set(["queued", "repo_discovery", "running", "resuming"]);
+
+export function isInvestigationInProgress(state: string | null | undefined): boolean {
+  return state != null && INVESTIGATING_STATES.has(state);
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -116,6 +116,44 @@ body {
   font-family: inherit;
 }
 
+@keyframes investigation-progress-dot {
+  0%,
+  100% {
+    opacity: 0.22;
+    transform: scale(0.78);
+  }
+  45% {
+    opacity: 1;
+    transform: scale(1.25);
+  }
+}
+
+@keyframes investigation-progress-phrase {
+  0%,
+  8% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  10%,
+  98% {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.investigation-progress-dot {
+  animation: investigation-progress-dot 1.35s ease-in-out infinite;
+}
+
+.investigation-progress-phrase {
+  opacity: 0;
+  animation: investigation-progress-phrase 30s ease-in-out infinite;
+}
+
 .incident-alert-card {
   opacity: 0;
   transform: translate3d(0, 44px, 0) scale(0.97);
@@ -548,6 +586,25 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .investigation-progress-dot,
+  .investigation-progress-phrase {
+    animation: none;
+  }
+
+  .investigation-progress-dot {
+    opacity: 0.5;
+    transform: none;
+  }
+
+  .investigation-progress-phrase {
+    opacity: 0;
+    transform: none;
+  }
+
+  .investigation-progress-phrase:first-child {
+    opacity: 1;
+  }
+
   .incident-alert-card,
   .incident-summary-card,
   .severity-main-card,


### PR DESCRIPTION
## Summary

- show a compact dot-matrix progress indicator at the end of active incident transcripts
- rotate through ten investigation-status phrases while work is underway
- keep the indicator flush left and accessible, with reduced-motion support

## Test plan

- `pnpm --filter @superlog/web test`
- `pnpm --filter @superlog/web typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a live investigation progress indicator to incident transcripts so users can see work is underway. Keeps the UI accessible—status text stays visible, honors reduced motion—and runs incident tests in CI.

- **New Features**
  - Appends a compact 3x3 dot-matrix with rotating phrases at the end of active transcripts.
  - Adds `isInvestigationInProgress(state)` and wires it via `Issues.tsx` to `IncidentActivityFeed` as `investigating`.
  - Adds `aria-live` and screen-reader text; keeps status copy visible; disables animation for reduced motion; hides the rail when only progress shows.

<sup>Written for commit f77e7467dfba93d81185dfa471d24055f1343ad2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

