### PR TITLE
Use official Sentry mark for connector icon

### DIFF
--- a/apps/web/src/onboarding/icons.tsx
+++ b/apps/web/src/onboarding/icons.tsx
@@ -373,23 +373,18 @@ export function RenderIcon({ size = 18, className }: IconProps) {
   );
 }
 
-// Sentry — a compact monochrome approximation of the brand's signal mark.
+// Sentry — the official mark (Simple Icons, CC0), monochrome via currentColor.
 export function SentryIcon({ size = 18, className }: IconProps) {
   return (
     <svg
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.7"
-      strokeLinecap="round"
-      strokeLinejoin="round"
+      fill="currentColor"
       className={className}
       aria-hidden="true"
     >
-      <path d="M12 3 3.7 18.5h4.1L12 10.7l4.2 7.8h4.1L12 3Z" />
-      <path d="M5.9 14.4H2.5M18.1 14.4h3.4M9.7 14.4h4.6" />
+      <path d="M13.91 2.505c-.873-1.448-2.972-1.448-3.844 0L6.904 7.92a15.478 15.478 0 0 1 8.53 12.811h-2.221A13.301 13.301 0 0 0 5.784 9.814l-2.926 5.06a7.65 7.65 0 0 1 4.435 5.848H2.194a.365.365 0 0 1-.298-.534l1.413-2.402a5.16 5.16 0 0 0-1.614-.913L.296 19.275a2.182 2.182 0 0 0 .812 2.999 2.24 2.24 0 0 0 1.086.288h6.983a9.322 9.322 0 0 0-3.845-8.318l1.11-1.922a11.47 11.47 0 0 1 4.95 10.24h5.915a17.242 17.242 0 0 0-7.885-15.28l2.244-3.845a.37.37 0 0 1 .504-.13c.255.14 9.75 16.708 9.928 16.9a.365.365 0 0 1-.327.543h-2.287c.029.612.029 1.223 0 1.831h2.297a2.206 2.206 0 0 0 1.922-3.31z" />
     </svg>
   );
 }


### PR DESCRIPTION
The Sentry connector icon was a hand-drawn stroke approximation that rendered as an ambiguous "A" glyph rather than the Sentry logo. It was the only connector in `onboarding/icons.tsx` still using an approximation — Vercel, Railway, Render, and Cloudflare already use the official brand marks (Simple Icons, CC0).

This swaps `SentryIcon` for the official Sentry mark and switches it to `fill="currentColor"` to match the sibling icons, so it still inherits the connector tile's muted color.

Before / after (monochrome, as rendered in the connect-data chooser):

- Before: a stroke triangle with crossbars reading as "A"
- After: the recognizable Sentry arch mark

Purely presentational; no behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the Sentry connector icon in `apps/web/src/onboarding/icons.tsx` with the official Sentry mark and switches to `fill="currentColor"` for consistency with other connectors. Visual-only change that improves brand recognition in the connect-data chooser.

<sup>Written for commit 5616a6031ab494fa44a0bad77d96122240334984. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

