### PR TITLE
Recover MCP telemetry timeouts

### DIFF
--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -141,12 +141,23 @@ export function createMcpServerForSession(session: McpSession): McpServer {
     projectId: string,
     query: () => Promise<T>,
   ) =>
-    executeRecoverableTelemetryQuery(tool, input, query, (error) => {
-      logger.warn(
-        { err: error, tool, projectId },
-        "MCP telemetry query timed out; returning narrower retry guidance",
-      );
-    });
+    executeRecoverableTelemetryQuery(
+      tool,
+      input,
+      query,
+      (error) => {
+        logger.warn(
+          { err: error, tool, projectId },
+          "MCP telemetry query timed out; returning narrower retry guidance",
+        );
+      },
+      (error) => {
+        logger.error(
+          { err: error, tool, projectId },
+          "MCP telemetry query failed permanently",
+        );
+      },
+    );
 
   server.registerTool(
     "query_logs",

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -146,7 +146,7 @@ export function createMcpServerForSession(session: McpSession): McpServer {
       input,
       query,
       (error) => {
-        logger.warn(
+        logger.info(
           { err: error, tool, projectId },
           "MCP telemetry query timed out; returning narrower retry guidance",
         );

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -3,10 +3,16 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { db, schema } from "@superlog/db";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
+import { logger } from "../logger.js";
 import { registerAgentConfigTools } from "./agent-config.js";
 import { registerAlertTools } from "./alerts.js";
 import { instrumentMcpToolAnalytics } from "./analytics.js";
-import { listServices, queryLogs, queryMetrics, queryTraces } from "./clickhouse.js";
+import {
+  listServices,
+  queryLogs,
+  queryMetrics,
+  queryTraces,
+} from "./clickhouse.js";
 import { registerDashboardTools } from "./dashboards.js";
 import { registerIncidentTools } from "./incidents.js";
 import {
@@ -14,6 +20,10 @@ import {
   listAccessibleProjects,
   setActiveProjectForToken,
 } from "./projects.js";
+import {
+  type McpTelemetryToolName,
+  executeRecoverableTelemetryQuery,
+} from "./telemetry-recovery.js";
 
 const timeRangeSchema = z
   .object({
@@ -25,7 +35,9 @@ const timeRangeSchema = z
       .optional(),
     until: z
       .string()
-      .describe("ISO-8601 timestamp or ClickHouse time expression. Defaults to 'now()'.")
+      .describe(
+        "ISO-8601 timestamp or ClickHouse time expression. Defaults to 'now()'.",
+      )
       .optional(),
   })
   .optional();
@@ -114,12 +126,27 @@ export function createMcpServerForSession(session: McpSession): McpServer {
     }
   };
 
-  const resolveProject = async (explicit: string | undefined): Promise<string> => {
+  const resolveProject = async (
+    explicit: string | undefined,
+  ): Promise<string> => {
     const id = explicit ?? session.activeProjectId;
     await assertTokenScope(id);
     await assertProjectAccess(session.userId, id);
     return id;
   };
+
+  const executeTelemetryQuery = <T>(
+    tool: McpTelemetryToolName,
+    input: Record<string, unknown>,
+    projectId: string,
+    query: () => Promise<T>,
+  ) =>
+    executeRecoverableTelemetryQuery(tool, input, query, (error) => {
+      logger.warn(
+        { err: error, tool, projectId },
+        "MCP telemetry query timed out; returning narrower retry guidance",
+      );
+    });
 
   server.registerTool(
     "query_logs",
@@ -135,7 +162,10 @@ export function createMcpServerForSession(session: McpSession): McpServer {
           .string()
           .optional()
           .describe("Filter by severity text (e.g. 'ERROR', 'WARN', 'INFO')"),
-        search: z.string().optional().describe("Case-insensitive substring match on log body"),
+        search: z
+          .string()
+          .optional()
+          .describe("Case-insensitive substring match on log body"),
         resource_attrs: resourceAttrsSchema,
         log_attrs: logAttrsSchema,
         limit: z.number().int().positive().max(500).default(50),
@@ -143,16 +173,22 @@ export function createMcpServerForSession(session: McpSession): McpServer {
     },
     async (input) => {
       const projectId = await resolveProject(input.project_id);
-      const rows = await queryLogs(session.ch, projectId, {
-        range: input.range,
-        service: input.service,
-        severity: input.severity,
-        search: input.search,
-        resourceAttrs: input.resource_attrs,
-        logAttrs: input.log_attrs,
-        limit: input.limit,
-      });
-      return { content: [{ type: "text", text: JSON.stringify(rows) }] };
+      const result = await executeTelemetryQuery(
+        "query_logs",
+        input,
+        projectId,
+        () =>
+          queryLogs(session.ch, projectId, {
+            range: input.range,
+            service: input.service,
+            severity: input.severity,
+            search: input.search,
+            resourceAttrs: input.resource_attrs,
+            logAttrs: input.log_attrs,
+            limit: input.limit,
+          }),
+      );
+      return { content: [{ type: "text", text: JSON.stringify(result) }] };
     },
   );
 
@@ -181,17 +217,23 @@ export function createMcpServerForSession(session: McpSession): McpServer {
     },
     async (input) => {
       const projectId = await resolveProject(input.project_id);
-      const rows = await queryTraces(session.ch, projectId, {
-        range: input.range,
-        service: input.service,
-        spanName: input.span_name,
-        statusCode: input.status_code,
-        minDurationMs: input.min_duration_ms,
-        resourceAttrs: input.resource_attrs,
-        spanAttrs: input.span_attrs,
-        limit: input.limit,
-      });
-      return { content: [{ type: "text", text: JSON.stringify(rows) }] };
+      const result = await executeTelemetryQuery(
+        "query_traces",
+        input,
+        projectId,
+        () =>
+          queryTraces(session.ch, projectId, {
+            range: input.range,
+            service: input.service,
+            spanName: input.span_name,
+            statusCode: input.status_code,
+            minDurationMs: input.min_duration_ms,
+            resourceAttrs: input.resource_attrs,
+            spanAttrs: input.span_attrs,
+            limit: input.limit,
+          }),
+      );
+      return { content: [{ type: "text", text: JSON.stringify(result) }] };
     },
   );
 
@@ -212,14 +254,20 @@ export function createMcpServerForSession(session: McpSession): McpServer {
     },
     async (input) => {
       const projectId = await resolveProject(input.project_id);
-      const rows = await queryMetrics(session.ch, projectId, {
-        metricName: input.metric_name,
-        service: input.service,
-        range: input.range,
-        resourceAttrs: input.resource_attrs,
-        limit: input.limit,
-      });
-      return { content: [{ type: "text", text: JSON.stringify(rows) }] };
+      const result = await executeTelemetryQuery(
+        "query_metrics",
+        input,
+        projectId,
+        () =>
+          queryMetrics(session.ch, projectId, {
+            metricName: input.metric_name,
+            service: input.service,
+            range: input.range,
+            resourceAttrs: input.resource_attrs,
+            limit: input.limit,
+          }),
+      );
+      return { content: [{ type: "text", text: JSON.stringify(result) }] };
     },
   );
 
@@ -227,7 +275,8 @@ export function createMcpServerForSession(session: McpSession): McpServer {
     "list_services",
     {
       title: "List services",
-      description: "List distinct service.name values emitting telemetry in the given window.",
+      description:
+        "List distinct service.name values emitting telemetry in the given window.",
       inputSchema: {
         project_id: projectIdSchema,
         range: timeRangeSchema,
@@ -235,8 +284,13 @@ export function createMcpServerForSession(session: McpSession): McpServer {
     },
     async (input) => {
       const projectId = await resolveProject(input.project_id);
-      const services = await listServices(session.ch, projectId, input.range);
-      return { content: [{ type: "text", text: JSON.stringify(services) }] };
+      const result = await executeTelemetryQuery(
+        "list_services",
+        input,
+        projectId,
+        () => listServices(session.ch, projectId, input.range),
+      );
+      return { content: [{ type: "text", text: JSON.stringify(result) }] };
     },
   );
 
@@ -264,14 +318,16 @@ export function createMcpServerForSession(session: McpSession): McpServer {
     "get_active_project",
     {
       title: "Get active project",
-      description: "Return the project that tools default to when project_id is omitted.",
+      description:
+        "Return the project that tools default to when project_id is omitted.",
       inputSchema: {},
     },
     async () => {
       const projects = (await listAccessibleProjects(session.userId)).filter(
         (p) => !session.allowedOrgId || p.orgId === session.allowedOrgId,
       );
-      const active = projects.find((p) => p.id === session.activeProjectId) ?? null;
+      const active =
+        projects.find((p) => p.id === session.activeProjectId) ?? null;
       return {
         content: [
           {

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -146,12 +146,16 @@ export function createMcpServerForSession(session: McpSession): McpServer {
       input,
       query,
       (error, recovery) => {
+        const suggestedRange = recovery.suggested_input.range as
+          | { since?: unknown; until?: unknown }
+          | undefined;
         logger.info(
           {
             err: error,
             tool,
             projectId,
-            suggestedRange: recovery.suggested_input.range,
+            retrySince: suggestedRange?.since,
+            retryUntil: suggestedRange?.until,
           },
           "MCP telemetry query timed out; returning narrower retry guidance",
         );

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -145,9 +145,14 @@ export function createMcpServerForSession(session: McpSession): McpServer {
       tool,
       input,
       query,
-      (error) => {
+      (error, recovery) => {
         logger.info(
-          { err: error, tool, projectId },
+          {
+            err: error,
+            tool,
+            projectId,
+            suggestedRange: recovery.suggested_input.range,
+          },
           "MCP telemetry query timed out; returning narrower retry guidance",
         );
       },

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -143,7 +143,7 @@ export function createMcpServerForSession(session: McpSession): McpServer {
   ) =>
     executeRecoverableTelemetryQuery(
       tool,
-      input,
+      { ...input, project_id: projectId },
       query,
       (error, recovery) => {
         const suggestedRange = recovery.suggested_input.range as

--- a/apps/api/src/mcp/telemetry-recovery.test.ts
+++ b/apps/api/src/mcp/telemetry-recovery.test.ts
@@ -55,6 +55,42 @@ test("a current or omitted range narrows to the latest hour", () => {
   }
 });
 
+test("a historical relative range retries the final hour within that range", () => {
+  const recovery = recoverTelemetryTimeout(
+    "query_logs",
+    {
+      range: {
+        since: "now() - INTERVAL 30 DAY",
+        until: "now() - INTERVAL 1 DAY",
+      },
+    },
+    new Error("Timeout error."),
+  );
+
+  assert.deepEqual(recovery?.suggested_input.range, {
+    since: "now() - INTERVAL 25 HOUR",
+    until: "now() - INTERVAL 1 DAY",
+  });
+});
+
+test("an absolute range shorter than one hour is narrowed within its bounds", () => {
+  const recovery = recoverTelemetryTimeout(
+    "query_traces",
+    {
+      range: {
+        since: "2026-07-01T00:00:00Z",
+        until: "2026-07-01T00:10:00Z",
+      },
+    },
+    new Error("Timeout error."),
+  );
+
+  assert.deepEqual(recovery?.suggested_input.range, {
+    since: "2026-07-01T00:05:00.000Z",
+    until: "2026-07-01T00:10:00Z",
+  });
+});
+
 test("a historical since-only range retries its first hour", () => {
   const recovery = recoverTelemetryTimeout(
     "query_metrics",

--- a/apps/api/src/mcp/telemetry-recovery.test.ts
+++ b/apps/api/src/mcp/telemetry-recovery.test.ts
@@ -43,6 +43,7 @@ test("a current or omitted range narrows to the latest hour", () => {
     {},
     { range: { since: "now() - INTERVAL 30 DAY", until: "now()" } },
     { range: { since: "now() - INTERVAL 1 MONTH", until: "now()" } },
+    { range: { since: "now() - INTERVAL 1 MONTH" } },
   ]) {
     const recovery = recoverTelemetryTimeout(
       "query_traces",

--- a/apps/api/src/mcp/telemetry-recovery.test.ts
+++ b/apps/api/src/mcp/telemetry-recovery.test.ts
@@ -92,6 +92,25 @@ test("a historical calendar-month range retries inside its original bounds", () 
   });
 });
 
+test("a mixed calendar-month range retries inside its original bounds", () => {
+  const recovery = recoverTelemetryTimeout(
+    "query_logs",
+    {
+      range: {
+        since: "now() - INTERVAL 1 MONTH",
+        until: "now() - INTERVAL 1 DAY",
+      },
+    },
+    new Error("Timeout error."),
+    new Date("2026-07-24T12:00:00Z"),
+  );
+
+  assert.deepEqual(recovery?.suggested_input.range, {
+    since: "2026-06-24T12:00:00.000Z",
+    until: "2026-06-24T13:00:00.000Z",
+  });
+});
+
 test("an absolute range shorter than one hour is narrowed within its bounds", () => {
   const recovery = recoverTelemetryTimeout(
     "query_traces",

--- a/apps/api/src/mcp/telemetry-recovery.test.ts
+++ b/apps/api/src/mcp/telemetry-recovery.test.ts
@@ -42,6 +42,7 @@ test("a current or omitted range narrows to the latest hour", () => {
   for (const input of [
     {},
     { range: { since: "now() - INTERVAL 30 DAY", until: "now()" } },
+    { range: { since: "now() - INTERVAL 1 MONTH", until: "now()" } },
   ]) {
     const recovery = recoverTelemetryTimeout(
       "query_traces",

--- a/apps/api/src/mcp/telemetry-recovery.test.ts
+++ b/apps/api/src/mcp/telemetry-recovery.test.ts
@@ -136,11 +136,19 @@ test("the MCP boundary still rejects permanent backend failures", async () => {
     code: 60,
     type: "UNKNOWN_TABLE",
   });
+  const observed: unknown[] = [];
 
   await assert.rejects(
-    executeRecoverableTelemetryQuery("query_logs", {}, async () => {
-      throw error;
-    }),
+    executeRecoverableTelemetryQuery(
+      "query_logs",
+      {},
+      async () => {
+        throw error;
+      },
+      undefined,
+      (cause) => observed.push(cause),
+    ),
     (cause) => cause === error,
   );
+  assert.deepEqual(observed, [error]);
 });

--- a/apps/api/src/mcp/telemetry-recovery.test.ts
+++ b/apps/api/src/mcp/telemetry-recovery.test.ts
@@ -73,6 +73,25 @@ test("a historical relative range retries the final hour within that range", () 
   });
 });
 
+test("a historical calendar-month range retries inside its original bounds", () => {
+  const recovery = recoverTelemetryTimeout(
+    "query_logs",
+    {
+      range: {
+        since: "now() - INTERVAL 2 MONTH",
+        until: "now() - INTERVAL 1 MONTH",
+      },
+    },
+    new Error("Timeout error."),
+    new Date("2026-07-24T12:00:00Z"),
+  );
+
+  assert.deepEqual(recovery?.suggested_input.range, {
+    since: "2026-05-24T12:00:00.000Z",
+    until: "2026-05-24T13:00:00.000Z",
+  });
+});
+
 test("an absolute range shorter than one hour is narrowed within its bounds", () => {
   const recovery = recoverTelemetryTimeout(
     "query_traces",

--- a/apps/api/src/mcp/telemetry-recovery.test.ts
+++ b/apps/api/src/mcp/telemetry-recovery.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  executeRecoverableTelemetryQuery,
+  recoverTelemetryTimeout,
+} from "./telemetry-recovery.js";
+
+test("a telemetry timeout becomes retry guidance without dropping filters", () => {
+  const recovery = recoverTelemetryTimeout(
+    "query_logs",
+    {
+      project_id: "project-1",
+      service: "checkout-api",
+      search: "payment failed",
+      range: {
+        since: "2026-07-01T00:00:00Z",
+        until: "2026-07-22T00:00:00Z",
+      },
+    },
+    new Error("Timeout error."),
+  );
+
+  assert.deepEqual(recovery, {
+    status: "retry_required",
+    tool: "query_logs",
+    message:
+      "The telemetry query did not complete, but telemetry access is still available. Retry with a narrower time range and keep the same filters.",
+    retryable: true,
+    suggested_input: {
+      project_id: "project-1",
+      service: "checkout-api",
+      search: "payment failed",
+      range: {
+        since: "2026-07-21T23:00:00.000Z",
+        until: "2026-07-22T00:00:00Z",
+      },
+    },
+  });
+});
+
+test("a current or omitted range narrows to the latest hour", () => {
+  for (const input of [
+    {},
+    { range: { since: "now() - INTERVAL 30 DAY", until: "now()" } },
+  ]) {
+    const recovery = recoverTelemetryTimeout(
+      "query_traces",
+      input,
+      new DOMException("", "AbortError"),
+    );
+    assert.deepEqual(recovery?.suggested_input.range, {
+      since: "now() - INTERVAL 1 HOUR",
+      until: "now()",
+    });
+  }
+});
+
+test("a historical since-only range retries its first hour", () => {
+  const recovery = recoverTelemetryTimeout(
+    "query_metrics",
+    { range: { since: "2026-07-01T00:00:00Z" } },
+    Object.assign(new Error("query exceeded execution time"), {
+      code: 159,
+      type: "TIMEOUT_EXCEEDED",
+    }),
+  );
+
+  assert.deepEqual(recovery?.suggested_input.range, {
+    since: "2026-07-01T00:00:00Z",
+    until: "2026-07-01T01:00:00.000Z",
+  });
+});
+
+test("permanent telemetry errors are not converted into retry guidance", () => {
+  const error = Object.assign(new Error("Unknown table otel_logs"), {
+    code: 60,
+    type: "UNKNOWN_TABLE",
+  });
+
+  assert.equal(recoverTelemetryTimeout("query_logs", {}, error), undefined);
+});
+
+test("the MCP boundary returns timeout recovery as a successful value", async () => {
+  const observed: unknown[] = [];
+  const result = await executeRecoverableTelemetryQuery(
+    "list_services",
+    { range: { since: "now() - INTERVAL 30 DAY", until: "now()" } },
+    async () => {
+      throw new Error("Timeout error.");
+    },
+    (error) => observed.push(error),
+  );
+
+  assert.equal(result.status, "retry_required");
+  assert.equal(observed.length, 1);
+});
+
+test("the MCP boundary still rejects permanent backend failures", async () => {
+  const error = Object.assign(new Error("Unknown table otel_logs"), {
+    code: 60,
+    type: "UNKNOWN_TABLE",
+  });
+
+  await assert.rejects(
+    executeRecoverableTelemetryQuery("query_logs", {}, async () => {
+      throw error;
+    }),
+    (cause) => cause === error,
+  );
+});

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -1,0 +1,110 @@
+export type McpTelemetryToolName =
+  | "query_logs"
+  | "query_traces"
+  | "query_metrics"
+  | "list_services";
+
+export type TelemetryRetryRequired = {
+  status: "retry_required";
+  tool: McpTelemetryToolName;
+  message: string;
+  retryable: true;
+  suggested_input: Record<string, unknown>;
+};
+
+function isRetryableTelemetryTimeout(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const details = error as Error & {
+    code?: string | number;
+    type?: string;
+  };
+
+  return (
+    details.name === "AbortError" ||
+    details.name === "TimeoutError" ||
+    details.message === "Timeout error." ||
+    details.type === "TIMEOUT_EXCEEDED" ||
+    details.type === "QUERY_WAS_CANCELLED" ||
+    String(details.code) === "159" ||
+    String(details.code) === "394"
+  );
+}
+
+function suggestedRetryRange(
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  const candidate = input.range;
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+    return { since: "now() - INTERVAL 1 HOUR", until: "now()" };
+  }
+
+  const original = candidate as Record<string, unknown>;
+  const until = typeof original.until === "string" ? original.until : undefined;
+  if (!until || until.trim().toLowerCase() === "now()") {
+    const since =
+      typeof original.since === "string" ? original.since : undefined;
+    const sinceMs = since ? Date.parse(since) : Number.NaN;
+    if (since && Number.isFinite(sinceMs) && !until) {
+      return {
+        since,
+        until: new Date(sinceMs + 60 * 60_000).toISOString(),
+      };
+    }
+    return { since: "now() - INTERVAL 1 HOUR", until: "now()" };
+  }
+
+  const untilMs = Date.parse(until);
+  if (Number.isFinite(untilMs)) {
+    return {
+      since: new Date(untilMs - 60 * 60_000).toISOString(),
+      until,
+    };
+  }
+
+  const since = typeof original.since === "string" ? original.since : undefined;
+  const sinceMs = since ? Date.parse(since) : Number.NaN;
+  if (since && Number.isFinite(sinceMs)) {
+    return {
+      since,
+      until: new Date(sinceMs + 60 * 60_000).toISOString(),
+    };
+  }
+
+  return original;
+}
+
+export function recoverTelemetryTimeout(
+  tool: McpTelemetryToolName,
+  input: Record<string, unknown>,
+  error: unknown,
+): TelemetryRetryRequired | undefined {
+  if (!isRetryableTelemetryTimeout(error)) return undefined;
+
+  return {
+    status: "retry_required",
+    tool,
+    message:
+      "The telemetry query did not complete, but telemetry access is still available. Retry with a narrower time range and keep the same filters.",
+    retryable: true,
+    suggested_input: {
+      ...input,
+      range: suggestedRetryRange(input),
+    },
+  };
+}
+
+export async function executeRecoverableTelemetryQuery<T>(
+  tool: McpTelemetryToolName,
+  input: Record<string, unknown>,
+  query: () => Promise<T>,
+  onTimeout?: (error: unknown) => void,
+): Promise<T | TelemetryRetryRequired> {
+  try {
+    return await query();
+  } catch (error) {
+    const recovery = recoverTelemetryTimeout(tool, input, error);
+    if (!recovery) throw error;
+    onTimeout?.(error);
+    return recovery;
+  }
+}

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -160,12 +160,16 @@ export async function executeRecoverableTelemetryQuery<T>(
   input: Record<string, unknown>,
   query: () => Promise<T>,
   onTimeout?: (error: unknown) => void,
+  onPermanentFailure?: (error: unknown) => void,
 ): Promise<T | TelemetryRetryRequired> {
   try {
     return await query();
   } catch (error) {
     const recovery = recoverTelemetryTimeout(tool, input, error);
-    if (!recovery) throw error;
+    if (!recovery) {
+      onPermanentFailure?.(error);
+      throw error;
+    }
     onTimeout?.(error);
     return recovery;
   }

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -21,7 +21,7 @@ function getTelemetryQueryOutcomeCounter(): Counter {
     .getMeter("@superlog/api/mcp")
     .createCounter("superlog.mcp.telemetry_query.outcomes", {
       description:
-        "Recovered timeouts and permanent failures at the MCP telemetry query boundary.",
+        "Successful queries, recovered timeouts, and permanent failures at the MCP telemetry boundary.",
       unit: "1",
     });
   return telemetryQueryOutcomeCounter;
@@ -214,7 +214,12 @@ export async function executeRecoverableTelemetryQuery<T>(
   onPermanentFailure?: (error: unknown) => void,
 ): Promise<T | TelemetryRetryRequired> {
   try {
-    return await query();
+    const result = await query();
+    getTelemetryQueryOutcomeCounter().add(1, {
+      tool,
+      outcome: "success",
+    });
+    return result;
   } catch (error) {
     const recovery = recoverTelemetryTimeout(tool, input, error);
     if (!recovery) {

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -1,4 +1,4 @@
-import { metrics, type Counter } from "@opentelemetry/api";
+import { metrics, type Counter, type Histogram } from "@opentelemetry/api";
 
 export type McpTelemetryToolName =
   | "query_logs"
@@ -15,6 +15,7 @@ export type TelemetryRetryRequired = {
 };
 
 let telemetryQueryOutcomeCounter: Counter | undefined;
+let telemetryQueryDurationHistogram: Histogram | undefined;
 
 function getTelemetryQueryOutcomeCounter(): Counter {
   telemetryQueryOutcomeCounter ??= metrics
@@ -25,6 +26,26 @@ function getTelemetryQueryOutcomeCounter(): Counter {
       unit: "1",
     });
   return telemetryQueryOutcomeCounter;
+}
+
+function getTelemetryQueryDurationHistogram(): Histogram {
+  telemetryQueryDurationHistogram ??= metrics
+    .getMeter("@superlog/api/mcp")
+    .createHistogram("superlog.mcp.telemetry_query.duration", {
+      description: "Elapsed time of MCP telemetry queries.",
+      unit: "ms",
+    });
+  return telemetryQueryDurationHistogram;
+}
+
+function recordTelemetryQueryOutcome(
+  tool: McpTelemetryToolName,
+  outcome: "success" | "timeout_recovered" | "permanent_failure",
+  durationMs: number,
+): void {
+  const attributes = { tool, outcome };
+  getTelemetryQueryOutcomeCounter().add(1, attributes);
+  getTelemetryQueryDurationHistogram().record(durationMs, attributes);
 }
 
 function isRetryableTelemetryTimeout(error: unknown): boolean {
@@ -213,27 +234,27 @@ export async function executeRecoverableTelemetryQuery<T>(
   onTimeout?: (error: unknown, recovery: TelemetryRetryRequired) => void,
   onPermanentFailure?: (error: unknown) => void,
 ): Promise<T | TelemetryRetryRequired> {
+  const startedAt = performance.now();
   try {
     const result = await query();
-    getTelemetryQueryOutcomeCounter().add(1, {
-      tool,
-      outcome: "success",
-    });
+    recordTelemetryQueryOutcome(tool, "success", performance.now() - startedAt);
     return result;
   } catch (error) {
     const recovery = recoverTelemetryTimeout(tool, input, error);
     if (!recovery) {
-      getTelemetryQueryOutcomeCounter().add(1, {
+      recordTelemetryQueryOutcome(
         tool,
-        outcome: "permanent_failure",
-      });
+        "permanent_failure",
+        performance.now() - startedAt,
+      );
       onPermanentFailure?.(error);
       throw error;
     }
-    getTelemetryQueryOutcomeCounter().add(1, {
+    recordTelemetryQueryOutcome(
       tool,
-      outcome: "timeout_recovered",
-    });
+      "timeout_recovered",
+      performance.now() - startedAt,
+    );
     onTimeout?.(error, recovery);
     return recovery;
   }

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -181,6 +181,10 @@ function suggestedRetryRange(
     };
   }
 
+  if (until?.trim().toLowerCase() === "now()") {
+    return { since: "now() - INTERVAL 1 HOUR", until: "now()" };
+  }
+
   const relativeSince = since ? resolveRelativeDate(since, now) : undefined;
   const relativeUntil = resolveRelativeDate(until ?? "now()", now);
   if (

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -30,6 +30,42 @@ function isRetryableTelemetryTimeout(error: unknown): boolean {
   );
 }
 
+const HOUR_MS = 60 * 60_000;
+const RELATIVE_TIME_RE =
+  /^now\(\)(?:\s*-\s*INTERVAL\s+([1-9][0-9]*)\s+(SECOND|MINUTE|HOUR|DAY|WEEK))?$/i;
+const UNIT_MS = {
+  SECOND: 1_000,
+  MINUTE: 60_000,
+  HOUR: HOUR_MS,
+  DAY: 24 * HOUR_MS,
+  WEEK: 7 * 24 * HOUR_MS,
+} as const;
+
+function relativeOffsetMs(value: string): number | undefined {
+  const match = RELATIVE_TIME_RE.exec(value.trim().replace(/\s+/g, " "));
+  if (!match) return undefined;
+  if (!match[1] || !match[2]) return 0;
+  const amount = Number(match[1]);
+  const unit = match[2].toUpperCase() as keyof typeof UNIT_MS;
+  const offset = amount * UNIT_MS[unit];
+  return Number.isSafeInteger(offset) ? offset : undefined;
+}
+
+function relativeTimeFromOffset(offsetMs: number): string {
+  if (offsetMs === 0) return "now()";
+  for (const unit of ["WEEK", "DAY", "HOUR", "MINUTE", "SECOND"] as const) {
+    if (offsetMs % UNIT_MS[unit] === 0) {
+      return `now() - INTERVAL ${offsetMs / UNIT_MS[unit]} ${unit}`;
+    }
+  }
+  return `now() - INTERVAL ${Math.ceil(offsetMs / 1_000)} SECOND`;
+}
+
+function narrowedDuration(durationMs: number): number {
+  if (durationMs > HOUR_MS) return HOUR_MS;
+  return Math.max(1, Math.floor(durationMs / 2));
+}
+
 function suggestedRetryRange(
   input: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -39,38 +75,64 @@ function suggestedRetryRange(
   }
 
   const original = candidate as Record<string, unknown>;
+  const since = typeof original.since === "string" ? original.since : undefined;
   const until = typeof original.until === "string" ? original.until : undefined;
+
+  const sinceMs = since ? Date.parse(since) : Number.NaN;
+  const untilMs = until ? Date.parse(until) : Number.NaN;
+  if (
+    since &&
+    until &&
+    Number.isFinite(sinceMs) &&
+    Number.isFinite(untilMs) &&
+    untilMs > sinceMs
+  ) {
+    const duration = narrowedDuration(untilMs - sinceMs);
+    return {
+      since: new Date(untilMs - duration).toISOString(),
+      until,
+    };
+  }
+
+  const sinceOffset = since ? relativeOffsetMs(since) : undefined;
+  const untilOffset = until ? relativeOffsetMs(until) : 0;
+  if (
+    sinceOffset !== undefined &&
+    untilOffset !== undefined &&
+    sinceOffset > untilOffset
+  ) {
+    const duration = narrowedDuration(sinceOffset - untilOffset);
+    return {
+      since: relativeTimeFromOffset(untilOffset + duration),
+      until: until ?? "now()",
+    };
+  }
+
   if (!until || until.trim().toLowerCase() === "now()") {
-    const since =
-      typeof original.since === "string" ? original.since : undefined;
-    const sinceMs = since ? Date.parse(since) : Number.NaN;
     if (since && Number.isFinite(sinceMs) && !until) {
       return {
         since,
-        until: new Date(sinceMs + 60 * 60_000).toISOString(),
+        until: new Date(sinceMs + HOUR_MS).toISOString(),
       };
     }
     return { since: "now() - INTERVAL 1 HOUR", until: "now()" };
   }
 
-  const untilMs = Date.parse(until);
   if (Number.isFinite(untilMs)) {
     return {
-      since: new Date(untilMs - 60 * 60_000).toISOString(),
+      since: new Date(untilMs - HOUR_MS).toISOString(),
       until,
     };
   }
 
-  const since = typeof original.since === "string" ? original.since : undefined;
-  const sinceMs = since ? Date.parse(since) : Number.NaN;
   if (since && Number.isFinite(sinceMs)) {
     return {
       since,
-      until: new Date(sinceMs + 60 * 60_000).toISOString(),
+      until: new Date(sinceMs + HOUR_MS).toISOString(),
     };
   }
 
-  return original;
+  return { since: "now() - INTERVAL 1 HOUR", until: "now()" };
 }
 
 export function recoverTelemetryTimeout(

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -122,6 +122,17 @@ function subtractUtcMonths(now: Date, months: number): Date {
   return result;
 }
 
+function resolveRelativeDate(value: string, now: Date): Date | undefined {
+  const offsetMs = relativeOffsetMs(value);
+  if (offsetMs !== undefined) {
+    return new Date(now.getTime() - offsetMs);
+  }
+  const monthOffset = relativeMonthOffset(value);
+  return monthOffset === undefined
+    ? undefined
+    : subtractUtcMonths(now, monthOffset);
+}
+
 function narrowedDuration(durationMs: number): number {
   if (durationMs > HOUR_MS) return HOUR_MS;
   return Math.max(1, Math.floor(durationMs / 2));
@@ -170,17 +181,19 @@ function suggestedRetryRange(
     };
   }
 
-  const sinceMonthOffset = since ? relativeMonthOffset(since) : undefined;
-  const untilMonthOffset = until ? relativeMonthOffset(until) : 0;
+  const relativeSince = since ? resolveRelativeDate(since, now) : undefined;
+  const relativeUntil = resolveRelativeDate(until ?? "now()", now);
   if (
-    sinceMonthOffset !== undefined &&
-    untilMonthOffset !== undefined &&
-    sinceMonthOffset > untilMonthOffset
+    relativeSince &&
+    relativeUntil &&
+    relativeUntil.getTime() > relativeSince.getTime()
   ) {
-    const retrySince = subtractUtcMonths(now, sinceMonthOffset);
     return {
-      since: retrySince.toISOString(),
-      until: new Date(retrySince.getTime() + HOUR_MS).toISOString(),
+      since: relativeSince.toISOString(),
+      until: new Date(
+        relativeSince.getTime() +
+          narrowedDuration(relativeUntil.getTime() - relativeSince.getTime()),
+      ).toISOString(),
     };
   }
 

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -1,4 +1,4 @@
-import { metrics } from "@opentelemetry/api";
+import { metrics, type Counter } from "@opentelemetry/api";
 
 export type McpTelemetryToolName =
   | "query_logs"
@@ -14,13 +14,18 @@ export type TelemetryRetryRequired = {
   suggested_input: Record<string, unknown>;
 };
 
-const telemetryQueryOutcomeCounter = metrics
-  .getMeter("@superlog/api/mcp")
-  .createCounter("superlog.mcp.telemetry_query.outcomes", {
-    description:
-      "Recovered timeouts and permanent failures at the MCP telemetry query boundary.",
-    unit: "1",
-  });
+let telemetryQueryOutcomeCounter: Counter | undefined;
+
+function getTelemetryQueryOutcomeCounter(): Counter {
+  telemetryQueryOutcomeCounter ??= metrics
+    .getMeter("@superlog/api/mcp")
+    .createCounter("superlog.mcp.telemetry_query.outcomes", {
+      description:
+        "Recovered timeouts and permanent failures at the MCP telemetry query boundary.",
+      unit: "1",
+    });
+  return telemetryQueryOutcomeCounter;
+}
 
 function isRetryableTelemetryTimeout(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
@@ -213,14 +218,14 @@ export async function executeRecoverableTelemetryQuery<T>(
   } catch (error) {
     const recovery = recoverTelemetryTimeout(tool, input, error);
     if (!recovery) {
-      telemetryQueryOutcomeCounter.add(1, {
+      getTelemetryQueryOutcomeCounter().add(1, {
         tool,
         outcome: "permanent_failure",
       });
       onPermanentFailure?.(error);
       throw error;
     }
-    telemetryQueryOutcomeCounter.add(1, {
+    getTelemetryQueryOutcomeCounter().add(1, {
       tool,
       outcome: "timeout_recovered",
     });

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -210,7 +210,7 @@ export async function executeRecoverableTelemetryQuery<T>(
   tool: McpTelemetryToolName,
   input: Record<string, unknown>,
   query: () => Promise<T>,
-  onTimeout?: (error: unknown) => void,
+  onTimeout?: (error: unknown, recovery: TelemetryRetryRequired) => void,
   onPermanentFailure?: (error: unknown) => void,
 ): Promise<T | TelemetryRetryRequired> {
   try {
@@ -234,7 +234,7 @@ export async function executeRecoverableTelemetryQuery<T>(
       tool,
       outcome: "timeout_recovered",
     });
-    onTimeout?.(error);
+    onTimeout?.(error, recovery);
     return recovery;
   }
 }

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -181,11 +181,14 @@ function suggestedRetryRange(
     };
   }
 
-  if (until?.trim().toLowerCase() === "now()") {
+  const relativeSince = since ? resolveRelativeDate(since, now) : undefined;
+  if (
+    until?.trim().toLowerCase() === "now()" ||
+    (!until && relativeSince)
+  ) {
     return { since: "now() - INTERVAL 1 HOUR", until: "now()" };
   }
 
-  const relativeSince = since ? resolveRelativeDate(since, now) : undefined;
   const relativeUntil = resolveRelativeDate(until ?? "now()", now);
   if (
     relativeSince &&

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -33,6 +33,8 @@ function isRetryableTelemetryTimeout(error: unknown): boolean {
 const HOUR_MS = 60 * 60_000;
 const RELATIVE_TIME_RE =
   /^now\(\)(?:\s*-\s*INTERVAL\s+([1-9][0-9]*)\s+(SECOND|MINUTE|HOUR|DAY|WEEK))?$/i;
+const RELATIVE_MONTH_RE =
+  /^now\(\)(?:\s*-\s*INTERVAL\s+([1-9][0-9]*)\s+MONTH)?$/i;
 const UNIT_MS = {
   SECOND: 1_000,
   MINUTE: 60_000,
@@ -61,6 +63,24 @@ function relativeTimeFromOffset(offsetMs: number): string {
   return `now() - INTERVAL ${Math.ceil(offsetMs / 1_000)} SECOND`;
 }
 
+function relativeMonthOffset(value: string): number | undefined {
+  const match = RELATIVE_MONTH_RE.exec(value.trim().replace(/\s+/g, " "));
+  if (!match) return undefined;
+  return match[1] ? Number(match[1]) : 0;
+}
+
+function subtractUtcMonths(now: Date, months: number): Date {
+  const result = new Date(now);
+  const originalDay = result.getUTCDate();
+  result.setUTCDate(1);
+  result.setUTCMonth(result.getUTCMonth() - months);
+  const daysInTargetMonth = new Date(
+    Date.UTC(result.getUTCFullYear(), result.getUTCMonth() + 1, 0),
+  ).getUTCDate();
+  result.setUTCDate(Math.min(originalDay, daysInTargetMonth));
+  return result;
+}
+
 function narrowedDuration(durationMs: number): number {
   if (durationMs > HOUR_MS) return HOUR_MS;
   return Math.max(1, Math.floor(durationMs / 2));
@@ -68,6 +88,7 @@ function narrowedDuration(durationMs: number): number {
 
 function suggestedRetryRange(
   input: Record<string, unknown>,
+  now: Date,
 ): Record<string, unknown> {
   const candidate = input.range;
   if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
@@ -108,6 +129,20 @@ function suggestedRetryRange(
     };
   }
 
+  const sinceMonthOffset = since ? relativeMonthOffset(since) : undefined;
+  const untilMonthOffset = until ? relativeMonthOffset(until) : 0;
+  if (
+    sinceMonthOffset !== undefined &&
+    untilMonthOffset !== undefined &&
+    sinceMonthOffset > untilMonthOffset
+  ) {
+    const retrySince = subtractUtcMonths(now, sinceMonthOffset);
+    return {
+      since: retrySince.toISOString(),
+      until: new Date(retrySince.getTime() + HOUR_MS).toISOString(),
+    };
+  }
+
   if (!until || until.trim().toLowerCase() === "now()") {
     if (since && Number.isFinite(sinceMs) && !until) {
       return {
@@ -139,6 +174,7 @@ export function recoverTelemetryTimeout(
   tool: McpTelemetryToolName,
   input: Record<string, unknown>,
   error: unknown,
+  now = new Date(),
 ): TelemetryRetryRequired | undefined {
   if (!isRetryableTelemetryTimeout(error)) return undefined;
 
@@ -150,7 +186,7 @@ export function recoverTelemetryTimeout(
     retryable: true,
     suggested_input: {
       ...input,
-      range: suggestedRetryRange(input),
+      range: suggestedRetryRange(input, now),
     },
   };
 }

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -1,3 +1,5 @@
+import { metrics } from "@opentelemetry/api";
+
 export type McpTelemetryToolName =
   | "query_logs"
   | "query_traces"
@@ -11,6 +13,14 @@ export type TelemetryRetryRequired = {
   retryable: true;
   suggested_input: Record<string, unknown>;
 };
+
+const telemetryQueryOutcomeCounter = metrics
+  .getMeter("@superlog/api/mcp")
+  .createCounter("superlog.mcp.telemetry_query.outcomes", {
+    description:
+      "Recovered timeouts and permanent failures at the MCP telemetry query boundary.",
+    unit: "1",
+  });
 
 function isRetryableTelemetryTimeout(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
@@ -203,9 +213,17 @@ export async function executeRecoverableTelemetryQuery<T>(
   } catch (error) {
     const recovery = recoverTelemetryTimeout(tool, input, error);
     if (!recovery) {
+      telemetryQueryOutcomeCounter.add(1, {
+        tool,
+        outcome: "permanent_failure",
+      });
       onPermanentFailure?.(error);
       throw error;
     }
+    telemetryQueryOutcomeCounter.add(1, {
+      tool,
+      outcome: "timeout_recovered",
+    });
     onTimeout?.(error);
     return recovery;
   }

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -34,6 +34,11 @@ function getTelemetryQueryDurationHistogram(): Histogram {
     .createHistogram("superlog.mcp.telemetry_query.duration", {
       description: "Elapsed time of MCP telemetry queries.",
       unit: "ms",
+      advice: {
+        explicitBucketBoundaries: [
+          100, 500, 1_000, 2_000, 5_000, 10_000, 20_000, 30_000,
+        ],
+      },
     });
   return telemetryQueryDurationHistogram;
 }


### PR DESCRIPTION
## Summary
- turn recognized telemetry query timeouts and cancellations into successful `retry_required` MCP results
- preserve the original project and filters while narrowing retries to a one-hour window
- log recovered timeouts with the tool and project for operational visibility
- keep permanent ClickHouse failures on the existing error path

## Why
The API ClickHouse client intentionally has a 20-second request timeout. Wide telemetry queries could therefore surface a raw MCP tool error even though a narrower query would succeed. Returning explicit retry guidance keeps telemetry access available without hiding schema or backend failures.

## Verification
- `pnpm exec tsx --test apps/api/src/mcp/telemetry-recovery.test.ts`
- `pnpm --filter @superlog/api typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts MCP telemetry timeouts and cancellations into actionable retries that keep the original query and suggest a ≤1‑hour sub‑range within the requested window. Adds metrics and logging; permanent backend errors still surface.

- **New Features**
  - Wrap `query_logs`, `query_traces`, `query_metrics`, and `list_services` with `executeRecoverableTelemetryQuery`.
  - Pin retry guidance to the original input: echo `project_id` and all filters; only narrow `range`. Month windows ending at `now()` prefer the latest hour; fully historical month windows stay within their original bounds; since‑only month ranges (e.g., `since: now() - INTERVAL 1 MONTH`) are treated as current and prefer the latest hour.
  - Range rules: current/omitted → latest hour; historical since‑only → first hour; since+until → final sub‑window near `until`; sub‑hour windows narrow within their bounds.
  - Log recovered timeouts at info with tool, project, and suggested range; log permanent failures at error. Count outcomes via `@opentelemetry/api` counter `superlog.mcp.telemetry_query.outcomes` and durations via histogram `superlog.mcp.telemetry_query.duration`. Keep ClickHouse schema/unknown‑table errors on the existing error path; add `telemetry-recovery.ts` and tests.

<sup>Written for commit de8b768cab29b2f6904ee1dbba0b05ae6bba381e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

