### PR TITLE
Silence issues when the last agent PR is closed without merge

### DIFF
--- a/apps/api/src/github.ts
+++ b/apps/api/src/github.ts
@@ -1027,8 +1027,12 @@ export async function resumeOrResolveIncidentForMergedAgentPr(
 // the human's decision on the delivery itself, so the incident resolves
 // deterministically instead of waiting for a confirmation nobody sends: as
 // `agent_pr_merged` when a sibling fix did land, as `agent_pr_closed` when
-// nothing merged. Issues cascade to resolved, so a real recurrence re-pages
-// through the ordinary resolved→recur path. While other PRs are still open
+// nothing merged. On a merge the issues cascade to resolved, so a real
+// recurrence re-pages through the ordinary resolved→recur path; on a plain
+// close they cascade to silenced (the human declined the fix while the errors
+// may still fire — resubmitting the same PR on every recurrence spams them),
+// with an un-silence button on the Slack root message to re-arm recurrence.
+// While other PRs are still open
 // the close is only context — it resumes the session (when one exists) so the
 // agent keeps driving the remaining delivery.
 export type ClosedAgentPullRequestContinuationDisposition =

--- a/apps/api/src/incidents/resolution-side-effects.test.ts
+++ b/apps/api/src/incidents/resolution-side-effects.test.ts
@@ -236,6 +236,45 @@ test("buildResolvedIncidentSlackRoot removes resolve action and keeps rating act
   assert.equal(json.includes("rate_incident:unhelpful:inc-1"), true);
 });
 
