### PR TITLE
Attribute mutating API requests to a user + org

### DIFF
--- a/apps/api/src/demo.test.ts
+++ b/apps/api/src/demo.test.ts
@@ -171,6 +171,7 @@ test("isDemoBlockedWrite matches the full mutating project-route inventory", () 
     { method: "POST", path: "/api/projects/p1/issues/lookup", block: false },
     { method: "POST", path: "/api/projects/p1/issue-filter/preview", block: false },
     { method: "POST", path: "/api/projects/p1/alerts/preview", block: false },
+    { method: "POST", path: "/api/projects/p1/alerts/preview-series", block: false },
   ];
   for (const r of ROUTES) {
     assert.equal(

--- a/apps/api/src/demo.ts
+++ b/apps/api/src/demo.ts
@@ -3,6 +3,7 @@ import { and, eq, isNotNull } from "drizzle-orm";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
+import { isReadOnlyPostPath } from "./request-actor-log.js";
 
 // ---------------------------------------------------------------------------
 // Demo data overlay
@@ -115,20 +116,17 @@ const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 // are exactly how a user leaves demo mode.
 const READ_ONLY_SEGMENTS = new Set(["dashboards", "incidents", "alerts", "issues"]);
 
-// POST-for-read endpoints under the protected segments above — never blocked.
-const POST_READ_SUBPATHS = new Set(["issues/lookup", "issue-filter/preview", "alerts/preview"]);
-
 /**
  * Pure: should this request be rejected as a write against demo-overlaid data?
  * Only true for mutating methods targeting a demo-overlaid resource, excluding
- * the POST-for-read endpoints. Callers still gate this on actual demo mode.
+ * the POST-for-read endpoints (shared with the mutation audit). Callers still
+ * gate this on actual demo mode.
  */
 export function isDemoBlockedWrite(args: { method: string; path: string }): boolean {
   if (!MUTATING_METHODS.has(args.method.toUpperCase())) return false;
-  const m = args.path.match(/^\/api\/projects\/[^/]+\/(.+?)(?:\?.*)?$/);
-  const sub = m?.[1];
+  if (isReadOnlyPostPath(args.path)) return false;
+  const sub = args.path.match(/^\/api\/projects\/[^/]+\/(.+?)(?:\?.*)?$/)?.[1];
   if (!sub) return false;
-  if (POST_READ_SUBPATHS.has(sub) || sub.startsWith("explore/")) return false;
   return READ_ONLY_SEGMENTS.has(sub.split("/")[0] ?? "");
 }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -141,6 +141,7 @@ import {
   type ActorAuditDeps,
   createAuthActorAuditMiddleware,
   isMutatingMethod,
+  statusFromThrown,
   writeActorAuditLog,
 } from "./request-actor-log.js";
 import { mountApiRequestSecurity, requestBodyLimit } from "./request-body-limits.js";
@@ -376,9 +377,18 @@ app.use("/api/*", async (c, next) => {
   // admin is acting as another user; surface it on `c.var` so /api/me can
   // expose a boolean without the web client having to inspect raw session.
   c.set("impersonating", typeof session.session.impersonatedBy === "string");
-  await next();
-  if (isMutatingMethod(c.req.method)) {
-    await writeActorAuditLog(actorAuditDeps, session, c.req.method, path, c.res.status);
+  if (!isMutatingMethod(c.req.method)) return next();
+  // Audit in a finally so writes that fail by throwing an HTTPException (e.g.
+  // invalid input) are attributed too, not just those returning an error body.
+  let status = 500;
+  try {
+    await next();
+    status = c.res.status;
+  } catch (err) {
+    status = statusFromThrown(err);
+    throw err;
+  } finally {
+    await writeActorAuditLog(actorAuditDeps, session, c.req.method, path, status);
   }
 });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -140,7 +140,7 @@ import { mountRenderAuthed } from "./render.js";
 import {
   type ActorAuditDeps,
   createAuthActorAuditMiddleware,
-  isMutatingMethod,
+  isAuditableMutation,
   statusFromThrown,
   writeActorAuditLog,
 } from "./request-actor-log.js";
@@ -377,7 +377,7 @@ app.use("/api/*", async (c, next) => {
   // admin is acting as another user; surface it on `c.var` so /api/me can
   // expose a boolean without the web client having to inspect raw session.
   c.set("impersonating", typeof session.session.impersonatedBy === "string");
-  if (!isMutatingMethod(c.req.method)) return next();
+  if (!isAuditableMutation({ method: c.req.method, path })) return next();
   // Audit in a finally so writes that fail by throwing an HTTPException (e.g.
   // invalid input) are attributed too, not just those returning an error body.
   let status = 500;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -55,7 +55,6 @@ import { shouldRunMigrationsOnBoot } from "./boot-migrations.js";
 import { mountCloudConnectionsAuthed } from "./cloud-connections.js";
 import { mountCloudflareAuthed, mountCloudflarePublic } from "./cloudflare.js";
 import { mountDashboards } from "./dashboards.js";
-import { mountSavedViews } from "./saved-views/interfaces.js";
 import {
   demoOverlay,
   demoProjectId,
@@ -138,7 +137,14 @@ import {
 import { mountProjectRouteContext } from "./project-route-context.js";
 import { mountRailwayAuthed, mountRailwayPublic } from "./railway.js";
 import { mountRenderAuthed } from "./render.js";
+import {
+  type ActorAuditDeps,
+  createAuthActorAuditMiddleware,
+  isMutatingMethod,
+  writeActorAuditLog,
+} from "./request-actor-log.js";
 import { mountApiRequestSecurity, requestBodyLimit } from "./request-body-limits.js";
+import { mountSavedViews } from "./saved-views/interfaces.js";
 import { mountSettingsAuthed } from "./settings.js";
 import { normalizeSignupIntentKeyHash, normalizeSignupIntentKeyPrefix } from "./signup-intents.js";
 import { mountSlackAuthed, mountSlackPublic } from "./slack.js";
@@ -304,6 +310,28 @@ app.post("/api/signup-intents", async (c) => {
   });
 });
 
+// Shared dependencies for the actor audit log — attributes every mutating API
+// request to a named user + org so failures can be traced back to who did what.
+const actorAuditDeps: ActorAuditDeps = {
+  getSession: (headers) => auth.api.getSession({ headers }),
+  resolveOrg: (orgId) =>
+    db.query.orgs
+      .findFirst({
+        where: eq(schema.orgs.id, orgId),
+        columns: { name: true, slug: true },
+      })
+      .then((org) => org ?? null),
+  log: (fields) => logger.info(fields, "api actor"),
+  onError: (err, path) => logger.warn({ err, path }, "failed to write actor audit log"),
+};
+
+// Better Auth handles its own routes under /api/auth/* and terminates the
+// request itself, so the session middleware below never runs for them. This
+// attributes the mutating ones (org/member/api-key changes) instead, stamping
+// identity onto the observability span and audit-logging after. Must stay
+// registered before the handler mount.
+app.use("/api/auth/*", createAuthActorAuditMiddleware(actorAuditDeps));
+
 // Better Auth handles its own routes under /api/auth/*. Mount before the
 // session middleware so sign-in/sign-up/oauth-callback endpoints don't trip
 // the unauthenticated guard.
@@ -330,12 +358,15 @@ mountManagementApi(app, { ch });
 mountProjectMcpServersManagement(app);
 
 app.use("/api/*", async (c, next) => {
-  if (c.req.path.startsWith("/api/v1/")) return next();
-  if (c.req.path.startsWith("/api/auth/")) return next();
-  if (c.req.path === "/api/auth-providers") return next();
+  const path = c.req.path;
+  if (path.startsWith("/api/v1/")) return next();
+  // /api/auth/* is handled (and attributed) by the middleware + mount above,
+  // which terminate the request before this ever runs.
+  if (path.startsWith("/api/auth/")) return next();
+  if (path === "/api/auth-providers") return next();
   // Zero-paste AWS-connect callback: no session — authenticated by the
   // connection's external ID inside the body (see cloud-connections.ts).
-  if (c.req.path === "/api/cloud-connections/callback") return next();
+  if (path === "/api/cloud-connections/callback") return next();
   const session = await auth.api.getSession({ headers: c.req.raw.headers });
   if (!session) return c.json({ error: "unauthenticated" }, 401);
   c.set("userId", session.user.id);
@@ -346,6 +377,9 @@ app.use("/api/*", async (c, next) => {
   // expose a boolean without the web client having to inspect raw session.
   c.set("impersonating", typeof session.session.impersonatedBy === "string");
   await next();
+  if (isMutatingMethod(c.req.method)) {
+    await writeActorAuditLog(actorAuditDeps, session, c.req.method, path, c.res.status);
+  }
 });
 
 // Demo overlay (framework level): decides demo-vs-real per request, enforces

--- a/apps/api/src/request-actor-audit-middleware.test.ts
+++ b/apps/api/src/request-actor-audit-middleware.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
 import {
   type ActorAuditDeps,
   type ActorSession,
@@ -13,7 +14,7 @@ const SESSION: ActorSession = {
   session: { id: "sess_1", activeOrganizationId: "org_1", impersonatedBy: null },
 };
 
-function buildApp(overrides: Partial<ActorAuditDeps> = {}) {
+function buildApp(overrides: Partial<ActorAuditDeps> = {}, throwStatus?: number) {
   const logs: Record<string, unknown>[] = [];
   let getSessionCalls = 0;
   let sawVars: { userId?: string; orgId: string | null } | undefined;
@@ -39,8 +40,12 @@ function buildApp(overrides: Partial<ActorAuditDeps> = {}) {
     sawVars = { userId: c.get("userId"), orgId: c.get("orgId") };
   });
   app.use("/api/auth/*", createAuthActorAuditMiddleware(deps));
-  // Mimics Better Auth's terminating handler — never calls next().
-  app.on(["POST", "GET"], "/api/auth/*", (c) => c.json({ error: "denied" }, 403));
+  // Mimics Better Auth's handler: either returns an error response or throws
+  // an HTTPException (e.g. invalid input), depending on the test.
+  app.on(["POST", "GET"], "/api/auth/*", (c) => {
+    if (throwStatus) throw new HTTPException(throwStatus as 400, { message: "boom" });
+    return c.json({ error: "denied" }, 403);
+  });
 
   return { app, logs, getSessionCalls: () => getSessionCalls, sawVars: () => sawVars };
 }
@@ -84,6 +89,17 @@ test("mutating auth route with no session passes through unlogged (sign-in/sign-
   assert.equal(res.status, 403);
   assert.equal(h.logs.length, 0);
   assert.equal(h.sawVars()?.userId, undefined, "no identity stamped without a session");
+});
+
+test("audits a mutation that fails by throwing, with the thrown status", async () => {
+  const h = buildApp({}, 400);
+  const res = await h.app.request("/api/auth/organization/update-member-role", { method: "POST" });
+
+  assert.equal(res.status, 400, "the thrown HTTPException still produces the response");
+  const [entry] = h.logs;
+  assert.ok(entry, "a throwing mutation is still attributed");
+  assert.equal(entry.status, 400);
+  assert.equal(entry.userId, "user_1");
 });
 
 test("a logging failure never breaks the request", async () => {

--- a/apps/api/src/request-actor-audit-middleware.test.ts
+++ b/apps/api/src/request-actor-audit-middleware.test.ts
@@ -1,0 +1,100 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { Hono } from "hono";
+import {
+  type ActorAuditDeps,
+  type ActorSession,
+  type ActorVars,
+  createAuthActorAuditMiddleware,
+} from "./request-actor-log.js";
+
+const SESSION: ActorSession = {
+  user: { id: "user_1", name: "Nicolo Magnante", email: "nicolo@superlog.sh" },
+  session: { id: "sess_1", activeOrganizationId: "org_1", impersonatedBy: null },
+};
+
+function buildApp(overrides: Partial<ActorAuditDeps> = {}) {
+  const logs: Record<string, unknown>[] = [];
+  let getSessionCalls = 0;
+  let sawVars: { userId?: string; orgId: string | null } | undefined;
+
+  const deps: ActorAuditDeps = {
+    getSession: async () => {
+      getSessionCalls++;
+      return SESSION;
+    },
+    resolveOrg: async () => ({ name: "Superlog prod", slug: "swish" }),
+    log: (fields) => logs.push(fields),
+    onError: (err) => {
+      throw err;
+    },
+    ...overrides,
+  };
+
+  const app = new Hono<{ Variables: ActorVars }>();
+  // Mimics the HTTP-observability middleware: registered first, reads c.var
+  // after the chain resolves.
+  app.use("/api/auth/*", async (c, next) => {
+    await next();
+    sawVars = { userId: c.get("userId"), orgId: c.get("orgId") };
+  });
+  app.use("/api/auth/*", createAuthActorAuditMiddleware(deps));
+  // Mimics Better Auth's terminating handler — never calls next().
+  app.on(["POST", "GET"], "/api/auth/*", (c) => c.json({ error: "denied" }, 403));
+
+  return { app, logs, getSessionCalls: () => getSessionCalls, sawVars: () => sawVars };
+}
+
+test("audits a mutating auth route and still reaches the terminating handler", async () => {
+  const h = buildApp();
+  const res = await h.app.request("/api/auth/organization/update-member-role", { method: "POST" });
+
+  assert.equal(res.status, 403, "Better Auth handler still produces the response");
+  assert.equal(h.logs.length, 1);
+  assert.deepEqual(h.logs[0], {
+    method: "POST",
+    path: "/api/auth/organization/update-member-role",
+    status: 403,
+    userId: "user_1",
+    userName: "Nicolo Magnante",
+    userEmail: "nicolo@superlog.sh",
+    orgId: "org_1",
+    orgName: "Superlog prod",
+    orgSlug: "swish",
+    sessionId: "sess_1",
+    impersonating: false,
+  });
+  // Identity is stamped for the observability span to pick up.
+  assert.deepEqual(h.sawVars(), { userId: "user_1", orgId: "org_1" });
+});
+
+test("skips reads without resolving a session (no double get-session lookup)", async () => {
+  const h = buildApp();
+  const res = await h.app.request("/api/auth/get-session", { method: "GET" });
+
+  assert.equal(res.status, 403);
+  assert.equal(h.logs.length, 0, "reads are not audited");
+  assert.equal(h.getSessionCalls(), 0, "reads do not trigger our extra getSession");
+});
+
+test("mutating auth route with no session passes through unlogged (sign-in/sign-up)", async () => {
+  const h = buildApp({ getSession: async () => null });
+  const res = await h.app.request("/api/auth/sign-in/email", { method: "POST" });
+
+  assert.equal(res.status, 403);
+  assert.equal(h.logs.length, 0);
+  assert.equal(h.sawVars()?.userId, undefined, "no identity stamped without a session");
+});
+
+test("a logging failure never breaks the request", async () => {
+  const h = buildApp({
+    resolveOrg: async () => {
+      throw new Error("db down");
+    },
+    onError: () => {}, // swallow, as the production logger.warn does
+  });
+  const res = await h.app.request("/api/auth/organization/update-member-role", { method: "POST" });
+
+  assert.equal(res.status, 403, "request succeeds even when audit logging throws");
+  assert.equal(h.logs.length, 0);
+});

--- a/apps/api/src/request-actor-audit-middleware.test.ts
+++ b/apps/api/src/request-actor-audit-middleware.test.ts
@@ -68,9 +68,26 @@ test("audits a mutating auth route and still reaches the terminating handler", a
     orgSlug: "swish",
     sessionId: "sess_1",
     impersonating: false,
+    impersonatedBy: null,
   });
   // Identity is stamped for the observability span to pick up.
   assert.deepEqual(h.sawVars(), { userId: "user_1", orgId: "org_1" });
+});
+
+test("attributes an impersonated mutation to the real staff user", async () => {
+  const h = buildApp({
+    getSession: async () => ({
+      user: { id: "customer_1", name: "Customer", email: "customer@acme.com" },
+      session: { id: "sess_2", activeOrganizationId: "org_1", impersonatedBy: "staff_9" },
+    }),
+  });
+  await h.app.request("/api/auth/organization/update-member-role", { method: "POST" });
+
+  const [entry] = h.logs;
+  assert.ok(entry);
+  assert.equal(entry.userId, "customer_1");
+  assert.equal(entry.impersonatedBy, "staff_9");
+  assert.equal(entry.impersonating, true);
 });
 
 test("skips reads without resolving a session (no double get-session lookup)", async () => {

--- a/apps/api/src/request-actor-log.test.ts
+++ b/apps/api/src/request-actor-log.test.ts
@@ -24,7 +24,7 @@ test("buildActorLogFields carries human-readable user + org identity", () => {
       orgName: "Superlog prod",
       orgSlug: "swish",
       sessionId: "sess_1",
-      impersonating: false,
+      impersonatedBy: null,
     }),
     {
       method: "POST",
@@ -38,8 +38,22 @@ test("buildActorLogFields carries human-readable user + org identity", () => {
       orgSlug: "swish",
       sessionId: "sess_1",
       impersonating: false,
+      impersonatedBy: null,
     },
   );
+});
+
+test("buildActorLogFields surfaces the impersonator so staff actions are traceable", () => {
+  const fields = buildActorLogFields({
+    method: "POST",
+    path: "/api/projects/p1/context",
+    status: 200,
+    userId: "customer_1",
+    impersonatedBy: "staff_9",
+  });
+  assert.equal(fields.userId, "customer_1");
+  assert.equal(fields.impersonatedBy, "staff_9");
+  assert.equal(fields.impersonating, true);
 });
 
 test("buildActorLogFields defaults missing org / session fields to null", () => {
@@ -56,4 +70,5 @@ test("buildActorLogFields defaults missing org / session fields to null", () => 
   assert.equal(fields.userEmail, null);
   assert.equal(fields.sessionId, null);
   assert.equal(fields.impersonating, false);
+  assert.equal(fields.impersonatedBy, null);
 });

--- a/apps/api/src/request-actor-log.test.ts
+++ b/apps/api/src/request-actor-log.test.ts
@@ -24,6 +24,8 @@ test("isReadOnlyPostPath treats Explore queries, lookups and previews as reads",
     "/api/projects/p1/issues/lookup",
     "/api/projects/p1/issue-filter/preview",
     "/api/projects/p1/alerts/preview",
+    "/api/projects/p1/alerts/preview-series",
+    "/api/projects/p1/explore/series",
   ]) {
     assert.equal(isReadOnlyPostPath(p), true, `${p} should be read-only`);
   }

--- a/apps/api/src/request-actor-log.test.ts
+++ b/apps/api/src/request-actor-log.test.ts
@@ -1,6 +1,11 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
-import { buildActorLogFields, isMutatingMethod } from "./request-actor-log.js";
+import {
+  buildActorLogFields,
+  isAuditableMutation,
+  isMutatingMethod,
+  isReadOnlyPostPath,
+} from "./request-actor-log.js";
 
 test("isMutatingMethod flags state-changing verbs case-insensitively", () => {
   for (const m of ["POST", "put", "Patch", "DELETE"]) {
@@ -9,6 +14,40 @@ test("isMutatingMethod flags state-changing verbs case-insensitively", () => {
   for (const m of ["GET", "head", "OPTIONS"]) {
     assert.equal(isMutatingMethod(m), false, `${m} should not be mutating`);
   }
+});
+
+test("isReadOnlyPostPath treats Explore queries, lookups and previews as reads", () => {
+  for (const p of [
+    "/api/projects/p1/explore/logs",
+    "/api/projects/p1/explore/traces",
+    "/api/projects/p1/explore/metric-series?foo=bar",
+    "/api/projects/p1/issues/lookup",
+    "/api/projects/p1/issue-filter/preview",
+    "/api/projects/p1/alerts/preview",
+  ]) {
+    assert.equal(isReadOnlyPostPath(p), true, `${p} should be read-only`);
+  }
+  for (const p of [
+    "/api/projects/p1/keys",
+    "/api/projects/p1/dashboards",
+    "/api/auth/organization/update-member-role",
+    "/api/me/orgs",
+  ]) {
+    assert.equal(isReadOnlyPostPath(p), false, `${p} should not be read-only`);
+  }
+});
+
+test("isAuditableMutation excludes read POSTs but keeps real writes", () => {
+  assert.equal(
+    isAuditableMutation({ method: "POST", path: "/api/projects/p1/explore/logs" }),
+    false,
+  );
+  assert.equal(isAuditableMutation({ method: "GET", path: "/api/projects/p1/keys" }), false);
+  assert.equal(isAuditableMutation({ method: "POST", path: "/api/projects/p1/keys" }), true);
+  assert.equal(
+    isAuditableMutation({ method: "POST", path: "/api/auth/organization/update-member-role" }),
+    true,
+  );
 });
 
 test("buildActorLogFields carries human-readable user + org identity", () => {

--- a/apps/api/src/request-actor-log.test.ts
+++ b/apps/api/src/request-actor-log.test.ts
@@ -1,0 +1,59 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { buildActorLogFields, isMutatingMethod } from "./request-actor-log.js";
+
+test("isMutatingMethod flags state-changing verbs case-insensitively", () => {
+  for (const m of ["POST", "put", "Patch", "DELETE"]) {
+    assert.equal(isMutatingMethod(m), true, `${m} should be mutating`);
+  }
+  for (const m of ["GET", "head", "OPTIONS"]) {
+    assert.equal(isMutatingMethod(m), false, `${m} should not be mutating`);
+  }
+});
+
+test("buildActorLogFields carries human-readable user + org identity", () => {
+  assert.deepEqual(
+    buildActorLogFields({
+      method: "post",
+      path: "/api/auth/organization/update-member-role",
+      status: 403,
+      userId: "user_123",
+      userName: "Nicolo Magnante",
+      userEmail: "nicolo@superlog.sh",
+      orgId: "org_abc",
+      orgName: "Superlog prod",
+      orgSlug: "swish",
+      sessionId: "sess_1",
+      impersonating: false,
+    }),
+    {
+      method: "POST",
+      path: "/api/auth/organization/update-member-role",
+      status: 403,
+      userId: "user_123",
+      userName: "Nicolo Magnante",
+      userEmail: "nicolo@superlog.sh",
+      orgId: "org_abc",
+      orgName: "Superlog prod",
+      orgSlug: "swish",
+      sessionId: "sess_1",
+      impersonating: false,
+    },
+  );
+});
+
+test("buildActorLogFields defaults missing org / session fields to null", () => {
+  const fields = buildActorLogFields({
+    method: "DELETE",
+    path: "/api/projects/p1",
+    status: 200,
+    userId: "user_9",
+  });
+  assert.equal(fields.orgId, null);
+  assert.equal(fields.orgName, null);
+  assert.equal(fields.orgSlug, null);
+  assert.equal(fields.userName, null);
+  assert.equal(fields.userEmail, null);
+  assert.equal(fields.sessionId, null);
+  assert.equal(fields.impersonating, false);
+});

--- a/apps/api/src/request-actor-log.ts
+++ b/apps/api/src/request-actor-log.ts
@@ -21,6 +21,27 @@ export function isMutatingMethod(method: string): boolean {
   return MUTATING_METHODS.has(method.toUpperCase());
 }
 
+// Project-scoped POST endpoints that are semantically reads — they carry query
+// filters in the body. The demo read-only guard (demo.ts) excludes the same
+// set; keep the two in sync.
+const POST_READ_SUBPATHS = new Set(["issues/lookup", "issue-filter/preview", "alerts/preview"]);
+
+/**
+ * Is this a POST that's really a read (Explore queries, lookups, previews)?
+ * Used to keep normal dashboard/query traffic out of the mutation audit — it
+ * would otherwise flood the log and do a per-query org lookup.
+ */
+export function isReadOnlyPostPath(path: string): boolean {
+  const sub = path.match(/^\/api\/projects\/[^/]+\/(.+?)(?:\?.*)?$/)?.[1];
+  if (!sub) return false;
+  return sub.startsWith("explore/") || POST_READ_SUBPATHS.has(sub);
+}
+
+/** A request worth auditing: a genuine state change, not a POST-for-read query. */
+export function isAuditableMutation(args: { method: string; path: string }): boolean {
+  return isMutatingMethod(args.method) && !isReadOnlyPostPath(args.path);
+}
+
 /**
  * Response status to attribute a mutation to when the handler threw before
  * producing a response — mirrors the HTTP-observability middleware so a failed
@@ -113,7 +134,7 @@ export function createAuthActorAuditMiddleware(
   deps: ActorAuditDeps,
 ): MiddlewareHandler<{ Variables: ActorVars }> {
   return async (c, next) => {
-    if (!isMutatingMethod(c.req.method)) return next();
+    if (!isAuditableMutation({ method: c.req.method, path: c.req.path })) return next();
     const session = await deps.getSession(c.req.raw.headers);
     if (session) {
       c.set("userId", session.user.id);

--- a/apps/api/src/request-actor-log.ts
+++ b/apps/api/src/request-actor-log.ts
@@ -24,7 +24,12 @@ export function isMutatingMethod(method: string): boolean {
 // Project-scoped POST endpoints that are semantically reads — they carry query
 // filters in the body. The demo read-only guard (demo.ts) excludes the same
 // set; keep the two in sync.
-const POST_READ_SUBPATHS = new Set(["issues/lookup", "issue-filter/preview", "alerts/preview"]);
+const POST_READ_SUBPATHS = new Set([
+  "issues/lookup",
+  "issue-filter/preview",
+  "alerts/preview",
+  "alerts/preview-series",
+]);
 
 /**
  * Is this a POST that's really a read (Explore queries, lookups, previews)?

--- a/apps/api/src/request-actor-log.ts
+++ b/apps/api/src/request-actor-log.ts
@@ -1,0 +1,145 @@
+import type { MiddlewareHandler } from "hono";
+
+// Actor attribution for authenticated API requests.
+//
+// Every state-changing API request should be traceable back to the user and org
+// that made it. The HTTP-observability span carries the opaque `enduser.id` /
+// `tenant.org.id`, but an operator investigating a failure (e.g. a denied member
+// role update) wants human-readable identity without a follow-up DB query. This
+// builds the structured fields for that audit log line; the caller resolves the
+// org name and emits it via the shared logger.
+
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * Whether an HTTP method mutates server state. Only mutating requests are
+ * audit-logged — reads (GET/HEAD/OPTIONS) would drown the log in volume and
+ * aren't "who did what" material.
+ */
+export function isMutatingMethod(method: string): boolean {
+  return MUTATING_METHODS.has(method.toUpperCase());
+}
+
+/** Minimal shape of a resolved Better Auth session used for attribution. */
+export type ActorSession = {
+  user: { id: string; name?: string | null; email?: string | null };
+  session: {
+    id: string;
+    activeOrganizationId?: string | null;
+    impersonatedBy?: unknown;
+  };
+};
+
+export type ActorAuditDeps = {
+  /** Resolve the session for a request, or null when unauthenticated. */
+  getSession: (headers: Headers) => Promise<ActorSession | null>;
+  /** Look up a human-readable org name/slug for the log, or null if unknown. */
+  resolveOrg: (orgId: string) => Promise<{ name: string | null; slug: string | null } | null>;
+  /** Emit the structured audit line. */
+  log: (fields: Record<string, unknown>) => void;
+  /** Report a logging failure without throwing into the request. */
+  onError: (err: unknown, path: string) => void;
+};
+
+/** Context vars this middleware stamps for downstream span attribution. */
+export type ActorVars = {
+  userId: string;
+  sessionId?: string;
+  orgId: string | null;
+  impersonating?: boolean;
+};
+
+/**
+ * Attribute a resolved session to the audit log. Shared by the /api/auth/*
+ * middleware and the main session middleware so both emit identical fields.
+ */
+export async function writeActorAuditLog(
+  deps: Pick<ActorAuditDeps, "resolveOrg" | "log" | "onError">,
+  session: ActorSession,
+  method: string,
+  path: string,
+  status: number,
+): Promise<void> {
+  try {
+    const orgId = session.session.activeOrganizationId ?? null;
+    const org = orgId ? await deps.resolveOrg(orgId) : null;
+    deps.log(
+      buildActorLogFields({
+        method,
+        path,
+        status,
+        userId: session.user.id,
+        userName: session.user.name,
+        userEmail: session.user.email,
+        orgId,
+        orgName: org?.name ?? null,
+        orgSlug: org?.slug ?? null,
+        sessionId: session.session.id,
+        impersonating: typeof session.session.impersonatedBy === "string",
+      }),
+    );
+  } catch (err) {
+    deps.onError(err, path);
+  }
+}
+
+/**
+ * Middleware for Better Auth's /api/auth/* routes. Those are terminated by
+ * Better Auth's own handler, so the main session middleware never sees them.
+ * This resolves the session best-effort for mutating requests, stamps identity
+ * onto the context (for span attribution), and audit-logs after the handler.
+ * Reads are passed straight through so we don't double the session lookup on
+ * the hot get-session poll. Must be registered before the auth handler mount.
+ */
+export function createAuthActorAuditMiddleware(
+  deps: ActorAuditDeps,
+): MiddlewareHandler<{ Variables: ActorVars }> {
+  return async (c, next) => {
+    if (!isMutatingMethod(c.req.method)) return next();
+    const session = await deps.getSession(c.req.raw.headers);
+    if (session) {
+      c.set("userId", session.user.id);
+      c.set("sessionId", session.session.id);
+      c.set("orgId", session.session.activeOrganizationId ?? null);
+      c.set("impersonating", typeof session.session.impersonatedBy === "string");
+    }
+    await next();
+    if (session) {
+      await writeActorAuditLog(deps, session, c.req.method, c.req.path, c.res.status);
+    }
+  };
+}
+
+export type ActorLogFieldsInput = {
+  method: string;
+  path: string;
+  status: number;
+  userId: string;
+  userName?: string | null;
+  userEmail?: string | null;
+  orgId?: string | null;
+  orgName?: string | null;
+  orgSlug?: string | null;
+  sessionId?: string | null;
+  impersonating?: boolean;
+};
+
+/**
+ * Build the structured fields for the actor audit log line. Pure: the caller
+ * feeds it session-derived identity plus the resolved org name/slug.
+ */
+export function buildActorLogFields(input: ActorLogFieldsInput): Record<string, unknown> {
+  return {
+    method: input.method.toUpperCase(),
+    path: input.path,
+    status: input.status,
+    userId: input.userId,
+    userName: input.userName ?? null,
+    userEmail: input.userEmail ?? null,
+    orgId: input.orgId ?? null,
+    orgName: input.orgName ?? null,
+    orgSlug: input.orgSlug ?? null,
+    sessionId: input.sessionId ?? null,
+    impersonating: input.impersonating ?? false,
+  };
+}

--- a/apps/api/src/request-actor-log.ts
+++ b/apps/api/src/request-actor-log.ts
@@ -85,7 +85,10 @@ export async function writeActorAuditLog(
         orgName: org?.name ?? null,
         orgSlug: org?.slug ?? null,
         sessionId: session.session.id,
-        impersonating: typeof session.session.impersonatedBy === "string",
+        impersonatedBy:
+          typeof session.session.impersonatedBy === "string"
+            ? session.session.impersonatedBy
+            : null,
       }),
     );
   } catch (err) {
@@ -146,7 +149,8 @@ export type ActorLogFieldsInput = {
   orgName?: string | null;
   orgSlug?: string | null;
   sessionId?: string | null;
-  impersonating?: boolean;
+  /** The real staff user id when this request is an impersonation, else null. */
+  impersonatedBy?: string | null;
 };
 
 /**
@@ -154,6 +158,7 @@ export type ActorLogFieldsInput = {
  * feeds it session-derived identity plus the resolved org name/slug.
  */
 export function buildActorLogFields(input: ActorLogFieldsInput): Record<string, unknown> {
+  const impersonatedBy = input.impersonatedBy ?? null;
   return {
     method: input.method.toUpperCase(),
     path: input.path,
@@ -165,6 +170,9 @@ export function buildActorLogFields(input: ActorLogFieldsInput): Record<string, 
     orgName: input.orgName ?? null,
     orgSlug: input.orgSlug ?? null,
     sessionId: input.sessionId ?? null,
-    impersonating: input.impersonating ?? false,
+    // When a staff user is impersonating, userId is the impersonated customer;
+    // impersonatedBy is the real actor, so keep it for attribution.
+    impersonating: impersonatedBy !== null,
+    impersonatedBy,
   };
 }

--- a/apps/api/src/request-actor-log.ts
+++ b/apps/api/src/request-actor-log.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler } from "hono";
+import { HTTPException } from "hono/http-exception";
 
 // Actor attribution for authenticated API requests.
 //
@@ -18,6 +19,15 @@ const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
  */
 export function isMutatingMethod(method: string): boolean {
   return MUTATING_METHODS.has(method.toUpperCase());
+}
+
+/**
+ * Response status to attribute a mutation to when the handler threw before
+ * producing a response — mirrors the HTTP-observability middleware so a failed
+ * write (e.g. an HTTPException on invalid input) is still audited, not dropped.
+ */
+export function statusFromThrown(err: unknown): number {
+  return err instanceof HTTPException ? err.status : 500;
 }
 
 /** Minimal shape of a resolved Better Auth session used for attribution. */
@@ -90,6 +100,11 @@ export async function writeActorAuditLog(
  * onto the context (for span attribution), and audit-logs after the handler.
  * Reads are passed straight through so we don't double the session lookup on
  * the hot get-session poll. Must be registered before the auth handler mount.
+ *
+ * The logged org is the actor's *active* org at request time. A few Better Auth
+ * flows target a different org (accepting an invitation before setActive, or
+ * passing an explicit organizationId), so this is best-effort context, not a
+ * guarantee of the mutated org — the user is always attributed correctly.
  */
 export function createAuthActorAuditMiddleware(
   deps: ActorAuditDeps,
@@ -103,9 +118,19 @@ export function createAuthActorAuditMiddleware(
       c.set("orgId", session.session.activeOrganizationId ?? null);
       c.set("impersonating", typeof session.session.impersonatedBy === "string");
     }
-    await next();
-    if (session) {
-      await writeActorAuditLog(deps, session, c.req.method, c.req.path, c.res.status);
+    // Audit in a finally so mutations that fail by throwing (not just those that
+    // return an error response) are still attributed, then rethrow.
+    let status = 500;
+    try {
+      await next();
+      status = c.res.status;
+    } catch (err) {
+      status = statusFromThrown(err);
+      throw err;
+    } finally {
+      if (session) {
+        await writeActorAuditLog(deps, session, c.req.method, c.req.path, status);
+      }
     }
   };
 }


### PR DESCRIPTION
## Problem

Better Auth mounts its routes under `/api/auth/*` and terminates each request in its own handler, which is registered **before** the `/api/*` session middleware. In Hono's registration order that means the session middleware never runs for auth routes — so state-changing Better Auth operations (org / member / api-key changes) went out with **no actor** on their request span or in the logs.

Concretely: a denied `updateOrganizationMemberRole` (`APIError: You are not allowed to update this member`) lands in telemetry with no `enduser.id` / `tenant.org.id` and nothing in the logs, so there's no way to tell who attempted it.

## Change

- New `apps/api/src/request-actor-log.ts`:
  - `createAuthActorAuditMiddleware` — registered on `/api/auth/*` **before** the Better Auth handler mount. For mutating methods it resolves the session best-effort, stamps `userId`/`orgId`/`sessionId` onto the context (so the existing HTTP-observability span picks up `enduser.id` / `tenant.org.id`), and audit-logs after the handler.
  - `writeActorAuditLog` — shared helper that emits an `"api actor"` log with user name/email and org name/slug, method, path, and status.
  - `isMutatingMethod` / `buildActorLogFields` — pure helpers.
- `index.ts` — wires the auth-route middleware and reuses `writeActorAuditLog` for non-auth mutations in the session middleware.

Design notes:
- **Mutations only** (`POST/PUT/PATCH/DELETE`). Reads pass straight through, so there's no second `getSession` on the hot get-session poll and no per-read log volume.
- Logging never throws into the request path (`onError` swallows and warns).

## Tests

- `request-actor-log.test.ts` — the method gate and the field builder (defaults, mapping).
- `request-actor-audit-middleware.test.ts` — a Hono app that mirrors the real registration order (observability-style reader → audit middleware → terminating handler) and asserts: the audit fires with full identity, the terminating handler still produces its response, identity is stamped for the span, reads are skipped without a session lookup, no-session mutations pass through unlogged, and a logging failure never breaks the request.

`@superlog/api` typechecks and biome is clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add actor attribution for mutating API requests so we can see who did what on auth routes and across the API. Restores span identity and writes a concise audit log for state changes, including thrown failures and staff impersonation; skips POST-for-read query endpoints (including `alerts/preview-series`) to avoid noise.

- **Bug Fixes**
  - Added `createAuthActorAuditMiddleware` on `/api/auth/*` (before the auth handler). For auditable mutations it resolves the session, stamps `userId`/`orgId`/`sessionId`/`impersonating`, then logs after; records `impersonatedBy`; skips reads and read-only POSTs (Explore queries, lookups, previews incl. `alerts/preview-series`); logging failures are swallowed.
  - Reused `writeActorAuditLog` in the main `/api/*` session middleware to audit non-auth auditable mutations. Wrapped handlers in try/finally and used `statusFromThrown` so thrown errors are attributed; the logged org is the actor’s active org. Shared `isReadOnlyPostPath` with the demo guard to exclude read-only POSTs.

<sup>Written for commit d41ea8fce557797ae059ca4f6bd39004184e112d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

