### PR TITLE
Fix OpenTelemetry log exporter wiring

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,6 +39,7 @@
     "@superlog/fingerprint": "workspace:*",
     "@superlog/gcp-auth": "workspace:*",
     "@superlog/net-guard": "workspace:*",
+    "@superlog/otel": "workspace:*",
     "@superlog/railway": "workspace:*",
     "@superlog/render": "workspace:*",
     "@superlog/telemetry-query": "workspace:*",

--- a/apps/api/tracing.ts
+++ b/apps/api/tracing.ts
@@ -48,7 +48,8 @@ import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { resourceFromAttributes } from "@opentelemetry/resources";
-import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
+import { LoggerProvider } from "@opentelemetry/sdk-logs";
+import { createBatchLogRecordProcessor } from "@superlog/otel";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
@@ -107,7 +108,7 @@ if (telemetryEnabled) {
   // a global LoggerProvider for `@opentelemetry/api-logs` consumers.
   const loggerProvider = new LoggerProvider({
     resource,
-    processors: [new BatchLogRecordProcessor(logExporter)],
+    processors: [createBatchLogRecordProcessor(logExporter)],
   });
   logs.setGlobalLoggerProvider(loggerProvider);
 

--- a/apps/proxy/package.json
+++ b/apps/proxy/package.json
@@ -32,6 +32,7 @@
     "@smithy/node-http-handler": "^4.7.4",
     "@superlog/db": "workspace:*",
     "@superlog/fingerprint": "workspace:*",
+    "@superlog/otel": "workspace:*",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
     "google-auth-library": "^10.9.0",

--- a/apps/proxy/tracing.ts
+++ b/apps/proxy/tracing.ts
@@ -44,7 +44,8 @@ import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { resourceFromAttributes } from "@opentelemetry/resources";
-import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
+import { LoggerProvider } from "@opentelemetry/sdk-logs";
+import { createBatchLogRecordProcessor } from "@superlog/otel";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
@@ -104,7 +105,7 @@ if (telemetryEnabled) {
   // a global LoggerProvider for `@opentelemetry/api-logs` consumers.
   const loggerProvider = new LoggerProvider({
     resource,
-    processors: [new BatchLogRecordProcessor(logExporter)],
+    processors: [createBatchLogRecordProcessor(logExporter)],
   });
   logs.setGlobalLoggerProvider(loggerProvider);
 

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -78,6 +78,7 @@
     "@superlog/fingerprint": "workspace:*",
     "@superlog/gcp-auth": "workspace:*",
     "@superlog/net-guard": "workspace:*",
+    "@superlog/otel": "workspace:*",
     "@superlog/railway": "workspace:*",
     "@superlog/render": "workspace:*",
     "@superlog/telemetry-query": "workspace:*",

--- a/apps/worker/tracing.ts
+++ b/apps/worker/tracing.ts
@@ -44,7 +44,8 @@ import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { resourceFromAttributes } from "@opentelemetry/resources";
-import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
+import { LoggerProvider } from "@opentelemetry/sdk-logs";
+import { createBatchLogRecordProcessor } from "@superlog/otel";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
@@ -104,7 +105,7 @@ if (telemetryEnabled) {
   // a global LoggerProvider for `@opentelemetry/api-logs` consumers.
   const loggerProvider = new LoggerProvider({
     resource,
-    processors: [new BatchLogRecordProcessor(logExporter)],
+    processors: [createBatchLogRecordProcessor(logExporter)],
   });
   logs.setGlobalLoggerProvider(loggerProvider);
 

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@superlog/otel",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "tsx --test src/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@opentelemetry/sdk-logs": "^0.220.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/otel/src/index.test.ts
+++ b/packages/otel/src/index.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { InMemoryLogRecordExporter, LoggerProvider } from "@opentelemetry/sdk-logs";
+import { createBatchLogRecordProcessor } from "./index.js";
+
+test("exports log records through the configured batch exporter", async () => {
+  const exporter = new InMemoryLogRecordExporter();
+  const provider = new LoggerProvider({
+    processors: [createBatchLogRecordProcessor(exporter, { scheduledDelayMillis: 1 })],
+  });
+
+  provider.getLogger("bootstrap-test").emit({ body: "worker is alive" });
+  await provider.forceFlush();
+
+  assert.deepEqual(
+    exporter.getFinishedLogRecords().map((record) => record.body),
+    ["worker is alive"],
+  );
+  await provider.shutdown();
+});

--- a/packages/otel/src/index.ts
+++ b/packages/otel/src/index.ts
@@ -1,0 +1,12 @@
+import {
+  BatchLogRecordProcessor,
+  type BatchLogRecordProcessorOptions,
+  type LogRecordExporter,
+} from "@opentelemetry/sdk-logs";
+
+export function createBatchLogRecordProcessor(
+  exporter: LogRecordExporter,
+  options: Omit<BatchLogRecordProcessorOptions, "exporter"> = {},
+): BatchLogRecordProcessor {
+  return new BatchLogRecordProcessor({ ...options, exporter });
+}

--- a/packages/otel/tsconfig.json
+++ b/packages/otel/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@superlog/net-guard':
         specifier: workspace:*
         version: link:../../packages/net-guard
+      '@superlog/otel':
+        specifier: workspace:*
+        version: link:../../packages/otel
       '@superlog/railway':
         specifier: workspace:*
         version: link:../../packages/railway
@@ -277,6 +280,9 @@ importers:
       '@superlog/fingerprint':
         specifier: workspace:*
         version: link:../../packages/fingerprint
+      '@superlog/otel':
+        specifier: workspace:*
+        version: link:../../packages/otel
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -547,6 +553,9 @@ importers:
       '@superlog/net-guard':
         specifier: workspace:*
         version: link:../../packages/net-guard
+      '@superlog/otel':
+        specifier: workspace:*
+        version: link:../../packages/otel
       '@superlog/railway':
         specifier: workspace:*
         version: link:../../packages/railway
@@ -685,6 +694,22 @@ importers:
       undici:
         specifier: ^7.16.0
         version: 7.28.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
+  packages/otel:
+    dependencies:
+      '@opentelemetry/sdk-logs':
+        specifier: ^0.220.0
+        version: 0.220.0(@opentelemetry/api@1.9.1)
     devDependencies:
       '@types/node':
         specifier: ^22.10.1


### PR DESCRIPTION
## What changed

- add a shared, type-checked factory for `BatchLogRecordProcessor`
- use it in the API, proxy, and worker telemetry bootstraps
- add a regression test that emits and flushes a log through the configured exporter

## Why

`@opentelemetry/sdk-logs` 0.220 changed the batch processor constructor from a positional exporter to an options object. The three service bootstraps still used the old form, so traces and metrics continued exporting while log batches failed at runtime.

Keeping the version-sensitive constructor call in a type-checked workspace package makes future SDK signature changes visible during CI.

## Validation

- `pnpm --filter @superlog/otel test`
- `pnpm --filter @superlog/otel typecheck`
- `pnpm --filter @superlog/api typecheck`
- `pnpm --filter @superlog/proxy typecheck`
- `pnpm --filter @superlog/worker typecheck`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OpenTelemetry log exporter wiring across `api`, `proxy`, and `worker` so log batches export correctly after `@opentelemetry/sdk-logs` 0.220 changed the processor constructor. Adds `@superlog/otel` with a type-checked `createBatchLogRecordProcessor` and uses it in all service bootstraps.

- **Bug Fixes**
  - Swap direct `BatchLogRecordProcessor` usage with `createBatchLogRecordProcessor` to match the new options-based constructor.
  - Add a regression test that emits and flushes a log using an in-memory exporter.

<sup>Written for commit cf47890bddcf3a0b019c9d4aa7472c2a96845dd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

