### PR TITLE
Bound oversized issue-grouping context

### DIFF
--- a/apps/worker/src/grouping/agent.test.ts
+++ b/apps/worker/src/grouping/agent.test.ts
@@ -460,6 +460,84 @@ test("runGroupingAgent: an omitted inspection must be repeated before joining", 
   });
 });
 
+test("runGroupingAgent: preserves every inspection result from the latest tool turn", async () => {
+  const oversizedMessage = `Build failed\n${"generatedCall();".repeat(40_000)}\nat normalizeUrl`;
+  const candidates = Array.from({ length: 8 }, (_, candidateIndex) =>
+    makeCandidate(`target-${candidateIndex}`, {
+      representative: {
+        exceptionType: "Error",
+        message: oversizedMessage,
+        topFrame: "normalizeUrl",
+        normalizedFrames: ["normalizeUrl"],
+        traceId: null,
+        spanId: null,
+      },
+      issues: Array.from({ length: 5 }, (_, issueIndex) => ({
+        id: `target-${candidateIndex}-issue-${issueIndex}`,
+        title: "Build failed",
+        service: "web",
+        exceptionType: "Error",
+        message: oversizedMessage,
+        topFrame: "normalizeUrl",
+        normalizedFrames: ["normalizeUrl"],
+        traceId: null,
+        spanId: null,
+        lastSeen: "2026-05-23T00:00:00Z",
+      })),
+    }),
+  );
+  let turn = 0;
+  let latestResultsWereVisible = false;
+  let latestRequestChars = 0;
+  const client: GroupingLLMClient = {
+    async send(input) {
+      turn += 1;
+      if (turn === 1) {
+        return makeMessage(
+          candidates.map((candidate, index) =>
+            toolUse("inspect_incident", { incident_id: candidate.id }, `inspect-${index}`),
+          ),
+        );
+      }
+
+      const messages = JSON.stringify(input.messages);
+      latestRequestChars = messages.length;
+      latestResultsWereVisible = candidates.every(
+        (_, index) =>
+          messages.includes(`target-${index}-issue-4`) &&
+          !messages.includes(
+            `\"tool_use_id\":\"inspect-${index}\",\"content\":\"[earlier tool result omitted`,
+          ),
+      );
+      return makeMessage([
+        toolUse(
+          "decide_grouping",
+          { decision: "standalone", evidence: "The inspected incidents are unrelated" },
+          "decide",
+        ),
+      ]);
+    },
+  };
+
+  const verdict = await runGroupingAgent(
+    { projectName: "p", newIssue: NEW_ISSUE, candidates },
+    {
+      client,
+      model: "test-model",
+      maxIterations: 3,
+      accountant: { record() {} },
+    },
+  );
+
+  assert.equal(latestResultsWereVisible, true);
+  assert.ok(latestRequestChars > 550_000, `latest request was ${latestRequestChars}`);
+  assert.ok(latestRequestChars < 650_000, `latest request was ${latestRequestChars}`);
+  assert.deepEqual(verdict, {
+    decision: "standalone",
+    evidence: "The inspected incidents are unrelated",
+  });
+});
+
 test("runGroupingAgent: text-only fallback parses JSON verdict from text", async () => {
   const deps = makeDeps([
     [

--- a/apps/worker/src/grouping/agent.test.ts
+++ b/apps/worker/src/grouping/agent.test.ts
@@ -530,8 +530,7 @@ test("runGroupingAgent: preserves every inspection result from the latest tool t
   );
 
   assert.equal(latestResultsWereVisible, true);
-  assert.ok(latestRequestChars > 550_000, `latest request was ${latestRequestChars}`);
-  assert.ok(latestRequestChars < 650_000, `latest request was ${latestRequestChars}`);
+  assert.ok(latestRequestChars < 550_000, `latest request was ${latestRequestChars}`);
   assert.deepEqual(verdict, {
     decision: "standalone",
     evidence: "The inspected incidents are unrelated",

--- a/apps/worker/src/grouping/agent.test.ts
+++ b/apps/worker/src/grouping/agent.test.ts
@@ -157,6 +157,57 @@ test("runGroupingAgent: join requires prior inspect_incident (else the tool resu
   }
 });
 
+test("runGroupingAgent: inspect and join in the same model turn requires a later decision", async () => {
+  let turn = 0;
+  let inspectionWasVisible = false;
+  const client: GroupingLLMClient = {
+    async send(input) {
+      turn += 1;
+      if (turn === 1) {
+        return makeMessage([
+          toolUse("inspect_incident", { incident_id: "a" }, "inspect"),
+          toolUse(
+            "decide_grouping",
+            {
+              decision: "join",
+              incidentId: "a",
+              evidence: "both fail on the same upstream postgres host and port",
+            },
+            "premature-decision",
+          ),
+        ]);
+      }
+
+      inspectionWasVisible = JSON.stringify(input.messages).includes('"tool_use_id":"inspect"');
+      return makeMessage([
+        toolUse(
+          "decide_grouping",
+          {
+            decision: "join",
+            incidentId: "a",
+            evidence: "both fail on the same upstream postgres host and port",
+          },
+          "later-decision",
+        ),
+      ]);
+    },
+  };
+
+  const verdict = await runGroupingAgent(
+    { projectName: "p", newIssue: NEW_ISSUE, candidates: [makeCandidate("a")] },
+    {
+      client,
+      model: "test-model",
+      maxIterations: 3,
+      accountant: { record() {} },
+    },
+  );
+
+  assert.equal(turn, 2);
+  assert.equal(inspectionWasVisible, true);
+  assert.equal(verdict.decision, "join");
+});
+
 test("runGroupingAgent: malformed decide_grouping input → is_error result, agent gets another shot", async () => {
   const deps = makeDeps([
     [toolUse("decide_grouping", { decision: "yes-maybe" }, "t_bad")],
@@ -356,7 +407,7 @@ test("runGroupingAgent: repeated oversized inspections keep the conversation bel
   );
 });
 
-test("runGroupingAgent: an omitted inspection must be repeated before joining", async () => {
+test("runGroupingAgent: a retained inspection remains valid while later results are compacted", async () => {
   const oversizedMessage = `Build failed\n${"generatedCall();".repeat(40_000)}\nat normalizeUrl`;
   const oversizedCandidate = (id: string) =>
     makeCandidate(id, {
@@ -451,12 +502,12 @@ test("runGroupingAgent: an omitted inspection must be repeated before joining", 
     },
   );
 
-  assert.equal(turn, 13);
-  assert.equal(sawReinspectionError, true);
+  assert.equal(turn, 11);
+  assert.equal(sawReinspectionError, false);
   assert.deepEqual(verdict, {
     decision: "join",
     incidentId: oldTarget.id,
-    evidence: "the refreshed inspection shows the same module and stack frame",
+    evidence: "the old target originally showed the same module and stack frame",
   });
 });
 
@@ -535,6 +586,74 @@ test("runGroupingAgent: preserves every inspection result from the latest tool t
     decision: "standalone",
     evidence: "The inspected incidents are unrelated",
   });
+});
+
+test("runGroupingAgent: inspection burst uses only the remaining conversation headroom", async () => {
+  const oversizedMessage = `Build failed\n${"generatedCall();".repeat(40_000)}\nat normalizeUrl`;
+  const candidates = Array.from({ length: 200 }, (_, candidateIndex) =>
+    makeCandidate(`target-${candidateIndex}`, {
+      title: `Build failed ${"candidate-title".repeat(65)} ${candidateIndex}`,
+      representative: {
+        exceptionType: "Error",
+        message: oversizedMessage,
+        topFrame: "normalizeUrl",
+        normalizedFrames: ["normalizeUrl"],
+        traceId: null,
+        spanId: null,
+      },
+      issues: Array.from({ length: 5 }, (_, issueIndex) => ({
+        id: `target-${candidateIndex}-issue-${issueIndex}`,
+        title: "Build failed",
+        service: "web",
+        exceptionType: "Error",
+        message: oversizedMessage,
+        topFrame: "normalizeUrl",
+        normalizedFrames: ["normalizeUrl"],
+        traceId: null,
+        spanId: null,
+        logAttrs: { "code.file.path": "a/very/long/path/".repeat(18) },
+        lastSeen: "2026-05-23T00:00:00Z",
+      })),
+    }),
+  );
+  const requestChars: number[] = [];
+  let turn = 0;
+  const client: GroupingLLMClient = {
+    async send(input) {
+      requestChars.push(JSON.stringify(input.messages).length);
+      turn += 1;
+      if (turn === 1) {
+        return makeMessage(
+          candidates.slice(0, 8).map((candidate, index) =>
+            toolUse("inspect_incident", { incident_id: candidate.id }, `inspect-${index}`),
+          ),
+        );
+      }
+      return makeMessage([
+        toolUse(
+          "decide_grouping",
+          { decision: "standalone", evidence: "The inspected incidents are unrelated" },
+          "decide",
+        ),
+      ]);
+    },
+  };
+
+  await runGroupingAgent(
+    { projectName: "p", newIssue: NEW_ISSUE, candidates },
+    {
+      client,
+      model: "test-model",
+      maxIterations: 3,
+      accountant: { record() {} },
+    },
+  );
+
+  assert.equal(requestChars.length, 2);
+  const [initialRequestChars = Number.POSITIVE_INFINITY, inspectionRequestChars = Number.POSITIVE_INFINITY] =
+    requestChars;
+  assert.ok(initialRequestChars < 550_000, `initial request was ${initialRequestChars}`);
+  assert.ok(inspectionRequestChars < 550_000, `inspection request was ${inspectionRequestChars}`);
 });
 
 test("runGroupingAgent: text-only fallback parses JSON verdict from text", async () => {

--- a/apps/worker/src/grouping/agent.test.ts
+++ b/apps/worker/src/grouping/agent.test.ts
@@ -356,6 +356,110 @@ test("runGroupingAgent: repeated oversized inspections keep the conversation bel
   );
 });
 
+test("runGroupingAgent: an omitted inspection must be repeated before joining", async () => {
+  const oversizedMessage = `Build failed\n${"generatedCall();".repeat(40_000)}\nat normalizeUrl`;
+  const oversizedCandidate = (id: string) =>
+    makeCandidate(id, {
+      representative: {
+        exceptionType: "Error",
+        message: oversizedMessage,
+        topFrame: "normalizeUrl",
+        normalizedFrames: ["normalizeUrl"],
+        traceId: null,
+        spanId: null,
+      },
+      issues: Array.from({ length: 5 }, (_, index) => ({
+        id: `${id}-issue-${index}`,
+        title: "Build failed",
+        service: "web",
+        exceptionType: "Error",
+        message: oversizedMessage,
+        topFrame: "normalizeUrl",
+        normalizedFrames: ["normalizeUrl"],
+        traceId: null,
+        spanId: null,
+        lastSeen: "2026-05-23T00:00:00Z",
+      })),
+    });
+  const oldTarget = oversizedCandidate("old-target");
+  const recentTarget = oversizedCandidate("recent-target");
+  let turn = 0;
+  let sawReinspectionError = false;
+  const client: GroupingLLMClient = {
+    async send(input) {
+      turn += 1;
+      if (turn === 1) {
+        return makeMessage([
+          toolUse("inspect_incident", { incident_id: oldTarget.id }, "inspect-old"),
+        ]);
+      }
+      if (turn <= 10) {
+        return makeMessage([
+          toolUse(
+            "inspect_incident",
+            { incident_id: recentTarget.id },
+            `inspect-recent-${turn}`,
+          ),
+        ]);
+      }
+      if (turn === 11) {
+        return makeMessage([
+          toolUse(
+            "decide_grouping",
+            {
+              decision: "join",
+              incidentId: oldTarget.id,
+              evidence: "the old target originally showed the same module and stack frame",
+            },
+            "premature-decide",
+          ),
+        ]);
+      }
+      if (turn === 12) {
+        sawReinspectionError = JSON.stringify(input.messages).includes(
+          "Before joining, call inspect_incident",
+        );
+        return makeMessage([
+          toolUse("inspect_incident", { incident_id: oldTarget.id }, "reinspect-old"),
+        ]);
+      }
+      return makeMessage([
+        toolUse(
+          "decide_grouping",
+          {
+            decision: "join",
+            incidentId: oldTarget.id,
+            evidence: "the refreshed inspection shows the same module and stack frame",
+          },
+          "final-decide",
+        ),
+      ]);
+    },
+  };
+
+  const verdict = await runGroupingAgent(
+    {
+      projectName: "p",
+      newIssue: NEW_ISSUE,
+      candidates: [oldTarget, recentTarget],
+    },
+    {
+      client,
+      model: "test-model",
+      maxIterations: 14,
+      accountant: { record() {} },
+    },
+  );
+
+  assert.equal(turn, 13);
+  assert.equal(sawReinspectionError, true);
+  assert.deepEqual(verdict, {
+    decision: "join",
+    incidentId: oldTarget.id,
+    evidence: "the refreshed inspection shows the same module and stack frame",
+  });
+});
+
 test("runGroupingAgent: text-only fallback parses JSON verdict from text", async () => {
   const deps = makeDeps([
     [

--- a/apps/worker/src/grouping/agent.test.ts
+++ b/apps/worker/src/grouping/agent.test.ts
@@ -3,7 +3,11 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import type Anthropic from "@anthropic-ai/sdk";
 import { type GroupingLLMClient, runGroupingAgent } from "./agent.js";
-import type { GroupingCandidateIncident, GroupingNewIssue } from "./domain.js";
+import {
+  type GroupingCandidateIncident,
+  type GroupingNewIssue,
+  compactDiagnosticText,
+} from "./domain.js";
 
 function makeMessage(blocks: Anthropic.Messages.ContentBlock[]): Anthropic.Messages.Message {
   return {
@@ -186,6 +190,170 @@ test("runGroupingAgent: search → inspect → decide chain", async () => {
     deps,
   );
   assert.equal(verdict.decision, "join");
+});
+
+test("runGroupingAgent: 100-candidate oversized bundler replay stays bounded and joins", async () => {
+  const headline = 'Failed to resolve import "./missing.png" from "app/cart.tsx"';
+  const oversizedMessage = `${headline}\nPlugin: vite:import-analysis\n${"generatedCall();".repeat(
+    40_000,
+  )}\nat normalizeUrl`;
+  const target = makeCandidate("target", {
+    title: headline,
+    service: "web",
+    representative: {
+      exceptionType: "Error",
+      message: oversizedMessage,
+      topFrame: "normalizeUrl",
+      normalizedFrames: ["normalizeUrl"],
+      traceId: null,
+      spanId: null,
+    },
+    issues: [
+      {
+        id: "old-issue",
+        title: headline,
+        service: "web",
+        exceptionType: "Error",
+        message: oversizedMessage,
+        topFrame: "normalizeUrl",
+        normalizedFrames: ["normalizeUrl"],
+        traceId: null,
+        spanId: null,
+        lastSeen: "2026-05-23T00:00:00Z",
+      },
+    ],
+  });
+  const candidates = [
+    target,
+    ...Array.from({ length: 99 }, (_, index) =>
+      makeCandidate(`unrelated-${index}`, {
+        title: `Unrelated failure ${index}`,
+        lastSeen: new Date(Date.UTC(2026, 4, 22, 0, index)).toISOString(),
+      }),
+    ),
+  ];
+  const requestChars: number[] = [];
+  let turn = 0;
+  const client: GroupingLLMClient = {
+    async send(input) {
+      requestChars.push(JSON.stringify(input.messages).length);
+      turn += 1;
+      if (turn === 1) {
+        return makeMessage([toolUse("search_incidents", { query: "missing.png vite" }, "search")]);
+      }
+      if (turn === 2) {
+        return makeMessage([toolUse("inspect_incident", { incident_id: "target" }, "inspect")]);
+      }
+      return makeMessage([
+        toolUse(
+          "decide_grouping",
+          {
+            decision: "join",
+            incidentId: "target",
+            evidence: "both errors are the same unresolved asset import in the same module",
+          },
+          "decide",
+        ),
+      ]);
+    },
+  };
+  const newIssue: GroupingNewIssue = {
+    ...NEW_ISSUE,
+    title: headline,
+    service: "web",
+    exceptionType: "Error",
+    message: compactDiagnosticText(oversizedMessage),
+    topFrame: "normalizeUrl",
+    normalizedFrames: ["normalizeUrl"],
+  };
+
+  const verdict = await runGroupingAgent(
+    { projectName: "p", newIssue, candidates },
+    {
+      client,
+      model: "test-model",
+      maxIterations: 5,
+      accountant: { record() {} },
+    },
+  );
+
+  assert.equal(oversizedMessage.length > 600_000, true);
+  assert.deepEqual(verdict, {
+    decision: "join",
+    incidentId: "target",
+    evidence: "both errors are the same unresolved asset import in the same module",
+  });
+  assert.equal(requestChars.length, 3);
+  assert.ok(
+    Math.max(...requestChars) < 100_000,
+    `largest request was ${Math.max(...requestChars)}`,
+  );
+});
+
+test("runGroupingAgent: repeated oversized inspections keep the conversation below 600 KB", async () => {
+  const oversizedMessage = `Build failed\n${"generatedCall();".repeat(40_000)}\nat normalizeUrl`;
+  const target = makeCandidate("target", {
+    representative: {
+      exceptionType: "Error",
+      message: oversizedMessage,
+      topFrame: "normalizeUrl",
+      normalizedFrames: ["normalizeUrl"],
+      traceId: null,
+      spanId: null,
+    },
+    issues: Array.from({ length: 5 }, (_, index) => ({
+      id: `old-issue-${index}`,
+      title: "Build failed",
+      service: "web",
+      exceptionType: "Error",
+      message: oversizedMessage,
+      topFrame: "normalizeUrl",
+      normalizedFrames: ["normalizeUrl"],
+      traceId: null,
+      spanId: null,
+      lastSeen: "2026-05-23T00:00:00Z",
+    })),
+  });
+  const requestChars: number[] = [];
+  let turn = 0;
+  const client: GroupingLLMClient = {
+    async send(input) {
+      requestChars.push(JSON.stringify(input.messages).length);
+      turn += 1;
+      if (turn <= 10) {
+        return makeMessage([
+          toolUse("inspect_incident", { incident_id: "target" }, `inspect-${turn}`),
+        ]);
+      }
+      return makeMessage([
+        toolUse(
+          "decide_grouping",
+          {
+            decision: "join",
+            incidentId: "target",
+            evidence: "the inspected diagnostics share the same failing module and stack frame",
+          },
+          "decide",
+        ),
+      ]);
+    },
+  };
+
+  const verdict = await runGroupingAgent(
+    { projectName: "p", newIssue: NEW_ISSUE, candidates: [target] },
+    {
+      client,
+      model: "test-model",
+      maxIterations: 12,
+      accountant: { record() {} },
+    },
+  );
+
+  assert.equal(verdict.decision, "join");
+  assert.ok(
+    Math.max(...requestChars) < 600_000,
+    `largest request was ${Math.max(...requestChars)}`,
+  );
 });
 
 test("runGroupingAgent: text-only fallback parses JSON verdict from text", async () => {

--- a/apps/worker/src/grouping/agent.ts
+++ b/apps/worker/src/grouping/agent.ts
@@ -67,21 +67,24 @@ function boundConversationContext(
 ): string[] {
   if (JSON.stringify(conversation).length <= MAX_GROUPING_CONVERSATION_CHARS) return [];
 
-  const priorResults: Anthropic.Messages.ToolResultBlockParam[] = [];
+  const resultTurns: Anthropic.Messages.ToolResultBlockParam[][] = [];
   for (const turn of conversation) {
     if (turn.role !== "user" || !Array.isArray(turn.content)) continue;
+    const turnResults: Anthropic.Messages.ToolResultBlockParam[] = [];
     for (const block of turn.content) {
       if (block.type === "tool_result" && typeof block.content === "string") {
-        priorResults.push(block);
+        turnResults.push(block);
       }
     }
+    if (turnResults.length > 0) resultTurns.push(turnResults);
   }
 
-  // Preserve the newest result: it is normally the inspect the model needs
-  // for its next decision. Older results remain structurally paired with
-  // their tool calls, but their bulky payload can be fetched again if useful.
+  // Preserve every result from the newest tool turn: the model has not seen
+  // any of them yet. Older results remain structurally paired with their tool
+  // calls, but their bulky payload can be fetched again if useful.
+  const priorResults = resultTurns.slice(0, -1).flat();
   const omittedToolUseIds: string[] = [];
-  for (const result of priorResults.slice(0, -1)) {
+  for (const result of priorResults) {
     if (JSON.stringify(conversation).length <= MAX_GROUPING_CONVERSATION_CHARS) break;
     if (result.content === OMITTED_TOOL_RESULT) continue;
     result.content = OMITTED_TOOL_RESULT;

--- a/apps/worker/src/grouping/agent.ts
+++ b/apps/worker/src/grouping/agent.ts
@@ -61,6 +61,7 @@ export type RunGroupingAgentDeps = {
 const MAX_GROUPING_CONVERSATION_CHARS = 550_000;
 const MAX_FRESH_INSPECTION_TURN_CHARS = 400_000;
 const MAX_SINGLE_INSPECTION_CHARS = 80_000;
+const FRESH_TOOL_TURN_STRUCTURE_RESERVE_CHARS = 10_000;
 const OMITTED_TOOL_RESULT =
   "[earlier tool result omitted to keep grouping context bounded; call the tool again if needed]";
 
@@ -114,10 +115,12 @@ export async function runGroupingAgent(
     visibleCandidateIds: new Set<string>(),
     candidateByToolUseId: new Map<string, string>(),
     latestToolUseIdByCandidate: new Map<string, string>(),
+    pendingToolUseIds: new Set<string>(),
   };
 
   for (let iter = 0; iter < deps.maxIterations; iter++) {
-    for (const toolUseId of boundConversationContext(conversation)) {
+    const omittedToolUseIds = new Set(boundConversationContext(conversation));
+    for (const toolUseId of omittedToolUseIds) {
       const incidentId = inspectionState.candidateByToolUseId.get(toolUseId);
       if (
         incidentId &&
@@ -126,6 +129,17 @@ export async function runGroupingAgent(
         inspectionState.visibleCandidateIds.delete(incidentId);
       }
     }
+    for (const toolUseId of inspectionState.pendingToolUseIds) {
+      const incidentId = inspectionState.candidateByToolUseId.get(toolUseId);
+      if (
+        incidentId &&
+        !omittedToolUseIds.has(toolUseId) &&
+        inspectionState.latestToolUseIdByCandidate.get(incidentId) === toolUseId
+      ) {
+        inspectionState.visibleCandidateIds.add(incidentId);
+      }
+    }
+    inspectionState.pendingToolUseIds.clear();
     const message = await deps.client.send({
       model: deps.model,
       system: GROUPING_SYSTEM_PROMPT,
@@ -173,9 +187,19 @@ export async function runGroupingAgent(
     const inspectionCount = toolUses.filter(
       (toolUse) => toolUse.name === "inspect_incident",
     ).length;
+    const remainingConversationChars = Math.max(
+      1,
+      MAX_GROUPING_CONVERSATION_CHARS -
+        JSON.stringify(conversation).length -
+        FRESH_TOOL_TURN_STRUCTURE_RESERVE_CHARS,
+    );
+    const freshInspectionTurnChars = Math.min(
+      MAX_FRESH_INSPECTION_TURN_CHARS,
+      remainingConversationChars,
+    );
     const inspectionResultMaxChars = Math.min(
       MAX_SINGLE_INSPECTION_CHARS,
-      Math.floor(MAX_FRESH_INSPECTION_TURN_CHARS / Math.max(1, inspectionCount)),
+      Math.max(1, Math.floor(freshInspectionTurnChars / Math.max(1, inspectionCount))),
     );
 
     for (const toolUse of toolUses) {
@@ -212,6 +236,7 @@ type InspectionState = {
   visibleCandidateIds: Set<string>;
   candidateByToolUseId: Map<string, string>;
   latestToolUseIdByCandidate: Map<string, string>;
+  pendingToolUseIds: Set<string>;
 };
 
 function dispatchTool(
@@ -258,9 +283,9 @@ function dispatchTool(
           : {};
       const incidentId = typeof obj.incident_id === "string" ? obj.incident_id : "";
       if (candidateIds.has(incidentId)) {
-        inspectionState.visibleCandidateIds.add(incidentId);
         inspectionState.candidateByToolUseId.set(toolUse.id, incidentId);
         inspectionState.latestToolUseIdByCandidate.set(incidentId, toolUse.id);
+        inspectionState.pendingToolUseIds.add(toolUse.id);
       }
       return {
         kind: "continue",

--- a/apps/worker/src/grouping/agent.ts
+++ b/apps/worker/src/grouping/agent.ts
@@ -3,7 +3,7 @@
 
 import type Anthropic from "@anthropic-ai/sdk";
 import {
-  inspectCandidate,
+  inspectCandidateResult,
   listIncidentFacets,
   listIncidentTitles,
   searchCandidates,
@@ -59,6 +59,8 @@ export type RunGroupingAgentDeps = {
 };
 
 const MAX_GROUPING_CONVERSATION_CHARS = 550_000;
+const MAX_FRESH_INSPECTION_TURN_CHARS = 400_000;
+const MAX_SINGLE_INSPECTION_CHARS = 80_000;
 const OMITTED_TOOL_RESULT =
   "[earlier tool result omitted to keep grouping context bounded; call the tool again if needed]";
 
@@ -168,9 +170,22 @@ export async function runGroupingAgent(
 
     const toolResults: Anthropic.Messages.ToolResultBlockParam[] = [];
     let terminal: GroupingVerdict | null = null;
+    const inspectionCount = toolUses.filter(
+      (toolUse) => toolUse.name === "inspect_incident",
+    ).length;
+    const inspectionResultMaxChars = Math.min(
+      MAX_SINGLE_INSPECTION_CHARS,
+      Math.floor(MAX_FRESH_INSPECTION_TURN_CHARS / Math.max(1, inspectionCount)),
+    );
 
     for (const toolUse of toolUses) {
-      const dispatch = dispatchTool(toolUse, input.candidates, candidateIds, inspectionState);
+      const dispatch = dispatchTool(
+        toolUse,
+        input.candidates,
+        candidateIds,
+        inspectionState,
+        inspectionResultMaxChars,
+      );
       if (dispatch.kind === "terminal") {
         terminal = dispatch.verdict;
         break;
@@ -204,6 +219,7 @@ function dispatchTool(
   candidates: GroupingCandidateIncident[],
   candidateIds: ReadonlySet<string>,
   inspectionState: InspectionState,
+  inspectionResultMaxChars: number,
 ): DispatchResult {
   switch (toolUse.name) {
     case "decide_grouping":
@@ -251,7 +267,11 @@ function dispatchTool(
         result: {
           type: "tool_result",
           tool_use_id: toolUse.id,
-          content: JSON.stringify(inspectCandidate(candidates, toolUse.input)),
+          content: inspectCandidateResult(
+            candidates,
+            toolUse.input,
+            inspectionResultMaxChars,
+          ),
         },
       };
     }

--- a/apps/worker/src/grouping/agent.ts
+++ b/apps/worker/src/grouping/agent.ts
@@ -58,6 +58,32 @@ export type RunGroupingAgentDeps = {
   maxIterations: number;
 };
 
+const MAX_GROUPING_CONVERSATION_CHARS = 550_000;
+const OMITTED_TOOL_RESULT =
+  "[earlier tool result omitted to keep grouping context bounded; call the tool again if needed]";
+
+function boundConversationContext(conversation: Anthropic.Messages.MessageParam[]): void {
+  if (JSON.stringify(conversation).length <= MAX_GROUPING_CONVERSATION_CHARS) return;
+
+  const priorResults: Anthropic.Messages.ToolResultBlockParam[] = [];
+  for (const turn of conversation) {
+    if (turn.role !== "user" || !Array.isArray(turn.content)) continue;
+    for (const block of turn.content) {
+      if (block.type === "tool_result" && typeof block.content === "string") {
+        priorResults.push(block);
+      }
+    }
+  }
+
+  // Preserve the newest result: it is normally the inspect the model needs
+  // for its next decision. Older results remain structurally paired with
+  // their tool calls, but their bulky payload can be fetched again if useful.
+  for (const result of priorResults.slice(0, -1)) {
+    if (JSON.stringify(conversation).length <= MAX_GROUPING_CONVERSATION_CHARS) break;
+    result.content = OMITTED_TOOL_RESULT;
+  }
+}
+
 function extractText(message: Anthropic.Messages.Message): string {
   return message.content
     .map((block) => (block.type === "text" ? block.text : ""))
@@ -76,6 +102,7 @@ export async function runGroupingAgent(
   const inspectedCandidateIds = new Set<string>();
 
   for (let iter = 0; iter < deps.maxIterations; iter++) {
+    boundConversationContext(conversation);
     const message = await deps.client.send({
       model: deps.model,
       system: GROUPING_SYSTEM_PROMPT,

--- a/apps/worker/src/grouping/agent.ts
+++ b/apps/worker/src/grouping/agent.ts
@@ -62,8 +62,10 @@ const MAX_GROUPING_CONVERSATION_CHARS = 550_000;
 const OMITTED_TOOL_RESULT =
   "[earlier tool result omitted to keep grouping context bounded; call the tool again if needed]";
 
-function boundConversationContext(conversation: Anthropic.Messages.MessageParam[]): void {
-  if (JSON.stringify(conversation).length <= MAX_GROUPING_CONVERSATION_CHARS) return;
+function boundConversationContext(
+  conversation: Anthropic.Messages.MessageParam[],
+): string[] {
+  if (JSON.stringify(conversation).length <= MAX_GROUPING_CONVERSATION_CHARS) return [];
 
   const priorResults: Anthropic.Messages.ToolResultBlockParam[] = [];
   for (const turn of conversation) {
@@ -78,10 +80,14 @@ function boundConversationContext(conversation: Anthropic.Messages.MessageParam[
   // Preserve the newest result: it is normally the inspect the model needs
   // for its next decision. Older results remain structurally paired with
   // their tool calls, but their bulky payload can be fetched again if useful.
+  const omittedToolUseIds: string[] = [];
   for (const result of priorResults.slice(0, -1)) {
     if (JSON.stringify(conversation).length <= MAX_GROUPING_CONVERSATION_CHARS) break;
+    if (result.content === OMITTED_TOOL_RESULT) continue;
     result.content = OMITTED_TOOL_RESULT;
+    omittedToolUseIds.push(result.tool_use_id);
   }
+  return omittedToolUseIds;
 }
 
 function extractText(message: Anthropic.Messages.Message): string {
@@ -99,10 +105,22 @@ export async function runGroupingAgent(
   const conversation: Anthropic.Messages.MessageParam[] = [
     { role: "user", content: buildInitialUserMessage(input) },
   ];
-  const inspectedCandidateIds = new Set<string>();
+  const inspectionState = {
+    visibleCandidateIds: new Set<string>(),
+    candidateByToolUseId: new Map<string, string>(),
+    latestToolUseIdByCandidate: new Map<string, string>(),
+  };
 
   for (let iter = 0; iter < deps.maxIterations; iter++) {
-    boundConversationContext(conversation);
+    for (const toolUseId of boundConversationContext(conversation)) {
+      const incidentId = inspectionState.candidateByToolUseId.get(toolUseId);
+      if (
+        incidentId &&
+        inspectionState.latestToolUseIdByCandidate.get(incidentId) === toolUseId
+      ) {
+        inspectionState.visibleCandidateIds.delete(incidentId);
+      }
+    }
     const message = await deps.client.send({
       model: deps.model,
       system: GROUPING_SYSTEM_PROMPT,
@@ -149,7 +167,7 @@ export async function runGroupingAgent(
     let terminal: GroupingVerdict | null = null;
 
     for (const toolUse of toolUses) {
-      const dispatch = dispatchTool(toolUse, input.candidates, candidateIds, inspectedCandidateIds);
+      const dispatch = dispatchTool(toolUse, input.candidates, candidateIds, inspectionState);
       if (dispatch.kind === "terminal") {
         terminal = dispatch.verdict;
         break;
@@ -172,15 +190,21 @@ type DispatchResult =
   | { kind: "terminal"; verdict: GroupingVerdict }
   | { kind: "continue"; result: Anthropic.Messages.ToolResultBlockParam };
 
+type InspectionState = {
+  visibleCandidateIds: Set<string>;
+  candidateByToolUseId: Map<string, string>;
+  latestToolUseIdByCandidate: Map<string, string>;
+};
+
 function dispatchTool(
   toolUse: Anthropic.Messages.ToolUseBlock,
   candidates: GroupingCandidateIncident[],
   candidateIds: ReadonlySet<string>,
-  inspectedCandidateIds: Set<string>,
+  inspectionState: InspectionState,
 ): DispatchResult {
   switch (toolUse.name) {
     case "decide_grouping":
-      return dispatchDecide(toolUse, candidateIds, inspectedCandidateIds);
+      return dispatchDecide(toolUse, candidateIds, inspectionState.visibleCandidateIds);
     case "search_incidents":
       return {
         kind: "continue",
@@ -214,7 +238,11 @@ function dispatchTool(
           ? (toolUse.input as Record<string, unknown>)
           : {};
       const incidentId = typeof obj.incident_id === "string" ? obj.incident_id : "";
-      if (candidateIds.has(incidentId)) inspectedCandidateIds.add(incidentId);
+      if (candidateIds.has(incidentId)) {
+        inspectionState.visibleCandidateIds.add(incidentId);
+        inspectionState.candidateByToolUseId.set(toolUse.id, incidentId);
+        inspectionState.latestToolUseIdByCandidate.set(incidentId, toolUse.id);
+      }
       return {
         kind: "continue",
         result: {

--- a/apps/worker/src/grouping/candidate-search.test.ts
+++ b/apps/worker/src/grouping/candidate-search.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import {
   candidatePreview,
   inspectCandidate,
+  inspectCandidateResult,
   listIncidentFacets,
   listIncidentTitles,
   searchCandidates,
@@ -261,4 +262,44 @@ test("inspectCandidate bounds oversized messages while retaining detailed contex
     message,
     "tool projection must not mutate source data",
   );
+});
+
+test("inspectCandidateResult enforces a whole-result budget and keeps diagnostic edges", () => {
+  const headline = 'Failed to resolve import "./missing.png" from "app/feature.tsx"';
+  const message = `${headline}\n${"generatedCall();".repeat(40_000)}\nat normalizeUrl`;
+  const candidate = makeCandidate({
+    representative: {
+      exceptionType: "Error",
+      message,
+      topFrame: "normalizeUrl",
+      normalizedFrames: ["normalizeUrl"],
+      traceId: null,
+      spanId: null,
+    },
+    issues: Array.from({ length: 5 }, (_, index) => ({
+      id: `issue-${index}`,
+      title: headline,
+      service: "web",
+      exceptionType: "Error",
+      message,
+      topFrame: "normalizeUrl",
+      normalizedFrames: ["normalizeUrl"],
+      traceId: null,
+      spanId: null,
+      lastSeen: "2026-05-23T00:00:00Z",
+    })),
+  });
+
+  const result = inspectCandidateResult([candidate], { incident_id: "inc-1" }, 20_000);
+  const parsed = JSON.parse(result) as {
+    truncated: boolean;
+    representative: { message: string };
+    issues: Array<{ id: string; message: string }>;
+  };
+
+  assert.ok(result.length <= 20_000, `inspection result was ${result.length}`);
+  assert.equal(parsed.truncated, true);
+  assert.match(parsed.representative.message, /Failed to resolve import/);
+  assert.equal(parsed.issues[4]?.id, "issue-4");
+  assert.match(parsed.issues[4]?.message ?? "", /at normalizeUrl/);
 });

--- a/apps/worker/src/grouping/candidate-search.test.ts
+++ b/apps/worker/src/grouping/candidate-search.test.ts
@@ -52,6 +52,27 @@ test("candidatePreview includes services, environments, latestInvestigation summ
   });
 });
 
+test("candidatePreview compacts an oversized diagnostic message", () => {
+  const headline = 'Failed to resolve import "./missing.png" from "app/feature.tsx"';
+  const candidate = makeCandidate({
+    representative: {
+      exceptionType: "Error",
+      message: `${headline}\n${"generatedCall();".repeat(40_000)}\nat normalizeUrl`,
+      topFrame: "normalizeUrl",
+      normalizedFrames: ["normalizeUrl"],
+      traceId: null,
+      spanId: null,
+    },
+  });
+
+  const preview = candidatePreview(candidate);
+
+  assert.ok((preview.representative?.message?.length ?? 0) <= 1_000);
+  assert.match(preview.representative?.message ?? "", /Failed to resolve import/);
+  assert.match(preview.representative?.message ?? "", /omitted [\d,]+ chars/);
+  assert.match(preview.representative?.message ?? "", /at normalizeUrl/);
+});
+
 test("listIncidentTitles filters by service and caps to limit", () => {
   const candidates = [
     makeCandidate({ id: "a", service: "api" }),
@@ -198,4 +219,46 @@ test("inspectCandidate returns the candidate when id matches, error otherwise", 
   assert.deepEqual(inspectCandidate(candidates, { incident_id: "ghost" }), {
     error: "unknown incident_id: ghost",
   });
+});
+
+test("inspectCandidate bounds oversized messages while retaining detailed context", () => {
+  const headline = 'Failed to resolve import "./missing.png" from "app/feature.tsx"';
+  const message = `${headline}\n${"generatedCall();".repeat(40_000)}\nat normalizeUrl`;
+  const candidate = makeCandidate({
+    representative: {
+      exceptionType: "Error",
+      message,
+      topFrame: "normalizeUrl",
+      normalizedFrames: ["normalizeUrl"],
+      traceId: null,
+      spanId: null,
+    },
+    issues: [
+      {
+        id: "issue-1",
+        title: headline,
+        service: "web",
+        exceptionType: "Error",
+        message,
+        topFrame: "normalizeUrl",
+        normalizedFrames: ["normalizeUrl"],
+        traceId: null,
+        spanId: null,
+        lastSeen: "2026-05-23T00:00:00Z",
+      },
+    ],
+  });
+
+  const inspected = inspectCandidate([candidate], { incident_id: "inc-1" }) as typeof candidate;
+
+  assert.ok((inspected.representative?.message?.length ?? 0) <= 12_000);
+  assert.ok((inspected.issues?.[0]?.message?.length ?? 0) <= 12_000);
+  assert.match(inspected.issues?.[0]?.message ?? "", /Failed to resolve import/);
+  assert.match(inspected.issues?.[0]?.message ?? "", /omitted [\d,]+ chars/);
+  assert.match(inspected.issues?.[0]?.message ?? "", /at normalizeUrl/);
+  assert.equal(
+    candidate.issues?.[0]?.message,
+    message,
+    "tool projection must not mutate source data",
+  );
 });

--- a/apps/worker/src/grouping/candidate-search.ts
+++ b/apps/worker/src/grouping/candidate-search.ts
@@ -2,6 +2,7 @@
 // of GroupingCandidateIncident. Used by the agent's tool dispatcher and
 // directly callable from tests.
 import {
+  GROUPING_DETAIL_MESSAGE_MAX_CHARS,
   GROUPING_SEARCH_MESSAGE_MAX_CHARS,
   type GroupingCandidateIncident,
   candidateIssues,
@@ -211,17 +212,86 @@ export function inspectCandidate(
   const incidentId = typeof obj.incident_id === "string" ? obj.incident_id : "";
   const candidate = candidates.find((item) => item.id === incidentId);
   if (!candidate) return { error: `unknown incident_id: ${incidentId}` };
+  return projectInspection(candidate, GROUPING_DETAIL_MESSAGE_MAX_CHARS, false);
+}
+
+function projectInspection(
+  candidate: GroupingCandidateIncident,
+  diagnosticMaxChars: number,
+  truncated: boolean,
+): unknown {
   return {
     ...candidate,
+    ...(truncated ? { truncated: true } : {}),
     representative: candidate.representative
       ? {
           ...candidate.representative,
-          message: compactDiagnosticText(candidate.representative.message),
+          message: compactDiagnosticText(candidate.representative.message, diagnosticMaxChars),
         }
       : null,
     issues: candidate.issues?.map((issue) => ({
       ...issue,
-      message: compactDiagnosticText(issue.message),
+      message: compactDiagnosticText(issue.message, diagnosticMaxChars),
+      stacktrace: issue.stacktrace
+        ? compactDiagnosticText(issue.stacktrace, diagnosticMaxChars)
+        : issue.stacktrace,
     })),
   };
+}
+
+// Serialize one inspection within a caller-supplied budget. A burst of
+// parallel inspect calls shares a turn-level budget in the agent; preserving a
+// compact head/tail from every fresh result is more useful than dropping an
+// inspection the model has not seen yet.
+export function inspectCandidateResult(
+  candidates: GroupingCandidateIncident[],
+  input: unknown,
+  maxChars: number,
+): string {
+  const obj = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+  const incidentId = typeof obj.incident_id === "string" ? obj.incident_id : "";
+  const candidate = candidates.find((item) => item.id === incidentId);
+  if (!candidate) return JSON.stringify({ error: `unknown incident_id: ${incidentId}` });
+
+  const serialized = JSON.stringify(
+    projectInspection(candidate, GROUPING_DETAIL_MESSAGE_MAX_CHARS, false),
+  );
+  if (serialized.length <= maxChars) return serialized;
+
+  const diagnosticCount =
+    (candidate.representative?.message ? 1 : 0) +
+    (candidate.issues ?? []).reduce(
+      (count, issue) => count + (issue.message ? 1 : 0) + (issue.stacktrace ? 1 : 0),
+      0,
+    );
+  let diagnosticMaxChars = Math.min(
+    GROUPING_DETAIL_MESSAGE_MAX_CHARS,
+    Math.floor(maxChars / Math.max(1, diagnosticCount)),
+  );
+  while (diagnosticMaxChars >= 100) {
+    const result = JSON.stringify(projectInspection(candidate, diagnosticMaxChars, true));
+    if (result.length <= maxChars) return result;
+    diagnosticMaxChars -= Math.max(
+      1,
+      Math.ceil((result.length - maxChars) / Math.max(1, diagnosticCount)),
+    );
+  }
+
+  const envelope = (content: string) =>
+    JSON.stringify({
+      truncated: true,
+      originalChars: serialized.length,
+      content,
+    });
+  const emptyEnvelope = envelope("");
+  let contentBudget = Math.max(0, maxChars - emptyEnvelope.length);
+
+  while (contentBudget > 0) {
+    const content = compactDiagnosticText(serialized, contentBudget) ?? "";
+    const result = envelope(content);
+    if (result.length <= maxChars) return result;
+    contentBudget = Math.max(0, contentBudget - (result.length - maxChars));
+  }
+
+  return JSON.stringify({ truncated: true, originalChars: serialized.length });
 }

--- a/apps/worker/src/grouping/candidate-search.ts
+++ b/apps/worker/src/grouping/candidate-search.ts
@@ -2,9 +2,11 @@
 // of GroupingCandidateIncident. Used by the agent's tool dispatcher and
 // directly callable from tests.
 import {
+  GROUPING_SEARCH_MESSAGE_MAX_CHARS,
   type GroupingCandidateIncident,
   candidateIssues,
   candidateMatchesFilters,
+  compactDiagnosticText,
   endpointHostsFromText,
   endpointKind,
   environmentForResourceAttrs,
@@ -66,7 +68,7 @@ export function candidatePreview(candidate: GroupingCandidateIncident) {
     representative: representative
       ? {
           exceptionType: representative.exceptionType,
-          message: representative.message,
+          message: compactDiagnosticText(representative.message, GROUPING_SEARCH_MESSAGE_MAX_CHARS),
           topFrame: representative.topFrame,
           traceId: representative.traceId,
           spanId: representative.spanId,
@@ -209,5 +211,17 @@ export function inspectCandidate(
   const incidentId = typeof obj.incident_id === "string" ? obj.incident_id : "";
   const candidate = candidates.find((item) => item.id === incidentId);
   if (!candidate) return { error: `unknown incident_id: ${incidentId}` };
-  return candidate;
+  return {
+    ...candidate,
+    representative: candidate.representative
+      ? {
+          ...candidate.representative,
+          message: compactDiagnosticText(candidate.representative.message),
+        }
+      : null,
+    issues: candidate.issues?.map((issue) => ({
+      ...issue,
+      message: compactDiagnosticText(issue.message),
+    })),
+  };
 }

--- a/apps/worker/src/grouping/domain.test.ts
+++ b/apps/worker/src/grouping/domain.test.ts
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  type GroupingCandidateIncident,
   candidateIssues,
   candidateMatchesFilters,
+  compactDiagnosticText,
   endpointHostsFromText,
   endpointKind,
   environmentForResourceAttrs,
-  type GroupingCandidateIncident,
   parseDecisionToolInput,
   parseListFilters,
   parseSearchInput,
@@ -14,6 +15,12 @@ import {
   tokenize,
   uniqueSorted,
 } from "./domain.js";
+
+test("compactDiagnosticText leaves normal diagnostics byte-for-byte unchanged", () => {
+  const message = "TypeError: cannot read properties of undefined\n    at render (app.tsx:42:7)";
+  assert.equal(compactDiagnosticText(message), message);
+  assert.equal(compactDiagnosticText(null), null);
+});
 
 function makeCandidate(overrides: Partial<GroupingCandidateIncident> = {}): GroupingCandidateIncident {
   return {

--- a/apps/worker/src/grouping/domain.ts
+++ b/apps/worker/src/grouping/domain.ts
@@ -9,6 +9,36 @@ export const MIN_EVIDENCE_LENGTH = 20;
 export const DEFAULT_SEARCH_LIMIT = 10;
 export const MAX_SEARCH_LIMIT = 25;
 export const MAX_LIST_LIMIT = 200;
+export const GROUPING_DETAIL_MESSAGE_MAX_CHARS = 12_000;
+export const GROUPING_SEARCH_MESSAGE_MAX_CHARS = 1_000;
+
+function omissionMarker(omittedChars: number): string {
+  return `\n\n[omitted ${omittedChars.toLocaleString("en-US")} chars]\n\n`;
+}
+
+// Telemetry can contain a generated source line hundreds of kilobytes long
+// (for example, a bundler code frame). Keep normal diagnostics untouched, but
+// preserve the diagnostic headline and stack tail when one sample would
+// otherwise dominate the grouping context.
+export function compactDiagnosticText(
+  text: string | null,
+  maxChars = GROUPING_DETAIL_MESSAGE_MAX_CHARS,
+): string | null {
+  if (text === null || text.length <= maxChars) return text;
+
+  let marker = omissionMarker(text.length - maxChars);
+  let available = Math.max(0, maxChars - marker.length);
+  let headChars = Math.ceil(available * 0.7);
+  let tailChars = available - headChars;
+  marker = omissionMarker(text.length - headChars - tailChars);
+  available = Math.max(0, maxChars - marker.length);
+  headChars = Math.ceil(available * 0.7);
+  tailChars = available - headChars;
+
+  return `${text.slice(0, headChars)}${omissionMarker(
+    text.length - headChars - tailChars,
+  )}${text.slice(text.length - tailChars)}`;
+}
 
 export type GroupingCandidateIssue = {
   id: string;

--- a/apps/worker/src/incidents/intake.test.ts
+++ b/apps/worker/src/incidents/intake.test.ts
@@ -1,7 +1,9 @@
 import "../agent-run.test-env.js";
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import type Anthropic from "@anthropic-ai/sdk";
 import type { schema } from "@superlog/db";
+import { type GroupingLLMClient, runGroupingAgent } from "../grouping/agent.js";
 import {
   type IntakeDeps,
   type IntakeLifecycle,
@@ -909,6 +911,114 @@ test("intake: LLM 'join' verdict links to the chosen incident", async () => {
     ),
   );
   assert.ok(calls.some((c) => c.startsWith("updateIssueGrouping:iss-new:grouped:llm")));
+});
+
+test("intake replay: oversized related bundler errors reuse one incident", async () => {
+  const calls: string[] = [];
+  const headline = 'Failed to resolve import "./missing.png" from "app/cart.tsx"';
+  const oversizedMessage = `${headline}\nPlugin: vite:import-analysis\n${"generatedCall();".repeat(
+    40_000,
+  )}\nat normalizeUrl`;
+  const candidate = makeIncident({
+    id: "inc-existing",
+    title: headline,
+    service: "web",
+    issueCount: 1,
+  });
+  const repo = makeRepo({
+    calls,
+    openCandidates: { withService: [], withoutService: [candidate] },
+    incidentById: new Map([[candidate.id, candidate]]),
+    project: { id: "proj-1", orgId: "org-1", name: "Production" } as schema.Project,
+  });
+  repo.loadLinkedIncidentIssues = async () => [
+    {
+      incidentId: candidate.id,
+      issueId: "iss-existing",
+      service: "web",
+      title: headline,
+      exceptionType: "Error",
+      message: oversizedMessage,
+      topFrame: "normalizeUrl",
+      normalizedFrames: ["normalizeUrl"],
+      lastSample: null,
+      lastSeen: NOW,
+    },
+  ];
+  const requestChars: number[] = [];
+  let turn = 0;
+  const client: GroupingLLMClient = {
+    async send(input) {
+      requestChars.push(JSON.stringify(input.messages).length);
+      turn += 1;
+      const content =
+        turn === 1
+          ? [
+              {
+                type: "tool_use",
+                id: "inspect",
+                name: "inspect_incident",
+                input: { incident_id: candidate.id },
+              },
+            ]
+          : [
+              {
+                type: "tool_use",
+                id: "decide",
+                name: "decide_grouping",
+                input: {
+                  decision: "join",
+                  incidentId: candidate.id,
+                  evidence: "both failures are the same unresolved asset import in the same module",
+                },
+              },
+            ];
+      return {
+        content,
+        usage: { input_tokens: 10, output_tokens: 5 },
+      } as unknown as Anthropic.Messages.Message;
+    },
+  };
+
+  const result = await ensureIncidentForIssueWorkflow(
+    makeIssue({
+      service: "web",
+      exceptionType: "Error",
+      title: headline,
+      message: oversizedMessage,
+      topFrame: "normalizeUrl",
+      normalizedFrames: [],
+    }),
+    "new",
+    makeDeps({
+      repo,
+      lifecycle: makeLifecycle({ calls }),
+      calls,
+      async analyzeGrouping(input) {
+        assert.ok((input.newIssue.message?.length ?? 0) <= 12_000);
+        return runGroupingAgent(
+          {
+            projectName: input.projectName,
+            newIssue: input.newIssue,
+            candidates: input.candidates,
+          },
+          {
+            client,
+            model: "test-model",
+            maxIterations: 3,
+            accountant: { record() {} },
+          },
+        );
+      },
+    }),
+  );
+
+  assert.ok(oversizedMessage.length > 600_000);
+  assert.equal(result.createdIncident, false);
+  assert.equal(result.incident.id, candidate.id);
+  assert.ok(calls.includes("linkIssueToIncident:iss-new->inc-existing"));
+  assert.ok(!calls.some((call) => call.startsWith("createOpen:")));
+  assert.ok(Math.max(...requestChars) < 100_000);
 });
 
 test("intake: LLM 'join' verdict with unknown id falls back to standalone (and opens new incident)", async () => {

--- a/apps/worker/src/issues/domain.test.ts
+++ b/apps/worker/src/issues/domain.test.ts
@@ -101,6 +101,23 @@ test("groupingIssueInput and buildGroupingCandidate keep LLM input shape explici
   assert.equal(candidate.issues?.[0]?.id, "iss-linked");
 });
 
+test("groupingIssueInput compacts an oversized generated-code frame without losing diagnostics", () => {
+  const headline =
+    'Internal server error: Failed to resolve import "./missing.png" from "app/feature.tsx".';
+  const stackTail = "at TransformPluginContext.error\nat normalizeUrl";
+  const generatedLine = `1 | ${"jsxDEV(path, generatedMetadata);".repeat(25_000)}`;
+  const message = `${headline}\nPlugin: vite:import-analysis\n${generatedLine}\n${stackTail}`;
+  const issue = { ...makeIssue([]), message } as schema.Issue;
+
+  const input = groupingIssueInput(issue);
+
+  assert.ok(message.length > 600_000);
+  assert.ok((input.message?.length ?? 0) <= 12_000);
+  assert.match(input.message ?? "", /Failed to resolve import/);
+  assert.match(input.message ?? "", /omitted [\d,]+ chars/);
+  assert.match(input.message ?? "", /at normalizeUrl/);
+});
+
 test("buildGroupingCandidate reads log-sample stacktraces and strips them from logAttrs", () => {
   const candidate = buildGroupingCandidate(makeIncident("inc-1"), [
     {

--- a/apps/worker/src/issues/domain.ts
+++ b/apps/worker/src/issues/domain.ts
@@ -1,5 +1,6 @@
 import type { IssueSample, schema } from "@superlog/db";
 import type { GroupingCandidateIncident, GroupingNewIssue } from "../grouping.js";
+import { compactDiagnosticText } from "../grouping/domain.js";
 
 export type IssueGroupingState = "grouped" | "pending" | "standalone" | "failed";
 export type IssueGroupingSource = "heuristic" | "llm" | "manual" | null;
@@ -62,7 +63,7 @@ export function groupingIssueInput(issue: schema.Issue): GroupingNewIssue {
     title: issue.title,
     service: issue.service,
     exceptionType: issue.exceptionType,
-    message: issue.message,
+    message: compactDiagnosticText(issue.message),
     topFrame: issue.topFrame,
     normalizedFrames: issue.normalizedFrames ?? [],
     observedAt: issue.lastSeen.toISOString(),


### PR DESCRIPTION
## Summary

- compact only oversized diagnostic messages before they enter issue-grouping context
- keep search previews and incident inspection payloads bounded while preserving the diagnostic headline and stack tail
- evict older tool results when a long grouping conversation approaches its context budget

## Root cause

A bundler can emit a generated code frame hundreds of kilobytes long on a single line. Raw issue messages were copied into grouping prompts and candidate inspection results without a bound, so one pathological diagnostic—or several accumulated inspections—could exceed the model context limit. The mechanical grouping failure then left related symptoms as separate incidents.

Raw telemetry and stored issue messages remain unchanged; compaction applies only to the grouping projection.

## Validation

- `pnpm --filter @superlog/worker test:grouping-domain`
- `pnpm --filter @superlog/worker test:grouping-candidate-search`
- `pnpm --filter @superlog/worker test:grouping-agent`
- `pnpm --filter @superlog/worker test:issue-domain`
- `pnpm --filter @superlog/worker test:incident-intake`
- `pnpm --filter @superlog/worker typecheck`

The regression replay covers a diagnostic larger than 600 KB, 100 candidates, and confirms that a related issue joins the existing incident without opening another one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound oversized diagnostic text and the grouping conversation to prevent context overflows. Inspections now use only the remaining context headroom and decisions require visible evidence, improving stability with huge bundler traces.

- **Bug Fixes**
  - Added `compactDiagnosticText` to trim large diagnostics while keeping the headline and stack tail.
  - Applied compaction only to grouping inputs: new-issue input, candidate previews (1,000 chars), and inspection payloads (12,000). Raw telemetry and stored messages are unchanged.
  - Bounded the grouping conversation to ~550k chars by omitting older tool results while preserving all results from the latest tool turn; require visible inspection evidence for `join` decisions (re‑inspect if the evidence was omitted or if inspect+join happen in the same turn).
  - Sized each inspection burst to the remaining conversation headroom (up to ~400k), split that budget across parallel inspections (max 80k per result), and mark results as truncated when trimmed.

<sup>Written for commit 6a408aab7d2352590e2c33af76c97e47f29e6ff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

