### PR TITLE
Use design-system Dropdown for the members role picker

### DIFF
--- a/apps/web/src/settings/OrgMembersCard.tsx
+++ b/apps/web/src/settings/OrgMembersCard.tsx
@@ -2,10 +2,12 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useMe } from "../api.ts";
 import { authClient } from "../auth-client.ts";
+import { Dropdown, type DropdownOption } from "../design/Dropdown.tsx";
 import { Btn, Chip, Input, Tile } from "../design/ui.tsx";
 
 type Role = "owner" | "admin" | "member";
 const ROLES: Role[] = ["owner", "admin", "member"];
+const ROLE_OPTIONS: DropdownOption[] = ROLES.map((r) => ({ value: r, label: r }));
 
 type Member = {
   id: string;
@@ -171,7 +173,7 @@ function InviteForm({ orgId, canManage }: { orgId: string; canManage: boolean })
           <label className="mb-1.5 block text-[12px] text-muted">Role</label>
           <RoleSelect value={role} onChange={(v) => setRole(v)} />
         </div>
-        <Btn type="submit" loading={invite.isPending} disabled={!email.trim()}>
+        <Btn type="submit" className="h-9" loading={invite.isPending} disabled={!email.trim()}>
           Send invite
         </Btn>
       </form>
@@ -241,15 +243,17 @@ function MemberRow({
       </div>
       <div className="flex items-center gap-2">
         {canEditRole ? (
-          <RoleSelect
-            value={role}
-            disabled={updateRole.isPending}
-            onChange={(v) => {
-              if (v === role) return;
-              setError(null);
-              updateRole.mutate(v);
-            }}
-          />
+          <div className="w-32">
+            <RoleSelect
+              value={role}
+              disabled={updateRole.isPending}
+              onChange={(v) => {
+                if (v === role) return;
+                setError(null);
+                updateRole.mutate(v);
+              }}
+            />
+          </div>
         ) : (
           <Chip tone={role === "owner" ? "accent" : "neutral"}>{role}</Chip>
         )}
@@ -332,29 +336,12 @@ function RoleSelect({
   disabled?: boolean;
 }) {
   return (
-    <div className="relative">
-      <select
-        value={value}
-        disabled={disabled}
-        onChange={(e) => onChange(e.target.value as Role)}
-        className="h-8 appearance-none rounded-sm border border-border bg-surface-2 pl-3 pr-7 text-[12.5px] text-fg focus:border-border-strong focus:outline-none disabled:opacity-50"
-      >
-        {ROLES.map((r) => (
-          <option key={r} value={r}>
-            {r}
-          </option>
-        ))}
-      </select>
-      <svg
-        aria-hidden
-        className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-subtle"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-      >
-        <path d="m6 9 6 6 6-6" />
-      </svg>
-    </div>
+    <Dropdown
+      value={value}
+      onChange={(v) => onChange(v as Role)}
+      options={ROLE_OPTIONS}
+      disabled={disabled}
+      searchable={false}
+    />
   );
 }


### PR DESCRIPTION
## What

The role picker in org settings → **Members** was a hand-rolled native `<select>` with an absolutely-positioned chevron. Because the wrapper was width-constrained (`sm:w-40` / a fixed member-row width) but the `<select>` sized to its own content, the chevron floated far to the right of the visible control — it read as a broken/crooked dropdown.

This swaps it for the shared `Dropdown` component (same popover language as `RangePicker` / `RowMenu`), so the trigger, menu, and option rows are themed consistently instead of falling back to OS chrome. The role list is short, so it's rendered with `searchable={false}`.

While here, the **Send invite** button was `h-8` (the `Btn` `md` default) next to the `h-9` email input and role dropdown, so it read as shorter than the fields it sits with. Bumped it to `h-9` so the invite row lines up.

## Scope

- `apps/web/src/settings/OrgMembersCard.tsx` only. Purely presentational — no behavior/data changes.

## Test

- `pnpm --filter @superlog/web typecheck` passes.
- Verified in a local worktree at org settings → Members: both the invite-form role picker and the per-member role picker render the themed dropdown; invite row controls are the same height.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the Members role picker with the design-system `Dropdown` to fix the crooked chevron and unify styling. Also aligned the invite row by matching the Send invite button height.

- **Bug Fixes**
  - Corrected dropdown alignment and chevron positioning; invite button set to h-9 to match input and dropdown heights.

- **Refactors**
  - Swapped the native select for `Dropdown` (non-searchable) and added a fixed-width wrapper in member rows; visual-only change with no behavior updates.

<sup>Written for commit 003e2e9855d3025bbf67b61bf2551ac8dfc775d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

