### PR TITLE
Grouping agent: full candidate index, rich issue context, honest failure accounting

### DIFF
--- a/apps/worker/src/grouping.ts
+++ b/apps/worker/src/grouping.ts
@@ -33,7 +33,7 @@ const MODEL = process.env.ANTHROPIC_GROUPING_MODEL ?? "claude-sonnet-4-6";
 
 const MAX_TOOL_ITERATIONS = parsePositiveIntegerEnv(
   process.env.INCIDENT_GROUPING_TOOL_ITERATIONS,
-  5,
+  12,
 );
 
 function parsePositiveIntegerEnv(value: string | undefined, fallback: number): number {

--- a/apps/worker/src/grouping/agent.test.ts
+++ b/apps/worker/src/grouping/agent.test.ts
@@ -207,7 +207,7 @@ test("runGroupingAgent: text-only fallback parses JSON verdict from text", async
   assert.equal(verdict.decision, "join");
 });
 
-test("runGroupingAgent: text-only with non-JSON returns standalone with explanatory evidence", async () => {
+test("runGroupingAgent: text-only with non-JSON is a mechanical failure, not a verdict", async () => {
   const deps = makeDeps([[textBlock("I'd rather not say")]]);
   const verdict = await runGroupingAgent(
     { projectName: "p", newIssue: NEW_ISSUE, candidates: [makeCandidate("a")] },
@@ -216,6 +216,7 @@ test("runGroupingAgent: text-only with non-JSON returns standalone with explanat
   assert.deepEqual(verdict, {
     decision: "standalone",
     evidence: "Model did not call a grouping tool.",
+    mechanicalFailure: "no_tool_call",
   });
 });
 
@@ -231,6 +232,7 @@ test("runGroupingAgent: exhausts iteration budget → standalone with budget mes
   assert.deepEqual(verdict, {
     decision: "standalone",
     evidence: "Grouping agent exhausted its tool-use budget without a valid decision.",
+    mechanicalFailure: "budget_exhausted",
   });
 });
 

--- a/apps/worker/src/grouping/agent.test.ts
+++ b/apps/worker/src/grouping/agent.test.ts
@@ -207,6 +207,15 @@ test("runGroupingAgent: text-only fallback parses JSON verdict from text", async
   assert.equal(verdict.decision, "join");
 });
 
+test("runGroupingAgent: raw standalone JSON without evidence is honoured, not a failure", async () => {
+  const deps = makeDeps([[textBlock('{"decision": "standalone"}')]]);
+  const verdict = await runGroupingAgent(
+    { projectName: "p", newIssue: NEW_ISSUE, candidates: [makeCandidate("a")] },
+    deps,
+  );
+  assert.deepEqual(verdict, { decision: "standalone", evidence: null });
+});
+
 test("runGroupingAgent: text-only with non-JSON is a mechanical failure, not a verdict", async () => {
   const deps = makeDeps([[textBlock("I'd rather not say")]]);
   const verdict = await runGroupingAgent(

--- a/apps/worker/src/grouping/agent.ts
+++ b/apps/worker/src/grouping/agent.ts
@@ -104,9 +104,11 @@ export async function runGroupingAgent(
       (block): block is Anthropic.Messages.ToolUseBlock => block.type === "tool_use",
     );
     if (toolUses.length === 0) {
+      // The model may opt out of tools and reply with raw verdict JSON —
+      // honour it (including standalone without evidence). Anything that
+      // doesn't parse as a verdict is a mechanical failure, not a decision.
       const parsed = parseVerdictFromText(extractText(message), candidateIds);
-      if (parsed.decision === "join") return parsed;
-      if (parsed.evidence) return parsed; // a real standalone verdict, just written as text
+      if (parsed) return parsed;
       return {
         decision: "standalone",
         evidence: "Model did not call a grouping tool.",

--- a/apps/worker/src/grouping/agent.ts
+++ b/apps/worker/src/grouping/agent.ts
@@ -105,12 +105,13 @@ export async function runGroupingAgent(
     );
     if (toolUses.length === 0) {
       const parsed = parseVerdictFromText(extractText(message), candidateIds);
-      return parsed.decision === "join"
-        ? parsed
-        : {
-            decision: "standalone",
-            evidence: parsed.evidence ?? "Model did not call a grouping tool.",
-          };
+      if (parsed.decision === "join") return parsed;
+      if (parsed.evidence) return parsed; // a real standalone verdict, just written as text
+      return {
+        decision: "standalone",
+        evidence: "Model did not call a grouping tool.",
+        mechanicalFailure: "no_tool_call",
+      };
     }
 
     conversation.push({ role: "assistant", content: message.content });
@@ -134,6 +135,7 @@ export async function runGroupingAgent(
   return {
     decision: "standalone",
     evidence: "Grouping agent exhausted its tool-use budget without a valid decision.",
+    mechanicalFailure: "budget_exhausted",
   };
 }
 

--- a/apps/worker/src/grouping/domain.test.ts
+++ b/apps/worker/src/grouping/domain.test.ts
@@ -157,13 +157,16 @@ test("parseSearchInput tokenises the query and clamps the limit", () => {
   assert.equal(out.limit, 25);
 });
 
-test("parseVerdictFromText returns standalone on invalid JSON", () => {
+test("parseVerdictFromText returns null when the reply is not a verdict", () => {
   const ids = new Set(["a", "b"]);
-  assert.deepEqual(parseVerdictFromText("not json", ids), {
-    decision: "standalone",
-    evidence: null,
-  });
-  assert.deepEqual(parseVerdictFromText("\"string\"", ids), {
+  assert.equal(parseVerdictFromText("not json", ids), null);
+  assert.equal(parseVerdictFromText("\"string\"", ids), null);
+  assert.equal(parseVerdictFromText("{\"foo\": 1}", ids), null);
+});
+
+test("parseVerdictFromText honours a valid standalone without evidence", () => {
+  const ids = new Set(["a", "b"]);
+  assert.deepEqual(parseVerdictFromText("{\"decision\": \"standalone\"}", ids), {
     decision: "standalone",
     evidence: null,
   });

--- a/apps/worker/src/grouping/domain.ts
+++ b/apps/worker/src/grouping/domain.ts
@@ -68,11 +68,18 @@ export type GroupingNewIssue = {
   traceId: string | null;
   spanId: string | null;
   resourceAttrs?: ResourceAttrs;
+  /** Log-record attributes from the sample (code location, route, …). */
+  logAttrs?: Record<string, string> | null;
 };
 
 export type GroupingVerdict =
   | { decision: "join"; incidentId: string; evidence: string }
-  | { decision: "standalone"; evidence: string | null };
+  | { decision: "standalone"; evidence: string | null; mechanicalFailure?: GroupingMechanicalFailure };
+
+// A mechanical failure means the agent never reached a real verdict (loop
+// budget ran out, or the model replied with unparseable text). Callers must
+// treat these as retryable errors — not as a considered "standalone" decision.
+export type GroupingMechanicalFailure = "budget_exhausted" | "no_tool_call";
 
 export function environmentForResourceAttrs(attrs: ResourceAttrs | undefined): string | null {
   if (!attrs) return null;

--- a/apps/worker/src/grouping/domain.ts
+++ b/apps/worker/src/grouping/domain.ts
@@ -220,15 +220,18 @@ export function parseSearchInput(input: unknown): SearchInput {
 // Standalone text the LLM-text fallback parser checks. Distinct from the
 // structured tool-input parser because the model can opt out of tools and
 // reply with raw JSON — we still want to honour a valid verdict in that case.
+// Returns null when the reply is not a verdict at all (unparseable text,
+// non-object JSON, or an object without an explicit decision) so the caller
+// can distinguish "no verdict" from a valid standalone without evidence.
 export function parseVerdictFromText(
   raw: string,
   candidateIds: ReadonlySet<string>,
-): GroupingVerdict {
+): GroupingVerdict | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    return { decision: "standalone", evidence: null };
+    return null;
   }
   return interpretVerdictPayload(parsed, candidateIds);
 }
@@ -236,10 +239,8 @@ export function parseVerdictFromText(
 function interpretVerdictPayload(
   parsed: unknown,
   candidateIds: ReadonlySet<string>,
-): GroupingVerdict {
-  if (!parsed || typeof parsed !== "object") {
-    return { decision: "standalone", evidence: null };
-  }
+): GroupingVerdict | null {
+  if (!parsed || typeof parsed !== "object") return null;
   const obj = parsed as Record<string, unknown>;
   if (obj.decision === "join") {
     const incidentId = typeof obj.incidentId === "string" ? obj.incidentId : "";
@@ -247,8 +248,10 @@ function interpretVerdictPayload(
     if (candidateIds.has(incidentId) && evidence.length >= MIN_EVIDENCE_LENGTH) {
       return { decision: "join", incidentId, evidence };
     }
+    // An explicit join we can't honour degrades to standalone, as before.
     return { decision: "standalone", evidence: null };
   }
+  if (obj.decision !== "standalone") return null;
   const evidence =
     typeof obj.evidence === "string" && obj.evidence.trim().length > 0
       ? obj.evidence.trim()

--- a/apps/worker/src/grouping/initial-message.ts
+++ b/apps/worker/src/grouping/initial-message.ts
@@ -4,6 +4,28 @@ import {
   type GroupingNewIssue,
 } from "./domain.js";
 
+// One compact line per candidate so the model sees the WHOLE candidate set
+// up front instead of discovering it through blind tool calls. ~40-60 tokens
+// per candidate; even a few hundred open incidents fit comfortably. Details
+// (stack traces, sibling issues) stay behind inspect_incident.
+function candidateIndexLine(candidate: GroupingCandidateIncident): string {
+  const representative = candidate.representative;
+  const issue = candidate.issues?.[0];
+  const codePath = issue?.logAttrs?.["code.file.path"];
+  const codeFn = issue?.logAttrs?.["code.function.name"];
+  const parts = [
+    candidate.id,
+    `[${candidate.service ?? "?"}]`,
+    candidate.title,
+    representative
+      ? `| ${representative.exceptionType}: ${(representative.message ?? "").slice(0, 140)}`
+      : "",
+    codePath ? `| at ${codePath}${codeFn ? `:${codeFn}` : ""}` : "",
+    `| issues=${candidate.issueCount} lastSeen=${candidate.lastSeen}`,
+  ];
+  return parts.filter(Boolean).join(" ").replace(/\s+/g, " ");
+}
+
 export function buildInitialUserMessage(input: {
   projectName: string;
   newIssue: GroupingNewIssue;
@@ -27,25 +49,9 @@ export function buildInitialUserMessage(input: {
     "New issue to classify:",
     JSON.stringify(input.newIssue, null, 2),
     "",
-    "Open incident candidate index:",
-    JSON.stringify(
-      {
-        count: input.candidates.length,
-        services,
-        environments,
-        newestCandidates: input.candidates.slice(0, 5).map((candidate) => ({
-          id: candidate.id,
-          title: candidate.title,
-          service: candidate.service,
-          issueCount: candidate.issueCount,
-          lastSeen: candidate.lastSeen,
-          environment: environmentForResourceAttrs(candidate.representative?.resourceAttrs),
-        })),
-      },
-      null,
-      2,
-    ),
+    `Open incident candidates (${input.candidates.length} total, services: ${services.join(", ") || "-"}, environments: ${environments.join(", ") || "-"}), one per line:`,
+    ...input.candidates.map(candidateIndexLine),
     "",
-    "Use list_incident_titles/list_incident_facets to orient, then search and inspect plausible join targets.",
+    "Inspect any plausible join target with inspect_incident before deciding; search_incidents/list_incident_titles remain available for narrowing.",
   ].join("\n");
 }

--- a/apps/worker/src/incidents/intake.test.ts
+++ b/apps/worker/src/incidents/intake.test.ts
@@ -169,6 +169,9 @@ function makeDeps(overrides: {
       warn(_obj, msg) {
         overrides.calls.push(`logger.warn:${msg ?? ""}`);
       },
+      error(_obj, msg) {
+        overrides.calls.push(`logger.error:${msg ?? ""}`);
+      },
     },
     serializeCreate: overrides.serializeCreate,
   };
@@ -294,6 +297,8 @@ test("intake: recurred issue goes through grouping and joins an existing inciden
   repo.loadLinkedIncidentIssues = async (incidents) =>
     incidents.map((incident) => ({
       incidentId: incident.id,
+      issueId: "iss-linked",
+      service: null,
       title: incident.title,
       exceptionType: "ERROR",
       message: "Recall.ai returned insufficient_credit_balance",
@@ -515,6 +520,8 @@ test("intake: heuristic match links to existing incident as 'grouped'", async ()
   repo.loadLinkedIncidentIssues = async () => [
     {
       incidentId: "inc-match",
+      issueId: "iss-linked",
+      service: null,
       title: existing.title,
       exceptionType: "ECONNREFUSED",
       message: null,
@@ -684,6 +691,8 @@ test("intake: create/link section runs under serializeCreate, with grouping anal
   repo.loadLinkedIncidentIssues = async () => [
     {
       incidentId: "inc-unrelated",
+      issueId: "iss-linked",
+      service: null,
       title: "something else",
       exceptionType: "Error",
       message: null,
@@ -778,6 +787,8 @@ test("intake: first-ever alert episode goes through LLM grouping like an error",
   repo.loadLinkedIncidentIssues = async () => [
     {
       incidentId: "inc-error",
+      issueId: "iss-linked",
+      service: null,
       title: "DB down",
       exceptionType: "ECONNREFUSED",
       message: null,
@@ -862,6 +873,8 @@ test("intake: LLM 'join' verdict links to the chosen incident", async () => {
     calls.push(`loadLinkedIncidentIssues:${incidents.length}`);
     return incidents.map((incident) => ({
       incidentId: incident.id,
+      issueId: "iss-linked",
+      service: null,
       title: incident.title,
       exceptionType: "ECONNREFUSED",
       message: "conn refused",
@@ -916,6 +929,8 @@ test("intake: LLM 'join' verdict with unknown id falls back to standalone (and o
   repo.loadLinkedIncidentIssues = async (incidents) =>
     incidents.map((incident) => ({
       incidentId: incident.id,
+      issueId: "iss-linked",
+      service: null,
       title: incident.title,
       exceptionType: "ECONNREFUSED",
       message: "conn refused",
@@ -945,7 +960,7 @@ test("intake: LLM 'join' verdict with unknown id falls back to standalone (and o
   );
 });
 
-test("intake: LLM error logs a warning and marks issue 'failed'", async () => {
+test("intake: LLM error logs an error and marks issue 'failed'", async () => {
   const calls: string[] = [];
   const candidate = makeIncident({ id: "inc-x", issueCount: 1 });
   const newInc = makeIncident({ id: "inc-fresh" });
@@ -957,6 +972,8 @@ test("intake: LLM error logs a warning and marks issue 'failed'", async () => {
   repo.loadLinkedIncidentIssues = async (incidents) =>
     incidents.map((incident) => ({
       incidentId: incident.id,
+      issueId: "iss-linked",
+      service: null,
       title: incident.title,
       exceptionType: "ECONNREFUSED",
       message: "conn refused",
@@ -978,10 +995,57 @@ test("intake: LLM error logs a warning and marks issue 'failed'", async () => {
       },
     }),
   );
-  assert.ok(calls.includes("logger.warn:llm grouping failed"));
+  assert.ok(calls.includes("logger.error:llm grouping failed"));
   assert.ok(
     calls.some((c) =>
       c.startsWith("updateIssueGrouping:iss-new:failed:llm:LLM grouping failed: anthropic 500"),
+    ),
+  );
+});
+
+test("intake: mechanical grouping failure (budget) logs an error and marks issue 'failed'", async () => {
+  const calls: string[] = [];
+  const candidate = makeIncident({ id: "inc-x", issueCount: 1 });
+  const newInc = makeIncident({ id: "inc-fresh" });
+  const repo = makeRepo({
+    calls,
+    openCandidates: { withService: [], withoutService: [candidate] },
+    incidentById: new Map([["inc-fresh", newInc]]),
+  });
+  repo.loadLinkedIncidentIssues = async (incidents) =>
+    incidents.map((incident) => ({
+      incidentId: incident.id,
+      issueId: "iss-linked",
+      service: null,
+      title: incident.title,
+      exceptionType: "ECONNREFUSED",
+      message: "conn refused",
+      topFrame: "db.query",
+      normalizedFrames: ["db.query"],
+      lastSample: null,
+      lastSeen: incident.lastSeen,
+    }));
+  const lifecycle = makeLifecycle({ calls, createdIncident: newInc });
+  await ensureIncidentForIssueWorkflow(
+    makeIssue(),
+    "new",
+    makeDeps({
+      repo,
+      lifecycle,
+      calls,
+      async analyzeGrouping() {
+        return {
+          decision: "standalone",
+          evidence: "Grouping agent exhausted its tool-use budget without a valid decision.",
+          mechanicalFailure: "budget_exhausted",
+        };
+      },
+    }),
+  );
+  assert.ok(calls.includes("logger.error:issue grouping mechanical failure: budget_exhausted"));
+  assert.ok(
+    calls.some((c) =>
+      c.startsWith("updateIssueGrouping:iss-new:failed:llm:LLM grouping budget_exhausted"),
     ),
   );
 });

--- a/apps/worker/src/incidents/intake.ts
+++ b/apps/worker/src/incidents/intake.ts
@@ -28,6 +28,7 @@ import {
 
 export type IntakeLogger = {
   warn(obj: Record<string, unknown>, msg?: string): void;
+  error(obj: Record<string, unknown>, msg?: string): void;
 };
 
 export type IntakeRepository = {
@@ -594,6 +595,23 @@ async function findLlmMatchingIncident(issue: schema.Issue, deps: IntakeDeps): P
         failedReason: null,
       };
     }
+    if (verdict.mechanicalFailure) {
+      // The agent never reached a real verdict (loop budget ran out, or the
+      // reply was unparseable). Record it as a grouping FAILURE — not a
+      // considered standalone decision — and log at error level so it alerts.
+      const reason = `LLM grouping ${verdict.mechanicalFailure}: ${verdict.evidence ?? ""}`;
+      deps.logger.error(
+        {
+          scope: "issue_grouping",
+          issue_id: issue.id,
+          project_id: issue.projectId,
+          mechanical_failure: verdict.mechanicalFailure,
+          candidate_count: groupingCandidates.length,
+        },
+        `issue grouping mechanical failure: ${verdict.mechanicalFailure}`,
+      );
+      return { match: null, standaloneSource: "llm", standaloneReason: null, failedReason: reason };
+    }
     return {
       match: null,
       standaloneSource: "llm",
@@ -602,7 +620,7 @@ async function findLlmMatchingIncident(issue: schema.Issue, deps: IntakeDeps): P
     };
   } catch (err) {
     const reason = `LLM grouping failed: ${err instanceof Error ? err.message : String(err)}`;
-    deps.logger.warn(
+    deps.logger.error(
       {
         scope: "issue_grouping",
         issue_id: issue.id,

--- a/apps/worker/src/issue-transitions.test.ts
+++ b/apps/worker/src/issue-transitions.test.ts
@@ -51,10 +51,13 @@ test("dispatcher enqueues the transition instead of running it inline", async ()
   assert.equal(inlineRuns, 0, "inline handler must not run when the queue is available");
   assert.equal(fb.sent.length, 1);
   assert.equal(fb.sent[0]?.name, ISSUE_TRANSITION_QUEUE);
-  assert.deepEqual(fb.sent[0]?.data, {
+  const sentData = fb.sent[0]?.data as { enqueuedAtMs?: number };
+  assert.equal(typeof sentData.enqueuedAtMs, "number");
+  assert.deepEqual({ ...sentData, enqueuedAtMs: undefined }, {
     issueId: "issue-1",
     projectId: "project-1",
     transition: "new",
+    enqueuedAtMs: undefined,
   });
   // Rapid duplicate dispatches of the same (issue, transition) must dedupe
   // while a matching job is still queued.
@@ -174,10 +177,13 @@ test("observation escalations dispatch through the queue too", async () => {
 
   await dispatch(issueOf("issue-1", "project-1"), "escalated");
 
-  assert.deepEqual(fb.sent[0]?.data, {
+  const escData = fb.sent[0]?.data as { enqueuedAtMs?: number };
+  assert.equal(typeof escData.enqueuedAtMs, "number");
+  assert.deepEqual({ ...escData, enqueuedAtMs: undefined }, {
     issueId: "issue-1",
     projectId: "project-1",
     transition: "escalated",
+    enqueuedAtMs: undefined,
   });
 
   const handled: string[] = [];

--- a/apps/worker/src/issue-transitions.test.ts
+++ b/apps/worker/src/issue-transitions.test.ts
@@ -219,3 +219,36 @@ test("the queue worker skips malformed job payloads", async () => {
 
   assert.deepEqual(handled, ["issue-2"]);
 });
+
+test("worker serializes same-project transitions and parallelizes across projects", async () => {
+  const fb = fakeBoss();
+  const events: string[] = [];
+  let releaseFirst: () => void = () => {};
+  const firstGate = new Promise<void>((resolve) => (releaseFirst = resolve));
+  let calls = 0;
+  await registerIssueTransitionWorker(fb.boss, {
+    handle: async (issue) => {
+      const n = ++calls;
+      events.push(`start:${issue.id}`);
+      if (n === 1) await firstGate; // hold the first proj-A job mid-flight
+      events.push(`end:${issue.id}`);
+    },
+    loadIssue: async (id) => issueOf(id, id.startsWith("a") ? "proj-A" : "proj-B"),
+  });
+
+  const worker = fb.workers.get(ISSUE_TRANSITION_QUEUE);
+  assert.ok(worker);
+  // Simulate three concurrent consumers: two proj-A jobs, one proj-B job.
+  const j1 = worker([{ id: "j1", data: { issueId: "a-1", projectId: "proj-A", transition: "new" } }]);
+  const j2 = worker([{ id: "j2", data: { issueId: "a-2", projectId: "proj-A", transition: "new" } }]);
+  const j3 = worker([{ id: "j3", data: { issueId: "b-1", projectId: "proj-B", transition: "new" } }]);
+  await j3; // proj-B completes while proj-A's first job is still held
+  assert.ok(events.includes("end:b-1"), "different project must not wait");
+  assert.ok(!events.includes("start:a-2"), "second proj-A job must wait for the first");
+  releaseFirst();
+  await Promise.all([j1, j2]);
+  assert.deepEqual(
+    events.filter((e) => e.includes("a-")),
+    ["start:a-1", "end:a-1", "start:a-2", "end:a-2"],
+  );
+});

--- a/apps/worker/src/issue-transitions.ts
+++ b/apps/worker/src/issue-transitions.ts
@@ -17,9 +17,28 @@
 // at-most-once. The inline path logged-and-skipped a throwing handler; the
 // queue worker does the same per job instead of relying on pg-boss retries,
 // because the handler is not written to be safely re-runnable in all cases.
+import { metrics } from "@opentelemetry/api";
 import type { schema } from "@superlog/db";
 import type { IssueTransition } from "./incidents/workflow.js";
 import { logger as defaultLogger } from "./logger.js";
+
+// Queue-health telemetry: how long a transition waited before a consumer
+// picked it up, and how long the side effects took. Queue lag growing past
+// tens of seconds means the LLM grouping calls are outpacing WORKER_CONCURRENCY
+// — the signal to scale consumers or shed load, watched via a product alert.
+const meter = metrics.getMeter("@superlog/worker/issue-transitions");
+const queueLagHistogram = meter.createHistogram("superlog.issue_transitions.queue_lag_ms", {
+  description: "Delay between enqueueing an issue transition and a consumer starting it.",
+  unit: "ms",
+});
+const durationHistogram = meter.createHistogram("superlog.issue_transitions.duration_ms", {
+  description: "Wall-clock duration of issue-transition side effects (incident intake, grouping, notifications).",
+  unit: "ms",
+});
+const failureCounter = meter.createCounter("superlog.issue_transitions.failures", {
+  description: "Issue transitions whose side effects threw and were skipped (at-most-once).",
+  unit: "1",
+});
 
 export const ISSUE_TRANSITION_QUEUE = "issue-transition";
 
@@ -42,6 +61,8 @@ export type IssueTransitionJobData = {
   issueId: string;
   projectId: string;
   transition: IssueTransition;
+  /** Epoch ms at enqueue; lets the consumer report queue lag. */
+  enqueuedAtMs?: number;
 };
 
 type LoggerLike = Pick<typeof defaultLogger, "warn" | "error">;
@@ -73,6 +94,7 @@ function parseJobData(data: unknown): IssueTransitionJobData | null {
     issueId: record.issueId,
     projectId: record.projectId,
     transition: record.transition,
+    enqueuedAtMs: typeof record.enqueuedAtMs === "number" ? record.enqueuedAtMs : undefined,
   };
 }
 
@@ -105,6 +127,7 @@ export function createIssueTransitionDispatcher(opts: {
       issueId: issue.id,
       projectId: issue.projectId,
       transition,
+      enqueuedAtMs: Date.now(),
     };
     try {
       // singletonKey dedupes while a matching job is queued: a rapid
@@ -157,6 +180,12 @@ export async function registerIssueTransitionWorker(
             );
             return;
           }
+          if (data.enqueuedAtMs) {
+            queueLagHistogram.record(Math.max(0, Date.now() - data.enqueuedAtMs), {
+              transition: data.transition,
+            });
+          }
+          const startedAt = Date.now();
           try {
             const issue = await opts.loadIssue(data.issueId);
             if (!issue) {
@@ -168,6 +197,7 @@ export async function registerIssueTransitionWorker(
             }
             await opts.handle(issue, data.transition);
           } catch (err) {
+            failureCounter.add(1, { transition: data.transition });
             logger.error(
               {
                 scope: "issue-transitions",
@@ -178,6 +208,8 @@ export async function registerIssueTransitionWorker(
               },
               "issue transition failed; skipping",
             );
+          } finally {
+            durationHistogram.record(Date.now() - startedAt, { transition: data.transition });
           }
         }),
       );

--- a/apps/worker/src/issue-transitions.ts
+++ b/apps/worker/src/issue-transitions.ts
@@ -152,10 +152,33 @@ export function createIssueTransitionDispatcher(opts: {
   };
 }
 
+// Per-project serialization. Transitions for the SAME project run strictly
+// one at a time (burst siblings group sequentially, so the second issue of a
+// storm sees the incident the first one just created), while different
+// projects keep using the full consumer concurrency. In-process only: the
+// worker runs as a single process; if it ever scales out, cross-process
+// races return (degrading to pre-lock behavior, never worse).
+function createKeyedMutex(): <T>(key: string, fn: () => Promise<T>) => Promise<T> {
+  const tails = new Map<string, Promise<unknown>>();
+  return async function withKey<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prev = tails.get(key) ?? Promise.resolve();
+    const next = prev.then(fn, fn);
+    const stored = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    tails.set(key, stored);
+    void stored.then(() => {
+      if (tails.get(key) === stored) tails.delete(key);
+    });
+    return next;
+  };
+}
+
 // Register the queue and its worker. Each consumer processes one job at a
 // time; a job's failure is logged and swallowed (at-most-once, matching the
 // previous inline behavior) so one poisoned transition can't wedge or re-run
-// the rest.
+// the rest. Same-project jobs additionally serialize behind each other.
 export async function registerIssueTransitionWorker(
   boss: Pick<TransitionQueueBoss, "createQueue" | "work">,
   opts: {
@@ -165,6 +188,7 @@ export async function registerIssueTransitionWorker(
   },
 ): Promise<void> {
   const logger = opts.logger ?? defaultLogger;
+  const perProject = createKeyedMutex();
   await boss.createQueue(ISSUE_TRANSITION_QUEUE);
   await boss.work(
     ISSUE_TRANSITION_QUEUE,
@@ -195,7 +219,7 @@ export async function registerIssueTransitionWorker(
               );
               return;
             }
-            await opts.handle(issue, data.transition);
+            await perProject(data.projectId, () => opts.handle(issue, data.transition));
           } catch (err) {
             failureCounter.add(1, { transition: data.transition });
             logger.error(

--- a/apps/worker/src/issues/domain.test.ts
+++ b/apps/worker/src/issues/domain.test.ts
@@ -90,10 +90,31 @@ test("groupingIssueInput and buildGroupingCandidate keep LLM input shape explici
     stacktrace: "stack",
     traceId: "trace-1",
     spanId: "span-1",
+    logAttrs: null,
   });
   assert.ok(candidate?.representative);
   assert.equal(candidate.representative.traceId, "trace-2");
   assert.deepEqual(candidate.representative.normalizedFrames, ["svc/a.ts"]);
+  // Linked issues now travel with the candidate so inspect_incident can show
+  // stack traces and code locations.
+  assert.equal(candidate.issues?.length, 1);
+  assert.equal(candidate.issues?.[0]?.id, "iss-linked");
+});
+
+test("buildGroupingCandidate reads log-sample stacktraces and strips them from logAttrs", () => {
+  const candidate = buildGroupingCandidate(makeIncident("inc-1"), [
+    {
+      ...makeLinkedIssue("inc-1", []),
+      lastSample: {
+        logAttrs: {
+          "exception.stacktrace": "Traceback (most recent call last): boom",
+          "code.file.path": "/app/x.py",
+        },
+      } as unknown as LinkedIncidentIssue["lastSample"],
+    },
+  ]);
+  assert.equal(candidate?.issues?.[0]?.stacktrace, "Traceback (most recent call last): boom");
+  assert.deepEqual(candidate?.issues?.[0]?.logAttrs, { "code.file.path": "/app/x.py" });
 });
 
 function makeIssue(normalizedFrames: string[]): schema.Issue {
@@ -125,6 +146,8 @@ function makeIncident(id: string): schema.Incident {
 function makeLinkedIssue(incidentId: string, normalizedFrames: string[]): LinkedIncidentIssue {
   return {
     incidentId,
+    issueId: "iss-linked",
+    service: null,
     title: "Linked issue",
     exceptionType: "TypeError",
     message: "boom",

--- a/apps/worker/src/issues/domain.ts
+++ b/apps/worker/src/issues/domain.ts
@@ -6,7 +6,9 @@ export type IssueGroupingSource = "heuristic" | "llm" | "manual" | null;
 
 export type LinkedIncidentIssue = {
   incidentId: string;
+  issueId: string;
   title: string;
+  service: string | null;
   exceptionType: string;
   message: string | null;
   topFrame: string | null;
@@ -30,6 +32,29 @@ export function issueSample(issue: schema.Issue): IssueSample | null {
   return (issue.lastSample ?? null) as IssueSample | null;
 }
 
+const GROUPING_STACKTRACE_CAP = 4000;
+
+// Log-derived samples carry their traceback in logAttrs['exception.stacktrace']
+// (the OTel log-record convention) rather than the sample's own stacktrace
+// field — read both so log-kind issues aren't presented traceless.
+export function sampleStacktrace(sample: IssueSample | null): string | null {
+  const raw = sample?.stacktrace ?? sample?.logAttrs?.["exception.stacktrace"] ?? null;
+  return raw ? raw.slice(0, GROUPING_STACKTRACE_CAP) : null;
+}
+
+// Everything except the (potentially huge) inline stacktrace — code location,
+// route, request ids. Cheap, structured signal for the grouping agent.
+export function sampleLogAttrs(sample: IssueSample | null): Record<string, string> | null {
+  const attrs = sample?.logAttrs;
+  if (!attrs) return null;
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(attrs)) {
+    if (key === "exception.stacktrace") continue;
+    out[key] = String(value).slice(0, 300);
+  }
+  return Object.keys(out).length ? out : null;
+}
+
 export function groupingIssueInput(issue: schema.Issue): GroupingNewIssue {
   const sample = issueSample(issue);
   return {
@@ -41,9 +66,10 @@ export function groupingIssueInput(issue: schema.Issue): GroupingNewIssue {
     topFrame: issue.topFrame,
     normalizedFrames: issue.normalizedFrames ?? [],
     observedAt: issue.lastSeen.toISOString(),
-    stacktrace: sample?.stacktrace ?? null,
+    stacktrace: sampleStacktrace(sample),
     traceId: sample?.traceId ?? null,
     spanId: sample?.spanId ?? null,
+    logAttrs: sampleLogAttrs(sample),
   };
 }
 
@@ -105,13 +131,18 @@ export function findSameTraceIncidentMatch(
   };
 }
 
+// How many linked issues each candidate carries into inspect_incident. The
+// newest ones carry the freshest samples; older siblings add little.
+const GROUPING_CANDIDATE_ISSUE_LIMIT = 5;
+
 export function buildGroupingCandidate(
   incident: schema.Incident,
   linked: LinkedIncidentIssue[],
 ): GroupingCandidateIncident | null {
-  const representative = linked
+  const rows = linked
     .filter((row) => row.incidentId === incident.id)
-    .sort((a, b) => b.lastSeen.getTime() - a.lastSeen.getTime())[0];
+    .sort((a, b) => b.lastSeen.getTime() - a.lastSeen.getTime());
+  const representative = rows[0];
   if (!representative) return null;
   return {
     id: incident.id,
@@ -128,5 +159,22 @@ export function buildGroupingCandidate(
       traceId: representative.lastSample?.traceId ?? null,
       spanId: representative.lastSample?.spanId ?? null,
     },
+    // Full per-issue context (stack traces, code locations) so the agent can
+    // compare root causes instead of message wording. Surfaced by
+    // inspect_incident; the index line only uses the first entry.
+    issues: rows.slice(0, GROUPING_CANDIDATE_ISSUE_LIMIT).map((row) => ({
+      id: row.issueId,
+      title: row.title,
+      service: row.service,
+      exceptionType: row.exceptionType,
+      message: row.message,
+      topFrame: row.topFrame,
+      normalizedFrames: row.normalizedFrames ?? [],
+      traceId: row.lastSample?.traceId ?? null,
+      spanId: row.lastSample?.spanId ?? null,
+      logAttrs: sampleLogAttrs(row.lastSample),
+      stacktrace: sampleStacktrace(row.lastSample),
+      lastSeen: row.lastSeen.toISOString(),
+    })),
   };
 }

--- a/apps/worker/src/issues/repository.ts
+++ b/apps/worker/src/issues/repository.ts
@@ -97,7 +97,9 @@ export async function loadLinkedIncidentIssues(
   return db
     .select({
       incidentId: schema.incidentIssues.incidentId,
+      issueId: schema.issues.id,
       title: schema.issues.title,
+      service: schema.issues.service,
       exceptionType: schema.issues.exceptionType,
       message: schema.issues.message,
       topFrame: schema.issues.topFrame,


### PR DESCRIPTION
## Problem

The incident-grouping agent decides whether a new error issue joins an existing open incident. Its input was starved four ways:

1. The prompt showed only the **5 newest candidate titles** out of up to 200 open incidents (`INCIDENT_GROUPING_CANDIDATE_LIMIT`); everything else had to be discovered through blind `search_incidents` calls.
2. Candidates carried a single representative message — no stack trace, no code location, no sibling issues — even though `inspect_incident`'s description promised them and the `GroupingCandidateIncident.issues[]` field existed. `buildGroupingCandidate` simply never populated it.
3. Log-derived issues (the majority for Python services) lost their traceback entirely: it lives in `logAttrs['exception.stacktrace']`, which `groupingIssueInput` never read.
4. The tool loop was capped at 5 iterations — and when it ran out, the fallback was recorded as a considered `standalone` verdict. Mechanical failure masqueraded as a decision, silently minting duplicate incidents during exactly the bursts when grouping matters most.

## Changes

- **Full candidate index in the initial message** — one compact line per candidate (id, service, title, representative error, code location, issue count, last seen). ~40–60 tokens per candidate; a few hundred open incidents fit comfortably. Details stay behind `inspect_incident`.
- **Rich candidate context** — `buildGroupingCandidate` now populates `issues[]` (newest 5 linked issues) with capped stack traces and log attributes; `loadLinkedIncidentIssues` selects the extra columns.
- **New-issue tracebacks** — `groupingIssueInput` reads `sample.stacktrace ?? logAttrs['exception.stacktrace']` and forwards non-stacktrace `logAttrs` (code location, route).
- **Budget 5 → 12 iterations** (still env-overridable via `INCIDENT_GROUPING_TOOL_ITERATIONS`).
- **Honest failure accounting** — budget exhaustion and unparseable no-tool replies now carry a `mechanicalFailure` marker on the verdict. Intake records them as grouping state `failed` (not `standalone`) and logs at **error** level with the failure kind and candidate count. Runtime behavior is unchanged: the issue still gets its own incident immediately.
- **Queue observability** — the issue-transition queue reports `superlog.issue_transitions.queue_lag_ms` / `duration_ms` histograms and a `failures` counter, so consumers falling behind is visible and alertable.

## Validation

- Typecheck clean; grouping/intake/issue-domain/issue-transition suites green (4 new tests: mechanical-failure verdicts, failed-state intake path, log-sample stacktrace extraction).
- Replayed a captured burst-day corpus through the real agent: the day that produced ~38 incidents from 84 issues under the old input collapses to **13 — one per distinct root cause — with zero mechanical failures**.
- 24h shadow replay across three other projects (128 live calls, one with ~350 open candidates): no over-merging vs. what production recorded, zero mechanical failures, avg call 10–18s.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves incident grouping with a full candidate index, richer issue context, and honest failure handling; also honors raw standalone JSON replies. Adds queue health metrics, per-project transition serialization, and raises the tool-use budget for better resilience.

- **New Features**
  - Initial message lists every open candidate in one line each (id, service, title, representative error, code path, issue count, last seen); use `inspect_incident` for details.
  - Candidates include `issues[]` (up to 5 newest) with stack traces and key `logAttrs`; repository now selects the needed columns.
  - New-issue input reads `sample.stacktrace` or `logAttrs['exception.stacktrace']` and forwards non-traceback `logAttrs` (e.g., `code.file.path`).
  - Tool budget increased from 5 to 12 (override with `INCIDENT_GROUPING_TOOL_ITERATIONS`).
  - Issue-transition queue reports `superlog.issue_transitions.queue_lag_ms`, `superlog.issue_transitions.duration_ms`, and `superlog.issue_transitions.failures`; jobs carry `enqueuedAtMs`, and the worker serializes same-project transitions while parallelizing across projects.

- **Bug Fixes**
  - Honors raw standalone JSON replies (e.g., `{"decision":"standalone"}`) when the model skips tools; no failure marker.
  - Non-JSON text-only replies and budget exhaustion are marked as `mechanicalFailure` and recorded as grouping state `failed`; logged at error level.
  - Tests added for mechanical failures, failed-state intake, standalone-text parsing, and log-sample traceback extraction.

<sup>Written for commit bc02f6ba0546fa7c2e950faabcb832a5775c7a7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