+test("buildResolvedIncidentSlackRoot renders the silenced variant for a closed-PR resolution", () => {
+  const update = buildResolvedIncidentSlackRoot({
+    incident: {
+      id: "inc-1",
+      title: "Checkout API timeout",
+      service: "checkout-api",
+    },
+    projectName: "Acme",
+    projectRoute: PROJECT_ROUTE,
+    silencedByClosedPr: { closedByLogin: "octocat" },
+  });
+
+  const json = JSON.stringify(update.blocks);
+  assert.equal(update.text, ":no_bell: Checkout API timeout - Incident resolved, errors silenced");
+  assert.equal(json.includes("PR closed by @octocat"), true);
+  assert.equal(json.includes("will not raise incidents anymore"), true);
+  assert.equal(json.includes("unsilence_resolve:inc-1"), true);
+  assert.equal(json.includes("Do not silence, resolve"), true);
+  // Rating buttons stay available alongside the un-silence action.
+  assert.equal(json.includes("rate_incident:helpful:inc-1"), true);
+});
+
+test("the silenced variant copes with an unknown closer login", () => {
+  const update = buildResolvedIncidentSlackRoot({
+    incident: {
+      id: "inc-1",
+      title: "Checkout API timeout",
+      service: "checkout-api",
+    },
+    projectName: "Acme",
+    projectRoute: PROJECT_ROUTE,
+    silencedByClosedPr: { closedByLogin: null },
+  });
+
+  const json = JSON.stringify(update.blocks);
+  assert.equal(json.includes("PR closed —"), true);
+  assert.equal(json.includes("unsilence_resolve:inc-1"), true);
+});
+
 test("resolution publication compensation restores an open incident root", () => {
   const update = buildIncidentResolutionCompensationSlackRoot({
     incident: {

--- a/apps/api/src/incidents/resolution-side-effects.ts
+++ b/apps/api/src/incidents/resolution-side-effects.ts
@@ -98,7 +98,8 @@ export async function runResolvedIncidentSideEffectsForIncident(opts: {
   resolutionProof: IncidentResolutionProof;
   reopenPullRequest: CloseIncidentPullRequest;
 }): Promise<CloseIncidentOpenPullRequestsResult | null> {
-  const { db, isIncidentResolutionProofCurrent, schema } = await import("@superlog/db");
+  const { db, incidentHasCurrentSilencedIssues, isIncidentResolutionProofCurrent, schema } =
+    await import("@superlog/db");
   const incident = await db.query.incidents.findFirst({
     where: eq(schema.incidents.id, opts.incidentId),
   });
@@ -118,22 +119,13 @@ export async function runResolvedIncidentSideEffectsForIncident(opts: {
   // A closed-PR resolution silenced the incident's issues (the settled-path
   // default in @superlog/db). Surface that on the root message, attributing
   // the close from the resolution event's recorded actor rather than parsing
-  // reason text. Gated on an issue actually being silenced so a re-render
-  // after the un-silence click paints the plain resolved copy.
+  // reason text. Gated on an issue whose *current* incident is this one still
+  // being silenced: a re-render after the un-silence click paints the plain
+  // resolved copy, and an issue that recurred into a newer incident cannot
+  // resurface the silenced variant here (the button could no longer touch it).
   let silencedByClosedPr: { closedByLogin: string | null } | undefined;
   if (incident.resolvedReasonCode === "agent_pr_closed") {
-    const silencedIssue = await db
-      .select({ id: schema.issues.id })
-      .from(schema.incidentIssues)
-      .innerJoin(schema.issues, eq(schema.issues.id, schema.incidentIssues.issueId))
-      .where(
-        and(
-          eq(schema.incidentIssues.incidentId, incident.id),
-          eq(schema.issues.status, "silenced"),
-        ),
-      )
-      .limit(1);
-    if (silencedIssue.length > 0) {
+    if (await incidentHasCurrentSilencedIssues(incident.id)) {
       const resolutionEvent = await db.query.incidentEvents.findFirst({
         where: and(
           eq(schema.incidentEvents.incidentId, incident.id),

--- a/apps/api/src/incidents/resolution-side-effects.ts
+++ b/apps/api/src/incidents/resolution-side-effects.ts
@@ -48,6 +48,7 @@ export async function runResolvedIncidentSideEffects(opts: {
   projectName: string;
   projectRoute: { orgSlug: string; projectSlug: string };
   resolutionEpoch?: ResolvedIncidentResolutionEpoch;
+  silencedByClosedPr?: { closedByLogin: string | null };
   deps: ResolvedIncidentSideEffectDeps;
 }): Promise<CloseIncidentOpenPullRequestsResult> {
   if (opts.resolutionEpoch && !(await opts.resolutionEpoch.isCurrent())) {
@@ -69,6 +70,7 @@ export async function runResolvedIncidentSideEffects(opts: {
     incident: opts.incident,
     projectName: opts.projectName,
     projectRoute: opts.projectRoute,
+    silencedByClosedPr: opts.silencedByClosedPr,
   });
   try {
     await opts.deps.updateSlackRootMessage({
@@ -113,12 +115,44 @@ export async function runResolvedIncidentSideEffectsForIncident(opts: {
     resolutionProof,
     reopenPullRequest: opts.reopenPullRequest,
   });
+  // A closed-PR resolution silenced the incident's issues (the settled-path
+  // default in @superlog/db). Surface that on the root message, attributing
+  // the close from the resolution event's recorded actor rather than parsing
+  // reason text. Gated on an issue actually being silenced so a re-render
+  // after the un-silence click paints the plain resolved copy.
+  let silencedByClosedPr: { closedByLogin: string | null } | undefined;
+  if (incident.resolvedReasonCode === "agent_pr_closed") {
+    const silencedIssue = await db
+      .select({ id: schema.issues.id })
+      .from(schema.incidentIssues)
+      .innerJoin(schema.issues, eq(schema.issues.id, schema.incidentIssues.issueId))
+      .where(
+        and(
+          eq(schema.incidentIssues.incidentId, incident.id),
+          eq(schema.issues.status, "silenced"),
+        ),
+      )
+      .limit(1);
+    if (silencedIssue.length > 0) {
+      const resolutionEvent = await db.query.incidentEvents.findFirst({
+        where: and(
+          eq(schema.incidentEvents.incidentId, incident.id),
+          eq(schema.incidentEvents.dedupeKey, resolutionProof.eventDedupeKey),
+        ),
+      });
+      const detail = resolutionEvent?.detail as { closedByLogin?: unknown } | null | undefined;
+      silencedByClosedPr = {
+        closedByLogin: typeof detail?.closedByLogin === "string" ? detail.closedByLogin : null,
+      };
+    }
+  }
   return runResolvedIncidentSideEffects({
     incident: {
       id: incident.id,
       title: incident.title,
       service: incident.service,
     },
+    silencedByClosedPr,
     projectName: project.name,
     projectRoute: { orgSlug: org.slug, projectSlug: project.slug },
     resolutionEpoch: {
@@ -153,39 +187,59 @@ export function buildResolvedIncidentSlackRoot(opts: {
   incident: ResolvedIncidentSideEffectIncident;
   projectName: string;
   projectRoute: { orgSlug: string; projectSlug: string };
+  // Set when the resolution came from the last agent PR being closed without
+  // merge: the resolve cascade silenced the incident's issues, so the root
+  // message says so and offers the un-silence action.
+  silencedByClosedPr?: { closedByLogin: string | null };
 }): ResolvedIncidentSlackRoot {
   const origin = WEB_ORIGIN.replace(/\/$/, "");
   const incidentUrl = escapeSlackLinkUrl(
     `${origin}/org/${encodeURIComponent(opts.projectRoute.orgSlug)}/project/${encodeURIComponent(opts.projectRoute.projectSlug)}/incidents/${encodeURIComponent(opts.incident.id)}`,
   );
   const titleLabel = escapeSlackLinkText(opts.incident.title);
+  const silenced = opts.silencedByClosedPr;
   const lines = [
-    ":white_check_mark: *Incident resolved*",
+    silenced ? ":no_bell: *Incident resolved — errors silenced*" : ":white_check_mark: *Incident resolved*",
     `*<${incidentUrl}|${titleLabel}>*`,
     opts.incident.service
       ? `\`${opts.projectName}\` · \`${opts.incident.service}\``
       : `\`${opts.projectName}\``,
   ];
+  if (silenced) {
+    const closedBy = silenced.closedByLogin ? `PR closed by @${silenced.closedByLogin}` : "PR closed";
+    lines.push(
+      `${closedBy} — this incident and its errors are silenced and will not raise incidents anymore. ` +
+        `If you'd like these errors to reopen incidents, click *Do not silence, resolve*.`,
+    );
+  }
+  const elements: unknown[] = [];
+  if (silenced) {
+    elements.push({
+      type: "button",
+      text: { type: "plain_text", text: "Do not silence, resolve", emoji: true },
+      action_id: `unsilence_resolve:${opts.incident.id}`,
+    });
+  }
+  elements.push(
+    {
+      type: "button",
+      text: { type: "plain_text", text: "👍 Helpful", emoji: true },
+      action_id: `rate_incident:helpful:${opts.incident.id}`,
+    },
+    {
+      type: "button",
+      text: { type: "plain_text", text: "👎 Not helpful", emoji: true },
+      action_id: `rate_incident:unhelpful:${opts.incident.id}`,
+    },
+  );
   const blocks: unknown[] = [
     { type: "section", text: { type: "mrkdwn", text: lines.join("\n") } },
-    {
-      type: "actions",
-      elements: [
-        {
-          type: "button",
-          text: { type: "plain_text", text: "👍 Helpful", emoji: true },
-          action_id: `rate_incident:helpful:${opts.incident.id}`,
-        },
-        {
-          type: "button",
-          text: { type: "plain_text", text: "👎 Not helpful", emoji: true },
-          action_id: `rate_incident:unhelpful:${opts.incident.id}`,
-        },
-      ],
-    },
+    { type: "actions", elements },
   ];
   return {
-    text: `:white_check_mark: ${opts.incident.title} - Incident resolved`,
+    text: silenced
+      ? `:no_bell: ${opts.incident.title} - Incident resolved, errors silenced`
+      : `:white_check_mark: ${opts.incident.title} - Incident resolved`,
     blocks,
   };
 }

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -15,6 +15,7 @@ import {
   schema,
   stripBotMention,
   syncLoopsContactsForOrg,
+  unsilenceIncidentIssues,
 } from "@superlog/db";
 import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import type { Hono } from "hono";
@@ -294,6 +295,8 @@ export function mountSlackPublic(app: Hono<any>): void {
 //   - `resolve_incident:<incident-uuid>` → "Problem resolved": incident
 //     resolved, issues resolved (recurrence opens a new chained incident)
 //   - `not_an_issue:<incident-uuid>` → incident resolved, issues silenced
+//   - `unsilence_resolve:<incident-uuid>` → flips issues a closed-PR
+//     resolution silenced back to resolved, so recurrences re-page
 //   - `merge_pr:<incident-uuid>` → merges the incident's latest open agent PR
 async function handleSlackBlockActions(payload: SlackInteractivityPayload): Promise<void> {
   const action = payload.actions?.[0];
@@ -309,6 +312,12 @@ async function handleSlackBlockActions(payload: SlackInteractivityPayload): Prom
   if (actionId.startsWith("not_an_issue:")) {
     const incidentId = actionId.slice("not_an_issue:".length);
     if (incidentId) await handleSlackResolveIncident(incidentId, payload, "not_an_issue");
+    return;
+  }
+
+  if (actionId.startsWith("unsilence_resolve:")) {
+    const incidentId = actionId.slice("unsilence_resolve:".length);
+    if (incidentId) await handleSlackUnsilenceResolve(incidentId, payload);
     return;
   }
 
@@ -658,6 +667,59 @@ async function handleSlackResolveIncident(
         resolution === "not_an_issue"
           ? `:no_bell: Marked not-an-issue by ${attribution}. The linked issues are silenced; future occurrences will not open incidents.`
           : `:white_check_mark: Incident resolved by ${attribution}. If the underlying error reappears, a new incident will open with this investigation's findings attached.`,
+    });
+  }
+}
+
+// Handle an `unsilence_resolve:<incidentId>` click: the closed-PR resolution
+// silenced the incident's issues by default; this flips them back to
+// `resolved` so the next occurrence opens a chained incident, then refreshes
+// the root message (which re-renders as plain resolved once nothing is
+// silenced). Idempotent — a repeat click finds nothing silenced and only
+// refreshes.
+async function handleSlackUnsilenceResolve(
+  incidentId: string,
+  payload: SlackInteractivityPayload,
+): Promise<void> {
+  const incident = await db.query.incidents.findFirst({
+    where: eq(schema.incidents.id, incidentId),
+  });
+  if (!incident) {
+    log.warn({ incidentId }, "unsilence_resolve click for unknown incident");
+    return;
+  }
+  const slackUserId = payload.user?.id ?? null;
+  const slackUserName = payload.user?.name ?? null;
+  const attribution = slackUserId ? `<@${slackUserId}>` : (slackUserName ?? "a teammate");
+
+  const { unsilencedIssueCount } = await unsilenceIncidentIssues({
+    incidentId,
+    resolvedBySlackUserId: slackUserId ?? undefined,
+  });
+
+  const resolutionProof = await loadCurrentIncidentResolutionProof({ incidentId });
+  if (resolutionProof) {
+    await runSlackResolvedIncidentSideEffects(incidentId, resolutionProof);
+  }
+  if (unsilencedIssueCount === 0) {
+    log.info({ incidentId }, "unsilence_resolve click found no silenced issues");
+    return;
+  }
+
+  const installation = await installationForIncident({
+    pinnedId: incident.slackInstallationId,
+    teamId: payload.team?.id ?? "",
+  });
+  if (!installation) {
+    log.warn({ team_id: payload.team?.id, incidentId }, "no installation to post unsilence reply");
+    return;
+  }
+  if (incident.slackChannelId && incident.slackThreadTs) {
+    await postSlackThreadReply({
+      botToken: installation.botAccessToken,
+      channel: incident.slackChannelId,
+      threadTs: incident.slackThreadTs,
+      text: `:bell: ${attribution} chose to keep tracking these errors. The issues are resolved instead of silenced — if the error recurs, a new incident will open.`,
     });
   }
 }

--- a/apps/web/src/issues/IssueDetailView.tsx
+++ b/apps/web/src/issues/IssueDetailView.tsx
@@ -210,7 +210,9 @@ function IssueActivityTimeline({ issueId, events }: { issueId: string; events: I
     const presentation =
       event.kind === "issue_silenced"
         ? { status: "Silenced", tone: "neutral" as const }
-        : event.kind === "issue_observed"
+        : event.kind === "issue_unsilenced"
+          ? { status: "Un-silenced", tone: "neutral" as const }
+          : event.kind === "issue_observed"
           ? { status: "Under observation", tone: "warning" as const }
           : event.kind === "issue_resolved"
             ? { status: "Resolved", tone: "success" as const }

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -6,6 +6,7 @@ import {
   closeIncidentOpenPullRequestsAfterResolution,
   createIncidentLifecycle,
   db,
+  incidentHasCurrentSilencedIssues,
   isIncidentResolutionProofCurrent,
   resolveAgentIncident,
   schema,
@@ -477,19 +478,28 @@ export async function completeWithoutPullRequest(
 ): Promise<boolean> {
   const noiseReason = completedNoiseReason(result);
   const resolutionReason = noiseReason ? null : completedResolutionReason(result);
+  // The settled outcome only says which PR event triggered the resolve. Read
+  // whether the committed cascade actually silenced issues from the database:
+  // a close with a merged sibling resolves as agent_pr_merged with the plain
+  // resolve cascade, and must not render silenced copy or a no-op un-silence
+  // button.
+  const settledClosedSilenced =
+    opts?.incidentOutcome?.kind === "all_pull_requests_settled" &&
+    opts.incidentOutcome.settledState === "closed" &&
+    (await incidentHasCurrentSilencedIssues(ctx.incident.id));
   const mergedResolutionCopy =
     opts?.incidentOutcome?.kind === "all_pull_requests_merged"
       ? mergedPullRequestResolutionCopy(opts.incidentOutcome)
       : opts?.incidentOutcome?.kind === "all_pull_requests_settled"
-        ? settledPullRequestResolutionCopy(opts.incidentOutcome)
+        ? settledPullRequestResolutionCopy({
+            ...opts.incidentOutcome,
+            silenced: settledClosedSilenced,
+          })
         : null;
   const alreadyClosedCopy =
     opts?.incidentOutcome?.kind === "incident_already_closed"
       ? incidentAlreadyClosedCompletionCopy()
       : null;
-  const settledClosedSilenced =
-    opts?.incidentOutcome?.kind === "all_pull_requests_settled" &&
-    opts.incidentOutcome.settledState === "closed";
   let closedElsewhereCopy = alreadyClosedCopy;
   let resolutionProof =
     opts?.incidentOutcome?.kind === "all_pull_requests_merged" ||

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -487,6 +487,9 @@ export async function completeWithoutPullRequest(
     opts?.incidentOutcome?.kind === "incident_already_closed"
       ? incidentAlreadyClosedCompletionCopy()
       : null;
+  const settledClosedSilenced =
+    opts?.incidentOutcome?.kind === "all_pull_requests_settled" &&
+    opts.incidentOutcome.settledState === "closed";
   let closedElsewhereCopy = alreadyClosedCopy;
   let resolutionProof =
     opts?.incidentOutcome?.kind === "all_pull_requests_merged" ||
@@ -759,7 +762,7 @@ export async function completeWithoutPullRequest(
               ? `Investigation complete · Linear ${ticket.identifier}`
               : "Investigation complete";
       const text = mergedResolutionCopy
-        ? `:white_check_mark: ${ctx.incident.title} — ${mergedResolutionCopy.mainTextSuffix}`
+        ? `:${settledClosedSilenced ? "no_bell" : "white_check_mark"}: ${ctx.incident.title} — ${mergedResolutionCopy.mainTextSuffix}`
         : noiseReason && noiseApplied
           ? `:no_bell: ${ctx.incident.title} — ${isAlertIncident(ctx) ? "Alert" : "Incident"} marked as noise`
           : resolutionReason
@@ -769,7 +772,8 @@ export async function completeWithoutPullRequest(
         ctx.incident.id,
         text,
         incidentBlocks({
-          emoji: noiseReason && noiseApplied ? "no_bell" : "white_check_mark",
+          emoji:
+            (noiseReason && noiseApplied) || settledClosedSilenced ? "no_bell" : "white_check_mark",
           status,
           title: ctx.incident.title,
           titleUrl: incidentUrl,
@@ -780,6 +784,7 @@ export async function completeWithoutPullRequest(
           links: ticket?.url ? [{ text: "View ticket", url: ticket.url }] : [],
           incidentId: ctx.incident.id,
           showFeedbackButtons: true,
+          showUnsilenceButton: settledClosedSilenced,
         }),
       );
     }

--- a/apps/worker/src/agent-runs/resolution-completion.test.ts
+++ b/apps/worker/src/agent-runs/resolution-completion.test.ts
@@ -94,11 +94,12 @@ test("merged fallback publishes Incident-resolved copy", () => {
   assert.doesNotMatch(`${copy.threadLead} ${copy.status}`, /investigation complete/i);
 });
 
-test("settled-closed fallback publishes silenced copy with the un-silence pointer", () => {
+test("settled-closed fallback publishes silenced copy when the cascade silenced issues", () => {
   const copy = settledPullRequestResolutionCopy({
     prNumber: 42,
     repoFullName: "acme/api",
     settledState: "closed",
+    silenced: true,
   });
 
   assert.match(copy.threadLead, /closed without merging/);
@@ -108,11 +109,28 @@ test("settled-closed fallback publishes silenced copy with the un-silence pointe
   assert.equal(copy.mainTextSuffix, "Incident resolved, errors silenced");
 });
 
+test("settled-closed fallback keeps plain copy when the committed resolution did not silence", () => {
+  // Mixed merged+closed delivery: the triggering PR is a close, but a merged
+  // sibling made the committed resolution agent_pr_merged with the plain
+  // resolve cascade — the copy must not claim silencing.
+  const copy = settledPullRequestResolutionCopy({
+    prNumber: 42,
+    repoFullName: "acme/api",
+    settledState: "closed",
+    silenced: false,
+  });
+
+  assert.doesNotMatch(copy.threadLead, /silenced/);
+  assert.equal(copy.status, "Incident resolved - all agent pull requests settled");
+  assert.equal(copy.mainTextSuffix, "Incident resolved");
+});
+
 test("settled-merged fallback keeps plain resolved copy", () => {
   const copy = settledPullRequestResolutionCopy({
     prNumber: 42,
     repoFullName: "acme/api",
     settledState: "merged",
+    silenced: false,
   });
 
   assert.doesNotMatch(copy.threadLead, /silenced/);

--- a/apps/worker/src/agent-runs/resolution-completion.test.ts
+++ b/apps/worker/src/agent-runs/resolution-completion.test.ts
@@ -8,6 +8,7 @@ import {
   incidentAlreadyClosedCompletionCopy,
   legacyResolutionEventDedupeKey,
   mergedPullRequestResolutionCopy,
+  settledPullRequestResolutionCopy,
   planLegacyTerminalResolutionCompletion,
   resolutionCompletionCopy,
   resolutionCompletionResult,
@@ -91,6 +92,31 @@ test("merged fallback publishes Incident-resolved copy", () => {
     mainTextSuffix: "Incident resolved",
   });
   assert.doesNotMatch(`${copy.threadLead} ${copy.status}`, /investigation complete/i);
+});
+
+test("settled-closed fallback publishes silenced copy with the un-silence pointer", () => {
+  const copy = settledPullRequestResolutionCopy({
+    prNumber: 42,
+    repoFullName: "acme/api",
+    settledState: "closed",
+  });
+
+  assert.match(copy.threadLead, /closed without merging/);
+  assert.match(copy.threadLead, /silenced/);
+  assert.match(copy.threadLead, /Do not silence, resolve/);
+  assert.equal(copy.status, "Incident resolved - errors silenced (agent PR closed)");
+  assert.equal(copy.mainTextSuffix, "Incident resolved, errors silenced");
+});
+
+test("settled-merged fallback keeps plain resolved copy", () => {
+  const copy = settledPullRequestResolutionCopy({
+    prNumber: 42,
+    repoFullName: "acme/api",
+    settledState: "merged",
+  });
+
+  assert.doesNotMatch(copy.threadLead, /silenced/);
+  assert.equal(copy.mainTextSuffix, "Incident resolved");
 });
 
 test("merged fallback that loses the resolution race uses thread-only closed-elsewhere copy", () => {

--- a/apps/worker/src/agent-runs/resolution-completion.ts
+++ b/apps/worker/src/agent-runs/resolution-completion.ts
@@ -19,28 +19,36 @@ export function settledPullRequestResolutionCopy(opts: {
   prNumber: number;
   repoFullName: string;
   settledState: "merged" | "closed";
+  // Whether the committed resolution actually silenced the incident's issues
+  // (query the incident/issue state, e.g. incidentHasCurrentSilencedIssues).
+  // The triggering PR's state alone cannot decide this: a close with a merged
+  // sibling commits agent_pr_merged with the plain resolve cascade.
+  silenced: boolean;
 }): {
   threadLead: string;
   status: string;
   mainTextSuffix: string;
 } {
-  if (opts.settledState === "merged") {
+  if (opts.settledState === "closed" && opts.silenced) {
+    // A close without a merged sibling silences the incident's issues (the
+    // settled-path default in @superlog/db), so the copy says so and points
+    // at the un-silence action on the root message.
     return {
-      threadLead: `:white_check_mark: Fix PR #${opts.prNumber} (${opts.repoFullName}) is merged and the remaining agent pull requests are closed; incident resolved.`,
-      status: "Incident resolved - all agent pull requests settled",
-      mainTextSuffix: "Incident resolved",
+      threadLead:
+        `:no_bell: PR #${opts.prNumber} (${opts.repoFullName}) was closed without merging and no agent pull request remains open; ` +
+        `incident resolved and its errors silenced — they will not raise incidents anymore. ` +
+        `Click *Do not silence, resolve* on the incident message to re-arm recurrence.`,
+      status: "Incident resolved - errors silenced (agent PR closed)",
+      mainTextSuffix: "Incident resolved, errors silenced",
     };
   }
-  // A close without a merged sibling silences the incident's issues (the
-  // settled-path default in @superlog/db), so the copy says so and points at
-  // the un-silence action on the root message.
   return {
     threadLead:
-      `:no_bell: PR #${opts.prNumber} (${opts.repoFullName}) was closed without merging and no agent pull request remains open; ` +
-      `incident resolved and its errors silenced — they will not raise incidents anymore. ` +
-      `Click *Do not silence, resolve* on the incident message to re-arm recurrence.`,
-    status: "Incident resolved - errors silenced (agent PR closed)",
-    mainTextSuffix: "Incident resolved, errors silenced",
+      opts.settledState === "merged"
+        ? `:white_check_mark: Fix PR #${opts.prNumber} (${opts.repoFullName}) is merged and the remaining agent pull requests are closed; incident resolved.`
+        : `:white_check_mark: PR #${opts.prNumber} (${opts.repoFullName}) was closed without merging and no agent pull request remains open; incident resolved.`,
+    status: "Incident resolved - all agent pull requests settled",
+    mainTextSuffix: "Incident resolved",
   };
 }
 

--- a/apps/worker/src/agent-runs/resolution-completion.ts
+++ b/apps/worker/src/agent-runs/resolution-completion.ts
@@ -24,13 +24,23 @@ export function settledPullRequestResolutionCopy(opts: {
   status: string;
   mainTextSuffix: string;
 } {
+  if (opts.settledState === "merged") {
+    return {
+      threadLead: `:white_check_mark: Fix PR #${opts.prNumber} (${opts.repoFullName}) is merged and the remaining agent pull requests are closed; incident resolved.`,
+      status: "Incident resolved - all agent pull requests settled",
+      mainTextSuffix: "Incident resolved",
+    };
+  }
+  // A close without a merged sibling silences the incident's issues (the
+  // settled-path default in @superlog/db), so the copy says so and points at
+  // the un-silence action on the root message.
   return {
     threadLead:
-      opts.settledState === "merged"
-        ? `:white_check_mark: Fix PR #${opts.prNumber} (${opts.repoFullName}) is merged and the remaining agent pull requests are closed; incident resolved.`
-        : `:white_check_mark: PR #${opts.prNumber} (${opts.repoFullName}) was closed without merging and no agent pull request remains open; incident resolved.`,
-    status: "Incident resolved - all agent pull requests settled",
-    mainTextSuffix: "Incident resolved",
+      `:no_bell: PR #${opts.prNumber} (${opts.repoFullName}) was closed without merging and no agent pull request remains open; ` +
+      `incident resolved and its errors silenced — they will not raise incidents anymore. ` +
+      `Click *Do not silence, resolve* on the incident message to re-arm recurrence.`,
+    status: "Incident resolved - errors silenced (agent PR closed)",
+    mainTextSuffix: "Incident resolved, errors silenced",
   };
 }
 

--- a/apps/worker/src/agent-runs/status.ts
+++ b/apps/worker/src/agent-runs/status.ts
@@ -4,6 +4,7 @@ import {
   db,
   enqueueAgentRunAwaitingInput,
   enqueueAgentRunFailed,
+  incidentHasCurrentSilencedIssues,
   schema,
 } from "@superlog/db";
 import type { AgentRunContext } from "../agent-run-context.js";
@@ -457,6 +458,12 @@ export async function reconcileStaleAgentRunPublication(ctx: AgentRunContext): P
         agentRun?.result?.summary ??
         presentation.summary);
 
+  // A closed-PR resolution (e.g. committed by the GitHub webhook while this
+  // run's provider calls were in flight) silences the incident's issues; this
+  // repaint must keep the un-silence escape hatch it would otherwise erase.
+  const showUnsilenceButton =
+    incident.status !== "open" && (await incidentHasCurrentSilencedIssues(incident.id));
+
   // Resolution or a resume may commit while the non-transactional provider
   // calls are in flight. Re-publish the aggregate's durable current state so
   // the waiting update cannot remain the final Slack/Linear state.
@@ -476,6 +483,7 @@ export async function reconcileStaleAgentRunPublication(ctx: AgentRunContext): P
       incidentId: incident.id,
       showResolveButton: incident.status === "open",
       showFeedbackButtons: incident.status !== "open",
+      showUnsilenceButton,
     }),
   );
   await postLinearIncidentResponse(incident.id, presentation.summary);

--- a/apps/worker/src/infra/slack/incident-messages.test.ts
+++ b/apps/worker/src/infra/slack/incident-messages.test.ts
@@ -24,6 +24,23 @@ test("incidentBlocks renders project · service · environment as code chips", (
   assert.equal(line, "`Acme` · `api` · `production`");
 });
 
+test("incidentBlocks renders the un-silence button ahead of the rating buttons", () => {
+  const blocks = incidentBlocks({
+    emoji: "no_bell",
+    status: "Incident resolved - errors silenced (agent PR closed)",
+    title: "boom",
+    projectName: "Acme",
+    buttons: [],
+    incidentId: "inc-1",
+    showUnsilenceButton: true,
+    showFeedbackButtons: true,
+  });
+  const json = JSON.stringify(blocks);
+  assert.equal(json.includes("unsilence_resolve:inc-1"), true);
+  assert.equal(json.includes("Do not silence, resolve"), true);
+  assert.ok(json.indexOf("unsilence_resolve:inc-1") < json.indexOf("rate_incident:helpful:inc-1"));
+});
+
 test("incidentBlocks omits environment when absent", () => {
   const line = contextLine(
     incidentBlocks({

--- a/apps/worker/src/infra/slack/incident-messages.ts
+++ b/apps/worker/src/infra/slack/incident-messages.ts
@@ -164,6 +164,11 @@ export function incidentBlocks(opts: {
   // Adds 👍/👎 rating buttons (rate_incident:<rating>:<incidentId>). Set on
   // states where there's an investigation worth rating.
   showFeedbackButtons?: boolean;
+  // Adds a "Do not silence, resolve" button (unsilence_resolve:<incidentId>).
+  // Set on the closed-PR resolution message, where the resolve cascade
+  // silenced the incident's issues — the click flips them back to `resolved`
+  // so a recurrence opens a chained incident again.
+  showUnsilenceButton?: boolean;
 }): unknown[] {
   const titleText = opts.titleUrl
     ? `*<${escapeSlackLinkUrl(opts.titleUrl)}|${escapeSlackLinkText(opts.title)}>*`
@@ -238,6 +243,13 @@ export function incidentBlocks(opts: {
           confirm: { type: "plain_text", text: "Silence" },
           deny: { type: "plain_text", text: "Cancel" },
         },
+      });
+    }
+    if (opts.showUnsilenceButton) {
+      elements.push({
+        type: "button",
+        text: { type: "plain_text", text: "Do not silence, resolve", emoji: true },
+        action_id: `unsilence_resolve:${opts.incidentId}`,
       });
     }
     if (opts.showFeedbackButtons) {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -309,6 +309,7 @@ export {
   resolveIncidentWithProof,
   resolveIncidentIfAllAgentPullRequestsMerged,
   resolveIncidentIfAllAgentPullRequestsSettled,
+  incidentHasCurrentSilencedIssues,
   unsilenceIncidentIssues,
   reconcileAgentRunCompletedByResolution,
   validateIncidentIssueOutcomes,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -309,6 +309,7 @@ export {
   resolveIncidentWithProof,
   resolveIncidentIfAllAgentPullRequestsMerged,
   resolveIncidentIfAllAgentPullRequestsSettled,
+  unsilenceIncidentIssues,
   reconcileAgentRunCompletedByResolution,
   validateIncidentIssueOutcomes,
   reserveAgentPullRequestBatch,

--- a/packages/db/src/issue-lifecycle.test.ts
+++ b/packages/db/src/issue-lifecycle.test.ts
@@ -1222,6 +1222,53 @@ test("unsilenceIncidentIssues flips silenced issues to resolved so recurrence re
   }
 });
 
+test("hasCurrentSilencedIssues follows the issue's current incident link", async () => {
+  const { db, client } = await freshDb();
+  try {
+    const project = await seedProject(db);
+    const { issue, incident } = await seedIncidentWithIssue(db, project.id, {
+      fingerprint: "fp-current-silenced",
+    });
+    await seedClosedAgentPullRequest(db, incident, project.orgId);
+    const lifecycle = createIncidentLifecycle(db);
+    await lifecycle.resolveIfAllAgentPullRequestsSettled({
+      incidentId: incident.id,
+      settlementEvidenceAt: new Date(),
+      buildInput: () => ({
+        incidentId: incident.id,
+        kind: "agent_pr_closed",
+        reasonCode: "agent_pr_closed",
+        reasonText: "Last agent PR closed without merge.",
+      }),
+    });
+    assert.equal(await lifecycle.hasCurrentSilencedIssues(incident.id), true);
+
+    await lifecycle.unsilenceIncidentIssues({ incidentId: incident.id });
+    assert.equal(await lifecycle.hasCurrentSilencedIssues(incident.id), false);
+
+    // The issue recurs into a NEW incident which later silences it. The old
+    // incident's historical link must not resurface the silenced state (its
+    // un-silence button could no longer touch the issue).
+    const reloaded = one(await db.select().from(schema.issues).where(eq(schema.issues.id, issue.id)));
+    const successor = await lifecycle.openRecurrence({
+      previousIncident: incident,
+      issue: reloaded,
+      origin: "resolved_issue_recurred",
+    });
+    await lifecycle.resolve({
+      incidentId: successor.id,
+      kind: "dashboard_manual",
+      reasonCode: "not_an_issue",
+      reasonText: null,
+      issueOutcome: { kind: "silence" },
+    });
+    assert.equal(await lifecycle.hasCurrentSilencedIssues(incident.id), false);
+    assert.equal(await lifecycle.hasCurrentSilencedIssues(successor.id), true);
+  } finally {
+    await client.close();
+  }
+});
+
 test("resolve with observe outcome stores the trigger and baseline", async () => {
   const { db, client } = await freshDb();
   try {

--- a/packages/db/src/issue-lifecycle.test.ts
+++ b/packages/db/src/issue-lifecycle.test.ts
@@ -1051,6 +1051,177 @@ test("silence cascade resolves alert-episode issues plainly (never silences them
   }
 });
 
+async function seedClosedAgentPullRequest(
+  db: DB,
+  incident: schema.Incident,
+  projectOrgId: string,
+  opts?: { state?: schema.AgentPrState },
+) {
+  const [run] = await db
+    .insert(schema.agentRuns)
+    .values({ incidentId: incident.id, runtime: "test", state: "complete" })
+    .returning();
+  assert.ok(run);
+  const [installation] = await db
+    .insert(schema.githubInstallations)
+    .values({
+      orgId: projectOrgId,
+      projectId: incident.projectId,
+      installationId: 424242,
+      accountLogin: "acme",
+      accountType: "Organization",
+      repos: [],
+    })
+    .returning();
+  assert.ok(installation);
+  const state = opts?.state ?? "closed";
+  const [pullRequest] = await db
+    .insert(schema.agentPullRequests)
+    .values({
+      incidentId: incident.id,
+      agentRunId: run.id,
+      installationId: installation.id,
+      repoFullName: "acme/api",
+      prNumber: 7,
+      url: "https://github.com/acme/api/pull/7",
+      branchName: "agent/fix",
+      baseBranch: "main",
+      state,
+      ...(state === "merged" ? { mergedAt: new Date() } : { closedAt: new Date() }),
+    })
+    .returning();
+  assert.ok(pullRequest);
+  return pullRequest;
+}
+
+// The closed-PR resolution is the customer saying "no" to the delivered fix
+// while the underlying errors may still be firing. Cascading `resolve` there
+// re-arms recurrence, which re-investigates and re-submits a PR the customer
+// just declined — so the settled path defaults the cascade to `silence` and
+// the Slack root message offers an explicit un-silence action instead.
+test("agent_pr_closed settled resolution silences current issues by default", async () => {
+  const { db, client } = await freshDb();
+  try {
+    const project = await seedProject(db);
+    const { issue, incident } = await seedIncidentWithIssue(db, project.id, {
+      fingerprint: "fp-pr-closed-silence",
+    });
+    await seedClosedAgentPullRequest(db, incident, project.orgId);
+    const result = await createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled({
+      incidentId: incident.id,
+      settlementEvidenceAt: new Date(),
+      buildInput: () => ({
+        incidentId: incident.id,
+        kind: "agent_pr_closed",
+        reasonCode: "agent_pr_closed",
+        reasonText: "Last agent PR closed without merge.",
+      }),
+    });
+    assert.equal(result.disposition, "resolved");
+    const after = one(await db.select().from(schema.issues).where(eq(schema.issues.id, issue.id)));
+    assert.equal(after.status, "silenced");
+    assert.ok(after.silencedAt);
+    const kinds = await eventKinds(db, incident.id);
+    assert.ok(kinds.includes("issue_silenced"));
+    assert.ok(!kinds.includes("issue_resolved"));
+  } finally {
+    await client.close();
+  }
+});
+
+test("agent_pr_merged settled resolution keeps the resolve cascade", async () => {
+  const { db, client } = await freshDb();
+  try {
+    const project = await seedProject(db);
+    const { issue, incident } = await seedIncidentWithIssue(db, project.id, {
+      fingerprint: "fp-pr-merged-resolve",
+    });
+    await seedClosedAgentPullRequest(db, incident, project.orgId, { state: "merged" });
+    const result = await createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled({
+      incidentId: incident.id,
+      settlementEvidenceAt: new Date(),
+      buildInput: () => ({
+        incidentId: incident.id,
+        kind: "agent_pr_merged",
+        reasonCode: "agent_pr_merged",
+        reasonText: "Agent PR merged.",
+      }),
+    });
+    assert.equal(result.disposition, "resolved");
+    const after = one(await db.select().from(schema.issues).where(eq(schema.issues.id, issue.id)));
+    assert.equal(after.status, "resolved");
+    assert.ok((await eventKinds(db, incident.id)).includes("issue_resolved"));
+  } finally {
+    await client.close();
+  }
+});
+
+test("an explicit issue outcome overrides the agent_pr_closed silence default", async () => {
+  const { db, client } = await freshDb();
+  try {
+    const project = await seedProject(db);
+    const { issue, incident } = await seedIncidentWithIssue(db, project.id, {
+      fingerprint: "fp-pr-closed-explicit",
+    });
+    await seedClosedAgentPullRequest(db, incident, project.orgId);
+    const result = await createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled({
+      incidentId: incident.id,
+      settlementEvidenceAt: new Date(),
+      buildInput: () => ({
+        incidentId: incident.id,
+        kind: "agent_pr_closed",
+        reasonCode: "agent_pr_closed",
+        reasonText: "Last agent PR closed without merge.",
+        issueOutcome: { kind: "resolve" },
+      }),
+    });
+    assert.equal(result.disposition, "resolved");
+    const after = one(await db.select().from(schema.issues).where(eq(schema.issues.id, issue.id)));
+    assert.equal(after.status, "resolved");
+  } finally {
+    await client.close();
+  }
+});
+
+test("unsilenceIncidentIssues flips silenced issues to resolved so recurrence re-arms", async () => {
+  const { db, client } = await freshDb();
+  try {
+    const project = await seedProject(db);
+    const { issue, incident } = await seedIncidentWithIssue(db, project.id, {
+      fingerprint: "fp-unsilence",
+    });
+    await seedClosedAgentPullRequest(db, incident, project.orgId);
+    await createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled({
+      incidentId: incident.id,
+      settlementEvidenceAt: new Date(),
+      buildInput: () => ({
+        incidentId: incident.id,
+        kind: "agent_pr_closed",
+        reasonCode: "agent_pr_closed",
+        reasonText: "Last agent PR closed without merge.",
+      }),
+    });
+    const outcome = await createIncidentLifecycle(db).unsilenceIncidentIssues({
+      incidentId: incident.id,
+      resolvedBySlackUserId: "U123",
+    });
+    assert.equal(outcome.unsilencedIssueCount, 1);
+    const after = one(await db.select().from(schema.issues).where(eq(schema.issues.id, issue.id)));
+    assert.equal(after.status, "resolved");
+    assert.equal(after.silencedAt, null);
+    assert.ok((await eventKinds(db, incident.id)).includes("issue_unsilenced"));
+
+    // Second click is a no-op.
+    const repeat = await createIncidentLifecycle(db).unsilenceIncidentIssues({
+      incidentId: incident.id,
+      resolvedBySlackUserId: "U123",
+    });
+    assert.equal(repeat.unsilencedIssueCount, 0);
+  } finally {
+    await client.close();
+  }
+});
+
 test("resolve with observe outcome stores the trigger and baseline", async () => {
   const { db, client } = await freshDb();
   try {

--- a/packages/db/src/resolve-incident.ts
+++ b/packages/db/src/resolve-incident.ts
@@ -703,6 +703,19 @@ export function createIncidentLifecycle(database: DB = db) {
       );
     },
 
+    // Whether any issue whose *current* incident is this one sits silenced.
+    // Drives the silenced variant of the resolution notification: derived
+    // from committed issue state (not the triggering PR event), and scoped to
+    // current links so an issue that recurred into a newer incident cannot
+    // resurface the silenced copy on a predecessor whose un-silence action
+    // could no longer touch it.
+    async hasCurrentSilencedIssues(incidentId: string): Promise<boolean> {
+      return repository.transaction(async (tx) => {
+        const issues = await repository.listCurrentIssuesForIncidentInTx(tx, incidentId);
+        return issues.some((issue) => issue.status === "silenced");
+      });
+    },
+
     // Undo for the closed-PR silence default: flip this incident's silenced
     // issues back to `resolved`, so the next occurrence is a recurrence that
     // opens a chained incident again. Only issues whose *current* incident is
@@ -1051,6 +1064,10 @@ export async function resolveIncidentIfAllAgentPullRequestsSettled(opts: {
   ): ResolveIncidentInput & { kind: "agent_pr_merged" | "agent_pr_closed" };
 }): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
   return createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled(opts);
+}
+
+export async function incidentHasCurrentSilencedIssues(incidentId: string): Promise<boolean> {
+  return createIncidentLifecycle(db).hasCurrentSilencedIssues(incidentId);
 }
 
 export async function unsilenceIncidentIssues(opts: {

--- a/packages/db/src/resolve-incident.ts
+++ b/packages/db/src/resolve-incident.ts
@@ -687,8 +687,55 @@ export function createIncidentLifecycle(database: DB = db) {
       return resolveIfIncidentPullRequestsSatisfy(
         { incidentId: opts.incidentId, settlementEvidenceAt: opts.settlementEvidenceAt },
         areAllIncidentPullRequestsSettled,
-        opts.buildInput,
+        (pullRequests, epoch) => {
+          const input = opts.buildInput(pullRequests, epoch);
+          // A close without a merged sibling is the human declining the fix
+          // while the underlying errors may still be firing. Cascading
+          // `resolve` there re-arms recurrence, which re-investigates and
+          // re-delivers a PR the human just closed — so this path defaults
+          // the issue cascade to `silence` (recurrences suppressed) and the
+          // notification surface offers an explicit un-silence action.
+          if (input.kind === "agent_pr_closed" && !input.issueOutcome && !input.issueOutcomes) {
+            return { ...input, issueOutcome: { kind: "silence" } };
+          }
+          return input;
+        },
       );
+    },
+
+    // Undo for the closed-PR silence default: flip this incident's silenced
+    // issues back to `resolved`, so the next occurrence is a recurrence that
+    // opens a chained incident again. Only issues whose *current* incident is
+    // this one are touched, mirroring the resolve cascade. Idempotent — a
+    // repeat click finds nothing silenced and reports zero.
+    async unsilenceIncidentIssues(opts: {
+      incidentId: string;
+      resolvedByUserId?: string;
+      resolvedBySlackUserId?: string;
+      now?: Date;
+    }): Promise<{ unsilencedIssueCount: number }> {
+      const now = opts.now ?? new Date();
+      return repository.transaction(async (tx) => {
+        const issues = await repository.listCurrentIssuesForIncidentInTx(tx, opts.incidentId);
+        const silenced = issues.filter((issue) => issue.status === "silenced");
+        for (const issue of silenced) {
+          await repository.updateIssueInTx(tx, issue.id, buildIssueResolvePatch());
+          await repository.insertEventInTx(tx, {
+            incidentId: opts.incidentId,
+            kind: "issue_unsilenced",
+            summary: `Issue un-silenced: ${issue.title}`,
+            detail: {
+              issueId: issue.id,
+              issueTitle: issue.title,
+              resolvedByUserId: opts.resolvedByUserId ?? null,
+              resolvedBySlackUserId: opts.resolvedBySlackUserId ?? null,
+            },
+            dedupeKey: `issue_unsilenced:${issue.id}:${now.getTime()}`,
+            processedAt: now,
+          });
+        }
+        return { unsilencedIssueCount: silenced.length };
+      });
     },
 
     async applyAgentRunResult(opts: {
@@ -1004,6 +1051,14 @@ export async function resolveIncidentIfAllAgentPullRequestsSettled(opts: {
   ): ResolveIncidentInput & { kind: "agent_pr_merged" | "agent_pr_closed" };
 }): Promise<ResolveIncidentAfterAgentPullRequestsMergedResult> {
   return createIncidentLifecycle(db).resolveIfAllAgentPullRequestsSettled(opts);
+}
+
+export async function unsilenceIncidentIssues(opts: {
+  incidentId: string;
+  resolvedByUserId?: string;
+  resolvedBySlackUserId?: string;
+}): Promise<{ unsilencedIssueCount: number }> {
+  return createIncidentLifecycle(db).unsilenceIncidentIssues(opts);
 }
 
 // Body of the resolve operation, parameterised on a transaction handle.


### PR DESCRIPTION
## Problem

Closing the last agent PR resolves the incident with the issue cascade set to `resolved`. When the underlying error is still firing (the usual case for a PR closed as duplicate/declined), the issue immediately recurs, opens a chained incident, runs a fresh investigation, and delivers another PR. Closing *that* PR repeats the cycle — every close of an unwanted PR generates the next one. Observed in production as the same issue producing 4+ investigate→PR→close loops in a single day.

## Change

- **`packages/db`**: `resolveIfAllAgentPullRequestsSettled` defaults the issue cascade to `{ kind: "silence" }` when the built resolution kind is `agent_pr_closed` and the caller didn't pass an explicit outcome. A merged sibling (`agent_pr_merged`) keeps the plain resolve cascade, and recurrence keeps working there. New `unsilenceIncidentIssues` helper flips this incident's silenced issues back to `resolved` (idempotent, emits `issue_unsilenced` events).
- **Slack root message** (both the api webhook path and the worker completion path): the closed-PR resolution now renders `:no_bell: Incident resolved — errors silenced`, states that these errors will not raise incidents anymore, and carries a **Do not silence, resolve** button (`unsilence_resolve:<incidentId>`). Closer attribution comes from the resolution event's recorded `closedByLogin`, not reason-text parsing.
- **`apps/api` interactivity**: the button flips the issues back to `resolved` (so the next occurrence opens a chained incident), refreshes the root message (which re-renders as plain resolved once nothing is silenced), and posts a thread reply attributing the choice.
- **`apps/web`**: issue activity timeline renders the new `issue_unsilenced` event.

## Tests

- `packages/db` lifecycle (PGlite): closed-PR settle silences; merged settle resolves; explicit outcome overrides; unsilence flips back and is idempotent.
- api: silenced Slack root variant (with and without closer login).
- worker: silenced resolution copy; `incidentBlocks` un-silence button placement.
- Typecheck green on db/api/worker/web; touched suites all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences issues when the last agent PR closes to stop repeat PR loops. Slack reliably shows the silenced state and the “Do not silence, resolve” control across renders, derived from committed issue state.

- **Bug Fixes**
  - Derive silenced Slack copy/button from committed issue state via `incidentHasCurrentSilencedIssues`, avoiding wrong renders on mixed merged+closed deliveries and on incidents superseded by recurrences.
  - Preserve the un-silence button during stale-publication repaints in the worker, so the escape hatch doesn’t disappear.

- **New Features**
  - `packages/db`: Default `agent_pr_closed` to silence; keep `agent_pr_merged` as resolve; add `unsilenceIncidentIssues` (idempotent) and `incidentHasCurrentSilencedIssues`.
  - Slack/Interactivity (`apps/api`, `apps/worker`): Show :no_bell: variant only when issues are currently silenced; add "Do not silence, resolve" `unsilence_resolve:<incidentId>`; attribute closer via `closedByLogin`; refresh root and post a thread reply on un-silence.
  - Web (`apps/web`): Render `issue_unsilenced` in the issue timeline.
  - Tests: Cover silenced variant derivation, button placement, worker/api copy, and DB lifecycle.

<sup>Written for commit ed05f636f7614acad82f7c93aab57d92912ec041. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

