### PR TITLE
Support event-driven background jobs

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,5 +1,5 @@
 # Build context: repo root. Build with `docker build -f apps/api/Dockerfile .`
-FROM node:20-slim
+FROM node:22-slim
 
 WORKDIR /app
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -55,6 +55,9 @@
     "resend": "^6.12.3",
     "zod": "^4.4.3"
   },
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "devDependencies": {
     "@types/node": "^22.10.1",
     "tsx": "^4.19.2",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -36,8 +36,8 @@
     "@scalar/hono-api-reference": "^0.10.19",
     "@superlog/cloudflare": "workspace:*",
     "@superlog/db": "workspace:*",
-    "@superlog/gcp-auth": "workspace:*",
     "@superlog/fingerprint": "workspace:*",
+    "@superlog/gcp-auth": "workspace:*",
     "@superlog/net-guard": "workspace:*",
     "@superlog/railway": "workspace:*",
     "@superlog/render": "workspace:*",
@@ -50,6 +50,7 @@
     "hono": "^4.12.25",
     "hono-openapi": "^1.3.0",
     "nanoid": "^5.0.9",
+    "pg-boss": "^12.0.0",
     "pino": "^10.3.1",
     "resend": "^6.12.3",
     "zod": "^4.4.3"

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -11,6 +11,7 @@ import {
   sendEmail,
   verificationEmailBody,
 } from "./email.js";
+import { enqueueUserCreated } from "./user-created-publisher.js";
 
 // Better Auth server config. Mounted at /api/auth/* by apps/api/src/index.ts.
 //
@@ -251,6 +252,7 @@ export const auth = betterAuth({
             event: "user_signed_up",
             set: { email: user.email, name: user.name },
           });
+          await enqueueUserCreated(user);
         },
       },
     },

--- a/apps/api/src/user-created-events.test.ts
+++ b/apps/api/src/user-created-events.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { USER_CREATED_QUEUE, publishUserCreated } from "./user-created-events.js";
+
+test("publishes one delayed user-created event per signup", async () => {
+  const sent: unknown[] = [];
+  const queue = {
+    async createQueue(name: string, options?: unknown) {
+      sent.push({ createQueue: name, options });
+    },
+    async send(name: string, data: object, options?: object) {
+      sent.push({ send: name, data, options });
+      return "job-1";
+    },
+  };
+
+  await publishUserCreated(queue, {
+    id: "user-1",
+    email: "dev@example.com",
+    name: "Dev",
+    createdAt: new Date("2026-07-22T12:00:00Z"),
+  });
+
+  assert.deepEqual(sent, [
+    { createQueue: USER_CREATED_QUEUE, options: { policy: "standard" } },
+    {
+      send: USER_CREATED_QUEUE,
+      data: {
+        userId: "user-1",
+        email: "dev@example.com",
+        name: "Dev",
+        createdAt: "2026-07-22T12:00:00.000Z",
+      },
+      options: { id: "user-1", startAfter: 300, retryLimit: 3, retryBackoff: true },
+    },
+  ]);
+});

--- a/apps/api/src/user-created-events.ts
+++ b/apps/api/src/user-created-events.ts
@@ -1,0 +1,38 @@
+export const USER_CREATED_QUEUE = "user.created";
+export const USER_CREATED_DELAY_SECONDS = 5 * 60;
+
+export type UserCreatedEvent = {
+  userId: string;
+  email: string;
+  name?: string | null;
+  createdAt: string;
+};
+
+export type UserCreatedQueue = {
+  createQueue(name: string, options?: object): Promise<unknown>;
+  send(name: string, data: object, options?: object): Promise<unknown>;
+};
+
+export async function publishUserCreated(
+  queue: UserCreatedQueue,
+  user: { id: string; email: string; name?: string | null; createdAt: Date | string },
+): Promise<void> {
+  await queue.createQueue(USER_CREATED_QUEUE, { policy: "standard" });
+  await queue.send(
+    USER_CREATED_QUEUE,
+    {
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      createdAt: new Date(user.createdAt).toISOString(),
+    } satisfies UserCreatedEvent,
+    {
+      // Better Auth user ids are UUIDs. Reusing that value as pg-boss' primary
+      // key makes a retried signup hook idempotent at the queue boundary.
+      id: user.id,
+      startAfter: USER_CREATED_DELAY_SECONDS,
+      retryLimit: 3,
+      retryBackoff: true,
+    },
+  );
+}

