### PR TITLE
Route closed incident threads to Q&A

### DIFF
--- a/apps/api/src/slack.test.ts
+++ b/apps/api/src/slack.test.ts
@@ -322,6 +322,29 @@ test("a mention sent before resolution does not become Q&A when its twin arrives
   );
 });
 
+test("closed incident Q&A keeps the installation that owns the incident", async () => {
+  const { findIncidentChatInstallation } = await import("./slack.js");
+  const wrongChannelDefault = { id: "install-b", projectId: "project-b" };
+  const incidentInstallation = { id: "install-a", projectId: "project-a" };
+
+  assert.equal(
+    findIncidentChatInstallation(
+      [wrongChannelDefault, incidentInstallation],
+      "project-a",
+      "install-a",
+    ),
+    incidentInstallation,
+  );
+  assert.equal(
+    findIncidentChatInstallation(
+      [wrongChannelDefault, incidentInstallation],
+      "project-a",
+      "deleted-install",
+    ),
+    incidentInstallation,
+  );
+});
+
 // The bot posts to public channels via chat:write.public WITHOUT joining them,
 // but Slack's Events API only delivers message events for channels the bot is
 // a member of — so thread replies in a never-joined channel vanish silently.

--- a/apps/api/src/slack.test.ts
+++ b/apps/api/src/slack.test.ts
@@ -263,6 +263,32 @@ test("chat anchors: DMs have no thread anchor (one conversation per channel)", a
   );
 });
 
+test("resolved incident threads route mentions to Q&A chat", async () => {
+  const { slackIncidentThreadRoute } = await import("./slack.js");
+
+  assert.equal(
+    slackIncidentThreadRoute({ incidentStatus: "resolved", eventType: "app_mention" }),
+    "chat",
+  );
+  assert.equal(
+    slackIncidentThreadRoute({ incidentStatus: "resolved", eventType: "message" }),
+    "chat",
+  );
+});
+
+test("open incident threads continue the investigation from the message event", async () => {
+  const { slackIncidentThreadRoute } = await import("./slack.js");
+
+  assert.equal(
+    slackIncidentThreadRoute({ incidentStatus: "open", eventType: "message" }),
+    "incident",
+  );
+  assert.equal(
+    slackIncidentThreadRoute({ incidentStatus: "open", eventType: "app_mention" }),
+    "ignore",
+  );
+});
+
 // The bot posts to public channels via chat:write.public WITHOUT joining them,
 // but Slack's Events API only delivers message events for channels the bot is
 // a member of — so thread replies in a never-joined channel vanish silently.

--- a/apps/api/src/slack.test.ts
+++ b/apps/api/src/slack.test.ts
@@ -267,11 +267,21 @@ test("resolved incident threads route mentions to Q&A chat", async () => {
   const { slackIncidentThreadRoute } = await import("./slack.js");
 
   assert.equal(
-    slackIncidentThreadRoute({ incidentStatus: "resolved", eventType: "app_mention" }),
+    slackIncidentThreadRoute({
+      incidentStatus: "resolved",
+      incidentClosedAt: new Date("2026-07-21T12:00:00.000Z"),
+      eventType: "app_mention",
+      eventTs: "1784635201.000000",
+    }),
     "chat",
   );
   assert.equal(
-    slackIncidentThreadRoute({ incidentStatus: "resolved", eventType: "message" }),
+    slackIncidentThreadRoute({
+      incidentStatus: "resolved",
+      incidentClosedAt: new Date("2026-07-21T12:00:00.000Z"),
+      eventType: "message",
+      eventTs: "1784635201.000000",
+    }),
     "chat",
   );
 });
