### PR TITLE
Load an optional website tag on the web (page views)

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,5 +1,6 @@
 import "./instrumentation";
 import { initGtm } from "./gtm";
+import { initXPixel } from "./x-pixel";
 import "@fontsource/geist-pixel/latin.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AutumnProvider } from "autumn-js/react";
@@ -21,6 +22,10 @@ const bootSpan = tracer.startSpan("app.bootstrap", {
 // VITE_GTM_CONTAINER_ID is set at build time, so dev/worktrees/self-hosted
 // builds ship no tag manager (same gating as PostHog below).
 initGtm(import.meta.env.VITE_GTM_CONTAINER_ID);
+
+// Install the X (Twitter) base pixel (page views / site visits). Same gating as
+// GTM — no-op unless VITE_X_PIXEL_ID is set in the prod build.
+initXPixel(import.meta.env.VITE_X_PIXEL_ID);
 
 // Wrap the app in PostHog only when a project token is configured. Local dev
 // and worktrees don't set VITE_PUBLIC_POSTHOG_PROJECT_TOKEN, so analytics stays

--- a/apps/web/src/x-pixel.test.ts
+++ b/apps/web/src/x-pixel.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { initXPixel } from "./x-pixel.ts";
+
+// A tiny stand-in for the pieces of the DOM `initXPixel` touches, so the
+// injection behaviour can be tested under `node --test` without a real document.
+function fakeEnv() {
+  const scripts: FakeScript[] = [];
+  const byId = new Map<string, FakeScript>();
+  const parent = {
+    insertBefore(node: FakeScript, _ref: FakeScript | null) {
+      scripts.unshift(node);
+      if (node.id) byId.set(node.id, node);
+      return node;
+    },
+  };
+  const doc = {
+    getElementById: (id: string) => byId.get(id) ?? null,
+    createElement: (_tag: string): FakeScript => ({
+      id: "",
+      async: false,
+      src: "",
+      parentNode: null,
+    }),
+    getElementsByTagName: (_tag: string) => (scripts[0] ? [scripts[0]] : ([] as FakeScript[])),
+    head: { appendChild: (node: FakeScript) => scripts.unshift(node) },
+  };
+  const win: { twq?: TwqLike } = {};
+  const seed: FakeScript = { id: "seed", async: false, src: "", parentNode: parent };
+  scripts.push(seed);
+  return { scripts, doc, win };
+}
+
+interface FakeScript {
+  id: string;
+  async: boolean;
+  src: string;
+  parentNode: { insertBefore(n: FakeScript, r: FakeScript | null): FakeScript } | null;
+}
+type TwqLike = ((...args: unknown[]) => void) & { queue?: unknown[]; version?: string };
+
+test("initXPixel is a no-op when no pixel id is configured", () => {
+  const { scripts, doc, win } = fakeEnv();
+  const before = scripts.length;
+  assert.equal(
+    initXPixel(undefined, { doc: doc as unknown as Document, win: win as unknown as Window }),
+    false,
+  );
+  assert.equal(
+    initXPixel("", { doc: doc as unknown as Document, win: win as unknown as Window }),
+    false,
+  );
+  assert.equal(scripts.length, before);
+  assert.equal(win.twq, undefined);
+});
+
+test("initXPixel installs the twq shim, injects uwt.js, and configures the pixel once", () => {
+  const { scripts, doc, win } = fakeEnv();
+
+  assert.equal(
+    initXPixel("re19o", { doc: doc as unknown as Document, win: win as unknown as Window }),
+    true,
+  );
+
+  assert.equal(typeof win.twq, "function");
+  assert.equal(win.twq?.version, "1.1");
+  assert.deepEqual(win.twq?.queue?.[0], ["config", "re19o"]);
+
+  const loader = scripts.find((s) => s.id === "x-pixel-loader");
+  assert.ok(loader);
+  assert.equal(loader?.src, "https://static.ads-twitter.com/uwt.js");
+  assert.equal(loader?.async, true);
+
+  // Re-running (e.g. HMR) must not inject a second loader or re-config.
+  const queuedBefore = win.twq?.queue?.length;
+  assert.equal(
+    initXPixel("re19o", { doc: doc as unknown as Document, win: win as unknown as Window }),
+    false,
+  );
+  assert.equal(scripts.filter((s) => s.id === "x-pixel-loader").length, 1);
+  assert.equal(win.twq?.queue?.length, queuedBefore);
+});

--- a/apps/web/src/x-pixel.ts
+++ b/apps/web/src/x-pixel.ts
@@ -1,0 +1,71 @@
+// X (Twitter) website tag loader.
+//
+// Injected only when `VITE_X_PIXEL_ID` is set, mirroring the GTM/PostHog gating
+// in `main.tsx`: local dev, worktrees, and self-hosted builds leave the var
+// unset, so no ad tag loads there. The pixel id is supplied at build time by
+// the deployment, never hardcoded here.
+//
+// This installs the base tag (page views + retargeting / "site visits"). Server
+// conversions (signup, first telemetry) are reported separately server-side.
+
+const X_PIXEL_SCRIPT_ID = "x-pixel-loader";
+const X_PIXEL_SRC = "https://static.ads-twitter.com/uwt.js";
+
+type Twq = ((...args: unknown[]) => void) & {
+  version?: string;
+  queue?: unknown[];
+  exe?: unknown;
+};
+
+interface InitXPixelOptions {
+  doc?: Document;
+  win?: Window & { twq?: Twq };
+}
+
+/**
+ * Initialize the X pixel against `pixelId`: install the `twq` command queue,
+ * inject the async `uwt.js` loader, and configure the pixel (which sends the
+ * initial page view).
+ *
+ * No-ops (returns false) when the id is blank or the loader is already present,
+ * so it's safe to call on every boot and under HMR. Returns true when it
+ * injected the loader.
+ */
+export function initXPixel(
+  pixelId: string | undefined,
+  options: InitXPixelOptions = {},
+): boolean {
+  if (!pixelId) return false;
+
+  const doc = options.doc ?? (typeof document !== "undefined" ? document : undefined);
+  if (!doc) return false;
+  const win =
+    options.win ??
+    (doc.defaultView as (Window & { twq?: Twq }) | null) ??
+    (typeof window !== "undefined" ? (window as Window & { twq?: Twq }) : undefined);
+  if (!win) return false;
+  if (doc.getElementById(X_PIXEL_SCRIPT_ID)) return false;
+
+  // The standard uwt.js command-queue shim: calls before the script loads are
+  // queued and replayed once it's ready.
+  if (!win.twq) {
+    const twq: Twq = (...args: unknown[]) => {
+      if (twq.exe) (twq.exe as (...a: unknown[]) => void).apply(twq, args);
+      else twq.queue?.push(args);
+    };
+    twq.version = "1.1";
+    twq.queue = [];
+    win.twq = twq;
+  }
+
+  const script = doc.createElement("script");
+  script.id = X_PIXEL_SCRIPT_ID;
+  script.async = true;
+  script.src = X_PIXEL_SRC;
+  const first = doc.getElementsByTagName("script")[0];
+  if (first?.parentNode) first.parentNode.insertBefore(script, first);
+  else (doc.head ?? doc.getElementsByTagName("head")[0]).appendChild(script);
+
+  win.twq("config", pixelId);
+  return true;
+}


### PR DESCRIPTION
Adds `initXPixel` — an env-gated website-tag loader that mirrors the existing `initGtm`: installs the tag command queue, injects the async loader script, and fires the initial page view. Wired into `main.tsx` beside the GTM/PostHog init.

No-op unless `VITE_X_PIXEL_ID` is set at build time, so local dev, worktrees, and self-hosted builds load nothing (same gating as `VITE_GTM_CONTAINER_ID`).

Test (`node:test`): no-op when unset; installs the shim + loader + config once and is idempotent under HMR. Web typecheck + biome clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional X (Twitter) website pixel for page view tracking. It only loads when `VITE_X_PIXEL_ID` is set; local and self-hosted builds remain unchanged.

- **New Features**
  - Added `initXPixel`: installs the `twq` queue, injects `uwt.js` async, and sends the initial page view.
  - Wired into `apps/web/src/main.tsx` beside `initGtm`; idempotent and safe under HMR.
  - Tests cover env gating (no-op) and single-injection behavior.

- **Migration**
  - To enable, set `VITE_X_PIXEL_ID` at build time (same gating as `VITE_GTM_CONTAINER_ID`).
  - Leave unset to keep the pixel off for local/worktrees/self-hosted builds.

<sup>Written for commit 4bfcf5a12686eeeca97727d43d3538d74853a928. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

