### PR TITLE
Align investigation progress spinner with the timeline rail

### DIFF
--- a/apps/web/src/incidents/IncidentTranscript.tsx
+++ b/apps/web/src/incidents/IncidentTranscript.tsx
@@ -222,7 +222,7 @@ const INVESTIGATION_PROGRESS_DOTS = [
 
 function InvestigationProgressEntry() {
   return (
-    <div className="-ml-7 -mt-3 mb-6 flex min-h-[22px] min-w-0 items-center gap-2">
+    <div className="-ml-[18px] -mt-1.5 mb-6 flex min-h-[22px] min-w-0 items-center gap-2">
       <span aria-hidden className="grid shrink-0 grid-cols-3 gap-[2px]">
         {INVESTIGATION_PROGRESS_DOTS.map((dot, index) => (
           <span

--- a/apps/web/src/incidents/IncidentTranscriptProgress.test.tsx
+++ b/apps/web/src/incidents/IncidentTranscriptProgress.test.tsx
@@ -11,7 +11,7 @@ test("an active investigation ends the transcript with rotating progress copy", 
   assert.match(html, /Investigation in progress/);
   assert.doesNotMatch(html, /border-accent\/40|rounded-full[^>]*investigation-progress-dot/);
   assert.doesNotMatch(html, /w-px bg-border/);
-  assert.match(html, /class="-ml-7 -mt-3 mb-6/);
+  assert.match(html, /class="-ml-\[18px\] -mt-1\.5 mb-6/);
   for (const phrase of [
     "Looking for evidence",
     "Following the signal",


### PR DESCRIPTION
The live "investigating" spinner row on the incident transcript sat ~10px left of the vertical rail line and hugged the node above it.

- Shift the row's left edge onto the rail so the spinner aligns with the circular node markers (`-ml-7` → `-ml-[18px]`; the row lives in the `pl-7` column, so -18px lands its left edge at the rail's `left-[10px]`).
- Halve the upward pull (`-mt-3` → `-mt-1.5`) so there's more space above the spinner.

Pure presentational tweak to `InvestigationProgressEntry` in `IncidentTranscript.tsx`; no logic changes. Verified in the browser against a rendered timeline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the live “investigating” spinner with the timeline rail and adds a bit more space above for a cleaner layout. Updated `IncidentTranscript.tsx` margins (`-ml-7` → `-ml-[18px]`, `-mt-3` → `-mt-1.5`) and adjusted `IncidentTranscriptProgress.test.tsx` to match; presentational only.

<sup>Written for commit 3295887905d696c910ea0553c34161dd806e37bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

