### PR TITLE
Disable Slack link unfurling on incident and agent messages

### DIFF
--- a/apps/api/src/follow-up-offer.ts
+++ b/apps/api/src/follow-up-offer.ts
@@ -86,6 +86,8 @@ export async function offerFollowUpForFeedback(feedback: schema.Feedback): Promi
         channel: incident.slackChannelId,
         thread_ts: incident.slackThreadTs,
         text,
+        unfurl_links: false,
+        unfurl_media: false,
         blocks: [
           { type: "section", text: { type: "mrkdwn", text } },
           {

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -1123,6 +1123,10 @@ async function postSlackThreadReply(opts: {
         channel: opts.channel,
         thread_ts: opts.threadTs ?? undefined,
         text: opts.text,
+        // Agent replies often quote incident/PR URLs; don't let Slack unfurl
+        // them into Open Graph preview cards.
+        unfurl_links: false,
+        unfurl_media: false,
       }),
     });
     const data = (await res.json()) as { ok: boolean; error?: string };

--- a/apps/worker/src/infra/slack/api.ts
+++ b/apps/worker/src/infra/slack/api.ts
@@ -51,6 +51,11 @@ export async function postSlackMessage(opts: {
         channel: opts.target.channelId,
         thread_ts: opts.threadTs ?? undefined,
         text: opts.text,
+        // Incident messages carry the incident/ticket URL as a text link, and
+        // Slack would otherwise unfurl it into a generic Open Graph card for
+        // the site (the page itself is behind auth). Suppress that noise.
+        unfurl_links: false,
+        unfurl_media: false,
         ...(opts.blocks ? { blocks: opts.blocks } : {}),
       }),
       ...(opts.timeoutMs ? { signal: AbortSignal.timeout(opts.timeoutMs) } : {}),
@@ -144,6 +149,10 @@ export async function updateSlackMessage(opts: {
         channel: opts.target.channelId,
         ts: opts.ts,
         text: opts.text,
+        // Match postSlackMessage: don't let Slack unfurl the incident/ticket
+        // URL into a generic Open Graph card when we repaint the message.
+        unfurl_links: false,
+        unfurl_media: false,
         ...(opts.blocks ? { blocks: opts.blocks } : {}),
       }),
     });


### PR DESCRIPTION
## What

Incident notifications and agent chat replies embed the incident, PR, and ticket URLs as text links. Slack auto-unfurls those into a generic Open Graph preview card for the site — a large, uninformative image the page's default OG tags (the incident pages themselves are behind auth) — under every thread.

Set `unfurl_links: false` and `unfurl_media: false` on the outbound Slack calls so nothing unfurls:

- `apps/worker/src/infra/slack/api.ts` — shared `postSlackMessage` (`chat.postMessage`) and `updateSlackMessage` (`chat.update`) helpers used by every incident/agent message.
- `apps/api/src/slack.ts` — `postSlackThreadReply` (agent chat replies).
- `apps/api/src/follow-up-offer.ts` — feedback follow-up offer post.

## Why not a text link vs button distinction

The "resolved" message keeps its incident URL in a Block Kit button (which Slack never unfurls), but the incident's root message and thread replies carry the URL/ticket link in mrkdwn text, and that is what unfurls. Disabling unfurling on all sends is the simplest complete fix.

## Testing

Notification-level change (two boolean fields on the request body). Typechecked `@superlog/worker` and `@superlog/api`. No behavior test added — the helpers do a raw `fetch` with no injection seam and the change is config on the request body.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Slack link unfurling for incident notifications and agent replies to remove noisy Open Graph previews in threads. Sets unfurl_links and unfurl_media to false on all relevant Slack sends and updates.

- **Bug Fixes**
  - Added unfurl flags to shared Slack helpers in `apps/worker/src/infra/slack/api.ts` for message post and update.
  - Added unfurl flags to thread replies and follow-up offers in `apps/api/src/slack.ts` and `apps/api/src/follow-up-offer.ts`.

<sup>Written for commit a8b2c6494a8fd2b4c96f276f9c2386f678fc051e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

