### PR TITLE
Use materialized project filters for telemetry

### DIFF
--- a/infra/clickhouse/migrations/009_materialized_project_filters.sql
+++ b/infra/clickhouse/migrations/009_materialized_project_filters.sql
@@ -1,0 +1,25 @@
+-- ClickHouse does not select the project set index from migration 001 when its
+-- expression reads a key directly from ResourceAttributes. Expose that value
+-- as a scalar materialized column and index the scalar instead.
+--
+-- Existing parts are intentionally not materialized here: applying local
+-- migrations must not start an unbounded whole-table mutation. New inserts get
+-- the index immediately. Deployments that need historical pruning can
+-- materialize idx_superlog_project_id_materialized in a separately monitored
+-- operation.
+
+ALTER TABLE superlog.otel_logs
+  ADD COLUMN IF NOT EXISTS SuperlogProjectId LowCardinality(String)
+    MATERIALIZED ResourceAttributes['superlog.project_id'];
+
+ALTER TABLE superlog.otel_logs
+  ADD INDEX IF NOT EXISTS idx_superlog_project_id_materialized
+    SuperlogProjectId TYPE set(0) GRANULARITY 1;
+
+ALTER TABLE superlog.otel_traces
+  ADD COLUMN IF NOT EXISTS SuperlogProjectId LowCardinality(String)
+    MATERIALIZED ResourceAttributes['superlog.project_id'];
+
+ALTER TABLE superlog.otel_traces
+  ADD INDEX IF NOT EXISTS idx_superlog_project_id_materialized
+    SuperlogProjectId TYPE set(0) GRANULARITY 1;

--- a/infra/clickhouse/schema/ha-replicated-otel.sql
+++ b/infra/clickhouse/schema/ha-replicated-otel.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS superlog.otel_traces ON CLUSTER superlog_ha
     `SpanKind` LowCardinality(String) CODEC(ZSTD(1)),
     `ServiceName` LowCardinality(String) CODEC(ZSTD(1)),
     `ResourceAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `SuperlogProjectId` LowCardinality(String) MATERIALIZED ResourceAttributes['superlog.project_id'],
     `ScopeName` String CODEC(ZSTD(1)),
     `ScopeVersion` String CODEC(ZSTD(1)),
     `SpanAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