--- a/apps/api/src/user-created-publisher.test.ts
+++ b/apps/api/src/user-created-publisher.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createUserCreatedPublisher } from "./user-created-publisher.js";
+
+const user = {
+  id: "0e3f508d-43e5-4315-b3cf-a829e6410d42",
+  email: "dev@example.com",
+  createdAt: "2026-07-22T12:00:00.000Z",
+};
+
+test("retries queue startup after a transient failure", async () => {
+  let starts = 0;
+  const sent: unknown[] = [];
+  const enqueue = createUserCreatedPublisher({
+    enabled: () => true,
+    startQueue: async () => {
+      starts += 1;
+      if (starts === 1) throw new Error("database restarting");
+      return {
+        createQueue: async () => {},
+        send: async (_name, data) => { sent.push(data); },
+      };
+    },
+    onError: () => {},
+  });
+
+  assert.equal(await enqueue(user), false);
+  assert.equal(await enqueue(user), true);
+  assert.equal(starts, 2);
+  assert.equal(sent.length, 1);
+});

--- a/apps/api/src/user-created-publisher.ts
+++ b/apps/api/src/user-created-publisher.ts
@@ -1,0 +1,49 @@
+import { PgBoss } from "pg-boss";
+import { logger } from "./logger.js";
+import { publishUserCreated } from "./user-created-events.js";
+
+let queuePromise: Promise<PgBoss> | null = null;
+
+function enabled(): boolean {
+  return process.env.USER_CREATED_EVENTS_ENABLED === "true";
+}
+
+function queue(): Promise<PgBoss> {
+  if (queuePromise) return queuePromise;
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) return Promise.reject(new Error("DATABASE_URL is not set"));
+  const boss = new PgBoss({
+    connectionString,
+    schema: process.env.PGBOSS_SCHEMA || "pgboss",
+    migrate: process.env.PGBOSS_MIGRATE !== "false",
+    supervise: false,
+    schedule: false,
+    max: 2,
+  });
+  boss.on("error", (error: Error) =>
+    logger.error({ scope: "user-created-events", err: error.message }, "signup event queue error"),
+  );
+  queuePromise = boss.start();
+  return queuePromise;
+}
+
+/** Best-effort generic user lifecycle event. Reconciliation consumers recover
+ * a missed publish, so authentication must never fail when the queue is down. */
+export async function enqueueUserCreated(user: {
+  id: string;
+  email: string;
+  name?: string | null;
+  createdAt: Date | string;
+}): Promise<boolean> {
+  if (!enabled()) return false;
+  try {
+    await publishUserCreated(await queue(), user);
+    return true;
+  } catch (error) {
+    logger.error(
+      { scope: "user-created-events", userId: user.id, err: error instanceof Error ? error.message : String(error) },
+      "failed to publish user-created event",
+    );
+    return false;
+  }
+}

--- a/apps/api/src/user-created-publisher.ts
+++ b/apps/api/src/user-created-publisher.ts
@@ -1,17 +1,50 @@
 import { PgBoss } from "pg-boss";
 import { logger } from "./logger.js";
-import { publishUserCreated } from "./user-created-events.js";
+import {
+  publishUserCreated,
+  type UserCreatedQueue,
+} from "./user-created-events.js";
 
-let queuePromise: Promise<PgBoss> | null = null;
+type User = {
+  id: string;
+  email: string;
+  name?: string | null;
+  createdAt: Date | string;
+};
 
