### PR TITLE
Add a lifecycle-event sink seam for signup and first-telemetry

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -254,8 +254,9 @@ export const auth = betterAuth({
           });
           // Vendor-neutral growth seam: a deployment may forward this to
           // external destinations (see @superlog/db lifecycle-events). No-op
-          // unless a sink was registered at boot; never blocks the signup.
-          await emitLifecycleEvent({
+          // unless a sink was registered at boot; fire-and-forget so a slow
+          // sink never blocks signup or delays enqueueUserCreated below.
+          void emitLifecycleEvent({
             event: "signup",
             userId: user.id,
             email: user.email,

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -1,4 +1,4 @@
-import { captureServerEvent, db, schema } from "@superlog/db";
+import { captureServerEvent, db, emitLifecycleEvent, schema } from "@superlog/db";
 import { autumn } from "autumn-js/better-auth";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
@@ -251,6 +251,15 @@ export const auth = betterAuth({
             distinctId: user.id,
             event: "user_signed_up",
             set: { email: user.email, name: user.name },
+          });
+          // Vendor-neutral growth seam: a deployment may forward this to
+          // external destinations (see @superlog/db lifecycle-events). No-op
+          // unless a sink was registered at boot; never blocks the signup.
+          await emitLifecycleEvent({
+            event: "signup",
+            userId: user.id,
+            email: user.email,
+            dedupeId: `signup-${user.id}`,
           });
           await enqueueUserCreated(user);
         },

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -4,6 +4,7 @@ import { serve } from "@hono/node-server";
 import { type Span, SpanStatusCode, metrics, trace } from "@opentelemetry/api";
 import {
   captureServerEvent,
+  emitLifecycleEvent,
   hashApiKey,
   schema,
   shutdownAnalytics,
@@ -293,9 +294,14 @@ async function maybeCaptureProjectActivation(projectId: string): Promise<void> {
     if (claimed.length === 0) return; // already activated; don't double-fire
 
     const [owner] = await db
-      .select({ userId: schema.orgMembers.userId, orgId: schema.orgMembers.orgId })
+      .select({
+        userId: schema.orgMembers.userId,
+        orgId: schema.orgMembers.orgId,
+        email: schema.users.email,
+      })
       .from(schema.projects)
       .innerJoin(schema.orgMembers, eq(schema.orgMembers.orgId, schema.projects.orgId))
+      .innerJoin(schema.users, eq(schema.users.id, schema.orgMembers.userId))
       .where(and(eq(schema.projects.id, projectId), eq(schema.orgMembers.role, "owner")))
       .limit(1);
     if (!owner) return;
@@ -303,6 +309,16 @@ async function maybeCaptureProjectActivation(projectId: string): Promise<void> {
       distinctId: owner.userId,
       event: "first_telemetry_received",
       properties: { project_id: projectId, org_id: owner.orgId },
+    });
+    // Vendor-neutral growth seam: a deployment may forward this to external
+    // destinations (see @superlog/db lifecycle-events). No-op unless a sink
+    // was registered at boot; fire-and-forget so it never delays ingest.
+    void emitLifecycleEvent({
+      event: "first_telemetry",
+      userId: owner.userId,
+      email: owner.email,
+      dedupeId: `first_telemetry-${projectId}`,
+      properties: { projectId, orgId: owner.orgId },
     });
   } catch (err) {
     // Don't cache on failure — a transient DB error should be retried on the

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21,6 +21,14 @@ export {
   shutdownAnalytics,
 } from "./analytics.js";
 export {
+  type LifecycleEvent,
+  type LifecycleEventName,
+  type LifecycleEventSink,
+  emitLifecycleEvent,
+  registerLifecycleEventSink,
+  resetLifecycleEventSink,
+} from "./lifecycle-events.js";
+export {
   type AgentPrAnalyticsOrg,
   type AgentPrAnalyticsPr,
   type AgentPrLifecycleEventInput,

--- a/packages/db/src/lifecycle-events.test.ts
+++ b/packages/db/src/lifecycle-events.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  type LifecycleEvent,
+  type LifecycleEventSink,
+  emitLifecycleEvent,
+  registerLifecycleEventSink,
+  resetLifecycleEventSink,
+} from "./lifecycle-events.js";
+
+test.afterEach(() => {
+  resetLifecycleEventSink();
+});
+
+function recordingSink(): { sink: LifecycleEventSink; calls: LifecycleEvent[] } {
+  const calls: LifecycleEvent[] = [];
+  return {
+    calls,
+    sink: {
+      record(e) {
+        calls.push(e);
+      },
+    },
+  };
+}
+
+test("default sink is a no-op and emit never throws", async () => {
+  await assert.doesNotReject(
+    emitLifecycleEvent({ event: "signup", userId: "u1", email: "a@b.com" }),
+  );
+});
+
+test("registerLifecycleEventSink installs a sink emit delegates to", async () => {
+  const { sink, calls } = recordingSink();
+  registerLifecycleEventSink(sink);
+  await emitLifecycleEvent({
+    event: "signup",
+    userId: "u1",
+    email: "a@b.com",
+    dedupeId: "signup-u1",
+  });
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], {
+    event: "signup",
+    userId: "u1",
+    email: "a@b.com",
+    dedupeId: "signup-u1",
+  });
+});
+
+test("registering a sink replaces the previous one", async () => {
+  const first = recordingSink();
+  const second = recordingSink();
+  registerLifecycleEventSink(first.sink);
+  registerLifecycleEventSink(second.sink);
+  await emitLifecycleEvent({ event: "first_telemetry", userId: "u1" });
+  assert.equal(first.calls.length, 0);
+  assert.equal(second.calls.length, 1);
+});
+
+test("resetLifecycleEventSink restores the no-op sink", async () => {
+  const { sink, calls } = recordingSink();
+  registerLifecycleEventSink(sink);
+  resetLifecycleEventSink();
+  await emitLifecycleEvent({ event: "signup", userId: "u1" });
+  assert.equal(calls.length, 0);
+});
+
+test("emit supports async sinks and swallows delivery failures", async () => {
+  registerLifecycleEventSink({
+    async record() {
+      throw new Error("network down");
+    },
+  });
+  await assert.doesNotReject(
+    emitLifecycleEvent({ event: "first_telemetry", userId: "u1", email: "a@b.com" }),
+  );
+});

--- a/packages/db/src/lifecycle-events.ts
+++ b/packages/db/src/lifecycle-events.ts
@@ -1,0 +1,69 @@
+// Lifecycle-event seam. Open-core emits vendor-neutral growth events (a user
+// signed up; a project received its first telemetry) to a pluggable sink; it
+// does NOT know which — if any — CRM, analytics, or ad network consumes them.
+// The default sink is a no-op, so a stock / self-hosted build emits nothing and
+// pulls in no third-party dependency.
+//
+// A deployment that wants to forward these somewhere provides a sink and calls
+// registerLifecycleEventSink() from its own service entrypoint, before the app
+// starts serving. Open-core never imports the sink — the dependency points only
+// inward (deployment → open-core), so the destination stays out of this repo.
+
+// The lifecycle moments we surface. Both are already emitted to server-side
+// product analytics next door (see analytics.ts); this seam lets a deployment
+// route the same moments to additional destinations without those destinations
+// leaking into open-core.
+export type LifecycleEventName = "signup" | "first_telemetry";
+
+export type LifecycleEvent = {
+  event: LifecycleEventName;
+  // Stable id of the acting user (the analytics distinct id).
+  userId: string;
+  // Contact email when known. A sink may hash it for identity matching; the
+  // seam itself neither stores nor transforms it.
+  email?: string | null;
+  // Stable id for this occurrence, so a sink can dedupe across delivery paths
+  // (e.g. `signup-<userId>`, `first_telemetry-<projectId>`).
+  dedupeId?: string;
+  // Extra non-sensitive context (project/org ids, source).
+  properties?: Record<string, unknown>;
+};
+
+type MaybePromise<T> = T | Promise<T>;
+
+export interface LifecycleEventSink {
+  record(event: LifecycleEvent): MaybePromise<void>;
+}
+
+const noopSink: LifecycleEventSink = {
+  record() {},
+};
+
+let activeSink: LifecycleEventSink = noopSink;
+
+/**
+ * Install the sink lifecycle events are delivered to. A deployment calls this
+ * once at service boot, before serving. Without it the no-op sink stays in
+ * place — the expected path for stock / self-hosted builds.
+ */
+export function registerLifecycleEventSink(sink: LifecycleEventSink): void {
+  activeSink = sink;
+}
+
+// Test/teardown helper: drop back to the no-op sink.
+export function resetLifecycleEventSink(): void {
+  activeSink = noopSink;
+}
+
+/**
+ * Emit a lifecycle event to the installed sink. Best-effort: never throws and
+ * never rejects, so callers can `await` it or fire-and-forget with `void`. A
+ * no-op unless a sink was registered at boot.
+ */
+export async function emitLifecycleEvent(event: LifecycleEvent): Promise<void> {
+  try {
+    await activeSink.record(event);
+  } catch {
+    /* lifecycle delivery is best-effort and must not affect the caller */
+  }
+}


### PR DESCRIPTION
## What

Adds a small vendor-neutral seam — `packages/db/src/lifecycle-events.ts` — that emits two growth-relevant lifecycle moments to a pluggable sink:

- **`signup`** — from the Better Auth `user.create` hook (fires for every provider)
- **`first_telemetry`** — from the proxy's once-per-project activation claim

## Why

We already emit these two moments as server-side PostHog events (`user_signed_up`, `first_telemetry_received`). This seam lets a deployment forward the same moments to an additional destination without that destination leaking into the codebase.

## Shape

- `registerLifecycleEventSink(sink)` — a deployment installs its sink once at boot (e.g. from an `--import` preload). The default is a **no-op**, so a stock / self-hosted build emits nothing and pulls in no new dependency.
- `emitLifecycleEvent(event)` — best-effort: never throws, never rejects, so callers `await` it or fire-and-forget with `void`. Never blocks or fails the request it rides on.
- Each event carries `userId`, `email`, a stable `dedupeId`, and non-sensitive `properties`.

The dependency points only inward — open-core never imports the sink.

## Tests

`packages/db/src/lifecycle-events.test.ts` (node:test): default no-op, register-delegates, replace, reset, async sink + swallowed failures. `@superlog/db` / `api` / `proxy` typecheck and biome clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a vendor-neutral lifecycle-event seam in `@superlog/db` to emit `signup` and `first_telemetry` to a pluggable sink. The default sink is a no-op; emits are fire-and-forget and never block requests.

- **New Features**
  - New APIs in `@superlog/db`: `registerLifecycleEventSink`, `emitLifecycleEvent`, plus `LifecycleEvent`, `LifecycleEventName`, `LifecycleEventSink`.
  - Emits `signup` from Better Auth `user.create` and `first_telemetry` from the proxy activation claim, with `userId`, `email`, `dedupeId`, and non-sensitive `properties`. Both emits are fire-and-forget so they never delay signup or ingest.
  - Tests cover no-op default, sink install/replace/reset, async sinks, and swallowed failures.

- **Migration**
  - Optional: register a sink at boot with `registerLifecycleEventSink(sink)` to forward events; otherwise no changes.

<sup>Written for commit e8ef7b31148192d7307b948729586767f6275eae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

