### PR TITLE
docs: update banner image alt text in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <a href="https://superlog.sh">
-  <img width="1200" height="675" alt="Twitter post - 2" src="https://github.com/user-attachments/assets/c6ac3418-8e2f-4f8b-b25c-d75b3a094036" />
+  <img width="1200" height="675" alt="Superlog Banner" src="https://github.com/user-attachments/assets/c6ac3418-8e2f-4f8b-b25c-d75b3a094036" />
 
 </a>
 


### PR DESCRIPTION
## Description
This PR improves image accessibility in `README.md`.

## Details
Updated banner image alt text from placeholder `Twitter post - 2` to `Superlog Banner`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve README accessibility by updating the banner image alt text from "Twitter post - 2" to "Superlog Banner".

<sup>Written for commit 003eb9ae7875980e45217564a24d5b2c08e62829. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

