### PR TITLE
Guard agent restarts against stale runs

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3023,6 +3023,9 @@ app.post("/api/projects/:projectId/incidents/:incidentId/agent-run/restart", asy
   if (restart.outcome === "incident_not_open") {
     throw new HTTPException(409, { message: "incident is no longer open" });
   }
+  if (restart.outcome === "latest_run_changed") {
+    throw new HTTPException(409, { message: "agent run changed before restart" });
+  }
 
   return c.json(restart.agentRun);
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3013,9 +3013,19 @@ app.post("/api/projects/:projectId/incidents/:incidentId/agent-run/restart", asy
     throw new HTTPException(400, { message: "incident agent_runs are disabled" });
   }
 
+  const body = (await c.req.json().catch(() => ({}))) as {
+    expectedLatestRunId?: unknown;
+  };
+  const expectedLatestRunId =
+    typeof body.expectedLatestRunId === "string" ? body.expectedLatestRunId.trim() : "";
+  if (!expectedLatestRunId) {
+    throw new HTTPException(400, { message: "expectedLatestRunId is required" });
+  }
+
   const restart = await restartAgentRun(db, {
     incidentId: incident.id,
     runtime: automation.agentRunProvider,
+    expectedLatestRunId,
   });
   if (restart.outcome === "no_prior_run") {
     throw new HTTPException(404, { message: "agent run not found" });

--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -1200,7 +1200,11 @@ function IncidentDetailBody({
   }
 
   function handleRestartAgentRun() {
-    restartAgentRun.mutate(incident.id);
+    if (!agentRun) return;
+    restartAgentRun.mutate({
+      incidentId: incident.id,
+      expectedLatestRunId: agentRun.id,
+    });
   }
 
   function handleRetryPrDelivery() {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -3105,6 +3105,11 @@ export function useRestartAgentRun(projectId: string) {
       qc.invalidateQueries({ queryKey: ["incident", projectId, incidentId] });
       qc.invalidateQueries({ queryKey: ["incident-agent run", projectId, incidentId] });
     },
+    onError: (_error, { incidentId }) => {
+      qc.invalidateQueries({ queryKey: ["incidents", projectId] });
+      qc.invalidateQueries({ queryKey: ["incident", projectId, incidentId] });
+      qc.invalidateQueries({ queryKey: ["incident-agent run", projectId, incidentId] });
+    },
   });
 }
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -3089,11 +3089,18 @@ export function useRestartAgentRun(projectId: string) {
   const fetcher = useFetcher();
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (incidentId: string) =>
+    mutationFn: ({
+      incidentId,
+      expectedLatestRunId,
+    }: {
+      incidentId: string;
+      expectedLatestRunId: string;
+    }) =>
       fetcher<AgentRun>(`/api/projects/${projectId}/incidents/${incidentId}/agent-run/restart`, {
         method: "POST",
+        body: JSON.stringify({ expectedLatestRunId }),
       }),
-    onSuccess: (_agentRun, incidentId) => {
+    onSuccess: (_agentRun, { incidentId }) => {
       qc.invalidateQueries({ queryKey: ["incidents", projectId] });
       qc.invalidateQueries({ queryKey: ["incident", projectId, incidentId] });
       qc.invalidateQueries({ queryKey: ["incident-agent run", projectId, incidentId] });

--- a/packages/db/src/agent-follow-up.test.ts
+++ b/packages/db/src/agent-follow-up.test.ts
@@ -1139,6 +1139,39 @@ test("restart preserves durable termination work for the superseded provider ses
   }
 });
 
+test("restart rejects a stale expected latest run without superseding its successor", async () => {
+  const { db, client } = await freshFollowUpDb();
+  try {
+    const { incident, priorRun } = await seedFollowUpIncident(db);
+    const successor = one(
+      await db
+        .insert(schema.agentRuns)
+        .values({
+          incidentId: incident.id,
+          runtime: "test",
+          state: "running",
+        })
+        .returning(),
+    );
+
+    const result = await restartAgentRun(db, {
+      incidentId: incident.id,
+      runtime: "test",
+      expectedLatestRunId: priorRun.id,
+      now: NOW,
+    });
+
+    assert.deepEqual(result, { outcome: "latest_run_changed" });
+    const runs = await db.query.agentRuns.findMany({
+      where: eq(schema.agentRuns.incidentId, incident.id),
+    });
+    assert.equal(runs.length, 2);
+    assert.equal(runs.find((run) => run.id === successor.id)?.state, "running");
+  } finally {
+    await client.close();
+  }
+});
+
 test("restart transfers an unprocessed PR lifecycle event to its viable successor", async () => {
   const { db, client } = await freshFollowUpDb();
   try {

--- a/packages/db/src/agent-follow-up.ts
+++ b/packages/db/src/agent-follow-up.ts
@@ -304,7 +304,8 @@ const RESTARTABLE_AGENT_RUN_STATES = [
 export type RestartAgentRunResult =
   | { outcome: "restarted"; agentRun: schema.AgentRun }
   | { outcome: "incident_not_open" }
-  | { outcome: "no_prior_run" };
+  | { outcome: "no_prior_run" }
+  | { outcome: "latest_run_changed" };
 
 export type RetryBlockedAgentRunResult =
   | { outcome: "retried"; agentRun: schema.AgentRun }
@@ -315,7 +316,12 @@ export type RetryBlockedAgentRunResult =
 
 export async function restartAgentRun(
   db: DB,
-  args: { incidentId: string; runtime: string; now?: Date },
+  args: {
+    incidentId: string;
+    runtime: string;
+    expectedLatestRunId?: string;
+    now?: Date;
+  },
 ): Promise<RestartAgentRunResult> {
   const now = args.now ?? new Date();
   return db.transaction(async (tx) => {
@@ -324,6 +330,9 @@ export async function restartAgentRun(
     if (aggregate.incident.status !== "open") return { outcome: "incident_not_open" };
     const latest = aggregate.runs[0];
     if (!latest) return { outcome: "no_prior_run" };
+    if (args.expectedLatestRunId && latest.id !== args.expectedLatestRunId) {
+      return { outcome: "latest_run_changed" };
+    }
 
     const created = await createRestartedAgentRun(tx, aggregate, {
       incidentId: args.incidentId,


### PR DESCRIPTION
## Summary
- allow restart callers to pin the expected latest agent run
- check that expectation while holding the incident lifecycle lock
- reject stale restart attempts without superseding a newer run

## Verification
- agent follow-up tests: 46/46 passed
- database package typecheck passed
- formatting checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale agent run restarts from superseding newer runs. The API pins restarts to the latest run, and the web app refreshes incident/run state after success or conflict to avoid stale UI.

- **New Features**
  - `restartAgentRun` now requires and validates `expectedLatestRunId` under the incident lifecycle lock; returns `latest_run_changed` on mismatch (API 409) and rejects requests without it (API 400).
  - Web: user-initiated restarts send the current run id as `expectedLatestRunId` and invalidate incident and agent run queries on success and error to refresh state.

<sup>Written for commit 0679d74a92242e8068e230570bad9beee7137b9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

