### PR TITLE
Expose Linear issue creation to incident agents

### DIFF
--- a/apps/worker/src/agent-chats/workflow.test.ts
+++ b/apps/worker/src/agent-chats/workflow.test.ts
@@ -66,6 +66,7 @@ function snapshot(overrides: Partial<AgentRunnerSnapshot> = {}): AgentRunnerSnap
     activeSeconds: 30,
     events: [],
     result: null,
+    declaredCustomToolNames: [],
     unknownCustomTools: [],
     latestMessage: "The deploy at 02:10 broke checkout.",
     modelUsage: {

--- a/apps/worker/src/agent-outcome-tools.test.ts
+++ b/apps/worker/src/agent-outcome-tools.test.ts
@@ -338,6 +338,7 @@ test("create_linear_issue completes a findings handoff without resolving the inc
   });
   assert.equal(result.state, "complete");
   assert.equal(result.completionKind, "investigation_complete");
+  assert.equal(result.linearTicketRequested, true);
   assert.equal(result.incidentResolution, undefined);
 });
 

--- a/apps/worker/src/agent-outcome-tools.test.ts
+++ b/apps/worker/src/agent-outcome-tools.test.ts
@@ -108,6 +108,7 @@ test("exposes the desired outcome tools with API-safe schemas", () => {
     [
       "report_findings",
       "propose_pr",
+      "create_linear_issue",
       "complete_investigation",
       "ask_human",
       "report_external_cause",
@@ -134,6 +135,7 @@ test("splits the contract into dispatched and terminal tools", () => {
     [...TERMINAL_OUTCOME_TOOL_NAMES],
     [
       "propose_pr",
+      "create_linear_issue",
       "complete_investigation",
       "ask_human",
       "report_external_cause",
@@ -152,6 +154,7 @@ test("offers complete_investigation only when no intervention tool is available"
   const withPrs = outcomeToolDefinitionsForCapabilities({
     prCreation: true,
     approvalPrompts: false,
+    linearTicketCreation: false,
   }).map((definition) => definition.name);
   assert.ok(withPrs.includes("propose_pr"));
   assert.ok(!withPrs.includes("complete_investigation"));
@@ -159,6 +162,7 @@ test("offers complete_investigation only when no intervention tool is available"
   const ticketOnly = outcomeToolDefinitionsForCapabilities({
     prCreation: false,
     approvalPrompts: false,
+    linearTicketCreation: false,
   }).map((definition) => definition.name);
   assert.ok(!ticketOnly.includes("propose_pr"));
   assert.ok(ticketOnly.includes("complete_investigation"));
@@ -166,8 +170,25 @@ test("offers complete_investigation only when no intervention tool is available"
   const withApprovals = outcomeToolDefinitionsForCapabilities({
     prCreation: false,
     approvalPrompts: true,
+    linearTicketCreation: false,
   }).map((definition) => definition.name);
   assert.ok(!withApprovals.includes("complete_investigation"));
+});
+
+test("offers create_linear_issue whenever Linear ticket creation is available", () => {
+  const withEveryIntervention = outcomeToolDefinitionsForCapabilities({
+    prCreation: true,
+    approvalPrompts: true,
+    linearTicketCreation: true,
+  }).map((definition) => definition.name);
+  assert.ok(withEveryIntervention.includes("create_linear_issue"));
+
+  const withoutLinear = outcomeToolDefinitionsForCapabilities({
+    prCreation: true,
+    approvalPrompts: true,
+    linearTicketCreation: false,
+  }).map((definition) => definition.name);
+  assert.ok(!withoutLinear.includes("create_linear_issue"));
 });
 
 // The load-bearing guidance in tool descriptions. Losing any of these
@@ -285,6 +306,7 @@ test("requires findings before findings-backed terminal tools", () => {
       },
     ],
     ["complete_investigation", {}],
+    ["create_linear_issue", {}],
   ];
   for (const [name, input] of cases) {
     const v = validateOutcomeToolInput(name, input, { hasFindings: false });
@@ -300,6 +322,19 @@ test("complete_investigation finishes without resolving the incident", () => {
   const result = assembleAgentRunResult({
     findings: FINDINGS,
     terminal: { name: "complete_investigation", payload: {} },
+  });
+  assert.equal(result.state, "complete");
+  assert.equal(result.completionKind, "investigation_complete");
+  assert.equal(result.incidentResolution, undefined);
+});
+
+test("create_linear_issue completes a findings handoff without resolving the incident", () => {
+  const validation = validateOutcomeToolInput("create_linear_issue", {}, { hasFindings: true });
+  assert.equal(validation.ok, true);
+
+  const result = assembleAgentRunResult({
+    findings: FINDINGS,
+    terminal: { name: "create_linear_issue", payload: {} },
   });
   assert.equal(result.state, "complete");
   assert.equal(result.completionKind, "investigation_complete");

--- a/apps/worker/src/agent-outcome-tools.ts
+++ b/apps/worker/src/agent-outcome-tools.ts
@@ -1140,6 +1140,9 @@ export function assembleAgentRunResult(args: {
   if (terminal?.name === "complete_investigation" || terminal?.name === "create_linear_issue") {
     result.completionKind = "investigation_complete";
   }
+  if (terminal?.name === "create_linear_issue") {
+    result.linearTicketRequested = true;
+  }
   if (terminal?.name === "ask_human") {
     result.question = terminal.payload.question;
   }

--- a/apps/worker/src/agent-outcome-tools.ts
+++ b/apps/worker/src/agent-outcome-tools.ts
@@ -48,6 +48,7 @@ export const DISPATCHED_OUTCOME_TOOL_NAMES = ["propose_pr", "resolve_incident"] 
 
 export const TERMINAL_OUTCOME_TOOL_NAMES = [
   "propose_pr",
+  "create_linear_issue",
   "complete_investigation",
   "ask_human",
   "report_external_cause",
@@ -389,6 +390,19 @@ export type AskHumanPayload = { question: string };
 
 export type CompleteInvestigationPayload = Record<string, never>;
 
+export type CreateLinearIssuePayload = Record<string, never>;
+
+const CREATE_LINEAR_ISSUE_DEFINITION: OutcomeToolDefinition = {
+  name: "create_linear_issue",
+  description:
+    "Terminal: create or reuse exactly one Linear issue for this investigation from the recorded findings, then complete the run while leaving the Incident open. Use this after report_findings when a human asks for a Linear issue or the findings need an explicit Linear handoff. The platform performs the Linear mutation idempotently; do not try to call Linear directly.",
+  input_schema: {
+    type: "object",
+    properties: {},
+    required: [],
+  },
+};
+
 const COMPLETE_INVESTIGATION_DEFINITION: OutcomeToolDefinition = {
   name: "complete_investigation",
   description:
@@ -427,6 +441,7 @@ export const OUTCOME_TOOL_DEFINITIONS: OutcomeToolDefinition[] = [
 export type AgentInterventionCapabilities = {
   prCreation: boolean;
   approvalPrompts: boolean;
+  linearTicketCreation: boolean;
 };
 
 export function hasInterventionTools(capabilities: AgentInterventionCapabilities): boolean {
@@ -439,7 +454,10 @@ export function outcomeToolDefinitionsForCapabilities(
   return [
     REPORT_FINDINGS_DEFINITION,
     ...(capabilities.prCreation ? [PROPOSE_PR_DEFINITION] : []),
-    ...(!hasInterventionTools(capabilities) ? [COMPLETE_INVESTIGATION_DEFINITION] : []),
+    ...(capabilities.linearTicketCreation ? [CREATE_LINEAR_ISSUE_DEFINITION] : []),
+    ...(!hasInterventionTools(capabilities) && !capabilities.linearTicketCreation
+      ? [COMPLETE_INVESTIGATION_DEFINITION]
+      : []),
     ASK_HUMAN_DEFINITION,
     REPORT_EXTERNAL_CAUSE_DEFINITION,
     RESOLVE_INCIDENT_DEFINITION,
@@ -452,6 +470,7 @@ export function outcomeToolDefinitionsForCapabilities(
 
 export type TerminalOutcome =
   | { name: "propose_pr"; payload: ProposePrPayload }
+  | { name: "create_linear_issue"; payload: CreateLinearIssuePayload }
   | { name: "complete_investigation"; payload: CompleteInvestigationPayload }
   | { name: "ask_human"; payload: AskHumanPayload }
   | { name: "report_external_cause"; payload: ReportExternalCausePayload }
@@ -492,6 +511,7 @@ export type ValidatedLegacyOutcome =
 const FINDINGS_REQUIRED = new Set<string>([
   "propose_pr",
   "resolve_incident",
+  "create_linear_issue",
   "complete_investigation",
   "report_external_cause",
 ]);
@@ -868,6 +888,9 @@ export function validateOutcomeToolInput(
     case "complete_investigation":
       return { ok: true, tool: "complete_investigation", payload: {} };
 
+    case "create_linear_issue":
+      return { ok: true, tool: "create_linear_issue", payload: {} };
+
     case "ask_human": {
       const question = pushRequiredString(errors, input, "question");
       if (errors.length > 0) return { ok: false, errors };
@@ -1114,7 +1137,7 @@ export function assembleAgentRunResult(args: {
     }
     result.issueClassifications = [...classificationsByIssue.values()];
   }
-  if (terminal?.name === "complete_investigation") {
+  if (terminal?.name === "complete_investigation" || terminal?.name === "create_linear_issue") {
     result.completionKind = "investigation_complete";
   }
   if (terminal?.name === "ask_human") {

--- a/apps/worker/src/agent-runner-backend.ts
+++ b/apps/worker/src/agent-runner-backend.ts
@@ -128,6 +128,9 @@ export type AgentRunnerStartInput = {
   // True only when at least one currently registered integration operation
   // is implemented as an approval prompt for this run.
   approvalPromptToolsAvailable: boolean;
+  // True when this run has an active, usable Linear installation. The runner
+  // exposes the idempotent ticket-handoff command only in that case.
+  linearTicketCreationAvailable: boolean;
   prBaseBranch: string | null;
   githubConnected: boolean;
   telemetryInvestigationHint: string;

--- a/apps/worker/src/agent-runner-backend.ts
+++ b/apps/worker/src/agent-runner-backend.ts
@@ -220,6 +220,10 @@ export type AgentRunnerSnapshot = {
   // with an error result so the session can leave requires_action; sync.ts
   // then fails the run with `unknown_custom_tool` so we can audit them later.
   unknownCustomTools: Array<{ toolUseId: string; name: string }>;
+  // Custom tools fixed in the provider session's start-time schema. Runtimes
+  // that can recover this list should return it so later nudges never
+  // advertise a tool that was connected only after the session started.
+  declaredCustomToolNames?: string[];
   // How many custom_tool_result acks this collect pass sent. When > 0 the
   // `status` above is stale — it was captured before the acks went out and
   // the model is about to resume with the tool results. sync.ts uses this to

--- a/apps/worker/src/agent-runner-backend.ts
+++ b/apps/worker/src/agent-runner-backend.ts
@@ -223,7 +223,7 @@ export type AgentRunnerSnapshot = {
   // Custom tools fixed in the provider session's start-time schema. Runtimes
   // that can recover this list should return it so later nudges never
   // advertise a tool that was connected only after the session started.
-  declaredCustomToolNames?: string[];
+  declaredCustomToolNames: string[];
   // How many custom_tool_result acks this collect pass sent. When > 0 the
   // `status` above is stale — it was captured before the acks went out and
   // the model is about to resume with the tool results. sync.ts uses this to

--- a/apps/worker/src/agent-runs/completion-policy.test.ts
+++ b/apps/worker/src/agent-runs/completion-policy.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  linearHandoffTerminalOutcome,
   shouldCreateLinearTicketForTerminalOutcome,
   shouldOfferOpenPr,
 } from "./completion-policy.js";
@@ -11,6 +12,17 @@ test("complete_investigation always attempts the connected Linear handoff", () =
 
 test("create_linear_issue always attempts the connected Linear handoff", () => {
   assert.equal(shouldCreateLinearTicketForTerminalOutcome("create_linear_issue", false), true);
+});
+
+test("the persisted explicit request retains the create_linear_issue terminal outcome", () => {
+  assert.equal(
+    linearHandoffTerminalOutcome({ linearTicketRequested: true }),
+    "create_linear_issue",
+  );
+  assert.equal(
+    linearHandoffTerminalOutcome({ linearTicketRequested: false }),
+    "complete_investigation",
+  );
 });
 
 test("resolve_incident follows the project's create-ticket-on-resolve toggle", () => {

--- a/apps/worker/src/agent-runs/completion-policy.test.ts
+++ b/apps/worker/src/agent-runs/completion-policy.test.ts
@@ -9,6 +9,10 @@ test("complete_investigation always attempts the connected Linear handoff", () =
   assert.equal(shouldCreateLinearTicketForTerminalOutcome("complete_investigation", false), true);
 });
 
+test("create_linear_issue always attempts the connected Linear handoff", () => {
+  assert.equal(shouldCreateLinearTicketForTerminalOutcome("create_linear_issue", false), true);
+});
+
 test("resolve_incident follows the project's create-ticket-on-resolve toggle", () => {
   assert.equal(shouldCreateLinearTicketForTerminalOutcome("resolve_incident", true), true);
   assert.equal(shouldCreateLinearTicketForTerminalOutcome("resolve_incident", false), false);

--- a/apps/worker/src/agent-runs/completion-policy.ts
+++ b/apps/worker/src/agent-runs/completion-policy.ts
@@ -5,6 +5,12 @@ export type TicketCreatingTerminalOutcome =
   | "complete_investigation"
   | "resolve_incident";
 
+export function linearHandoffTerminalOutcome(
+  result: Pick<AgentRunResult, "linearTicketRequested">,
+): Extract<TicketCreatingTerminalOutcome, "create_linear_issue" | "complete_investigation"> {
+  return result.linearTicketRequested ? "create_linear_issue" : "complete_investigation";
+}
+
 export function shouldCreateLinearTicketForTerminalOutcome(
   outcome: TicketCreatingTerminalOutcome,
   createOnResolve: boolean,

--- a/apps/worker/src/agent-runs/completion-policy.ts
+++ b/apps/worker/src/agent-runs/completion-policy.ts
@@ -1,12 +1,17 @@
 import type { AgentRunResult, PrPolicy } from "@superlog/db";
 
-export type TicketCreatingTerminalOutcome = "complete_investigation" | "resolve_incident";
+export type TicketCreatingTerminalOutcome =
+  | "create_linear_issue"
+  | "complete_investigation"
+  | "resolve_incident";
 
 export function shouldCreateLinearTicketForTerminalOutcome(
   outcome: TicketCreatingTerminalOutcome,
   createOnResolve: boolean,
 ): boolean {
-  return outcome === "complete_investigation" || createOnResolve;
+  return (
+    outcome === "create_linear_issue" || outcome === "complete_investigation" || createOnResolve
+  );
 }
 
 export function shouldOfferOpenPr(input: {

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -613,6 +613,18 @@ export async function completeWithoutPullRequest(
         }
         let deliveredTicket = null;
         try {
+          if (explicitLinearHandoff && !shouldCreateTicket) {
+            logger.error(
+              {
+                scope: "agent_run.linear_handoff",
+                agent_run_id: ctx.agentRun.id,
+                incident_id: ctx.incident.id,
+                terminal_outcome: terminalOutcome,
+                should_create_ticket: shouldCreateTicket,
+              },
+              "explicit Linear handoff skipped by completion policy",
+            );
+          }
           deliveredTicket = shouldCreateTicket
             ? await scheduleLinearHandoff(
                 ctx,
@@ -653,6 +665,8 @@ export async function completeWithoutPullRequest(
               agent_run_id: ctx.agentRun.id,
               incident_id: ctx.incident.id,
               terminal_outcome: terminalOutcome,
+              should_create_ticket: shouldCreateTicket,
+              delivered_ticket: !!deliveredTicket,
             },
             "explicit Linear handoff returned without a ticket",
           );

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -628,7 +628,7 @@ export async function completeWithoutPullRequest(
                 agent_run_id: ctx.agentRun.id,
                 incident_id: ctx.incident.id,
                 terminal_outcome: terminalOutcome,
-                err: err instanceof Error ? err.message : String(err),
+                err,
               },
               "explicit Linear handoff failed",
             );

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -36,6 +36,7 @@ import {
 import { logger } from "../logger.js";
 import { enqueueAgentRunCompleted } from "../webhooks.js";
 import {
+  linearHandoffTerminalOutcome,
   shouldCreateLinearTicketForTerminalOutcome,
   shouldOfferOpenPr,
 } from "./completion-policy.js";
@@ -593,11 +594,47 @@ export async function completeWithoutPullRequest(
           state: "complete",
         }),
       publish: async () => {
-        const deliveredTicket = await scheduleLinearHandoff(
-          ctx,
-          completionResult,
-          completionResult.completionKind ?? "complete_without_pr",
+        const terminalOutcome = linearHandoffTerminalOutcome(completionResult);
+        const explicitLinearHandoff = terminalOutcome === "create_linear_issue";
+        const shouldCreateTicket = shouldCreateLinearTicketForTerminalOutcome(
+          terminalOutcome,
+          false,
         );
+        if (explicitLinearHandoff) {
+          logger.info(
+            {
+              scope: "agent_run.linear_handoff",
+              agent_run_id: ctx.agentRun.id,
+              incident_id: ctx.incident.id,
+              terminal_outcome: terminalOutcome,
+            },
+            "scheduling explicit Linear handoff",
+          );
+        }
+        let deliveredTicket = null;
+        try {
+          deliveredTicket = shouldCreateTicket
+            ? await scheduleLinearHandoff(
+                ctx,
+                completionResult,
+                completionResult.completionKind ?? "complete_without_pr",
+              )
+            : null;
+        } catch (err) {
+          if (explicitLinearHandoff) {
+            logger.error(
+              {
+                scope: "agent_run.linear_handoff",
+                agent_run_id: ctx.agentRun.id,
+                incident_id: ctx.incident.id,
+                terminal_outcome: terminalOutcome,
+                err: err instanceof Error ? err.message : String(err),
+              },
+              "explicit Linear handoff failed",
+            );
+          }
+          throw err;
+        }
         if (!deliveredTicket && completionResult.linearTicket) {
           await recordFiledLinearTicket(ctx, completionResult.linearTicket);
         }
@@ -609,6 +646,17 @@ export async function completeWithoutPullRequest(
                 url: completionResult.linearTicket.url ?? null,
               }
             : null;
+        if (explicitLinearHandoff && !ticket) {
+          logger.error(
+            {
+              scope: "agent_run.linear_handoff",
+              agent_run_id: ctx.agentRun.id,
+              incident_id: ctx.incident.id,
+              terminal_outcome: terminalOutcome,
+            },
+            "explicit Linear handoff returned without a ticket",
+          );
+        }
         logger.info(
           {
             scope: "agent_run",

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -143,6 +143,22 @@ test("startQueuedAgentRunWorkflow exposes ask_human as an approval boundary", as
   assert.equal(approvalPromptToolsAvailable, true);
 });
 
+test("startQueuedAgentRunWorkflow exposes Linear ticket creation only for an active install", async () => {
+  const calls: string[] = [];
+  const ctx = makeContext();
+  ctx.linearInstall = { id: "linear-install-1" } as schema.LinearInstallation;
+  let linearTicketCreationAvailable: boolean | null = null;
+
+  await startQueuedAgentRunWorkflow(
+    ctx,
+    makeDeps(calls, {}, (input) => {
+      linearTicketCreationAvailable = input.linearTicketCreationAvailable;
+    }),
+  );
+
+  assert.equal(linearTicketCreationAvailable, true);
+});
+
 test("startQueuedAgentRunWorkflow passes agent memories to the runner", async () => {
   const calls: string[] = [];
   const ctx = makeContext();

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -320,6 +320,7 @@ async function startRunnerSession(
         // project setting decides whether it counts as an available
         // intervention when terminal tools are registered.
         approvalPromptToolsAvailable: true,
+        linearTicketCreationAvailable: !!ctx.linearInstall,
         prBaseBranch: ctx.prBaseBranch,
         githubConnected: ctx.githubInstalls.length > 0,
         telemetryInvestigationHint: TELEMETRY_INVESTIGATION_HINT,

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -20,6 +20,7 @@ import {
   shouldFailForRuntimeBudget,
   shouldParkCompatibilityPullRequests,
   steerIdleRunnerWithPendingContext,
+  terminalOutcomeNudgeCapabilities,
   terminalOutcomeNudgePrompt,
 } from "./sync.js";
 
@@ -843,6 +844,45 @@ test("terminalOutcomeNudgePrompt keeps PR creation alongside the Linear handoff"
   });
   assert.match(prompt, /create_linear_issue/);
   assert.match(prompt, /propose_pr/);
+});
+
+test("terminalOutcomeNudgeCapabilities uses the tools declared for the running session", () => {
+  assert.deepEqual(
+    terminalOutcomeNudgeCapabilities(
+      { declaredCustomToolNames: ["report_findings", "propose_pr"] },
+      { prCreationAvailable: false, completeInvestigationAvailable: true },
+    ),
+    {
+      prCreationAvailable: true,
+      linearTicketCreationAvailable: false,
+      completeInvestigationAvailable: false,
+    },
+  );
+  assert.deepEqual(
+    terminalOutcomeNudgeCapabilities(
+      { declaredCustomToolNames: ["report_findings", "create_linear_issue"] },
+      { prCreationAvailable: true, completeInvestigationAvailable: false },
+    ),
+    {
+      prCreationAvailable: false,
+      linearTicketCreationAvailable: true,
+      completeInvestigationAvailable: false,
+    },
+  );
+});
+
+test("terminalOutcomeNudgeCapabilities does not add Linear to legacy snapshots", () => {
+  assert.deepEqual(
+    terminalOutcomeNudgeCapabilities(
+      {},
+      { prCreationAvailable: true, completeInvestigationAvailable: false },
+    ),
+    {
+      prCreationAvailable: true,
+      linearTicketCreationAvailable: false,
+      completeInvestigationAvailable: false,
+    },
+  );
 });
 
 test("partialPullRequestRetryNudgePrompt requires exactly the pending repositories", () => {

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -446,6 +446,26 @@ test("complete_investigation is rejected when an intervention is available", () 
   );
 });
 
+test("an explicit Linear handoff is allowed when another intervention is available", () => {
+  assert.equal(
+    isCompleteInvestigationAllowed(
+      {
+        state: "complete",
+        summary: "Findings ready for the owning team.",
+        completionKind: "investigation_complete",
+        linearTicketRequested: true,
+      },
+      {
+        prPolicy: "always",
+        githubConnected: true,
+        approvalPromptsEnabled: true,
+        approvalPromptToolsAvailable: true,
+      },
+    ),
+    true,
+  );
+});
+
 test("steerIdleRunnerWithPendingContext steers idle sessions with joined context deltas", async () => {
   const steered: Array<{ sessionId: string; message: string }> = [];
   const processedIds: string[][] = [];
@@ -802,6 +822,15 @@ test("terminalOutcomeNudgePrompt uses complete_investigation when interventions 
   const prompt = terminalOutcomeNudgePrompt({ completeInvestigationAvailable: true });
   assert.match(prompt, /complete_investigation/);
   assert.doesNotMatch(prompt, /propose_pr/);
+});
+
+test("terminalOutcomeNudgePrompt preserves the explicit Linear handoff", () => {
+  const prompt = terminalOutcomeNudgePrompt({
+    completeInvestigationAvailable: true,
+    linearTicketCreationAvailable: true,
+  });
+  assert.match(prompt, /create_linear_issue/);
+  assert.doesNotMatch(prompt, /complete_investigation/);
 });
 
 test("partialPullRequestRetryNudgePrompt requires exactly the pending repositories", () => {

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -828,9 +828,21 @@ test("terminalOutcomeNudgePrompt preserves the explicit Linear handoff", () => {
   const prompt = terminalOutcomeNudgePrompt({
     completeInvestigationAvailable: true,
     linearTicketCreationAvailable: true,
+    prCreationAvailable: false,
   });
   assert.match(prompt, /create_linear_issue/);
   assert.doesNotMatch(prompt, /complete_investigation/);
+  assert.doesNotMatch(prompt, /propose_pr/);
+});
+
+test("terminalOutcomeNudgePrompt keeps PR creation alongside the Linear handoff", () => {
+  const prompt = terminalOutcomeNudgePrompt({
+    completeInvestigationAvailable: false,
+    linearTicketCreationAvailable: true,
+    prCreationAvailable: true,
+  });
+  assert.match(prompt, /create_linear_issue/);
+  assert.match(prompt, /propose_pr/);
 });
 
 test("partialPullRequestRetryNudgePrompt requires exactly the pending repositories", () => {

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -472,6 +472,13 @@ export function terminalOutcomeNudgeCapabilities(
 } {
   const declared = snapshot.declaredCustomToolNames;
   if (!declared) {
+    logger.info(
+      {
+        scope: "agent_run.nudge",
+        fallback_capabilities: fallback,
+      },
+      "terminal outcome nudge is using legacy snapshot capabilities",
+    );
     return {
       ...fallback,
       linearTicketCreationAvailable: false,

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -439,15 +439,22 @@ export function terminalOutcomeNudgePrompt(
   args: {
     completeInvestigationAvailable?: boolean;
     linearTicketCreationAvailable?: boolean;
+    prCreationAvailable?: boolean;
   } = {},
 ): string {
+  const terminalTools: string[] = [];
+  const prCreationAvailable = args.prCreationAvailable ?? !args.completeInvestigationAvailable;
+  if (prCreationAvailable) terminalTools.push("batched `propose_pr`");
+  if (args.linearTicketCreationAvailable) terminalTools.push("`create_linear_issue`");
+  else if (args.completeInvestigationAvailable) terminalTools.push("`complete_investigation`");
+  terminalTools.push(
+    "`resolve_incident` with all Issue outcomes",
+    "`report_external_cause`",
+    "`ask_human`",
+  );
   return [
     TERMINAL_OUTCOME_NUDGE_MARKER,
-    args.linearTicketCreationAvailable
-      ? "Call `report_findings` now, then explicitly end your turn with `create_linear_issue`, `report_external_cause`, `resolve_incident` with all Issue outcomes, or `ask_human`."
-      : args.completeInvestigationAvailable
-        ? "Call `report_findings` now, then explicitly end your turn with `complete_investigation`, `report_external_cause`, `resolve_incident` with all Issue outcomes, or `ask_human`."
-        : "Call `report_findings` now if you have findings to record, then end the turn with exactly one terminal tool: batched `propose_pr`, `resolve_incident` with all Issue outcomes, `report_external_cause`, or `ask_human`.",
+    `Call \`report_findings\` now if you have findings to record, then end the turn with exactly one terminal tool: ${terminalTools.join(", ")}.`,
   ].join("\n");
 }
 
@@ -1424,6 +1431,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
               approvalPromptToolsAvailable: true,
             }),
             linearTicketCreationAvailable: !!ctx.linearInstall,
+            prCreationAvailable: ctx.githubInstalls.length > 0 && ctx.prPolicy !== "never",
           });
         const redeliveryMarker = partialRetryPrompt
           ? `${PARTIAL_PULL_REQUEST_RETRY_NUDGE_MARKER} ${JSON.stringify(pendingRepoFullNames)}`

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -123,6 +123,7 @@ export function isCompleteInvestigationAllowed(
   },
 ): boolean {
   if (result.completionKind !== "investigation_complete") return true;
+  if (result.linearTicketRequested) return true;
   return completeInvestigationAvailable(capabilities);
 }
 
@@ -437,13 +438,16 @@ export function shouldDeferSteering(snapshot: {
 export function terminalOutcomeNudgePrompt(
   args: {
     completeInvestigationAvailable?: boolean;
+    linearTicketCreationAvailable?: boolean;
   } = {},
 ): string {
   return [
     TERMINAL_OUTCOME_NUDGE_MARKER,
-    args.completeInvestigationAvailable
-      ? "Call `report_findings` now, then explicitly end your turn with `complete_investigation`, `report_external_cause`, `resolve_incident` with all Issue outcomes, or `ask_human`."
-      : "Call `report_findings` now if you have findings to record, then end the turn with exactly one terminal tool: batched `propose_pr`, `resolve_incident` with all Issue outcomes, `report_external_cause`, or `ask_human`.",
+    args.linearTicketCreationAvailable
+      ? "Call `report_findings` now, then explicitly end your turn with `create_linear_issue`, `report_external_cause`, `resolve_incident` with all Issue outcomes, or `ask_human`."
+      : args.completeInvestigationAvailable
+        ? "Call `report_findings` now, then explicitly end your turn with `complete_investigation`, `report_external_cause`, `resolve_incident` with all Issue outcomes, or `ask_human`."
+        : "Call `report_findings` now if you have findings to record, then end the turn with exactly one terminal tool: batched `propose_pr`, `resolve_incident` with all Issue outcomes, `report_external_cause`, or `ask_human`.",
   ].join("\n");
 }
 
@@ -1419,6 +1423,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
               approvalPromptsEnabled: ctx.approvalPromptsEnabled,
               approvalPromptToolsAvailable: true,
             }),
+            linearTicketCreationAvailable: !!ctx.linearInstall,
           });
         const redeliveryMarker = partialRetryPrompt
           ? `${PARTIAL_PULL_REQUEST_RETRY_NUDGE_MARKER} ${JSON.stringify(pendingRepoFullNames)}`

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -460,7 +460,7 @@ export function terminalOutcomeNudgePrompt(
 }
 
 export function terminalOutcomeNudgeCapabilities(
-  snapshot: Pick<AgentRunnerSnapshot, "declaredCustomToolNames">,
+  snapshot: Partial<Pick<AgentRunnerSnapshot, "declaredCustomToolNames">>,
   fallback: {
     prCreationAvailable: boolean;
     completeInvestigationAvailable: boolean;

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -17,6 +17,7 @@ import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
 import { TERMINAL_OUTCOME_NUDGE_MARKER, assembleAgentRunResult } from "../agent-outcome-tools.js";
 import type { AgentRunContext } from "../agent-run-context.js";
 import { type PauseForEventsOutcome, createAgentRunLifecycle } from "../agent-run.js";
+import type { AgentRunnerSnapshot } from "../agent-runner-backend.js";
 import { type AgentRunOutcome, recordAgentRunCompletion } from "../ai-usage.js";
 import { investigationGate } from "../billing/investigation-gate.js";
 import { usageNotifier } from "../billing/usage-notifier-infra.js";
@@ -456,6 +457,32 @@ export function terminalOutcomeNudgePrompt(
     TERMINAL_OUTCOME_NUDGE_MARKER,
     `Call \`report_findings\` now if you have findings to record, then end the turn with exactly one terminal tool: ${terminalTools.join(", ")}.`,
   ].join("\n");
+}
+
+export function terminalOutcomeNudgeCapabilities(
+  snapshot: Pick<AgentRunnerSnapshot, "declaredCustomToolNames">,
+  fallback: {
+    prCreationAvailable: boolean;
+    completeInvestigationAvailable: boolean;
+  },
+): {
+  prCreationAvailable: boolean;
+  linearTicketCreationAvailable: boolean;
+  completeInvestigationAvailable: boolean;
+} {
+  const declared = snapshot.declaredCustomToolNames;
+  if (!declared) {
+    return {
+      ...fallback,
+      linearTicketCreationAvailable: false,
+    };
+  }
+  const names = new Set(declared);
+  return {
+    prCreationAvailable: names.has("propose_pr"),
+    linearTicketCreationAvailable: names.has("create_linear_issue"),
+    completeInvestigationAvailable: names.has("complete_investigation"),
+  };
 }
 
 const PARTIAL_PULL_REQUEST_RETRY_NUDGE_MARKER = "[superlog:partial-pull-request-retry-nudge]";
@@ -1423,16 +1450,17 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         // steering a duplicate.
         const nudgePrompt =
           partialRetryPrompt ??
-          terminalOutcomeNudgePrompt({
-            completeInvestigationAvailable: completeInvestigationAvailable({
-              prPolicy: ctx.prPolicy,
-              githubConnected: ctx.githubInstalls.length > 0,
-              approvalPromptsEnabled: ctx.approvalPromptsEnabled,
-              approvalPromptToolsAvailable: true,
+          terminalOutcomeNudgePrompt(
+            terminalOutcomeNudgeCapabilities(snapshot, {
+              completeInvestigationAvailable: completeInvestigationAvailable({
+                prPolicy: ctx.prPolicy,
+                githubConnected: ctx.githubInstalls.length > 0,
+                approvalPromptsEnabled: ctx.approvalPromptsEnabled,
+                approvalPromptToolsAvailable: true,
+              }),
+              prCreationAvailable: ctx.githubInstalls.length > 0 && ctx.prPolicy !== "never",
             }),
-            linearTicketCreationAvailable: !!ctx.linearInstall,
-            prCreationAvailable: ctx.githubInstalls.length > 0 && ctx.prPolicy !== "never",
-          });
+          );
         const redeliveryMarker = partialRetryPrompt
           ? `${PARTIAL_PULL_REQUEST_RETRY_NUDGE_MARKER} ${JSON.stringify(pendingRepoFullNames)}`
           : TERMINAL_OUTCOME_NUDGE_MARKER;

--- a/apps/worker/src/infra/agent-runner/backend.test.ts
+++ b/apps/worker/src/infra/agent-runner/backend.test.ts
@@ -56,6 +56,7 @@ test("getAgentRunnerBackend returns the default community backend", async () => 
       prPolicy: "never",
       approvalPromptsEnabled: false,
       approvalPromptToolsAvailable: false,
+      linearTicketCreationAvailable: false,
       prBaseBranch: null,
       githubConnected: false,
       telemetryInvestigationHint:
@@ -110,6 +111,7 @@ test("getAgentRunnerBackend returns a built-in disabled backend for community in
         prPolicy: "never",
         approvalPromptsEnabled: false,
         approvalPromptToolsAvailable: false,
+        linearTicketCreationAvailable: false,
         prBaseBranch: null,
         githubConnected: false,
         telemetryInvestigationHint:

--- a/apps/worker/src/infra/agent-runner/community.ts
+++ b/apps/worker/src/infra/agent-runner/community.ts
@@ -33,6 +33,7 @@ export const communityRunnerBackend: AgentRunnerBackend = {
         noiseClassification: null,
         resolutionClassification: null,
       },
+      declaredCustomToolNames: [],
       unknownCustomTools: [],
       latestMessage: null,
       modelUsage: {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -356,6 +356,10 @@ export type AgentRunResult = {
   // Explicit terminal signal for runs that finish their investigation while
   // deliberately leaving the incident open for an external ticket workflow.
   completionKind?: "investigation_complete" | null;
+  // The agent explicitly chose the Linear handoff terminal. This lets the
+  // completion gate distinguish it from a findings-only completion when
+  // remediation tools were also available.
+  linearTicketRequested?: boolean | null;
   // Why an awaiting_events run is parked when it is not waiting on a PR.
   waitReason?: "external_cause" | null;
   externalCause?: AgentRunExternalCause | null;


### PR DESCRIPTION
## What changed

- add a conditional `create_linear_issue` terminal outcome for incident agents with an active Linear installation
- require recorded findings before the handoff and keep the Incident open after completion
- route the outcome through the existing durable, idempotent Linear handoff instead of exposing a raw provider mutation
- keep the tool unavailable to sessions that were not created with the Linear capability

## Why

An incident agent could have a usable Linear installation while its toolset still had no explicit way to honor a human request to create an issue. The agent would fall back to `ask_human` even though the platform already had a safe ticket-delivery path.

## Validation

- `pnpm --filter @superlog/worker exec tsx --test src/agent-outcome-tools.test.ts src/agent-runs/start.test.ts src/agent-runs/completion-policy.test.ts src/agent-runs/linear-handoff.test.ts` (59 passed)
- `pnpm --filter @superlog/worker typecheck` currently reaches an unrelated `origin/main` error in `src/incident-auto-resolution/slack.ts`: `projectName` is not present in the `incidentBlocks` parameter type

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `create_linear_issue` terminal action so incident agents can open or reuse a Linear ticket from findings, finish the investigation, and keep the Incident open. Idle nudges now prefer `create_linear_issue` when Linear is installed and only list tools declared at session start.

- **New Features**
  - Added `create_linear_issue` terminal tool, shown only with an active Linear install. Requires recorded findings, uses the durable/idempotent Linear handoff, sets `investigation_complete`, and leaves the Incident open.
  - Introduced `linearTicketCreationAvailable` and `declaredCustomToolNames` in the runner; idle nudges list only tools declared at session start, prefer `create_linear_issue`, keep batched `propose_pr` when available, otherwise fall back to `complete_investigation` (legacy snapshots never add Linear).
  - Updated completion policy to always attempt the Linear handoff for `create_linear_issue` and `complete_investigation`, allow explicit Linear handoffs even when other interventions exist, and persist via `linearTicketRequested` in `@superlog/db`. Added diagnostic logs for explicit Linear handoffs (scheduling, policy skips, failures with error context, and missing-ticket cases).

<sup>Written for commit b05a4a857e2a70b5be4d4e6dfaa94b9e8d34b941. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