@@ -286,6 +296,29 @@ test("open incident threads continue the investigation from the message event", 
   assert.equal(
     slackIncidentThreadRoute({ incidentStatus: "open", eventType: "app_mention" }),
     "ignore",
+  );
+});
+
+test("a mention sent before resolution does not become Q&A when its twin arrives late", async () => {
+  const { slackIncidentThreadRoute } = await import("./slack.js");
+
+  assert.equal(
+    slackIncidentThreadRoute({
+      incidentStatus: "resolved",
+      incidentClosedAt: new Date("2026-07-21T12:00:01.000Z"),
+      eventType: "app_mention",
+      eventTs: "1784635200.500000",
+    }),
+    "ignore",
+  );
+  assert.equal(
+    slackIncidentThreadRoute({
+      incidentStatus: "resolved",
+      incidentClosedAt: new Date("2026-07-21T12:00:01.000Z"),
+      eventType: "message",
+      eventTs: "1784635200.500000",
+    }),
+    "incident",
   );
 });
 

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -1513,10 +1513,12 @@ async function handleSlackEventEnvelope(payload: SlackEventEnvelope): Promise<vo
     text: event.text,
   };
 
-  // Incident threads first: replies there talk to the investigation, never to
-  // a chat. A channel mention fires BOTH a `message` and an `app_mention`
-  // event (with distinct event_ids), so only the `message` copy is processed
-  // here — otherwise one reply would record two human_reply events.
+  // Open incident threads continue the investigation. Once an incident is
+  // closed, the thread becomes an ordinary Q&A surface: an explicit mention
+  // starts a chat and subsequent replies continue it through handleChatEvent.
+  // A channel mention fires BOTH a `message` and an `app_mention` event (with
+  // distinct event_ids), so open incidents process only the `message` copy —
+  // otherwise one reply would record two human_reply events.
   if (inbound.thread_ts && inbound.thread_ts !== inbound.ts) {
     const incident = await db.query.incidents.findFirst({
       where: and(
@@ -1525,13 +1527,27 @@ async function handleSlackEventEnvelope(payload: SlackEventEnvelope): Promise<vo
       ),
     });
     if (incident) {
-      if (inbound.type !== "message") return;
-      await handleIncidentThreadReply(payload, inbound, incident);
-      return;
+      const route = slackIncidentThreadRoute({
+        incidentStatus: incident.status,
+        eventType: inbound.type,
+      });
+      if (route === "ignore") return;
+      if (route === "incident") {
+        await handleIncidentThreadReply(payload, inbound, incident);
+        return;
+      }
     }
   }
 
   await handleChatEvent(payload, inbound);
+}
+
+export function slackIncidentThreadRoute(input: {
+  incidentStatus: schema.IncidentStatus;
+  eventType?: string;
+}): "incident" | "chat" | "ignore" {
+  if (input.incidentStatus !== "open") return "chat";
+  return input.eventType === "message" ? "incident" : "ignore";
 }
 
 type SlackInboundEvent = NonNullable<SlackEventEnvelope["event"]> & {

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -1529,7 +1529,9 @@ async function handleSlackEventEnvelope(payload: SlackEventEnvelope): Promise<vo
     if (incident) {
       const route = slackIncidentThreadRoute({
         incidentStatus: incident.status,
+        incidentClosedAt: incident.resolvedAt ?? incident.noiseResolvedAt ?? incident.mergedAt,
         eventType: inbound.type,
+        eventTs: inbound.ts,
       });
       if (route === "ignore") return;
       if (route === "incident") {
@@ -1544,9 +1546,18 @@ async function handleSlackEventEnvelope(payload: SlackEventEnvelope): Promise<vo
 
 export function slackIncidentThreadRoute(input: {
   incidentStatus: schema.IncidentStatus;
+  incidentClosedAt?: Date | null;
   eventType?: string;
+  eventTs?: string;
 }): "incident" | "chat" | "ignore" {
-  if (input.incidentStatus !== "open") return "chat";
+  const eventTimeSeconds = Number.parseFloat(input.eventTs ?? "");
+  const eventOccurredWhileOpen =
+    input.incidentStatus === "open" ||
+    (input.incidentClosedAt !== null &&
+      input.incidentClosedAt !== undefined &&
+      Number.isFinite(eventTimeSeconds) &&
+      eventTimeSeconds * 1_000 <= input.incidentClosedAt.getTime());
+  if (!eventOccurredWhileOpen) return "chat";
   return input.eventType === "message" ? "incident" : "ignore";
 }
 

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -1512,6 +1512,7 @@ async function handleSlackEventEnvelope(payload: SlackEventEnvelope): Promise<vo
     user: event.user,
     text: event.text,
   };
+  let chatTargetHint: { projectId: string; installationId: string | null } | null = null;
 
   // Open incident threads continue the investigation. Once an incident is
   // closed, the thread becomes an ordinary Q&A surface: an explicit mention
@@ -1538,10 +1539,14 @@ async function handleSlackEventEnvelope(payload: SlackEventEnvelope): Promise<vo
         await handleIncidentThreadReply(payload, inbound, incident);
         return;
       }
+      chatTargetHint = {
+        projectId: incident.projectId,
+        installationId: incident.slackInstallationId,
+      };
     }
   }
 
