### PR TITLE
Route Sentry callbacks to the product surface

### DIFF
--- a/apps/web/src/entry-surface.test.ts
+++ b/apps/web/src/entry-surface.test.ts
@@ -60,7 +60,14 @@ test("the legacy GitHub installation callback still boots the product surface", 
 });
 
 test("legacy root OAuth callback markers still boot the product surface", () => {
-  for (const search of ["?gh=done", "?gh=error", "?slack=installed", "?slack=error"]) {
+  for (const search of [
+    "?gh=done",
+    "?gh=error",
+    "?slack=installed",
+    "?slack=error",
+    "?sentry=installed",
+    "?sentry=error",
+  ]) {
     assert.equal(surfaceForPath("/", search), "product", search);
   }
 });

--- a/apps/web/src/entry-surface.ts
+++ b/apps/web/src/entry-surface.ts
@@ -31,7 +31,7 @@ export function surfaceForPath(pathname: string, search = ""): EntrySurface {
   if (pathname === "/") {
     const params = new URLSearchParams(search);
     if (params.has("installation_id") && params.has("state")) return "product";
-    if (params.has("gh") || params.has("slack")) return "product";
+    if (params.has("gh") || params.has("slack") || params.has("sentry")) return "product";
   }
   return PRODUCT_ROUTE_ROOTS.some((root) => pathname === root || pathname.startsWith(`${root}/`))
     ? "product"


### PR DESCRIPTION
## Summary
- boot the product surface for Sentry OAuth callback markers
- keep installed and error returns out of the marketing surface
- cover both callback outcomes with regression tests

## Tests
- `pnpm --filter @superlog/web exec tsx --import ./src/test-setup.ts --test src/entry-surface.test.ts`
- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route Sentry OAuth callback markers (?sentry=installed, ?sentry=error) on the root path to the product surface. Keeps these flows out of marketing pages and adds regression tests alongside existing GitHub/Slack markers.

<sup>Written for commit 15e7bb1ebbfbc506aed33e0f7d1f34151c84200f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

