### PR TITLE
Tolerate partial GitHub repository discovery failures

### DIFF
--- a/apps/worker/src/agent-run-context.test.ts
+++ b/apps/worker/src/agent-run-context.test.ts
@@ -200,7 +200,7 @@ test("repository discovery surfaces failure when every enabled installation erro
   );
 });
 
-test("repository discovery surfaces failure when successful installs have no usable repos", async () => {
+test("repository discovery tolerates a partial failure when another enabled install succeeds", async () => {
   const githubUnavailable = new Error("github returned 503");
   const githubInstalls = [
     {
@@ -221,18 +221,17 @@ test("repository discovery surfaces failure when successful installs have no usa
     },
   ];
 
-  await assert.rejects(
-    listAccessibleGithubRepositories(
-      { githubInstalls },
-      {
-        listInstallationRepositories: async (installationId) => {
-          if (installationId === 101) {
-            return [{ id: 42, fullName: "acme/disabled", private: true }];
-          }
-          throw githubUnavailable;
-        },
+  const repositories = await listAccessibleGithubRepositories(
+    { githubInstalls },
+    {
+      listInstallationRepositories: async (installationId) => {
+        if (installationId === 101) {
+          return [{ id: 42, fullName: "acme/disabled", private: true }];
+        }
+        throw githubUnavailable;
       },
-    ),
-    githubUnavailable,
+    },
   );
+
+  assert.deepEqual(repositories, []);
 });

--- a/apps/worker/src/agent-run-context.test.ts
+++ b/apps/worker/src/agent-run-context.test.ts
@@ -200,6 +200,43 @@ test("repository discovery surfaces failure when every enabled installation erro
   );
 });
 
+test("repository lookup surfaces a partial failure when successful installs have no usable repos", async () => {
+  const githubUnavailable = new Error("github returned 503");
+  const githubInstalls = [
+    {
+      installation: {
+        installationId: 101,
+        agentEnabled: true,
+        repoAccess: { disabledRepoIds: [42] },
+      } as schema.GithubInstallation,
+      allowedRepoIds: null,
+    },
+    {
+      installation: {
+        installationId: 202,
+        agentEnabled: true,
+        repoAccess: null,
+      } as schema.GithubInstallation,
+      allowedRepoIds: null,
+    },
+  ];
+
+  await assert.rejects(
+    listAccessibleGithubRepositories(
+      { githubInstalls },
+      {
+        listInstallationRepositories: async (installationId) => {
+          if (installationId === 101) {
+            return [{ id: 42, fullName: "acme/disabled", private: true }];
+          }
+          throw githubUnavailable;
+        },
+      },
+    ),
+    githubUnavailable,
+  );
+});
+
 test("repository discovery tolerates a partial failure when another enabled install succeeds", async () => {
   const githubUnavailable = new Error("github returned 503");
   const githubInstalls = [
@@ -224,6 +261,7 @@ test("repository discovery tolerates a partial failure when another enabled inst
   const repositories = await listAccessibleGithubRepositories(
     { githubInstalls },
     {
+      toleratePartialFailure: true,
       listInstallationRepositories: async (installationId) => {
         if (installationId === 101) {
           return [{ id: 42, fullName: "acme/disabled", private: true }];

--- a/apps/worker/src/agent-run-context.test.ts
+++ b/apps/worker/src/agent-run-context.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { schema } from "@superlog/db";
 import {
+  PartialGithubRepoDiscoveryError,
   buildFollowUpContext,
   effectivePrPolicyForAgentRun,
   listAccessibleGithubRepositories,
@@ -200,7 +201,7 @@ test("repository discovery surfaces failure when every enabled installation erro
   );
 });
 
-test("repository lookup surfaces a partial failure when successful installs have no usable repos", async () => {
+test("repository lookup preserves a partial failure when successful installs have no usable repos", async () => {
   const githubUnavailable = new Error("github returned 503");
   const githubInstalls = [
     {
@@ -233,43 +234,10 @@ test("repository lookup surfaces a partial failure when successful installs have
         },
       },
     ),
-    githubUnavailable,
-  );
-});
-
-test("repository discovery tolerates a partial failure when another enabled install succeeds", async () => {
-  const githubUnavailable = new Error("github returned 503");
-  const githubInstalls = [
-    {
-      installation: {
-        installationId: 101,
-        agentEnabled: true,
-        repoAccess: { disabledRepoIds: [42] },
-      } as schema.GithubInstallation,
-      allowedRepoIds: null,
-    },
-    {
-      installation: {
-        installationId: 202,
-        agentEnabled: true,
-        repoAccess: null,
-      } as schema.GithubInstallation,
-      allowedRepoIds: null,
-    },
-  ];
-
-  const repositories = await listAccessibleGithubRepositories(
-    { githubInstalls },
-    {
-      toleratePartialFailure: true,
-      listInstallationRepositories: async (installationId) => {
-        if (installationId === 101) {
-          return [{ id: 42, fullName: "acme/disabled", private: true }];
-        }
-        throw githubUnavailable;
-      },
+    (error) => {
+      assert.ok(error instanceof PartialGithubRepoDiscoveryError);
+      assert.equal(error.cause, githubUnavailable);
+      return true;
     },
   );
-
-  assert.deepEqual(repositories, []);
 });

--- a/apps/worker/src/agent-run-context.ts
+++ b/apps/worker/src/agent-run-context.ts
@@ -393,7 +393,7 @@ export async function listAccessibleGithubRepositories(
   );
 
   const repos = dedupeInstalledGithubRepos(results.flatMap((result) => result.repos));
-  if (repos.length === 0 && results.some((result) => result.err)) {
+  if (repos.length === 0 && results.length > 0 && results.every((result) => result.err)) {
     const firstError = results.find((result) => result.err)?.err;
     throw firstError instanceof Error
       ? firstError

--- a/apps/worker/src/agent-run-context.ts
+++ b/apps/worker/src/agent-run-context.ts
@@ -359,17 +359,19 @@ function isGithubRepoEnabled(repoAccess: GithubRepoAccess, repoId: number): bool
 export async function listAccessibleGithubRepositories(
   // Only the installs are needed — chats (no incident) share this path.
   ctx: Pick<AgentRunContext, "githubInstalls">,
-  deps: {
-    listInstallationRepositories: typeof listInstallationRepositories;
-  } = { listInstallationRepositories },
+  options: {
+    toleratePartialFailure?: boolean;
+    listInstallationRepositories?: typeof listInstallationRepositories;
+  } = {},
 ): Promise<InstalledGithubRepo[]> {
+  const listRepositories = options.listInstallationRepositories ?? listInstallationRepositories;
   const results = await Promise.all(
     ctx.githubInstalls
       .filter(({ installation }) => installation.agentEnabled)
       .map(async ({ installation, allowedRepoIds }) => {
         try {
           const repoAccess = normalizeGithubRepoAccess(installation.repoAccess);
-          const repos = await deps.listInstallationRepositories(installation.installationId);
+          const repos = await listRepositories(installation.installationId);
           const grantSet = allowedRepoIds === null ? null : new Set(allowedRepoIds);
           return {
             repos: repos
@@ -393,7 +395,10 @@ export async function listAccessibleGithubRepositories(
   );
 
   const repos = dedupeInstalledGithubRepos(results.flatMap((result) => result.repos));
-  if (repos.length === 0 && results.length > 0 && results.every((result) => result.err)) {
+  const failedEnoughToAbort = options.toleratePartialFailure
+    ? results.every((result) => result.err)
+    : results.some((result) => result.err);
+  if (repos.length === 0 && results.length > 0 && failedEnoughToAbort) {
     const firstError = results.find((result) => result.err)?.err;
     throw firstError instanceof Error
       ? firstError

--- a/apps/worker/src/agent-run-context.ts
+++ b/apps/worker/src/agent-run-context.ts
@@ -23,6 +23,15 @@ export type InstalledGithubRepo = {
   installation: schema.GithubInstallation;
 };
 
+export class PartialGithubRepoDiscoveryError extends Error {
+  constructor(cause: unknown) {
+    super("some GitHub installations failed before repository access could be determined", {
+      cause,
+    });
+    this.name = "PartialGithubRepoDiscoveryError";
+  }
+}
+
 type GithubRepoAccess = {
   disabledRepoIds?: number[];
 };
@@ -360,7 +369,6 @@ export async function listAccessibleGithubRepositories(
   // Only the installs are needed — chats (no incident) share this path.
   ctx: Pick<AgentRunContext, "githubInstalls">,
   options: {
-    toleratePartialFailure?: boolean;
     listInstallationRepositories?: typeof listInstallationRepositories;
   } = {},
 ): Promise<InstalledGithubRepo[]> {
@@ -395,11 +403,12 @@ export async function listAccessibleGithubRepositories(
   );
 
   const repos = dedupeInstalledGithubRepos(results.flatMap((result) => result.repos));
-  const failedEnoughToAbort = options.toleratePartialFailure
-    ? results.every((result) => result.err)
-    : results.some((result) => result.err);
-  if (repos.length === 0 && results.length > 0 && failedEnoughToAbort) {
+  const errors = results.filter((result) => result.err);
+  if (repos.length === 0 && errors.length > 0) {
     const firstError = results.find((result) => result.err)?.err;
+    if (errors.length < results.length) {
+      throw new PartialGithubRepoDiscoveryError(firstError);
+    }
     throw firstError instanceof Error
       ? firstError
       : new Error("failed to list repositories for all GitHub installations");

--- a/apps/worker/src/agent-runs/start-run.ts
+++ b/apps/worker/src/agent-runs/start-run.ts
@@ -29,8 +29,7 @@ export async function startQueuedAgentRun(ctx: AgentRunContext): Promise<void> {
   await startQueuedAgentRunWorkflow(ctx, {
     lifecycle: agentRunLifecycle,
     getRunnerBackend: getAgentRunnerBackend,
-    listRepositories: (ctx) =>
-      listAccessibleGithubRepositories(ctx, { toleratePartialFailure: true }),
+    listRepositories: listAccessibleGithubRepositories,
     scoreRepositories: scoreRepos,
     createRepositoryReadToken,
     listRepositoryInstructionFiles,

--- a/apps/worker/src/agent-runs/start-run.ts
+++ b/apps/worker/src/agent-runs/start-run.ts
@@ -29,7 +29,8 @@ export async function startQueuedAgentRun(ctx: AgentRunContext): Promise<void> {
   await startQueuedAgentRunWorkflow(ctx, {
     lifecycle: agentRunLifecycle,
     getRunnerBackend: getAgentRunnerBackend,
-    listRepositories: listAccessibleGithubRepositories,
+    listRepositories: (ctx) =>
+      listAccessibleGithubRepositories(ctx, { toleratePartialFailure: true }),
     scoreRepositories: scoreRepos,
     createRepositoryReadToken,
     listRepositoryInstructionFiles,

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -2,7 +2,11 @@ import "../agent-run.test-env.js";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { schema } from "@superlog/db";
-import type { AgentRunContext, InstalledGithubRepo } from "../agent-run-context.js";
+import {
+  type AgentRunContext,
+  type InstalledGithubRepo,
+  PartialGithubRepoDiscoveryError,
+} from "../agent-run-context.js";
 import type { AgentRunnerBackend, AgentRunnerStartInput } from "../agent-runner-backend.js";
 import { type StartQueuedAgentRunDeps, startQueuedAgentRunWorkflow } from "./start.js";
 
@@ -81,6 +85,24 @@ test("startQueuedAgentRunWorkflow blocks before repo discovery when GitHub is no
     "getRunnerBackend",
     "blockForGithub:no_github_install:Investigation blocked: no GitHub App install for this project.",
   ]);
+});
+
+test("startQueuedAgentRunWorkflow leaves a partial GitHub failure active for the next sweep", async () => {
+  const calls: string[] = [];
+  const ctx = makeContext();
+
+  await startQueuedAgentRunWorkflow(
+    ctx,
+    makeDeps(calls, {
+      async listRepositories() {
+        calls.push("listRepositories");
+        throw new PartialGithubRepoDiscoveryError(new Error("github returned 503"));
+      },
+    }),
+  );
+
+  assert.deepEqual(calls, ["beginRepoDiscovery", "getRunnerBackend", "listRepositories"]);
+  assert.equal(ctx.agentRun.state, "repo_discovery");
 });
 
 test("startQueuedAgentRunWorkflow asks for human repo selection when scoring produces no candidates", async () => {

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -5,6 +5,7 @@ import type {
   InstalledGithubRepo,
   ScoredGithubRepo,
 } from "../agent-run-context.js";
+import { PartialGithubRepoDiscoveryError } from "../agent-run-context.js";
 import type { AgentRunLifecycle } from "../agent-run.js";
 import type {
   AgentRunnerBackend,
@@ -186,6 +187,17 @@ async function discoverAccessibleRepositories(
   try {
     repos = await deps.listRepositories(ctx);
   } catch (err) {
+    if (err instanceof PartialGithubRepoDiscoveryError) {
+      logger.warn(
+        {
+          err,
+          agent_run_id: ctx.agentRun.id,
+          incident_id: ctx.incident.id,
+        },
+        "repository discovery partially unavailable; will retry on the next sweep",
+      );
+      return null;
+    }
     await deps.fail(
       ctx,
       "github_repo_discovery_failed",


### PR DESCRIPTION
## Summary

- distinguish partial GitHub installation failures from a total repository-discovery outage
- keep partially unavailable investigations in `repo_discovery` so the minute sweep retries automatically
- preserve strict lookup behavior for PR delivery and terminal failure behavior when every enabled installation errors
- cover repository error classification and start-workflow retry semantics with regression tests

## Root cause

A transient error from one enabled GitHub installation could fail the entire investigation even when another installation responded successfully but had no usable repositories. Treating that case as either a terminal discovery failure or a no-access configuration block prevents automatic recovery.

## Validation

- `pnpm --filter @superlog/worker exec tsx --test src/agent-run-context.test.ts src/agent-runs/start.test.ts`
- `pnpm --filter @superlog/worker test:agent-run`
- `pnpm --filter @superlog/worker typecheck`
- `pnpm exec biome check apps/worker/src/agent-run-context.ts apps/worker/src/agent-run-context.test.ts apps/worker/src/agent-runs/start.ts apps/worker/src/agent-runs/start.test.ts apps/worker/src/agent-runs/start-run.ts`