-  await handleChatEvent(payload, inbound);
+  await handleChatEvent(payload, inbound, chatTargetHint);
 }
 
 export function slackIncidentThreadRoute(input: {
@@ -1559,6 +1564,18 @@ export function slackIncidentThreadRoute(input: {
       eventTimeSeconds * 1_000 <= input.incidentClosedAt.getTime());
   if (!eventOccurredWhileOpen) return "chat";
   return input.eventType === "message" ? "incident" : "ignore";
+}
+
+export function findIncidentChatInstallation<T extends { id: string; projectId: string }>(
+  installations: T[],
+  projectId: string,
+  pinnedInstallationId: string | null,
+): T | null {
+  return (
+    installations.find((installation) => installation.id === pinnedInstallationId) ??
+    installations.find((installation) => installation.projectId === projectId) ??
+    null
+  );
 }
 
 type SlackInboundEvent = NonNullable<SlackEventEnvelope["event"]> & {
@@ -1683,6 +1700,7 @@ export function chatAnchorThreadTs(event: {
 async function handleChatEvent(
   payload: SlackEventEnvelope,
   event: SlackInboundEvent,
+  targetHint: { projectId: string; installationId: string | null } | null = null,
 ): Promise<void> {
   const teamId = payload.team_id ?? "";
   if (!teamId) return;
@@ -1728,6 +1746,18 @@ async function handleChatEvent(
     };
     if (!target.installationId && installations[0]) target.installationId = installations[0].id;
     if (!target.installationId) return;
+  } else if (targetHint) {
+    const row = findIncidentChatInstallation(
+      installations,
+      targetHint.projectId,
+      targetHint.installationId,
+    );
+    if (!row) return;
+    target = {
+      projectId: targetHint.projectId,
+      installationId: row.id,
+      installation: row,
+    };
   } else {
     const resolution = resolveChatInstallation(
       installations.map((i) => ({


### PR DESCRIPTION
## Summary
- route messages in closed incident threads through the existing Q&A chat flow
- keep open incident threads attached to their investigation session
- preserve duplicate-event suppression for open incident mentions

## Validation
- `pnpm --filter @superlog/api exec tsx --test src/slack.test.ts`
- `pnpm --filter @superlog/api typecheck`
- `pnpm exec biome check apps/api/src/slack.ts apps/api/src/slack.test.ts`
- `pnpm worktree:bootstrap --seed` (including worktree verification)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes closed incident threads to the Q&A chat flow and pins them to the incident’s project/installation. Open threads continue the investigation, with duplicate app_mention events ignored and closure races handled via event timestamps.

- **Bug Fixes**
  - Treat events with ts ≤ incident closed time as part of the investigation to prevent late mention/message twins from rerouting to Q&A.

- **Refactors**
  - Centralized routing in `slackIncidentThreadRoute`; closed-thread Q&A targets the incident’s installation via `findIncidentChatInstallation`, with tests.

<sup>Written for commit 0b9251fa9f57f4058f25cd203cfbd4eeb3fa6674. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

