### PR TITLE
Keep attribution test labels generic

### DIFF
--- a/apps/web/src/signupAttribution.test.ts
+++ b/apps/web/src/signupAttribution.test.ts
@@ -129,15 +129,15 @@ test("parseAttribution captures ad-network click ids", () => {
 });
 
 test("a click id alone is enough signal to persist first-touch", () => {
-  // A paid X click often lands with only ?twclid= (no UTM). It must persist so
-  // the conversion + PostHog attribution survive the OAuth round-trip.
+  // A paid click may land with only a click id and no UTM parameters. It must
+  // persist so conversion and analytics attribution survive the OAuth round-trip.
   const store = fakeStorage();
   persistFirstTouchAttribution(store, { twclid: "tw123" });
   assert.equal(readFirstTouchAttribution(store)?.twclid, "tw123");
 });
 
 test("buildSignupEventProperties surfaces click ids for PostHog breakdowns", () => {
-  // "signup from X ads" in PostHog = `twclid is set`.
+  // Analytics breakdowns can identify the source from the populated click-id field.
   const props = buildSignupEventProperties({ twclid: "tw123", gclid: "gg456" }, {});
   assert.equal(props.twclid, "tw123");
   assert.equal(props.gclid, "gg456");


### PR DESCRIPTION
## Summary
- describe click-only attribution without naming a particular advertising destination
- keep analytics examples destination-neutral

## Verification
- `pnpm --filter @superlog/web exec tsx --import ./src/test-setup.ts --test src/signupAttribution.test.ts` (18 passed)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generalize signup attribution tests to use generic click-id wording and destination-neutral analytics examples. No logic or behavior changes.

<sup>Written for commit 29cc1f2068e21b3ed7c324fcda139fde79f3f3a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

