### PR TITLE
Fix quiet incident Slack message typecheck

### DIFF
--- a/apps/worker/src/incident-auto-resolution/slack.ts
+++ b/apps/worker/src/incident-auto-resolution/slack.ts
@@ -41,7 +41,6 @@ export async function postQuietIncidentResolvedSlackNotification(
       title: incident.title,
       titleUrl: incidentUrl,
       tagline: "No linked errors recurred for 14 days.",
-      projectName: project.name,
       service: incident.service,
       environment: incident.environment,
       buttons: [],


### PR DESCRIPTION
## Summary

- remove the obsolete `projectName` argument from the quiet incident resolution message
- restore the worker typecheck after the incident message context stopped accepting project names

## Testing

- `pnpm --filter @superlog/worker typecheck`
- `pnpm exec biome check apps/worker/src/incident-auto-resolution/slack.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the obsolete `projectName` field from the quiet incident resolved Slack notification to match the updated message context. This restores typechecking in `@superlog/worker`.

<sup>Written for commit f14273a84526bed7c8523f5c4e808739562494cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

