### PR TITLE
Add an Open a PR action to findings-only Slack incidents

### DIFF
--- a/apps/api/src/slack.test.ts
+++ b/apps/api/src/slack.test.ts
@@ -91,6 +91,14 @@ test("parseRetryInvestigationAction extracts only non-empty incident ids", async
   assert.equal(parseRetryInvestigationAction("resolve_incident:incident-1"), null);
 });
 
+test("parseOpenPrAction extracts only non-empty incident ids", async () => {
+  const { parseOpenPrAction } = await import("./slack.js");
+
+  assert.equal(parseOpenPrAction("open_pr:incident-1"), "incident-1");
+  assert.equal(parseOpenPrAction("open_pr:"), null);
+  assert.equal(parseOpenPrAction("merge_pr:incident-1"), null);
+});
+
 test("ratingTimelineSummary carries the 👍/👎 signal for the incident timeline", async () => {
   const { ratingTimelineSummary } = await import("./slack.js");
   assert.match(ratingTimelineSummary("helpful"), /^👍 /);

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -479,7 +479,9 @@ async function handleSlackOpenPr(
   const result = await requestOpenPrAgentRun(db, {
     incidentId,
     requestedBy: payload.user?.id ?? null,
+    requestId: `${payload.user?.id ?? "anon"}:${payload.actions?.[0]?.action_ts ?? crypto.randomUUID()}`,
   });
+  if (result.outcome === "duplicate") return;
   const installation = await installationForIncident({
     pinnedId: incident.slackInstallationId,
     teamId: payload.team?.id ?? "",

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -10,6 +10,7 @@ import {
   recordInboundChatMessage,
   recordInboundInteraction,
   requestFollowUpAgentRun,
+  requestOpenPrAgentRun,
   resolveChatInstallation,
   resolveIncidentWithProof,
   retryBlockedAgentRun,
@@ -301,6 +302,8 @@ export function mountSlackPublic(app: Hono<any>): void {
 //   - `merge_pr:<incident-uuid>` → merges the incident's latest open agent PR
 //   - `retry_investigation:<incident-uuid>` → retries only when the latest run
 //     is still blocked on GitHub, making repeated clicks idempotent
+//   - `open_pr:<incident-uuid>` → starts a one-shot PR-enabled implementation
+//     run from a findings-only investigation
 async function handleSlackBlockActions(payload: SlackInteractivityPayload): Promise<void> {
   const action = payload.actions?.[0];
   if (!action) return;
@@ -327,6 +330,12 @@ async function handleSlackBlockActions(payload: SlackInteractivityPayload): Prom
   if (actionId.startsWith("merge_pr:")) {
     const incidentId = actionId.slice("merge_pr:".length);
     if (incidentId) await handleSlackMergePr(incidentId, payload);
+    return;
+  }
+
+  const openPrIncidentId = parseOpenPrAction(actionId);
+  if (openPrIncidentId) {
+    await handleSlackOpenPr(openPrIncidentId, payload);
     return;
   }
 
@@ -447,6 +456,49 @@ export function parseRetryInvestigationAction(actionId: string): string | null {
   const prefix = "retry_investigation:";
   if (!actionId.startsWith(prefix)) return null;
   return actionId.slice(prefix.length) || null;
+}
+
+export function parseOpenPrAction(actionId: string): string | null {
+  const prefix = "open_pr:";
+  if (!actionId.startsWith(prefix)) return null;
+  return actionId.slice(prefix.length) || null;
+}
+
+async function handleSlackOpenPr(
+  incidentId: string,
+  payload: SlackInteractivityPayload,
+): Promise<void> {
+  const incident = await db.query.incidents.findFirst({
+    where: eq(schema.incidents.id, incidentId),
+  });
+  if (!incident) {
+    log.warn({ incidentId }, "Open a PR click for unknown incident");
+    return;
+  }
+
+  const result = await requestOpenPrAgentRun(db, {
+    incidentId,
+    requestedBy: payload.user?.id ?? null,
+  });
+  const installation = await installationForIncident({
+    pinnedId: incident.slackInstallationId,
+    teamId: payload.team?.id ?? "",
+  });
+  if (!installation || !incident.slackChannelId || !incident.slackThreadTs) return;
+
+  const clickedBy = payload.user?.id ? `<@${payload.user.id}>` : "A teammate";
+  const text =
+    result.outcome === "skipped"
+      ? result.reason === "run_active"
+        ? ":hourglass: An agent run is already active for this incident."
+        : `:no_entry: PR implementation not started (${result.reason.replace(/_/g, " ")}).`
+      : `:hammer_and_wrench: ${clickedBy} asked the agent to implement the confirmed fix and open a PR.`;
+  await postSlackThreadReply({
+    botToken: installation.botAccessToken,
+    channel: incident.slackChannelId,
+    threadTs: incident.slackThreadTs,
+    text,
+  });
 }
 
 async function handleSlackRetryInvestigation(

--- a/apps/worker/src/agent-run-context.test.ts
+++ b/apps/worker/src/agent-run-context.test.ts
@@ -2,7 +2,11 @@ import "./agent-run.test-env.js";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { schema } from "@superlog/db";
-import { buildFollowUpContext, listAccessibleGithubRepositories } from "./agent-run-context.js";
+import {
+  buildFollowUpContext,
+  effectivePrPolicyForAgentRun,
+  listAccessibleGithubRepositories,
+} from "./agent-run-context.js";
 import { buildAgentRunInstructions } from "./agent-run-instructions.js";
 
 test("agent run instructions include org guidance, project context, and project instructions", () => {
@@ -144,6 +148,12 @@ test("buildFollowUpContext tolerates a missing prior run and empty detail", () =
   assert.deepEqual(followUp.interactions, []);
   assert.deepEqual(followUp.pullRequests, []);
   assert.deepEqual(followUp.timeline, []);
+});
+
+test("only an explicit Slack Open a PR run overrides a do-not-PR project policy", () => {
+  assert.equal(effectivePrPolicyForAgentRun("never", "incident"), "never");
+  assert.equal(effectivePrPolicyForAgentRun("never", "slack_open_pr"), "on_ready_to_pr");
+  assert.equal(effectivePrPolicyForAgentRun("always", "slack_open_pr"), "always");
 });
 
 test("agent run instructions skip blank project context", () => {

--- a/apps/worker/src/agent-run-context.ts
+++ b/apps/worker/src/agent-run-context.ts
@@ -67,6 +67,15 @@ export type AgentRunContext = {
 // investigations carry the relevant findings.
 export const PREDECESSOR_CHAIN_LIMIT = 3;
 
+export function effectivePrPolicyForAgentRun(
+  projectPolicy: schema.PrPolicy,
+  trigger: schema.AgentRunTrigger,
+): schema.PrPolicy {
+  return projectPolicy === "never" && trigger === "slack_open_pr"
+    ? "on_ready_to_pr"
+    : projectPolicy;
+}
+
 // Walk the previous_incident_id chain and load a compact summary of each
 // predecessor: resolution, agent findings, handoff notes, and PR links.
 export async function loadPredecessorIncidents(
@@ -274,7 +283,7 @@ export async function loadAgentRunContext(
     linearTicketPolicy: automation.linearTicketPolicy,
     linearTicketInstructions: automation.linearTicketInstructions,
     linearDefaultTeamId: automation.linearDefaultTeamId,
-    prPolicy: automation.prPolicy,
+    prPolicy: effectivePrPolicyForAgentRun(automation.prPolicy, agentRun.trigger),
     approvalPromptsEnabled: automation.approvalPromptsEnabled,
     createLinearTicketOnResolve: automation.createLinearTicketOnResolve,
     prBaseBranch: automation.prBaseBranch,

--- a/apps/worker/src/agent-runs/completion-policy.test.ts
+++ b/apps/worker/src/agent-runs/completion-policy.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { shouldCreateLinearTicketForTerminalOutcome } from "./completion-policy.js";
+import {
+  shouldCreateLinearTicketForTerminalOutcome,
+  shouldOfferOpenPr,
+} from "./completion-policy.js";
 
 test("complete_investigation always attempts the connected Linear handoff", () => {
   assert.equal(shouldCreateLinearTicketForTerminalOutcome("complete_investigation", false), true);
@@ -9,4 +12,39 @@ test("complete_investigation always attempts the connected Linear handoff", () =
 test("resolve_incident follows the project's create-ticket-on-resolve toggle", () => {
   assert.equal(shouldCreateLinearTicketForTerminalOutcome("resolve_incident", true), true);
   assert.equal(shouldCreateLinearTicketForTerminalOutcome("resolve_incident", false), false);
+});
+
+test("Open a PR is offered only after a GitHub-connected findings-only completion", () => {
+  assert.equal(
+    shouldOfferOpenPr({
+      completionKind: "investigation_complete",
+      prPolicy: "never",
+      githubConnected: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldOfferOpenPr({
+      completionKind: null,
+      prPolicy: "never",
+      githubConnected: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldOfferOpenPr({
+      completionKind: "investigation_complete",
+      prPolicy: "never",
+      githubConnected: false,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldOfferOpenPr({
+      completionKind: "investigation_complete",
+      prPolicy: "on_ready_to_pr",
+      githubConnected: true,
+    }),
+    false,
+  );
 });

--- a/apps/worker/src/agent-runs/completion-policy.ts
+++ b/apps/worker/src/agent-runs/completion-policy.ts
@@ -1,3 +1,5 @@
+import type { AgentRunResult, PrPolicy } from "@superlog/db";
+
 export type TicketCreatingTerminalOutcome = "complete_investigation" | "resolve_incident";
 
 export function shouldCreateLinearTicketForTerminalOutcome(
@@ -5,4 +7,16 @@ export function shouldCreateLinearTicketForTerminalOutcome(
   createOnResolve: boolean,
 ): boolean {
   return outcome === "complete_investigation" || createOnResolve;
+}
+
+export function shouldOfferOpenPr(input: {
+  completionKind: AgentRunResult["completionKind"];
+  prPolicy: PrPolicy;
+  githubConnected: boolean;
+}): boolean {
+  return (
+    input.completionKind === "investigation_complete" &&
+    input.prPolicy === "never" &&
+    input.githubConnected
+  );
 }

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -35,7 +35,10 @@ import {
 } from "../infra/slack/incident-messages.js";
 import { logger } from "../logger.js";
 import { enqueueAgentRunCompleted } from "../webhooks.js";
-import { shouldCreateLinearTicketForTerminalOutcome } from "./completion-policy.js";
+import {
+  shouldCreateLinearTicketForTerminalOutcome,
+  shouldOfferOpenPr,
+} from "./completion-policy.js";
 import { recordFiledLinearTicket } from "./deliverable-records.js";
 import { scheduleLinearHandoff } from "./linear-handoff.js";
 import {
@@ -639,6 +642,11 @@ export async function completeWithoutPullRequest(
             buttons: [],
             links: ticket?.url ? [{ text: "View ticket", url: ticket.url }] : [],
             incidentId: ctx.incident.id,
+            showOpenPrButton: shouldOfferOpenPr({
+              completionKind: completionResult.completionKind,
+              prPolicy: ctx.prPolicy,
+              githubConnected: ctx.githubInstalls.length > 0,
+            }),
             showFeedbackButtons: true,
           }),
         );
@@ -793,6 +801,11 @@ export async function completeWithoutPullRequest(
           buttons: [],
           links: ticket?.url ? [{ text: "View ticket", url: ticket.url }] : [],
           incidentId: ctx.incident.id,
+          showOpenPrButton: shouldOfferOpenPr({
+            completionKind: completionResult.completionKind,
+            prPolicy: ctx.prPolicy,
+            githubConnected: ctx.githubInstalls.length > 0,
+          }),
           showFeedbackButtons: true,
           showUnsilenceButton: settledClosedSilenced,
         }),

--- a/apps/worker/src/infra/slack/incident-messages.test.ts
+++ b/apps/worker/src/infra/slack/incident-messages.test.ts
@@ -174,6 +174,21 @@ test("incidentBlocks omits rating buttons when showFeedbackButtons is unset", ()
   assert.equal(JSON.stringify(blocks).includes("rate_incident:"), false);
 });
 
+test("incidentBlocks renders an Open a PR button for a findings-only investigation", () => {
+  const blocks = incidentBlocks({
+    emoji: "white_check_mark",
+    status: "Investigation complete",
+    title: "boom",
+    projectName: "Acme",
+    buttons: [],
+    incidentId: "inc-1",
+    showOpenPrButton: true,
+  });
+  const json = JSON.stringify(blocks);
+  assert.equal(json.includes("open_pr:inc-1"), true);
+  assert.equal(json.includes("Open a PR"), true);
+});
+
 // Thread replies only reach us from channels the bot is a MEMBER of (posting
 // works unjoined via chat:write.public — receiving does not). When the bot
 // can't self-join (legacy install without channels:join, private channel) and

--- a/apps/worker/src/infra/slack/incident-messages.ts
+++ b/apps/worker/src/infra/slack/incident-messages.ts
@@ -165,6 +165,8 @@ export function incidentBlocks(opts: {
   // Adds 👍/👎 rating buttons (rate_incident:<rating>:<incidentId>). Set on
   // states where there's an investigation worth rating.
   showFeedbackButtons?: boolean;
+  // Adds a one-shot "Open a PR" action for a findings-only investigation.
+  showOpenPrButton?: boolean;
   // Adds a "Do not silence, resolve" button (unsilence_resolve:<incidentId>).
   // Set on the closed-PR resolution message, where the resolve cascade
   // silenced the incident's issues — the click flips them back to `resolved`
@@ -204,6 +206,23 @@ export function incidentBlocks(opts: {
     action_id: btn.actionId,
   }));
   if (opts.incidentId) {
+    if (opts.showOpenPrButton) {
+      elements.push({
+        type: "button",
+        text: { type: "plain_text", text: "Open a PR", emoji: true },
+        style: "primary",
+        action_id: `open_pr:${opts.incidentId}`,
+        confirm: {
+          title: { type: "plain_text", text: "Open a PR" },
+          text: {
+            type: "mrkdwn",
+            text: "Starts a new agent run to implement the confirmed fix, validate it, and open a pull request.",
+          },
+          confirm: { type: "plain_text", text: "Start" },
+          deny: { type: "plain_text", text: "Cancel" },
+        },
+      });
+    }
     if (opts.showMergePrButton) {
       elements.push({
         type: "button",

--- a/packages/db/src/agent-follow-up.test.ts
+++ b/packages/db/src/agent-follow-up.test.ts
@@ -596,6 +596,7 @@ test("an explicit Open a PR request queues a fresh run with remediation instruct
     const result = await requestOpenPrAgentRun(db, {
       incidentId: incident.id,
       requestedBy: "U123",
+      requestId: "U123:1712345.6789",
       now: NOW,
     });
 
@@ -638,6 +639,7 @@ test("an Open a PR request upgrades an already-queued follow-up to PR capability
     const result = await requestOpenPrAgentRun(db, {
       incidentId: incident.id,
       requestedBy: "U456",
+      requestId: "U456:1712346.6789",
       now: new Date(NOW.getTime() + 1_000),
     });
 
@@ -648,6 +650,33 @@ test("an Open a PR request upgrades an already-queued follow-up to PR capability
     });
     assert.equal(run?.trigger, "slack_open_pr");
     assert.equal(run?.triggerDetail?.interactions.length, 2);
+  } finally {
+    await client.close();
+  }
+});
+
+test("Open a PR requests deduplicate Slack retries before enqueue side effects", async () => {
+  const { db, client } = await freshFollowUpDb();
+  try {
+    const { incident } = await seedFollowUpIncident(db);
+    const args = {
+      incidentId: incident.id,
+      requestedBy: "U123",
+      requestId: "U123:1712345.6789",
+      now: NOW,
+    };
+
+    const first = await requestOpenPrAgentRun(db, args);
+    const retry = await requestOpenPrAgentRun(db, args);
+
+    assert.equal(first.outcome, "enqueued");
+    assert.deepEqual(retry, { outcome: "duplicate" });
+    const runs = await db.query.agentRuns.findMany({
+      where: eq(schema.agentRuns.incidentId, incident.id),
+    });
+    assert.equal(runs.filter((run) => run.trigger === "slack_open_pr").length, 1);
+    const openPrRun = runs.find((run) => run.trigger === "slack_open_pr");
+    assert.equal(openPrRun?.triggerDetail?.interactions.length, 1);
   } finally {
     await client.close();
   }

--- a/packages/db/src/agent-follow-up.test.ts
+++ b/packages/db/src/agent-follow-up.test.ts
@@ -13,6 +13,7 @@ import {
   evaluateFollowUpEligibility,
   recordInboundInteraction,
   requestFollowUpAgentRun,
+  requestOpenPrAgentRun,
   restartAgentRun,
   retryBlockedAgentRun,
 } from "./agent-follow-up.js";
@@ -580,6 +581,76 @@ test("direct follow-up requests do not enqueue or append after Incident resoluti
 
   assert.deepEqual(result, { outcome: "skipped", reason: "incident_not_open" });
   assert.deepEqual(writes, []);
+});
+
+test("an explicit Open a PR request queues a fresh run with remediation instructions", async () => {
+  const { db, client } = await freshFollowUpDb();
+  try {
+    const { incident } = await seedFollowUpIncident(db);
+    await db.insert(schema.projectAutomationSettings).values({
+      projectId: incident.projectId,
+      autoFollowUpEnabled: false,
+      prPolicy: "never",
+    });
+
+    const result = await requestOpenPrAgentRun(db, {
+      incidentId: incident.id,
+      requestedBy: "U123",
+      now: NOW,
+    });
+
+    assert.equal(result.outcome, "enqueued");
+    if (result.outcome !== "enqueued") return;
+    const run = await db.query.agentRuns.findFirst({
+      where: eq(schema.agentRuns.id, result.agentRunId),
+    });
+    assert.equal(run?.trigger, "slack_open_pr");
+    assert.deepEqual(run?.triggerDetail?.interactions, [
+      {
+        channel: "slack_open_pr",
+        author: "U123",
+        text: "Fix the confirmed incident cause and open a pull request with the validated changes.",
+        occurredAt: NOW.toISOString(),
+      },
+    ]);
+  } finally {
+    await client.close();
+  }
+});
+
+test("an Open a PR request upgrades an already-queued follow-up to PR capability", async () => {
+  const { db, client } = await freshFollowUpDb();
+  try {
+    const { incident } = await seedFollowUpIncident(db);
+    const queued = await requestFollowUpAgentRun(db, {
+      incidentId: incident.id,
+      trigger: "slack_reply",
+      interaction: {
+        channel: "slack_reply",
+        author: "U123",
+        text: "Please keep investigating.",
+        occurredAt: NOW.toISOString(),
+      },
+      now: NOW,
+    });
+    assert.equal(queued.outcome, "enqueued");
+
+    const result = await requestOpenPrAgentRun(db, {
+      incidentId: incident.id,
+      requestedBy: "U456",
+      now: new Date(NOW.getTime() + 1_000),
+    });
+
+    assert.equal(result.outcome, "appended");
+    if (result.outcome !== "appended") return;
+    const run = await db.query.agentRuns.findFirst({
+      where: eq(schema.agentRuns.id, result.agentRunId),
+    });
+    assert.equal(run?.trigger, "slack_open_pr");
+    assert.equal(run?.triggerDetail?.interactions.length, 2);
+  } finally {
+    await client.close();
+  }
 });
 
 test("a newly-enqueued follow-up carries every currently-open Incident PR", async () => {

--- a/packages/db/src/agent-follow-up.ts
+++ b/packages/db/src/agent-follow-up.ts
@@ -234,6 +234,28 @@ type RequestFollowUpArgs = {
   now?: Date;
 };
 
+export const OPEN_PR_REQUEST_TEXT =
+  "Fix the confirmed incident cause and open a pull request with the validated changes.";
+
+export function requestOpenPrAgentRun(
+  db: DB,
+  args: { incidentId: string; requestedBy: string | null; now?: Date },
+): Promise<RequestFollowUpResult> {
+  const now = args.now ?? new Date();
+  return requestFollowUpAgentRun(db, {
+    incidentId: args.incidentId,
+    trigger: "slack_open_pr",
+    confirmed: true,
+    interaction: {
+      channel: "slack_open_pr",
+      author: args.requestedBy,
+      text: OPEN_PR_REQUEST_TEXT,
+      occurredAt: now.toISOString(),
+    },
+    now,
+  });
+}
+
 const RESTARTABLE_AGENT_RUN_STATES = [
   "queued",
   "repo_discovery",
@@ -507,7 +529,13 @@ async function requestFollowUpAgentRunInTx(
     // interaction was persisted.
     const [appended] = await db
       .update(schema.agentRuns)
-      .set({ triggerDetail: detail, updatedAt: now })
+      .set({
+        triggerDetail: detail,
+        // A human explicitly asking for implementation must upgrade a queued
+        // findings-only follow-up so the worker grants its one-shot PR tools.
+        ...(args.trigger === "slack_open_pr" ? { trigger: args.trigger } : {}),
+        updatedAt: now,
+      })
       .where(and(eq(schema.agentRuns.id, verdict.runId), eq(schema.agentRuns.state, "queued")))
       .returning({ id: schema.agentRuns.id });
     if (!appended) return { outcome: "skipped", reason: "run_active" };
@@ -756,6 +784,8 @@ function followUpQueuedSummary(trigger: AgentRunFollowUpTrigger): string {
       return "Follow-up investigation queued from user feedback.";
     case "slack_reply":
       return "Follow-up investigation queued from a Slack reply.";
+    case "slack_open_pr":
+      return "Pull request implementation queued from Slack.";
     case "linear_reply":
       return "Follow-up investigation queued from a Linear prompt.";
     case "web_chat":

--- a/packages/db/src/agent-follow-up.ts
+++ b/packages/db/src/agent-follow-up.ts
@@ -237,22 +237,56 @@ type RequestFollowUpArgs = {
 export const OPEN_PR_REQUEST_TEXT =
   "Fix the confirmed incident cause and open a pull request with the validated changes.";
 
-export function requestOpenPrAgentRun(
+export type RequestOpenPrAgentRunResult = RequestFollowUpResult | { outcome: "duplicate" };
+
+export async function requestOpenPrAgentRun(
   db: DB,
-  args: { incidentId: string; requestedBy: string | null; now?: Date },
-): Promise<RequestFollowUpResult> {
+  args: {
+    incidentId: string;
+    requestedBy: string | null;
+    requestId: string;
+    now?: Date;
+  },
+): Promise<RequestOpenPrAgentRunResult> {
   const now = args.now ?? new Date();
-  return requestFollowUpAgentRun(db, {
-    incidentId: args.incidentId,
-    trigger: "slack_open_pr",
-    confirmed: true,
-    interaction: {
-      channel: "slack_open_pr",
-      author: args.requestedBy,
-      text: OPEN_PR_REQUEST_TEXT,
-      occurredAt: now.toISOString(),
-    },
-    now,
+  return db.transaction(async (tx) => {
+    const aggregate = await lockAgentFollowUpAggregate(tx, args.incidentId);
+    if (!aggregate) return { outcome: "skipped", reason: "no_prior_run" };
+
+    // Slack retries a block action with the same action timestamp when the
+    // acknowledgement misses its deadline. Claim that stable request id in
+    // the same transaction as enqueueing so a retry cannot append duplicate
+    // instructions or produce a second acknowledgement message.
+    const [claimed] = await tx
+      .insert(schema.incidentEvents)
+      .values({
+        incidentId: args.incidentId,
+        kind: "open_pr_requested",
+        summary: "Pull request implementation requested from Slack.",
+        detail: { requestedBy: args.requestedBy },
+        dedupeKey: `open_pr_request:${args.requestId}`,
+        processedAt: now,
+      })
+      .onConflictDoNothing()
+      .returning({ id: schema.incidentEvents.id });
+    if (!claimed) return { outcome: "duplicate" };
+
+    return requestFollowUpAgentRunInTx(
+      tx,
+      {
+        incidentId: args.incidentId,
+        trigger: "slack_open_pr",
+        confirmed: true,
+        interaction: {
+          channel: "slack_open_pr",
+          author: args.requestedBy,
+          text: OPEN_PR_REQUEST_TEXT,
+          occurredAt: now.toISOString(),
+        },
+        now,
+      },
+      aggregate,
+    );
   });
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -193,6 +193,8 @@ export {
   restartAgentRun,
   retryBlockedAgentRun,
   requestFollowUpAgentRun,
+  requestOpenPrAgentRun,
+  OPEN_PR_REQUEST_TEXT,
   type RestartAgentRunResult,
   type RetryBlockedAgentRunResult,
   FOLLOW_UP_MAX_AGE_DAYS,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -195,6 +195,7 @@ export {
   requestFollowUpAgentRun,
   requestOpenPrAgentRun,
   OPEN_PR_REQUEST_TEXT,
+  type RequestOpenPrAgentRunResult,
   type RestartAgentRunResult,
   type RetryBlockedAgentRunResult,
   FOLLOW_UP_MAX_AGE_DAYS,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -261,6 +261,7 @@ export type AgentRunTrigger =
   | "pr_closed"
   | "feedback"
   | "slack_reply"
+  | "slack_open_pr"
   | "linear_reply"
   | "web_chat"
   | "issue_joined";


### PR DESCRIPTION
## What changed

- show an `Open a PR` Slack action after a findings-only investigation when pull-request creation is disabled but GitHub is connected
- enqueue a confirmed follow-up carrying an explicit implementation request
- grant pull-request creation for that run only, without changing the project's automation policy
- upgrade an already queued follow-up when the action is clicked, preserving idempotent serialization

## Why

Findings-only projects currently stop after reporting an incident. A teammate should be able to explicitly authorize implementation from the incident thread without permanently enabling automatic pull requests.

## Validation

- database follow-up tests, including the queued-run race
- Slack API and message block tests
- worker context, completion-policy, lifecycle start/sync tests
- database, API, and worker typechecks
- production worker image build and capability-specific prompt/tool tests
- worktree bootstrap, seed, and verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an “Open a PR” Slack action to findings-only incidents so teammates can start a one-shot implementation run that opens a PR without changing the project’s PR policy.

- **New Features**
  - Shows an “Open a PR” button after an `investigation_complete` when GitHub is connected and PR policy is `never`.
  - Clicking enqueues a follow-up run with PR capability enabled for that run only; posts a confirmation reply in the thread.
  - Upgrades an already queued follow-up to a PR-capable run; deduplicates Slack action retries to avoid double-enqueue and duplicate replies.
  - Worker applies a temporary PR policy override only for the `slack_open_pr` trigger.
  - Exposes `requestOpenPrAgentRun` and `OPEN_PR_REQUEST_TEXT` in `packages/db`.
  - Slack API: parses `open_pr:<incident-id>` actions and handles them appropriately.

<sup>Written for commit ff0cab190c6e5d848e04650fb0afea1769745839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

