### PR TITLE
Clarify free-plan copy to "5 incidents investigated / month"

### DIFF
--- a/apps/web/src/Pricing.tsx
+++ b/apps/web/src/Pricing.tsx
@@ -24,7 +24,7 @@ const FREE_INCLUDED = [
   "5M logs",
   "10M metric points",
   "30-day retention",
-  "5 investigations / month",
+  "5 incidents investigated / month",
 ];
 
 type Pack = {

--- a/apps/web/src/settings/BillingCard.tsx
+++ b/apps/web/src/settings/BillingCard.tsx
@@ -46,7 +46,7 @@ const PLAN_OPTIONS = [
     name: "Free",
     price: "$0",
     cta: "Switch to Free",
-    details: ["5 investigations / mo", "1M spans · 5M logs · 10M metrics", "Hard caps — ingest pauses at limit"],
+    details: ["5 incidents investigated / mo", "1M spans · 5M logs · 10M metrics", "Hard caps — ingest pauses at limit"],
   },
 ];
 


### PR DESCRIPTION
Rewords the Free tier's monthly-allowance copy in both places it appears.

**Pricing page** — `apps/web/src/Pricing.tsx` (`FREE_INCLUDED`):
- Before: `5 investigations / month`
- After: `5 incidents investigated / month`

**In-app billing card** — `apps/web/src/settings/BillingCard.tsx` (Settings → Billing, Free plan):
- Before: `5 investigations / mo`
- After: `5 incidents investigated / mo`

Copy-only change, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)