### PR TITLE
Allow findings-only completion with approval prompts

### DIFF
--- a/apps/worker/src/agent-outcome-tools.test.ts
+++ b/apps/worker/src/agent-outcome-tools.test.ts
@@ -150,7 +150,7 @@ test("splits the contract into dispatched and terminal tools", () => {
   assert.ok(!isDispatchedOutcomeToolName("report_external_cause"));
 });
 
-test("offers complete_investigation only when no intervention tool is available", () => {
+test("offers complete_investigation when no PR or ticket handoff is available", () => {
   const withPrs = outcomeToolDefinitionsForCapabilities({
     prCreation: true,
     approvalPrompts: false,
@@ -172,7 +172,7 @@ test("offers complete_investigation only when no intervention tool is available"
     approvalPrompts: true,
     linearTicketCreation: false,
   }).map((definition) => definition.name);
-  assert.ok(!withApprovals.includes("complete_investigation"));
+  assert.ok(withApprovals.includes("complete_investigation"));
 });
 
 test("offers create_linear_issue whenever Linear ticket creation is available", () => {

--- a/apps/worker/src/agent-outcome-tools.ts
+++ b/apps/worker/src/agent-outcome-tools.ts
@@ -406,7 +406,7 @@ const CREATE_LINEAR_ISSUE_DEFINITION: OutcomeToolDefinition = {
 const COMPLETE_INVESTIGATION_DEFINITION: OutcomeToolDefinition = {
   name: "complete_investigation",
   description:
-    "Terminal: finish the investigation and hand the recorded findings to the configured external ticket workflow, while leaving the incident open. Use this only after report_findings when no PR or approval action is available. This does not resolve the incident and does not require every linked issue to be classified.",
+    "Terminal: finish the investigation and hand the recorded findings to the configured external workflow, while leaving the incident open. Use this only after report_findings when no PR or ticket handoff is being produced and no specific human answer or approval is needed. This does not resolve the incident and does not require every linked issue to be classified.",
   input_schema: {
     type: "object",
     properties: {},
@@ -455,7 +455,7 @@ export function outcomeToolDefinitionsForCapabilities(
     REPORT_FINDINGS_DEFINITION,
     ...(capabilities.prCreation ? [PROPOSE_PR_DEFINITION] : []),
     ...(capabilities.linearTicketCreation ? [CREATE_LINEAR_ISSUE_DEFINITION] : []),
-    ...(!hasInterventionTools(capabilities) && !capabilities.linearTicketCreation
+    ...(!capabilities.prCreation && !capabilities.linearTicketCreation
       ? [COMPLETE_INVESTIGATION_DEFINITION]
       : []),
     ASK_HUMAN_DEFINITION,

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -412,7 +412,7 @@ test("a terminal result wins when it lands at the runtime budget boundary", () =
   );
 });
 
-test("complete_investigation is rejected when an intervention is available", () => {
+test("complete_investigation is rejected for PR runs but allowed for findings-only runs", () => {
   const result = {
     state: "complete" as const,
     summary: "Findings ready.",
@@ -434,7 +434,7 @@ test("complete_investigation is rejected when an intervention is available", () 
       approvalPromptsEnabled: true,
       approvalPromptToolsAvailable: true,
     }),
-    false,
+    true,
   );
   assert.equal(
     isCompleteInvestigationAllowed(result, {

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { TERMINAL_OUTCOME_NUDGE_MARKER } from "../agent-outcome-tools.js";
 import {
+  completeInvestigationAvailable,
   continueSettledPullRequestLifecycle,
   isCompleteInvestigationAllowed,
   isSessionBusyError,
@@ -444,6 +445,18 @@ test("complete_investigation is rejected for PR runs but allowed for findings-on
       approvalPromptToolsAvailable: true,
     }),
     true,
+  );
+});
+
+test("legacy sessions do not advertise completion tools absent from their schema", () => {
+  assert.equal(
+    completeInvestigationAvailable({
+      prPolicy: "never",
+      githubConnected: true,
+      approvalPromptsEnabled: true,
+      approvalPromptToolsAvailable: true,
+    }),
+    false,
   );
 });
 

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -138,9 +138,7 @@ export function completeInvestigationAvailable(capabilities: {
   approvalPromptToolsAvailable: boolean;
 }): boolean {
   const prCreation = capabilities.githubConnected && capabilities.prPolicy !== "never";
-  const approvalPrompts =
-    capabilities.approvalPromptsEnabled && capabilities.approvalPromptToolsAvailable;
-  return !prCreation && !approvalPrompts;
+  return !prCreation;
 }
 
 const agentRunLifecycle = createAgentRunLifecycle(db);
@@ -1318,7 +1316,7 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         const failed = await failAgentRun(
           ctx,
           "sync_failed",
-          "Investigation tried to finish while a remediation intervention was still available.",
+          "Investigation tried to finish without a pull request while PR creation was still available.",
           { existingResult: snapshot.result },
         );
         if (failed) {

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -128,7 +128,8 @@ export function isCompleteInvestigationAllowed(
 ): boolean {
   if (result.completionKind !== "investigation_complete") return true;
   if (result.linearTicketRequested) return true;
-  return completeInvestigationAvailable(capabilities);
+  const prCreation = capabilities.githubConnected && capabilities.prPolicy !== "never";
+  return !prCreation;
 }
 
 export function completeInvestigationAvailable(capabilities: {
@@ -138,7 +139,9 @@ export function completeInvestigationAvailable(capabilities: {
   approvalPromptToolsAvailable: boolean;
 }): boolean {
   const prCreation = capabilities.githubConnected && capabilities.prPolicy !== "never";
-  return !prCreation;
+  const approvalPrompts =
+    capabilities.approvalPromptsEnabled && capabilities.approvalPromptToolsAvailable;
+  return !prCreation && !approvalPrompts;
 }
 
 const agentRunLifecycle = createAgentRunLifecycle(db);


### PR DESCRIPTION
## Summary

- keep `complete_investigation` available when a findings-only run also has approval prompts enabled
- allow sync to accept that completion while still rejecting findings-only completion when PR creation is available
- clarify that human approval remains an optional terminal path when a specific decision is needed

## Root cause

The outcome contract treated any approval-capable integration as a mandatory remediation intervention. Findings-only projects therefore lost their only non-resolving terminal outcome whenever approval prompts were enabled, even though no PR or ticket handoff was available.

## Validation

- `pnpm --filter @superlog/worker test:agent-outcome-tools`
- `pnpm --filter @superlog/worker test:agent-run-sync`
- `pnpm --filter @superlog/worker typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow findings-only runs to finish with `complete_investigation` even when approval prompts are enabled, and preserve compatibility with legacy sessions. Restores a terminal path when no PR or ticket handoff exists, while still blocking completion if PR creation is available.

- **Bug Fixes**
  - Offer `complete_investigation` only when both PR and ticket creation are unavailable.
  - Accept `complete_investigation` during sync for findings-only runs; reject it when PR creation is available.
  - Preserve legacy outcome-nudge compatibility by not advertising completion tools missing from a session’s schema.

<sup>Written for commit 528949d5f1487ab6a579e9d0a34176ab248f1940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

