### PR TITLE
Preserve scoped route context

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -37,11 +37,11 @@ import { McpInstallPill } from "./onboarding/McpInstallPill.tsx";
 import { OnboardingGate } from "./onboarding/OnboardingGate.tsx";
 import { useDemoExploration } from "./onboarding/demoExploration.tsx";
 import {
-  appLocationFromProjectRoute,
   appPathFromProjectRoute,
   buildProjectPath,
   canonicalProjectLocation,
   legacyProductLocation,
+  scopedProjectRoutePattern,
 } from "./project-route.ts";
 import {
   APP_FRAME_CLASS,
@@ -204,11 +204,6 @@ function AuthenticatedApp() {
       />
     );
   }
-  const appLocation = appLocationFromProjectRoute({
-    pathname,
-    search: location.search,
-    hash: location.hash,
-  });
   const projectRoot =
     orgSlug && projectSlug ? buildProjectPath({ orgSlug, projectSlug }, "/") : "/app";
   const app = (
@@ -224,19 +219,22 @@ function AuthenticatedApp() {
           anomalyScannerEnabled={me.data?.features?.anomalyScanner === true}
         >
           <RouteContainer>
-            <Routes location={appLocation}>
-              <Route path="explore/*" element={<Explore />} />
-              <Route path="incidents" element={<Issues />} />
-              <Route path="incidents/:id" element={<Issues />} />
-              <Route path="issues" element={<Issues />} />
-              <Route path="issues/:id" element={<Issues />} />
-              <Route path="alerts" element={<AlertsList />} />
-              <Route path="alerts/new" element={<AlertEdit />} />
-              <Route path="alerts/:id" element={<AlertEdit />} />
-              <Route path="dashboards" element={<DashboardsList />} />
-              <Route path="dashboards/:id" element={<DashboardView />} />
+            <Routes>
+              <Route path={scopedProjectRoutePattern("/explore/*")} element={<Explore />} />
+              <Route path={scopedProjectRoutePattern("/incidents")} element={<Issues />} />
+              <Route path={scopedProjectRoutePattern("/incidents/:id")} element={<Issues />} />
+              <Route path={scopedProjectRoutePattern("/issues")} element={<Issues />} />
+              <Route path={scopedProjectRoutePattern("/issues/:id")} element={<Issues />} />
+              <Route path={scopedProjectRoutePattern("/alerts")} element={<AlertsList />} />
+              <Route path={scopedProjectRoutePattern("/alerts/new")} element={<AlertEdit />} />
+              <Route path={scopedProjectRoutePattern("/alerts/:id")} element={<AlertEdit />} />
+              <Route path={scopedProjectRoutePattern("/dashboards")} element={<DashboardsList />} />
               <Route
-                path="anomaly-scanner"
+                path={scopedProjectRoutePattern("/dashboards/:id")}
+                element={<DashboardView />}
+              />
+              <Route
+                path={scopedProjectRoutePattern("/anomaly-scanner")}
                 element={
                   me.data?.features?.anomalyScanner === true ? (
                     <AnomalyScanner />
@@ -246,7 +244,7 @@ function AuthenticatedApp() {
                 }
               />
               <Route
-                path="anomaly-scanner/scans/:scanId"
+                path={scopedProjectRoutePattern("/anomaly-scanner/scans/:scanId")}
                 element={
                   me.data?.features?.anomalyScanner === true ? (
                     <AnomalyScanDetail />
@@ -255,8 +253,8 @@ function AuthenticatedApp() {
                   )
                 }
               />
-              <Route path="settings" element={<Settings />} />
-              <Route path="*" element={<Overview />} />
+              <Route path={scopedProjectRoutePattern("/settings")} element={<Settings />} />
+              <Route path={scopedProjectRoutePattern("/*")} element={<Overview />} />
             </Routes>
           </RouteContainer>
         </ProductShell>

--- a/apps/web/src/project-route.test.ts
+++ b/apps/web/src/project-route.test.ts
@@ -2,13 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createElement } from "react";
 import { renderToString } from "react-dom/server";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, NavLink, Route, Routes } from "react-router-dom";
 import {
-  appLocationFromProjectRoute,
   appPathFromProjectRoute,
   buildProjectPath,
   canonicalProjectLocation,
   legacyProductLocation,
+  scopedProjectRoutePattern,
 } from "./project-route.ts";
 
 test("buildProjectPath creates shareable incident URLs with org and project slugs", () => {
@@ -128,36 +128,33 @@ test("canonical project navigation replaces an existing project scope", () => {
   );
 });
 
-test("scoped browser locations are translated back to app routes", () => {
-  assert.deepEqual(
-    appLocationFromProjectRoute({
-      pathname: "/app/org/superlog/project/demo-project/dashboards/dashboard-1",
-      search: "?range=1h",
-      hash: "#latency",
-    }),
-    {
-      pathname: "/app/dashboards/dashboard-1",
-      search: "?range=1h",
-      hash: "#latency",
-    },
+test("scoped product route patterns remain relative to the /app boundary", () => {
+  assert.equal(
+    scopedProjectRoutePattern("/dashboards/:id"),
+    "org/:orgSlug/project/:projectSlug/dashboards/:id",
+  );
+  assert.equal(
+    scopedProjectRoutePattern("/*"),
+    "org/:orgSlug/project/:projectSlug/*",
   );
 });
 
 test("scoped project locations can render inside the /app route boundary", () => {
   const browserPath = "/app/org/superlog/project/demo-project/settings";
-  const productLocation = appLocationFromProjectRoute({
-    pathname: browserPath,
-    search: "",
-    hash: "",
-  });
-
   function ProductRoutes() {
     return createElement(
       Routes,
-      { location: productLocation },
+      null,
       createElement(Route, {
-        path: "settings",
-        element: createElement("p", null, "Project settings"),
+        path: scopedProjectRoutePattern("/settings"),
+        element: createElement(
+          NavLink,
+          {
+            to: browserPath,
+            className: ({ isActive }) => (isActive ? "active" : "inactive"),
+          },
+          "Project settings",
+        ),
       }),
     );
   }
@@ -177,6 +174,6 @@ test("scoped project locations can render inside the /app route boundary", () =>
         ),
       ),
     ),
-    /Project settings/,
+    /class="active"/,
   );
 });

--- a/apps/web/src/project-route.ts
+++ b/apps/web/src/project-route.ts
@@ -9,6 +9,8 @@ export type ProjectRouteLocation = {
   hash: string;
 };
 
+const PROJECT_ROUTE_PATTERN = "org/:orgSlug/project/:projectSlug";
+
 export function buildProjectPath(slugs: ProjectRouteSlugs, appPath: string): string {
   const root = `/app/org/${encodeURIComponent(slugs.orgSlug)}/project/${encodeURIComponent(slugs.projectSlug)}`;
   if (appPath === "/" || appPath === "") return root;
@@ -34,15 +36,10 @@ export function canonicalProjectLocation(
   };
 }
 
-export function appLocationFromProjectRoute(location: ProjectRouteLocation): ProjectRouteLocation {
-  const appPath = appPathFromProjectRoute(location.pathname);
-  return {
-    ...location,
-    // This location is consumed by a descendant <Routes> below the top-level
-    // /app/* route. React Router requires an overridden location to retain the
-    // already-matched parent pathname base; only the project scope is virtual.
-    pathname: appPath === "/" ? "/app" : `/app${appPath}`,
-  };
+export function scopedProjectRoutePattern(appPath: string): string {
+  if (appPath === "/" || appPath === "") return PROJECT_ROUTE_PATTERN;
+  const suffix = appPath.startsWith("/") ? appPath.slice(1) : appPath;
+  return `${PROJECT_ROUTE_PATTERN}/${suffix}`;
 }
 
 export function legacyProductLocation(location: ProjectRouteLocation): string {


### PR DESCRIPTION
## Summary
- match nested product routes directly against canonical scoped URLs
- remove the virtual location override that crashed below `/app` and hid active navigation state
- cover both route rendering and canonical `NavLink` activity

## Testing
- `pnpm --filter @superlog/web test`
- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves scoped route context by matching product routes directly to canonical project-scoped URLs. Removes the virtual `/app` location override to prevent crashes and restore correct `NavLink` active state.

- **Bug Fixes**
  - Replace `appLocationFromProjectRoute` with `scopedProjectRoutePattern` and update route declarations to use it.
  - Stop overriding nested `Routes` location under `/app`.
  - Update tests to assert scoped patterns and verify active `NavLink` state.

<sup>Written for commit 170c698a807f9f68bd2d8c65601a42bfc975a0c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

