### PR TITLE
Add server.json for MCP registry publishing

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "sh.superlog/superlog",
+  "title": "Superlog",
+  "description": "Open-source agent that observes and fixes your application. Query logs, traces, metrics, incidents.",
+  "websiteUrl": "https://superlog.sh",
+  "repository": {
+    "url": "https://github.com/superloglabs/superlog",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.superlog.sh/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a `server.json` describing the hosted MCP server so it can be listed in the [official MCP registry](https://registry.modelcontextprotocol.io).

- Remote server, `streamable-http` transport at `https://api.superlog.sh/mcp` (OAuth-gated at runtime).
- Namespace `sh.superlog`, verified via a DNS TXT record on the `superlog.sh` apex.
- Validated with `mcp-publisher validate`; the entry is already live (v1.0.0, status `active`).

Committing the manifest so the registry entry is documented in-repo and future version bumps are a tracked diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `server.json` to list Superlog’s hosted MCP server in the official MCP registry.

Defines `sh.superlog/superlog` (namespace `sh.superlog`), `streamable-http` remote at https://api.superlog.sh/mcp, version `1.0.0`, and metadata (title, website, repository).

<sup>Written for commit b134e32e7030d13139b53d3d729178d168114680. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

