### PR TITLE
Add default home pulse widgets

### DIFF
--- a/apps/api/src/dashboards-service.ts
+++ b/apps/api/src/dashboards-service.ts
@@ -136,33 +136,58 @@ export function dashboardRouteCanMutateDashboard({
   return !isHome;
 }
 
+const HOME_BUILTIN_DEFINITIONS = {
+  setup_todos: {
+    type: "setup_todos",
+    title: "Setup",
+    config: { filter: {} },
+    layout: defaultWidgetLayout("setup_todos"),
+  },
+  active_incidents: {
+    type: "active_incidents",
+    title: "Active critical incidents",
+    config: { filter: {} },
+    layout: defaultWidgetLayout("active_incidents"),
+  },
+  service_map: {
+    type: "service_map",
+    title: "Service map",
+    config: { filter: {} },
+    layout: defaultWidgetLayout("service_map"),
+  },
+  incoming_signals: {
+    type: "incoming_signals",
+    title: "Incoming signals",
+    config: { filter: {} },
+    layout: defaultWidgetLayout("incoming_signals"),
+  },
+  incident_count: {
+    type: "incident_count",
+    title: "Active incidents",
+    config: { filter: {} },
+    layout: defaultWidgetLayout("incident_count"),
+  },
+  agent_pull_requests: {
+    type: "agent_pull_requests",
+    title: "PRs opened by Superlog",
+    config: { filter: {} },
+    layout: defaultWidgetLayout("agent_pull_requests"),
+  },
+} satisfies Record<HomeBuiltinType, DashboardWidgetCreateInput>;
+
+export function homeBuiltinDefinition(type: HomeBuiltinType): DashboardWidgetCreateInput {
+  return HOME_BUILTIN_DEFINITIONS[type];
+}
+
+const DEFAULT_HOME_BUILTIN_TYPES = [
+  "setup_todos",
+  "incoming_signals",
+  "incident_count",
+  "agent_pull_requests",
+] as const satisfies readonly HomeBuiltinType[];
+
 export function defaultHomeWidgets(): DashboardWidgetCreateInput[] {
-  return [
-    {
-      type: "setup_todos",
-      title: "Setup",
-      config: { filter: {} },
-      layout: defaultWidgetLayout("setup_todos"),
-    },
-    {
-      type: "incoming_signals",
-      title: "Incoming signals",
-      config: { filter: {} },
-      layout: defaultWidgetLayout("incoming_signals"),
-    },
-    {
-      type: "incident_count",
-      title: "Active incidents",
-      config: { filter: {} },
-      layout: defaultWidgetLayout("incident_count"),
-    },
-    {
-      type: "agent_pull_requests",
-      title: "PRs opened by Superlog",
-      config: { filter: {} },
-      layout: defaultWidgetLayout("agent_pull_requests"),
-    },
-  ];
+  return DEFAULT_HOME_BUILTIN_TYPES.map(homeBuiltinDefinition);
 }
 
 // A dashboard-level template variable. Widget filters reference it from a
@@ -342,9 +367,7 @@ export async function setHomeBuiltin(
   const home = await getOrCreateHomeDashboard(projectId, userId);
   const existing = home.widgets.find((widget) => widget.type === type);
   if (enabled && !existing) {
-    const definition = defaultHomeWidgets().find((widget) => widget.type === type);
-    if (!definition) throw new Error(`missing definition for home widget: ${type}`);
-    await insertDashboardWidget(home.id, definition);
+    await insertDashboardWidget(home.id, homeBuiltinDefinition(type));
   }
   if (!enabled && existing) {
     await removeDashboardWidget(home.id, existing.id);

--- a/apps/api/src/dashboards-service.ts
+++ b/apps/api/src/dashboards-service.ts
@@ -12,6 +12,9 @@ export const dashboardWidgetTypeSchema = z.enum([
   "setup_todos",
   "active_incidents",
   "service_map",
+  "incoming_signals",
+  "incident_count",
+  "agent_pull_requests",
 ]);
 
 export const dashboardDataWidgetTypeSchema = z.enum([
@@ -77,6 +80,12 @@ export function defaultWidgetLayout(type: DashboardWidgetType): DashboardWidgetL
       return { x: 0, y: 5, w: 6, h: 3 };
     case "service_map":
       return { x: 6, y: 5, w: 6, h: 8 };
+    case "incoming_signals":
+      return { x: 0, y: 5, w: 4, h: 5 };
+    case "incident_count":
+      return { x: 4, y: 5, w: 4, h: 5 };
+    case "agent_pull_requests":
+      return { x: 8, y: 5, w: 4, h: 5 };
     case "trace_table":
     case "log_table":
       return { x: 0, y: 9999, w: 12, h: 6 };
@@ -96,6 +105,9 @@ export const HOME_BUILTIN_TYPES = [
   "setup_todos",
   "active_incidents",
   "service_map",
+  "incoming_signals",
+  "incident_count",
+  "agent_pull_requests",
 ] as const satisfies readonly DashboardWidgetType[];
 
 export type HomeBuiltinType = (typeof HOME_BUILTIN_TYPES)[number];
@@ -133,16 +145,22 @@ export function defaultHomeWidgets(): DashboardWidgetCreateInput[] {
       layout: defaultWidgetLayout("setup_todos"),
     },
     {
-      type: "active_incidents",
-      title: "Active critical incidents",
+      type: "incoming_signals",
+      title: "Incoming signals",
       config: { filter: {} },
-      layout: defaultWidgetLayout("active_incidents"),
+      layout: defaultWidgetLayout("incoming_signals"),
     },
     {
-      type: "service_map",
-      title: "Service map",
+      type: "incident_count",
+      title: "Active incidents",
       config: { filter: {} },
-      layout: defaultWidgetLayout("service_map"),
+      layout: defaultWidgetLayout("incident_count"),
+    },
+    {
+      type: "agent_pull_requests",
+      title: "PRs opened by Superlog",
+      config: { filter: {} },
+      layout: defaultWidgetLayout("agent_pull_requests"),
     },
   ];
 }

--- a/apps/api/src/dashboards.ts
+++ b/apps/api/src/dashboards.ts
@@ -1,4 +1,6 @@
+import type { ClickHouseClient } from "@clickhouse/client";
 import { db, schema } from "@superlog/db";
+import { pickStep } from "@superlog/telemetry-query";
 import { eq } from "drizzle-orm";
 import type { Context, Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -13,27 +15,32 @@ import {
   dashboardWidgetCreateSchema,
   dashboardWidgetLayoutSchema,
   dashboardWidgetUpdateSchema,
-  deleteHomeItem,
   deleteDashboard,
   deleteDashboardWidget,
+  deleteHomeItem,
   getDashboardWithWidgets,
   getOrCreateHomeDashboard,
   homeBuiltinTypeSchema,
   homeDataWidgetCreateSchema,
   homeLinkCreateSchema,
   listDashboardsForProject,
+  setHomeBuiltin,
   updateDashboard,
   updateDashboardLayout,
   updateDashboardWidget,
   updateHomeLayout,
-  setHomeBuiltin,
 } from "./dashboards-service.js";
 import { resolveEffectiveReadProjectId } from "./demo.js";
+import { getHomeSignalSeries } from "./home-signal-series.js";
+import { getProjectAgentPullRequestSummary } from "./home-summary.js";
 import { resolveActiveOrgContext } from "./org-context.js";
 
 type Vars = { userId: string; orgId: string | null; demoReadProjectId?: string };
 
-export function mountDashboards(app: Hono<{ Variables: Vars }>) {
+export function mountDashboards(
+  app: Hono<{ Variables: Vars }>,
+  deps: { clickhouse: ClickHouseClient },
+) {
   // Authorizes against the real project and also returns `readProjectId` — the
   // demo project's id when the real project hasn't ingested yet (read-only
   // overlay), else the real id. GET handlers read from `readProjectId`; writes
@@ -64,6 +71,33 @@ export function mountDashboards(app: Hono<{ Variables: Vars }>) {
     const projectId = c.req.param("projectId");
     const { user } = await requireAccess(c, projectId);
     return c.json(await getOrCreateHomeDashboard(projectId, user.id));
+  });
+
+  app.get("/api/projects/:projectId/home/pull-request-summary", async (c) => {
+    const projectId = c.req.param("projectId");
+    const { readProjectId } = await requireAccess(c, projectId);
+    return c.json(await getProjectAgentPullRequestSummary(readProjectId));
+  });
+
+  app.get("/api/projects/:projectId/home/signal-series", async (c) => {
+    const projectId = c.req.param("projectId");
+    const { readProjectId } = await requireAccess(c, projectId);
+    const parsed = z
+      .object({ since: z.string().datetime(), until: z.string().datetime() })
+      .safeParse({ since: c.req.query("since"), until: c.req.query("until") });
+    if (!parsed.success) throw new HTTPException(400, { message: "invalid signal range" });
+    const rangeSeconds = (Date.parse(parsed.data.until) - Date.parse(parsed.data.since)) / 1000;
+    if (rangeSeconds <= 0 || rangeSeconds > 7 * 24 * 60 * 60) {
+      throw new HTTPException(400, { message: "signal range must be between 0 and 7 days" });
+    }
+    return c.json(
+      await getHomeSignalSeries(
+        deps.clickhouse,
+        readProjectId,
+        parsed.data,
+        pickStep(rangeSeconds, 36),
+      ),
+    );
   });
 
   app.put("/api/projects/:projectId/home/builtins/:type", async (c) => {

--- a/apps/api/src/dashboards.ts
+++ b/apps/api/src/dashboards.ts
@@ -32,7 +32,7 @@ import {
 } from "./dashboards-service.js";
 import { resolveEffectiveReadProjectId } from "./demo.js";
 import { getHomeSignalSeries } from "./home-signal-series.js";
-import { getProjectAgentPullRequestSummary } from "./home-summary.js";
+import { getProjectAgentPullRequestSummary, getProjectHomeIncidentTrend } from "./home-summary.js";
 import { resolveActiveOrgContext } from "./org-context.js";
 
 type Vars = { userId: string; orgId: string | null; demoReadProjectId?: string };
@@ -77,6 +77,12 @@ export function mountDashboards(
     const projectId = c.req.param("projectId");
     const { readProjectId } = await requireAccess(c, projectId);
     return c.json(await getProjectAgentPullRequestSummary(readProjectId));
+  });
+
+  app.get("/api/projects/:projectId/home/incident-trend", async (c) => {
+    const projectId = c.req.param("projectId");
+    const { readProjectId } = await requireAccess(c, projectId);
+    return c.json(await getProjectHomeIncidentTrend(readProjectId));
   });
 
   app.get("/api/projects/:projectId/home/signal-series", async (c) => {

--- a/apps/api/src/home-dashboard.test.ts
+++ b/apps/api/src/home-dashboard.test.ts
@@ -4,11 +4,20 @@ import { test } from "node:test";
 process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
 
 const {
+  HOME_BUILTIN_TYPES,
   defaultHomeWidgets,
+  homeBuiltinDefinition,
   homeLinkCreateSchema,
   dashboardRouteCanMutateDashboard,
   dashboardRouteCanWriteWidget,
 } = await import("./dashboards-service.js");
+
+test("every customizable home built-in keeps a definition even when it is not a default", () => {
+  assert.deepEqual(
+    HOME_BUILTIN_TYPES.map((type) => homeBuiltinDefinition(type).type),
+    HOME_BUILTIN_TYPES,
+  );
+});
 
 test("a new project home starts with the three operational pulse widgets", () => {
   const widgets = defaultHomeWidgets();

--- a/apps/api/src/home-dashboard.test.ts
+++ b/apps/api/src/home-dashboard.test.ts
@@ -10,16 +10,20 @@ const {
   dashboardRouteCanWriteWidget,
 } = await import("./dashboards-service.js");
 
-test("a new project home preserves the three existing overview sections as widgets", () => {
+test("a new project home starts with the three operational pulse widgets", () => {
   const widgets = defaultHomeWidgets();
 
   assert.deepEqual(
     widgets.map((widget) => widget.type),
-    ["setup_todos", "active_incidents", "service_map"],
+    ["setup_todos", "incoming_signals", "incident_count", "agent_pull_requests"],
   );
-  assert.equal(
-    widgets.every((widget) => (widget.layout?.w ?? 0) >= 6),
-    true,
+  assert.deepEqual(
+    widgets.slice(1).map((widget) => widget.layout),
+    [
+      { x: 0, y: 5, w: 4, h: 5 },
+      { x: 4, y: 5, w: 4, h: 5 },
+      { x: 8, y: 5, w: 4, h: 5 },
+    ],
   );
 });
 

--- a/apps/api/src/home-signal-series.test.ts
+++ b/apps/api/src/home-signal-series.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { mergeHomeSignalSeriesRows } from "./home-signal-series.js";
+import { getHomeSignalSeries, mergeHomeSignalSeriesRows } from "./home-signal-series.js";
 
 test("home signal series merges traces, logs, and metrics into chronological chart points", () => {
   const series = mergeHomeSignalSeriesRows([
@@ -15,4 +15,30 @@ test("home signal series merges traces, logs, and metrics into chronological cha
     { bucket: "2026-07-21 10:00:00", traces: 9, logs: 0, metrics: 21 },
     { bucket: "2026-07-21 10:05:00", traces: 11, logs: 14, metrics: 0 },
   ]);
+});
+
+test("home signal series reads event rollups and metric usage projections", async () => {
+  const queries: string[] = [];
+  const clickhouse = {
+    async query({ query }: { query: string }) {
+      queries.push(query);
+      return {
+        async json() {
+          return [];
+        },
+      };
+    },
+  };
+
+  await getHomeSignalSeries(
+    clickhouse as never,
+    "project-1",
+    { since: "2026-07-21T09:00:00.000Z", until: "2026-07-21T10:00:00.000Z" },
+    { n: 5, unit: "MINUTE" },
+  );
+
+  assert.equal(queries.length, 1);
+  assert.match(queries[0] ?? "", /FROM events_per_minute/);
+  assert.match(queries[0] ?? "", /SuperlogProjectId/);
+  assert.doesNotMatch(queries[0] ?? "", /ResourceAttributes/);
 });

--- a/apps/api/src/home-signal-series.test.ts
+++ b/apps/api/src/home-signal-series.test.ts
@@ -24,6 +24,16 @@ test("home signal series reads event rollups and metric usage projections", asyn
       queries.push(query);
       return {
         async json() {
+          if (query.includes("FROM system.columns")) {
+            return [
+              { table: "events_per_minute", optimized: 0 },
+              { table: "otel_metrics_gauge", optimized: 1 },
+              { table: "otel_metrics_sum", optimized: 1 },
+              { table: "otel_metrics_histogram", optimized: 1 },
+              { table: "otel_metrics_summary", optimized: 1 },
+              { table: "otel_metrics_exp_histogram", optimized: 1 },
+            ];
+          }
           return [];
         },
       };
@@ -37,8 +47,33 @@ test("home signal series reads event rollups and metric usage projections", asyn
     { n: 5, unit: "MINUTE" },
   );
 
-  assert.equal(queries.length, 1);
-  assert.match(queries[0] ?? "", /FROM events_per_minute/);
-  assert.match(queries[0] ?? "", /SuperlogProjectId/);
-  assert.doesNotMatch(queries[0] ?? "", /ResourceAttributes/);
+  assert.equal(queries.length, 2);
+  assert.match(queries[1] ?? "", /FROM events_per_minute/);
+  assert.match(queries[1] ?? "", /SuperlogProjectId/);
+  assert.doesNotMatch(queries[1] ?? "", /ResourceAttributes/);
+});
+
+test("home signal series falls back when optional rollups are absent", async () => {
+  const queries: string[] = [];
+  const clickhouse = {
+    async query({ query }: { query: string }) {
+      queries.push(query);
+      return {
+        async json() {
+          return [];
+        },
+      };
+    },
+  };
+
+  await getHomeSignalSeries(
+    clickhouse as never,
+    "project-1",
+    { since: "2026-07-21T09:00:00.000Z", until: "2026-07-21T10:00:00.000Z" },
+    { n: 5, unit: "MINUTE" },
+  );
+
+  assert.equal(queries.length, 2);
+  assert.doesNotMatch(queries[1] ?? "", /FROM events_per_minute/);
+  assert.match(queries[1] ?? "", /ResourceAttributes\['superlog\.project_id'\]/);
 });

--- a/apps/api/src/home-signal-series.test.ts
+++ b/apps/api/src/home-signal-series.test.ts
@@ -1,7 +1,16 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { getHomeSignalSeries, mergeHomeSignalSeriesRows } from "./home-signal-series.js";
+import {
+  clampHomeSignalStep,
+  getHomeSignalSeries,
+  mergeHomeSignalSeriesRows,
+} from "./home-signal-series.js";
+
+test("home signal rollups never use sub-minute buckets", () => {
+  assert.deepEqual(clampHomeSignalStep({ n: 30, unit: "SECOND" }), { n: 1, unit: "MINUTE" });
+  assert.deepEqual(clampHomeSignalStep({ n: 5, unit: "MINUTE" }), { n: 5, unit: "MINUTE" });
+});
 
 test("home signal series merges traces, logs, and metrics into chronological chart points", () => {
   const series = mergeHomeSignalSeriesRows([
@@ -60,6 +69,12 @@ test("home signal series falls back when optional rollups are absent", async () 
       queries.push(query);
       return {
         async json() {
+          if (query.includes("FROM system.columns")) {
+            return [
+              { table: "otel_metrics_gauge", optimized: 0 },
+              { table: "otel_metrics_sum", optimized: 0 },
+            ];
+          }
           return [];
         },
       };
@@ -76,4 +91,5 @@ test("home signal series falls back when optional rollups are absent", async () 
   assert.equal(queries.length, 2);
   assert.doesNotMatch(queries[1] ?? "", /FROM events_per_minute/);
   assert.match(queries[1] ?? "", /ResourceAttributes\['superlog\.project_id'\]/);
+  assert.doesNotMatch(queries[1] ?? "", /FROM otel_metrics_exp_histogram/);
 });

--- a/apps/api/src/home-signal-series.test.ts
+++ b/apps/api/src/home-signal-series.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { mergeHomeSignalSeriesRows } from "./home-signal-series.js";
+
+test("home signal series merges traces, logs, and metrics into chronological chart points", () => {
+  const series = mergeHomeSignalSeriesRows([
+    { bucket: "2026-07-21 10:05:00", signal: "logs", count: "14" },
+    { bucket: "2026-07-21 10:00:00", signal: "traces", count: 9 },
+    { bucket: "2026-07-21 10:00:00", signal: "metrics", count: "21" },
+    { bucket: "2026-07-21 10:05:00", signal: "traces", count: 11 },
+  ]);
+
+  assert.deepEqual(series, [
+    { bucket: "2026-07-21 10:00:00", traces: 9, logs: 0, metrics: 21 },
+    { bucket: "2026-07-21 10:05:00", traces: 11, logs: 14, metrics: 0 },
+  ]);
+});

--- a/apps/api/src/home-signal-series.ts
+++ b/apps/api/src/home-signal-series.ts
@@ -16,14 +16,12 @@ export type HomeSignalSeriesPoint = {
   metrics: number;
 };
 
-const SIGNAL_TABLES = [
-  { table: "otel_traces", timestamp: "Timestamp", signal: "traces" },
-  { table: "otel_logs", timestamp: "TimestampTime", signal: "logs" },
-  { table: "otel_metrics_gauge", timestamp: "TimeUnix", signal: "metrics" },
-  { table: "otel_metrics_sum", timestamp: "TimeUnix", signal: "metrics" },
-  { table: "otel_metrics_histogram", timestamp: "TimeUnix", signal: "metrics" },
-  { table: "otel_metrics_summary", timestamp: "TimeUnix", signal: "metrics" },
-  { table: "otel_metrics_exp_histogram", timestamp: "TimeUnix", signal: "metrics" },
+const METRIC_TABLES = [
+  "otel_metrics_gauge",
+  "otel_metrics_sum",
+  "otel_metrics_histogram",
+  "otel_metrics_summary",
+  "otel_metrics_exp_histogram",
 ] as const;
 
 export function mergeHomeSignalSeriesRows(rows: RawSignalSeriesRow[]): HomeSignalSeriesPoint[] {
@@ -47,22 +45,37 @@ export async function getHomeSignalSeries(
   range: { since: string; until: string },
   step: Step,
 ): Promise<{ step: string; rows: HomeSignalSeriesPoint[] }> {
-  // Tables, timestamp columns, signal names, and interval units are all selected
-  // from closed allowlists above / in telemetry-query's pickStep(). User input is
-  // bound through ClickHouse parameters.
-  const parts = SIGNAL_TABLES.map(
-    ({ table, timestamp, signal }) => `
+  // Traces and logs use the per-minute event rollup. Metrics use the exact-count
+  // usage projections, whose materialized project column avoids scanning the
+  // ResourceAttributes map. Tables and interval units come from closed allowlists;
+  // all request input is bound through ClickHouse parameters.
+  const parts = [
+    `
       SELECT
-        toString(toStartOfInterval(${timestamp}, INTERVAL ${step.n} ${step.unit})) AS bucket,
-        '${signal}' AS signal,
-        count() AS count
-      FROM ${table}
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
-        AND ${timestamp} >= parseDateTime64BestEffortOrZero({since:String})
-        AND ${timestamp} <= parseDateTime64BestEffortOrZero({until:String})
-      GROUP BY bucket
+        toString(toStartOfInterval(minute, INTERVAL ${step.n} ${step.unit})) AS bucket,
+        signal,
+        sum(c) AS count
+      FROM events_per_minute
+      PREWHERE minute >= toStartOfMinute(parseDateTime64BestEffortOrZero({since:String}))
+        AND minute <= parseDateTime64BestEffortOrZero({until:String})
+      WHERE project_id = {projectId:String}
+        AND signal IN ('traces', 'logs')
+      GROUP BY bucket, signal
     `,
-  );
+    ...METRIC_TABLES.map(
+      (table) => `
+        SELECT
+          toString(toStartOfInterval(TimeUnix, INTERVAL ${step.n} ${step.unit})) AS bucket,
+          'metrics' AS signal,
+          count() AS count
+        FROM ${table}
+        PREWHERE TimeUnix >= parseDateTime64BestEffortOrZero({since:String})
+          AND TimeUnix <= parseDateTime64BestEffortOrZero({until:String})
+        WHERE SuperlogProjectId = {projectId:String}
+        GROUP BY bucket
+      `,
+    ),
+  ];
   const result = await clickhouse.query({
     query: `
       SELECT bucket, signal, sum(count) AS count

--- a/apps/api/src/home-signal-series.ts
+++ b/apps/api/src/home-signal-series.ts
@@ -24,6 +24,45 @@ const METRIC_TABLES = [
   "otel_metrics_exp_histogram",
 ] as const;
 
+type HomeSignalSchema = {
+  eventsRollup: boolean;
+  optimizedMetricTables: ReadonlySet<string>;
+};
+
+async function inspectHomeSignalSchema(clickhouse: ClickHouseClient): Promise<HomeSignalSchema> {
+  try {
+    const result = await clickhouse.query({
+      query: `
+        SELECT table, max(name = 'SuperlogProjectId') AS optimized
+        FROM system.columns
+        WHERE database = currentDatabase()
+          AND table IN (
+            'events_per_minute',
+            'otel_metrics_gauge',
+            'otel_metrics_sum',
+            'otel_metrics_histogram',
+            'otel_metrics_summary',
+            'otel_metrics_exp_histogram'
+          )
+        GROUP BY table
+      `,
+      format: "JSONEachRow",
+    });
+    const rows = (await result.json()) as Array<{
+      table: string;
+      optimized: number | string;
+    }>;
+    return {
+      eventsRollup: rows.some(({ table }) => table === "events_per_minute"),
+      optimizedMetricTables: new Set(
+        rows.filter(({ optimized }) => Number(optimized) === 1).map(({ table }) => table),
+      ),
+    };
+  } catch {
+    return { eventsRollup: false, optimizedMetricTables: new Set() };
+  }
+}
+
 export function mergeHomeSignalSeriesRows(rows: RawSignalSeriesRow[]): HomeSignalSeriesPoint[] {
   const points = new Map<string, HomeSignalSeriesPoint>();
   for (const row of rows) {
@@ -45,12 +84,15 @@ export async function getHomeSignalSeries(
   range: { since: string; until: string },
   step: Step,
 ): Promise<{ step: string; rows: HomeSignalSeriesPoint[] }> {
+  const schema = await inspectHomeSignalSchema(clickhouse);
   // Traces and logs use the per-minute event rollup. Metrics use the exact-count
   // usage projections, whose materialized project column avoids scanning the
-  // ResourceAttributes map. Tables and interval units come from closed allowlists;
-  // all request input is bound through ClickHouse parameters.
-  const parts = [
-    `
+  // ResourceAttributes map. Older/self-hosted schemas retain a raw-table fallback.
+  // Tables and interval units come from closed allowlists; all request input is
+  // bound through ClickHouse parameters.
+  const eventParts = schema.eventsRollup
+    ? [
+        `
       SELECT
         toString(toStartOfInterval(minute, INTERVAL ${step.n} ${step.unit})) AS bucket,
         signal,
@@ -62,20 +104,48 @@ export async function getHomeSignalSeries(
         AND signal IN ('traces', 'logs')
       GROUP BY bucket, signal
     `,
-    ...METRIC_TABLES.map(
-      (table) => `
-        SELECT
-          toString(toStartOfInterval(TimeUnix, INTERVAL ${step.n} ${step.unit})) AS bucket,
-          'metrics' AS signal,
-          count() AS count
-        FROM ${table}
-        PREWHERE TimeUnix >= parseDateTime64BestEffortOrZero({since:String})
-          AND TimeUnix <= parseDateTime64BestEffortOrZero({until:String})
-        WHERE SuperlogProjectId = {projectId:String}
-        GROUP BY bucket
-      `,
-    ),
-  ];
+      ]
+    : [
+        `
+          SELECT
+            toString(toStartOfInterval(Timestamp, INTERVAL ${step.n} ${step.unit})) AS bucket,
+            'traces' AS signal,
+            count() AS count
+          FROM otel_traces
+          WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+            AND Timestamp >= parseDateTime64BestEffortOrZero({since:String})
+            AND Timestamp <= parseDateTime64BestEffortOrZero({until:String})
+          GROUP BY bucket
+        `,
+        `
+          SELECT
+            toString(toStartOfInterval(TimestampTime, INTERVAL ${step.n} ${step.unit})) AS bucket,
+            'logs' AS signal,
+            count() AS count
+          FROM otel_logs
+          WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+            AND TimestampTime >= parseDateTime64BestEffortOrZero({since:String})
+            AND TimestampTime <= parseDateTime64BestEffortOrZero({until:String})
+          GROUP BY bucket
+        `,
+      ];
+  const metricParts = METRIC_TABLES.map((table) => {
+    const projectId = schema.optimizedMetricTables.has(table)
+      ? "SuperlogProjectId"
+      : "ResourceAttributes['superlog.project_id']";
+    return `
+      SELECT
+        toString(toStartOfInterval(TimeUnix, INTERVAL ${step.n} ${step.unit})) AS bucket,
+        'metrics' AS signal,
+        count() AS count
+      FROM ${table}
+      PREWHERE TimeUnix >= parseDateTime64BestEffortOrZero({since:String})
+        AND TimeUnix <= parseDateTime64BestEffortOrZero({until:String})
+      WHERE ${projectId} = {projectId:String}
+      GROUP BY bucket
+    `;
+  });
+  const parts = [...eventParts, ...metricParts];
   const result = await clickhouse.query({
     query: `
       SELECT bucket, signal, sum(count) AS count

--- a/apps/api/src/home-signal-series.ts
+++ b/apps/api/src/home-signal-series.ts
@@ -1,0 +1,79 @@
+import type { ClickHouseClient } from "@clickhouse/client";
+import type { Step } from "@superlog/telemetry-query";
+
+type SignalKind = "traces" | "logs" | "metrics";
+
+type RawSignalSeriesRow = {
+  bucket: string;
+  signal: SignalKind;
+  count: number | string;
+};
+
+export type HomeSignalSeriesPoint = {
+  bucket: string;
+  traces: number;
+  logs: number;
+  metrics: number;
+};
+
+const SIGNAL_TABLES = [
+  { table: "otel_traces", timestamp: "Timestamp", signal: "traces" },
+  { table: "otel_logs", timestamp: "TimestampTime", signal: "logs" },
+  { table: "otel_metrics_gauge", timestamp: "TimeUnix", signal: "metrics" },
+  { table: "otel_metrics_sum", timestamp: "TimeUnix", signal: "metrics" },
+  { table: "otel_metrics_histogram", timestamp: "TimeUnix", signal: "metrics" },
+  { table: "otel_metrics_summary", timestamp: "TimeUnix", signal: "metrics" },
+  { table: "otel_metrics_exp_histogram", timestamp: "TimeUnix", signal: "metrics" },
+] as const;
+
+export function mergeHomeSignalSeriesRows(rows: RawSignalSeriesRow[]): HomeSignalSeriesPoint[] {
+  const points = new Map<string, HomeSignalSeriesPoint>();
+  for (const row of rows) {
+    const point = points.get(row.bucket) ?? {
+      bucket: row.bucket,
+      traces: 0,
+      logs: 0,
+      metrics: 0,
+    };
+    point[row.signal] += Number(row.count);
+    points.set(row.bucket, point);
+  }
+  return [...points.values()].sort((a, b) => a.bucket.localeCompare(b.bucket));
+}
+
+export async function getHomeSignalSeries(
+  clickhouse: ClickHouseClient,
+  projectId: string,
+  range: { since: string; until: string },
+  step: Step,
+): Promise<{ step: string; rows: HomeSignalSeriesPoint[] }> {
+  // Tables, timestamp columns, signal names, and interval units are all selected
+  // from closed allowlists above / in telemetry-query's pickStep(). User input is
+  // bound through ClickHouse parameters.
+  const parts = SIGNAL_TABLES.map(
+    ({ table, timestamp, signal }) => `
+      SELECT
+        toString(toStartOfInterval(${timestamp}, INTERVAL ${step.n} ${step.unit})) AS bucket,
+        '${signal}' AS signal,
+        count() AS count
+      FROM ${table}
+      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+        AND ${timestamp} >= parseDateTime64BestEffortOrZero({since:String})
+        AND ${timestamp} <= parseDateTime64BestEffortOrZero({until:String})
+      GROUP BY bucket
+    `,
+  );
+  const result = await clickhouse.query({
+    query: `
+      SELECT bucket, signal, sum(count) AS count
+      FROM (${parts.join(" UNION ALL ")})
+      GROUP BY bucket, signal
+      ORDER BY bucket ASC
+      LIMIT 10000
+    `,
+    query_params: { projectId, since: range.since, until: range.until },
+    format: "JSONEachRow",
+  });
+  const rows = (await result.json()) as RawSignalSeriesRow[];
+  return { step: `${step.n} ${step.unit}`, rows: mergeHomeSignalSeriesRows(rows) };
+}

--- a/apps/api/src/home-signal-series.ts
+++ b/apps/api/src/home-signal-series.ts
@@ -26,8 +26,13 @@ const METRIC_TABLES = [
 
 type HomeSignalSchema = {
   eventsRollup: boolean;
+  metricTables: ReadonlySet<string>;
   optimizedMetricTables: ReadonlySet<string>;
 };
+
+export function clampHomeSignalStep(step: Step): Step {
+  return step.unit === "SECOND" ? { n: 1, unit: "MINUTE" } : step;
+}
 
 async function inspectHomeSignalSchema(clickhouse: ClickHouseClient): Promise<HomeSignalSchema> {
   try {
@@ -54,12 +59,17 @@ async function inspectHomeSignalSchema(clickhouse: ClickHouseClient): Promise<Ho
     }>;
     return {
       eventsRollup: rows.some(({ table }) => table === "events_per_minute"),
+      metricTables: new Set(
+        rows
+          .map(({ table }) => table)
+          .filter((table) => METRIC_TABLES.includes(table as (typeof METRIC_TABLES)[number])),
+      ),
       optimizedMetricTables: new Set(
         rows.filter(({ optimized }) => Number(optimized) === 1).map(({ table }) => table),
       ),
     };
   } catch {
-    return { eventsRollup: false, optimizedMetricTables: new Set() };
+    return { eventsRollup: false, metricTables: new Set(), optimizedMetricTables: new Set() };
   }
 }
 
@@ -85,6 +95,7 @@ export async function getHomeSignalSeries(
   step: Step,
 ): Promise<{ step: string; rows: HomeSignalSeriesPoint[] }> {
   const schema = await inspectHomeSignalSchema(clickhouse);
+  const safeStep = clampHomeSignalStep(step);
   // Traces and logs use the per-minute event rollup. Metrics use the exact-count
   // usage projections, whose materialized project column avoids scanning the
   // ResourceAttributes map. Older/self-hosted schemas retain a raw-table fallback.
@@ -94,7 +105,7 @@ export async function getHomeSignalSeries(
     ? [
         `
       SELECT
-        toString(toStartOfInterval(minute, INTERVAL ${step.n} ${step.unit})) AS bucket,
+        toString(toStartOfInterval(minute, INTERVAL ${safeStep.n} ${safeStep.unit})) AS bucket,
         signal,
         sum(c) AS count
       FROM events_per_minute
@@ -108,7 +119,7 @@ export async function getHomeSignalSeries(
     : [
         `
           SELECT
-            toString(toStartOfInterval(Timestamp, INTERVAL ${step.n} ${step.unit})) AS bucket,
+            toString(toStartOfInterval(Timestamp, INTERVAL ${safeStep.n} ${safeStep.unit})) AS bucket,
             'traces' AS signal,
             count() AS count
           FROM otel_traces
@@ -119,7 +130,7 @@ export async function getHomeSignalSeries(
         `,
         `
           SELECT
-            toString(toStartOfInterval(TimestampTime, INTERVAL ${step.n} ${step.unit})) AS bucket,
+            toString(toStartOfInterval(TimestampTime, INTERVAL ${safeStep.n} ${safeStep.unit})) AS bucket,
             'logs' AS signal,
             count() AS count
           FROM otel_logs
@@ -129,13 +140,14 @@ export async function getHomeSignalSeries(
           GROUP BY bucket
         `,
       ];
-  const metricParts = METRIC_TABLES.map((table) => {
-    const projectId = schema.optimizedMetricTables.has(table)
-      ? "SuperlogProjectId"
-      : "ResourceAttributes['superlog.project_id']";
-    return `
+  const metricParts = METRIC_TABLES.filter((table) => schema.metricTables.has(table)).map(
+    (table) => {
+      const projectId = schema.optimizedMetricTables.has(table)
+        ? "SuperlogProjectId"
+        : "ResourceAttributes['superlog.project_id']";
+      return `
       SELECT
-        toString(toStartOfInterval(TimeUnix, INTERVAL ${step.n} ${step.unit})) AS bucket,
+        toString(toStartOfInterval(TimeUnix, INTERVAL ${safeStep.n} ${safeStep.unit})) AS bucket,
         'metrics' AS signal,
         count() AS count
       FROM ${table}
@@ -144,7 +156,8 @@ export async function getHomeSignalSeries(
       WHERE ${projectId} = {projectId:String}
       GROUP BY bucket
     `;
-  });
+    },
+  );
   const parts = [...eventParts, ...metricParts];
   const result = await clickhouse.query({
     query: `
@@ -158,5 +171,8 @@ export async function getHomeSignalSeries(
     format: "JSONEachRow",
   });
   const rows = (await result.json()) as RawSignalSeriesRow[];
-  return { step: `${step.n} ${step.unit}`, rows: mergeHomeSignalSeriesRows(rows) };
+  return {
+    step: `${safeStep.n} ${safeStep.unit}`,
+    rows: mergeHomeSignalSeriesRows(rows),
+  };
 }

--- a/apps/api/src/home-summary.test.ts
+++ b/apps/api/src/home-summary.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
+
+const { summarizeAgentPullRequestStates } = await import("./home-summary.js");
+
+test("the home pull request summary groups every non-merged PR without losing its lifecycle state", () => {
+  const summary = summarizeAgentPullRequestStates([
+    { state: "merged", count: 18 },
+    { state: "open", count: 4 },
+    { state: "closed", count: 2 },
+  ]);
+
+  assert.deepEqual(summary, {
+    window: "30d",
+    total: 24,
+    merged: 18,
+    unmerged: 6,
+    open: 4,
+    closed: 2,
+  });
+});

--- a/apps/api/src/home-summary.test.ts
+++ b/apps/api/src/home-summary.test.ts
@@ -3,7 +3,33 @@ import { test } from "node:test";
 
 process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
 
-const { summarizeAgentPullRequestStates } = await import("./home-summary.js");
+const { buildHomeIncidentTrend, summarizeAgentPullRequestStates } = await import(
+  "./home-summary.js"
+);
+
+test("the home incident trend preserves uncapped aggregate counts", () => {
+  const trend = buildHomeIncidentTrend(
+    204,
+    [
+      { day: "2026-07-20", severity: "SEV-1", count: 3 },
+      { day: "2026-07-20", severity: "SEV-2", count: "225" },
+      { day: "2026-07-21", severity: null, count: 7 },
+    ],
+    new Date("2026-07-21T12:00:00.000Z"),
+  );
+
+  assert.equal(trend.active, 204);
+  assert.equal(trend.rows.length, 7);
+  assert.deepEqual(trend.rows.at(-2), {
+    day: "2026-07-20",
+    label: "Mon",
+    sev1: 3,
+    sev2: 225,
+    sev3: 0,
+    untriaged: 0,
+  });
+  assert.equal(trend.rows.at(-1)?.untriaged, 7);
+});
 
 test("the home pull request summary groups every non-merged PR without losing its lifecycle state", () => {
   const summary = summarizeAgentPullRequestStates([

--- a/apps/api/src/home-summary.ts
+++ b/apps/api/src/home-summary.ts
@@ -1,9 +1,27 @@
 import { db, schema } from "@superlog/db";
-import { and, count, eq, gte } from "drizzle-orm";
+import { and, count, eq, gte, sql } from "drizzle-orm";
 
 const PULL_REQUEST_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
 type AgentPullRequestState = "open" | "closed" | "merged";
+
+type HomeIncidentAggregateRow = {
+  day: string;
+  severity: string | null;
+  count: number | string;
+};
+
+export type HomeIncidentTrend = {
+  active: number;
+  rows: Array<{
+    day: string;
+    label: string;
+    sev1: number;
+    sev2: number;
+    sev3: number;
+    untriaged: number;
+  }>;
+};
 
 export type AgentPullRequestSummary = {
   window: "30d";
@@ -29,6 +47,61 @@ export function summarizeAgentPullRequestStates(
     open: counts.open,
     closed: counts.closed,
   };
+}
+
+export function buildHomeIncidentTrend(
+  active: number,
+  aggregates: HomeIncidentAggregateRow[],
+  now = new Date(),
+): HomeIncidentTrend {
+  const rows = Array.from({ length: 7 }, (_, index) => {
+    const day = new Date(now);
+    day.setUTCHours(0, 0, 0, 0);
+    day.setUTCDate(day.getUTCDate() - (6 - index));
+    return {
+      day: day.toISOString().slice(0, 10),
+      label: day.toLocaleDateString("en", { weekday: "short", timeZone: "UTC" }),
+      sev1: 0,
+      sev2: 0,
+      sev3: 0,
+      untriaged: 0,
+    };
+  });
+  const byDay = new Map(rows.map((row) => [row.day, row]));
+  for (const aggregate of aggregates) {
+    const row = byDay.get(aggregate.day);
+    if (!row) continue;
+    const value = Number(aggregate.count);
+    if (aggregate.severity === "SEV-1") row.sev1 += value;
+    else if (aggregate.severity === "SEV-2") row.sev2 += value;
+    else if (aggregate.severity === "SEV-3") row.sev3 += value;
+    else row.untriaged += value;
+  }
+  return { active, rows };
+}
+
+export async function getProjectHomeIncidentTrend(
+  projectId: string,
+  now = new Date(),
+): Promise<HomeIncidentTrend> {
+  const since = new Date(now);
+  since.setUTCHours(0, 0, 0, 0);
+  since.setUTCDate(since.getUTCDate() - 6);
+  const day = sql<string>`to_char(${schema.incidents.firstSeen} AT TIME ZONE 'UTC', 'YYYY-MM-DD')`;
+
+  const [activeRows, aggregates] = await Promise.all([
+    db
+      .select({ count: count() })
+      .from(schema.incidents)
+      .where(and(eq(schema.incidents.projectId, projectId), eq(schema.incidents.status, "open"))),
+    db
+      .select({ day, severity: schema.incidents.severity, count: count() })
+      .from(schema.incidents)
+      .where(and(eq(schema.incidents.projectId, projectId), gte(schema.incidents.firstSeen, since)))
+      .groupBy(day, schema.incidents.severity),
+  ]);
+
+  return buildHomeIncidentTrend(Number(activeRows[0]?.count ?? 0), aggregates, now);
 }
 
 export async function getProjectAgentPullRequestSummary(

--- a/apps/api/src/home-summary.ts
+++ b/apps/api/src/home-summary.ts
@@ -1,0 +1,52 @@
+import { db, schema } from "@superlog/db";
+import { and, count, eq, gte } from "drizzle-orm";
+
+const PULL_REQUEST_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+type AgentPullRequestState = "open" | "closed" | "merged";
+
+export type AgentPullRequestSummary = {
+  window: "30d";
+  total: number;
+  merged: number;
+  unmerged: number;
+  open: number;
+  closed: number;
+};
+
+export function summarizeAgentPullRequestStates(
+  rows: Array<{ state: AgentPullRequestState; count: number | string }>,
+): AgentPullRequestSummary {
+  const counts: Record<AgentPullRequestState, number> = { open: 0, closed: 0, merged: 0 };
+  for (const row of rows) counts[row.state] = Number(row.count);
+
+  const unmerged = counts.open + counts.closed;
+  return {
+    window: "30d",
+    total: counts.merged + unmerged,
+    merged: counts.merged,
+    unmerged,
+    open: counts.open,
+    closed: counts.closed,
+  };
+}
+
+export async function getProjectAgentPullRequestSummary(
+  projectId: string,
+  now = new Date(),
+): Promise<AgentPullRequestSummary> {
+  const since = new Date(now.getTime() - PULL_REQUEST_WINDOW_MS);
+  const rows = await db
+    .select({ state: schema.agentPullRequests.state, count: count() })
+    .from(schema.agentPullRequests)
+    .innerJoin(schema.incidents, eq(schema.incidents.id, schema.agentPullRequests.incidentId))
+    .where(
+      and(
+        eq(schema.incidents.projectId, projectId),
+        gte(schema.agentPullRequests.createdAt, since),
+      ),
+    )
+    .groupBy(schema.agentPullRequests.state);
+
+  return summarizeAgentPullRequestStates(rows);
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -448,7 +448,7 @@ mountSettingsAuthed(app);
 mountProjectMcpServersAuthed(app);
 mountPorterAuthed(app);
 mountOrgKeyManagementAuthed(app);
-mountDashboards(app);
+mountDashboards(app, { clickhouse: ch });
 mountSavedViews(app);
 mountCloudConnectionsAuthed(app);
 mountIngestFilters(app);

--- a/apps/api/src/mcp/dashboards.ts
+++ b/apps/api/src/mcp/dashboards.ts
@@ -18,11 +18,11 @@ import {
   homeBuiltinTypeSchema,
   listDashboardsForProject,
   setDashboardVariables,
+  setHomeBuiltin,
   updateDashboard,
   updateDashboardLayout,
   updateDashboardWidget,
   updateHomeLayout,
-  setHomeBuiltin,
 } from "../dashboards-service.js";
 import { assertProjectAccess } from "./projects.js";
 
@@ -80,7 +80,7 @@ export function registerDashboardTools(
     {
       title: "Enable or disable a home built-in",
       description:
-        "Show or hide one of the built-in home widgets: setup_todos, active_incidents, or service_map.",
+        "Show or hide one of the built-in home widgets: setup_todos, active_incidents, service_map, incoming_signals, incident_count, or agent_pull_requests.",
       inputSchema: {
         project_id: projectIdSchema,
         type: homeBuiltinTypeSchema,

--- a/apps/web/components.json
+++ b/apps/web/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "src/index.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  }
+}

--- a/apps/web/dither-kit.json
+++ b/apps/web/dither-kit.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://tripwire.sh/schema/dither-kit.json",
+  "lockfileVersion": 1,
+  "registry": "https://tripwire.sh",
+  "mode": "source",
+  "components": {
+    "area-chart": {
+      "version": "0.1.0",
+      "hash": "sha256:197d088204a38580fec861579c89e8c5aff7fe158222ce9b7a1a4b0a605e415e",
+      "files": [
+        {
+          "path": "components/dither-kit/area-chart.tsx",
+          "hash": "sha256:307883b537e005386a8090499eaf3ea636767a10235271181cb089c3477eab1e"
+        },
+        {
+          "path": "components/dither-kit/area.tsx",
+          "hash": "sha256:ecfb990f9083dd4c813eb431e3674822b7272076294de4ae038e81552d678532"
+        },
+        {
+          "path": "components/dither-kit/cartesian-canvas.tsx",
+          "hash": "sha256:180a1525cbe10ec35bc79f689bd018cfdf115ebb4e1e6b1ff31d4bd37ecc6f09"
+        },
+        {
+          "path": "components/dither-kit/sparkline.tsx",
+          "hash": "sha256:b5dab0b68af7ebc976ec51a74776761ac26d79f4aacd9c453a6e79c49e8d11ff"
+        }
+      ]
+    },
+    "bar-chart": {
+      "version": "0.1.0",
+      "hash": "sha256:fb4a2e9bba84e3558e0e162de42eaf07a741557bfa43167c0e319cdfa75acd0d",
+      "files": [
+        {
+          "path": "components/dither-kit/bar-canvas.tsx",
+          "hash": "sha256:80ed40b87eb3dbf3d9f768cf42b3b55f4f738db8b193c1a616f7abf525d83f87"
+        },
+        {
+          "path": "components/dither-kit/bar-chart.tsx",
+          "hash": "sha256:e19ce3540f15756aba615eb19072aeec81d8ac71e51219691cc1d0be004c18bb"
+        },
+        {
+          "path": "components/dither-kit/bar.tsx",
+          "hash": "sha256:2904ff1b0813ae20b976f5a78d57a314729ea3e890b18ba762bbb46d2f550057"
+        }
+      ]
+    },
+    "core": {
+      "version": "0.1.0",
+      "hash": "sha256:c2d71baa1313a822cbef24de39414e21df7029fc80ad297ab8471d3d727235e9",
+      "files": [
+        {
+          "path": "components/dither-kit/block-legend.tsx",
+          "hash": "sha256:4ddf215c6187ac0ca2640501c0342699bc210b33c1cec1d3e138ee3d38f77433"
+        },
+        {
+          "path": "components/dither-kit/cartesian-root.tsx",
+          "hash": "sha256:6b5297d75de22ae5a0fc1960bef0419a4984b54ff493e7acd527aa0ccb150098"
+        },
+        {
+          "path": "components/dither-kit/chart-context.tsx",
+          "hash": "sha256:955657f21fdbf7e04b80917be52b7c3839eb535b8d07f15053c06d9320683d8f"
+        },
+        {
+          "path": "components/dither-kit/common-context.tsx",
+          "hash": "sha256:aafb26404977148144a3d81da81a678d5956e14024f394ccdc7ae881dd07e52a"
+        },
+        {
+          "path": "components/dither-kit/dither-paint.ts",
+          "hash": "sha256:1bcd3d7de3ae3091caf63ed4c2c862d80d1899c9b55a70078acb12f7b44e51c7"
+        },
+        {
+          "path": "components/dither-kit/dot.tsx",
+          "hash": "sha256:207bf90662237064940d14a4d8411135d75027b97a9582c0e61c8af74ea5d65a"
+        },
+        {
+          "path": "components/dither-kit/grid.tsx",
+          "hash": "sha256:ad09d80b3898a4d3f588ff1f2f4f82984864c3918cb09d31350be6ac18d2446f"
+        },
+        {
+          "path": "components/dither-kit/legend.tsx",
+          "hash": "sha256:2a067ebdc484c7bd9efb2afc4e8a0aa6718a14ec44ccd7bb94c871d192e501e6"
+        },
+        {
+          "path": "components/dither-kit/lib.ts",
+          "hash": "sha256:41493601eb53a70f7629f6e50bad233f7185eaad42ba2397ca56ac1afcf1bb5f"
+        },
+        {
+          "path": "components/dither-kit/palette.ts",
+          "hash": "sha256:fd020c230ad818a5d9d6dfdfcb6ef50b0dba012c77f44f1a61449fc9a65947f7"
+        },
+        {
+          "path": "components/dither-kit/polar-context.tsx",
+          "hash": "sha256:514ac9a4984b036598a14ecd7acc29ee121e9259c8a85309d7ed3c1e22af6831"
+        },
+        {
+          "path": "components/dither-kit/polar-root.tsx",
+          "hash": "sha256:63cecb6193ce3cd296b93b018e2441ccdefcc055cdc31bf131c808f0cf0c0c52"
+        },
+        {
+          "path": "components/dither-kit/polar.ts",
+          "hash": "sha256:3ad3f99bac2ee21e6580abd6903720af11cedcb8d8c69a06c40690be6229672c"
+        },
+        {
+          "path": "components/dither-kit/reference-line.tsx",
+          "hash": "sha256:b0df8cf1144ab56fcce577bac4a39e06d9215a1fdf81bb112a4190a0445b138b"
+        },
+        {
+          "path": "components/dither-kit/scales.ts",
+          "hash": "sha256:62ec74acdd3e335b959423a228b47edd70c14f07a468a385d039f5c6b66ebc2b"
+        },
+        {
+          "path": "components/dither-kit/series-context.tsx",
+          "hash": "sha256:1802f1f488cc46542294f533c55fae03a4b067feca0761df75ce21de8a6a429a"
+        },
+        {
+          "path": "components/dither-kit/tooltip.tsx",
+          "hash": "sha256:d053ac2135c6f29d011cb0a83be29a797f8954ccbb02916402d2d3c2a52b17f2"
+        },
+        {
+          "path": "components/dither-kit/use-chart-dimensions.ts",
+          "hash": "sha256:74b7f2a08cce5b891348eed845fc8c218ed16fce362ef4f35587ec4cc864c834"
+        },
+        {
+          "path": "components/dither-kit/x-axis.tsx",
+          "hash": "sha256:7997bd96c341816a0f1cc6f966ad386fedc78be39e51201fa368dab1fd943d62"
+        },
+        {
+          "path": "components/dither-kit/y-axis.tsx",
+          "hash": "sha256:96d8cad3d7ca87a2a6f092399a60ba2f32612413a190f2885da67854229cdeff"
+        }
+      ]
+    },
+    "pie-chart": {
+      "version": "0.1.0",
+      "hash": "sha256:2c08ce4e2ebe3b522541b38f3e37d2b124ab7692c6501225a3558dbf3ea964ca",
+      "files": [
+        {
+          "path": "components/dither-kit/pie-canvas.tsx",
+          "hash": "sha256:bcf6f1d8024448b55a3a198afad0ee5db002b2748c5282bb27679422c6a6c2bf"
+        },
+        {
+          "path": "components/dither-kit/pie-chart.tsx",
+          "hash": "sha256:2dae2f8e6193e0bca31164ba7d7b829cc5295533cdb207783d6bdb4e346d2c13"
+        },
+        {
+          "path": "components/dither-kit/pie.tsx",
+          "hash": "sha256:1e44525a3119913b042b660be50c9c2c0e34a265ee8ed0aa32c65ce4ce9fd655"
+        }
+      ]
+    }
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
+    "@fontsource/geist-pixel": "^5.3.0",
     "@git-diff-view/file": "^0.1.3",
     "@git-diff-view/react": "^0.1.3",
     "@hugeicons/core-free-icons": "^4.1.4",
@@ -35,7 +36,11 @@
     "@types/react-grid-layout": "^2.1.0",
     "autumn-js": "^1.2.27",
     "better-auth": "^1.6.13",
+    "clsx": "^2.1.1",
+    "d3-scale": "^4.0.2",
+    "d3-shape": "^3.2.0",
     "echarts": "^6",
+    "motion": "^12.42.2",
     "posthog-js": "^1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -44,9 +49,12 @@
     "react-router-dom": "^7.15.1",
     "recharts": "^3.8.1",
     "remark-gfm": "^4.0.0",
-    "shiki": "^4.0.2"
+    "shiki": "^4.0.2",
+    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
+    "@types/d3-scale": "^4.0.9",
+    "@types/d3-shape": "^3.1.8",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",
     "@vitejs/plugin-react": "^4.3.4",

--- a/apps/web/src/components/dither-kit/area-chart.tsx
+++ b/apps/web/src/components/dither-kit/area-chart.tsx
@@ -1,0 +1,19 @@
+import { CartesianCanvas } from "./cartesian-canvas";
+import { type CartesianChartProps, CartesianRoot } from "./cartesian-root";
+
+// `object` rather than `Record<string, unknown>`: interfaces don't get an
+// implicit index signature, so interface-typed rows failed to satisfy the
+// generic. Internal layers still index rows through their own Row type.
+type Row = object;
+
+/** Composable dither **area** chart. Compose `<Area>`, `<Grid>`, axes, … inside. */
+export function AreaChart<TData extends Row>(props: CartesianChartProps<TData>) {
+  return <CartesianRoot chartType="area" Canvas={CartesianCanvas} {...props} />;
+}
+
+/** Composable dither **line** chart — `<Line>` series with a glow under the line. */
+export function LineChart<TData extends Row>(props: CartesianChartProps<TData>) {
+  return <CartesianRoot chartType="line" Canvas={CartesianCanvas} {...props} />;
+}
+
+export type AreaChartProps<TData extends Row> = CartesianChartProps<TData>;

--- a/apps/web/src/components/dither-kit/area.tsx
+++ b/apps/web/src/components/dither-kit/area.tsx
@@ -1,0 +1,94 @@
+// @ts-nocheck -- upstream Dither Kit source is not noUncheckedIndexedAccess-safe.
+import { type ReactNode, useEffect } from "react";
+import {
+  type AreaVariant,
+  type SeriesKind,
+  type StrokeVariant,
+  useChartPart,
+} from "./chart-context";
+import { SeriesContext } from "./series-context";
+
+export type SeriesProps = {
+  dataKey: string;
+  variant?: AreaVariant;
+  strokeVariant?: StrokeVariant;
+  isClickable?: boolean;
+  children?: ReactNode;
+};
+
+/**
+ * Shared implementation for the continuous series (`<Area>`, `<Line>`). The
+ * dithered fill/line is painted on the canvas; this registers the series so the
+ * canvas knows how to draw it, wires click-to-select via a transparent band
+ * polygon, and exposes the series to child `<Dot>`/`<ActiveDot>` markers.
+ */
+function CartesianSeries({
+  part,
+  kind,
+  dataKey,
+  variant = "gradient",
+  strokeVariant = "solid",
+  isClickable = false,
+  children,
+}: SeriesProps & { part: string; kind: SeriesKind }) {
+  const ctx = useChartPart(part, kind === "line" ? "line" : "area");
+  const { registerSeries, unregisterSeries } = ctx;
+
+  if (process.env.NODE_ENV !== "production" && !ctx.config[dataKey]) {
+    console.warn(
+      `<${part} dataKey="${dataKey}" />: "${dataKey}" is not in the chart \`config\`. Add it so the series has a colour and label.`,
+    );
+  }
+
+  useEffect(() => {
+    registerSeries({ dataKey, kind, variant, strokeVariant });
+    return () => unregisterSeries(dataKey);
+  }, [dataKey, kind, variant, strokeVariant, registerSeries, unregisterSeries]);
+
+  const band = ctx.bands[dataKey];
+  if (!ctx.ready || !band) return null;
+
+  const seed = ctx.seedOf(dataKey);
+  const emphasis = ctx.selectedDataKey ?? ctx.focusDataKey;
+  const dimmed = emphasis !== null && emphasis !== dataKey;
+  const onClick = isClickable
+    ? () => ctx.selectDataKey(ctx.selectedDataKey === dataKey ? null : dataKey)
+    : undefined;
+
+  // Transparent hit polygon tracing the series' own band, so clicking a series
+  // selects *that* series. The Legend offers the same toggle accessibly.
+  // One pass out along the top edge, one pass back along the floor.
+  let hitPath: string | null = null;
+  if (isClickable) {
+    const parts: string[] = [];
+    for (const [i, b] of band.entries()) {
+      parts.push(`${i === 0 ? "M" : "L"}${ctx.xCenter(i)},${ctx.y(b[1])}`);
+    }
+    for (let i = band.length - 1; i >= 0; i -= 1) {
+      parts.push(`L${ctx.xCenter(i)},${ctx.y(band[i][0])}`);
+    }
+    hitPath = `${parts.join(" ")} Z`;
+  }
+
+  return (
+    <>
+      {hitPath && (
+        // biome-ignore lint/a11y/useKeyWithClickEvents: the accessible Legend exposes the same selection action
+        <path d={hitPath} fill="transparent" style={{ cursor: "pointer" }} onClick={onClick} />
+      )}
+      <SeriesContext value={{ dataKey, seed, dimmed }}>{children}</SeriesContext>
+    </>
+  );
+}
+
+export type AreaProps = SeriesProps;
+
+/** One area series — dithered fill from the value line down to its floor. */
+export function Area(props: AreaProps) {
+  return <CartesianSeries part="Area" kind="area" {...props} />;
+}
+
+/** One line series — bright line with a thin dither glow hugging it. */
+export function Line(props: AreaProps) {
+  return <CartesianSeries part="Line" kind="line" {...props} />;
+}

--- a/apps/web/src/components/dither-kit/bar-canvas.tsx
+++ b/apps/web/src/components/dither-kit/bar-canvas.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { useChart } from "./chart-context";
+import {
+  backingSize,
+  bloomLayerStyle,
+  clamp01,
+  easeOutCubic,
+  paintColumn,
+  prefersReducedMotion,
+} from "./dither-paint";
+
+type Bars = { top: number[]; base: number[] }; // per data index, in backing rows
+
+// Fraction of the timeline spent staggering bar starts — the rest is each bar's
+// own grow window, so the rise sweeps across the chart as a wave.
+const STAGGER = 0.55;
+
+/**
+ * Dither canvas for bar charts. Each category owns a band; grouped series split
+ * it into side-by-side bars, stacked series share its full width and pile in y.
+ * Every bar is filled with the shared {@link paintColumn} ordered dither. Bars
+ * grow up from their base in a staggered left-to-right wave (eased), and the
+ * hovered category lifts while the rest dim.
+ */
+export function BarCanvas() {
+  const ctx = useChart();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const bloomRef = useRef<HTMLCanvasElement>(null);
+
+  const { width, height } = ctx.plot;
+  const { cols, rows } = backingSize(width, height);
+  const { ready, configKeys, bands, y } = ctx;
+
+  // Memoized: per-series bar tops/bases (backing rows) over the data indices.
+  // The canvas re-renders on every hover/cursor tick, so pin this map to the
+  // exact ctx fields it reads plus the backing geometry — a bar hover must not
+  // rebuild every band's geometry.
+  const targets = useMemo(() => {
+    const out: Record<string, Bars> = {};
+    if (!ready) return out;
+    const h = height || 1;
+    for (const key of configKeys) {
+      const band = bands[key];
+      if (!band) continue;
+      out[key] = {
+        top: band.map((b) => (y(b[1]) / h) * (rows - 1)),
+        base: band.map((b) => (y(b[0]) / h) * (rows - 1)),
+      };
+    }
+    return out;
+  }, [ready, configKeys, bands, y, height, rows]);
+
+  // The RAF loop reads these through refs so it always sees the latest values;
+  // refs are written in an effect (never during render) — mutating a ref
+  // mid-render tears under Strict Mode / concurrent rendering.
+  const state = useRef(ctx);
+  const targetsRef = useRef(targets);
+  useEffect(() => {
+    state.current = ctx;
+    targetsRef.current = targets;
+  });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const c = canvas?.getContext("2d");
+    if (!(canvas && c) || cols <= 0 || rows <= 0) return;
+    canvas.width = cols;
+    canvas.height = rows;
+
+    const bloomCanvas = bloomRef.current;
+    const bloomCtx = bloomCanvas?.getContext("2d") ?? null;
+    if (bloomCanvas) {
+      bloomCanvas.width = cols;
+      bloomCanvas.height = rows;
+    }
+
+    const reduce = prefersReducedMotion();
+    const animate = state.current.animate && !reduce;
+    const duration = state.current.animationDuration;
+    const fx = cols / Math.max(width, 1);
+
+    // Eased grow factor for bar `i` at global progress `prog`.
+    const barProgress = (i: number, len: number, prog: number) => {
+      if (!animate) return 1;
+      const start = len > 1 ? (i / (len - 1)) * STAGGER : 0;
+      return easeOutCubic(clamp01((prog - start) / (1 - STAGGER)));
+    };
+
+    const paint = (prog: number) => {
+      const s = state.current;
+      c.clearRect(0, 0, cols, rows);
+      const stacked = s.stackType === "stacked" || s.stackType === "percent";
+      const keys = s.configKeys;
+      keys.forEach((key, si) => {
+        const t = targetsRef.current[key];
+        if (!t) return;
+        const seed = s.seedOf(key);
+        const variant = s.seriesSpecs[key]?.variant ?? "gradient";
+        const emphasis = s.selectedDataKey ?? s.focusDataKey;
+        const selDim = emphasis !== null && emphasis !== key ? 0.3 : 1;
+        for (let i = 0; i < s.dataLength; i++) {
+          const bp = barProgress(i, s.dataLength, prog);
+          const base = t.base[i] ?? rows - 1;
+          const grown = base + ((t.top[i] ?? base) - base) * bp;
+          // Bars grow from the zero baseline toward the value. Positive values
+          // sit above the baseline (smaller pixel), negative ones below it —
+          // paintColumn wants the higher edge first, so order the pair.
+          const top = Math.min(grown, base);
+          const bottom = Math.max(grown, base);
+          const active = s.hoverIndex === i;
+          const hoverDim = s.hoverIndex != null && !active && s.isMouseInChart ? 0.5 : 1;
+          const slot = s.barSlot(i, si, keys.length);
+          const c0 = Math.round(slot.x * fx);
+          const c1 = Math.round((slot.x + slot.width) * fx);
+          for (let x = c0; x < c1; x++) {
+            paintColumn(c, x, top, bottom, seed, {
+              variant,
+              intensity: intensity + (active ? 0.4 : 0),
+              dim: selDim * hoverDim,
+              stacked,
+            });
+          }
+        }
+      });
+    };
+
+    let raf = 0;
+    let animStart = 0;
+    let lastProg = -1;
+    let lastRevision = state.current.revision;
+    let intensity = 0;
+    let needsFill = true;
+    let lastPaintSig = "";
+    let lastSelected: string | null | undefined = Symbol() as never;
+    let lastHover: number | null | undefined = Symbol() as never;
+
+    const draw = (now: number) => {
+      raf = requestAnimationFrame(draw);
+      const s = state.current;
+      if (!s.ready) return;
+      if (bloomCtx) {
+        const on = s.bloom !== "off" && (!s.bloomOnHover || s.isMouseInChart || s.hovered);
+        if (on) {
+          bloomCtx.clearRect(0, 0, cols, rows);
+          bloomCtx.drawImage(canvas, 0, 0);
+        }
+      }
+      if (s.revision !== lastRevision) {
+        lastRevision = s.revision;
+        animStart = 0; // re-play the wave on data change / replay
+        lastProg = -1;
+      }
+      if (!animStart) animStart = now;
+      const prog = animate ? Math.min(1, (now - animStart) / duration) : 1;
+
+      if (prog !== lastProg) {
+        lastProg = prog;
+        needsFill = true;
+      }
+      const emphasisNow = s.selectedDataKey ?? s.focusDataKey;
+      if (emphasisNow !== lastSelected) {
+        lastSelected = emphasisNow;
+        needsFill = true;
+      }
+      if (s.hoverIndex !== lastHover) {
+        lastHover = s.hoverIndex;
+        needsFill = true;
+      }
+      const itTarget = s.isMouseInChart || s.hovered ? 1 : 0;
+      if (Math.abs(intensity - itTarget) > 0.001) {
+        intensity += (itTarget - intensity) * (reduce ? 1 : 0.16);
+        needsFill = true;
+      } else intensity = itTarget;
+
+      // Live tweak repaint (variant, stacking) without replaying the wave.
+      const paintSig = `${s.stackType}|${s.configKeys
+        .map((k) => s.seriesSpecs[k]?.variant ?? "")
+        .join(",")}`;
+      if (paintSig !== lastPaintSig) {
+        lastPaintSig = paintSig;
+        needsFill = true;
+      }
+
+      if (!needsFill) return;
+      paint(prog);
+      needsFill = false;
+    };
+
+    raf = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(raf);
+  }, [cols, rows, width]);
+
+  const bloomActive = ctx.bloomOnHover ? ctx.isMouseInChart || ctx.hovered : true;
+  const bloom = bloomLayerStyle(ctx.bloom, bloomActive);
+  const pos = {
+    left: ctx.margins.left,
+    top: ctx.margins.top,
+    width,
+    height,
+  } as const;
+
+  return (
+    <>
+      <canvas
+        ref={canvasRef}
+        className="pointer-events-none absolute"
+        style={{ ...pos, imageRendering: "pixelated" }}
+      />
+      <canvas
+        ref={bloomRef}
+        className="pointer-events-none absolute"
+        style={{
+          ...pos,
+          transition: "opacity 220ms ease",
+          ...(bloom ?? { opacity: 0 }),
+        }}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/dither-kit/bar-chart.tsx
+++ b/apps/web/src/components/dither-kit/bar-chart.tsx
@@ -1,0 +1,12 @@
+import { BarCanvas } from "./bar-canvas";
+import { type CartesianChartProps, CartesianRoot } from "./cartesian-root";
+
+// `object` rather than `Record<string, unknown>`: interfaces don't get an
+// implicit index signature, so interface-typed rows failed to satisfy the
+// generic. Internal layers still index rows through their own Row type.
+type Row = object;
+
+/** Composable dither **bar** chart — `<Bar>` series, grouped or stacked. */
+export function BarChart<TData extends Row>(props: CartesianChartProps<TData>) {
+  return <CartesianRoot chartType="bar" Canvas={BarCanvas} {...props} />;
+}

--- a/apps/web/src/components/dither-kit/bar.tsx
+++ b/apps/web/src/components/dither-kit/bar.tsx
@@ -1,0 +1,74 @@
+import { type ReactNode, useEffect } from "react";
+import { type AreaVariant, type StrokeVariant, useChartPart } from "./chart-context";
+import { SeriesContext } from "./series-context";
+
+export type BarProps = {
+  dataKey: string;
+  variant?: AreaVariant;
+  strokeVariant?: StrokeVariant;
+  isClickable?: boolean;
+  children?: ReactNode;
+};
+
+/**
+ * One bar series. The dithered bars are painted on the canvas; this registers
+ * the series and (when `isClickable`) lays transparent hit rects over each bar
+ * — using the shared `barSlot` geometry so clicks line up with the pixels — to
+ * select the series. The Legend offers the same toggle accessibly.
+ */
+export function Bar({
+  dataKey,
+  variant = "gradient",
+  strokeVariant = "solid",
+  isClickable = false,
+  children,
+}: BarProps) {
+  const ctx = useChartPart("Bar", "bar");
+  const { registerSeries, unregisterSeries } = ctx;
+
+  if (process.env.NODE_ENV !== "production" && !ctx.config[dataKey]) {
+    console.warn(
+      `<Bar dataKey="${dataKey}" />: "${dataKey}" is not in the chart \`config\`. Add it so the series has a colour and label.`,
+    );
+  }
+
+  useEffect(() => {
+    registerSeries({ dataKey, kind: "bar", variant, strokeVariant });
+    return () => unregisterSeries(dataKey);
+  }, [dataKey, variant, strokeVariant, registerSeries, unregisterSeries]);
+
+  const band = ctx.bands[dataKey];
+  if (!ctx.ready || !band) return null;
+
+  const seed = ctx.seedOf(dataKey);
+  const dimmed = ctx.selectedDataKey !== null && ctx.selectedDataKey !== dataKey;
+  const si = ctx.configKeys.indexOf(dataKey);
+  const n = ctx.configKeys.length;
+  const onClick = () => ctx.selectDataKey(ctx.selectedDataKey === dataKey ? null : dataKey);
+
+  return (
+    <>
+      {isClickable &&
+        band.map((b, i) => {
+          const slot = ctx.barSlot(i, si, n);
+          const top = ctx.y(b[1]);
+          const base = ctx.y(b[0]);
+          return (
+            // biome-ignore lint/a11y/useKeyWithClickEvents: the accessible Legend exposes the same selection action
+            <rect
+              // biome-ignore lint/suspicious/noArrayIndexKey: index is the stable category position
+              key={i}
+              x={slot.x}
+              y={Math.min(top, base)}
+              width={slot.width}
+              height={Math.abs(base - top)}
+              fill="transparent"
+              style={{ cursor: "pointer" }}
+              onClick={onClick}
+            />
+          );
+        })}
+      <SeriesContext value={{ dataKey, seed, dimmed }}>{children}</SeriesContext>
+    </>
+  );
+}

--- a/apps/web/src/components/dither-kit/block-legend.tsx
+++ b/apps/web/src/components/dither-kit/block-legend.tsx
@@ -1,0 +1,58 @@
+import type { ChartConfig } from "./chart-context";
+import { cn } from "./lib";
+import { rgb, seedOfColor } from "./palette";
+
+/**
+ * An in-flow legend rendered as a sibling of the chart rather than an overlay.
+ *
+ * The overlay {@link Legend} is pinned absolutely to the top of the plot, so
+ * with more than ~3 entries (or a narrow container) its wrapped rows sit on top
+ * of the chart. `<BlockLegend>` lives in normal document flow, so it can never
+ * overlap the plot at any width — use it for multi-entry charts (donuts, many
+ * series) and reserve the overlay `<Legend>` for ≤2–3 entries.
+ *
+ * It needs no chart context: feed it the same `config` you pass the chart, and
+ * optionally a `values` map to show a number beside each entry (e.g. allocation
+ * shares or totals).
+ */
+export function BlockLegend({
+  config,
+  values,
+  valueFormatter = (v) => String(v),
+  align = "start",
+  className,
+}: {
+  config: ChartConfig;
+  values?: Record<string, number>;
+  valueFormatter?: (value: number) => string;
+  align?: "start" | "center" | "end";
+  className?: string;
+}) {
+  return (
+    <ul
+      className={cn(
+        "flex flex-wrap gap-x-4 gap-y-1.5 px-1",
+        align === "center" && "justify-center",
+        align === "end" && "justify-end",
+        className,
+      )}
+    >
+      {Object.entries(config).map(([name, entry]) => {
+        const seed = seedOfColor(entry.color);
+        const value = values?.[name];
+        return (
+          <li
+            key={name}
+            className="flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground"
+          >
+            <span className="size-2 rounded-[1px]" style={{ backgroundColor: rgb(seed.fill) }} />
+            <span>{entry.label ?? name}</span>
+            {value !== undefined ? (
+              <span className="text-foreground">{valueFormatter(value)}</span>
+            ) : null}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/web/src/components/dither-kit/cartesian-canvas.tsx
+++ b/apps/web/src/components/dither-kit/cartesian-canvas.tsx
@@ -1,0 +1,388 @@
+// @ts-nocheck -- upstream Dither Kit source is not noUncheckedIndexedAccess-safe.
+"use client";
+
+import { type RefObject, useEffect, useMemo, useRef } from "react";
+import { type ChartContextValue, useChart } from "./chart-context";
+import {
+  backingSize,
+  bloomLayerStyle,
+  easeInOutCubic,
+  paintColumn,
+  prefersReducedMotion,
+  resample,
+} from "./dither-paint";
+import { rgb } from "./palette";
+
+type Star = { key: string; xi: number; depth: number; phase: number };
+type Surface = { top: number[]; floor: number[] };
+
+type LoopArgs = {
+  canvas: HTMLCanvasElement;
+  bloomCanvas: HTMLCanvasElement | null;
+  cols: number;
+  rows: number;
+  state: RefObject<ChartContextValue>;
+  targets: RefObject<Record<string, Surface>>;
+  stars: RefObject<Star[]>;
+};
+
+/**
+ * The requestAnimationFrame paint loop — eases each series toward its target
+ * surface, paints the dither fill (with the entrance reveal), then layers the
+ * crosshair marker and winking stars on top. Lives outside the component so the
+ * component stays small and this hot closure isn't re-created on every render.
+ * Returns a cleanup that cancels the loop.
+ */
+function startCartesianLoop({
+  canvas,
+  bloomCanvas,
+  cols,
+  rows,
+  state,
+  targets,
+  stars,
+}: LoopArgs): (() => void) | undefined {
+  const c = canvas.getContext("2d");
+  if (!c || cols <= 0 || rows <= 0) return undefined;
+  canvas.width = cols;
+  canvas.height = rows;
+
+  const off = document.createElement("canvas");
+  off.width = cols;
+  off.height = rows;
+  const octx = off.getContext("2d");
+  if (!octx) return undefined;
+
+  // Bloom layer: a blurred, additive copy of the crisp canvas.
+  const bloomCtx = bloomCanvas?.getContext("2d") ?? null;
+  if (bloomCanvas) {
+    bloomCanvas.width = cols;
+    bloomCanvas.height = rows;
+  }
+
+  const reduce = prefersReducedMotion();
+  const EASE = reduce ? 1 : 0.18;
+  const animate = state.current.animate && !reduce;
+  const duration = state.current.animationDuration;
+  const current: Record<string, Surface> = {};
+
+  // `reveal` (0–1) sweeps the fill in left-to-right on first paint.
+  const paintFill = (intensity: number, reveal: number) => {
+    octx.clearRect(0, 0, cols, rows);
+    const s = state.current;
+    const stacked = s.stackType === "stacked" || s.stackType === "percent";
+    const revealCols = Math.ceil(reveal * cols);
+    s.configKeys.forEach((key, si) => {
+      const cur = current[key];
+      if (!cur) return;
+      const seed = s.seedOf(key);
+      const variant = s.seriesSpecs[key]?.variant ?? "gradient";
+      const isLine =
+        (s.seriesSpecs[key]?.kind ?? (s.chartType === "line" ? "line" : "area")) === "line";
+      const emphasis = s.selectedDataKey ?? s.focusDataKey;
+      const dim = emphasis !== null && emphasis !== key ? 0.3 : 1;
+      // Overlapping (non-stacked) layers thin out front-to-back so they
+      // read as distinct layers instead of a muddy blend.
+      const sparse = stacked ? 0 : si * 0.14;
+      for (let x = 0; x < cols; x++) {
+        if (x > revealCols) break;
+        // For a value that dips below the zero baseline the value line ends up
+        // *below* the floor in pixels; paintColumn needs the higher edge first,
+        // so order the pair (a no-op for the common positive case).
+        const a = cur.top[x] ?? 0;
+        const b = cur.floor[x] ?? 0;
+        paintColumn(octx, x, Math.min(a, b), Math.max(a, b), seed, {
+          variant,
+          intensity,
+          dim,
+          stacked: stacked && !isLine,
+          sparse,
+        });
+      }
+    });
+  };
+
+  let raf = 0;
+  let tick = 0;
+  let last = 0;
+  let animStart = 0;
+  let lastProg = -1;
+  let lastRevision = state.current.revision;
+  let entranceReported = !animate;
+  let intensity = 0;
+  let needsFill = true;
+  let lastPaintSig = "";
+  let lastSelected: string | null | undefined = Symbol() as never;
+
+  const draw = (now: number) => {
+    raf = requestAnimationFrame(draw);
+    const s = state.current;
+    if (!s.ready) return;
+    // Keep the bloom layer in sync with the crisp canvas while it's active.
+    if (bloomCtx) {
+      const on = s.bloom !== "off" && (!s.bloomOnHover || s.isMouseInChart || s.hovered);
+      if (on) {
+        bloomCtx.clearRect(0, 0, cols, rows);
+        bloomCtx.drawImage(canvas, 0, 0);
+      }
+    }
+    const tgt = targets.current;
+    if (s.revision !== lastRevision) {
+      lastRevision = s.revision;
+      animStart = 0; // re-play the entrance on data change / replay
+      lastProg = -1;
+      entranceReported = false;
+    }
+    if (!animStart) animStart = now;
+    const prog = animate ? Math.min(1, (now - animStart) / duration) : 1;
+    const progChanged = prog !== lastProg;
+    // Tell the context the reveal is done so DOM markers fade in in sync.
+    if (prog >= 1 && !entranceReported) {
+      entranceReported = true;
+      s.markEntranceDone();
+    }
+
+    let moving = false;
+    for (const key of s.configKeys) {
+      const t = tgt[key];
+      if (!t) continue;
+      const cur = current[key];
+      if (!cur || cur.top.length !== cols) {
+        current[key] = { top: t.top.slice(), floor: t.floor.slice() };
+        needsFill = true;
+        continue;
+      }
+      for (let x = 0; x < cols; x++) {
+        const dt = t.top[x] - cur.top[x];
+        const df = t.floor[x] - cur.floor[x];
+        if (Math.abs(dt) > 0.01 || Math.abs(df) > 0.01) {
+          cur.top[x] += dt * EASE;
+          cur.floor[x] += df * EASE;
+          moving = true;
+        } else {
+          cur.top[x] = t.top[x];
+          cur.floor[x] = t.floor[x];
+        }
+      }
+    }
+    for (const key of Object.keys(current)) {
+      if (!tgt[key]) {
+        delete current[key];
+        needsFill = true;
+      }
+    }
+    if (moving) needsFill = true;
+    const emphasisNow = s.selectedDataKey ?? s.focusDataKey;
+    if (emphasisNow !== lastSelected) {
+      lastSelected = emphasisNow;
+      needsFill = true;
+    }
+
+    const itTarget = s.isMouseInChart || s.hovered ? 1 : 0;
+    let settling = false;
+    if (Math.abs(intensity - itTarget) > 0.001) {
+      intensity += (itTarget - intensity) * 0.16;
+      settling = true;
+      needsFill = true;
+    } else intensity = itTarget;
+
+    // Live hover wins; the controlled markerIndex (e.g. a committed point)
+    // is the fallback shown when nothing is hovered.
+    const marker = s.hoverIndex != null ? s.hoverIndex : s.markerIndex;
+    const winkDue = !reduce && now - last >= 100;
+    // Repaint when a tweak-driven paint input changes (variant, stacking) so
+    // the panel updates the fill live — without resetting the entrance reveal.
+    const paintSig = `${s.stackType}|${s.configKeys
+      .map((k) => s.seriesSpecs[k]?.variant ?? "")
+      .join(",")}`;
+    const sigChanged = paintSig !== lastPaintSig;
+    if (sigChanged) {
+      lastPaintSig = paintSig;
+      needsFill = true;
+    }
+    if (!(moving || settling || winkDue || marker != null || progChanged || sigChanged)) return;
+    if (progChanged) {
+      lastProg = prog;
+      needsFill = true;
+    }
+    if (winkDue) {
+      last = now;
+      tick += 1;
+    }
+
+    // Reveal front (left-to-right) — stars + crosshair stay behind it so
+    // they don't float over the not-yet-drawn area during the entrance.
+    const reveal = animate ? easeInOutCubic(prog) : 1;
+    const revealCols = reveal * cols;
+
+    if (needsFill) {
+      paintFill(intensity, reveal);
+      needsFill = false;
+    }
+    c.clearRect(0, 0, cols, rows);
+    c.drawImage(off, 0, 0);
+
+    const mx =
+      marker != null && s.dataLength > 1
+        ? Math.round((marker / (s.dataLength - 1)) * (cols - 1))
+        : -1;
+    if (mx >= 0 && mx <= revealCols) {
+      for (const key of s.configKeys) {
+        const cur = current[key];
+        if (!cur) continue;
+        const seed = s.seedOf(key);
+        const my = Math.round(cur.top[mx] ?? 0);
+        // Full-height column + a chunky marker block at the point — the
+        // series colour at higher opacity, so it reads on either theme.
+        c.fillStyle = rgb(seed.fill, 1, 0.55);
+        for (let y = my; y < rows; y++) c.fillRect(mx, y, 1, 1);
+        c.fillStyle = rgb(seed.fill);
+        c.fillRect(mx - 1, my - 1, 3, 3);
+      }
+    }
+
+    for (const star of stars.current) {
+      const cur = current[star.key];
+      if (!cur) continue;
+      const sx = Math.round((star.xi / Math.max(s.dataLength - 1, 1)) * (cols - 1));
+      if (sx > revealCols) continue; // behind the reveal front
+      const top = cur.top[sx] ?? 0;
+      const floor = cur.floor[sx] ?? rows - 1;
+      const sy = Math.round(top + star.depth * (floor - top));
+      const tw = reduce ? 0.85 : (Math.sin((tick + star.phase) * 0.35) + 1) / 2;
+      const lift = tw * (0.7 + 0.3 * intensity);
+      if (lift < 0.55 || sy < 0 || sy >= rows) continue;
+      // Sparkles glint in the series colour via opacity (the `lift` wink)
+      // rather than a lighter shade — so they never read as stray white
+      // pixels on a light background.
+      const starColor = s.seedOf(star.key).fill;
+      c.fillStyle = rgb(starColor, 1, lift);
+      c.fillRect(sx, sy, 1, 1);
+      // At the peak of a wink the star flares into a 4-point glint.
+      if (tw > 0.9) {
+        c.fillStyle = rgb(starColor, 1, lift * 0.6 * (tw - 0.9) * 10);
+        c.fillRect(sx - 1, sy, 1, 1);
+        c.fillRect(sx + 1, sy, 1, 1);
+        c.fillRect(sx, sy - 1, 1, 1);
+        c.fillRect(sx, sy + 1, 1, 1);
+      }
+    }
+  };
+
+  raf = requestAnimationFrame(draw);
+  return () => cancelAnimationFrame(raf);
+}
+
+/**
+ * Continuous dither canvas for area and line charts. Each series is reduced to a
+ * `[top, floor]` band per backing column: areas fill from their value line down
+ * to their floor; lines fill only a thin glow band hugging the line. The shared
+ * {@link paintColumn} renders the ordered-dither scatter, capped by the bright
+ * series line, with winking stars + scrub crosshair on top.
+ */
+export function CartesianCanvas() {
+  const ctx = useChart();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const bloomRef = useRef<HTMLCanvasElement>(null);
+
+  const { width, height } = ctx.plot;
+  const { cols, rows } = backingSize(width, height);
+  const { ready, chartType, configKeys, bands, seriesSpecs, y, dataLength } = ctx;
+
+  // Memoized: the pricey bit in the render path — a `resample` per series to
+  // the backing column count. The canvas re-renders on every hover/cursor tick
+  // (it consumes ctx), so without this the whole surface is rebuilt each time.
+  // Pinned to the exact ctx fields it reads, plus the backing geometry.
+  const targets = useMemo(() => {
+    const out: Record<string, Surface> = {};
+    if (!ready) return out;
+    const h = height || 1;
+    const glow = Math.max(6, Math.round(rows * 0.16));
+    const defaultKind = chartType === "line" ? "line" : "area";
+    for (const key of configKeys) {
+      const band = bands[key];
+      if (!band) continue;
+      const line = (seriesSpecs[key]?.kind ?? defaultKind) === "line";
+      const top = band.map((b) => (y(b[1]) / h) * (rows - 1));
+      const floor = band.map((b, i) =>
+        line ? Math.min(rows - 1, top[i] + glow) : (y(b[0]) / h) * (rows - 1),
+      );
+      out[key] = { top: resample(top, cols), floor: resample(floor, cols) };
+    }
+    return out;
+  }, [ready, chartType, configKeys, bands, seriesSpecs, y, height, rows, cols]);
+
+  // Memoized: the star field is deterministic — only its shape (series ×
+  // column count) matters, so it need not be rebuilt on unrelated re-renders.
+  const stars = useMemo(() => {
+    const out: Star[] = [];
+    const per = Math.max(4, Math.round(cols / 14));
+    configKeys.forEach((key, k) => {
+      for (let i = 0; i < per; i++) {
+        const seed = i * 67 + 13 + k * 131;
+        out.push({
+          key,
+          xi: seed % Math.max(dataLength, 1),
+          depth: ((seed * 53 + 7) % 100) / 100,
+          phase: (seed * 41) % 360,
+        });
+      }
+    });
+    return out;
+  }, [configKeys, dataLength, cols]);
+
+  // The RAF loop reads these through refs so it always sees the latest values
+  // without re-subscribing. Refs are written in an effect (never during
+  // render) — mutating a ref mid-render is a React anti-pattern that tears
+  // under Strict Mode / concurrent rendering.
+  const stateRef = useRef(ctx);
+  const targetsRef = useRef(targets);
+  const starsRef = useRef(stars);
+  useEffect(() => {
+    stateRef.current = ctx;
+    targetsRef.current = targets;
+    starsRef.current = stars;
+  });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    return startCartesianLoop({
+      canvas,
+      bloomCanvas: bloomRef.current,
+      cols,
+      rows,
+      state: stateRef,
+      targets: targetsRef,
+      stars: starsRef,
+    });
+  }, [cols, rows]);
+
+  const bloomActive = ctx.bloomOnHover ? ctx.isMouseInChart || ctx.hovered : true;
+  const bloom = bloomLayerStyle(ctx.bloom, bloomActive);
+  const pos = {
+    left: ctx.margins.left,
+    top: ctx.margins.top,
+    width,
+    height,
+  } as const;
+
+  return (
+    <>
+      <canvas
+        ref={canvasRef}
+        className="pointer-events-none absolute"
+        style={{ ...pos, imageRendering: "pixelated" }}
+      />
+      <canvas
+        ref={bloomRef}
+        className="pointer-events-none absolute"
+        style={{
+          ...pos,
+          transition: "opacity 220ms ease",
+          ...(bloom ?? { opacity: 0 }),
+        }}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/dither-kit/cartesian-root.tsx
+++ b/apps/web/src/components/dither-kit/cartesian-root.tsx
@@ -1,0 +1,181 @@
+import { Children, type ComponentType, type ReactNode, isValidElement } from "react";
+import {
+  type ChartConfig,
+  ChartContext,
+  type ChartType,
+  type Margins,
+  useChartController,
+} from "./chart-context";
+import { CommonChartContext } from "./common-context";
+import type { BloomInput } from "./dither-paint";
+import { cn } from "./lib";
+import type { StackType } from "./scales";
+import { useChartDimensions } from "./use-chart-dimensions";
+
+// `object` rather than `Record<string, unknown>`: interfaces don't get an
+// implicit index signature, so interface-typed rows failed to satisfy the
+// generic. Internal layers still index rows through their own Row type.
+type Row = object;
+
+const DEFAULT_MARGINS: Margins = {
+  top: 10,
+  right: 12,
+  bottom: 22,
+  left: 36,
+};
+
+export type CartesianChartProps<TData extends Row> = {
+  data: TData[];
+  config: ChartConfig;
+  children: ReactNode;
+  stackType?: StackType;
+  margins?: Partial<Margins>;
+  className?: string;
+  animate?: boolean;
+  animationDuration?: number;
+  replayToken?: number; // change to re-play the entrance without remounting
+  /** Set false for a decorative sparkline: keeps the hover lift but no scrub
+   * crosshair / tooltip. */
+  interactive?: boolean;
+  /** Controlled crosshair position (e.g. a committed point) — overrides the
+   * internal hover when set. */
+  markerIndex?: number | null;
+  /** Parent-driven hover (e.g. the whole card/row) — lifts the fill. */
+  hovered?: boolean;
+  /** Glow on the dither fill. */
+  bloom?: BloomInput;
+  /** Only bloom while the chart is hovered. */
+  bloomOnHover?: boolean;
+  /** Fires with the scrubbed index as the pointer moves (null on leave). */
+  onHoverChange?: (index: number | null) => void;
+  defaultSelectedDataKey?: string | null;
+  onSelectionChange?: (key: string | null) => void;
+};
+
+/** Which render layer a composed part targets — defaults to the front SVG. */
+function layerOf(node: ReactNode): "back" | "dom" | "svg" {
+  if (!isValidElement(node) || typeof node.type === "string") return "svg";
+  return (node.type as { chartLayer?: "back" | "dom" }).chartLayer ?? "svg";
+}
+
+/**
+ * Shared root for the cartesian dither charts (area, line, bar). Owns the
+ * measured size, the shared context, and pointer interaction; every visual is
+ * composed as children. Back chrome (grid) sits behind the dither canvas; the
+ * canvas paints the fill/line/bars + stars; front chrome (axes, dots) and DOM
+ * legend/tooltip layer on top. `chartType` drives the scales/interaction and the
+ * `Canvas` prop supplies the family's painter (continuous for area/line, bars for
+ * bar) — so each chart ships only its own canvas.
+ */
+export function CartesianRoot<TData extends Row>({
+  chartType,
+  Canvas,
+  data,
+  config,
+  children,
+  stackType = "default",
+  margins: marginsProp,
+  className,
+  animate = true,
+  animationDuration = 900,
+  replayToken = 0,
+  interactive = true,
+  markerIndex = null,
+  hovered = false,
+  bloom = "off",
+  bloomOnHover = false,
+  onHoverChange,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+}: CartesianChartProps<TData> & {
+  chartType: ChartType;
+  Canvas: ComponentType;
+}) {
+  const { ref, size } = useChartDimensions<HTMLDivElement>();
+  const margins = { ...DEFAULT_MARGINS, ...marginsProp };
+
+  const ctx = useChartController({
+    chartType,
+    // Safe: the controller only reads row[key] for the configured series keys.
+    data: data as Record<string, unknown>[],
+    config,
+    stackType,
+    dimensions: size,
+    margins,
+    animate,
+    animationDuration,
+    replayToken,
+    markerIndex,
+    hovered,
+    bloom,
+    bloomOnHover,
+    defaultSelectedDataKey,
+    onSelectionChange,
+  });
+
+  const backChildren: ReactNode[] = [];
+  const svgChildren: ReactNode[] = [];
+  const domChildren: ReactNode[] = [];
+  Children.forEach(children, (child) => {
+    const layer = layerOf(child);
+    if (layer === "back") backChildren.push(child);
+    else if (layer === "dom") domChildren.push(child);
+    else svgChildren.push(child);
+  });
+
+  const onMove = (clientX: number) => {
+    const el = ref.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const px = clientX - rect.left - margins.left;
+    const index = ctx.indexAtX(px);
+    ctx.setHoverIndex(index);
+    ctx.setCursorX(clientX - rect.left);
+    onHoverChange?.(index);
+  };
+
+  return (
+    <ChartContext value={ctx}>
+      <CommonChartContext value={ctx.common}>
+        <div
+          ref={ref}
+          className={cn("relative h-full w-full", className)}
+          onPointerEnter={() => ctx.setMouseInChart(true)}
+          onPointerMove={interactive ? (e) => onMove(e.clientX) : undefined}
+          onPointerLeave={() => {
+            ctx.setMouseInChart(false);
+            ctx.setHoverIndex(null);
+            onHoverChange?.(null);
+          }}
+        >
+          {ctx.ready && backChildren.length > 0 && (
+            <svg
+              width={size.width}
+              height={size.height}
+              className="absolute inset-0 overflow-visible"
+              aria-hidden
+              role="presentation"
+            >
+              <g transform={`translate(${margins.left},${margins.top})`}>{backChildren}</g>
+            </svg>
+          )}
+          <Canvas />
+          {ctx.ready && (
+            <svg
+              width={size.width}
+              height={size.height}
+              className="absolute inset-0 overflow-visible"
+              role="img"
+              aria-label="Chart"
+            >
+              <g transform={`translate(${margins.left},${margins.top})`}>{svgChildren}</g>
+            </svg>
+          )}
+          {domChildren}
+        </div>
+      </CommonChartContext>
+    </ChartContext>
+  );
+}
+
+export type AreaChartProps<TData extends Row> = CartesianChartProps<TData>;

--- a/apps/web/src/components/dither-kit/chart-context.tsx
+++ b/apps/web/src/components/dither-kit/chart-context.tsx
@@ -1,0 +1,478 @@
+// @ts-nocheck -- upstream Dither Kit source is not noUncheckedIndexedAccess-safe.
+import type { ScaleLinear } from "d3-scale";
+import { createContext, use, useCallback, useMemo, useState } from "react";
+import type { CommonChart } from "./common-context";
+import type { BloomInput } from "./dither-paint";
+import type { DitherColor, Seed } from "./palette";
+import { seedOfColor } from "./palette";
+import {
+  type StackType,
+  buildBandScale,
+  buildXScale,
+  buildYScale,
+  computeBands,
+  indexAtBand,
+  nearestIndex,
+} from "./scales";
+import type { Dimensions } from "./use-chart-dimensions";
+
+/** Which chart root a part is composed under — drives the boundary guards. */
+export type ChartType = "area" | "bar" | "line" | "pie" | "radar";
+
+export type ChartConfig = Record<string, { label?: string; color: DitherColor }>;
+
+export type Margins = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+type Row = Record<string, unknown>;
+
+export type AreaVariant = "gradient" | "dotted" | "hatched" | "solid";
+export type StrokeVariant = "solid" | "dashed";
+export type SeriesKind = "area" | "line" | "bar";
+
+/** What each series part (<Area />, <Line />, <Bar />) registers so the canvas
+ * knows which series to paint and how. */
+export type SeriesSpec = {
+  dataKey: string;
+  kind: SeriesKind;
+  variant: AreaVariant;
+  strokeVariant: StrokeVariant;
+};
+
+export type ChartContextValue = {
+  chartType: ChartType; // which root this part is under
+  config: ChartConfig;
+  configKeys: string[]; // series order — drives stacking + legend
+  data: Row[];
+  dataLength: number;
+  stackType: StackType;
+
+  margins: Margins;
+  plot: { width: number; height: number }; // inner drawing area
+  ready: boolean; // true once measured (width > 0)
+
+  xCenter: (index: number) => number; // category centre px within the plot
+  bandwidth: number; // category slot width (0 for point/area scales)
+  indexAtX: (px: number) => number; // nearest category for a pointer x
+  // Bar geometry in plot px — one source of truth for the canvas + click rects.
+  barSlot: (
+    index: number,
+    seriesIndex: number,
+    seriesCount: number,
+  ) => { x: number; width: number };
+  y: ScaleLinear<number, number>; // value → px within the plot
+  bands: Record<string, [number, number][]>; // per-series [y0, y1] per row
+  max: number;
+  min: number; // most-negative value (0 when nothing dips below the baseline)
+
+  // Interaction state, shared by every part.
+  selectedDataKey: string | null;
+  selectDataKey: (key: string | null) => void;
+  /** Legend-hover spotlight — dims every series but this one while set. */
+  focusDataKey: string | null;
+  setFocusDataKey: (key: string | null) => void;
+  hoverIndex: number | null;
+  setHoverIndex: (index: number | null) => void;
+  markerIndex: number | null; // controlled crosshair override (e.g. committed point)
+  cursorX: number;
+  setCursorX: (px: number) => void;
+  isMouseInChart: boolean;
+  setMouseInChart: (over: boolean) => void;
+  hovered: boolean; // parent-driven hover (e.g. the whole card) — lifts the fill
+  bloom: BloomInput; // glow on the dither canvas
+  bloomOnHover: boolean; // only bloom while hovered
+
+  // Series register themselves so the canvas knows what (and how) to paint.
+  seriesSpecs: Record<string, SeriesSpec>;
+  registerSeries: (spec: SeriesSpec) => void;
+  unregisterSeries: (dataKey: string) => void;
+
+  // Entrance animation (prop-driven). `revision` bumps when the data changes or
+  // the replay token advances, so the canvas can re-play its entrance.
+  animate: boolean;
+  animationDuration: number;
+  revision: number;
+  entranceDone: boolean; // true once the entrance has played — gates SVG markers
+  markEntranceDone: () => void; // the canvas calls this when its reveal completes
+
+  // Helpers.
+  seedOf: (key: string) => Seed;
+  common: CommonChart; // shared surface for <Legend> / <Tooltip>
+};
+
+const ChartContext = createContext<ChartContextValue | null>(null);
+
+const ROOT_OF: Record<ChartType, string> = {
+  area: "<AreaChart />",
+  bar: "<BarChart />",
+  line: "<LineChart />",
+  pie: "<PieChart />",
+  radar: "<RadarChart />",
+};
+
+/** Generic accessor for internal layers (canvas/overlay) that work for any root. */
+export function useChart() {
+  const ctx = use(ChartContext);
+  if (!ctx) {
+    throw new Error("Chart parts must be used within a chart root (e.g. <AreaChart />).");
+  }
+  return ctx;
+}
+
+/**
+ * Boundary guard for a composable part. Throws a precise error when used outside
+ * a root, or inside the wrong chart type — e.g. `<Bar />` placed in an area
+ * chart. `kind` omitted means the part works under any root (grid, axes, …).
+ */
+export function useChartPart(part: string, kind?: ChartType | ChartType[]): ChartContextValue {
+  const ctx = use(ChartContext);
+  if (!ctx) {
+    const where = kind ? ROOT_OF[Array.isArray(kind) ? kind[0] : kind] : "a chart root";
+    throw new Error(`<${part} /> must be used within ${where}.`);
+  }
+  if (kind) {
+    const allowed = Array.isArray(kind) ? kind : [kind];
+    if (!allowed.includes(ctx.chartType)) {
+      throw new Error(
+        `<${part} /> is not valid inside ${ROOT_OF[ctx.chartType]} — it belongs in ${allowed
+          .map((k) => ROOT_OF[k])
+          .join(" or ")}.`,
+      );
+    }
+  }
+  return ctx;
+}
+
+export { ChartContext };
+
+/** A counter that advances whenever `data` changes identity or `token` advances
+ * — drives entrance replays without remounting. Uses the adjust-state-during-
+ * render pattern (https://react.dev/reference/react/useState) instead of a ref:
+ * the revision is derived purely from render inputs, so it stays consistent
+ * across the memoized values below rather than lagging a render behind. */
+export function useRevision(data: unknown, token: number) {
+  const [prev, setPrev] = useState({ data, token, revision: 0 });
+  if (prev.data !== data || prev.token !== token) {
+    const next = { data, token, revision: prev.revision + 1 };
+    setPrev(next);
+    return next.revision;
+  }
+  return prev.revision;
+}
+
+/**
+ * Builds the shared context value: resolves the plot rect from the measured
+ * size minus margins, computes the x/y scales and the per-series stack bands,
+ * and owns the selection + hover state every part reads.
+ */
+export function useChartController({
+  chartType,
+  data,
+  config,
+  stackType,
+  dimensions,
+  margins,
+  animate = true,
+  animationDuration = 900,
+  replayToken = 0,
+  markerIndex = null,
+  hovered = false,
+  bloom = "off",
+  bloomOnHover = false,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+}: {
+  chartType: ChartType;
+  data: Row[];
+  config: ChartConfig;
+  stackType: StackType;
+  dimensions: Dimensions;
+  margins: Margins;
+  animate?: boolean;
+  animationDuration?: number;
+  replayToken?: number;
+  markerIndex?: number | null;
+  hovered?: boolean;
+  bloom?: BloomInput;
+  bloomOnHover?: boolean;
+  defaultSelectedDataKey?: string | null;
+  onSelectionChange?: (key: string | null) => void;
+}): ChartContextValue {
+  // This object becomes the ChartContext value, so its identity — and the
+  // identity of every function/object it carries — must stay stable across
+  // renders that don't change the underlying inputs. Otherwise every consumer
+  // (axes, legend, tooltip, dots) re-renders on every parent render. So the
+  // expensive derivations, the exposed callbacks, and the returned value are
+  // memoized below; only cheap scalars (bandwidth, ready, plot sizes) are left
+  // bare, since they're just recomputed reads, not identities anyone depends on.
+
+  // Memoized: configKeys is the dep that drives `bands`, `common` and the
+  // canvas `targets` memo — a fresh array each render would bust all of them.
+  const configKeys = useMemo(() => Object.keys(config), [config]);
+  const revision = useRevision(data, replayToken);
+
+  const [selectedDataKey, setSelectedDataKey] = useState<string | null>(defaultSelectedDataKey);
+  const [focusDataKey, setFocusDataKey] = useState<string | null>(null);
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+  const [cursorX, setCursorX] = useState(0);
+  const [isMouseInChart, setMouseInChart] = useState(false);
+  const [seriesSpecs, setSeriesSpecs] = useState<Record<string, SeriesSpec>>({});
+
+  // useCallback because the series effects in area.tsx/bar.tsx list these as
+  // deps — without stable identities the unregister/register effect re-fires
+  // every render and its setState pair loops ("Maximum update depth exceeded").
+  const registerSeries = useCallback((spec: SeriesSpec) => {
+    setSeriesSpecs((prev) => {
+      const cur = prev[spec.dataKey];
+      return cur &&
+        cur.kind === spec.kind &&
+        cur.variant === spec.variant &&
+        cur.strokeVariant === spec.strokeVariant
+        ? prev
+        : { ...prev, [spec.dataKey]: spec };
+    });
+  }, []);
+  const unregisterSeries = useCallback((dataKey: string) => {
+    setSeriesSpecs((prev) => {
+      if (!(dataKey in prev)) return prev;
+      const next = { ...prev };
+      delete next[dataKey];
+      return next;
+    });
+  }, []);
+
+  // Stable so the memoized value keeps its identity; only re-created when the
+  // caller's selection handler does.
+  const selectDataKey = useCallback(
+    (key: string | null) => {
+      setSelectedDataKey(key);
+      onSelectionChange?.(key);
+    },
+    [onSelectionChange],
+  );
+
+  // The root spreads `{ ...DEFAULT_MARGINS, ...marginsProp }` fresh every
+  // render, so `margins` never keeps its identity. Pin one off the four numbers
+  // so it doesn't, on its own, invalidate the value or the plot geometry.
+  const { top: mTop, right: mRight, bottom: mBottom, left: mLeft } = margins;
+  const stableMargins = useMemo(
+    () => ({ top: mTop, right: mRight, bottom: mBottom, left: mLeft }),
+    [mTop, mRight, mBottom, mLeft],
+  );
+
+  const plotWidth = Math.max(0, dimensions.width - mLeft - mRight);
+  const plotHeight = Math.max(0, dimensions.height - mTop - mBottom);
+  const ready = plotWidth > 0 && plotHeight > 0;
+
+  // The entrance gate flips true when the canvas reveal completes (via
+  // `markEntranceDone`) so DOM markers fade in with the fill, and re-arms on
+  // each replay. Adjust-state-during-render instead of an effect, so the reset
+  // lands in the same render as the revision bump.
+  const [entrance, setEntrance] = useState({ revision, done: !animate });
+  if (entrance.revision !== revision) {
+    setEntrance({ revision, done: !animate });
+  }
+  const entranceDone = entrance.revision === revision ? entrance.done : !animate;
+  // Stable across renders at the same revision; the canvas holds this in a ref.
+  const markEntranceDone = useCallback(() => setEntrance({ revision, done: true }), [revision]);
+
+  // Memoized: the priciest derivation in the render path — it walks every
+  // row × series to build the stack bands. Hover/cursor state changes must not
+  // recompute it, only a real data/series/stack change.
+  const { bands, max, min } = useMemo(
+    () => computeBands(data, configKeys, stackType),
+    [data, configKeys, stackType],
+  );
+
+  const isBar = chartType === "bar";
+  // The d3 scale factories are memoized so `y` keeps a stable identity: the
+  // canvas `targets` memo (cartesian-canvas / bar-canvas) deps on ctx.y, and
+  // xCenter/indexAtX/barSlot below close over these.
+  const xPoint = useMemo(() => buildXScale(data.length, plotWidth), [data.length, plotWidth]);
+  const xBand = useMemo(() => buildBandScale(data.length, plotWidth), [data.length, plotWidth]);
+  const bandwidth = isBar ? xBand.bandwidth() : 0;
+  const xCenter = useCallback(
+    (i: number) => (isBar ? (xBand(i) ?? 0) + xBand.bandwidth() / 2 : (xPoint(i) ?? 0)),
+    [isBar, xBand, xPoint],
+  );
+  const indexAtX = useCallback(
+    (px: number) =>
+      isBar ? indexAtBand(px, data.length, plotWidth) : nearestIndex(px, data.length, plotWidth),
+    [isBar, data.length, plotWidth],
+  );
+  const stacked = stackType === "stacked" || stackType === "percent";
+  const barSlot = useCallback(
+    (i: number, si: number, n: number) => {
+      const center = xCenter(i);
+      if (stacked) {
+        const w = bandwidth * 0.9;
+        return { x: center - w / 2, width: w };
+      }
+      const slot = bandwidth / Math.max(n, 1);
+      return {
+        x: center - bandwidth / 2 + si * slot + slot * 0.08,
+        width: slot * 0.84,
+      };
+    },
+    [xCenter, stacked, bandwidth],
+  );
+  const y = useMemo(() => buildYScale(min, max, plotHeight), [min, max, plotHeight]);
+
+  // Stable so `common` and the value stay stable; re-created only on config.
+  const seedOf = useCallback((key: string) => seedOfColor(config[key]?.color ?? "grey"), [config]);
+
+  // Memoized: this is the value handed to CommonChartContext (Legend/Tooltip),
+  // so it needs its own stable identity independent of the parent value.
+  const common: CommonChart = useMemo(
+    () => ({
+      names: configKeys,
+      labelOf: (n) => config[n]?.label ?? n,
+      seedOf,
+      selectedDataKey,
+      selectDataKey,
+      focusDataKey,
+      setFocusDataKey,
+      hoverIndex,
+      ready,
+      tooltipLeft: Math.max(48, Math.min(plotWidth + mLeft - 48, cursorX)),
+      // Follow the highest hovered node so the card rides the data path, but
+      // keep enough headroom that the upward-lifted card never clips the top.
+      tooltipTop: (() => {
+        const floor = mTop + 44;
+        if (hoverIndex == null) return floor;
+        let minY = Number.POSITIVE_INFINITY;
+        for (const key of configKeys) {
+          const b = bands[key]?.[hoverIndex];
+          if (b) minY = Math.min(minY, y(b[1]));
+        }
+        if (!Number.isFinite(minY)) return floor;
+        return Math.max(floor, mTop + minY);
+      })(),
+      heading: (i, labelKey) => (labelKey ? String(data[i]?.[labelKey] ?? "") : null),
+      itemsAt: (i) =>
+        configKeys.map((name) => {
+          const raw = data[i]?.[name];
+          return {
+            name,
+            label: config[name]?.label ?? name,
+            value: typeof raw === "number" ? raw : 0,
+            seed: seedOf(name),
+            dimmed: (() => {
+              const emphasis = selectedDataKey ?? focusDataKey;
+              return emphasis !== null && emphasis !== name;
+            })(),
+          };
+        }),
+    }),
+    [
+      configKeys,
+      config,
+      seedOf,
+      selectedDataKey,
+      selectDataKey,
+      focusDataKey,
+      hoverIndex,
+      ready,
+      plotWidth,
+      mLeft,
+      mTop,
+      cursorX,
+      bands,
+      y,
+      data,
+    ],
+  );
+
+  // Memoized: this is the ChartContext value. A fresh object here would
+  // re-render every consumer on every parent render — the whole reason the
+  // pieces above are stabilized. Rebuilds only when a listed input changes
+  // (which is exactly when a consumer needs the update).
+  return useMemo<ChartContextValue>(
+    () => ({
+      chartType,
+      config,
+      configKeys,
+      data,
+      dataLength: data.length,
+      stackType,
+      margins: stableMargins,
+      plot: { width: plotWidth, height: plotHeight },
+      ready,
+      xCenter,
+      bandwidth,
+      indexAtX,
+      barSlot,
+      y,
+      bands,
+      max,
+      min,
+      selectedDataKey,
+      selectDataKey,
+      focusDataKey,
+      setFocusDataKey,
+      hoverIndex,
+      setHoverIndex,
+      markerIndex,
+      cursorX,
+      setCursorX,
+      isMouseInChart,
+      setMouseInChart,
+      hovered,
+      bloom,
+      bloomOnHover,
+      seriesSpecs,
+      registerSeries,
+      unregisterSeries,
+      animate,
+      animationDuration,
+      revision,
+      entranceDone,
+      markEntranceDone,
+      seedOf,
+      common,
+    }),
+    [
+      chartType,
+      config,
+      configKeys,
+      data,
+      stackType,
+      stableMargins,
+      plotWidth,
+      plotHeight,
+      ready,
+      xCenter,
+      bandwidth,
+      indexAtX,
+      barSlot,
+      y,
+      bands,
+      max,
+      min,
+      selectedDataKey,
+      selectDataKey,
+      focusDataKey,
+      hoverIndex,
+      markerIndex,
+      cursorX,
+      isMouseInChart,
+      hovered,
+      bloom,
+      bloomOnHover,
+      seriesSpecs,
+      registerSeries,
+      unregisterSeries,
+      animate,
+      animationDuration,
+      revision,
+      entranceDone,
+      markEntranceDone,
+      seedOf,
+      common,
+    ],
+  );
+}

--- a/apps/web/src/components/dither-kit/common-context.tsx
+++ b/apps/web/src/components/dither-kit/common-context.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { createContext, use } from "react";
+import type { Seed } from "./palette";
+
+/** A single tooltip row — one series (cartesian/radar) or one slice (pie). */
+export type TooltipItem = {
+  name: string;
+  label: string;
+  value: number;
+  seed: Seed;
+  dimmed: boolean;
+};
+
+/**
+ * The minimal surface shared by every chart family, so `<Legend>` and
+ * `<Tooltip>` work identically whether they sit in a cartesian, bar, or polar
+ * root. Each root publishes one of these alongside its family-specific context.
+ */
+export type CommonChart = {
+  names: string[]; // legend entries — series keys (cartesian) or slice names (pie)
+  labelOf: (name: string) => string;
+  seedOf: (name: string) => Seed;
+  selectedDataKey: string | null;
+  selectDataKey: (key: string | null) => void;
+  /** Transient legend-hover emphasis — spotlights one series (others dim)
+   * while the pointer rests on its legend entry. Selection still wins. */
+  focusDataKey: string | null;
+  setFocusDataKey: (key: string | null) => void;
+  hoverIndex: number | null;
+  heading: (index: number, labelKey?: string) => string | null;
+  itemsAt: (index: number) => TooltipItem[];
+  ready: boolean;
+  tooltipLeft: number; // clamped px for the floating tooltip
+  tooltipTop: number; // px — follows the hovered node (cartesian) / cursor (polar)
+};
+
+export const CommonChartContext = createContext<CommonChart | null>(null);
+
+export function useCommonChart() {
+  const ctx = use(CommonChartContext);
+  if (!ctx) {
+    throw new Error("<Legend /> / <Tooltip /> must be used within a chart root.");
+  }
+  return ctx;
+}

--- a/apps/web/src/components/dither-kit/dither-paint.ts
+++ b/apps/web/src/components/dither-kit/dither-paint.ts
@@ -1,0 +1,170 @@
+// @ts-nocheck -- upstream Dither Kit source is not noUncheckedIndexedAccess-safe.
+import type { AreaVariant } from "./chart-context";
+import { type Seed, rgb } from "./palette";
+
+// 4×4 ordered (Bayer) matrix, normalized to 0–1 thresholds — the exact matrix
+// the legacy chart dithers with.
+export const BAYER = [
+  [0, 8, 2, 10],
+  [12, 4, 14, 6],
+  [3, 11, 1, 9],
+  [15, 7, 13, 5],
+].map((row) => row.map((v) => (v + 0.5) / 16));
+
+export const CELL = 2; // css px per dither cell — chunky enough to read pixelated
+export const MAX_COLS = 520;
+export const MAX_ROWS = 200;
+// Opacity of the top border outline (just under solid, so it reads as a soft
+// edge rather than a hard line). See the note on colour vs opacity below.
+export const BORDER_ALPHA = 0.72;
+// Opacity of a dither "off" cell relative to an "on" cell. The scatter modulates
+// between these two tiers of the *same* colour instead of leaving holes, so the
+// background never shows through as stark white on a light theme.
+export const OFF_TIER = 0.4;
+
+export type PaintOpts = {
+  variant: AreaVariant;
+  intensity: number; // 0–1 hover lift
+  dim: number; // selection dim multiplier (0.3 dimmed, 1 normal)
+  stacked: boolean; // denser + solid floor when layers stack
+  sparse?: number; // raise the dither threshold (thin out) — front layers
+};
+
+// Colour vs opacity — the guiding rule for the whole engine:
+//
+//   Work with opacities instead of different shades of the same color. This will
+//   make sure it looks good on both light and dark mode.
+//
+// So every pixel is the series' single `fill` colour and we vary only its alpha.
+// The old lighter `line` / near-white `star` shades were dropped: a shade that
+// pops on a dark background reads as a jarring bright speck on a light one, while
+// the same colour at a lower opacity simply blends into whatever sits behind it.
+
+/**
+ * Fill one backing-canvas column `x` from row `top` down to `floor` with the
+ * ordered-dither scatter — solid at the floor, dissolving upward so it *fades
+ * out toward the value line* — then cap the top with a soft border outline in
+ * the series colour. Density drives opacity (see the note above), so the fade
+ * reads correctly against both light and dark backgrounds. The single source of
+ * the dither look across area / line / bar.
+ */
+export function paintColumn(
+  octx: CanvasRenderingContext2D,
+  x: number,
+  top: number,
+  floor: number,
+  seed: Seed,
+  { variant, intensity, dim, stacked, sparse = 0 }: PaintOpts,
+) {
+  const t = Math.round(top);
+  const f = Math.round(floor);
+  const depth = f - t;
+  if (depth <= 0) {
+    octx.fillStyle = rgb(seed.fill, 1, BORDER_ALPHA * dim);
+    octx.fillRect(x, t, 1, 1);
+    return;
+  }
+  const bias = (variant === "dotted" ? 0.12 : 0) + (stacked ? 0.2 : 0) - sparse;
+  for (let y = t; y < f; y++) {
+    // Inverted falloff: 0 at the top line, 1 at the floor — dense at the
+    // bottom, thinning as it rises toward the outline.
+    let density = (y - t) / depth;
+    if (stacked) density = 0.5 + 0.5 * density;
+    if (variant === "hatched" && ((x + y) & 3) >= 2) continue;
+    const lit = variant === "solid" || density > BAYER[y & 3][x & 3] - 0.1 * intensity - bias;
+    // "dotted" keeps real gaps for its open look; every other variant covers
+    // the cell and lets the dither ride the alpha (on = full tier, off = a
+    // faint tint) so nothing shows the background through as white.
+    if (variant === "dotted" && !lit) continue;
+    // Density → alpha (see the colour-vs-opacity note above).
+    const k = (0.3 + density * 0.7) * (1 + 0.22 * intensity);
+    const alpha = clamp01((lit ? k : k * OFF_TIER) * dim);
+    octx.fillStyle = rgb(seed.fill, 1, alpha);
+    octx.fillRect(x, y, 1, 1);
+  }
+  // Top border outline — the shape's edge now that the fill fades out here.
+  // Kept just under full opacity, with a faint feather row beneath, so it reads
+  // as a soft edge rather than a hard line floating over the fade.
+  octx.fillStyle = rgb(seed.fill, 1, BORDER_ALPHA * dim);
+  octx.fillRect(x, t, 1, 1);
+  if (depth > 1) {
+    octx.fillStyle = rgb(seed.fill, 1, BORDER_ALPHA * 0.5 * dim);
+    octx.fillRect(x, t + 1, 1, 1);
+  }
+}
+
+/** Linear-resample a per-index fraction array to `cols` columns. */
+export function resample(src: number[], cols: number): number[] {
+  const out = new Array<number>(cols);
+  const last = Math.max(src.length - 1, 1);
+  for (let c = 0; c < cols; c++) {
+    const t = (c / Math.max(cols - 1, 1)) * last;
+    const i = Math.floor(t);
+    const f = t - i;
+    const a = src[i] ?? 0;
+    const b = src[Math.min(i + 1, src.length - 1)] ?? a;
+    out[c] = a + (b - a) * f;
+  }
+  return out;
+}
+
+/** Backing-canvas resolution for a plot rect — low-res, scaled up `pixelated`. */
+export function backingSize(width: number, height: number) {
+  return {
+    cols: Math.min(MAX_COLS, Math.max(8, Math.round(width / CELL))),
+    rows: Math.min(MAX_ROWS, Math.max(8, Math.round(height / CELL))),
+  };
+}
+
+// Bloom — a real "shader" glow that comes from the colours themselves: a blurred
+// copy of the rendered canvas, composited additively (`plus-lighter`) so each
+// hue blooms in its own colour instead of a grey wash. Lives on a second canvas
+// layered over the crisp one (which stays sharp/pixelated).
+export type BloomLevel = "off" | "low" | "high" | "aura";
+export type BloomBlend = "plus-lighter" | "screen" | "lighten";
+export type BloomConfig = {
+  blur: number; // px
+  brightness: number; // 1 = none
+  opacity: number; // 0–1
+  /** Saturation of the glow — >1 keeps it vividly in the dither's colour
+   * instead of washing toward white. */
+  saturate?: number;
+  blend?: BloomBlend; // additive by default
+};
+/** A preset name, a full config, or "off". */
+export type BloomInput = BloomLevel | BloomConfig;
+
+const PRESET: Record<Exclude<BloomLevel, "off">, BloomConfig> = {
+  low: { blur: 3, brightness: 1.35, opacity: 0.7, saturate: 1.4 },
+  high: { blur: 5, brightness: 1.5, opacity: 0.78, saturate: 1.5 },
+  aura: { blur: 15, brightness: 2.9, opacity: 0.1, saturate: 3 },
+};
+
+export type BloomStyle = {
+  filter: string;
+  opacity: number;
+  mixBlendMode: BloomBlend;
+  imageRendering: "auto";
+};
+
+/** Style for the bloom *layer* canvas (a blurred, additive copy). null when off. */
+export function bloomLayerStyle(input: BloomInput, active: boolean): BloomStyle | null {
+  if (!active || input === "off") return null;
+  const cfg = typeof input === "string" ? PRESET[input] : input;
+  return {
+    filter: `blur(${cfg.blur}px) brightness(${cfg.brightness}) saturate(${cfg.saturate ?? 1})`,
+    opacity: cfg.opacity,
+    mixBlendMode: cfg.blend ?? "plus-lighter",
+    imageRendering: "auto",
+  };
+}
+
+// Easing — gentle start + soft settle so entrances don't feel linear.
+export const easeInOutCubic = (t: number) => (t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2);
+export const easeOutCubic = (t: number) => 1 - (1 - t) ** 3;
+export const clamp01 = (t: number) => (t < 0 ? 0 : t > 1 ? 1 : t);
+
+/** Whether the OS asks for reduced motion (snap + steady stars). */
+export function prefersReducedMotion() {
+  return window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
+}

--- a/apps/web/src/components/dither-kit/dot.tsx
+++ b/apps/web/src/components/dither-kit/dot.tsx
@@ -1,0 +1,87 @@
+import { useChart } from "./chart-context";
+import { type Seed, rgb } from "./palette";
+import { useSeries } from "./series-context";
+
+export type DotVariant = "border" | "colored-border" | "filled";
+
+function dotPaint(variant: DotVariant, seed: Seed) {
+  switch (variant) {
+    case "colored-border":
+      return {
+        fill: "var(--card, #0b0b0c)",
+        stroke: rgb(seed.line),
+        strokeWidth: 1.5,
+      };
+    case "filled":
+      return { fill: rgb(seed.star), stroke: rgb(seed.line), strokeWidth: 1 };
+    default:
+      return {
+        fill: "var(--card, #0b0b0c)",
+        stroke: rgb(seed.star, 0.8),
+        strokeWidth: 1,
+      };
+  }
+}
+
+/** A marker at every data point along the series' top line. */
+export function Dot({
+  variant = "border",
+  r = 2,
+}: {
+  variant?: DotVariant;
+  r?: number;
+}) {
+  const ctx = useChart();
+  const { dataKey, seed } = useSeries("Dot");
+  const band = ctx.bands[dataKey];
+  if (!ctx.ready || !band) return null;
+  const paint = dotPaint(variant, seed);
+
+  return (
+    // Fade in once the fill has drawn so dots don't float over the entrance.
+    <g
+      style={{
+        opacity: ctx.entranceDone ? 1 : 0,
+        transition: "opacity 300ms ease",
+      }}
+    >
+      {band.map((b, i) => (
+        <circle
+          {...paint}
+          // biome-ignore lint/suspicious/noArrayIndexKey: index is the stable x position
+          key={i}
+          cx={ctx.xCenter(i) ?? 0}
+          cy={ctx.y(b[1])}
+          r={r}
+        />
+      ))}
+    </g>
+  );
+}
+
+/** A single marker at the hovered point — keys off the shared hover index. */
+export function ActiveDot({
+  variant = "colored-border",
+  r = 3,
+}: {
+  variant?: DotVariant;
+  r?: number;
+}) {
+  const ctx = useChart();
+  const { dataKey, seed } = useSeries("ActiveDot");
+  const band = ctx.bands[dataKey];
+  if (!ctx.ready || !band || ctx.hoverIndex == null || !ctx.entranceDone) return null;
+  const b = band[ctx.hoverIndex];
+  if (!b) return null;
+  const paint = dotPaint(variant, seed);
+  const cx = ctx.xCenter(ctx.hoverIndex);
+  const cy = ctx.y(b[1]);
+
+  return (
+    <g>
+      {/* Soft halo so the active point is unmistakable over the dither. */}
+      <circle cx={cx} cy={cy} r={r + 3} fill={rgb(seed.line, 1, 0.18)} />
+      <circle cx={cx} cy={cy} r={r} {...paint} strokeWidth={2} />
+    </g>
+  );
+}

--- a/apps/web/src/components/dither-kit/grid.tsx
+++ b/apps/web/src/components/dither-kit/grid.tsx
@@ -1,0 +1,38 @@
+import { useChartPart } from "./chart-context";
+
+export function Grid({
+  horizontal = true,
+  vertical = false,
+  strokeDasharray = "3 3",
+}: {
+  horizontal?: boolean;
+  vertical?: boolean;
+  strokeDasharray?: string;
+}) {
+  const ctx = useChartPart("Grid");
+  if (!ctx.ready) return null;
+  const { width } = ctx.plot;
+
+  return (
+    <g className="stroke-border" strokeDasharray={strokeDasharray}>
+      {horizontal &&
+        ctx.y
+          .ticks(4)
+          .map((t) => <line key={`h-${t}`} x1={0} x2={width} y1={ctx.y(t)} y2={ctx.y(t)} />)}
+      {vertical &&
+        ctx.data.map((_, i) => (
+          <line
+            // biome-ignore lint/suspicious/noArrayIndexKey: index is the stable x position
+            key={`v-${i}`}
+            x1={ctx.xCenter(i) ?? 0}
+            x2={ctx.xCenter(i) ?? 0}
+            y1={0}
+            y2={ctx.plot.height}
+          />
+        ))}
+    </g>
+  );
+}
+
+// Render beneath the dither canvas so grid lines sit behind the fill.
+Grid.chartLayer = "back" as const;

--- a/apps/web/src/components/dither-kit/legend.tsx
+++ b/apps/web/src/components/dither-kit/legend.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useCommonChart } from "./common-context";
+import { cn } from "./lib";
+import { rgb } from "./palette";
+
+/** Series/slice legend. With `isClickable`, each entry toggles its selection.
+ * Works in every chart family via the shared common context.
+ *
+ * Note: this is an absolute overlay pinned to the top of the plot, so it's best
+ * for ≤2–3 entries. With more entries (or a narrow container) it wraps onto
+ * extra rows that overlay the chart — reach for the in-flow `<BlockLegend>`
+ * instead, which renders as a sibling and can't overlap at any width. */
+export function Legend({
+  isClickable = false,
+  align = "right",
+}: {
+  isClickable?: boolean;
+  align?: "left" | "center" | "right";
+}) {
+  const chart = useCommonChart();
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-none absolute inset-x-0 top-0 flex flex-wrap gap-3 px-1",
+        align === "right" && "justify-end",
+        align === "center" && "justify-center",
+        align === "left" && "justify-start",
+      )}
+    >
+      {chart.names.map((name) => {
+        const seed = chart.seedOf(name);
+        const emphasis = chart.selectedDataKey ?? chart.focusDataKey;
+        const dimmed = emphasis !== null && emphasis !== name;
+        return (
+          <button
+            key={name}
+            type="button"
+            disabled={!isClickable}
+            onClick={() => chart.selectDataKey(chart.selectedDataKey === name ? null : name)}
+            // Hovering an entry spotlights its series so overlapping layers
+            // (e.g. two meshed radar polygons) can be told apart at a glance.
+            onPointerEnter={() => chart.setFocusDataKey(name)}
+            onPointerLeave={() => chart.setFocusDataKey(null)}
+            onFocus={() => chart.setFocusDataKey(name)}
+            onBlur={() => chart.setFocusDataKey(null)}
+            className={cn(
+              "flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground transition-opacity",
+              isClickable && "pointer-events-auto cursor-pointer hover:text-foreground",
+              dimmed && "opacity-40",
+            )}
+          >
+            <span className="size-2 rounded-[1px]" style={{ backgroundColor: rgb(seed.fill) }} />
+            {chart.labelOf(name)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+Legend.chartLayer = "dom" as const;

--- a/apps/web/src/components/dither-kit/lib.ts
+++ b/apps/web/src/components/dither-kit/lib.ts
@@ -1,0 +1,8 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/** Tailwind-aware className combiner — local copy so the chart pack is
+ * self-contained and portable as a registry. */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/web/src/components/dither-kit/palette.ts
+++ b/apps/web/src/components/dither-kit/palette.ts
@@ -1,0 +1,33 @@
+export type Rgb = [number, number, number];
+
+export type DitherColor = "green" | "blue" | "purple" | "pink" | "orange" | "red" | "grey";
+
+export type Seed = { fill: Rgb; line: Rgb; star: Rgb };
+
+// Each seed: the area-fill hue, the bright series line, and the star sparkle.
+export const PALETTE: Record<DitherColor, Seed> = {
+  green: { fill: [40, 210, 110], line: [150, 255, 180], star: [200, 255, 220] },
+  blue: { fill: [53, 143, 243], line: [150, 200, 255], star: [205, 228, 255] },
+  purple: {
+    fill: [150, 110, 255],
+    line: [200, 175, 255],
+    star: [225, 210, 255],
+  },
+  pink: { fill: [240, 90, 190], line: [255, 170, 220], star: [255, 205, 235] },
+  orange: {
+    fill: [255, 150, 50],
+    line: [255, 195, 130],
+    star: [255, 220, 175],
+  },
+  red: { fill: [240, 70, 70], line: [255, 150, 140], star: [255, 195, 185] },
+  // No-data: a muted grey so empty metrics read as "nothing here".
+  grey: { fill: [92, 92, 100], line: [140, 140, 150], star: [165, 165, 175] },
+};
+
+export const rgb = ([r, g, b]: Rgb, k = 1, a = 1) =>
+  `rgba(${Math.round(r * k)},${Math.round(g * k)},${Math.round(b * k)},${a})`;
+
+export const seedOfColor = (color: DitherColor): Seed => PALETTE[color];
+
+export const isDitherColor = (value: unknown): value is DitherColor =>
+  typeof value === "string" && value in PALETTE;

--- a/apps/web/src/components/dither-kit/pie-canvas.tsx
+++ b/apps/web/src/components/dither-kit/pie-canvas.tsx
@@ -1,0 +1,215 @@
+// @ts-nocheck -- upstream Dither Kit source is not noUncheckedIndexedAccess-safe.
+import { useEffect, useRef } from "react";
+import {
+  BAYER,
+  OFF_TIER,
+  backingSize,
+  bloomLayerStyle,
+  easeInOutCubic,
+  prefersReducedMotion,
+} from "./dither-paint";
+import { rgb } from "./palette";
+import { sliceAtAngle } from "./polar";
+import { usePolarChart } from "./polar-context";
+
+const TOP = -Math.PI / 2;
+const TAU = Math.PI * 2;
+const POP = 6; // px the hovered slice bulges outward
+
+/**
+ * Dither canvas for pie / donut charts. Each backing pixel is mapped back to
+ * plot space, tested for its slice by angle, and filled with the ordered-dither
+ * scatter — dense at the outer edge, thinning toward the centre — capped by a
+ * bright arc on the rim. The pie sweeps in clockwise on mount; the hovered slice
+ * bulges outward with a brighter rim while the rest dim.
+ */
+export function PieCanvas() {
+  const ctx = usePolarChart();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const bloomRef = useRef<HTMLCanvasElement>(null);
+
+  const { width, height } = ctx.plot;
+  const { cols, rows } = backingSize(width, height);
+
+  // The RAF loop reads the latest ctx through a ref; written in an effect
+  // (never during render) — mutating a ref mid-render tears under Strict Mode /
+  // concurrent rendering.
+  const state = useRef(ctx);
+  useEffect(() => {
+    state.current = ctx;
+  });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const c = canvas?.getContext("2d");
+    if (!(canvas && c) || cols <= 0 || rows <= 0) return;
+    canvas.width = cols;
+    canvas.height = rows;
+
+    const bloomCanvas = bloomRef.current;
+    const bloomCtx = bloomCanvas?.getContext("2d") ?? null;
+    if (bloomCanvas) {
+      bloomCanvas.width = cols;
+      bloomCanvas.height = rows;
+    }
+
+    const reduce = prefersReducedMotion();
+    const animate = state.current.animate && !reduce;
+    const duration = state.current.animationDuration;
+    let raf = 0;
+    let animStart = 0;
+    let lastProg = -1;
+    let lastRevision = state.current.revision;
+    let intensity = 0;
+    let popEase = 0; // eases the hovered slice's outward bulge
+    let needsFill = true;
+    let lastPaintSig = "";
+    let lastSelected: string | null | undefined = Symbol() as never;
+    let lastHover: number | null | undefined = Symbol() as never;
+
+    const paint = (prog: number) => {
+      const s = state.current;
+      const slices = s.pie;
+      if (!slices) return;
+      c.clearRect(0, 0, cols, rows);
+      const cx = s.center.x;
+      const cy = s.center.y;
+      const outerR = s.outerRadius;
+      const innerR = s.innerRadius;
+      const revealAngle = TOP + easeInOutCubic(prog) * TAU;
+
+      for (let y = 0; y < rows; y++) {
+        const py = ((y + 0.5) * height) / rows;
+        for (let x = 0; x < cols; x++) {
+          const px = ((x + 0.5) * width) / cols;
+          const dx = px - cx;
+          const dy = py - cy;
+          const r = Math.hypot(dx, dy);
+          if (r < innerR) continue;
+          const angle = Math.atan2(dy, dx);
+          let na = angle;
+          while (na < TOP) na += TAU;
+          while (na >= TOP + TAU) na -= TAU;
+          if (na > revealAngle) continue; // clockwise sweep-in
+          const si = sliceAtAngle(slices, angle);
+          if (si < 0) continue;
+          const slice = slices[si];
+          const active = s.hoverIndex === si;
+          const localOuter = active ? outerR + POP * popEase : outerR;
+          if (r > localOuter) continue;
+
+          const seed = s.seedOf(slice.name);
+          const variant = s.variantOf(slice.name);
+          const emphasis = s.selectedDataKey ?? s.focusDataKey;
+          const selDim = emphasis !== null && emphasis !== slice.name ? 0.3 : 1;
+          const it = intensity + (active ? 0.4 * popEase : 0);
+
+          // Bright rim on the outer edge — thicker on the hovered slice.
+          if (localOuter - r < (active ? 1.4 + popEase : 1.4)) {
+            c.fillStyle = rgb(seed.fill, 1, selDim);
+            c.fillRect(x, y, 1, 1);
+            continue;
+          }
+          const density = (r - innerR) / Math.max(localOuter - innerR, 1);
+          const bias = variant === "dotted" ? 0.12 : 0;
+          if (variant === "hatched" && ((x + y) & 3) >= 2) continue;
+          const lit = variant === "solid" || density > BAYER[y & 3][x & 3] - 0.1 * it - bias;
+          if (variant === "dotted" && !lit) continue;
+          // Density → opacity (see the colour-vs-opacity note in dither-paint);
+          // off cells drop to a faint tier, never a hole to the background.
+          const k = (0.35 + density * 0.65) * (1 + 0.22 * it);
+          const alpha = Math.min(1, (lit ? k : k * OFF_TIER) * selDim);
+          c.fillStyle = rgb(seed.fill, 1, alpha);
+          c.fillRect(x, y, 1, 1);
+        }
+      }
+    };
+
+    const draw = (now: number) => {
+      raf = requestAnimationFrame(draw);
+      const s = state.current;
+      if (!s.ready || !s.pie) return;
+      if (bloomCtx) {
+        const on = s.bloom !== "off" && (!s.bloomOnHover || s.isMouseInChart);
+        if (on) {
+          bloomCtx.clearRect(0, 0, cols, rows);
+          bloomCtx.drawImage(canvas, 0, 0);
+        }
+      }
+      if (s.revision !== lastRevision) {
+        lastRevision = s.revision;
+        animStart = 0;
+        lastProg = -1;
+      }
+      if (!animStart) animStart = now;
+      const prog = animate ? Math.min(1, (now - animStart) / duration) : 1;
+
+      const emphasisNow = s.selectedDataKey ?? s.focusDataKey;
+      if (emphasisNow !== lastSelected) {
+        lastSelected = emphasisNow;
+        needsFill = true;
+      }
+      if (s.hoverIndex !== lastHover) {
+        lastHover = s.hoverIndex;
+        popEase = 0; // a freshly-hovered slice bulges out from rest
+        needsFill = true;
+      }
+      const itTarget = s.isMouseInChart ? 1 : 0;
+      if (Math.abs(intensity - itTarget) > 0.001) {
+        intensity += (itTarget - intensity) * (reduce ? 1 : 0.16);
+        needsFill = true;
+      } else intensity = itTarget;
+      // Ease the hovered slice's bulge in (and back out when nothing's hovered).
+      const popTarget = s.hoverIndex != null ? 1 : 0;
+      if (Math.abs(popEase - popTarget) > 0.001) {
+        popEase += (popTarget - popEase) * (reduce ? 1 : 0.22);
+        needsFill = true;
+      } else popEase = popTarget;
+      if (prog !== lastProg) {
+        lastProg = prog;
+        needsFill = true;
+      }
+
+      // Live tweak repaint (variant, donut inner radius) without re-sweeping.
+      const paintSig = `${s.innerRadius}|${s.pie.map((sl) => s.variantOf(sl.name)).join(",")}`;
+      if (paintSig !== lastPaintSig) {
+        lastPaintSig = paintSig;
+        needsFill = true;
+      }
+
+      if (!needsFill) return;
+      paint(prog);
+      needsFill = false;
+    };
+
+    raf = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(raf);
+  }, [cols, rows, width, height]);
+
+  const bloom = bloomLayerStyle(ctx.bloom, ctx.bloomOnHover ? ctx.isMouseInChart : true);
+  const pos = {
+    left: ctx.margins.left,
+    top: ctx.margins.top,
+    width,
+    height,
+  } as const;
+
+  return (
+    <>
+      <canvas
+        ref={canvasRef}
+        className="pointer-events-none absolute"
+        style={{ ...pos, imageRendering: "pixelated" }}
+      />
+      <canvas
+        ref={bloomRef}
+        className="pointer-events-none absolute"
+        style={{
+          ...pos,
+          transition: "opacity 220ms ease",
+          ...(bloom ?? { opacity: 0 }),
+        }}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/dither-kit/pie-chart.tsx
+++ b/apps/web/src/components/dither-kit/pie-chart.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { ChartConfig, Margins } from "./chart-context";
+import type { BloomInput } from "./dither-paint";
+import { PieCanvas } from "./pie-canvas";
+import { PolarRoot } from "./polar-root";
+
+// `object` rather than `Record<string, unknown>`: interfaces don't get an
+// implicit index signature, so interface-typed rows failed to satisfy the
+// generic. Internal layers still index rows through their own Row type.
+type Row = object;
+
+export type PieChartProps<TData extends Row> = {
+  data: TData[];
+  config: ChartConfig;
+  children: ReactNode;
+  dataKey: string; // value field
+  nameKey: string; // slice-name field (looked up in config for colour)
+  innerRadius?: number; // 0–1 ratio for a donut
+  margins?: Partial<Margins>;
+  className?: string;
+  animate?: boolean;
+  animationDuration?: number;
+  replayToken?: number;
+  bloom?: BloomInput;
+  bloomOnHover?: boolean;
+  defaultSelectedDataKey?: string | null;
+  onSelectionChange?: (key: string | null) => void;
+};
+
+/** Composable dither **pie / donut** chart. Compose `<Pie>`, `<Legend>`, … inside. */
+export function PieChart<TData extends Row>(props: PieChartProps<TData>) {
+  return <PolarRoot chartType="pie" Canvas={PieCanvas} {...props} />;
+}

--- a/apps/web/src/components/dither-kit/pie.tsx
+++ b/apps/web/src/components/dither-kit/pie.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import type { AreaVariant } from "./chart-context";
+import { usePolarPart } from "./polar-context";
+
+export type PieProps = {
+  /** Fill texture applied to every slice. */
+  variant?: AreaVariant;
+};
+
+/**
+ * The pie/donut ring. Slices come from the chart `data` (one per row); this part
+ * sets the shared fill variant. The dithered wedges are painted on the canvas.
+ */
+export function Pie({ variant = "gradient" }: PieProps) {
+  const ctx = usePolarPart("Pie", "pie");
+  const { registerVariant, unregisterVariant } = ctx;
+
+  useEffect(() => {
+    registerVariant("*", variant);
+    return () => unregisterVariant("*");
+  }, [variant, registerVariant, unregisterVariant]);
+
+  return null;
+}

--- a/apps/web/src/components/dither-kit/polar-context.tsx
+++ b/apps/web/src/components/dither-kit/polar-context.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import { createContext, use, useCallback, useMemo, useState } from "react";
+import {
+  type AreaVariant,
+  type ChartConfig,
+  type ChartType,
+  type Margins,
+  useRevision,
+} from "./chart-context";
+import type { CommonChart } from "./common-context";
+import type { BloomInput } from "./dither-paint";
+import type { Seed } from "./palette";
+import { seedOfColor } from "./palette";
+import { type PieSlice, type RadarAxis, pieSlices, radarAxes } from "./polar";
+import type { Dimensions } from "./use-chart-dimensions";
+
+type Row = Record<string, unknown>;
+
+const ROOT_OF: Record<string, string> = {
+  pie: "<PieChart />",
+  radar: "<RadarChart />",
+};
+
+export type PolarChartContextValue = {
+  chartType: ChartType;
+  config: ChartConfig;
+  configKeys: string[];
+  data: Row[];
+  dataLength: number;
+  ready: boolean;
+  plot: { width: number; height: number };
+  margins: Margins;
+  center: { x: number; y: number };
+  outerRadius: number;
+  innerRadius: number;
+  animate: boolean;
+  animationDuration: number;
+  revision: number;
+  bloom: BloomInput;
+  bloomOnHover: boolean;
+
+  seedOf: (key: string) => Seed;
+  variantOf: (key: string) => AreaVariant;
+  registerVariant: (key: string, variant: AreaVariant) => void;
+  unregisterVariant: (key: string) => void;
+
+  selectedDataKey: string | null;
+  selectDataKey: (key: string | null) => void;
+  /** Legend-hover spotlight — dims every series but this one while set. */
+  focusDataKey: string | null;
+  setFocusDataKey: (key: string | null) => void;
+  hoverIndex: number | null;
+  setHoverIndex: (i: number | null) => void;
+  setCursor: (px: number, py: number) => void;
+  isMouseInChart: boolean;
+  setMouseInChart: (over: boolean) => void;
+
+  pie: PieSlice[] | null; // present for pie charts
+  radar: { axes: RadarAxis[]; max: number } | null; // present for radar charts
+
+  common: CommonChart;
+};
+
+const PolarChartContext = createContext<PolarChartContextValue | null>(null);
+
+export function usePolarChart() {
+  const ctx = use(PolarChartContext);
+  if (!ctx) {
+    throw new Error("Polar chart parts must be used within a polar chart root.");
+  }
+  return ctx;
+}
+
+/** Boundary guard for polar parts (`<Pie>`, `<Radar>`). */
+export function usePolarPart(part: string, kind: "pie" | "radar") {
+  const ctx = use(PolarChartContext);
+  if (!ctx) {
+    throw new Error(`<${part} /> must be used within ${ROOT_OF[kind]}.`);
+  }
+  if (ctx.chartType !== kind) {
+    throw new Error(
+      `<${part} /> is not valid inside ${ROOT_OF[ctx.chartType]} — it belongs in ${ROOT_OF[kind]}.`,
+    );
+  }
+  return ctx;
+}
+
+export { PolarChartContext };
+
+export function usePolarController({
+  chartType,
+  data,
+  config,
+  dataKey,
+  nameKey,
+  innerRadiusRatio,
+  dimensions,
+  margins,
+  animate = true,
+  animationDuration = 900,
+  replayToken = 0,
+  bloom = "off",
+  bloomOnHover = false,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+}: {
+  chartType: "pie" | "radar";
+  data: Row[];
+  config: ChartConfig;
+  dataKey: string;
+  nameKey: string;
+  innerRadiusRatio: number;
+  dimensions: Dimensions;
+  margins: Margins;
+  animate?: boolean;
+  animationDuration?: number;
+  replayToken?: number;
+  bloom?: BloomInput;
+  bloomOnHover?: boolean;
+  defaultSelectedDataKey?: string | null;
+  onSelectionChange?: (key: string | null) => void;
+}): PolarChartContextValue {
+  // This object becomes the PolarChartContext value, so its identity — and the
+  // identity of every function/object it carries — must stay stable across
+  // renders that don't change the inputs; otherwise every consumer (legend,
+  // tooltip, slices, axes) re-renders on every parent render. The expensive
+  // derivations, exposed callbacks, and returned value are memoized below;
+  // cheap scalars (radii, ready) are left bare as plain recomputed reads.
+
+  // Memoized: drives `pie`/`radar`/`common` — a fresh array would bust them.
+  const configKeys = useMemo(() => Object.keys(config), [config]);
+  const revision = useRevision(data, replayToken);
+
+  const [selectedDataKey, setSelectedDataKey] = useState<string | null>(defaultSelectedDataKey);
+  const [focusDataKey, setFocusDataKey] = useState<string | null>(null);
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+  const [cursorX, setCursorX] = useState(0);
+  const [cursorY, setCursorY] = useState(0);
+  const [isMouseInChart, setMouseInChart] = useState(false);
+  // Stable (only wraps two useState setters) so the value keeps its identity.
+  const setCursor = useCallback((px: number, py: number) => {
+    setCursorX(px);
+    setCursorY(py);
+  }, []);
+  const [variants, setVariants] = useState<Record<string, AreaVariant>>({});
+
+  // useCallback for the same reason as registerSeries in chart-context.tsx:
+  // pie.tsx/radar.tsx list these as effect deps, so without stable identities
+  // the unregister/register effect re-fires and its setState pair loops.
+  const registerVariant = useCallback((key: string, variant: AreaVariant) => {
+    setVariants((prev) => (prev[key] === variant ? prev : { ...prev, [key]: variant }));
+  }, []);
+  const unregisterVariant = useCallback((key: string) => {
+    setVariants((prev) => {
+      if (!(key in prev)) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  }, []);
+
+  // Stable so the value keeps its identity; re-created only on config change.
+  const selectDataKey = useCallback(
+    (key: string | null) => {
+      setSelectedDataKey(key);
+      onSelectionChange?.(key);
+    },
+    [onSelectionChange],
+  );
+
+  // The root spreads margins fresh every render; pin a stable object off the
+  // four numbers so it doesn't, on its own, invalidate the value.
+  const { top: mTop, right: mRight, bottom: mBottom, left: mLeft } = margins;
+  const stableMargins = useMemo(
+    () => ({ top: mTop, right: mRight, bottom: mBottom, left: mLeft }),
+    [mTop, mRight, mBottom, mLeft],
+  );
+
+  const plotWidth = Math.max(0, dimensions.width - mLeft - mRight);
+  const plotHeight = Math.max(0, dimensions.height - mTop - mBottom);
+  const ready = plotWidth > 0 && plotHeight > 0;
+  const pad = chartType === "radar" ? 20 : 6;
+  const outerRadius = Math.max(0, Math.min(plotWidth, plotHeight) / 2 - pad);
+  const innerRadius = chartType === "pie" ? outerRadius * innerRadiusRatio : 0;
+  const centerX = plotWidth / 2;
+  const centerY = plotHeight / 2;
+
+  // Stable so `common` and the value stay stable; re-created only on config.
+  const seedOf = useCallback((key: string) => seedOfColor(config[key]?.color ?? "grey"), [config]);
+  // "*" is the pie-wide variant set by <Pie>; radar registers per series key.
+  const variantOf = useCallback(
+    (key: string) => variants[key] ?? variants["*"] ?? "gradient",
+    [variants],
+  );
+
+  // Memoized: slice geometry — recomputing it on every hover/cursor tick would
+  // rebuild the pie layout needlessly.
+  const pie = useMemo(
+    () => (chartType === "pie" ? pieSlices(data, dataKey, nameKey) : null),
+    [chartType, data, dataKey, nameKey],
+  );
+
+  // Memoized: walks every row × series for the axis max, then builds the axes.
+  const radar = useMemo(() => {
+    if (chartType !== "radar") return null;
+    let max = 0;
+    for (const row of data) {
+      for (const key of configKeys) {
+        const v = Number(row[key]) || 0;
+        if (v > max) max = v;
+      }
+    }
+    return { axes: radarAxes(data, nameKey), max: max || 1 };
+  }, [chartType, data, configKeys, nameKey]);
+
+  // Memoized: this is the value handed to CommonChartContext (Legend/Tooltip),
+  // so it needs its own stable identity independent of the parent value.
+  const common: CommonChart = useMemo<CommonChart>(() => {
+    const tooltipLeft = Math.max(48, Math.min(plotWidth + mLeft - 48, cursorX));
+    const tooltipTop = Math.max(mTop + 44, cursorY);
+    const emphasis = selectedDataKey ?? focusDataKey;
+    if (chartType === "pie" && pie) {
+      const names = pie.map((s) => s.name);
+      return {
+        names,
+        tooltipTop,
+        labelOf: (n) => config[n]?.label ?? n,
+        seedOf,
+        selectedDataKey,
+        selectDataKey,
+        focusDataKey,
+        setFocusDataKey,
+        hoverIndex,
+        ready,
+        tooltipLeft,
+        heading: (i) => pie[i]?.name ?? null,
+        itemsAt: (i) => {
+          const s = pie[i];
+          if (!s) return [];
+          return [
+            {
+              name: s.name,
+              label: config[s.name]?.label ?? s.name,
+              value: s.value,
+              seed: seedOf(s.name),
+              dimmed: emphasis !== null && emphasis !== s.name,
+            },
+          ];
+        },
+      };
+    }
+    // radar
+    return {
+      names: configKeys,
+      tooltipTop,
+      labelOf: (n) => config[n]?.label ?? n,
+      seedOf,
+      selectedDataKey,
+      selectDataKey,
+      focusDataKey,
+      setFocusDataKey,
+      hoverIndex,
+      ready,
+      tooltipLeft,
+      heading: (i) => radar?.axes[i]?.label ?? null,
+      itemsAt: (i) =>
+        configKeys.map((name) => {
+          const raw = data[i]?.[name];
+          return {
+            name,
+            label: config[name]?.label ?? name,
+            value: typeof raw === "number" ? raw : 0,
+            seed: seedOf(name),
+            dimmed: emphasis !== null && emphasis !== name,
+          };
+        }),
+    };
+  }, [
+    chartType,
+    config,
+    configKeys,
+    data,
+    pie,
+    radar,
+    seedOf,
+    selectedDataKey,
+    selectDataKey,
+    focusDataKey,
+    hoverIndex,
+    ready,
+    plotWidth,
+    mLeft,
+    mTop,
+    cursorX,
+    cursorY,
+  ]);
+
+  // Memoized: this is the PolarChartContext value. A fresh object here would
+  // re-render every consumer on every parent render — the reason the pieces
+  // above are stabilized. Rebuilds only when a listed input changes.
+  return useMemo<PolarChartContextValue>(
+    () => ({
+      chartType,
+      config,
+      configKeys,
+      data,
+      dataLength: data.length,
+      ready,
+      plot: { width: plotWidth, height: plotHeight },
+      margins: stableMargins,
+      center: { x: centerX, y: centerY },
+      outerRadius,
+      innerRadius,
+      animate,
+      animationDuration,
+      revision,
+      bloom,
+      bloomOnHover,
+      seedOf,
+      variantOf,
+      registerVariant,
+      unregisterVariant,
+      selectedDataKey,
+      selectDataKey,
+      focusDataKey,
+      setFocusDataKey,
+      hoverIndex,
+      setHoverIndex,
+      setCursor,
+      isMouseInChart,
+      setMouseInChart,
+      pie,
+      radar,
+      common,
+    }),
+    [
+      chartType,
+      config,
+      configKeys,
+      data,
+      ready,
+      plotWidth,
+      plotHeight,
+      stableMargins,
+      centerX,
+      centerY,
+      outerRadius,
+      innerRadius,
+      animate,
+      animationDuration,
+      revision,
+      bloom,
+      bloomOnHover,
+      seedOf,
+      variantOf,
+      registerVariant,
+      unregisterVariant,
+      selectedDataKey,
+      selectDataKey,
+      focusDataKey,
+      hoverIndex,
+      setCursor,
+      isMouseInChart,
+      pie,
+      radar,
+      common,
+    ],
+  );
+}

--- a/apps/web/src/components/dither-kit/polar-root.tsx
+++ b/apps/web/src/components/dither-kit/polar-root.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { Children, type ComponentType, type ReactNode, isValidElement } from "react";
+import type { ChartConfig, Margins } from "./chart-context";
+import { CommonChartContext } from "./common-context";
+import type { BloomInput } from "./dither-paint";
+import { cn } from "./lib";
+import { axisAtAngle, sliceAtAngle } from "./polar";
+import { PolarChartContext, usePolarController } from "./polar-context";
+import { useChartDimensions } from "./use-chart-dimensions";
+
+// `object` rather than `Record<string, unknown>`: interfaces don't get an
+// implicit index signature, so interface-typed rows failed to satisfy the
+// generic. Internal layers still index rows through their own Row type.
+type Row = object;
+
+const DEFAULT_POLAR_MARGINS: Margins = {
+  top: 22,
+  right: 14,
+  bottom: 14,
+  left: 14,
+};
+
+function layerOf(node: ReactNode): "back" | "dom" | "svg" {
+  if (!isValidElement(node) || typeof node.type === "string") return "svg";
+  return (node.type as { chartLayer?: "back" | "dom" }).chartLayer ?? "svg";
+}
+
+export type PolarRootProps<TData extends Row> = {
+  chartType: "pie" | "radar";
+  /** Family painter — `PieCanvas` or `RadarCanvas`; ships with each chart. */
+  Canvas: ComponentType;
+  /** Extra back-layer SVG content (e.g. the radar frame). */
+  backDecoration?: ReactNode;
+  data: TData[];
+  config: ChartConfig;
+  children: ReactNode;
+  dataKey: string;
+  nameKey: string;
+  innerRadius?: number; // 0–1 ratio (donut); pie only
+  margins?: Partial<Margins>;
+  className?: string;
+  animate?: boolean;
+  animationDuration?: number;
+  replayToken?: number;
+  bloom?: BloomInput;
+  bloomOnHover?: boolean;
+  defaultSelectedDataKey?: string | null;
+  onSelectionChange?: (key: string | null) => void;
+};
+
+export function PolarRoot<TData extends Row>({
+  chartType,
+  Canvas,
+  backDecoration,
+  data,
+  config,
+  children,
+  dataKey,
+  nameKey,
+  innerRadius = 0,
+  margins: marginsProp,
+  className,
+  animate = true,
+  animationDuration = 900,
+  replayToken = 0,
+  bloom = "off",
+  bloomOnHover = false,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+}: PolarRootProps<TData>) {
+  const { ref, size } = useChartDimensions<HTMLDivElement>();
+  const margins = { ...DEFAULT_POLAR_MARGINS, ...marginsProp };
+
+  const ctx = usePolarController({
+    chartType,
+    // Safe: the controller only reads row[key] for the configured keys.
+    data: data as Record<string, unknown>[],
+    config,
+    dataKey,
+    nameKey,
+    innerRadiusRatio: innerRadius,
+    dimensions: size,
+    margins,
+    animate,
+    animationDuration,
+    replayToken,
+    bloom,
+    bloomOnHover,
+    defaultSelectedDataKey,
+    onSelectionChange,
+  });
+
+  const backChildren: ReactNode[] = [];
+  const svgChildren: ReactNode[] = [];
+  const domChildren: ReactNode[] = [];
+  Children.forEach(children, (child) => {
+    const layer = layerOf(child);
+    if (layer === "back") backChildren.push(child);
+    else if (layer === "dom") domChildren.push(child);
+    else svgChildren.push(child);
+  });
+
+  const onMove = (clientX: number, clientY: number) => {
+    const el = ref.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const dx = clientX - rect.left - margins.left - ctx.center.x;
+    const dy = clientY - rect.top - margins.top - ctx.center.y;
+    const angle = Math.atan2(dy, dx);
+    const r = Math.hypot(dx, dy);
+    if (chartType === "pie" && ctx.pie) {
+      const inside = r <= ctx.outerRadius && r >= ctx.innerRadius;
+      const i = inside ? sliceAtAngle(ctx.pie, angle) : -1;
+      ctx.setHoverIndex(i >= 0 ? i : null);
+    } else if (ctx.radar) {
+      ctx.setHoverIndex(axisAtAngle(ctx.radar.axes, angle));
+    }
+    ctx.setCursor(clientX - rect.left, clientY - rect.top);
+  };
+
+  return (
+    <PolarChartContext value={ctx}>
+      <CommonChartContext value={ctx.common}>
+        <div
+          ref={ref}
+          className={cn("relative h-full w-full", className)}
+          onPointerEnter={() => ctx.setMouseInChart(true)}
+          onPointerMove={(e) => onMove(e.clientX, e.clientY)}
+          onPointerLeave={() => {
+            ctx.setMouseInChart(false);
+            ctx.setHoverIndex(null);
+          }}
+        >
+          {ctx.ready && (
+            <svg
+              width={size.width}
+              height={size.height}
+              className="absolute inset-0 overflow-visible"
+              aria-hidden
+              role="presentation"
+            >
+              <g transform={`translate(${margins.left},${margins.top})`}>
+                {backDecoration}
+                {backChildren}
+              </g>
+            </svg>
+          )}
+          <Canvas />
+          {ctx.ready && (
+            <svg
+              width={size.width}
+              height={size.height}
+              className="absolute inset-0 overflow-visible"
+              role="img"
+              aria-label="Chart"
+            >
+              <g transform={`translate(${margins.left},${margins.top})`}>{svgChildren}</g>
+            </svg>
+          )}
+          {domChildren}
+        </div>
+      </CommonChartContext>
+    </PolarChartContext>
+  );
+}

--- a/apps/web/src/components/dither-kit/polar.ts
+++ b/apps/web/src/components/dither-kit/polar.ts
@@ -1,0 +1,109 @@
+// @ts-nocheck -- upstream Dither Kit source is not noUncheckedIndexedAccess-safe.
+type Row = Record<string, unknown>;
+
+const TOP = -Math.PI / 2;
+const TAU = Math.PI * 2;
+
+export type PieSlice = {
+  name: string;
+  value: number;
+  start: number; // radians
+  end: number;
+  mid: number;
+};
+
+/** Slice angles from each data row's value under `dataKey`, named by `nameKey`. */
+export function pieSlices(data: Row[], dataKey: string, nameKey: string): PieSlice[] {
+  const vals = data.map((r) => Math.max(0, Number(r[dataKey]) || 0));
+  const total = vals.reduce((a, b) => a + b, 0) || 1;
+  let a = TOP;
+  return data.map((r, i) => {
+    const span = (vals[i] / total) * TAU;
+    const slice = {
+      name: String(r[nameKey] ?? i),
+      value: vals[i],
+      start: a,
+      end: a + span,
+      mid: a + span / 2,
+    };
+    a += span;
+    return slice;
+  });
+}
+
+/** Which slice a pointer angle falls in (or -1). */
+export function sliceAtAngle(slices: PieSlice[], angle: number): number {
+  // Normalize so comparisons against [start, end) (which begin at TOP) work.
+  let a = angle;
+  while (a < TOP) a += TAU;
+  while (a >= TOP + TAU) a -= TAU;
+  return slices.findIndex((s) => a >= s.start && a < s.end);
+}
+
+export type RadarAxis = { label: string; angle: number };
+
+/** Evenly-spaced spokes, one per data row, labelled by `nameKey`. */
+export function radarAxes(data: Row[], nameKey: string): RadarAxis[] {
+  const n = Math.max(data.length, 1);
+  return data.map((r, i) => ({
+    label: String(r[nameKey] ?? i),
+    angle: TOP + (i / n) * TAU,
+  }));
+}
+
+/** Nearest radar spoke to a pointer angle. */
+export function axisAtAngle(axes: RadarAxis[], angle: number): number {
+  let best = 0;
+  let bestD = Number.POSITIVE_INFINITY;
+  axes.forEach((ax, i) => {
+    let d = Math.abs(((angle - ax.angle + Math.PI * 3) % TAU) - Math.PI);
+    d = Math.abs(d);
+    if (d < bestD) {
+      bestD = d;
+      best = i;
+    }
+  });
+  return best;
+}
+
+export const polarX = (cx: number, r: number, angle: number) => cx + Math.cos(angle) * r;
+export const polarY = (cy: number, r: number, angle: number) => cy + Math.sin(angle) * r;
+
+/** Even-odd point-in-polygon test (polygon as flat [x0,y0,x1,y1,…]). */
+export function pointInPolygon(px: number, py: number, poly: number[]): boolean {
+  let inside = false;
+  const n = poly.length / 2;
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const xi = poly[i * 2];
+    const yi = poly[i * 2 + 1];
+    const xj = poly[j * 2];
+    const yj = poly[j * 2 + 1];
+    if (yi > py !== yj > py && px < ((xj - xi) * (py - yi)) / (yj - yi) + xi) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+/** Distance from a point to the nearest edge of a polygon — drives the radial
+ * dither density (dense near the edge, thinning to the centre). */
+export function distToPolygonEdge(px: number, py: number, poly: number[]): number {
+  let best = Number.POSITIVE_INFINITY;
+  const n = poly.length / 2;
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const xi = poly[i * 2];
+    const yi = poly[i * 2 + 1];
+    const xj = poly[j * 2];
+    const yj = poly[j * 2 + 1];
+    const dx = xj - xi;
+    const dy = yj - yi;
+    const len2 = dx * dx + dy * dy || 1;
+    let t = ((px - xi) * dx + (py - yi) * dy) / len2;
+    t = Math.max(0, Math.min(1, t));
+    const ex = xi + t * dx - px;
+    const ey = yi + t * dy - py;
+    const d = Math.hypot(ex, ey);
+    if (d < best) best = d;
+  }
+  return best;
+}

--- a/apps/web/src/components/dither-kit/reference-line.tsx
+++ b/apps/web/src/components/dither-kit/reference-line.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useChartPart } from "./chart-context";
+
+/**
+ * A horizontal marker line at a value on the y-axis — most useful as the zero
+ * baseline for diverging data (`<ReferenceLine y={0} />`), or to mark a target
+ * / threshold. Renders in the front SVG layer so it stays visible over the
+ * dither fill; pass an optional `label` to annotate it at the right edge.
+ */
+export function ReferenceLine({
+  y = 0,
+  label,
+  strokeDasharray = "4 4",
+  className = "stroke-muted-foreground/60",
+}: {
+  y?: number;
+  label?: string;
+  strokeDasharray?: string;
+  className?: string;
+}) {
+  const ctx = useChartPart("ReferenceLine");
+  if (!ctx.ready) return null;
+
+  const { width } = ctx.plot;
+  const py = ctx.y(y);
+
+  return (
+    <g>
+      <line
+        x1={0}
+        x2={width}
+        y1={py}
+        y2={py}
+        className={className}
+        strokeDasharray={strokeDasharray}
+      />
+      {label ? (
+        <text
+          x={width - 2}
+          y={py - 3}
+          textAnchor="end"
+          className="fill-muted-foreground font-mono text-[10px]"
+        >
+          {label}
+        </text>
+      ) : null}
+    </g>
+  );
+}

--- a/apps/web/src/components/dither-kit/scales.ts
+++ b/apps/web/src/components/dither-kit/scales.ts
@@ -1,0 +1,106 @@
+import { scaleBand, scaleLinear, scalePoint } from "d3-scale";
+import { stack as d3Stack, stackOffsetExpand } from "d3-shape";
+
+export type StackType = "default" | "stacked" | "percent";
+
+type Row = Record<string, unknown>;
+
+const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : 0);
+
+/**
+ * Per-series [y0, y1] bands for every row. For `default` every series sits on
+ * the zero baseline (y0 = 0), so a negative value yields `[0, v]` with `v < 0`
+ * and draws below the baseline; for `stacked`/`percent` they pile on top of
+ * each other via d3's stack layout (which splits negatives below zero). The
+ * shape `bands[key][i] = [y0, y1]` is what both the SVG area paths and the
+ * canvas overlay read from. `max`/`min` bound the value range so the y-scale
+ * can span a diverging (below-zero) domain.
+ */
+export function computeBands(
+  data: Row[],
+  keys: string[],
+  stackType: StackType,
+): { bands: Record<string, [number, number][]>; max: number; min: number } {
+  if (stackType === "default") {
+    const bands: Record<string, [number, number][]> = {};
+    let max = 0;
+    let min = 0;
+    for (const key of keys) {
+      bands[key] = data.map((row) => {
+        const v = num(row[key]);
+        if (v > max) max = v;
+        if (v < min) min = v;
+        return [0, v];
+      });
+    }
+    // Only fall back to a unit span when there's no range at all (empty /
+    // all-zero) — a purely negative series keeps max = 0 so the baseline
+    // stays pinned to the top of the plot.
+    const flat = max === 0 && min === 0;
+    return { bands, max: flat ? 1 : max, min };
+  }
+
+  const series = d3Stack<Row>()
+    .keys(keys)
+    .value((row, key) => num(row[key]))
+    .offset(stackType === "percent" ? stackOffsetExpand : (undefined as never))(data);
+
+  const bands: Record<string, [number, number][]> = {};
+  let max = 0;
+  let min = 0;
+  for (const layer of series) {
+    bands[layer.key] = layer.map((point) => {
+      if (point[1] > max) max = point[1];
+      if (point[0] < min) min = point[0];
+      return [point[0], point[1]];
+    });
+  }
+  const flat = max === 0 && min === 0;
+  return { bands, max: flat ? 1 : max, min };
+}
+
+/** x positions for each row index, evenly spread across the plot width. */
+export function buildXScale(length: number, plotWidth: number) {
+  return scalePoint<number>()
+    .domain(Array.from({ length }, (_, i) => i))
+    .range([0, plotWidth]);
+}
+
+/** Banded x for bar categories — each index owns a slot of `bandwidth` width. */
+export function buildBandScale(length: number, plotWidth: number) {
+  return scaleBand<number>()
+    .domain(Array.from({ length }, (_, i) => i))
+    .range([0, plotWidth])
+    .paddingInner(0.28)
+    .paddingOuter(0.18);
+}
+
+/** Index of the category whose band a horizontal pixel offset falls in. */
+export function indexAtBand(px: number, length: number, plotWidth: number) {
+  if (length <= 0 || plotWidth <= 0) return 0;
+  const t = Math.max(0, Math.min(0.999, px / plotWidth));
+  return Math.min(length - 1, Math.floor(t * length));
+}
+
+/**
+ * value → vertical pixel. The domain always includes zero, so charts with only
+ * positive values keep a floor at the plot bottom, while diverging data (values
+ * below zero) draws below a zero baseline that sits somewhere inside the plot.
+ */
+export function buildYScale(min: number, max: number, plotHeight: number) {
+  const lo = Math.min(0, min);
+  const hi = Math.max(0, max);
+  // Guard a degenerate (zero-width) domain so `nice()` and the range map stay
+  // finite even when every value is exactly zero.
+  return scaleLinear()
+    .domain([lo, hi === lo ? lo + 1 : hi])
+    .nice()
+    .range([plotHeight, 0]);
+}
+
+/** Index of the row nearest a horizontal pixel offset within the plot. */
+export function nearestIndex(px: number, length: number, plotWidth: number) {
+  if (length <= 1 || plotWidth <= 0) return 0;
+  const t = Math.max(0, Math.min(1, px / plotWidth));
+  return Math.round(t * (length - 1));
+}

--- a/apps/web/src/components/dither-kit/series-context.tsx
+++ b/apps/web/src/components/dither-kit/series-context.tsx
@@ -1,0 +1,19 @@
+import { createContext, use } from "react";
+import type { Seed } from "./palette";
+
+export type SeriesContextValue = {
+  dataKey: string;
+  seed: Seed;
+  dimmed: boolean;
+};
+
+export const SeriesContext = createContext<SeriesContextValue | null>(null);
+
+/** Boundary guard for series-scoped markers (`<Dot>`, `<ActiveDot>`). */
+export function useSeries(part: string) {
+  const ctx = use(SeriesContext);
+  if (!ctx) {
+    throw new Error(`<${part} /> must be rendered inside a series (e.g. <Area />).`);
+  }
+  return ctx;
+}

--- a/apps/web/src/components/dither-kit/sparkline.tsx
+++ b/apps/web/src/components/dither-kit/sparkline.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useMemo } from "react";
+import { Area } from "./area";
+import { AreaChart } from "./area-chart";
+import type { AreaVariant } from "./chart-context";
+import type { BloomInput } from "./dither-paint";
+import type { DitherColor } from "./palette";
+
+export type SparklineProps = {
+  /** Plain numeric series — the common sparkline case. */
+  data: number[];
+  color: DitherColor;
+  variant?: AreaVariant;
+  /** Controlled crosshair position (e.g. a committed point). */
+  markerIndex?: number | null;
+  /** Parent-driven hover (e.g. the whole card/row) — lifts the fill. */
+  hovered?: boolean;
+  /** Glow on the dither fill. */
+  bloom?: BloomInput;
+  /** Only bloom while hovered. */
+  bloomOnHover?: boolean;
+  /** Play the entrance sweep — off by default for a calm spark. */
+  animate?: boolean;
+  className?: string;
+};
+
+/**
+ * Thin wrapper over {@link AreaChart} for the decorative-sparkline case: a
+ * single `number[]` series, no axes/grid/tooltip, no scrub crosshair (unless a
+ * `markerIndex` is supplied). Keeps the hover brightness lift.
+ */
+export function Sparkline({
+  data,
+  color,
+  variant = "gradient",
+  markerIndex = null,
+  hovered = false,
+  bloom = "off",
+  bloomOnHover = false,
+  animate = false,
+  className,
+}: SparklineProps) {
+  // Memoized explicitly so the chart works without React Compiler: `rows`
+  // identity drives the entrance-replay revision, so a fresh array every
+  // render would re-trigger the revision's state adjustment each pass.
+  const rows = useMemo(() => data.map((v) => ({ v })), [data]);
+  const config = useMemo(() => ({ v: { color } }), [color]);
+
+  return (
+    <AreaChart
+      data={rows}
+      config={config}
+      interactive={false}
+      animate={animate}
+      markerIndex={markerIndex}
+      hovered={hovered}
+      bloom={bloom}
+      bloomOnHover={bloomOnHover}
+      margins={{ top: 0, right: 0, bottom: 0, left: 0 }}
+      className={className}
+    >
+      <Area dataKey="v" variant={variant} />
+    </AreaChart>
+  );
+}

--- a/apps/web/src/components/dither-kit/tooltip.tsx
+++ b/apps/web/src/components/dither-kit/tooltip.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { AnimatePresence, motion } from "motion/react";
+import { useState } from "react";
+import { useCommonChart } from "./common-context";
+import { cn } from "./lib";
+import { rgb } from "./palette";
+
+export type TooltipVariant = "default" | "frosted-glass";
+
+const VARIANT: Record<TooltipVariant, string> = {
+  default: "bg-popover",
+  "frosted-glass": "bg-popover/70 backdrop-blur-sm",
+};
+
+/**
+ * Floating hover tooltip. Reads the shared common context so it works in every
+ * chart family. It glides between points and fades in/out (instead of snapping),
+ * and dims unselected series/slices.
+ */
+export function Tooltip({
+  labelKey,
+  valueFormatter,
+  variant = "default",
+}: {
+  labelKey?: string;
+  valueFormatter?: (value: number, name: string) => string;
+  variant?: TooltipVariant;
+}) {
+  const chart = useCommonChart();
+  const show = chart.ready && chart.hoverIndex != null;
+
+  // Retain the last hovered index so the card keeps its content while fading
+  // out — adjust-state-during-render (no refs in render).
+  const [lastIndex, setLastIndex] = useState(0);
+  if (chart.hoverIndex != null && chart.hoverIndex !== lastIndex) {
+    setLastIndex(chart.hoverIndex);
+  }
+  const index = chart.hoverIndex ?? lastIndex;
+
+  const heading = chart.heading(index, labelKey);
+  const items = chart.itemsAt(index);
+
+  return (
+    <AnimatePresence>
+      {show && items.length > 0 && (
+        <motion.div
+          key="dither-tooltip"
+          initial={{
+            opacity: 0,
+            x: "-50%",
+            y: "-115%",
+            top: chart.tooltipTop,
+            left: chart.tooltipLeft,
+          }}
+          animate={{
+            opacity: 1,
+            x: "-50%",
+            y: "-115%",
+            top: chart.tooltipTop,
+            left: chart.tooltipLeft,
+          }}
+          exit={{ opacity: 0 }}
+          transition={{
+            type: "spring",
+            stiffness: 520,
+            damping: 38,
+            mass: 0.6,
+          }}
+          className={cn(
+            "pointer-events-none absolute z-10 rounded-md border px-2 py-1 shadow-sm",
+            VARIANT[variant],
+          )}
+        >
+          {heading && (
+            <div className="mb-0.5 font-mono text-[10px] text-muted-foreground">{heading}</div>
+          )}
+          <div className="flex flex-col gap-0.5">
+            {items.map((item) => (
+              <div
+                key={item.name}
+                className="flex items-center gap-1.5 font-mono text-[11px] text-popover-foreground tabular-nums"
+                style={{ opacity: item.dimmed ? 0.4 : 1 }}
+              >
+                <span
+                  className="size-2 rounded-[1px]"
+                  style={{ backgroundColor: rgb(item.seed.fill) }}
+                />
+                <span className="text-muted-foreground">{item.label}</span>
+                <span className="ml-auto pl-2 text-foreground">
+                  {valueFormatter
+                    ? valueFormatter(item.value, item.name)
+                    : item.value.toLocaleString()}
+                </span>
+              </div>
+            ))}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+Tooltip.chartLayer = "dom" as const;

--- a/apps/web/src/components/dither-kit/use-chart-dimensions.ts
+++ b/apps/web/src/components/dither-kit/use-chart-dimensions.ts
@@ -1,0 +1,37 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
+export type Dimensions = { width: number; height: number };
+
+/**
+ * Tracks an element's CSS pixel size via {@link ResizeObserver}. Uses
+ * `clientWidth`/`clientHeight` (the layout size) rather than
+ * `getBoundingClientRect()` so a parent `layoutId` morph — which scales the
+ * element via a transform — can't trick the chart into measuring a scaled size
+ * and locking its canvas to it.
+ */
+export function useChartDimensions<T extends HTMLElement>() {
+  const ref = useRef<T>(null);
+  const [size, setSize] = useState<Dimensions>({ width: 0, height: 0 });
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const measure = () => {
+      const width = Math.max(0, el.clientWidth);
+      const height = Math.max(0, el.clientHeight);
+      setSize((prev) =>
+        prev.width === width && prev.height === height
+          ? prev // guard against repeat fires
+          : { width, height },
+      );
+    };
+
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    measure();
+    return () => ro.disconnect();
+  }, []);
+
+  return { ref, size };
+}

--- a/apps/web/src/components/dither-kit/x-axis.tsx
+++ b/apps/web/src/components/dither-kit/x-axis.tsx
@@ -1,0 +1,42 @@
+import { useChartPart } from "./chart-context";
+
+export function XAxis({
+  dataKey,
+  tickFormatter,
+  tickMargin = 8,
+  maxTicks = 8,
+}: {
+  dataKey?: string;
+  tickFormatter?: (value: unknown, index: number) => string;
+  tickMargin?: number;
+  maxTicks?: number;
+}) {
+  const ctx = useChartPart("XAxis");
+  if (!ctx.ready) return null;
+
+  const step = Math.max(1, Math.ceil(ctx.dataLength / maxTicks));
+  const y = ctx.plot.height + tickMargin;
+
+  return (
+    <g className="fill-current font-mono text-[10px] text-muted-foreground">
+      {ctx.data.map((row, i) => {
+        if (i % step !== 0) return null;
+        const raw = dataKey ? row[dataKey] : i;
+        const label = tickFormatter ? tickFormatter(raw, i) : String(raw ?? "");
+        return (
+          <text
+            // biome-ignore lint/suspicious/noArrayIndexKey: index is the stable x position
+            key={i}
+            x={ctx.xCenter(i) ?? 0}
+            y={y}
+            textAnchor="middle"
+            dominantBaseline="hanging"
+            fill="currentColor"
+          >
+            {label}
+          </text>
+        );
+      })}
+    </g>
+  );
+}

--- a/apps/web/src/components/dither-kit/y-axis.tsx
+++ b/apps/web/src/components/dither-kit/y-axis.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useChartPart } from "./chart-context";
+
+export function YAxis({
+  tickFormatter,
+  tickCount = 4,
+  tickMargin = 8,
+}: {
+  tickFormatter?: (value: number) => string;
+  tickCount?: number;
+  tickMargin?: number;
+}) {
+  const ctx = useChartPart("YAxis");
+  if (!ctx.ready) return null;
+
+  return (
+    <g className="fill-current font-mono text-[10px] text-muted-foreground">
+      {ctx.y.ticks(tickCount).map((t) => (
+        <text
+          key={t}
+          x={-tickMargin}
+          y={ctx.y(t)}
+          textAnchor="end"
+          dominantBaseline="central"
+          fill="currentColor"
+        >
+          {tickFormatter ? tickFormatter(t) : t}
+        </text>
+      ))}
+    </g>
+  );
+}

--- a/apps/web/src/dashboards/api.ts
+++ b/apps/web/src/dashboards/api.ts
@@ -73,6 +73,28 @@ export function useAgentPullRequestSummary(projectId: string | undefined) {
   });
 }
 
+export type HomeIncidentTrend = {
+  active: number;
+  rows: Array<{
+    day: string;
+    label: string;
+    sev1: number;
+    sev2: number;
+    sev3: number;
+    untriaged: number;
+  }>;
+};
+
+export function useHomeIncidentTrend(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  return useQuery({
+    queryKey: ["home-incident-trend", projectId],
+    queryFn: () => fetcher<HomeIncidentTrend>(`/api/projects/${projectId}/home/incident-trend`),
+    enabled: !!projectId,
+    staleTime: 30_000,
+  });
+}
+
 export type HomeSignalSeries = {
   step: string;
   rows: Array<{

--- a/apps/web/src/dashboards/api.ts
+++ b/apps/web/src/dashboards/api.ts
@@ -53,7 +53,58 @@ export function useHomeDashboard(projectId: string | undefined) {
   });
 }
 
-export type HomeBuiltinType = "setup_todos" | "active_incidents" | "service_map";
+export type AgentPullRequestSummary = {
+  window: "30d";
+  total: number;
+  merged: number;
+  unmerged: number;
+  open: number;
+  closed: number;
+};
+
+export function useAgentPullRequestSummary(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  return useQuery({
+    queryKey: ["home-pull-request-summary", projectId],
+    queryFn: () =>
+      fetcher<AgentPullRequestSummary>(`/api/projects/${projectId}/home/pull-request-summary`),
+    enabled: !!projectId,
+    staleTime: 60_000,
+  });
+}
+
+export type HomeSignalSeries = {
+  step: string;
+  rows: Array<{
+    bucket: string;
+    traces: number;
+    logs: number;
+    metrics: number;
+  }>;
+};
+
+export function useHomeSignalSeries(
+  projectId: string | undefined,
+  range: { since: string; until: string },
+) {
+  const fetcher = useFetcher();
+  const query = new URLSearchParams({ since: range.since, until: range.until });
+  return useQuery({
+    queryKey: ["home-signal-series", projectId, range.since, range.until],
+    queryFn: () =>
+      fetcher<HomeSignalSeries>(`/api/projects/${projectId}/home/signal-series?${query}`),
+    enabled: !!projectId,
+    staleTime: 30_000,
+  });
+}
+
+export type HomeBuiltinType =
+  | "setup_todos"
+  | "active_incidents"
+  | "service_map"
+  | "incoming_signals"
+  | "incident_count"
+  | "agent_pull_requests";
 
 export function useSetHomeBuiltin(projectId: string) {
   const fetcher = useFetcher();

--- a/apps/web/src/dashboards/types.ts
+++ b/apps/web/src/dashboards/types.ts
@@ -12,7 +12,10 @@ export type WidgetType =
   | "link"
   | "setup_todos"
   | "active_incidents"
-  | "service_map";
+  | "service_map"
+  | "incoming_signals"
+  | "incident_count"
+  | "agent_pull_requests";
 
 export type ChartType = "line" | "bar";
 
@@ -107,6 +110,15 @@ export function defaultLayoutFor(type: WidgetType): WidgetLayout {
   }
   if (type === "service_map") {
     return { x: 6, y: 5, w: 6, h: 8 };
+  }
+  if (type === "incoming_signals") {
+    return { x: 0, y: 5, w: 4, h: 5 };
+  }
+  if (type === "incident_count") {
+    return { x: 4, y: 5, w: 4, h: 5 };
+  }
+  if (type === "agent_pull_requests") {
+    return { x: 8, y: 5, w: 4, h: 5 };
   }
   if (type === "trace_table" || type === "log_table") {
     return { x: 0, y: 9999, w: 12, h: 6 };

--- a/apps/web/src/home/HomeCustomizePanel.tsx
+++ b/apps/web/src/home/HomeCustomizePanel.tsx
@@ -1,5 +1,5 @@
-import { Btn } from "../design/ui.tsx";
 import type { HomeBuiltinType } from "../dashboards/api.ts";
+import { Btn } from "../design/ui.tsx";
 
 const BUILTINS: Array<{
   type: HomeBuiltinType;
@@ -20,6 +20,21 @@ const BUILTINS: Array<{
     type: "service_map",
     label: "Service map",
     description: "Connected services and infrastructure",
+  },
+  {
+    type: "incoming_signals",
+    label: "Incoming signals",
+    description: "Traces, logs, and metrics received in the last hour",
+  },
+  {
+    type: "incident_count",
+    label: "Incident count",
+    description: "Open incidents grouped by severity",
+  },
+  {
+    type: "agent_pull_requests",
+    label: "Superlog pull requests",
+    description: "Merged and unmerged PRs from the last 30 days",
   },
 ];
 

--- a/apps/web/src/home/HomeDashboard.tsx
+++ b/apps/web/src/home/HomeDashboard.tsx
@@ -2,13 +2,6 @@ import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } fro
 import GridLayout, { type Layout, type LayoutItem, useContainerWidth } from "react-grid-layout";
 import { verticalCompactor } from "react-grid-layout";
 import { type ExploreRange, useCloudConnections } from "../api.ts";
-import {
-  RANGE_PRESETS,
-  RangePicker,
-  type RangeSelection,
-  rangeFromSeconds,
-} from "../design/RangePicker.tsx";
-import { Btn, Input, PageHeader } from "../design/ui.tsx";
 import { WidgetForm } from "../dashboards/WidgetForm.tsx";
 import {
   type HomeBuiltinType,
@@ -23,11 +16,23 @@ import type { Widget, WidgetLayout } from "../dashboards/types.ts";
 import { defaultLayoutFor } from "../dashboards/types.ts";
 import { emptyWidgetForm } from "../dashboards/widget-config.ts";
 import { WidgetBody } from "../dashboards/widgets/WidgetBody.tsx";
+import {
+  RANGE_PRESETS,
+  RangePicker,
+  type RangeSelection,
+  rangeFromSeconds,
+} from "../design/RangePicker.tsx";
+import { Btn, Input, PageHeader } from "../design/ui.tsx";
 import { SetupTodos } from "../onboarding/SetupTodos.tsx";
 import type { ProjectRouteSlugs } from "../project-route.ts";
 import { ActiveIncidentsHomeWidget, ServiceMapHomeWidget } from "./BuiltinHomeWidgets.tsx";
 import { HomeCustomizePanel } from "./HomeCustomizePanel.tsx";
-import { homeWidgetPresentation, splitHomeWidgets } from "./home-layout.ts";
+import {
+  AgentPullRequestsHomeWidget,
+  IncidentCountHomeWidget,
+  IncomingSignalsHomeWidget,
+} from "./HomePulseWidgets.tsx";
+import { homeWidgetMinWidth, homeWidgetPresentation, splitHomeWidgets } from "./home-layout.ts";
 
 const GRID_CONFIG = {
   cols: 12,
@@ -36,7 +41,14 @@ const GRID_CONFIG = {
   containerPadding: [0, 0] as [number, number],
 };
 const DEFAULT_RANGE: RangeSelection = { seconds: 3 * 60 * 60, label: "Last 3h" };
-const BUILTIN_TYPES = new Set<HomeBuiltinType>(["setup_todos", "active_incidents", "service_map"]);
+const BUILTIN_TYPES = new Set<HomeBuiltinType>([
+  "setup_todos",
+  "active_incidents",
+  "service_map",
+  "incoming_signals",
+  "incident_count",
+  "agent_pull_requests",
+]);
 
 export function HomeDashboard({
   projectId,
@@ -75,12 +87,8 @@ export function HomeDashboard({
   // doesn't flicker away (or stay hidden on a transient failure). Also keep it while
   // customizing so it stays draggable/removable.
   const hideServiceMap =
-    cloudConnections.isSuccess &&
-    (cloudConnections.data?.length ?? 0) === 0 &&
-    !customizing;
-  const visibleGrid = grid.filter(
-    (widget) => widget.type !== "service_map" || !hideServiceMap,
-  );
+    cloudConnections.isSuccess && (cloudConnections.data?.length ?? 0) === 0 && !customizing;
+  const visibleGrid = grid.filter((widget) => widget.type !== "service_map" || !hideServiceMap);
 
   return (
     <div className="flex flex-col gap-6">
@@ -180,8 +188,7 @@ function HomeGrid({
       widgets.map((widget) => ({
         i: widget.id,
         ...widget.layout,
-        minW:
-          widget.type === "link" ? 3 : BUILTIN_TYPES.has(widget.type as HomeBuiltinType) ? 6 : 3,
+        minW: homeWidgetMinWidth(widget.type),
         minH: widget.type === "link" ? 2 : 3,
       })),
     [widgets],
@@ -276,9 +283,7 @@ function HomeItemTile({
           </button>
         )}
       </div>
-      <div
-        className={`min-h-0 flex-1 overflow-auto ${presentation.bodyPadding ? "p-4" : ""}`}
-      >
+      <div className={`min-h-0 flex-1 overflow-auto ${presentation.bodyPadding ? "p-4" : ""}`}>
         <HomeItemBody projectId={projectId} slugs={slugs} range={range} widget={widget} />
       </div>
     </section>
@@ -303,6 +308,12 @@ function HomeItemBody({
       return <ActiveIncidentsHomeWidget projectId={projectId} slugs={slugs} />;
     case "service_map":
       return <ServiceMapHomeWidget projectId={projectId} />;
+    case "incoming_signals":
+      return <IncomingSignalsHomeWidget projectId={projectId} range={range} />;
+    case "incident_count":
+      return <IncidentCountHomeWidget projectId={projectId} />;
+    case "agent_pull_requests":
+      return <AgentPullRequestsHomeWidget projectId={projectId} />;
     case "link":
       return <HomeLink widget={widget} />;
     default:
@@ -414,6 +425,7 @@ function Dialog({
 }: { title: string; children: ReactNode; onClose: () => void }) {
   return (
     <div className="fixed inset-0 z-50 grid place-items-center bg-black/60 p-4" role="presentation">
+      {/* biome-ignore lint/a11y/useSemanticElements: this controlled overlay intentionally avoids native dialog top-layer behavior */}
       <section
         role="dialog"
         aria-modal="true"
@@ -439,6 +451,7 @@ function Dialog({
 
 function Field({ label, children }: { label: string; children: ReactNode }) {
   return (
+    // biome-ignore lint/a11y/noLabelWithoutControl: every caller passes its form control as children
     <label className="block">
       <span className="mb-2 block text-[11px] font-medium text-muted">{label}</span>
       {children}

--- a/apps/web/src/home/HomePulseWidgets.tsx
+++ b/apps/web/src/home/HomePulseWidgets.tsx
@@ -1,0 +1,344 @@
+import { Area } from "@/components/dither-kit/area";
+import { AreaChart } from "@/components/dither-kit/area-chart";
+import { Bar } from "@/components/dither-kit/bar";
+import { BarChart } from "@/components/dither-kit/bar-chart";
+import type { ChartConfig } from "@/components/dither-kit/chart-context";
+import { Grid } from "@/components/dither-kit/grid";
+import { Legend } from "@/components/dither-kit/legend";
+import { Pie } from "@/components/dither-kit/pie";
+import { PieChart } from "@/components/dither-kit/pie-chart";
+import { Tooltip } from "@/components/dither-kit/tooltip";
+import { XAxis } from "@/components/dither-kit/x-axis";
+import { YAxis } from "@/components/dither-kit/y-axis";
+import type { CSSProperties } from "react";
+import type { IncidentListItem } from "../api.ts";
+import { useIncidents } from "../api.ts";
+import {
+  type AgentPullRequestSummary,
+  type HomeSignalSeries,
+  useAgentPullRequestSummary,
+  useHomeSignalSeries,
+} from "../dashboards/api.ts";
+
+const compactNumber = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+const PIXEL_NUMBER_STYLE = {
+  fontFamily: '"Geist Pixel", ui-monospace, monospace',
+  fontSynthesis: "none",
+  WebkitFontSmoothing: "none",
+} satisfies CSSProperties;
+
+const SIGNAL_CONFIG = {
+  traces: { label: "Traces", color: "green" },
+  metrics: { label: "Metrics", color: "orange" },
+  logs: { label: "Logs", color: "blue" },
+} satisfies ChartConfig;
+
+const INCIDENT_CONFIG = {
+  sev1: { label: "SEV-1", color: "red" },
+  sev2: { label: "SEV-2", color: "orange" },
+  sev3: { label: "SEV-3", color: "blue" },
+  untriaged: { label: "Untriaged", color: "grey" },
+} satisfies ChartConfig;
+
+const PR_CONFIG = {
+  merged: { label: "Merged", color: "green" },
+  unmerged: { label: "Not merged", color: "blue" },
+} satisfies ChartConfig;
+
+export function IncomingSignalsHomeWidget({
+  projectId,
+  range,
+}: {
+  projectId: string;
+  range: { since: string; until: string };
+}) {
+  const series = useHomeSignalSeries(projectId, range);
+  if (series.isLoading) return <PulseMessage>Loading signals…</PulseMessage>;
+  if (!series.data || series.error) {
+    return <PulseMessage tone="danger">Signals unavailable</PulseMessage>;
+  }
+  return <IncomingSignalsWidgetContent series={series.data} />;
+}
+
+export function IncomingSignalsWidgetContent({ series }: { series: HomeSignalSeries }) {
+  const signals = [
+    {
+      label: "Traces",
+      value: series.rows.reduce((sum, point) => sum + point.traces, 0),
+      dotClass: "bg-success",
+    },
+    {
+      label: "Metrics",
+      value: series.rows.reduce((sum, point) => sum + point.metrics, 0),
+      dotClass: "bg-warning",
+    },
+    {
+      label: "Logs",
+      value: series.rows.reduce((sum, point) => sum + point.logs, 0),
+      dotClass: "bg-accent",
+    },
+  ];
+
+  return (
+    <div className="flex h-full min-h-52 flex-col p-4" aria-label="Incoming signals over time">
+      <div className="grid min-w-0 grid-cols-3 gap-3">
+        {signals.map((signal) => (
+          <SignalStat key={signal.label} {...signal} />
+        ))}
+      </div>
+
+      <div className="mt-4 min-h-0 flex-1">
+        <AreaChart
+          data={series.rows}
+          config={SIGNAL_CONFIG}
+          stackType="stacked"
+          bloom="aura"
+          margins={{ top: 22, right: 6, bottom: 20, left: 34 }}
+          animate={false}
+        >
+          <Grid />
+          <XAxis dataKey="bucket" tickFormatter={formatSignalBucket} maxTicks={4} />
+          <YAxis tickFormatter={(value) => compactNumber.format(value)} tickCount={3} />
+          <Tooltip labelKey="bucket" valueFormatter={(value) => compactNumber.format(value)} />
+          <Area dataKey="traces" variant="dotted" />
+          <Area dataKey="metrics" variant="gradient" />
+          <Area dataKey="logs" variant="hatched" />
+        </AreaChart>
+      </div>
+    </div>
+  );
+}
+
+function SignalStat({
+  label,
+  value,
+  dotClass,
+}: {
+  label: string;
+  value: number;
+  dotClass: string;
+}) {
+  const formatted = value > 0 ? compactNumber.format(value) : null;
+  return (
+    <div aria-label={`${label}: ${formatted ?? "no data"}`} className="min-w-0">
+      <div
+        className="h-9 text-[32px] font-normal leading-9 tracking-[0.02em] text-fg tabular-nums"
+        style={PIXEL_NUMBER_STYLE}
+      >
+        {formatted}
+      </div>
+      <div className="mt-1 flex items-center gap-1.5 text-[10px] text-muted">
+        <span className={`size-1.5 rounded-[1px] ${dotClass}`} aria-hidden="true" />
+        {label.toLowerCase()}
+      </div>
+    </div>
+  );
+}
+
+export type IncidentTrend = {
+  active: number;
+  rows: Array<{
+    day: string;
+    label: string;
+    sev1: number;
+    sev2: number;
+    sev3: number;
+    untriaged: number;
+  }>;
+};
+
+export function buildIncidentTrend(incidents: IncidentListItem[], now = new Date()): IncidentTrend {
+  const days = Array.from({ length: 7 }, (_, index) => {
+    const day = new Date(now);
+    day.setUTCHours(0, 0, 0, 0);
+    day.setUTCDate(day.getUTCDate() - (6 - index));
+    return {
+      day: day.toISOString().slice(0, 10),
+      label: day.toLocaleDateString("en", { weekday: "short", timeZone: "UTC" }),
+      sev1: 0,
+      sev2: 0,
+      sev3: 0,
+      untriaged: 0,
+    };
+  });
+  const byDay = new Map(days.map((day) => [day.day, day]));
+  for (const { incident } of incidents) {
+    const point = byDay.get(incident.firstSeen.slice(0, 10));
+    if (!point) continue;
+    if (incident.severity === "SEV-1") point.sev1 += 1;
+    else if (incident.severity === "SEV-2") point.sev2 += 1;
+    else if (incident.severity === "SEV-3") point.sev3 += 1;
+    else point.untriaged += 1;
+  }
+  return {
+    active: incidents.filter(({ incident }) => incident.status === "open").length,
+    rows: days,
+  };
+}
+
+export function IncidentCountHomeWidget({ projectId }: { projectId: string }) {
+  const incidents = useIncidents(projectId, "all");
+  if (incidents.isLoading) return <PulseMessage>Loading incidents…</PulseMessage>;
+  if (!incidents.data || incidents.error) {
+    return <PulseMessage tone="danger">Incidents unavailable</PulseMessage>;
+  }
+  return <IncidentCountWidgetContent trend={buildIncidentTrend(incidents.data)} />;
+}
+
+export function IncidentCountWidgetContent({ trend }: { trend: IncidentTrend }) {
+  return (
+    <div className="flex h-full min-h-52 flex-col p-4" aria-label="Incidents opened by severity">
+      <div aria-label={`${trend.active} active ${trend.active === 1 ? "incident" : "incidents"}`}>
+        <div className="flex items-baseline gap-2">
+          <span
+            className="text-[32px] font-normal leading-none tracking-[0.02em] text-fg tabular-nums"
+            style={PIXEL_NUMBER_STYLE}
+          >
+            {trend.active}
+          </span>
+          <span className="text-[11px] text-muted">
+            active {trend.active === 1 ? "incident" : "incidents"}
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-4 min-h-0 flex-1">
+        <BarChart
+          data={trend.rows}
+          config={INCIDENT_CONFIG}
+          stackType="stacked"
+          bloom="aura"
+          margins={{ top: 22, right: 6, bottom: 20, left: 24 }}
+          animate={false}
+        >
+          <Grid />
+          <XAxis dataKey="label" maxTicks={7} />
+          <YAxis tickCount={3} />
+          <Legend isClickable />
+          <Tooltip labelKey="label" />
+          <Bar dataKey="sev1" variant="dotted" />
+          <Bar dataKey="sev2" variant="hatched" />
+          <Bar dataKey="sev3" variant="gradient" />
+          <Bar dataKey="untriaged" variant="solid" />
+        </BarChart>
+      </div>
+    </div>
+  );
+}
+
+export function AgentPullRequestsHomeWidget({ projectId }: { projectId: string }) {
+  const summary = useAgentPullRequestSummary(projectId);
+  if (summary.isLoading) return <PulseMessage>Loading pull requests…</PulseMessage>;
+  if (!summary.data || summary.error) {
+    return <PulseMessage tone="danger">Pull requests unavailable</PulseMessage>;
+  }
+  return <AgentPullRequestsWidgetContent summary={summary.data} />;
+}
+
+export function AgentPullRequestsWidgetContent({ summary }: { summary: AgentPullRequestSummary }) {
+  const data = [
+    { outcome: "merged", value: summary.merged },
+    { outcome: "unmerged", value: summary.unmerged },
+  ];
+
+  return (
+    <div
+      className="grid h-full min-h-52 grid-cols-[minmax(68px,1fr)_minmax(0,3fr)] grid-rows-[minmax(0,1fr)_auto] gap-x-3 gap-y-3 p-4"
+      aria-label={`${summary.merged} merged and ${summary.unmerged} not merged`}
+    >
+      <div className="min-w-0 self-start pt-3">
+        <div
+          className="text-[32px] font-normal leading-none tracking-[0.02em] text-fg tabular-nums"
+          style={PIXEL_NUMBER_STYLE}
+        >
+          {summary.total}
+        </div>
+        <div className="mt-2 text-[10px] leading-tight text-muted">pull requests</div>
+        <div className="mt-1 font-mono text-[8px] uppercase tracking-[0.08em] text-subtle">
+          last 30 days
+        </div>
+      </div>
+
+      <div className="relative aspect-square h-full max-h-48 w-full max-w-48 place-self-center">
+        <PieChart
+          data={data}
+          config={PR_CONFIG}
+          dataKey="value"
+          nameKey="outcome"
+          innerRadius={0.54}
+          bloom="aura"
+          animate={false}
+          margins={{ top: 2, right: 2, bottom: 2, left: 2 }}
+        >
+          <Pie variant="dotted" />
+          <Tooltip valueFormatter={(value) => String(value)} />
+        </PieChart>
+      </div>
+
+      <div className="col-span-2 grid grid-cols-2 gap-x-5 gap-y-2 border-t border-border pt-3">
+        <div className="min-w-0">
+          <LegendRow color="var(--color-success)" label="Merged" value={summary.merged} />
+        </div>
+        <div className="min-w-0">
+          <LegendRow color="var(--color-accent)" label="Not merged" value={summary.unmerged} />
+        </div>
+        <div className="col-span-2 flex items-center gap-4 font-mono text-[8px] uppercase tracking-[0.08em] text-subtle">
+          <span>{summary.open} open</span>
+          <span>{summary.closed} closed</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatSignalBucket(value: unknown): string {
+  const normalized = String(value).replace(" ", "T");
+  const date = new Date(normalized.endsWith("Z") ? normalized : `${normalized}Z`);
+  if (Number.isNaN(date.getTime())) return String(value);
+  return date.toLocaleTimeString("en", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+function LegendRow({ color, label, value }: { color: string; label: string; value: number }) {
+  return (
+    <div className="flex items-center justify-between gap-3 text-[11px]">
+      <span className="flex items-center gap-2 text-muted">
+        <span
+          className="h-2.5 w-2.5 rounded-[2px]"
+          style={{
+            backgroundColor: color,
+            backgroundImage: "radial-gradient(rgb(var(--color-bg-rgb)) 0.7px, transparent 0.8px)",
+            backgroundSize: "3px 3px",
+          }}
+        />
+        {label}
+      </span>
+      <span className="font-mono text-fg tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+function PulseMessage({
+  children,
+  tone = "muted",
+}: {
+  children: string;
+  tone?: "muted" | "danger";
+}) {
+  return (
+    <div
+      className={`grid h-full min-h-52 place-items-center p-4 text-center text-[11px] ${
+        tone === "danger" ? "text-danger" : "text-muted"
+      }`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/home/HomePulseWidgets.tsx
+++ b/apps/web/src/home/HomePulseWidgets.tsx
@@ -11,12 +11,12 @@ import { Tooltip } from "@/components/dither-kit/tooltip";
 import { XAxis } from "@/components/dither-kit/x-axis";
 import { YAxis } from "@/components/dither-kit/y-axis";
 import type { CSSProperties } from "react";
-import type { IncidentListItem } from "../api.ts";
-import { useIncidents } from "../api.ts";
 import {
   type AgentPullRequestSummary,
+  type HomeIncidentTrend,
   type HomeSignalSeries,
   useAgentPullRequestSummary,
+  useHomeIncidentTrend,
   useHomeSignalSeries,
 } from "../dashboards/api.ts";
 
@@ -139,57 +139,16 @@ function SignalStat({
   );
 }
 
-export type IncidentTrend = {
-  active: number;
-  rows: Array<{
-    day: string;
-    label: string;
-    sev1: number;
-    sev2: number;
-    sev3: number;
-    untriaged: number;
-  }>;
-};
-
-export function buildIncidentTrend(incidents: IncidentListItem[], now = new Date()): IncidentTrend {
-  const days = Array.from({ length: 7 }, (_, index) => {
-    const day = new Date(now);
-    day.setUTCHours(0, 0, 0, 0);
-    day.setUTCDate(day.getUTCDate() - (6 - index));
-    return {
-      day: day.toISOString().slice(0, 10),
-      label: day.toLocaleDateString("en", { weekday: "short", timeZone: "UTC" }),
-      sev1: 0,
-      sev2: 0,
-      sev3: 0,
-      untriaged: 0,
-    };
-  });
-  const byDay = new Map(days.map((day) => [day.day, day]));
-  for (const { incident } of incidents) {
-    const point = byDay.get(incident.firstSeen.slice(0, 10));
-    if (!point) continue;
-    if (incident.severity === "SEV-1") point.sev1 += 1;
-    else if (incident.severity === "SEV-2") point.sev2 += 1;
-    else if (incident.severity === "SEV-3") point.sev3 += 1;
-    else point.untriaged += 1;
-  }
-  return {
-    active: incidents.filter(({ incident }) => incident.status === "open").length,
-    rows: days,
-  };
-}
-
 export function IncidentCountHomeWidget({ projectId }: { projectId: string }) {
-  const incidents = useIncidents(projectId, "all");
-  if (incidents.isLoading) return <PulseMessage>Loading incidents…</PulseMessage>;
-  if (!incidents.data || incidents.error) {
+  const trend = useHomeIncidentTrend(projectId);
+  if (trend.isLoading) return <PulseMessage>Loading incidents…</PulseMessage>;
+  if (!trend.data || trend.error) {
     return <PulseMessage tone="danger">Incidents unavailable</PulseMessage>;
   }
-  return <IncidentCountWidgetContent trend={buildIncidentTrend(incidents.data)} />;
+  return <IncidentCountWidgetContent trend={trend.data} />;
 }
 
-export function IncidentCountWidgetContent({ trend }: { trend: IncidentTrend }) {
+export function IncidentCountWidgetContent({ trend }: { trend: HomeIncidentTrend }) {
   return (
     <div className="flex h-full min-h-52 flex-col p-4" aria-label="Incidents opened by severity">
       <div aria-label={`${trend.active} active ${trend.active === 1 ? "incident" : "incidents"}`}>

--- a/apps/web/src/home/home-layout.ts
+++ b/apps/web/src/home/home-layout.ts
@@ -1,4 +1,6 @@
-export function splitHomeWidgets<T extends { type: string }>(widgets: T[]): {
+export function splitHomeWidgets<T extends { type: string }>(
+  widgets: T[],
+): {
   setup: T | undefined;
   grid: T[];
 } {
@@ -13,8 +15,22 @@ export function homeWidgetPresentation(type: string): {
   innerShell: boolean;
   defaultHeight: number | undefined;
 } {
-  if (type === "active_incidents") {
+  if (
+    type === "active_incidents" ||
+    type === "incoming_signals" ||
+    type === "incident_count" ||
+    type === "agent_pull_requests"
+  ) {
     return { bodyPadding: false, innerShell: false, defaultHeight: 3 };
   }
   return { bodyPadding: true, innerShell: true, defaultHeight: undefined };
+}
+
+export function homeWidgetMinWidth(type: string): number {
+  if (type === "link") return 3;
+  if (type === "incoming_signals" || type === "incident_count" || type === "agent_pull_requests") {
+    return 4;
+  }
+  if (type === "setup_todos" || type === "active_incidents" || type === "service_map") return 6;
+  return 3;
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,4 +1,5 @@
 import "./instrumentation";
+import "@fontsource/geist-pixel/latin.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AutumnProvider } from "autumn-js/react";
 import { PostHogProvider } from "posthog-js/react";

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -5,6 +5,7 @@ export default {
   theme: {
     extend: {
       fontFamily: {
+        pixel: ["Geist Pixel", "ui-monospace", "monospace"],
         sans: [
           "Inter",
           "ui-sans-serif",
@@ -37,8 +38,12 @@ export default {
         border: "var(--color-border)",
         "border-strong": "var(--color-border-strong)",
         fg: "rgb(var(--color-fg-rgb) / <alpha-value>)",
+        foreground: "rgb(var(--color-fg-rgb) / <alpha-value>)",
         muted: "rgb(var(--color-muted-rgb) / <alpha-value>)",
+        "muted-foreground": "rgb(var(--color-muted-rgb) / <alpha-value>)",
         subtle: "rgb(var(--color-subtle-rgb) / <alpha-value>)",
+        popover: "rgb(var(--color-surface-rgb) / <alpha-value>)",
+        "popover-foreground": "rgb(var(--color-fg-rgb) / <alpha-value>)",
         accent: "rgb(var(--color-accent-rgb) / <alpha-value>)",
         "accent-ink": "rgb(var(--color-accent-ink-rgb) / <alpha-value>)",
         "accent-soft": "var(--color-accent-soft)",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -12,7 +12,11 @@
     "isolatedModules": true,
     "noEmit": true,
     "allowImportingTsExtensions": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["src/**/*"]
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -36,6 +36,11 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [react()],
+    resolve: {
+      alias: {
+        "@": path.resolve(process.cwd(), "src"),
+      },
+    },
     server: {
       host: env.HOST ?? "127.0.0.1",
       port: Number(env.PORT ?? env.WEB_PORT ?? 5173),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2025,7 +2025,10 @@ export type DashboardWidgetType =
   | "link"
   | "setup_todos"
   | "active_incidents"
-  | "service_map";
+  | "service_map"
+  | "incoming_signals"
+  | "incident_count"
+  | "agent_pull_requests";
 
 export type DashboardWidgetConfig = {
   source?: "logs" | "traces";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,10 +170,10 @@ importers:
         version: link:../../packages/telemetry-query
       autumn-js:
         specifier: ^1.2.27
-        version: 1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.6.13
-        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -339,6 +339,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.5.0
         version: 1.5.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@fontsource/geist-pixel':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@git-diff-view/file':
         specifier: ^0.1.3
         version: 0.1.3
@@ -401,13 +404,25 @@ importers:
         version: 2.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       autumn-js:
         specifier: ^1.2.27
-        version: 1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.6.13
-        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      d3-scale:
+        specifier: ^4.0.2
+        version: 4.0.2
+      d3-shape:
+        specifier: ^3.2.0
+        version: 3.2.0
       echarts:
         specifier: ^6
         version: 6.1.0
+      motion:
+        specifier: ^12.42.2
+        version: 12.42.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       posthog-js:
         specifier: ^1
         version: 1.379.0
@@ -435,7 +450,16 @@ importers:
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
     devDependencies:
+      '@types/d3-scale':
+        specifier: ^4.0.9
+        version: 4.0.9
+      '@types/d3-shape':
+        specifier: ^3.1.8
+        version: 3.1.8
       '@types/react':
         specifier: ^19.0.2
         version: 19.2.14
@@ -589,7 +613,7 @@ importers:
     dependencies:
       better-auth:
         specifier: ^1.6.13
-        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
@@ -1690,6 +1714,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource/geist-pixel@5.3.0':
+    resolution: {integrity: sha512-lno6MaxiPlE8ex9T8GMXvU9ZzGBdt1GSQ7ub00RMrhd7SUs9Qy/L6f3sLwzs1F7YcwAZiIa8pxW5dIqZz3zgCg==}
 
   '@git-diff-view/core@0.1.3':
     resolution: {integrity: sha512-HNuxWv/DqxFRuZMq4EHmnFL4bVM68ON/GnCoTz35Q9SfIScgN3Qppoh2rj/GEpWV1XG+TjBFuSSoW8XBcx8+ew==}
@@ -4270,6 +4297,20 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  framer-motion@12.42.2:
+    resolution: {integrity: sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -4924,6 +4965,26 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  motion-dom@12.42.2:
+    resolution: {integrity: sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+
+  motion@12.42.2:
+    resolution: {integrity: sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -5746,6 +5807,9 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
+
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss@3.4.19:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
@@ -7041,6 +7105,8 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource/geist-pixel@5.3.0': {}
 
   '@git-diff-view/core@0.1.3':
     dependencies:
@@ -9002,13 +9068,13 @@ snapshots:
       postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  autumn-js@1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
+  autumn-js@1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
     dependencies:
       query-string: 9.4.0
       rou3: 0.6.3
       zod: 4.4.3
     optionalDependencies:
-      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       better-call: 1.3.7(zod@4.4.3)
       express: 5.2.1
       hono: 4.12.30
@@ -9031,7 +9097,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.21: {}
 
-  better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))
@@ -9704,6 +9770,15 @@ snapshots:
   forwarded@0.2.0: {}
 
   fraction.js@5.3.4: {}
+
+  framer-motion@12.42.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      motion-dom: 12.42.2
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   fresh@2.0.0: {}
 
@@ -10559,6 +10634,20 @@ snapshots:
   mimic-function@5.0.1: {}
 
   module-details-from-path@1.0.4: {}
+
+  motion-dom@12.42.2:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
+
+  motion@12.42.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      framer-motion: 12.42.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   ms@2.1.3: {}
 
@@ -11466,6 +11555,8 @@ snapshots:
   systeminformation@5.31.17: {}
 
   tagged-tag@1.0.0: {}
+
+  tailwind-merge@3.6.0: {}
 
   tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3):
     dependencies:


### PR DESCRIPTION
## Summary

- make incoming signals, active incidents, and Superlog pull requests the default home pulse widgets
- add project-scoped signal-series and pull-request-summary APIs for the new cards
- render the widgets with source-installed Dither Kit charts and Geist Pixel headline figures
- expose all three widgets through home customization and preserve four-column minimum layouts

## User impact

New home dashboards start with a compact operational overview: traces, metrics, and logs over time; incidents by severity; and merged versus unmerged pull requests. Existing dashboards keep their saved layout and can add or remove the new built-ins from Customize.

## Validation

- `pnpm exec biome check` on changed TypeScript and TSX files
- `DATABASE_URL=... pnpm exec tsx --test apps/api/src/home-dashboard.test.ts apps/api/src/home-signal-series.test.ts apps/api/src/home-summary.test.ts`
- `pnpm --filter @superlog/api typecheck`
- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets Incoming Signals, Incident Count, and Superlog Pull Requests as the default Home pulse widgets with Dither Kit charts. The signal series now aligns bucket sizes to available ClickHouse rollups/metric tables (clamped to ≥1m) and cleanly falls back when rollups aren’t present.

- New Features
  - Default widgets: `incoming_signals`, `incident_count`, `agent_pull_requests` (4-column min).
  - Project-scoped APIs: signal-series with schema-aware bucket alignment (uses rollups when available, clamps sub-minute to 1m, falls back to raw tables), incident trend (7d by severity), and agent pull‑request summary (30d); mount Dashboards API with a ClickHouse client.
  - Home Customize: expose the three widgets, preserve existing layouts, and keep definitions for all built-ins for toggling (Customize and MCP).

- Dependencies
  - Add `@fontsource/geist-pixel`, `d3-scale`, `d3-shape`, `motion`, `tailwind-merge`, and `clsx`.
  - Add Dither Kit chart components as source and update Tailwind theme tokens.
  - Add Vite `@` alias and TS path mapping for `@/*`.

<sup>Written for commit 2d4f689aa5dfd28508544c8ac1ada8de45bf0bef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

