### PR TITLE
Honor repository PR title conventions

### DIFF
--- a/apps/worker/src/agent-outcome-tools.test.ts
+++ b/apps/worker/src/agent-outcome-tools.test.ts
@@ -205,6 +205,21 @@ test("propose_pr description explains the terminal multi-PR contract", () => {
   assert.ok(text.includes("NOT for noise"));
 });
 
+test("propose_pr title guidance defers to repository and organization conventions", () => {
+  const proposePr = OUTCOME_TOOL_DEFINITIONS.find((definition) => definition.name === "propose_pr");
+  assert.ok(proposePr);
+  const pullRequests = proposePr.input_schema.properties.pullRequests;
+  assert.ok(pullRequests);
+  const item = pullRequests.items as {
+    properties: Record<string, { description?: string }>;
+  };
+  const titleDescription = item.properties.title?.description ?? "";
+
+  assert.match(titleDescription, /repository's agent-instruction files/i);
+  assert.match(titleDescription, /organization-specific guidance/i);
+  assert.doesNotMatch(titleDescription, /\[superlog\]/i);
+});
+
 test("resolve_incident description requires atomic per-issue outcomes", () => {
   const def = OUTCOME_TOOL_DEFINITIONS.find((d) => d.name === "resolve_incident");
   assert.ok(def?.description.includes("exactly one outcome for every linked Issue"));

--- a/apps/worker/src/agent-outcome-tools.ts
+++ b/apps/worker/src/agent-outcome-tools.ts
@@ -211,7 +211,7 @@ const PULL_REQUEST_PROPERTIES = {
   title: {
     type: "string",
     description:
-      "Exact PR title for human review: '[superlog] <imperative fix summary>' describing the fix outcome, not the incident title.",
+      "Exact PR title for human review, describing the fix outcome rather than the incident title. Preserve every title convention from the repository's agent-instruction files and organization-specific guidance, including required or forbidden prefixes and required suffixes. When neither defines a format, use a concise imperative fix summary.",
   },
   body: {
     type: "string",

--- a/apps/worker/src/agent-runs/pr-copy.test.ts
+++ b/apps/worker/src/agent-runs/pr-copy.test.ts
@@ -2,14 +2,14 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { buildPrBody, buildPrTitle } from "./pr-copy.js";
 
-test("buildPrTitle prefers explicit PR title and keeps a single superlog prefix", () => {
+test("buildPrTitle preserves an explicit PR title with repository conventions", () => {
   const title = buildPrTitle({
     ctx: { incident: { id: "inc-1", title: "API returns 403" } },
     result: { summary: "summary", proposedTitle: "Allow members to access projects" },
-    pr: { title: "[superlog] Allow members to access projects outside the active org" },
+    pr: { title: "fix(auth): allow members to access projects #SUPERLOG" },
   });
 
-  assert.equal(title, "[superlog] Allow members to access projects outside the active org");
+  assert.equal(title, "fix(auth): allow members to access projects #SUPERLOG");
 });
 
 test("buildPrTitle falls back to proposedTitle without adding Fix to the incident title", () => {

--- a/apps/worker/src/agent-runs/pr-copy.ts
+++ b/apps/worker/src/agent-runs/pr-copy.ts
@@ -24,7 +24,9 @@ export function buildPrTitle(opts: {
   pr: PrCopyPr;
 }): string {
   const explicit = opts.pr.title?.trim();
-  if (explicit) return withSuperlogPrefix(explicit);
+  // The explicit title already reflects repository and organization guidance;
+  // delivery must not silently override required or forbidden conventions.
+  if (explicit) return explicit;
   const proposed = opts.result.proposedTitle?.trim();
   if (proposed) return withSuperlogPrefix(proposed);
   return withSuperlogPrefix(opts.ctx.incident.title);

--- a/apps/worker/src/agent-runs/pr-copy.ts
+++ b/apps/worker/src/agent-runs/pr-copy.ts
@@ -13,7 +13,7 @@ type PrCopyPr = {
   body?: string | null;
 };
 
-function withSuperlogPrefix(title: string): string {
+export function buildLegacyPrReceiptTitle(title: string): string {
   const trimmed = title.trim();
   return trimmed.startsWith("[superlog]") ? trimmed : `[superlog] ${trimmed}`;
 }
@@ -28,8 +28,8 @@ export function buildPrTitle(opts: {
   // delivery must not silently override required or forbidden conventions.
   if (explicit) return explicit;
   const proposed = opts.result.proposedTitle?.trim();
-  if (proposed) return withSuperlogPrefix(proposed);
-  return withSuperlogPrefix(opts.ctx.incident.title);
+  if (proposed) return buildLegacyPrReceiptTitle(proposed);
+  return buildLegacyPrReceiptTitle(opts.ctx.incident.title);
 }
 
 export function buildPrBody(opts: {

--- a/apps/worker/src/agent-runs/pr-delivery.test.ts
+++ b/apps/worker/src/agent-runs/pr-delivery.test.ts
@@ -74,13 +74,13 @@ test("legacy completion derives a stable opaque delivery identity per run and re
     agentRunId: "run-1",
     repoFullName: "acme/api",
     requestedBranchName: "superlog/fix-api",
-    input: { patch: "first patch" },
+    input: { patch: "first patch", title: "[superlog] Fix API" },
   });
   const replay = pullRequestDeliveryIdentityForLegacyCompletion({
     agentRunId: "run-1",
     repoFullName: "acme/api",
     requestedBranchName: "superlog/fix-api",
-    input: { patch: "first patch" },
+    input: { patch: "first patch", title: "Fix API" },
   });
   const conflictingInput = pullRequestDeliveryIdentityForLegacyCompletion({
     agentRunId: "run-1",

--- a/apps/worker/src/agent-runs/pr-delivery.ts
+++ b/apps/worker/src/agent-runs/pr-delivery.ts
@@ -49,7 +49,7 @@ import type { DeliveredLinearTicket } from "./linear-delivery.js";
 import { scheduleLinearHandoff } from "./linear-handoff.js";
 import { linearTicketSlackReference } from "./linear-pr-linking.js";
 import { outcomeActionInputHash } from "./outcome-action-receipts.js";
-import { buildPrBody, buildPrTitle } from "./pr-copy.js";
+import { buildLegacyPrReceiptTitle, buildPrBody, buildPrTitle } from "./pr-copy.js";
 import { summarizePrOpenFailure } from "./pr-open-failure.js";
 import {
   failAgentRun,
@@ -164,6 +164,14 @@ export function pullRequestDeliveryIdentityForLegacyCompletion(args: {
   requestedBranchName: string;
   input: unknown;
 }): PullRequestDeliveryIdentity {
+  const input =
+    args.input && typeof args.input === "object" && !Array.isArray(args.input)
+      ? (args.input as Record<string, unknown>)
+      : null;
+  const receiptInput =
+    input && typeof input.title === "string"
+      ? { ...input, title: buildLegacyPrReceiptTitle(input.title) }
+      : args.input;
   return {
     // The provider marker must survive retries of the same durable run and
     // repository, even when two pollers reach delivery concurrently.
@@ -172,7 +180,9 @@ export function pullRequestDeliveryIdentityForLegacyCompletion(args: {
       agentRunId: args.agentRunId,
       repoFullName: args.repoFullName,
     }),
-    inputHash: outcomeActionInputHash(args.input),
+    // Keep hashes compatible with receipts written before explicit titles
+    // began passing through to GitHub unchanged.
+    inputHash: outcomeActionInputHash(receiptInput),
     requestedBranchName: args.requestedBranchName,
   };
 }


### PR DESCRIPTION
## Summary

Remove the hardcoded `[superlog]` prefix from the pull-request title guidance used by incident remediation runs. The title contract now preserves repository instruction files and organization-specific guidance, including required or forbidden prefixes and required suffixes.

The hardcoded field-level guidance overrode repository conventions even when the run had read and followed those instructions elsewhere. A regression test pins the title guidance so the fixed prefix cannot return.

## Validation

- `pnpm --filter @superlog/worker test:agent-outcome-tools`
- `pnpm --filter @superlog/worker typecheck`
- `pnpm exec biome check apps/worker/src/agent-outcome-tools.ts apps/worker/src/agent-outcome-tools.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the hardcoded `[superlog]` prefix from PR title guidance, preserve explicit PR titles, and keep legacy delivery receipts stable. Delivery now follows repository and org title conventions end-to-end while maintaining backward-compatible receipt hashes.

- **Bug Fixes**
  - Updated guidance in `apps/worker/src/agent-outcome-tools.ts` to honor repo/org rules and fall back to a concise imperative summary when no format is defined; added a regression test to assert references and exclude `[superlog]`.
  - Changed `buildPrTitle` in `apps/worker/src/agent-runs/pr-copy.ts` to return an explicit title as-is; added `buildLegacyPrReceiptTitle` and updated `pullRequestDeliveryIdentityForLegacyCompletion` in `apps/worker/src/agent-runs/pr-delivery.ts` to normalize titles only for legacy receipt hashing; updated tests to confirm conventions are preserved and receipts remain stable.

<sup>Written for commit 31d177c17bc45a0f6493d3810384e754992d10cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

