### PR TITLE
Make investigation completion own external handoff

### DIFF
--- a/apps/worker/src/agent-outcome-tools.test.ts
+++ b/apps/worker/src/agent-outcome-tools.test.ts
@@ -234,7 +234,7 @@ test("maps legacy create_linear_issue calls to deterministic completion", () => 
   assert.equal(validation.ok, true);
   if (validation.ok) {
     assert.equal(validation.tool, "complete_investigation");
-    assert.deepEqual(validation.payload, {});
+    assert.deepEqual(validation.payload, { legacyLinearTicketRequested: true });
   }
 });
 
@@ -336,7 +336,20 @@ test("complete_investigation finishes without resolving the incident", () => {
   });
   assert.equal(result.state, "complete");
   assert.equal(result.completionKind, "investigation_complete");
+  assert.equal(result.linearTicketRequested, undefined);
   assert.equal(result.incidentResolution, undefined);
+});
+
+test("legacy handoff aliases preserve their compatibility marker in the result", () => {
+  const result = assembleAgentRunResult({
+    findings: FINDINGS,
+    terminal: {
+      name: "complete_investigation",
+      payload: { legacyLinearTicketRequested: true },
+    },
+  });
+  assert.equal(result.completionKind, "investigation_complete");
+  assert.equal(result.linearTicketRequested, true);
 });
 
 test("allows ask_human without findings", () => {

--- a/apps/worker/src/agent-outcome-tools.test.ts
+++ b/apps/worker/src/agent-outcome-tools.test.ts
@@ -229,13 +229,19 @@ test("rejects retired tools (incl. mark_already_resolved) with redirect guidance
   }
 });
 
