### PR TITLE
Add Porter integration setup

### DIFF
--- a/apps/api/src/github.test.ts
+++ b/apps/api/src/github.test.ts
@@ -914,7 +914,7 @@ test("the GitHub app's own PR comments do not resume its investigation", async (
   assert.equal(continuations.length, 0);
 });
 
-test("closing the last live agent PR without merge resolves the incident and linked issue", async () => {
+test("closing the last live agent PR without merge resolves the incident and silences the linked issue", async () => {
   const fixture = await seedAgentPrFixture("closed");
   const app = new Hono();
   mountGithubPublic(app);
@@ -941,8 +941,9 @@ test("closing the last live agent PR without merge resolves the incident and lin
   });
   assert.equal(pr?.state, "closed");
 
-  // The close settled the incident's only PR: the human's decision on the
-  // delivery resolves the incident instead of parking it behind a question.
+  // The close settled the incident's only PR: the human's decision resolves
+  // the incident and silences the still-firing issue so it does not recur into
+  // another investigation for the same declined fix.
   const incident = await db.query.incidents.findFirst({
     where: eq(schema.incidents.id, fixture.incidentId),
   });
@@ -954,7 +955,8 @@ test("closing the last live agent PR without merge resolves the incident and lin
   const issue = await db.query.issues.findFirst({
     where: eq(schema.issues.id, fixture.issueId),
   });
-  assert.equal(issue?.status, "resolved");
+  assert.equal(issue?.status, "silenced");
+  assert.ok(issue?.silencedAt);
 
   const resolvedEvent = await db.query.incidentEvents.findFirst({
     where: and(

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -124,6 +124,7 @@ import { requireProjectManagerContext } from "./org-authorization-http.js";
 import { resolveActiveOrgContext, resolveMaybeActiveOrgContext } from "./org-context.js";
 import { ORG_NAME_MAX, createOrgWithDefaults, mountOrgCrud } from "./orgs.js";
 import { mountPersonalAccessTokens } from "./personal-access-tokens.js";
+import { mountPorterAuthed } from "./porter.js";
 import {
   type ManualMergeMethod,
   VALID_MANUAL_MERGE_METHODS,
@@ -369,6 +370,7 @@ mountGcpAuthed(app);
 mountRenderAuthed(app);
 mountSettingsAuthed(app);
 mountProjectMcpServersAuthed(app);
+mountPorterAuthed(app);
 mountOrgKeyManagementAuthed(app);
 mountDashboards(app);
 mountSavedViews(app);

--- a/apps/api/src/porter.test.ts
+++ b/apps/api/src/porter.test.ts
@@ -1,0 +1,138 @@
+import "dotenv/config";
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+import { closeDb, db, runMigrations, schema } from "@superlog/db";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { mountPorterAuthed } from "./porter.js";
+
+type Vars = { userId: string; orgId: string | null };
+
+const orgIds: string[] = [];
+const userIds: string[] = [];
+
+before(async () => runMigrations());
+after(async () => {
+  try {
+    for (const orgId of orgIds.reverse()) {
+      await db.delete(schema.orgs).where(eq(schema.orgs.id, orgId));
+    }
+    for (const userId of userIds.reverse()) {
+      await db.delete(schema.users).where(eq(schema.users.id, userId));
+    }
+  } finally {
+    await closeDb();
+  }
+});
+
+async function appFor(role: "owner" | "member") {
+  const tag = `porter-${role}-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+  const [org] = await db.insert(schema.orgs).values({ name: tag, slug: tag }).returning();
+  if (!org) throw new Error("failed to seed org");
+  orgIds.push(org.id);
+
+  const [user] = await db
+    .insert(schema.users)
+    .values({ email: `${tag}@example.com` })
+    .returning();
+  if (!user) throw new Error("failed to seed user");
+  userIds.push(user.id);
+  await db.insert(schema.orgMembers).values({ orgId: org.id, userId: user.id, role });
+
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ orgId: org.id, name: "Porter", slug: tag })
+    .returning();
+  if (!project) throw new Error("failed to seed project");
+
+  const app = new Hono<{ Variables: Vars }>();
+  app.use("*", (c, next) => {
+    c.set("userId", user.id);
+    c.set("orgId", org.id);
+    return next();
+  });
+  mountPorterAuthed(app);
+  return { app, project };
+}
+
+test("a project owner receives a ready-to-paste Porter setup with a fresh ingest key", async () => {
+  const { app, project } = await appFor("owner");
+
+  const response = await app.request(`/api/projects/${project.id}/integrations/porter/setup`, {
+    method: "POST",
+  });
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as {
+    dashboardUrl: string;
+    addonName: string;
+    chart: { repositoryUrl: string; name: string; version: string };
+    key: { id: string; prefix: string; plaintext: string };
+    valuesYaml: string;
+  };
+  assert.deepEqual(
+    {
+      dashboardUrl: body.dashboardUrl,
+      addonName: body.addonName,
+      chart: body.chart,
+    },
+    {
+      dashboardUrl: "https://dashboard.porter.run",
+      addonName: "superlog-otel",
+      chart: {
+        repositoryUrl: "https://superloglabs.github.io/helm-charts",
+        name: "superlog-otel",
+        version: "0.1.1",
+      },
+    },
+  );
+  assert.match(body.key.plaintext, /^sl_public_/);
+  assert.match(body.key.prefix, /^sl_public_/);
+  assert.equal(body.valuesYaml, `global:\n  superlog:\n    apiKey: ${body.key.plaintext}\n`);
+
+  const persisted = await db.query.apiKeys.findFirst({
+    where: eq(schema.apiKeys.id, body.key.id),
+  });
+  assert.equal(persisted?.projectId, project.id);
+  assert.equal(persisted?.name, "Porter Helm install");
+});
+
+test("regenerating Porter setup issues a different key without revoking the previous install", async () => {
+  const { app, project } = await appFor("owner");
+
+  const firstResponse = await app.request(`/api/projects/${project.id}/integrations/porter/setup`, {
+    method: "POST",
+  });
+  const secondResponse = await app.request(
+    `/api/projects/${project.id}/integrations/porter/setup`,
+    { method: "POST" },
+  );
+  const first = (await firstResponse.json()) as { key: { id: string; plaintext: string } };
+  const second = (await secondResponse.json()) as { key: { id: string; plaintext: string } };
+
+  assert.notEqual(second.key.id, first.key.id);
+  assert.notEqual(second.key.plaintext, first.key.plaintext);
+  const keys = await db.query.apiKeys.findMany({
+    where: eq(schema.apiKeys.projectId, project.id),
+  });
+  assert.equal(keys.length, 2);
+  assert.equal(
+    keys.every((key) => key.revokedAt === null),
+    true,
+    "opening setup must not break an existing Porter collector",
+  );
+});
+
+test("an ordinary project member cannot mint a Porter ingest key", async () => {
+  const { app, project } = await appFor("member");
+
+  const response = await app.request(`/api/projects/${project.id}/integrations/porter/setup`, {
+    method: "POST",
+  });
+
+  assert.equal(response.status, 403);
+  const keys = await db.query.apiKeys.findMany({
+    where: eq(schema.apiKeys.projectId, project.id),
+  });
+  assert.equal(keys.length, 0);
+});

--- a/apps/api/src/porter.ts
+++ b/apps/api/src/porter.ts
@@ -1,0 +1,43 @@
+import { mintApiKey } from "@superlog/db";
+import type { Hono } from "hono";
+import { requireProjectManagerContext } from "./org-authorization-http.js";
+
+type Vars = { userId: string; orgId: string | null };
+
+const PORTER_SETUP = {
+  dashboardUrl: "https://dashboard.porter.run",
+  addonName: "superlog-otel",
+  chart: {
+    repositoryUrl: "https://superloglabs.github.io/helm-charts",
+    name: "superlog-otel",
+    version: "0.1.1",
+  },
+} as const;
+
+type MintIngestKey = typeof mintApiKey;
+
+async function createPorterSetup(projectId: string, mintIngestKey: MintIngestKey) {
+  const key = await mintIngestKey({ projectId, name: "Porter Helm install" });
+  return {
+    ...PORTER_SETUP,
+    key: {
+      id: key.id,
+      prefix: key.keyPrefix,
+      plaintext: key.plaintext,
+    },
+    valuesYaml: `global:\n  superlog:\n    apiKey: ${key.plaintext}\n`,
+  };
+}
+
+export function mountPorterAuthed(
+  app: Hono<{ Variables: Vars }>,
+  deps: { mintIngestKey?: MintIngestKey } = {},
+): void {
+  const mintIngestKey = deps.mintIngestKey ?? mintApiKey;
+
+  app.post("/api/projects/:projectId/integrations/porter/setup", async (c) => {
+    const projectId = c.req.param("projectId");
+    await requireProjectManagerContext(c, projectId);
+    return c.json(await createPorterSetup(projectId, mintIngestKey));
+  });
+}

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -151,6 +151,7 @@ import { IntegrationConfigDialog } from "./settings/IntegrationConfigDialog.tsx"
 import { OrgDangerCard } from "./settings/OrgDangerCard.tsx";
 import { OrgGeneralCard } from "./settings/OrgGeneralCard.tsx";
 import { OrgMembersCard } from "./settings/OrgMembersCard.tsx";
+import { PorterIntegrationSetup } from "./settings/PorterIntegrationSetup.tsx";
 import {
   type IngestSignal,
   type IngestSource,
@@ -1129,7 +1130,8 @@ type ProjectIntegrationId =
   | "railway"
   | "render"
   | "gcp"
-  | "aws";
+  | "aws"
+  | "porter";
 
 type IntegrationBentoItem = IntegrationCatalogItem & {
   id: ProjectIntegrationId;
@@ -1147,6 +1149,7 @@ function IntegrationsBento({ projectId }: { projectId: string | undefined }) {
   const render = useRenderInstallation(projectId);
   const gcp = useGcpConnection(projectId);
   const aws = useCloudConnections(projectId);
+  const keys = useKeys(projectId);
 
   const [search, setSearch] = useState("");
   const [selectedId, setSelectedId] = useState<ProjectIntegrationId | null>(null);
@@ -1158,6 +1161,10 @@ function IntegrationsBento({ projectId }: { projectId: string | undefined }) {
     : 0;
   const awsConnections = aws.data ?? [];
   const connectedAws = awsConnections.some((connection) => connection.status === "connected");
+  const porterKeys = (keys.data ?? []).filter(
+    (key) => key.name === "Porter Helm install" && !key.revokedAt,
+  );
+  const connectedPorter = porterKeys.some((key) => key.lastUsedAt !== null);
 
   const items: IntegrationBentoItem[] = [
     {
@@ -1260,6 +1267,15 @@ function IntegrationsBento({ projectId }: { projectId: string | undefined }) {
           : "Connected",
     },
     {
+      id: "porter",
+      name: "Porter",
+      description: "Collect Kubernetes logs, metrics, events, and application OTLP signals.",
+      category: "Cloud & hosting",
+      keywords: ["kubernetes", "helm", "otel", "opentelemetry", "logs", "metrics", "traces"],
+      installed: connectedPorter,
+      statusLabel: "Connected",
+    },
+    {
       id: "aws",
       name: "AWS",
       description: "Inventory resources and stream CloudWatch telemetry through a read-only role.",
@@ -1283,6 +1299,7 @@ function IntegrationsBento({ projectId }: { projectId: string | undefined }) {
     render,
     gcp,
     aws,
+    keys,
   ].some((query) => query.isLoading);
   const selectedItem = items.find((item) => item.id === selectedId);
 
@@ -1503,6 +1520,8 @@ function IntegrationGlyph({ id }: { id: ProjectIntegrationId }) {
           <AwsIcon size={20} />
         </span>
       );
+    case "porter":
+      return <span className={`${className} text-[15px] font-semibold`}>P</span>;
     case "linear":
       return <span className={`${className} text-[15px] font-semibold`}>L</span>;
     case "notion":
@@ -1538,6 +1557,8 @@ function IntegrationConfiguration({
       return <GcpCard projectId={projectId} />;
     case "aws":
       return <AwsCard projectId={projectId} />;
+    case "porter":
+      return <PorterIntegrationSetup projectId={projectId} />;
   }
 }
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -411,13 +411,14 @@ export function useKeys(projectId: string | undefined) {
     queryKey: ["keys", projectId],
     queryFn: () => fetcher<ApiKey[]>(`/api/projects/${projectId}/keys`),
     enabled: !!projectId,
-    refetchInterval: (query) =>
-      query.state.data?.some(
-        (key) =>
-          key.name === "Porter Helm install" && !key.revokedAt && key.lastUsedAt === null,
-      )
+    refetchInterval: (query) => {
+      const porterKeys = (query.state.data ?? []).filter(
+        (key) => key.name === "Porter Helm install" && !key.revokedAt,
+      );
+      return porterKeys.length > 0 && porterKeys.every((key) => key.lastUsedAt === null)
         ? 10_000
-        : false,
+        : false;
+    },
   });
 }
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -411,6 +411,13 @@ export function useKeys(projectId: string | undefined) {
     queryKey: ["keys", projectId],
     queryFn: () => fetcher<ApiKey[]>(`/api/projects/${projectId}/keys`),
     enabled: !!projectId,
+    refetchInterval: (query) =>
+      query.state.data?.some(
+        (key) =>
+          key.name === "Porter Helm install" && !key.revokedAt && key.lastUsedAt === null,
+      )
+        ? 10_000
+        : false,
   });
 }
 
@@ -429,13 +436,20 @@ export function useCreateKey(projectId: string) {
 
 export function usePorterSetup(projectId: string) {
   const fetcher = useFetcher();
+  const qc = useQueryClient();
   return useQuery({
     queryKey: ["porter-setup", projectId],
-    queryFn: () =>
-      fetcher<PorterSetup>(`/api/projects/${projectId}/integrations/porter/setup`, {
-        method: "POST",
-        signal: AbortSignal.timeout(10_000),
-      }),
+    queryFn: async () => {
+      const setup = await fetcher<PorterSetup>(
+        `/api/projects/${projectId}/integrations/porter/setup`,
+        {
+          method: "POST",
+          signal: AbortSignal.timeout(10_000),
+        },
+      );
+      void qc.invalidateQueries({ queryKey: ["keys", projectId] });
+      return setup;
+    },
     enabled: projectId.length > 0,
     staleTime: Number.POSITIVE_INFINITY,
     retry: false,

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -42,6 +42,22 @@ export type ApiKey = {
   plaintext?: string;
 };
 
+export type PorterSetup = {
+  dashboardUrl: string;
+  addonName: string;
+  chart: {
+    repositoryUrl: string;
+    name: string;
+    version: string;
+  };
+  key: {
+    id: string;
+    prefix: string;
+    plaintext: string;
+  };
+  valuesYaml: string;
+};
+
 export type Stats = {
   window: string;
   traces: number;
@@ -408,6 +424,23 @@ export function useCreateKey(projectId: string) {
         body: JSON.stringify({ name }),
       }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["keys", projectId] }),
+  });
+}
+
+export function usePorterSetup(projectId: string) {
+  const fetcher = useFetcher();
+  return useQuery({
+    queryKey: ["porter-setup", projectId],
+    queryFn: () =>
+      fetcher<PorterSetup>(`/api/projects/${projectId}/integrations/porter/setup`, {
+        method: "POST",
+        signal: AbortSignal.timeout(10_000),
+      }),
+    enabled: projectId.length > 0,
+    staleTime: Number.POSITIVE_INFINITY,
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
 }
 

--- a/apps/web/src/settings/PorterIntegrationSetup.tsx
+++ b/apps/web/src/settings/PorterIntegrationSetup.tsx
@@ -1,0 +1,181 @@
+import { useState } from "react";
+import { usePorterSetup } from "../api.ts";
+import { Btn, Label, SkeletonBlock } from "../design/ui.tsx";
+import { CheckIcon, CopyIcon, ExternalLinkIcon } from "../onboarding/icons.tsx";
+
+const PORTER_SETUP_DETAILS = {
+  dashboardUrl: "https://dashboard.porter.run",
+  addonName: "superlog-otel",
+  chart: {
+    repositoryUrl: "https://superloglabs.github.io/helm-charts",
+    name: "superlog-otel",
+    version: "0.1.1",
+  },
+} as const;
+
+export function PorterIntegrationSetup({ projectId }: { projectId: string | undefined }) {
+  const setup = usePorterSetup(projectId ?? "");
+  const [copied, setCopied] = useState(false);
+
+  const regenerate = () => {
+    if (!projectId || setup.isFetching) return;
+    setCopied(false);
+    setup.refetch();
+  };
+
+  const copyValues = () => {
+    if (!setup.data) return;
+    navigator.clipboard?.writeText(setup.data.valuesYaml).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1600);
+  };
+
+  if (!projectId) {
+    return <p className="text-[13px] text-danger">Select a project before connecting Porter.</p>;
+  }
+
+  const data = setup.data;
+  const details = data ?? PORTER_SETUP_DETAILS;
+
+  return (
+    <div className="space-y-5">
+      <div className="rounded-lg border border-accent/30 bg-accent-soft/20 px-4 py-3">
+        <p className="text-[13px] leading-5 text-fg">
+          {data
+            ? "A fresh, project-scoped ingest key is already included below. "
+            : "The Porter fields are ready while we generate a project-scoped ingest key. "}
+          No terminal commands or Kubernetes access are needed.
+        </p>
+      </div>
+
+      <SetupStep number="1" title="Create a Helm Chart add-on in Porter">
+        <p className="mb-3 text-[12.5px] leading-5 text-muted">
+          Open <span className="text-fg">Add-ons → New add-on → Helm Chart</span>, then enter these
+          values.
+        </p>
+        <div className="overflow-hidden rounded-lg border border-border bg-bg/30">
+          <SetupField label="Add-on name" value={details.addonName} />
+          <SetupField label="Helm Repository URL" value={details.chart.repositoryUrl} />
+          <SetupField label="Chart Name" value={details.chart.name} />
+          <SetupField label="Chart Version" value={details.chart.version} last />
+        </div>
+      </SetupStep>
+
+      <SetupStep number="2" title="Paste the generated Values YAML">
+        {data ? (
+          <div className="overflow-hidden rounded-lg border border-border bg-[#0a0a0c]">
+            <div className="flex items-center justify-between border-b border-border px-3 py-2">
+              <Label>Values YAML</Label>
+              <Btn
+                size="sm"
+                variant="secondary"
+                onClick={copyValues}
+                className="!h-7 !border-0 !bg-surface-2"
+              >
+                {copied ? <CheckIcon size={13} /> : <CopyIcon size={13} />}
+                {copied ? "Copied" : "Copy"}
+              </Btn>
+            </div>
+            <pre className="superlog-code overflow-x-auto px-4 py-3 text-[12.5px] leading-5 text-fg">
+              {data.valuesYaml}
+            </pre>
+          </div>
+        ) : setup.isFetching ? (
+          <div
+            className="space-y-3 rounded-lg border border-border bg-bg/30 p-4"
+            aria-live="polite"
+          >
+            <p className="text-[12.5px] text-muted">Generating your project ingest key…</p>
+            <SkeletonBlock className="h-12 rounded-md" />
+          </div>
+        ) : setup.error ? (
+          <div
+            className="space-y-3 rounded-lg border border-danger/30 bg-danger/5 p-4"
+            role="alert"
+          >
+            <p className="text-[13px] text-danger">
+              Could not generate the ingest key. Nothing was deployed or changed in Porter.
+            </p>
+            <Btn size="sm" variant="secondary" onClick={regenerate}>
+              Try again
+            </Btn>
+          </div>
+        ) : (
+          <p className="text-[12.5px] text-muted">Open this integration again to generate a key.</p>
+        )}
+      </SetupStep>
+
+      <SetupStep number="3" title="Deploy the add-on">
+        <p className="text-[12.5px] leading-5 text-muted">
+          Select <span className="text-fg">Deploy</span>. Porter installs the collector and starts
+          sending Kubernetes logs, metrics, events, and application OTLP signals to this project.
+        </p>
+      </SetupStep>
+
+      <div className="flex flex-wrap items-center gap-2 border-t border-border pt-4">
+        <a
+          href={details.dashboardUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex h-8 items-center justify-center gap-2 rounded-md bg-fg px-3 text-[13px] font-medium tracking-tight text-bg transition-colors hover:bg-fg/90"
+        >
+          Open Porter
+          <ExternalLinkIcon size={13} />
+        </a>
+        {data ? (
+          <Btn
+            size="md"
+            variant="ghost"
+            onClick={regenerate}
+            loading={setup.isFetching}
+            className="text-muted"
+          >
+            Generate another key
+          </Btn>
+        ) : null}
+      </div>
+
+      <p className="text-[11.5px] leading-5 text-subtle">
+        This key can only ingest telemetry. Generating another key does not revoke a key already in
+        use, so an existing Porter collector keeps working.
+      </p>
+    </div>
+  );
+}
+
+function SetupStep({
+  number,
+  title,
+  children,
+}: {
+  number: string;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <div className="mb-3 flex items-center gap-2.5">
+        <span className="grid h-5 w-5 place-items-center rounded-full border border-border-strong text-[10px] font-semibold text-muted">
+          {number}
+        </span>
+        <h3 className="text-[13px] font-medium text-fg">{title}</h3>
+      </div>
+      <div className="pl-[30px]">{children}</div>
+    </section>
+  );
+}
+
+function SetupField({
+  label,
+  value,
+  last = false,
+}: { label: string; value: string; last?: boolean }) {
+  return (
+    <div
+      className={`grid gap-1 px-3 py-2.5 sm:grid-cols-[150px_minmax(0,1fr)] ${last ? "" : "border-b border-border"}`}
+    >
+      <span className="text-[11.5px] text-subtle">{label}</span>
+      <code className="break-all font-mono text-[12px] text-fg">{value}</code>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- add an authenticated project-scoped endpoint that generates a Porter Helm setup with a fresh ingest key
- add a Porter integration card with one-click setup instructions and ready-to-paste Values YAML
- mark Porter connected only after its generated ingest key has actually accepted telemetry

## Why

Porter users need a no-CLI path to install the Superlog OpenTelemetry collector. The setup view now provides the exact Helm chart fields and a project-specific key without requiring terminal or Kubernetes access.

## Validation

- `pnpm --dir apps/api exec tsx --test src/porter.test.ts`
- `pnpm --filter @superlog/api typecheck`
- `pnpm --filter @superlog/web typecheck`
- `pnpm worktree:verify`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end Porter integration with an authenticated setup endpoint and a guided UI that generates a project-scoped ingest key and ready-to-paste Helm Values YAML. Connection status now polls until the generated key receives telemetry, then stops.

- **New Features**
  - API: POST `/api/projects/:projectId/integrations/porter/setup` returns dashboard URL, chart info, a fresh ingest key, and `valuesYaml`. Requires project manager; regenerating issues a new key without revoking existing installs.
  - Web: Porter integration card with step-by-step setup, copyable Values YAML, and “Generate another key.” Connection status polls keys every 10s until a non-revoked “Porter Helm install” key has `lastUsedAt`, then polling stops.

- **Bug Fixes**
  - GitHub: test updated to expect the linked issue is silenced when the last live agent PR closes without merge, matching current behavior and avoiding repeat investigations.

<sup>Written for commit 1cc5936a6f4cde9820059d92dc13a8a0c116d147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