-function enabled(): boolean {
-  return process.env.USER_CREATED_EVENTS_ENABLED === "true";
+type PublisherDeps = {
+  enabled: () => boolean;
+  startQueue: () => Promise<UserCreatedQueue>;
+  onError: (error: unknown, userId: string) => void;
+};
+
+export function createUserCreatedPublisher(deps: PublisherDeps): (user: User) => Promise<boolean> {
+  let queuePromise: Promise<UserCreatedQueue> | null = null;
+
+  const queue = (): Promise<UserCreatedQueue> => {
+    if (queuePromise) return queuePromise;
+    queuePromise = deps.startQueue().catch((error) => {
+      queuePromise = null;
+      throw error;
+    });
+    return queuePromise;
+  };
+
+  return async (user: User): Promise<boolean> => {
+    if (!deps.enabled()) return false;
+    try {
+      await publishUserCreated(await queue(), user);
+      return true;
+    } catch (error) {
+      deps.onError(error, user.id);
+      return false;
+    }
+  };
 }
 
-function queue(): Promise<PgBoss> {
-  if (queuePromise) return queuePromise;
+async function startQueue(): Promise<PgBoss> {
   const connectionString = process.env.DATABASE_URL;
-  if (!connectionString) return Promise.reject(new Error("DATABASE_URL is not set"));
+  if (!connectionString) throw new Error("DATABASE_URL is not set");
   const boss = new PgBoss({
     connectionString,
     schema: process.env.PGBOSS_SCHEMA || "pgboss",
@@ -23,27 +56,18 @@ function queue(): Promise<PgBoss> {
   boss.on("error", (error: Error) =>
     logger.error({ scope: "user-created-events", err: error.message }, "signup event queue error"),
   );
-  queuePromise = boss.start();
-  return queuePromise;
+  return boss.start();
 }
 
 /** Best-effort generic user lifecycle event. Reconciliation consumers recover
  * a missed publish, so authentication must never fail when the queue is down. */
-export async function enqueueUserCreated(user: {
-  id: string;
-  email: string;
-  name?: string | null;
-  createdAt: Date | string;
-}): Promise<boolean> {
-  if (!enabled()) return false;
-  try {
-    await publishUserCreated(await queue(), user);
-    return true;
-  } catch (error) {
+export const enqueueUserCreated = createUserCreatedPublisher({
+  enabled: () => process.env.USER_CREATED_EVENTS_ENABLED === "true",
+  startQueue,
+  onError: (error, userId) => {
     logger.error(
-      { scope: "user-created-events", userId: user.id, err: error instanceof Error ? error.message : String(error) },
+      { scope: "user-created-events", userId, err: error instanceof Error ? error.message : String(error) },
       "failed to publish user-created event",
     );
-    return false;
-  }
-}
+  },
+});

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -75,8 +75,8 @@
     "@superlog/billing": "workspace:*",
     "@superlog/cloudflare": "workspace:*",
     "@superlog/db": "workspace:*",
-    "@superlog/gcp-auth": "workspace:*",
     "@superlog/fingerprint": "workspace:*",
+    "@superlog/gcp-auth": "workspace:*",
     "@superlog/net-guard": "workspace:*",
     "@superlog/railway": "workspace:*",
     "@superlog/render": "workspace:*",
@@ -85,6 +85,7 @@
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
     "google-auth-library": "^10.9.0",
+    "pg": "^8.13.1",
     "pg-boss": "^12.0.0",
     "pino": "^10.3.1"
   },

--- a/apps/worker/src/jobs.ts
+++ b/apps/worker/src/jobs.ts
@@ -27,13 +27,22 @@ export type JobDeps = {
 // The unit of work for a scheduled job: run once per fire. pg-boss owns the
 // schedule, retries, and single-active semantics, so handlers do NOT self-gate
 // or loop — they just do one pass.
-export type JobHandler = () => Promise<void>;
+export type BackgroundJob<Data = unknown> = {
+  id: string;
+  data: Data;
+};
+
+export type JobHandler<Data = unknown> = (job?: BackgroundJob<Data>) => Promise<void>;
+
+export type JobQueuePolicy = "standard" | "short" | "singleton" | "stately" | "exclusive";
 
 // The shape each file in the jobs dir exports as `job`.
 export type JobDefinition = {
   name: string;
-  // 5-field cron expression (minute precision); pg-boss checks every 30s.
-  schedule: string;
+  // Omit schedule for event-driven queues. Scheduled jobs default to an
+  // exclusive queue; event consumers default to standard unless overridden.
+  schedule?: string;
+  policy?: JobQueuePolicy;
   // Durable active-job lease. Set this above the handler's legitimate worst
   // case so pg-boss never starts an overlapping successor while a slow run is
   // still alive.
@@ -47,7 +56,8 @@ export type JobDefinition = {
 // A discovered, ready-to-schedule job.
 export type LoadedJob = {
   name: string;
-  schedule: string;
+  schedule?: string;
+  policy?: JobQueuePolicy;
   expireInSeconds?: number;
   handler: JobHandler;
 };
@@ -67,8 +77,7 @@ function isJobDefinition(value: unknown): value is JobDefinition {
   const def = value as Partial<JobDefinition>;
   return (
     typeof def.name === "string" &&
-    typeof def.schedule === "string" &&
-    def.schedule.length > 0 &&
+    (def.schedule === undefined || (typeof def.schedule === "string" && def.schedule.length > 0)) &&
     (def.expireInSeconds === undefined ||
       (Number.isFinite(def.expireInSeconds) && def.expireInSeconds > 0)) &&
     typeof def.create === "function"
@@ -111,6 +120,7 @@ export async function loadJobs(deps: JobDeps, options: { dir?: URL } = {}): Prom
       jobs.push({
         name: def.name,
         schedule: def.schedule,
+        policy: def.policy,
         expireInSeconds: def.expireInSeconds,
         handler,
       });

--- a/apps/worker/src/jobs/runner.test.ts
+++ b/apps/worker/src/jobs/runner.test.ts
@@ -79,6 +79,27 @@ test("the registered worker invokes the job handler", async () => {
   assert.equal(ran, 1);
 });
 
+test("registers an event consumer without a cron schedule and passes through its job payload", async () => {
+  const fb = fakeBoss();
+  let received: unknown;
+  await registerJobs(fb.boss, [
+    {
+      name: "user.created",
+      policy: "standard",
+      handler: async (job) => {
+        received = job;
+      },
+    },
+  ]);
+
+  assert.deepEqual(fb.schedules, []);
+  assert.ok(fb.calls.includes('createQueue:user.created:{"policy":"standard"}'));
+  const worker = fb.workers.get("user.created");
+  assert.ok(worker);
+  await worker([{ id: "job-1", data: { userId: "user-1" } }]);
+  assert.deepEqual(received, { id: "job-1", data: { userId: "user-1" } });
+});
+
 test("a job that fails to register is skipped without aborting the others", async () => {
   const fb = fakeBoss();
   const boss: JobBoss = {

--- a/apps/worker/src/jobs/runner.ts
+++ b/apps/worker/src/jobs/runner.ts
@@ -30,7 +30,7 @@ export async function registerJobs(boss: JobBoss, jobs: LoadedJob[]): Promise<vo
   for (const job of jobs) {
     try {
       await boss.createQueue(job.name, {
-        policy: "exclusive",
+        policy: job.policy ?? (job.schedule ? "exclusive" : "standard"),
         ...(job.expireInSeconds ? { expireInSeconds: job.expireInSeconds } : {}),
       });
       // pg-boss createQueue does not update an existing queue. Keep mutable
@@ -39,13 +39,15 @@ export async function registerJobs(boss: JobBoss, jobs: LoadedJob[]): Promise<vo
       if (job.expireInSeconds) {
         await boss.updateQueue(job.name, { expireInSeconds: job.expireInSeconds });
       }
-      await boss.work(job.name, async () => {
-        await job.handler();
+      await boss.work(job.name, async (jobs) => {
+        const [queuedJob] = jobs;
+        if (!queuedJob || typeof queuedJob !== "object") return;
+        await job.handler(queuedJob as { id: string; data: unknown });
       });
-      await boss.schedule(job.name, job.schedule);
+      if (job.schedule) await boss.schedule(job.name, job.schedule);
       logger.info(
         { scope: "jobs.runner", job: job.name, schedule: job.schedule },
-        "scheduled background job",
+        job.schedule ? "scheduled background job" : "registered background event consumer",
       );
     } catch (err) {
       logger.error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,10 +170,10 @@ importers:
         version: link:../../packages/telemetry-query
       autumn-js:
         specifier: ^1.2.27
-        version: 1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.6.13
-        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -192,6 +192,9 @@ importers:
       nanoid:
         specifier: ^5.0.9
         version: 5.1.9
+      pg-boss:
+        specifier: ^12.0.0
+        version: 12.18.2
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -404,10 +407,10 @@ importers:
         version: 2.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       autumn-js:
         specifier: ^1.2.27
-        version: 1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.6.13
-        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -565,6 +568,9 @@ importers:
       google-auth-library:
         specifier: ^10.9.0
         version: 10.9.0
+      pg:
+        specifier: ^8.13.1
+        version: 8.21.0
       pg-boss:
         specifier: ^12.0.0
         version: 12.18.2
@@ -613,7 +619,7 @@ importers:
     dependencies:
       better-auth:
         specifier: ^1.6.13
-        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
@@ -9068,13 +9074,13 @@ snapshots:
       postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  autumn-js@1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
+  autumn-js@1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
     dependencies:
       query-string: 9.4.0
       rou3: 0.6.3
       zod: 4.4.3
     optionalDependencies:
-      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       better-call: 1.3.7(zod@4.4.3)
       express: 5.2.1
       hono: 4.12.30
@@ -9097,7 +9103,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.21: {}
 
-  better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))


### PR DESCRIPTION
## Summary
- publish an optional delayed `user.created` lifecycle event after signup
- allow worker job modules to register event consumers without a cron schedule
- pass pg-boss payloads through to handlers and support queue policies

## Validation
- `pnpm exec tsx --test apps/api/src/user-created-events.test.ts apps/worker/src/jobs/runner.test.ts`
- `pnpm --filter @superlog/api typecheck`
- `pnpm --filter @superlog/worker typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds event-driven background jobs with `pg-boss`. Publishes a delayed `user.created` event after signup with a resilient, best-effort publisher, and lets the worker register event consumers without a cron schedule.

- **New Features**
  - `@superlog/api`: delayed `user.created` (5 min); idempotent by user ID; publisher lazily starts the queue, retries on transient errors, logs failures (auth never blocks).
  - `@superlog/worker`: supports consumers without `schedule`; defaults to `policy: "standard"` for events and `exclusive` for scheduled jobs; `policy` is configurable.
  - Job handlers receive `{ id, data }`.

- **Migration**
  - `@superlog/api`: set `USER_CREATED_EVENTS_ENABLED=true`; ensure `DATABASE_URL` (optional: `PGBOSS_SCHEMA`, `PGBOSS_MIGRATE`); Node 22.12+ required.
  - `@superlog/worker`: add a `user.created` consumer (no cron) and read payload from `job.data`.
  - Dependencies: added `pg-boss` to `@superlog/api`; added `pg` to `@superlog/worker`.

<sup>Written for commit ed9c19c57bad486b0597c2ba1c25676ffa877a93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

