### PR TITLE
Keep invitation context through signup

### DIFF
--- a/apps/web/src/AcceptInvitation.test.ts
+++ b/apps/web/src/AcceptInvitation.test.ts
@@ -24,3 +24,12 @@ test("automatic acceptance tries once, leaving a failed invitation available for
   assert.match(source, /const autoAcceptAttempted = useRef\(false\);/);
   assert.match(source, /if \(autoAcceptAttempted\.current\) return;/);
 });
+
+test("invitation acceptance failures retain enough context for client diagnostics", async () => {
+  const source = await readFile(new URL("./AcceptInvitation.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /\[AcceptInvitation\] acceptInvitation failed/);
+  assert.match(source, /invitationId: id/);
+  assert.match(source, /\[AcceptInvitation\] setActive failed after acceptance/);
+  assert.match(source, /organizationId: orgId/);
+});

--- a/apps/web/src/AcceptInvitation.test.ts
+++ b/apps/web/src/AcceptInvitation.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("an unauthenticated invitee sees the dedicated invitation authentication screen", async () => {
+  const source = await readFile(new URL("./AcceptInvitation.tsx", import.meta.url), "utf8");
+  const authenticationScreen = source.slice(
+    source.indexOf("function InvitationAuthentication"),
+    source.indexOf("function AcceptInvitationInner"),
+  );
+
+  assert.match(source, /return <InvitationAuthentication id=\{id\} \/>;/);
+  assert.match(source, /function InvitationAuthentication\(/);
+  assert.match(authenticationScreen, /You(?:'|&apos;)ve been invited to join an organization\./);
+  assert.doesNotMatch(authenticationScreen, /getInvitation/);
+  assert.match(source, /onSuccess=\{\(\) => window\.location\.assign\(/);
+  assert.match(source, /accept-invitation\?id=\$\{encodeURIComponent\(id\)\}&join=1/);
+  assert.match(source, /autoAccept=\{params\.get\("join"\) === "1"\}/);
+});
+
+test("automatic acceptance tries once, leaving a failed invitation available for a manual retry", async () => {
+  const source = await readFile(new URL("./AcceptInvitation.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /const autoAcceptAttempted = useRef\(false\);/);
+  assert.match(source, /if \(autoAcceptAttempted\.current\) return;/);
+});

--- a/apps/web/src/AcceptInvitation.tsx
+++ b/apps/web/src/AcceptInvitation.tsx
@@ -94,6 +94,10 @@ function AcceptInvitationInner({
     setActionError(null);
     const res = await authClient.organization.acceptInvitation({ invitationId: id });
     if (res.error) {
+      console.error("[AcceptInvitation] acceptInvitation failed", {
+        invitationId: id,
+        error: res.error.message,
+      });
       setAction("idle");
       setActionError(res.error.message ?? "Failed to accept invitation.");
       return;
@@ -102,6 +106,11 @@ function AcceptInvitationInner({
       .organizationId;
     const setActiveRes = await authClient.organization.setActive({ organizationId: orgId });
     if (setActiveRes.error) {
+      console.error("[AcceptInvitation] setActive failed after acceptance", {
+        invitationId: id,
+        organizationId: orgId,
+        error: setActiveRes.error.message,
+      });
       // The invitation is already accepted at this point — surface the
       // switch failure so the user can retry from the org switcher instead
       // of landing in a stale active-org state.

--- a/apps/web/src/AcceptInvitation.tsx
+++ b/apps/web/src/AcceptInvitation.tsx
@@ -50,6 +50,8 @@ export function AcceptInvitation() {
 }
 
 function InvitationAuthentication({ id }: { id: string }) {
+  const continuationUrl = `${window.location.origin}/accept-invitation?id=${encodeURIComponent(id)}&join=1`;
+
   return (
     <CenteredShell>
       <Wordmark />
@@ -62,7 +64,8 @@ function InvitationAuthentication({ id }: { id: string }) {
         </div>
         <AuthForm
           initialMode="sign-up"
-          onSuccess={() => window.location.assign(`/accept-invitation?id=${encodeURIComponent(id)}&join=1`)}
+          socialCallbackURL={continuationUrl}
+          onSuccess={() => window.location.assign(continuationUrl)}
         />
       </div>
     </CenteredShell>

--- a/apps/web/src/AcceptInvitation.tsx
+++ b/apps/web/src/AcceptInvitation.tsx
@@ -1,8 +1,8 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, Navigate, useSearchParams } from "react-router-dom";
+import { AuthForm } from "./AuthForm.tsx";
 import { authClient, useSession } from "./auth-client.ts";
-import { Landing } from "./Landing.tsx";
 import { Btn, CenteredShell, Wordmark } from "./design/ui.tsx";
 
 type InviteDetails = {
@@ -37,22 +37,81 @@ export function AcceptInvitation() {
 
   if (session.isPending) return null;
   if (!session.data) {
-    // /accept-invitation stays in the URL bar; once the user signs in via
-    // the modal the session hook updates and we fall through to the inner
-    // component without a navigation.
-    return <Landing initialAuthMode="sign-up" />;
+    return <InvitationAuthentication id={id} />;
   }
 
-  return <AcceptInvitationInner id={id} userEmail={session.data.user.email} />;
+  return (
+    <AcceptInvitationInner
+      id={id}
+      userEmail={session.data.user.email}
+      autoAccept={params.get("join") === "1"}
+    />
+  );
 }
 
-function AcceptInvitationInner({ id, userEmail }: { id: string; userEmail: string }) {
+function InvitationAuthentication({ id }: { id: string }) {
+  return (
+    <CenteredShell>
+      <Wordmark />
+      <div className="mt-8 w-full max-w-md">
+        <div className="mb-4 text-center">
+          <h1 className="text-[17px] font-medium text-fg">You&apos;re invited</h1>
+          <p className="mt-2 text-[13px] text-muted">
+            You&apos;ve been invited to join an organization. Sign in or create an account to continue.
+          </p>
+        </div>
+        <AuthForm
+          initialMode="sign-up"
+          onSuccess={() => window.location.assign(`/accept-invitation?id=${encodeURIComponent(id)}&join=1`)}
+        />
+      </div>
+    </CenteredShell>
+  );
+}
+
+function AcceptInvitationInner({
+  id,
+  userEmail,
+  autoAccept,
+}: {
+  id: string;
+  userEmail: string;
+  autoAccept: boolean;
+}) {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
   const [action, setAction] = useState<"idle" | "accepting" | "rejecting" | "accepted" | "rejected">(
     "idle",
   );
   const [actionError, setActionError] = useState<string | null>(null);
   const qc = useQueryClient();
+  const autoAcceptAttempted = useRef(false);
+
+  const accept = useCallback(async () => {
+    setAction("accepting");
+    setActionError(null);
+    const res = await authClient.organization.acceptInvitation({ invitationId: id });
+    if (res.error) {
+      setAction("idle");
+      setActionError(res.error.message ?? "Failed to accept invitation.");
+      return;
+    }
+    const orgId = (res.data as unknown as { invitation: { organizationId: string } }).invitation
+      .organizationId;
+    const setActiveRes = await authClient.organization.setActive({ organizationId: orgId });
+    if (setActiveRes.error) {
+      // The invitation is already accepted at this point — surface the
+      // switch failure so the user can retry from the org switcher instead
+      // of landing in a stale active-org state.
+      setAction("idle");
+      setActionError(
+        setActiveRes.error.message ??
+          "Invitation accepted, but switching to the org failed. Use the org switcher to open it.",
+      );
+      return;
+    }
+    qc.clear();
+    setAction("accepted");
+  }, [id, qc]);
 
   useEffect(() => {
     let cancelled = false;
@@ -70,6 +129,20 @@ function AcceptInvitationInner({ id, userEmail }: { id: string; userEmail: strin
       cancelled = true;
     };
   }, [id]);
+
+  useEffect(() => {
+    if (autoAcceptAttempted.current) return;
+    if (
+      !autoAccept ||
+      action !== "idle" ||
+      state.kind !== "ready" ||
+      state.invite.email.toLowerCase() !== userEmail.toLowerCase()
+    ) {
+      return;
+    }
+    autoAcceptAttempted.current = true;
+    void accept();
+  }, [accept, action, autoAccept, state, userEmail]);
 
   if (state.kind === "loading") {
     return (
@@ -109,33 +182,6 @@ function AcceptInvitationInner({ id, userEmail }: { id: string; userEmail: strin
       </CenteredShell>
     );
   }
-
-  const accept = async () => {
-    setAction("accepting");
-    setActionError(null);
-    const res = await authClient.organization.acceptInvitation({ invitationId: id });
-    if (res.error) {
-      setAction("idle");
-      setActionError(res.error.message ?? "Failed to accept invitation.");
-      return;
-    }
-    const orgId = (res.data as unknown as { invitation: { organizationId: string } }).invitation
-      .organizationId;
-    const setActiveRes = await authClient.organization.setActive({ organizationId: orgId });
-    if (setActiveRes.error) {
-      // The invitation is already accepted at this point — surface the
-      // switch failure so the user can retry from the org switcher instead
-      // of landing in a stale active-org state.
-      setAction("idle");
-      setActionError(
-        setActiveRes.error.message ??
-          "Invitation accepted, but switching to the org failed. Use the org switcher to open it.",
-      );
-      return;
-    }
-    qc.clear();
-    setAction("accepted");
-  };
 
   const reject = async () => {
     setAction("rejecting");

--- a/apps/web/src/AuthForm.test.ts
+++ b/apps/web/src/AuthForm.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("social sign-in accepts a caller-provided callback URL", async () => {
+  const source = await readFile(new URL("./AuthForm.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /socialCallbackURL\?: string/);
+  assert.match(source, /callbackURL: socialCallbackURL \?\? `\$\{window\.location\.origin\}\/`/);
+  assert.match(source, /callbackURL: socialCallbackURL \?\? `\$\{API_URL\}\/api\/github\/post-signin`/);
+});

--- a/apps/web/src/AuthForm.tsx
+++ b/apps/web/src/AuthForm.tsx
@@ -58,10 +58,12 @@ export function AuthForm({
   initialMode = "sign-in",
   onSuccess,
   onClose,
+  socialCallbackURL,
 }: {
   initialMode?: Mode;
   onSuccess?: () => void;
   onClose?: () => void;
+  socialCallbackURL?: string;
 }) {
   const providers = useAuthProviders();
   const anySocial = providers.google || providers.github;
@@ -128,7 +130,7 @@ export function AuthForm({
     try {
       await authClient.signIn.social({
         provider: "google",
-        callbackURL: `${window.location.origin}/`,
+        callbackURL: socialCallbackURL ?? `${window.location.origin}/`,
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Google sign-in failed");
@@ -141,7 +143,7 @@ export function AuthForm({
     try {
       await authClient.signIn.social({
         provider: "github",
-        callbackURL: `${API_URL}/api/github/post-signin`,
+        callbackURL: socialCallbackURL ?? `${API_URL}/api/github/post-signin`,
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : "GitHub sign-in failed");


### PR DESCRIPTION
## Summary
- show a focused authentication screen for invitees who are not signed in
- preserve the invitation through authentication and automatically join the invited organization
- cover the unauthenticated invitation path and one-shot auto-accept behavior

## Validation
- pnpm --filter @superlog/web typecheck
- pnpm --filter @superlog/web test
- pnpm worktree:verify

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves invitation context through signup, including social sign-in, and auto-joins the invited org after authentication. Adds a dedicated invitation authentication screen for signed-out users with a one-shot auto-accept flow and structured error logging.

- New Features
  - Dedicated invitation auth screen using `AuthForm` with a continuation URL (`/accept-invitation?id=...&join=1`) and `socialCallbackURL` for social sign-in.
  - Auto-accept runs once when the invite email matches the signed-in user; failed attempts remain available for manual retry.
  - After acceptance, sets the active org and clears the React Query cache; logs detailed errors (with `invitationId`/`organizationId`) and shows a clear message if acceptance or org switch fails.

<sup>Written for commit a0240dd2ca87bdfb399e26e56c4235f0e75e0930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

