### PR TITLE
Preserve legacy product route redirects

### DIFF
--- a/apps/web/src/entry-surface.test.ts
+++ b/apps/web/src/entry-surface.test.ts
@@ -31,6 +31,18 @@ test("marketing and product URLs boot independent client surfaces", () => {
     "/connect/vercel",
     "/feedback/pr/acme/repo/1",
     "/design",
+    "/explore",
+    "/explore/traces",
+    "/incidents",
+    "/incidents/incident-1",
+    "/issues",
+    "/issues/incident-1",
+    "/alerts",
+    "/alerts/alert-1",
+    "/dashboards",
+    "/dashboards/dashboard-1",
+    "/anomaly-scanner",
+    "/anomaly-scanner/scans/scan-1",
   ]) {
     assert.equal(surfaceForPath(path), "product", path);
   }

--- a/apps/web/src/entry-surface.ts
+++ b/apps/web/src/entry-surface.ts
@@ -13,6 +13,12 @@ const PRODUCT_ROUTE_ROOTS = [
   "/connect",
   "/feedback/pr",
   "/design",
+  "/explore",
+  "/incidents",
+  "/issues",
+  "/alerts",
+  "/dashboards",
+  "/anomaly-scanner",
 ];
 
 export function surfaceForPath(pathname: string, search = ""): EntrySurface {


### PR DESCRIPTION
## Summary
- classify legacy product URLs as product entry points
- preserve redirects into project-scoped application routes
- cover exact and nested legacy paths with routing tests

## Validation
- `pnpm --filter @superlog/web exec tsx --test src/entry-surface.test.ts`
- `pnpm --filter @superlog/web typecheck`
- `pnpm biome check apps/web/src/entry-surface.ts apps/web/src/entry-surface.test.ts`
- `pnpm --filter @superlog/web build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies legacy product routes (e.g., /explore, /incidents, /issues, /alerts, /dashboards, /anomaly-scanner) as product entry points so old URLs keep redirecting into project-scoped app routes. Adds routing tests for exact and nested legacy paths to prevent regressions.

<sup>Written for commit 998084a5809aac11ce7fca12c96a654cdd91ff6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

