### PR TITLE
Fix auto-resolve Slack formatter compatibility

### DIFF
--- a/apps/worker/src/incident-auto-resolution/slack.ts
+++ b/apps/worker/src/incident-auto-resolution/slack.ts
@@ -41,7 +41,6 @@ export async function postQuietIncidentResolvedSlackNotification(
       title: incident.title,
       titleUrl: incidentUrl,
       tagline: "No linked errors recurred for 14 days.",
-      projectName: project.name,
       service: incident.service,
       environment: incident.environment,
       buttons: [],


### PR DESCRIPTION
## Summary

- remove the obsolete project name argument from the auto-resolution incident blocks
- keep automatic-resolution thread copy and incident links unchanged
- restore worker image typechecking after the shared Slack formatter update

## Verification

- `pnpm --filter @superlog/worker typecheck`
- `pnpm --filter @superlog/worker exec tsx --test src/incident-auto-resolution/domain.test.ts src/incident-auto-resolution/sweep.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the auto-resolution Slack notification payload with the shared formatter by removing the obsolete `projectName` field. Restores typechecking in `@superlog/worker` and keeps thread copy and incident links unchanged.

<sup>Written for commit 866d5d7091a50b145419e01c7bfeee77b589505a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

