### PR TITLE
Add org_name to first_telemetry_received analytics event

### DIFF
--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -298,17 +298,21 @@ async function maybeCaptureProjectActivation(projectId: string): Promise<void> {
         userId: schema.orgMembers.userId,
         orgId: schema.orgMembers.orgId,
         email: schema.users.email,
+        orgName: schema.orgs.name,
       })
       .from(schema.projects)
       .innerJoin(schema.orgMembers, eq(schema.orgMembers.orgId, schema.projects.orgId))
       .innerJoin(schema.users, eq(schema.users.id, schema.orgMembers.userId))
+      .innerJoin(schema.orgs, eq(schema.orgs.id, schema.projects.orgId))
       .where(and(eq(schema.projects.id, projectId), eq(schema.orgMembers.role, "owner")))
       .limit(1);
     if (!owner) return;
     captureServerEvent({
       distinctId: owner.userId,
       event: "first_telemetry_received",
-      properties: { project_id: projectId, org_id: owner.orgId },
+      // Carry the org name alongside org_id so the event is readable in the
+      // funnel without a separate join back to Postgres.
+      properties: { project_id: projectId, org_id: owner.orgId, org_name: owner.orgName },
     });
     // Vendor-neutral growth seam: a deployment may forward this to external
     // destinations (see @superlog/db lifecycle-events). No-op unless a sink


### PR DESCRIPTION
## What

The `first_telemetry_received` server-side analytics event (emitted from the proxy when a project first has telemetry accepted) was attributed to the org owner but only carried `project_id` and `org_id`.

This joins the org and adds `org_name` to the event properties, so the activation event is readable in the funnel without a separate join back to the database.

## Change

`apps/proxy/src/index.ts` (`maybeCaptureProjectActivation`):
- Join `orgs` on the project's `orgId`, select the org name.
- Add `org_name` to the event `properties`.

Best-effort and once-only semantics are unchanged (the atomic `first_telemetry_at` claim still gates it).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added org_name to the first_telemetry_received analytics event so the activation funnel is readable without a DB join. The proxy now joins orgs by the project's orgId and includes org_name in event properties. Once-only gating via first_telemetry_at is unchanged.

<sup>Written for commit 9082ea82afb7b83c431df0212304630ef885b37c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

