### PR TITLE
Preserve MCP OAuth scopes through registration

### DIFF
--- a/apps/api/src/project-mcp-oauth.test.ts
+++ b/apps/api/src/project-mcp-oauth.test.ts
@@ -47,6 +47,25 @@ test("OAuth discovery rejects private destinations at the outbound request bound
   );
 });
 
+test("OAuth dynamic registration restricts the client to requested scopes", async () => {
+  const registrationBodies: Record<string, unknown>[] = [];
+  const fakeFetch = (async (_input: URL | string | Request, init?: RequestInit) => {
+    registrationBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+    return new Response(JSON.stringify({ client_id: "dynamic-client" }), {
+      status: 201,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+
+  await createFetchProjectMcpOAuthHttp(fakeFetch).register(
+    "https://auth.example/register",
+    "https://api.superlog.sh/api/agent-mcp-oauth/callback",
+    ["projects:read", "database:read"],
+  );
+
+  assert.equal(registrationBodies[0]?.scope, "projects:read database:read");
+});
+
 test("OAuth start uses discovery, dynamic registration, PKCE, and resource binding", async () => {
   let server = oauthServer();
   let attempt: ProjectMcpOAuthAttempt | null = null;
@@ -411,7 +430,10 @@ test("OAuth start requests the server's advertised scopes when none are configur
         grantTypes: ["authorization_code", "refresh_token"],
         scopesSupported: ["projects:read", "database:read"],
       }),
-      register: async () => ({ clientId: "dynamic-client", clientSecret: null }),
+      register: async (_registrationEndpoint, _redirectUri, scopes) => {
+        assert.deepEqual(scopes, ["projects:read", "database:read"]);
+        return { clientId: "dynamic-client", clientSecret: null };
+      },
       exchange: async () => {
         throw new Error("not called");
       },

--- a/apps/api/src/project-mcp-oauth.test.ts
+++ b/apps/api/src/project-mcp-oauth.test.ts
@@ -466,6 +466,10 @@ test("OAuth start requests the server's advertised scopes when none are configur
     "projects:read",
     "database:read",
   ]);
+  assert.equal(server.auth.type, "oauth");
+  if (server.auth.type === "oauth") {
+    assert.deepEqual(server.auth.scopes, ["projects:read", "database:read"]);
+  }
 });
 
 test("OAuth discovery prefers the protected-resource scopes_supported over the auth server's", async () => {

--- a/apps/api/src/project-mcp-oauth.ts
+++ b/apps/api/src/project-mcp-oauth.ts
@@ -114,6 +114,7 @@ export function createProjectMcpOAuthService(deps: {
         server.auth.scopes.length > 0 ? server.auth.scopes : discovery.scopesSupported;
       let clientId = server.auth.clientId;
       let clientSecret = server.auth.clientSecret;
+      let persistedScopes = server.auth.scopes;
       if (!clientId) {
         if (!discovery.registrationEndpoint) {
           throw new Error(
@@ -127,6 +128,7 @@ export function createProjectMcpOAuthService(deps: {
         );
         clientId = registration.clientId;
         clientSecret = registration.clientSecret;
+        persistedScopes = requestedScopes;
       }
       const state = randomToken();
       const codeVerifier = randomToken();
@@ -153,6 +155,7 @@ export function createProjectMcpOAuthService(deps: {
           status: "pending",
           clientId,
           clientSecret,
+          scopes: persistedScopes,
           tokenEndpoint: discovery.tokenEndpoint,
           authorizationServer: discovery.authorizationServer,
           resource: discovery.resource,

--- a/apps/api/src/project-mcp-oauth.ts
+++ b/apps/api/src/project-mcp-oauth.ts
@@ -14,11 +14,9 @@ export type ProjectMcpOAuthDiscovery = {
   resource: string;
   codeChallengeMethods: string[];
   grantTypes: string[];
-  // Scopes the server advertises for this resource (RFC 9728 protected-resource
-  // metadata, falling back to the authorization server's own list). Servers use
-  // this to narrow what a URL variant grants — e.g. a read-only URL advertises
-  // only read scopes — so a client should request exactly these unless the
-  // operator has pinned an explicit subset.
+  // Scopes the server advertises for this resource in RFC 9728
+  // protected-resource metadata. A read-only URL can therefore advertise only
+  // read scopes, which the client requests unless the operator pins a subset.
   scopesSupported: string[];
 };
 
@@ -55,6 +53,7 @@ export type ProjectMcpOAuthHttp = {
   register(
     registrationEndpoint: string,
     redirectUri: string,
+    scopes: string[],
   ): Promise<{ clientId: string; clientSecret: string | null }>;
   exchange(input: {
     tokenEndpoint: string;
@@ -107,6 +106,12 @@ export function createProjectMcpOAuthService(deps: {
       if (!discovery.codeChallengeMethods.includes("S256")) {
         throw new Error("OAuth server does not advertise PKCE S256 support");
       }
+      // An operator-pinned scope list wins; otherwise request everything the
+      // server advertises for this resource. This is what makes a read-only
+      // resource URL request only read scopes, matching other MCP clients,
+      // instead of falling through to the server's "grant everything" default.
+      const requestedScopes =
+        server.auth.scopes.length > 0 ? server.auth.scopes : discovery.scopesSupported;
       let clientId = server.auth.clientId;
       let clientSecret = server.auth.clientSecret;
       if (!clientId) {
@@ -118,16 +123,11 @@ export function createProjectMcpOAuthService(deps: {
         const registration = await deps.http.register(
           discovery.registrationEndpoint,
           input.redirectUri,
+          requestedScopes,
         );
         clientId = registration.clientId;
         clientSecret = registration.clientSecret;
       }
-      // An operator-pinned scope list wins; otherwise request everything the
-      // server advertises for this resource. This is what makes a read-only
-      // resource URL request only read scopes, matching other MCP clients,
-      // instead of falling through to the server's "grant everything" default.
-      const requestedScopes =
-        server.auth.scopes.length > 0 ? server.auth.scopes : discovery.scopesSupported;
       const state = randomToken();
       const codeVerifier = randomToken();
       const expiresAt = new Date(now().getTime() + OAUTH_ATTEMPT_TTL_MS);
@@ -403,7 +403,7 @@ export function createFetchProjectMcpOAuthHttp(fetchOverride?: typeof fetch): Pr
   const fetchImpl = fetchOverride ?? strictProjectMcpFetch;
   return {
     discover: (serverUrl, signal) => discoverProjectMcpOAuth(fetchImpl, serverUrl, signal),
-    async register(registrationEndpoint, redirectUri) {
+    async register(registrationEndpoint, redirectUri, scopes) {
       const response = await fetchImpl(registrationEndpoint, {
         method: "POST",
         redirect: "manual",
@@ -417,6 +417,7 @@ export function createFetchProjectMcpOAuthHttp(fetchOverride?: typeof fetch): Pr
           grant_types: ["authorization_code", "refresh_token"],
           response_types: ["code"],
           token_endpoint_auth_method: "none",
+          ...(scopes.length > 0 ? { scope: scopes.join(" ") } : {}),
         }),
       });
       const body = await responseJson(response, "OAuth dynamic registration failed");

--- a/apps/web/src/settings/AgentMcpServersCard.tsx
+++ b/apps/web/src/settings/AgentMcpServersCard.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState } from "react";
 import {
-  type ProjectMcpAuthInput,
   type ProjectMcpServer,
   useConnectProjectMcpClientCredentials,
   useCreateProjectMcpServer,
@@ -22,6 +21,7 @@ import {
   detectProjectMcpAuthSafely,
   projectMcpAuthDetectionIsCurrent,
   projectMcpAuthDraftAfterUrlChange,
+  projectMcpAuthInputFromDraft,
   projectMcpAuthSelectionAfterUrlChange,
   resolveProjectMcpAuthForSubmit,
   resolveSelectedScopes,
@@ -111,7 +111,7 @@ export function AgentMcpServersCard({ projectId }: { projectId: string | undefin
         name,
         url,
         enabled: (query.data?.enabledCount ?? 0) < (query.data?.enabledLimit ?? 19),
-        auth: authInput(submittedAuth),
+        auth: projectMcpAuthInputFromDraft(submittedAuth),
         confirmTrusted: trusted,
       },
       {
@@ -525,7 +525,7 @@ function ServerEditor({
               name,
               url,
               confirmTrusted,
-              ...(replaceAuth ? { auth: authInput(auth) } : {}),
+              ...(replaceAuth ? { auth: projectMcpAuthInputFromDraft(auth) } : {}),
             });
             closeEditor();
           }}
@@ -726,20 +726,6 @@ function Switch({
       />
     </button>
   );
-}
-
-function authInput(auth: AuthDraft): ProjectMcpAuthInput {
-  if (auth.type === "none") return { type: "none" };
-  if (auth.type === "bearer") return { type: "bearer", token: auth.token };
-  if (auth.type === "api_key")
-    return { type: "api_key", headerName: auth.headerName, key: auth.key };
-  return {
-    type: "oauth",
-    grantType: auth.grantType,
-    scopes: auth.scopes.split(/\s+/).filter(Boolean),
-    ...(auth.clientId.trim() ? { clientId: auth.clientId.trim() } : {}),
-    ...(auth.clientSecret ? { clientSecret: auth.clientSecret } : {}),
-  };
 }
 
 function authLabel(server: ProjectMcpServer): string {

--- a/apps/web/src/settings/project-mcp-editor.test.ts
+++ b/apps/web/src/settings/project-mcp-editor.test.ts
@@ -8,12 +8,28 @@ import {
   detectProjectMcpAuthSafely,
   projectMcpAuthDetectionIsCurrent,
   projectMcpAuthDraftAfterUrlChange,
+  projectMcpAuthInputFromDraft,
   projectMcpAuthSelectionAfterUrlChange,
   resolveProjectMcpAuthForSubmit,
   resolveSelectedScopes,
   shouldDetectProjectMcpAuth,
   toggleScopeSelection,
 } from "./project-mcp-editor.ts";
+
+test("submitting detected OAuth persists every scope displayed as selected", () => {
+  assert.deepEqual(
+    projectMcpAuthInputFromDraft({
+      ...EMPTY_AUTH,
+      type: "oauth",
+      advertisedScopes: ["projects:read", "database:read"],
+    }),
+    {
+      type: "oauth",
+      grantType: "authorization_code",
+      scopes: ["projects:read", "database:read"],
+    },
+  );
+});
 
 test("opening an MCP editor starts from the persisted server instead of a stale draft", () => {
   const server = {

--- a/apps/web/src/settings/project-mcp-editor.ts
+++ b/apps/web/src/settings/project-mcp-editor.ts
@@ -1,4 +1,4 @@
-import type { ProjectMcpAuthDetection, ProjectMcpServer } from "../api.ts";
+import type { ProjectMcpAuthDetection, ProjectMcpAuthInput, ProjectMcpServer } from "../api.ts";
 
 export type AuthDraft = {
   type: "none" | "bearer" | "api_key" | "oauth";
@@ -6,10 +6,8 @@ export type AuthDraft = {
   headerName: string;
   key: string;
   grantType: "authorization_code" | "client_credentials";
-  // Explicit scope selection. An empty string means "request everything the
-  // server advertises" — the server, not us, decides that set (see
-  // advertisedScopes), so a read-only resource URL is honoured without the
-  // operator having to type anything.
+  // Explicit scope selection. An empty string means every advertised scope is
+  // selected; submission expands it to the concrete advertised list.
   scopes: string;
   // Scopes the server advertised at detection time; drives the customize UI.
   advertisedScopes: string[];
@@ -36,6 +34,20 @@ export const EMPTY_AUTH: AuthDraft = {
 export function resolveSelectedScopes(scopes: string, advertised: string[]): string[] {
   const explicit = scopes.split(/\s+/).filter(Boolean);
   return explicit.length > 0 ? explicit : advertised;
+}
+
+export function projectMcpAuthInputFromDraft(auth: AuthDraft): ProjectMcpAuthInput {
+  if (auth.type === "none") return { type: "none" };
+  if (auth.type === "bearer") return { type: "bearer", token: auth.token };
+  if (auth.type === "api_key")
+    return { type: "api_key", headerName: auth.headerName, key: auth.key };
+  return {
+    type: "oauth",
+    grantType: auth.grantType,
+    scopes: resolveSelectedScopes(auth.scopes, auth.advertisedScopes),
+    ...(auth.clientId.trim() ? { clientId: auth.clientId.trim() } : {}),
+    ...(auth.clientSecret ? { clientSecret: auth.clientSecret } : {}),
+  };
 }
 
 // Toggle one advertised scope in/out of the selection, keeping advertised


### PR DESCRIPTION
## Summary

- persist the effective advertised scope selection when an MCP server is created
- include the same requested scopes in RFC 7591 dynamic client registration
- keep the authorization request and registered client on one least-privilege scope set

## Validation

- `pnpm --filter @superlog/api test`
- `pnpm --filter @superlog/web test`
- `pnpm --filter @superlog/api typecheck`
- `pnpm --filter @superlog/web typecheck`
- `pnpm exec biome check apps/api/src/project-mcp-oauth.ts apps/api/src/project-mcp-oauth.test.ts apps/web/src/settings/AgentMcpServersCard.tsx apps/web/src/settings/project-mcp-editor.ts apps/web/src/settings/project-mcp-editor.test.ts`
- `pnpm worktree:verify`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves MCP OAuth scopes end-to-end. We now persist the resolved scope set and include it in dynamic client registration, keeping the client, persisted server, and auth request on the same least‑privilege set.

- **Bug Fixes**
  - Persist selected/advertised scopes on submit; empty selection expands to all advertised scopes.
  - Send scopes during RFC 7591 registration (`scope: "…"`) and update `register()` to accept `scopes: string[]`.
  - Persist the resolved scopes when dynamic registration creates a client; use the same set for authorization.
  - Centralize draft-to-input logic as `projectMcpAuthInputFromDraft`; remove duplicate helper and add tests.

<sup>Written for commit 874533851eea66ea075390f8e62b347f2533b270. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

