### PR TITLE
Keep absolute telemetry retries within bounds

### DIFF
--- a/apps/api/src/mcp/telemetry-recovery.test.ts
+++ b/apps/api/src/mcp/telemetry-recovery.test.ts
@@ -131,6 +131,25 @@ test("an absolute range shorter than one hour is narrowed within its bounds", ()
   });
 });
 
+test("an absolute range ending at now stays within its lower bound", () => {
+  const recovery = recoverTelemetryTimeout(
+    "query_traces",
+    {
+      range: {
+        since: "2026-07-24T12:45:00Z",
+        until: "now()",
+      },
+    },
+    new Error("Timeout error."),
+    new Date("2026-07-24T13:00:00Z"),
+  );
+
+  assert.deepEqual(recovery?.suggested_input.range, {
+    since: "2026-07-24T12:52:30.000Z",
+    until: "now()",
+  });
+});
+
 test("a historical since-only range retries its first hour", () => {
   const recovery = recoverTelemetryTimeout(
     "query_metrics",

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -183,6 +183,17 @@ function suggestedRetryRange(
 
   const relativeSince = since ? resolveRelativeDate(since, now) : undefined;
   if (
+    until?.trim().toLowerCase() === "now()" &&
+    Number.isFinite(sinceMs) &&
+    now.getTime() > sinceMs
+  ) {
+    const duration = narrowedDuration(now.getTime() - sinceMs);
+    return {
+      since: new Date(now.getTime() - duration).toISOString(),
+      until: "now()",
+    };
+  }
+  if (
     until?.trim().toLowerCase() === "now()" ||
     (!until && relativeSince)
   ) {


### PR DESCRIPTION
## Summary
- keep retry suggestions inside an absolute lower bound when the query ends at `now()`
- narrow sub-hour ranges instead of widening them backward
- add a regression test with an injected clock

## Verification
- `pnpm exec tsx --test apps/api/src/mcp/telemetry-recovery.test.ts`
- `pnpm --filter @superlog/api typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep retry suggestions for absolute telemetry ranges ending at `now()` within the original lower bound by narrowing the window toward `now()` instead of widening it backward. Adds a regression test with a fixed clock to cover this case.

<sup>Written for commit 386dccee169d46afb7cb08a0c8f6c7b2b3ad4700. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

