### PR TITLE
worker jobs: optional per-job timezone for cron schedules

### DIFF
--- a/apps/worker/src/jobs.ts
+++ b/apps/worker/src/jobs.ts
@@ -42,6 +42,9 @@ export type JobDefinition = {
   // Omit schedule for event-driven queues. Scheduled jobs default to an
   // exclusive queue; event consumers default to standard unless overridden.
   schedule?: string;
+  // IANA timezone (e.g. "Europe/Rome") the cron `schedule` is evaluated in.
+  // Omit to keep pg-boss's default of UTC. Only meaningful alongside a schedule.
+  tz?: string;
   policy?: JobQueuePolicy;
   // Durable active-job lease. Set this above the handler's legitimate worst
   // case so pg-boss never starts an overlapping successor while a slow run is
@@ -57,6 +60,7 @@ export type JobDefinition = {
 export type LoadedJob = {
   name: string;
   schedule?: string;
+  tz?: string;
   policy?: JobQueuePolicy;
   expireInSeconds?: number;
   handler: JobHandler;
@@ -120,6 +124,7 @@ export async function loadJobs(deps: JobDeps, options: { dir?: URL } = {}): Prom
       jobs.push({
         name: def.name,
         schedule: def.schedule,
+        tz: def.tz,
         policy: def.policy,
         expireInSeconds: def.expireInSeconds,
         handler,

--- a/apps/worker/src/jobs/runner.test.ts
+++ b/apps/worker/src/jobs/runner.test.ts
@@ -9,7 +9,7 @@ function fakeBoss() {
   const calls: string[] = [];
   const queues: string[] = [];
   const queueUpdates: Array<{ name: string; options: unknown }> = [];
-  const schedules: Array<{ name: string; cron: string }> = [];
+  const schedules: Array<{ name: string; cron: string; options: unknown }> = [];
   const workers = new Map<string, WorkHandler>();
   const boss: JobBoss = {
     async start() {
@@ -27,8 +27,8 @@ function fakeBoss() {
       workers.set(name, handler);
       calls.push(`work:${name}`);
     },
-    async schedule(name, cron) {
-      schedules.push({ name, cron });
+    async schedule(name, cron, _data, options) {
+      schedules.push({ name, cron, options });
       calls.push(`schedule:${name}:${cron}`);
     },
   };
@@ -52,8 +52,8 @@ test("registerJobs starts the boss and registers a queue, worker, and cron sched
   assert.equal(fb.calls[0], "start", "boss must be started before registration");
   assert.deepEqual(fb.queues, ["a.sync", "b.sync"]);
   assert.deepEqual(fb.schedules, [
-    { name: "a.sync", cron: "0 */6 * * *" },
-    { name: "b.sync", cron: "*/5 * * * *" },
+    { name: "a.sync", cron: "0 */6 * * *", options: undefined },
+    { name: "b.sync", cron: "*/5 * * * *", options: undefined },
   ]);
   // Each queue is created exclusive (at most one queued-or-active).
   assert.ok(fb.calls.includes('createQueue:a.sync:{"policy":"exclusive","expireInSeconds":3600}'));
@@ -115,5 +115,18 @@ test("a job that fails to register is skipped without aborting the others", asyn
   ]);
 
   // good.sync still got scheduled despite bad.sync throwing.
-  assert.deepEqual(fb.schedules, [{ name: "good.sync", cron: "* * * * *" }]);
+  assert.deepEqual(fb.schedules, [{ name: "good.sync", cron: "* * * * *", options: undefined }]);
+});
+
+test("a job's timezone is passed through to the cron schedule; a job without one is not", async () => {
+  const fb = fakeBoss();
+  await registerJobs(fb.boss, [
+    { name: "tz.sync", schedule: "30 8 * * *", tz: "Europe/Rome", handler: async () => {} },
+    { name: "utc.sync", schedule: "0 8 * * *", handler: async () => {} },
+  ]);
+
+  assert.deepEqual(fb.schedules, [
+    { name: "tz.sync", cron: "30 8 * * *", options: { tz: "Europe/Rome" } },
+    { name: "utc.sync", cron: "0 8 * * *", options: undefined },
+  ]);
 });

--- a/apps/worker/src/jobs/runner.ts
+++ b/apps/worker/src/jobs/runner.ts
@@ -44,7 +44,9 @@ export async function registerJobs(boss: JobBoss, jobs: LoadedJob[]): Promise<vo
         if (!queuedJob || typeof queuedJob !== "object") return;
         await job.handler(queuedJob as { id: string; data: unknown });
       });
-      if (job.schedule) await boss.schedule(job.name, job.schedule);
+      if (job.schedule) {
+        await boss.schedule(job.name, job.schedule, undefined, job.tz ? { tz: job.tz } : undefined);
+      }
       logger.info(
         { scope: "jobs.runner", job: job.name, schedule: job.schedule },
         job.schedule ? "scheduled background job" : "registered background event consumer",


### PR DESCRIPTION
## What

Adds an optional `tz` (IANA timezone, e.g. `Europe/Rome`) to the background-job
`JobDefinition`. It is carried through `loadJobs` into `LoadedJob` and passed to
pg-boss `schedule()` as `{ tz }`.

## Why

The job runner schedules every cron in UTC today (`boss.schedule(name, cron)`),
so a job that should fire at a fixed *local* wall-clock time drifts by an hour
across daylight-saving transitions. `tz` lets a job pin its schedule to a real
timezone (e.g. "08:30 in Europe/Rome year-round") without each job reimplementing
DST math.

## Scope

- `apps/worker/src/jobs.ts` — `tz?: string` on `JobDefinition` + `LoadedJob`,
  carried in `loadJobs`.
- `apps/worker/src/jobs/runner.ts` — pass `{ tz }` to `boss.schedule` when set.
- `apps/worker/src/jobs/runner.test.ts` — asserts a `tz` job passes the option
  through and a job without one does not (default UTC behavior unchanged).

Omitting `tz` preserves today's behavior exactly. No existing job sets it.

## Test

`tsx --test src/jobs/runner.test.ts` (5 pass), `src/jobs.test.ts` (7 pass),
`pnpm --filter @superlog/worker typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)