### PR TITLE
Fix scoped app route rendering

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -225,18 +225,18 @@ function AuthenticatedApp() {
         >
           <RouteContainer>
             <Routes location={appLocation}>
-              <Route path="/explore/*" element={<Explore />} />
-              <Route path="/incidents" element={<Issues />} />
-              <Route path="/incidents/:id" element={<Issues />} />
-              <Route path="/issues" element={<Issues />} />
-              <Route path="/issues/:id" element={<Issues />} />
-              <Route path="/alerts" element={<AlertsList />} />
-              <Route path="/alerts/new" element={<AlertEdit />} />
-              <Route path="/alerts/:id" element={<AlertEdit />} />
-              <Route path="/dashboards" element={<DashboardsList />} />
-              <Route path="/dashboards/:id" element={<DashboardView />} />
+              <Route path="explore/*" element={<Explore />} />
+              <Route path="incidents" element={<Issues />} />
+              <Route path="incidents/:id" element={<Issues />} />
+              <Route path="issues" element={<Issues />} />
+              <Route path="issues/:id" element={<Issues />} />
+              <Route path="alerts" element={<AlertsList />} />
+              <Route path="alerts/new" element={<AlertEdit />} />
+              <Route path="alerts/:id" element={<AlertEdit />} />
+              <Route path="dashboards" element={<DashboardsList />} />
+              <Route path="dashboards/:id" element={<DashboardView />} />
               <Route
-                path="/anomaly-scanner"
+                path="anomaly-scanner"
                 element={
                   me.data?.features?.anomalyScanner === true ? (
                     <AnomalyScanner />
@@ -246,7 +246,7 @@ function AuthenticatedApp() {
                 }
               />
               <Route
-                path="/anomaly-scanner/scans/:scanId"
+                path="anomaly-scanner/scans/:scanId"
                 element={
                   me.data?.features?.anomalyScanner === true ? (
                     <AnomalyScanDetail />
@@ -255,7 +255,7 @@ function AuthenticatedApp() {
                   )
                 }
               />
-              <Route path="/settings" element={<Settings />} />
+              <Route path="settings" element={<Settings />} />
               <Route path="*" element={<Overview />} />
             </Routes>
           </RouteContainer>

--- a/apps/web/src/project-route.test.ts
+++ b/apps/web/src/project-route.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import {
   appLocationFromProjectRoute,
   appPathFromProjectRoute,
@@ -133,9 +136,47 @@ test("scoped browser locations are translated back to app routes", () => {
       hash: "#latency",
     }),
     {
-      pathname: "/dashboards/dashboard-1",
+      pathname: "/app/dashboards/dashboard-1",
       search: "?range=1h",
       hash: "#latency",
     },
+  );
+});
+
+test("scoped project locations can render inside the /app route boundary", () => {
+  const browserPath = "/app/org/superlog/project/demo-project/settings";
+  const productLocation = appLocationFromProjectRoute({
+    pathname: browserPath,
+    search: "",
+    hash: "",
+  });
+
+  function ProductRoutes() {
+    return createElement(
+      Routes,
+      { location: productLocation },
+      createElement(Route, {
+        path: "settings",
+        element: createElement("p", null, "Project settings"),
+      }),
+    );
+  }
+
+  assert.match(
+    renderToString(
+      createElement(
+        MemoryRouter,
+        { initialEntries: [browserPath] },
+        createElement(
+          Routes,
+          null,
+          createElement(Route, {
+            path: "/app/*",
+            element: createElement(ProductRoutes),
+          }),
+        ),
+      ),
+    ),
+    /Project settings/,
   );
 });

--- a/apps/web/src/project-route.ts
+++ b/apps/web/src/project-route.ts
@@ -35,9 +35,13 @@ export function canonicalProjectLocation(
 }
 
 export function appLocationFromProjectRoute(location: ProjectRouteLocation): ProjectRouteLocation {
+  const appPath = appPathFromProjectRoute(location.pathname);
   return {
     ...location,
-    pathname: appPathFromProjectRoute(location.pathname),
+    // This location is consumed by a descendant <Routes> below the top-level
+    // /app/* route. React Router requires an overridden location to retain the
+    // already-matched parent pathname base; only the project scope is virtual.
+    pathname: appPath === "/" ? "/app" : `/app${appPath}`,
   };
 }
 


### PR DESCRIPTION
## Summary
- retain the matched `/app` pathname base when virtualizing project-scoped URLs
- make nested product routes relative to the app route boundary
- cover the production render failure with a router integration test

## Testing
- `pnpm --filter @superlog/web test`
- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rendering of project-scoped routes under the `/app` boundary by keeping the `/app` base and switching nested routes to be relative. Prevents production render failures and broken navigation in scoped views.

- **Bug Fixes**
  - Keep the matched `/app` base in `appLocationFromProjectRoute` when virtualizing project URLs.
  - Convert nested product routes in `App.tsx` to relative paths (e.g., `"settings"`, `"alerts"`).
  - Add a router integration test to confirm scoped locations render inside `/app/*` in production.

<sup>Written for commit 6abca22cc752531a3765f7aac1f06d707ed2317c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