@@ -31,7 +32,7 @@ CREATE TABLE IF NOT EXISTS superlog.otel_traces ON CLUSTER superlog_ha
     INDEX idx_span_attr_key mapKeys(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_span_attr_value mapValues(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_duration Duration TYPE minmax GRANULARITY 1,
-    INDEX idx_superlog_project_id ResourceAttributes['superlog.project_id'] TYPE set(0) GRANULARITY 4
+    INDEX idx_superlog_project_id_materialized SuperlogProjectId TYPE set(0) GRANULARITY 1
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
 PARTITION BY toDate(Timestamp)
@@ -52,6 +53,7 @@ CREATE TABLE IF NOT EXISTS superlog.otel_logs ON CLUSTER superlog_ha
     `Body` String CODEC(ZSTD(1)),
     `ResourceSchemaUrl` LowCardinality(String) CODEC(ZSTD(1)),
     `ResourceAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `SuperlogProjectId` LowCardinality(String) MATERIALIZED ResourceAttributes['superlog.project_id'],
     `ScopeSchemaUrl` LowCardinality(String) CODEC(ZSTD(1)),
     `ScopeName` String CODEC(ZSTD(1)),
     `ScopeVersion` LowCardinality(String) CODEC(ZSTD(1)),
@@ -66,7 +68,7 @@ CREATE TABLE IF NOT EXISTS superlog.otel_logs ON CLUSTER superlog_ha
     INDEX idx_log_attr_key mapKeys(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_log_attr_value mapValues(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_body Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 8,
-    INDEX idx_superlog_project_id ResourceAttributes['superlog.project_id'] TYPE set(0) GRANULARITY 4
+    INDEX idx_superlog_project_id_materialized SuperlogProjectId TYPE set(0) GRANULARITY 1
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
 PARTITION BY toDate(TimestampTime)

--- a/packages/telemetry-query/src/index.ts
+++ b/packages/telemetry-query/src/index.ts
@@ -196,7 +196,7 @@ export async function queryLogs(
   const logAttr = attrConds([...split.log, ...(params.logAttrs ?? [])], "LogAttributes", "lattr");
   const field = fieldConds(split.field, "logs");
   const conds: string[] = [
-    "ResourceAttributes['superlog.project_id'] = {projectId:String}",
+    "SuperlogProjectId = {projectId:String}",
     `Timestamp >= ${sinceExpr}`,
     `Timestamp <= ${untilExpr}`,
     // otel_logs is partitioned by toDate(TimestampTime) and sorted by
@@ -281,7 +281,7 @@ export async function queryTraces(
   );
   const field = fieldConds(split.field, "traces");
   const conds: string[] = [
-    "ResourceAttributes['superlog.project_id'] = {projectId:String}",
+    "SuperlogProjectId = {projectId:String}",
     `Timestamp >= ${sinceExpr}`,
     `Timestamp <= ${untilExpr}`,
     ...attr.conds,
@@ -503,7 +503,7 @@ export async function queryTracesAggregated(
   // trace in the window so span_count / duration_ms / error_count describe the
   // whole trace rather than only the spans matching span-level filters.
   const outerConds: string[] = [
-    "ResourceAttributes['superlog.project_id'] = {projectId:String}",
+    "SuperlogProjectId = {projectId:String}",
     `Timestamp >= ${sinceExpr}`,
     `Timestamp <= ${untilExpr}`,
     ...attr.conds,
@@ -637,7 +637,7 @@ export async function getTraceDetail(ch: ClickHouseClient, projectId: string, tr
         if(exception_event_index = 0, '', Events.Attributes[exception_event_index]['exception.message']) AS exception_message,
         if(exception_event_index = 0, '', Events.Attributes[exception_event_index]['exception.stacktrace']) AS exception_stacktrace
       FROM otel_traces
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND TraceId = {traceId:String}${traceWindow}
       ORDER BY Timestamp ASC, SpanId ASC
       LIMIT 5000
@@ -662,7 +662,7 @@ export async function getTraceDetail(ch: ClickHouseClient, projectId: string, tr
         LogAttributes['exception.message'] AS exception_message,
         LogAttributes['exception.stacktrace'] AS exception_stacktrace
       FROM otel_logs
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND TraceId = {traceId:String}${logWindow}
       ORDER BY Timestamp ASC
       LIMIT 5000
@@ -802,10 +802,13 @@ export async function listServices(ch: ClickHouseClient, projectId: string, rang
           AND TimestampTime >= (${sinceExpr}) - INTERVAL 1 SECOND
           AND TimestampTime <= ${untilExpr}`
           : "";
+      const projectFilter = source.table.startsWith("otel_metrics_")
+        ? "ResourceAttributes['superlog.project_id'] = {projectId:String}"
+        : "SuperlogProjectId = {projectId:String}";
       const query = `
         SELECT DISTINCT ${source.service} AS service
         FROM ${source.table}
-        WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+        WHERE ${projectFilter}
           AND ${source.time} >= ${sinceExpr}
           AND ${source.time} <= ${untilExpr}${logPartitionWindow}
           AND ${source.service} != ''
@@ -859,7 +862,7 @@ export async function listAttributeKeys(
       SELECT ${keyExpr} AS k, count() AS c FROM (
         SELECT mapKeys(${column}) AS mk
         FROM ${table}
-        WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+        WHERE SuperlogProjectId = {projectId:String}
           AND Timestamp >= ${sinceExpr}
           AND Timestamp <= ${untilExpr}
         LIMIT ${ATTRIBUTE_KEY_SCAN_ROW_CAP}
@@ -919,7 +922,7 @@ export async function listAttributeValues(
       subqueries.push(`
       SELECT ResourceAttributes[{key:String}] AS v, count() AS c
       FROM otel_logs
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND Timestamp >= ${sinceExpr}
         AND Timestamp <= ${untilExpr}
         AND mapContains(ResourceAttributes, {key:String})
@@ -929,7 +932,7 @@ export async function listAttributeValues(
       subqueries.push(`
       SELECT ResourceAttributes[{key:String}] AS v, count() AS c
       FROM otel_traces
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND Timestamp >= ${sinceExpr}
         AND Timestamp <= ${untilExpr}
         AND mapContains(ResourceAttributes, {key:String})
@@ -939,7 +942,7 @@ export async function listAttributeValues(
     subqueries.push(`
       SELECT LogAttributes[{key:String}] AS v, count() AS c
       FROM otel_logs
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND Timestamp >= ${sinceExpr}
         AND Timestamp <= ${untilExpr}
         AND mapContains(LogAttributes, {key:String})
@@ -948,7 +951,7 @@ export async function listAttributeValues(
     subqueries.push(`
       SELECT SpanAttributes[{key:String}] AS v, count() AS c
       FROM otel_traces
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND Timestamp >= ${sinceExpr}
         AND Timestamp <= ${untilExpr}
         AND mapContains(SpanAttributes, {key:String})
@@ -2265,7 +2268,7 @@ export async function countSeries(
   const field = fieldConds(split.field, source === "logs" ? "logs" : "traces");
   const table = source === "logs" ? "otel_logs" : "otel_traces";
   const conds: string[] = [
-    "ResourceAttributes['superlog.project_id'] = {projectId:String}",
+    "SuperlogProjectId = {projectId:String}",
     `Timestamp >= ${sinceExpr}`,
     `Timestamp <= ${untilExpr}`,
     ...attr.conds,
@@ -2343,28 +2346,28 @@ export async function listIssueFilterAttributeKeys(
     SELECT k, sum(c) AS c FROM (
       SELECT arrayJoin(mapKeys(ResourceAttributes)) AS k, count() AS c
       FROM otel_logs
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND Timestamp >= ${sinceExpr}
         AND Timestamp <= ${untilExpr}
       GROUP BY k
       UNION ALL
       SELECT arrayJoin(mapKeys(LogAttributes)) AS k, count() AS c
       FROM otel_logs
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND Timestamp >= ${sinceExpr}
         AND Timestamp <= ${untilExpr}
       GROUP BY k
       UNION ALL
       SELECT arrayJoin(mapKeys(ResourceAttributes)) AS k, count() AS c
       FROM otel_traces
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND Timestamp >= ${sinceExpr}
         AND Timestamp <= ${untilExpr}
       GROUP BY k
       UNION ALL
       SELECT arrayJoin(mapKeys(SpanAttributes)) AS k, count() AS c
       FROM otel_traces
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND Timestamp >= ${sinceExpr}
         AND Timestamp <= ${untilExpr}
       GROUP BY k
@@ -2395,7 +2398,7 @@ export async function listIssueFilterAttributeValues(
     SELECT v, sum(c) AS c FROM (
       SELECT ResourceAttributes[{key:String}] AS v, count() AS c
       FROM otel_logs
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND Timestamp >= ${sinceExpr}
         AND Timestamp <= ${untilExpr}
         AND mapContains(ResourceAttributes, {key:String})
@@ -2403,7 +2406,7 @@ export async function listIssueFilterAttributeValues(
       UNION ALL
       SELECT LogAttributes[{key:String}] AS v, count() AS c
       FROM otel_logs
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND Timestamp >= ${sinceExpr}
         AND Timestamp <= ${untilExpr}
         AND mapContains(LogAttributes, {key:String})
@@ -2411,7 +2414,7 @@ export async function listIssueFilterAttributeValues(
       UNION ALL
       SELECT ResourceAttributes[{key:String}] AS v, count() AS c
       FROM otel_traces
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND Timestamp >= ${sinceExpr}
         AND Timestamp <= ${untilExpr}
         AND mapContains(ResourceAttributes, {key:String})
@@ -2419,7 +2422,7 @@ export async function listIssueFilterAttributeValues(
       UNION ALL
       SELECT SpanAttributes[{key:String}] AS v, count() AS c
       FROM otel_traces
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND Timestamp >= ${sinceExpr}
         AND Timestamp <= ${untilExpr}
         AND mapContains(SpanAttributes, {key:String})
@@ -2528,7 +2531,7 @@ export async function previewIssueFilterMatches(
         coalesce(LogAttributes['exception.type'], '') AS exception_type,
         mapConcat(ResourceAttributes, LogAttributes) AS attrs
       FROM otel_logs
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND Timestamp >= ${sinceExpr}
         AND Timestamp <= ${untilExpr}
         AND SeverityNumber >= 17
@@ -2545,7 +2548,7 @@ export async function previewIssueFilterMatches(
         mapConcat(ResourceAttributes, SpanAttributes) AS attrs
       FROM otel_traces
       ARRAY JOIN Events.Name AS event_name, Events.Attributes AS event_attrs
-      WHERE ResourceAttributes['superlog.project_id'] = {projectId:String}
+      WHERE SuperlogProjectId = {projectId:String}
         AND Timestamp >= ${sinceExpr}
         AND Timestamp <= ${untilExpr}
         AND event_name = 'exception'

--- a/packages/telemetry-query/src/project-filter.test.ts
+++ b/packages/telemetry-query/src/project-filter.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ClickHouseClient } from "@clickhouse/client";
+import {
+  countSeries,
+  listAttributeKeys,
+  listServices,
+  queryLogs,
+  queryMetrics,
+  queryTraces,
+} from "./index.js";
+
+function recordingClient(queries: string[]): ClickHouseClient {
+  return {
+    query: async ({ query }: { query: string }) => {
+      queries.push(query);
+      return { json: async () => [] };
+    },
+  } as unknown as ClickHouseClient;
+}
+
+test("raw telemetry queries filter through the materialized project column", async () => {
+  const queries: string[] = [];
+  const ch = recordingClient(queries);
+  const range = {
+    since: "2026-07-23T00:00:00.000Z",
+    until: "2026-07-23T01:00:00.000Z",
+  };
+
+  await queryLogs(ch, "project-1", { range, limit: 10 });
+  await queryTraces(ch, "project-1", { range, limit: 10 });
+  await queryMetrics(ch, "project-1", { range, limit: 10 });
+  await listServices(ch, "project-1", range);
+  await listAttributeKeys(ch, "project-1", range);
+  await countSeries(ch, "project-1", "logs", { range }, undefined, {
+    n: 1,
+    unit: "HOUR",
+  });
+
+  const logAndTraceQueries = queries.filter((query) =>
+    /\bFROM otel_(logs|traces)\b/.test(query),
+  );
+  assert.ok(logAndTraceQueries.length > 0);
+  for (const query of logAndTraceQueries) {
+    assert.match(query, /SuperlogProjectId = \{projectId:String\}/);
+    assert.doesNotMatch(
+      query,
+      /ResourceAttributes\['superlog\.project_id'\] = \{projectId:String\}/,
+    );
+  }
+
+  const metricQueries = queries.filter((query) =>
+    /\bFROM otel_metrics_/.test(query),
+  );
+  assert.ok(metricQueries.length > 0);
+  for (const query of metricQueries) {
+    assert.match(
+      query,
+      /ResourceAttributes\['superlog\.project_id'\] = \{projectId:String\}/,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add a materialized `SuperlogProjectId` column and dedicated set index to logs and traces
- include replay-safe metadata migration for existing installations without starting an unbounded backfill
- route log and trace queries through the materialized project column
- keep metric queries on their existing map-value index path
- cover representative logs, traces, metrics, service, attribute, and series query paths

## Why
ClickHouse does not select a set index whose expression reads a key directly from a `Map`. A materialized scalar column makes the project predicate indexable and avoids broad multi-tenant scans.

## Verification
- `pnpm --filter @superlog/telemetry-query test`
- `pnpm --filter @superlog/telemetry-query typecheck`
- validated an add-column/add-index/materialize sequence against pre-existing MergeTree parts with `force_data_skipping_indices`