### PR TITLE
Guard the integration config dialog portal for DOM-less rendering

### DIFF
--- a/apps/web/src/settings/IntegrationConfigDialog.tsx
+++ b/apps/web/src/settings/IntegrationConfigDialog.tsx
@@ -80,7 +80,7 @@ export function IntegrationConfigDialog({
     };
   }, []);
 
-  return createPortal(
+  const overlay = (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-6"
       // biome-ignore lint/a11y/useSemanticElements: <dialog> would require .showModal() lifecycle wiring; conditional render with role="dialog" is intentional.
@@ -134,7 +134,12 @@ export function IntegrationConfigDialog({
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto px-[22px] py-5">{children}</div>
       </div>
-    </div>,
-    document.body,
+    </div>
   );
+
+  // Portal to <body> so the fixed-position scrim escapes the product shell's
+  // stacking contexts and covers the full viewport (header included). Fall
+  // back to inline rendering when there's no DOM (server/static rendering).
+  if (typeof document === "undefined") return overlay;
+  return createPortal(overlay, document.body);
 }


### PR DESCRIPTION
Follow-up to #329. That change portals the integration configuration dialog to `document.body`, but does so unconditionally — so rendering the component without a DOM (e.g. `renderToStaticMarkup` in `apps/web/src/settings/IntegrationConfigDialog.test.tsx`) throws on `document.body` before React can produce markup.

Render the overlay inline when `document` is undefined (server/static render) and portal to `<body>` in the browser. The browser behaviour — a full-viewport backdrop that covers the sticky header — is unchanged.

Typechecks clean; both component tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix crash when rendering the integration config dialog without a DOM by guarding the portal. When `document` is undefined, render the overlay inline; in the browser, continue portaling to `document.body` to preserve the full-viewport backdrop.

<sup>Written for commit 700af0902d97ab3f6d6a417d912d2a85f2a8dc86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

