### PR TITLE
Portal the integration config dialog so its backdrop covers the header

### DIFF
--- a/apps/web/src/settings/IntegrationConfigDialog.tsx
+++ b/apps/web/src/settings/IntegrationConfigDialog.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 
 /**
  * Centered modal that hosts a single integration's configuration. Opened by
@@ -79,7 +80,7 @@ export function IntegrationConfigDialog({
     };
   }, []);
 
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-6"
       // biome-ignore lint/a11y/useSemanticElements: <dialog> would require .showModal() lifecycle wiring; conditional render with role="dialog" is intentional.
@@ -133,6 +134,7 @@ export function IntegrationConfigDialog({
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto px-[22px] py-5">{children}</div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
The centered integration configuration modal (opened from the integrations settings) rendered inline inside the product shell's content column. Because it sits next to the sticky, `z-index`ed app header, its `fixed inset-0` backdrop got entangled with the header's stacking context — leaving a strip at the top of the page un-dimmed and un-blurred instead of the scrim covering the full viewport.

Render the dialog through a `createPortal(..., document.body)` (matching the app's other modal dialogs, e.g. the dashboard widget/variables forms). As a direct child of `<body>` the `fixed inset-0` scrim resolves against the viewport and covers the whole page, header included.

Pure presentational change — no behaviour or data flow affected. Typechecks clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Portal the integration config dialog to `document.body` so the backdrop covers the sticky header and dims the full viewport. Fixes the undimmed strip at the top; visual-only change with no behavior impact.

<sup>Written for commit 624f7237faf94930a82103f7f440320097be3dcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