-test("redirects legacy create_linear_issue calls to deterministic completion", () => {
+test("maps legacy create_linear_issue calls to deterministic completion", () => {
   const validation = validateOutcomeToolInput("create_linear_issue", {}, { hasFindings: true });
-  assert.equal(validation.ok, false);
-  if (!validation.ok) {
-    assert.match(validation.errors.join(" "), /complete_investigation/);
-    assert.match(validation.errors.join(" "), /Linear/);
+  assert.equal(validation.ok, true);
+  if (validation.ok) {
+    assert.equal(validation.tool, "complete_investigation");
+    assert.deepEqual(validation.payload, {});
   }
+});
+
+test("keeps the findings gate for legacy create_linear_issue calls", () => {
+  const validation = validateOutcomeToolInput("create_linear_issue", {}, { hasFindings: false });
+  assert.equal(validation.ok, false);
+  if (!validation.ok) assert.match(validation.errors.join(" "), /report_findings/);
 });
 
 test("validates immutable legacy resolve calls without relaxing the advertised contract", () => {

--- a/apps/worker/src/agent-outcome-tools.test.ts
+++ b/apps/worker/src/agent-outcome-tools.test.ts
@@ -108,7 +108,6 @@ test("exposes the desired outcome tools with API-safe schemas", () => {
     [
       "report_findings",
       "propose_pr",
-      "create_linear_issue",
       "complete_investigation",
       "ask_human",
       "report_external_cause",
@@ -135,7 +134,6 @@ test("splits the contract into dispatched and terminal tools", () => {
     [...TERMINAL_OUTCOME_TOOL_NAMES],
     [
       "propose_pr",
-      "create_linear_issue",
       "complete_investigation",
       "ask_human",
       "report_external_cause",
@@ -150,45 +148,27 @@ test("splits the contract into dispatched and terminal tools", () => {
   assert.ok(!isDispatchedOutcomeToolName("report_external_cause"));
 });
 
-test("offers complete_investigation when no PR or ticket handoff is available", () => {
+test("offers complete_investigation whenever PR creation is unavailable", () => {
   const withPrs = outcomeToolDefinitionsForCapabilities({
     prCreation: true,
     approvalPrompts: false,
-    linearTicketCreation: false,
   }).map((definition) => definition.name);
   assert.ok(withPrs.includes("propose_pr"));
   assert.ok(!withPrs.includes("complete_investigation"));
 
-  const ticketOnly = outcomeToolDefinitionsForCapabilities({
+  const findingsOnly = outcomeToolDefinitionsForCapabilities({
     prCreation: false,
     approvalPrompts: false,
-    linearTicketCreation: false,
   }).map((definition) => definition.name);
-  assert.ok(!ticketOnly.includes("propose_pr"));
-  assert.ok(ticketOnly.includes("complete_investigation"));
+  assert.ok(!findingsOnly.includes("propose_pr"));
+  assert.ok(findingsOnly.includes("complete_investigation"));
 
   const withApprovals = outcomeToolDefinitionsForCapabilities({
     prCreation: false,
     approvalPrompts: true,
-    linearTicketCreation: false,
   }).map((definition) => definition.name);
   assert.ok(withApprovals.includes("complete_investigation"));
-});
-
-test("offers create_linear_issue whenever Linear ticket creation is available", () => {
-  const withEveryIntervention = outcomeToolDefinitionsForCapabilities({
-    prCreation: true,
-    approvalPrompts: true,
-    linearTicketCreation: true,
-  }).map((definition) => definition.name);
-  assert.ok(withEveryIntervention.includes("create_linear_issue"));
-
-  const withoutLinear = outcomeToolDefinitionsForCapabilities({
-    prCreation: true,
-    approvalPrompts: true,
-    linearTicketCreation: false,
-  }).map((definition) => definition.name);
-  assert.ok(!withoutLinear.includes("create_linear_issue"));
+  assert.ok(!withApprovals.includes("create_linear_issue"));
 });
 
 // The load-bearing guidance in tool descriptions. Losing any of these
@@ -232,7 +212,9 @@ test("resolve_incident description requires atomic per-issue outcomes", () => {
 // unknown-tool path would hard-fail the run instead.
 test("rejects retired tools (incl. mark_already_resolved) with redirect guidance", () => {
   assert.ok((RETIRED_OUTCOME_TOOL_NAMES as readonly string[]).includes("mark_already_resolved"));
-  for (const name of RETIRED_OUTCOME_TOOL_NAMES) {
+  for (const name of RETIRED_OUTCOME_TOOL_NAMES.filter(
+    (toolName) => toolName !== "create_linear_issue",
+  )) {
     const v = validateOutcomeToolInput(
       name,
       { reason: "upstream_recovered", evidence: "e" },
@@ -244,6 +226,15 @@ test("rejects retired tools (incl. mark_already_resolved) with redirect guidance
       assert.ok(text.includes("resolve_incident"), name);
       assert.ok(text.includes("issueOutcomes"), name);
     }
+  }
+});
+
+test("redirects legacy create_linear_issue calls to deterministic completion", () => {
+  const validation = validateOutcomeToolInput("create_linear_issue", {}, { hasFindings: true });
+  assert.equal(validation.ok, false);
+  if (!validation.ok) {
+    assert.match(validation.errors.join(" "), /complete_investigation/);
+    assert.match(validation.errors.join(" "), /Linear/);
   }
 });
 
@@ -321,7 +312,6 @@ test("requires findings before findings-backed terminal tools", () => {
       },
     ],
     ["complete_investigation", {}],
-    ["create_linear_issue", {}],
   ];
   for (const [name, input] of cases) {
     const v = validateOutcomeToolInput(name, input, { hasFindings: false });
@@ -340,20 +330,6 @@ test("complete_investigation finishes without resolving the incident", () => {
   });
   assert.equal(result.state, "complete");
   assert.equal(result.completionKind, "investigation_complete");
-  assert.equal(result.incidentResolution, undefined);
-});
-
-test("create_linear_issue completes a findings handoff without resolving the incident", () => {
-  const validation = validateOutcomeToolInput("create_linear_issue", {}, { hasFindings: true });
-  assert.equal(validation.ok, true);
-
-  const result = assembleAgentRunResult({
-    findings: FINDINGS,
-    terminal: { name: "create_linear_issue", payload: {} },
-  });
-  assert.equal(result.state, "complete");
-  assert.equal(result.completionKind, "investigation_complete");
-  assert.equal(result.linearTicketRequested, true);
   assert.equal(result.incidentResolution, undefined);
 });
 

--- a/apps/worker/src/agent-outcome-tools.ts
+++ b/apps/worker/src/agent-outcome-tools.ts
@@ -388,7 +388,12 @@ const REPORT_EXTERNAL_CAUSE_DEFINITION: OutcomeToolDefinition = {
 
 export type AskHumanPayload = { question: string };
 
-export type CompleteInvestigationPayload = Record<string, never>;
+export type CompleteInvestigationPayload = {
+  // Internal drain marker for pre-cutover sessions whose frozen schema still
+  // declared the provider-specific handoff terminal. Never exposed in the
+  // complete_investigation input schema and never set by new sessions.
+  legacyLinearTicketRequested?: true;
+};
 
 const COMPLETE_INVESTIGATION_DEFINITION: OutcomeToolDefinition = {
   name: "complete_investigation",
@@ -745,7 +750,7 @@ export function validateOutcomeToolInput(
     return {
       ok: true,
       tool: "complete_investigation",
-      payload: {},
+      payload: { legacyLinearTicketRequested: true },
     };
   }
   if ((RETIRED_OUTCOME_TOOL_NAMES as readonly string[]).includes(name)) {
@@ -1130,6 +1135,9 @@ export function assembleAgentRunResult(args: {
   }
   if (terminal?.name === "complete_investigation") {
     result.completionKind = "investigation_complete";
+    if (terminal.payload.legacyLinearTicketRequested) {
+      result.linearTicketRequested = true;
+    }
   }
   if (terminal?.name === "ask_human") {
     result.question = terminal.payload.question;

--- a/apps/worker/src/agent-outcome-tools.ts
+++ b/apps/worker/src/agent-outcome-tools.ts
@@ -736,11 +736,16 @@ export function validateOutcomeToolInput(
   ctx: { hasFindings: boolean },
 ): ValidateOutcome {
   if (name === "create_linear_issue") {
+    if (!ctx.hasFindings) {
+      return {
+        ok: false,
+        errors: ["Call report_findings before create_linear_issue."],
+      };
+    }
     return {
-      ok: false,
-      errors: [
-        "`create_linear_issue` is no longer available. Call `complete_investigation`; the platform creates or reuses the connected Linear issue deterministically as part of completion.",
-      ],
+      ok: true,
+      tool: "complete_investigation",
+      payload: {},
     };
   }
   if ((RETIRED_OUTCOME_TOOL_NAMES as readonly string[]).includes(name)) {

--- a/apps/worker/src/agent-outcome-tools.ts
+++ b/apps/worker/src/agent-outcome-tools.ts
@@ -48,7 +48,6 @@ export const DISPATCHED_OUTCOME_TOOL_NAMES = ["propose_pr", "resolve_incident"] 
 
 export const TERMINAL_OUTCOME_TOOL_NAMES = [
   "propose_pr",
-  "create_linear_issue",
   "complete_investigation",
   "ask_human",
   "report_external_cause",
@@ -62,6 +61,7 @@ export type TerminalOutcomeToolName = (typeof TERMINAL_OUTCOME_TOOL_NAMES)[numbe
 // these must be error-acked with redirect guidance — not routed to the
 // unknown-tool path, which hard-fails the run.
 export const RETIRED_OUTCOME_TOOL_NAMES = [
+  "create_linear_issue",
   "report_failure",
   "mark_already_resolved",
   "silence_as_noise",
@@ -390,19 +390,6 @@ export type AskHumanPayload = { question: string };
 
 export type CompleteInvestigationPayload = Record<string, never>;
 
-export type CreateLinearIssuePayload = Record<string, never>;
-
-const CREATE_LINEAR_ISSUE_DEFINITION: OutcomeToolDefinition = {
-  name: "create_linear_issue",
-  description:
-    "Terminal: create or reuse exactly one Linear issue for this investigation from the recorded findings, then complete the run while leaving the Incident open. Use this after report_findings when a human asks for a Linear issue or the findings need an explicit Linear handoff. The platform performs the Linear mutation idempotently; do not try to call Linear directly.",
-  input_schema: {
-    type: "object",
-    properties: {},
-    required: [],
-  },
-};
-
 const COMPLETE_INVESTIGATION_DEFINITION: OutcomeToolDefinition = {
   name: "complete_investigation",
   description:
@@ -441,7 +428,6 @@ export const OUTCOME_TOOL_DEFINITIONS: OutcomeToolDefinition[] = [
 export type AgentInterventionCapabilities = {
   prCreation: boolean;
   approvalPrompts: boolean;
-  linearTicketCreation: boolean;
 };
 
 export function hasInterventionTools(capabilities: AgentInterventionCapabilities): boolean {
@@ -454,10 +440,7 @@ export function outcomeToolDefinitionsForCapabilities(
   return [
     REPORT_FINDINGS_DEFINITION,
     ...(capabilities.prCreation ? [PROPOSE_PR_DEFINITION] : []),
-    ...(capabilities.linearTicketCreation ? [CREATE_LINEAR_ISSUE_DEFINITION] : []),
-    ...(!capabilities.prCreation && !capabilities.linearTicketCreation
-      ? [COMPLETE_INVESTIGATION_DEFINITION]
-      : []),
+    ...(!capabilities.prCreation ? [COMPLETE_INVESTIGATION_DEFINITION] : []),
     ASK_HUMAN_DEFINITION,
     REPORT_EXTERNAL_CAUSE_DEFINITION,
     RESOLVE_INCIDENT_DEFINITION,
@@ -470,7 +453,6 @@ export function outcomeToolDefinitionsForCapabilities(
 
 export type TerminalOutcome =
   | { name: "propose_pr"; payload: ProposePrPayload }
-  | { name: "create_linear_issue"; payload: CreateLinearIssuePayload }
   | { name: "complete_investigation"; payload: CompleteInvestigationPayload }
   | { name: "ask_human"; payload: AskHumanPayload }
   | { name: "report_external_cause"; payload: ReportExternalCausePayload }
@@ -511,7 +493,6 @@ export type ValidatedLegacyOutcome =
 const FINDINGS_REQUIRED = new Set<string>([
   "propose_pr",
   "resolve_incident",
-  "create_linear_issue",
   "complete_investigation",
   "report_external_cause",
 ]);
@@ -754,6 +735,14 @@ export function validateOutcomeToolInput(
   rawInput: unknown,
   ctx: { hasFindings: boolean },
 ): ValidateOutcome {
+  if (name === "create_linear_issue") {
+    return {
+      ok: false,
+      errors: [
+        "`create_linear_issue` is no longer available. Call `complete_investigation`; the platform creates or reuses the connected Linear issue deterministically as part of completion.",
+      ],
+    };
+  }
   if ((RETIRED_OUTCOME_TOOL_NAMES as readonly string[]).includes(name)) {
     return {
       ok: false,
@@ -887,9 +876,6 @@ export function validateOutcomeToolInput(
 
     case "complete_investigation":
       return { ok: true, tool: "complete_investigation", payload: {} };
-
-    case "create_linear_issue":
-      return { ok: true, tool: "create_linear_issue", payload: {} };
 
     case "ask_human": {
       const question = pushRequiredString(errors, input, "question");
@@ -1137,11 +1123,8 @@ export function assembleAgentRunResult(args: {
     }
     result.issueClassifications = [...classificationsByIssue.values()];
   }
-  if (terminal?.name === "complete_investigation" || terminal?.name === "create_linear_issue") {
+  if (terminal?.name === "complete_investigation") {
     result.completionKind = "investigation_complete";
-  }
-  if (terminal?.name === "create_linear_issue") {
-    result.linearTicketRequested = true;
   }
   if (terminal?.name === "ask_human") {
     result.question = terminal.payload.question;

--- a/apps/worker/src/agent-runner-backend.ts
+++ b/apps/worker/src/agent-runner-backend.ts
@@ -128,9 +128,6 @@ export type AgentRunnerStartInput = {
   // True only when at least one currently registered integration operation
   // is implemented as an approval prompt for this run.
   approvalPromptToolsAvailable: boolean;
-  // True when this run has an active, usable Linear installation. The runner
-  // exposes the idempotent ticket-handoff command only in that case.
-  linearTicketCreationAvailable: boolean;
   prBaseBranch: string | null;
   githubConnected: boolean;
   telemetryInvestigationHint: string;

--- a/apps/worker/src/agent-runs/completion-policy.test.ts
+++ b/apps/worker/src/agent-runs/completion-policy.test.ts
@@ -1,28 +1,12 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
-  linearHandoffTerminalOutcome,
   shouldCreateLinearTicketForTerminalOutcome,
   shouldOfferOpenPr,
 } from "./completion-policy.js";
 
-test("complete_investigation always attempts the connected Linear handoff", () => {
+test("complete_investigation deterministically attempts the connected Linear handoff", () => {
   assert.equal(shouldCreateLinearTicketForTerminalOutcome("complete_investigation", false), true);
-});
-
-test("create_linear_issue always attempts the connected Linear handoff", () => {
-  assert.equal(shouldCreateLinearTicketForTerminalOutcome("create_linear_issue", false), true);
-});
-
-test("the persisted explicit request retains the create_linear_issue terminal outcome", () => {
-  assert.equal(
-    linearHandoffTerminalOutcome({ linearTicketRequested: true }),
-    "create_linear_issue",
-  );
-  assert.equal(
-    linearHandoffTerminalOutcome({ linearTicketRequested: false }),
-    "complete_investigation",
-  );
 });
 
 test("resolve_incident follows the project's create-ticket-on-resolve toggle", () => {

--- a/apps/worker/src/agent-runs/completion-policy.ts
+++ b/apps/worker/src/agent-runs/completion-policy.ts
@@ -1,23 +1,12 @@
 import type { AgentRunResult, PrPolicy } from "@superlog/db";
 
-export type TicketCreatingTerminalOutcome =
-  | "create_linear_issue"
-  | "complete_investigation"
-  | "resolve_incident";
-
-export function linearHandoffTerminalOutcome(
-  result: Pick<AgentRunResult, "linearTicketRequested">,
-): Extract<TicketCreatingTerminalOutcome, "create_linear_issue" | "complete_investigation"> {
-  return result.linearTicketRequested ? "create_linear_issue" : "complete_investigation";
-}
+export type TicketCreatingTerminalOutcome = "complete_investigation" | "resolve_incident";
 
 export function shouldCreateLinearTicketForTerminalOutcome(
   outcome: TicketCreatingTerminalOutcome,
   createOnResolve: boolean,
 ): boolean {
-  return (
-    outcome === "create_linear_issue" || outcome === "complete_investigation" || createOnResolve
-  );
+  return outcome === "complete_investigation" || createOnResolve;
 }
 
 export function shouldOfferOpenPr(input: {

--- a/apps/worker/src/agent-runs/completion.ts
+++ b/apps/worker/src/agent-runs/completion.ts
@@ -36,7 +36,6 @@ import {
 import { logger } from "../logger.js";
 import { enqueueAgentRunCompleted } from "../webhooks.js";
 import {
-  linearHandoffTerminalOutcome,
   shouldCreateLinearTicketForTerminalOutcome,
   shouldOfferOpenPr,
 } from "./completion-policy.js";
@@ -594,59 +593,17 @@ export async function completeWithoutPullRequest(
           state: "complete",
         }),
       publish: async () => {
-        const terminalOutcome = linearHandoffTerminalOutcome(completionResult);
-        const explicitLinearHandoff = terminalOutcome === "create_linear_issue";
         const shouldCreateTicket = shouldCreateLinearTicketForTerminalOutcome(
-          terminalOutcome,
+          "complete_investigation",
           false,
         );
-        if (explicitLinearHandoff) {
-          logger.info(
-            {
-              scope: "agent_run.linear_handoff",
-              agent_run_id: ctx.agentRun.id,
-              incident_id: ctx.incident.id,
-              terminal_outcome: terminalOutcome,
-            },
-            "scheduling explicit Linear handoff",
-          );
-        }
-        let deliveredTicket = null;
-        try {
-          if (explicitLinearHandoff && !shouldCreateTicket) {
-            logger.error(
-              {
-                scope: "agent_run.linear_handoff",
-                agent_run_id: ctx.agentRun.id,
-                incident_id: ctx.incident.id,
-                terminal_outcome: terminalOutcome,
-                should_create_ticket: shouldCreateTicket,
-              },
-              "explicit Linear handoff skipped by completion policy",
-            );
-          }
-          deliveredTicket = shouldCreateTicket
-            ? await scheduleLinearHandoff(
-                ctx,
-                completionResult,
-                completionResult.completionKind ?? "complete_without_pr",
-              )
-            : null;
-        } catch (err) {
-          if (explicitLinearHandoff) {
-            logger.error(
-              {
-                scope: "agent_run.linear_handoff",
-                agent_run_id: ctx.agentRun.id,
-                incident_id: ctx.incident.id,
-                terminal_outcome: terminalOutcome,
-                err,
-              },
-              "explicit Linear handoff failed",
-            );
-          }
-          throw err;
-        }
+        const deliveredTicket = shouldCreateTicket
+          ? await scheduleLinearHandoff(
+              ctx,
+              completionResult,
+              completionResult.completionKind ?? "complete_without_pr",
+            )
+          : null;
         if (!deliveredTicket && completionResult.linearTicket) {
           await recordFiledLinearTicket(ctx, completionResult.linearTicket);
         }
@@ -658,19 +615,6 @@ export async function completeWithoutPullRequest(
                 url: completionResult.linearTicket.url ?? null,
               }
             : null;
-        if (explicitLinearHandoff && !ticket) {
-          logger.error(
-            {
-              scope: "agent_run.linear_handoff",
-              agent_run_id: ctx.agentRun.id,
-              incident_id: ctx.incident.id,
-              terminal_outcome: terminalOutcome,
-              should_create_ticket: shouldCreateTicket,
-              delivered_ticket: !!deliveredTicket,
-            },
-            "explicit Linear handoff returned without a ticket",
-          );
-        }
         logger.info(
           {
             scope: "agent_run",

--- a/apps/worker/src/agent-runs/outcome-actions.test.ts
+++ b/apps/worker/src/agent-runs/outcome-actions.test.ts
@@ -254,6 +254,32 @@ test("retired outcome tools are handled with migration guidance", async () => {
   assert.match(JSON.stringify(result.payload), /resolve_incident\.issueOutcomes/);
 });
 
+test("the legacy handoff alias remains owned by terminal collection", async () => {
+  let receiptClaims = 0;
+  const receiptLock: OutcomeActionReceiptLock = {
+    async exclusive(_args, task) {
+      receiptClaims += 1;
+      return task({
+        async load() {
+          return null;
+        },
+        async save() {},
+      });
+    },
+  };
+  const execute = createOutcomeActionExecutor(receiptContext, "session-1", receiptLock);
+  const result = await execute({
+    toolUseId: "legacy-linear-1",
+    name: "create_linear_issue",
+    input: {},
+    hasFindings: true,
+    findings: null,
+  });
+
+  assert.deepEqual(result, { handled: false });
+  assert.equal(receiptClaims, 0);
+});
+
 test("a durable legacy issue action is error-acked with classification-at-resolution guidance", async () => {
   const calls: Array<Record<string, unknown>> = [];
   const dependencies = {

--- a/apps/worker/src/agent-runs/outcome-actions.ts
+++ b/apps/worker/src/agent-runs/outcome-actions.ts
@@ -303,6 +303,10 @@ export function createOutcomeActionExecutor(
 ): (call: OutcomeActionCall) => Promise<OutcomeActionExecution> {
   const dependencies = { ...databaseOutcomeActionDependencies, ...dependencyOverrides };
   return async (call) => {
+    // Frozen pre-cutover sessions still declare this findings terminal. It is
+    // normalized and acknowledged by terminal collection, not dispatched as a
+    // provider mutation. New sessions never declare it.
+    if (call.name === "create_linear_issue") return { handled: false };
     if (!isDispatchedOutcomeToolName(call.name) && !isRetiredOutcomeToolName(call.name)) {
       return { handled: false };
     }

--- a/apps/worker/src/agent-runs/outcome-actions.ts
+++ b/apps/worker/src/agent-runs/outcome-actions.ts
@@ -306,7 +306,18 @@ export function createOutcomeActionExecutor(
     // Frozen pre-cutover sessions still declare this findings terminal. It is
     // normalized and acknowledged by terminal collection, not dispatched as a
     // provider mutation. New sessions never declare it.
-    if (call.name === "create_linear_issue") return { handled: false };
+    if (call.name === "create_linear_issue") {
+      logger.info(
+        {
+          agentRunId: ctx.agentRun.id,
+          incidentId: ctx.incident.id,
+          sessionId,
+          toolUseId: call.toolUseId,
+        },
+        "leaving legacy handoff terminal to terminal collection",
+      );
+      return { handled: false };
+    }
     if (!isDispatchedOutcomeToolName(call.name) && !isRetiredOutcomeToolName(call.name)) {
       return { handled: false };
     }

--- a/apps/worker/src/agent-runs/outcome-actions.ts
+++ b/apps/worker/src/agent-runs/outcome-actions.ts
@@ -309,6 +309,7 @@ export function createOutcomeActionExecutor(
     if (call.name === "create_linear_issue") {
       logger.info(
         {
+          scope: "agent_run.outcome_action",
           agentRunId: ctx.agentRun.id,
           incidentId: ctx.incident.id,
           sessionId,

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -165,22 +165,6 @@ test("startQueuedAgentRunWorkflow exposes ask_human as an approval boundary", as
   assert.equal(approvalPromptToolsAvailable, true);
 });
 
-test("startQueuedAgentRunWorkflow exposes Linear ticket creation only for an active install", async () => {
-  const calls: string[] = [];
-  const ctx = makeContext();
-  ctx.linearInstall = { id: "linear-install-1" } as schema.LinearInstallation;
-  let linearTicketCreationAvailable: boolean | null = null;
-
-  await startQueuedAgentRunWorkflow(
-    ctx,
-    makeDeps(calls, {}, (input) => {
-      linearTicketCreationAvailable = input.linearTicketCreationAvailable;
-    }),
-  );
-
-  assert.equal(linearTicketCreationAvailable, true);
-});
-
 test("startQueuedAgentRunWorkflow passes agent memories to the runner", async () => {
   const calls: string[] = [];
   const ctx = makeContext();

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -332,7 +332,6 @@ async function startRunnerSession(
         // project setting decides whether it counts as an available
         // intervention when terminal tools are registered.
         approvalPromptToolsAvailable: true,
-        linearTicketCreationAvailable: !!ctx.linearInstall,
         prBaseBranch: ctx.prBaseBranch,
         githubConnected: ctx.githubInstalls.length > 0,
         telemetryInvestigationHint: TELEMETRY_INVESTIGATION_HINT,

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -442,6 +442,24 @@ test("complete_investigation is rejected for PR runs but allowed for findings-on
   );
 });
 
+test("persisted legacy Linear handoffs can drain after the tool contract changes", () => {
+  assert.equal(
+    isCompleteInvestigationAllowed(
+      {
+        state: "complete",
+        summary: "Findings ready.",
+        completionKind: "investigation_complete",
+        linearTicketRequested: true,
+      },
+      {
+        prPolicy: "always",
+        githubConnected: true,
+      },
+    ),
+    true,
+  );
+});
+
 test("findings-only completion remains available alongside approval prompts when PRs are disabled", () => {
   assert.equal(
     completeInvestigationAvailable({

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -423,8 +423,6 @@ test("complete_investigation is rejected for PR runs but allowed for findings-on
     isCompleteInvestigationAllowed(result, {
       prPolicy: "always",
       githubConnected: true,
-      approvalPromptsEnabled: false,
-      approvalPromptToolsAvailable: false,
     }),
     false,
   );
@@ -432,8 +430,6 @@ test("complete_investigation is rejected for PR runs but allowed for findings-on
     isCompleteInvestigationAllowed(result, {
       prPolicy: "never",
       githubConnected: true,
-      approvalPromptsEnabled: true,
-      approvalPromptToolsAvailable: true,
     }),
     true,
   );
@@ -441,42 +437,35 @@ test("complete_investigation is rejected for PR runs but allowed for findings-on
     isCompleteInvestigationAllowed(result, {
       prPolicy: "on_ready_to_pr",
       githubConnected: false,
-      approvalPromptsEnabled: false,
-      approvalPromptToolsAvailable: true,
     }),
     true,
   );
 });
 
-test("legacy sessions do not advertise completion tools absent from their schema", () => {
+test("findings-only completion remains available alongside approval prompts when PRs are disabled", () => {
   assert.equal(
     completeInvestigationAvailable({
       prPolicy: "never",
       githubConnected: true,
-      approvalPromptsEnabled: true,
-      approvalPromptToolsAvailable: true,
     }),
-    false,
+    true,
   );
 });
 
-test("an explicit Linear handoff is allowed when another intervention is available", () => {
+test("findings-only completion cannot bypass the PR-creation guard", () => {
   assert.equal(
     isCompleteInvestigationAllowed(
       {
         state: "complete",
         summary: "Findings ready for the owning team.",
         completionKind: "investigation_complete",
-        linearTicketRequested: true,
       },
       {
         prPolicy: "always",
         githubConnected: true,
-        approvalPromptsEnabled: true,
-        approvalPromptToolsAvailable: true,
       },
     ),
-    true,
+    false,
   );
 });
 
@@ -838,24 +827,23 @@ test("terminalOutcomeNudgePrompt uses complete_investigation when interventions 
   assert.doesNotMatch(prompt, /propose_pr/);
 });
 
-test("terminalOutcomeNudgePrompt preserves the explicit Linear handoff", () => {
+test("terminalOutcomeNudgePrompt exposes complete_investigation for findings-only handoff", () => {
   const prompt = terminalOutcomeNudgePrompt({
     completeInvestigationAvailable: true,
-    linearTicketCreationAvailable: true,
     prCreationAvailable: false,
   });
-  assert.match(prompt, /create_linear_issue/);
-  assert.doesNotMatch(prompt, /complete_investigation/);
+  assert.match(prompt, /complete_investigation/);
+  assert.doesNotMatch(prompt, /create_linear_issue/);
   assert.doesNotMatch(prompt, /propose_pr/);
 });
 
-test("terminalOutcomeNudgePrompt keeps PR creation alongside the Linear handoff", () => {
+test("terminalOutcomeNudgePrompt does not expose findings-only completion with PR creation", () => {
   const prompt = terminalOutcomeNudgePrompt({
     completeInvestigationAvailable: false,
-    linearTicketCreationAvailable: true,
     prCreationAvailable: true,
   });
-  assert.match(prompt, /create_linear_issue/);
+  assert.doesNotMatch(prompt, /complete_investigation/);
+  assert.doesNotMatch(prompt, /create_linear_issue/);
   assert.match(prompt, /propose_pr/);
 });
 
@@ -867,24 +855,22 @@ test("terminalOutcomeNudgeCapabilities uses the tools declared for the running s
     ),
     {
       prCreationAvailable: true,
-      linearTicketCreationAvailable: false,
       completeInvestigationAvailable: false,
     },
   );
   assert.deepEqual(
     terminalOutcomeNudgeCapabilities(
-      { declaredCustomToolNames: ["report_findings", "create_linear_issue"] },
+      { declaredCustomToolNames: ["report_findings", "complete_investigation"] },
       { prCreationAvailable: true, completeInvestigationAvailable: false },
     ),
     {
       prCreationAvailable: false,
-      linearTicketCreationAvailable: true,
-      completeInvestigationAvailable: false,
+      completeInvestigationAvailable: true,
     },
   );
 });
 
-test("terminalOutcomeNudgeCapabilities does not add Linear to legacy snapshots", () => {
+test("terminalOutcomeNudgeCapabilities preserves legacy fallback tool availability", () => {
   assert.deepEqual(
     terminalOutcomeNudgeCapabilities(
       {},
@@ -892,7 +878,6 @@ test("terminalOutcomeNudgeCapabilities does not add Linear to legacy snapshots",
     ),
     {
       prCreationAvailable: true,
-      linearTicketCreationAvailable: false,
       completeInvestigationAvailable: false,
     },
   );

--- a/apps/worker/src/agent-runs/sync.test.ts
+++ b/apps/worker/src/agent-runs/sync.test.ts
@@ -865,6 +865,16 @@ test("terminalOutcomeNudgePrompt does not expose findings-only completion with P
   assert.match(prompt, /propose_pr/);
 });
 
+test("terminalOutcomeNudgePrompt names the frozen handoff terminal for legacy sessions", () => {
+  const prompt = terminalOutcomeNudgePrompt({
+    legacyLinearHandoffAvailable: true,
+    prCreationAvailable: true,
+  });
+  assert.match(prompt, /create_linear_issue/);
+  assert.doesNotMatch(prompt, /complete_investigation/);
+  assert.match(prompt, /propose_pr/);
+});
+
 test("terminalOutcomeNudgeCapabilities uses the tools declared for the running session", () => {
   assert.deepEqual(
     terminalOutcomeNudgeCapabilities(
@@ -884,6 +894,17 @@ test("terminalOutcomeNudgeCapabilities uses the tools declared for the running s
     {
       prCreationAvailable: false,
       completeInvestigationAvailable: true,
+    },
+  );
+  assert.deepEqual(
+    terminalOutcomeNudgeCapabilities(
+      { declaredCustomToolNames: ["report_findings", "propose_pr", "create_linear_issue"] },
+      { prCreationAvailable: false, completeInvestigationAvailable: true },
+    ),
+    {
+      prCreationAvailable: true,
+      completeInvestigationAvailable: false,
+      legacyLinearHandoffAvailable: true,
     },
   );
 });

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -122,12 +122,9 @@ export function isCompleteInvestigationAllowed(
   capabilities: {
     prPolicy: schema.PrPolicy;
     githubConnected: boolean;
-    approvalPromptsEnabled: boolean;
-    approvalPromptToolsAvailable: boolean;
   },
 ): boolean {
   if (result.completionKind !== "investigation_complete") return true;
-  if (result.linearTicketRequested) return true;
   const prCreation = capabilities.githubConnected && capabilities.prPolicy !== "never";
   return !prCreation;
 }
@@ -135,13 +132,9 @@ export function isCompleteInvestigationAllowed(
 export function completeInvestigationAvailable(capabilities: {
   prPolicy: schema.PrPolicy;
   githubConnected: boolean;
-  approvalPromptsEnabled: boolean;
-  approvalPromptToolsAvailable: boolean;
 }): boolean {
   const prCreation = capabilities.githubConnected && capabilities.prPolicy !== "never";
-  const approvalPrompts =
-    capabilities.approvalPromptsEnabled && capabilities.approvalPromptToolsAvailable;
-  return !prCreation && !approvalPrompts;
+  return !prCreation;
 }
 
 const agentRunLifecycle = createAgentRunLifecycle(db);
@@ -443,15 +436,13 @@ export function shouldDeferSteering(snapshot: {
 export function terminalOutcomeNudgePrompt(
   args: {
     completeInvestigationAvailable?: boolean;
-    linearTicketCreationAvailable?: boolean;
     prCreationAvailable?: boolean;
   } = {},
 ): string {
   const terminalTools: string[] = [];
   const prCreationAvailable = args.prCreationAvailable ?? !args.completeInvestigationAvailable;
   if (prCreationAvailable) terminalTools.push("batched `propose_pr`");
-  if (args.linearTicketCreationAvailable) terminalTools.push("`create_linear_issue`");
-  else if (args.completeInvestigationAvailable) terminalTools.push("`complete_investigation`");
+  if (args.completeInvestigationAvailable) terminalTools.push("`complete_investigation`");
   terminalTools.push(
     "`resolve_incident` with all Issue outcomes",
     "`report_external_cause`",
@@ -471,7 +462,6 @@ export function terminalOutcomeNudgeCapabilities(
   },
 ): {
   prCreationAvailable: boolean;
-  linearTicketCreationAvailable: boolean;
   completeInvestigationAvailable: boolean;
 } {
   const declared = snapshot.declaredCustomToolNames;
@@ -483,15 +473,11 @@ export function terminalOutcomeNudgeCapabilities(
       },
       "terminal outcome nudge is using legacy snapshot capabilities",
     );
-    return {
-      ...fallback,
-      linearTicketCreationAvailable: false,
-    };
+    return fallback;
   }
   const names = new Set(declared);
   return {
     prCreationAvailable: names.has("propose_pr"),
-    linearTicketCreationAvailable: names.has("create_linear_issue"),
     completeInvestigationAvailable: names.has("complete_investigation"),
   };
 }
@@ -1312,8 +1298,6 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
         !isCompleteInvestigationAllowed(snapshot.result, {
           prPolicy: ctx.prPolicy,
           githubConnected: ctx.githubInstalls.length > 0,
-          approvalPromptsEnabled: ctx.approvalPromptsEnabled,
-          approvalPromptToolsAvailable: true,
         })
       ) {
         const failed = await failAgentRun(
@@ -1564,8 +1548,6 @@ export async function syncRunningAgentRun(ctx: AgentRunContext): Promise<void> {
               completeInvestigationAvailable: completeInvestigationAvailable({
                 prPolicy: ctx.prPolicy,
                 githubConnected: ctx.githubInstalls.length > 0,
-                approvalPromptsEnabled: ctx.approvalPromptsEnabled,
-                approvalPromptToolsAvailable: true,
               }),
               prCreationAvailable: ctx.githubInstalls.length > 0 && ctx.prPolicy !== "never",
             }),

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -125,6 +125,10 @@ export function isCompleteInvestigationAllowed(
   },
 ): boolean {
   if (result.completionKind !== "investigation_complete") return true;
+  // Pre-cutover sessions persisted this flag for the provider-specific handoff
+  // terminal. Let those immutable snapshots drain even when PR creation would
+  // block a newly declared complete_investigation call.
+  if (result.linearTicketRequested) return true;
   const prCreation = capabilities.githubConnected && capabilities.prPolicy !== "never";
   return !prCreation;
 }

--- a/apps/worker/src/agent-runs/sync.ts
+++ b/apps/worker/src/agent-runs/sync.ts
@@ -440,13 +440,20 @@ export function shouldDeferSteering(snapshot: {
 export function terminalOutcomeNudgePrompt(
   args: {
     completeInvestigationAvailable?: boolean;
+    legacyLinearHandoffAvailable?: boolean;
     prCreationAvailable?: boolean;
   } = {},
 ): string {
   const terminalTools: string[] = [];
-  const prCreationAvailable = args.prCreationAvailable ?? !args.completeInvestigationAvailable;
+  const prCreationAvailable =
+    args.prCreationAvailable ??
+    !(args.completeInvestigationAvailable || args.legacyLinearHandoffAvailable);
   if (prCreationAvailable) terminalTools.push("batched `propose_pr`");
-  if (args.completeInvestigationAvailable) terminalTools.push("`complete_investigation`");
+  if (args.completeInvestigationAvailable) {
+    terminalTools.push("`complete_investigation`");
+  } else if (args.legacyLinearHandoffAvailable) {
+    terminalTools.push("`create_linear_issue` (legacy session compatibility)");
+  }
   terminalTools.push(
     "`resolve_incident` with all Issue outcomes",
     "`report_external_cause`",
@@ -467,6 +474,7 @@ export function terminalOutcomeNudgeCapabilities(
 ): {
   prCreationAvailable: boolean;
   completeInvestigationAvailable: boolean;
+  legacyLinearHandoffAvailable?: true;
 } {
   const declared = snapshot.declaredCustomToolNames;
   if (!declared) {
@@ -483,6 +491,7 @@ export function terminalOutcomeNudgeCapabilities(
   return {
     prCreationAvailable: names.has("propose_pr"),
     completeInvestigationAvailable: names.has("complete_investigation"),
+    ...(names.has("create_linear_issue") ? { legacyLinearHandoffAvailable: true as const } : {}),
   };
 }
 

--- a/apps/worker/src/infra/agent-runner/backend.test.ts
+++ b/apps/worker/src/infra/agent-runner/backend.test.ts
@@ -56,7 +56,6 @@ test("getAgentRunnerBackend returns the default community backend", async () => 
       prPolicy: "never",
       approvalPromptsEnabled: false,
       approvalPromptToolsAvailable: false,
-      linearTicketCreationAvailable: false,
       prBaseBranch: null,
       githubConnected: false,
       telemetryInvestigationHint:
@@ -111,7 +110,6 @@ test("getAgentRunnerBackend returns a built-in disabled backend for community in
         prPolicy: "never",
         approvalPromptsEnabled: false,
         approvalPromptToolsAvailable: false,
-        linearTicketCreationAvailable: false,
         prBaseBranch: null,
         githubConnected: false,
         telemetryInvestigationHint:

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -356,6 +356,9 @@ export type AgentRunResult = {
   // Explicit terminal signal for runs that finish their investigation while
   // deliberately leaving the incident open for an external ticket workflow.
   completionKind?: "investigation_complete" | null;
+  // Compatibility marker persisted by pre-cutover sessions that explicitly
+  // requested the provider-specific handoff terminal. New runs never set it.
+  linearTicketRequested?: boolean | null;
   // Why an awaiting_events run is parked when it is not waiting on a PR.
   waitReason?: "external_cause" | null;
   externalCause?: AgentRunExternalCause | null;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -356,10 +356,6 @@ export type AgentRunResult = {
   // Explicit terminal signal for runs that finish their investigation while
   // deliberately leaving the incident open for an external ticket workflow.
   completionKind?: "investigation_complete" | null;
-  // The agent explicitly chose the Linear handoff terminal. This lets the
-  // completion gate distinguish it from a findings-only completion when
-  // remediation tools were also available.
-  linearTicketRequested?: boolean | null;
   // Why an awaiting_events run is parked when it is not waiting on a PR.
   waitReason?: "external_cause" | null;
   externalCause?: AgentRunExternalCause | null;

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -249,7 +249,7 @@ This tool is only for defects with real user or business impact. Noise is classi
 
 #### 3. `complete_investigation`
 
-Available only when PR creation is disabled or unavailable and no approval-prompt action is available. It finishes a findings-only investigation while leaving the Incident open. When Linear is connected, it triggers the Linear handoff. Requires `report_findings`; does not classify issues. No params.
+Available whenever PR creation is disabled or unavailable. It finishes a findings-only investigation while leaving the Incident open; approval prompts remain available separately when a specific authorization is required. When Linear is connected, the platform deterministically triggers the Linear handoff from this outcome — Linear issue creation is not an agent tool. Requires `report_findings`; does not classify issues. No params.
 
 #### 4. `ask_human`
 
@@ -330,3 +330,4 @@ July 9, 2026 - merged the managed-agent spec into this document
 July 10, 2026 - agent loop rework: full-text reasons, non-terminal propose_pr (multiple PRs, keyed by branch), per-issue classification tools, terminal resolve_incident, awaiting_events parking, PR merge/close resumes the session
 July 14, 2026 - deterministic Linear handoff: when Linear is connected, each explicitly completed investigation gets its own ticket, while PR-producing runs create/reuse their run-scoped ticket on the first recorded PR and cross-link every later PR; resolve-time filing is configurable; completed Linear tickets resolve incidents and count as accepted remediation. Projects without PR or approval actions finish through complete_investigation.
 July 14, 2026 - desired agent contract: terminal batched PR proposals (one PR and patch per repository), atomic per-Issue outcomes inside resolve_incident, report_external_cause waiting with the Incident open, and Approval prompts documented as in progress
+July 22, 2026 - restored deterministic findings handoff: `complete_investigation` is the only findings-only terminal when PR creation is unavailable, and the platform creates or reuses the connected Linear issue as a completion side effect rather than exposing Linear mutation as an agent tool.


### PR DESCRIPTION
## Summary

- remove provider-specific issue creation from the agent outcome tool contract
- expose complete_investigation whenever pull-request creation is unavailable
- create or reuse the configured external handoff deterministically during completion
- redirect immutable legacy sessions to the supported completion outcome

## Validation

- 101 focused worker tests pass
- worker and database typechecks pass
- production-shaped incident replay selects complete_investigation with no pull request or incident resolution

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `complete_investigation` the only findings-only terminal outcome and deterministically trigger the Linear handoff on completion, with scoped telemetry for legacy handoff interception and safe drain of frozen sessions.

- **New Features**
  - `complete_investigation` always triggers the Linear handoff when connected.
  - Legacy `create_linear_issue` calls are mapped to `complete_investigation`, preserving `linearTicketRequested` in the result.
  - Findings-only completion is shown whenever PR creation is unavailable; nudge prompts use `complete_investigation` and keep `create_linear_issue` only for legacy sessions.
  - Legacy handoff interception is logged with scoped telemetry and left to terminal collection.

- **Migration**
  - Stop calling `create_linear_issue`; invoke `complete_investigation` after `report_findings`.
  - Remove `linearTicketCreationAvailable` from runner inputs and capability checks.
  - Do not set `AgentRunResult.linearTicketRequested` in new runs; it remains only as a drain marker for pre-cutover sessions.

<sup>Written for commit 5dc964015335efdb528172ab7998cbd97595311e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

