### PR TITLE
Add project skip index to HA log schema

### DIFF
--- a/infra/clickhouse/schema/ha-replicated-otel.sql
+++ b/infra/clickhouse/schema/ha-replicated-otel.sql
@@ -65,7 +65,8 @@ CREATE TABLE IF NOT EXISTS superlog.otel_logs ON CLUSTER superlog_ha
     INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_log_attr_key mapKeys(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_log_attr_value mapValues(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-    INDEX idx_body Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 8
+    INDEX idx_body Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 8,
+    INDEX idx_superlog_project_id ResourceAttributes['superlog.project_id'] TYPE set(0) GRANULARITY 4
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
 PARTITION BY toDate(TimestampTime)


### PR DESCRIPTION
## Summary

- add the project-specific `set(0)` skip index to the HA `otel_logs` schema
- align fresh HA log tables with the existing `otel_traces` project index

## Why

Per-project log searches filter on `ResourceAttributes['superlog.project_id']`. Without the dedicated index, wide searches can scan tens of millions of unrelated rows even when they return only a handful of results.

## Validation

- `git diff --check`
- applied the equivalent `ADD INDEX` and `MATERIALIZE INDEX` statements to a temporary local ClickHouse `MergeTree` table and verified `SHOW CREATE TABLE`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `set(0)` skip index on `ResourceAttributes['superlog.project_id']` to the HA `otel_logs` schema to speed up per-project log queries and avoid wide scans. Aligns logs with the existing project index in `otel_traces`.

- **Migration**
  - Existing tables: add and materialize `idx_superlog_project_id` on the HA cluster for `superlog.otel_logs`.

<sup>Written for commit d8794215f102aa7a4fe465a12b38e7fb46274012. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

