### PR TITLE
Make GitHub repository discovery resilient

### DIFF
--- a/apps/worker/src/agent-run-context.test.ts
+++ b/apps/worker/src/agent-run-context.test.ts
@@ -3,12 +3,13 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { schema } from "@superlog/db";
 import {
-  PartialGithubRepoDiscoveryError,
+  RetryableGithubRepoDiscoveryError,
   buildFollowUpContext,
   effectivePrPolicyForAgentRun,
   listAccessibleGithubRepositories,
 } from "./agent-run-context.js";
 import { buildAgentRunInstructions } from "./agent-run-instructions.js";
+import { GithubRequestError } from "./github-app.js";
 
 test("agent run instructions include org guidance, project context, and project instructions", () => {
   const instructions = buildAgentRunInstructions({
@@ -201,6 +202,42 @@ test("repository discovery surfaces failure when every enabled installation erro
   );
 });
 
+test("repository discovery retries when every installation hits a transient GitHub failure", async () => {
+  const connectTimeout = new GithubRequestError(
+    "github POST /app/installations/101/access_tokens failed before receiving a response",
+    {
+      retryable: true,
+      cause: new TypeError("fetch failed"),
+    },
+  );
+  const githubInstalls = [
+    {
+      installation: {
+        installationId: 101,
+        agentEnabled: true,
+        repoAccess: null,
+      } as schema.GithubInstallation,
+      allowedRepoIds: null,
+    },
+  ];
+
+  await assert.rejects(
+    listAccessibleGithubRepositories(
+      { githubInstalls },
+      {
+        listInstallationRepositories: async () => {
+          throw connectTimeout;
+        },
+      },
+    ),
+    (error) => {
+      assert.ok(error instanceof RetryableGithubRepoDiscoveryError);
+      assert.equal(error.cause, connectTimeout);
+      return true;
+    },
+  );
+});
+
 test("repository lookup preserves a partial failure when successful installs have no usable repos", async () => {
   const githubUnavailable = new Error("github returned 503");
   const githubInstalls = [
@@ -235,7 +272,7 @@ test("repository lookup preserves a partial failure when successful installs hav
       },
     ),
     (error) => {
-      assert.ok(error instanceof PartialGithubRepoDiscoveryError);
+      assert.ok(error instanceof RetryableGithubRepoDiscoveryError);
       assert.equal(error.cause, githubUnavailable);
       return true;
     },

--- a/apps/worker/src/agent-run-context.ts
+++ b/apps/worker/src/agent-run-context.ts
@@ -13,7 +13,10 @@ import type {
   AgentRunnerFollowUp,
   AgentRunnerPredecessorIncident,
 } from "./agent-runner-backend.js";
-import { listInstallationRepositories } from "./infra/github/repositories.js";
+import {
+  isRetryableGithubRequestError,
+  listInstallationRepositories,
+} from "./infra/github/repositories.js";
 import { logger } from "./logger.js";
 
 export type InstalledGithubRepo = {
@@ -23,12 +26,12 @@ export type InstalledGithubRepo = {
   installation: schema.GithubInstallation;
 };
 
-export class PartialGithubRepoDiscoveryError extends Error {
+export class RetryableGithubRepoDiscoveryError extends Error {
   constructor(cause: unknown) {
-    super("some GitHub installations failed before repository access could be determined", {
+    super("GitHub repository access could not be determined yet", {
       cause,
     });
-    this.name = "PartialGithubRepoDiscoveryError";
+    this.name = "RetryableGithubRepoDiscoveryError";
   }
 }
 
@@ -406,8 +409,9 @@ export async function listAccessibleGithubRepositories(
   const errors = results.filter((result) => result.err);
   if (repos.length === 0 && errors.length > 0) {
     const firstError = results.find((result) => result.err)?.err;
-    if (errors.length < results.length) {
-      throw new PartialGithubRepoDiscoveryError(firstError);
+    const retryableError = errors.find((result) => isRetryableGithubRequestError(result.err))?.err;
+    if (errors.length < results.length || retryableError) {
+      throw new RetryableGithubRepoDiscoveryError(retryableError ?? firstError);
     }
     throw firstError instanceof Error
       ? firstError

--- a/apps/worker/src/agent-runs/start-run.ts
+++ b/apps/worker/src/agent-runs/start-run.ts
@@ -6,6 +6,7 @@ import { buildContextIncidentUrl } from "../incident-route.js";
 import { getAgentRunnerBackend } from "../infra/agent-runner/backend.js";
 import {
   createRepositoryReadTokenForRepositories,
+  isGithubRepositorySelectionError,
   isRetryableGithubRequestError,
   listRepositoryInstructionFiles,
 } from "../infra/github/repositories.js";
@@ -33,6 +34,7 @@ export async function startQueuedAgentRun(ctx: AgentRunContext): Promise<void> {
     listRepositories: listAccessibleGithubRepositories,
     scoreRepositories: scoreRepos,
     createRepositoryReadTokenForRepositories,
+    isRepositorySelectionError: isGithubRepositorySelectionError,
     isRetryableRepositoryError: isRetryableGithubRequestError,
     listRepositoryInstructionFiles,
     buildIssueSummaries: (ctx) =>

--- a/apps/worker/src/agent-runs/start-run.ts
+++ b/apps/worker/src/agent-runs/start-run.ts
@@ -5,7 +5,8 @@ import { createAgentRunLifecycle } from "../agent-run.js";
 import { buildContextIncidentUrl } from "../incident-route.js";
 import { getAgentRunnerBackend } from "../infra/agent-runner/backend.js";
 import {
-  createRepositoryReadToken,
+  createRepositoryReadTokenForRepositories,
+  isRetryableGithubRequestError,
   listRepositoryInstructionFiles,
 } from "../infra/github/repositories.js";
 import {
@@ -31,7 +32,8 @@ export async function startQueuedAgentRun(ctx: AgentRunContext): Promise<void> {
     getRunnerBackend: getAgentRunnerBackend,
     listRepositories: listAccessibleGithubRepositories,
     scoreRepositories: scoreRepos,
-    createRepositoryReadToken,
+    createRepositoryReadTokenForRepositories,
+    isRetryableRepositoryError: isRetryableGithubRequestError,
     listRepositoryInstructionFiles,
     buildIssueSummaries: (ctx) =>
       Promise.all(ctx.issueRows.map((issue) => buildIssueSummaryWithTrace(ctx.project.id, issue))),

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -213,6 +213,48 @@ test("startQueuedAgentRunWorkflow chunks installation tokens at GitHub's reposit
   assert.equal(candidateTokens[500], "token-2");
 });
 
+test("startQueuedAgentRunWorkflow bisects a permanently invalid token batch", async () => {
+  const calls: string[] = [];
+  const ctx = makeContext();
+  const tokenRequests: number[][] = [];
+  let candidateNames: string[] = [];
+  const deps = makeDeps(
+    calls,
+    {
+      async listRepositories() {
+        return [makeRepo("repo-1", 1), makeRepo("removed-repo", 2), makeRepo("repo-3", 3)];
+      },
+      async createRepositoryReadTokenForRepositories(_installationId, repositoryIds) {
+        tokenRequests.push(repositoryIds);
+        if (repositoryIds.includes(2)) {
+          throw new GithubRequestError("repository is not accessible to the installation", {
+            retryable: false,
+            status: 422,
+          });
+        }
+        return `token-${repositoryIds.join("-")}`;
+      },
+    },
+    (input) => {
+      candidateNames = input.repoCandidates.map((repo) => repo.fullName);
+    },
+  );
+  const getRunnerBackend = deps.getRunnerBackend;
+  deps.getRunnerBackend = async (runtime) => ({
+    ...(await getRunnerBackend(runtime)),
+    maxRepoResources: 3,
+  });
+
+  await startQueuedAgentRunWorkflow(ctx, deps);
+
+  assert.deepEqual(tokenRequests, [[1, 2, 3], [1], [2, 3], [2], [3]]);
+  assert.deepEqual(candidateNames, ["org/repo-1", "org/repo-3"]);
+  assert.equal(
+    calls.some((call) => call.startsWith("fail:")),
+    false,
+  );
+});
+
 test("startQueuedAgentRunWorkflow retries transient GitHub token failures without announcing failure", async () => {
   const calls: string[] = [];
   const ctx = makeContext();

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -239,6 +239,44 @@ test("startQueuedAgentRunWorkflow retries transient GitHub token failures withou
   );
 });
 
+test("startQueuedAgentRunWorkflow defers partial transient GitHub token failures", async () => {
+  const calls: string[] = [];
+  const ctx = makeContext();
+  const firstRepo = makeRepo("repo-1", 1);
+  const secondRepo = makeRepo("repo-2", 2);
+  secondRepo.installation = {
+    ...secondRepo.installation,
+    installationId: 456,
+  };
+  const deps = makeDeps(calls, {
+    async listRepositories() {
+      return [firstRepo, secondRepo];
+    },
+    async createRepositoryReadTokenForRepositories(installationId) {
+      if (installationId === 123) {
+        throw new GithubRequestError("github returned 503", {
+          retryable: true,
+          status: 503,
+        });
+      }
+      return "token-456";
+    },
+  });
+  const getRunnerBackend = deps.getRunnerBackend;
+  deps.getRunnerBackend = async (runtime) => ({
+    ...(await getRunnerBackend(runtime)),
+    maxRepoResources: 2,
+  });
+
+  await startQueuedAgentRunWorkflow(ctx, deps);
+
+  assert.equal(ctx.agentRun.state, "repo_discovery");
+  assert.equal(
+    calls.some((call) => call.startsWith("runner.start:") || call.startsWith("fail:")),
+    false,
+  );
+});
+
 test("startQueuedAgentRunWorkflow exposes ask_human as an approval boundary", async () => {
   const calls: string[] = [];
   const ctx = makeContext();

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -176,6 +176,43 @@ test("startQueuedAgentRunWorkflow bounds concurrent GitHub token creation", asyn
   assert.equal(maxActiveTokenRequests, 1);
 });
 
+test("startQueuedAgentRunWorkflow chunks installation tokens at GitHub's repository limit", async () => {
+  const calls: string[] = [];
+  const ctx = makeContext();
+  const tokenRequests: number[][] = [];
+  let candidateTokens: string[] = [];
+  const deps = makeDeps(
+    calls,
+    {
+      async listRepositories() {
+        return Array.from({ length: 501 }, (_, index) => makeRepo(`repo-${index + 1}`, index + 1));
+      },
+      async createRepositoryReadTokenForRepositories(_installationId, repositoryIds) {
+        tokenRequests.push(repositoryIds);
+        return `token-${tokenRequests.length}`;
+      },
+    },
+    (input) => {
+      candidateTokens = input.repoCandidates.map((repo) => repo.installationToken);
+    },
+  );
+  const getRunnerBackend = deps.getRunnerBackend;
+  deps.getRunnerBackend = async (runtime) => ({
+    ...(await getRunnerBackend(runtime)),
+    maxRepoResources: 501,
+  });
+
+  await startQueuedAgentRunWorkflow(ctx, deps);
+
+  assert.deepEqual(
+    tokenRequests.map((repositoryIds) => repositoryIds.length),
+    [500, 1],
+  );
+  assert.equal(candidateTokens[0], "token-1");
+  assert.equal(candidateTokens[499], "token-1");
+  assert.equal(candidateTokens[500], "token-2");
+});
+
 test("startQueuedAgentRunWorkflow retries transient GitHub token failures without announcing failure", async () => {
   const calls: string[] = [];
   const ctx = makeContext();

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -284,6 +284,7 @@ test("startQueuedAgentRunWorkflow retries transient GitHub token failures withou
 test("startQueuedAgentRunWorkflow defers partial transient GitHub token failures", async () => {
   const calls: string[] = [];
   const ctx = makeContext();
+  let instructionProbes = 0;
   const firstRepo = makeRepo("repo-1", 1);
   const secondRepo = makeRepo("repo-2", 2);
   secondRepo.installation = {
@@ -303,6 +304,10 @@ test("startQueuedAgentRunWorkflow defers partial transient GitHub token failures
       }
       return "token-456";
     },
+    async listRepositoryInstructionFiles() {
+      instructionProbes += 1;
+      return [];
+    },
   });
   const getRunnerBackend = deps.getRunnerBackend;
   deps.getRunnerBackend = async (runtime) => ({
@@ -317,6 +322,7 @@ test("startQueuedAgentRunWorkflow defers partial transient GitHub token failures
     calls.some((call) => call.startsWith("runner.start:") || call.startsWith("fail:")),
     false,
   );
+  assert.equal(instructionProbes, 0);
 });
 
 test("startQueuedAgentRunWorkflow exposes ask_human as an approval boundary", async () => {

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -8,7 +8,7 @@ import {
   RetryableGithubRepoDiscoveryError,
 } from "../agent-run-context.js";
 import type { AgentRunnerBackend, AgentRunnerStartInput } from "../agent-runner-backend.js";
-import { GithubRequestError } from "../github-app.js";
+import { GithubRequestError, isGithubRepositorySelectionError } from "../github-app.js";
 import { type StartQueuedAgentRunDeps, startQueuedAgentRunWorkflow } from "./start.js";
 
 test("startQueuedAgentRunWorkflow stops before external work when the Incident no longer owns the queued run", async () => {
@@ -252,6 +252,41 @@ test("startQueuedAgentRunWorkflow bisects a permanently invalid token batch", as
   assert.equal(
     calls.some((call) => call.startsWith("fail:")),
     false,
+  );
+});
+
+test("startQueuedAgentRunWorkflow does not bisect installation-wide token failures", async () => {
+  const calls: string[] = [];
+  const ctx = makeContext();
+  let tokenRequests = 0;
+  const deps = makeDeps(calls, {
+    async listRepositories() {
+      return Array.from({ length: 501 }, (_, index) => makeRepo(`repo-${index + 1}`, index + 1));
+    },
+    async createRepositoryReadTokenForRepositories() {
+      tokenRequests += 1;
+      throw new GithubRequestError("installation not found", {
+        retryable: false,
+        status: 404,
+      });
+    },
+  });
+  const getRunnerBackend = deps.getRunnerBackend;
+  deps.getRunnerBackend = async (runtime) => ({
+    ...(await getRunnerBackend(runtime)),
+    maxRepoResources: 501,
+  });
+
+  await startQueuedAgentRunWorkflow(ctx, deps);
+
+  assert.equal(tokenRequests, 1);
+  assert.equal(
+    calls.some((call) => call.startsWith("runner.start:")),
+    false,
+  );
+  assert.equal(
+    calls.some((call) => call.startsWith("fail:github_repo_token_failed:")),
+    true,
   );
 });
 
@@ -559,6 +594,7 @@ function makeDeps(
       calls.push(`createRepositoryReadToken:repos-${repositoryIds.join("-")}`);
       return `token-${repositoryIds.join("-")}`;
     },
+    isRepositorySelectionError: isGithubRepositorySelectionError,
     isRetryableRepositoryError(error) {
       return error instanceof GithubRequestError && error.retryable;
     },

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -290,6 +290,46 @@ test("startQueuedAgentRunWorkflow does not bisect installation-wide token failur
   );
 });
 
+test("startQueuedAgentRunWorkflow stops bisection after a retryable half fails", async () => {
+  const calls: string[] = [];
+  const ctx = makeContext();
+  const tokenRequests: number[][] = [];
+  let instructionProbes = 0;
+  const deps = makeDeps(calls, {
+    async listRepositories() {
+      return [makeRepo("repo-1", 1), makeRepo("repo-2", 2), makeRepo("repo-3", 3)];
+    },
+    async createRepositoryReadTokenForRepositories(_installationId, repositoryIds) {
+      tokenRequests.push(repositoryIds);
+      if (repositoryIds.length > 1) {
+        throw new GithubRequestError("repository selection is invalid", {
+          retryable: false,
+          status: 422,
+        });
+      }
+      throw new GithubRequestError("github returned 503", {
+        retryable: true,
+        status: 503,
+      });
+    },
+    async listRepositoryInstructionFiles() {
+      instructionProbes += 1;
+      return [];
+    },
+  });
+  const getRunnerBackend = deps.getRunnerBackend;
+  deps.getRunnerBackend = async (runtime) => ({
+    ...(await getRunnerBackend(runtime)),
+    maxRepoResources: 3,
+  });
+
+  await startQueuedAgentRunWorkflow(ctx, deps);
+
+  assert.deepEqual(tokenRequests, [[1, 2, 3], [1]]);
+  assert.equal(instructionProbes, 0);
+  assert.equal(ctx.agentRun.state, "repo_discovery");
+});
+
 test("startQueuedAgentRunWorkflow retries transient GitHub token failures without announcing failure", async () => {
   const calls: string[] = [];
   const ctx = makeContext();

--- a/apps/worker/src/agent-runs/start.test.ts
+++ b/apps/worker/src/agent-runs/start.test.ts
@@ -5,9 +5,10 @@ import type { schema } from "@superlog/db";
 import {
   type AgentRunContext,
   type InstalledGithubRepo,
-  PartialGithubRepoDiscoveryError,
+  RetryableGithubRepoDiscoveryError,
 } from "../agent-run-context.js";
 import type { AgentRunnerBackend, AgentRunnerStartInput } from "../agent-runner-backend.js";
+import { GithubRequestError } from "../github-app.js";
 import { type StartQueuedAgentRunDeps, startQueuedAgentRunWorkflow } from "./start.js";
 
 test("startQueuedAgentRunWorkflow stops before external work when the Incident no longer owns the queued run", async () => {
@@ -96,7 +97,7 @@ test("startQueuedAgentRunWorkflow leaves a partial GitHub failure active for the
     makeDeps(calls, {
       async listRepositories() {
         calls.push("listRepositories");
-        throw new PartialGithubRepoDiscoveryError(new Error("github returned 503"));
+        throw new RetryableGithubRepoDiscoveryError(new Error("github returned 503"));
       },
     }),
   );
@@ -135,7 +136,7 @@ test("startQueuedAgentRunWorkflow starts runner with capped repo candidates", as
     "beginRepoDiscovery",
     "getRunnerBackend",
     "listRepositories",
-    "createRepositoryReadToken:repo-1",
+    "createRepositoryReadToken:repos-1",
     "buildIssueSummaries",
     "runner.start:1",
     "prBaseBranch:development",
@@ -145,6 +146,60 @@ test("startQueuedAgentRunWorkflow starts runner with capped repo candidates", as
     "startRunning:session-1:1",
     "notifyStarted:1",
   ]);
+});
+
+test("startQueuedAgentRunWorkflow bounds concurrent GitHub token creation", async () => {
+  const calls: string[] = [];
+  const ctx = makeContext();
+  let activeTokenRequests = 0;
+  let maxActiveTokenRequests = 0;
+  const deps = makeDeps(calls, {
+    async listRepositories() {
+      return Array.from({ length: 12 }, (_, index) => makeRepo(`repo-${index + 1}`, index + 1));
+    },
+    async createRepositoryReadTokenForRepositories(_installationId, repositoryIds) {
+      activeTokenRequests += 1;
+      maxActiveTokenRequests = Math.max(maxActiveTokenRequests, activeTokenRequests);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      activeTokenRequests -= 1;
+      return `token-${repositoryIds.join("-")}`;
+    },
+  });
+  const getRunnerBackend = deps.getRunnerBackend;
+  deps.getRunnerBackend = async (runtime) => ({
+    ...(await getRunnerBackend(runtime)),
+    maxRepoResources: 12,
+  });
+
+  await startQueuedAgentRunWorkflow(ctx, deps);
+
+  assert.equal(maxActiveTokenRequests, 1);
+});
+
+test("startQueuedAgentRunWorkflow retries transient GitHub token failures without announcing failure", async () => {
+  const calls: string[] = [];
+  const ctx = makeContext();
+
+  await startQueuedAgentRunWorkflow(
+    ctx,
+    makeDeps(calls, {
+      async createRepositoryReadTokenForRepositories() {
+        throw new GithubRequestError(
+          "github POST /app/installations/123/access_tokens failed before receiving a response",
+          {
+            retryable: true,
+            cause: new TypeError("fetch failed"),
+          },
+        );
+      },
+    }),
+  );
+
+  assert.equal(ctx.agentRun.state, "repo_discovery");
+  assert.equal(
+    calls.some((call) => call.startsWith("fail:")),
+    false,
+  );
 });
 
 test("startQueuedAgentRunWorkflow exposes ask_human as an approval boundary", async () => {
@@ -377,9 +432,12 @@ function makeDeps(
     scoreRepositories(repos) {
       return repos.map((repo, index) => ({ ...repo, score: 100 - index }));
     },
-    async createRepositoryReadToken(_installationId, repoId) {
-      calls.push(`createRepositoryReadToken:repo-${repoId}`);
-      return `token-${repoId}`;
+    async createRepositoryReadTokenForRepositories(_installationId, repositoryIds) {
+      calls.push(`createRepositoryReadToken:repos-${repositoryIds.join("-")}`);
+      return `token-${repositoryIds.join("-")}`;
+    },
+    isRetryableRepositoryError(error) {
+      return error instanceof GithubRequestError && error.retryable;
     },
     async listRepositoryInstructionFiles() {
       return [];

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -264,42 +264,47 @@ async function createRunnerRepoCandidates(
     repos.push(repo);
     reposByInstallation.set(installationId, repos);
   }
-  // One token can be scoped to every selected repository from an installation.
-  // Sharing it across those runner resources preserves the run's aggregate
+  // One token can cover up to 500 selected repositories from an installation.
+  // Sharing each token across a bounded chunk preserves the run's aggregate
   // access while avoiding one token POST per repository (a 100-request burst
   // previously triggered GitHub's secondary rate limit).
-  const tokenResults = new Map<
-    number,
-    Promise<{ token: string; error: null } | { token: null; error: unknown }>
-  >();
+  type TokenResult = { token: string; error: null } | { token: null; error: unknown };
+  const tokenResults: Promise<TokenResult>[] = [];
+  const tokenResultByRepo = new Map<ScoredGithubRepo, Promise<TokenResult>>();
   for (const [installationId, repos] of reposByInstallation) {
-    tokenResults.set(
-      installationId,
-      deps
-        .createRepositoryReadTokenForRepositories(
-          installationId,
-          repos.map((repo) => repo.id),
+    let previousChunk = Promise.resolve();
+    for (let offset = 0; offset < repos.length; offset += GITHUB_TOKEN_MAX_REPOSITORIES) {
+      const chunk = repos.slice(offset, offset + GITHUB_TOKEN_MAX_REPOSITORIES);
+      const tokenResult = previousChunk
+        .then(() =>
+          deps.createRepositoryReadTokenForRepositories(
+            installationId,
+            chunk.map((repo) => repo.id),
+          ),
         )
-        .then(
+        .then<TokenResult, TokenResult>(
           (token) => ({ token, error: null }),
           (error: unknown) => {
-            logger.warn(
+            logger.error(
               {
                 err: error,
                 installationId,
-                repo_count: repos.length,
+                repo_count: chunk.length,
               },
               "failed to authorize GitHub repository candidates",
             );
             return { token: null, error };
           },
-        ),
-    );
+        );
+      previousChunk = tokenResult.then(() => undefined);
+      tokenResults.push(tokenResult);
+      for (const repo of chunk) tokenResultByRepo.set(repo, tokenResult);
+    }
   }
 
   const candidates = await Promise.all(
     topScored.map(async (repo, index) => {
-      const tokenResult = await tokenResults.get(repo.installation.installationId);
+      const tokenResult = await tokenResultByRepo.get(repo);
       if (!tokenResult?.token) return null;
       return createRunnerRepoCandidate(
         repo,
@@ -309,12 +314,14 @@ async function createRunnerRepoCandidates(
       );
     }),
   );
-  const resolvedTokenResults = await Promise.all(tokenResults.values());
+  const resolvedTokenResults = await Promise.all(tokenResults);
   return {
     candidates: candidates.filter((repo): repo is AgentRunnerRepoCandidate => repo !== null),
     errors: resolvedTokenResults.flatMap((result) => (result.error === null ? [] : [result.error])),
   };
 }
+
+const GITHUB_TOKEN_MAX_REPOSITORIES = 500;
 
 // Each probe costs up to three GitHub contents-API requests, so only the
 // strongest candidates get one; the rest start with an empty list and the

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -5,7 +5,7 @@ import type {
   InstalledGithubRepo,
   ScoredGithubRepo,
 } from "../agent-run-context.js";
-import { PartialGithubRepoDiscoveryError } from "../agent-run-context.js";
+import { RetryableGithubRepoDiscoveryError } from "../agent-run-context.js";
 import type { AgentRunLifecycle } from "../agent-run.js";
 import type {
   AgentRunnerBackend,
@@ -29,7 +29,11 @@ export type StartQueuedAgentRunDeps = {
   getRunnerBackend(runtime: string): AgentRunnerBackend | Promise<AgentRunnerBackend>;
   listRepositories(ctx: AgentRunContext): Promise<InstalledGithubRepo[]>;
   scoreRepositories(repos: InstalledGithubRepo[], ctx: AgentRunContext): ScoredGithubRepo[];
-  createRepositoryReadToken(installationId: number, repoId: number): Promise<string>;
+  createRepositoryReadTokenForRepositories(
+    installationId: number,
+    repositoryIds: number[],
+  ): Promise<string>;
+  isRetryableRepositoryError(error: unknown): boolean;
   listRepositoryInstructionFiles(
     installationToken: string,
     repoFullName: string,
@@ -83,8 +87,20 @@ export async function startQueuedAgentRunWorkflow(
   }
 
   try {
-    const repoCandidates = await createRunnerRepoCandidates(ctx, runner, scored, deps);
+    const { candidates: repoCandidates, errors: repoCandidateErrors } =
+      await createRunnerRepoCandidates(ctx, runner, scored, deps);
     if (repoCandidates.length === 0) {
+      if (repoCandidateErrors.some(deps.isRetryableRepositoryError)) {
+        logger.warn(
+          {
+            agent_run_id: ctx.agentRun.id,
+            incident_id: ctx.incident.id,
+            failed_installation_count: repoCandidateErrors.length,
+          },
+          "repository authorization temporarily unavailable; will retry on the next sweep",
+        );
+        return;
+      }
       await deps.fail(
         ctx,
         "github_repo_token_failed",
@@ -187,14 +203,14 @@ async function discoverAccessibleRepositories(
   try {
     repos = await deps.listRepositories(ctx);
   } catch (err) {
-    if (err instanceof PartialGithubRepoDiscoveryError) {
+    if (err instanceof RetryableGithubRepoDiscoveryError) {
       logger.warn(
         {
           err,
           agent_run_id: ctx.agentRun.id,
           incident_id: ctx.incident.id,
         },
-        "repository discovery partially unavailable; will retry on the next sweep",
+        "repository discovery temporarily unavailable; will retry on the next sweep",
       );
       return null;
     }
@@ -226,7 +242,7 @@ async function createRunnerRepoCandidates(
   runner: AgentRunnerBackend,
   scored: ScoredGithubRepo[],
   deps: StartQueuedAgentRunDeps,
-): Promise<AgentRunnerRepoCandidate[]> {
+): Promise<{ candidates: AgentRunnerRepoCandidate[]; errors: unknown[] }> {
   const topScored = scored.slice(0, runner.maxRepoResources);
   if (scored.length > topScored.length) {
     logger.info(
@@ -241,12 +257,63 @@ async function createRunnerRepoCandidates(
     );
   }
 
+  const reposByInstallation = new Map<number, ScoredGithubRepo[]>();
+  for (const repo of topScored) {
+    const installationId = repo.installation.installationId;
+    const repos = reposByInstallation.get(installationId) ?? [];
+    repos.push(repo);
+    reposByInstallation.set(installationId, repos);
+  }
+  // One token can be scoped to every selected repository from an installation.
+  // Sharing it across those runner resources preserves the run's aggregate
+  // access while avoiding one token POST per repository (a 100-request burst
+  // previously triggered GitHub's secondary rate limit).
+  const tokenResults = new Map<
+    number,
+    Promise<{ token: string; error: null } | { token: null; error: unknown }>
+  >();
+  for (const [installationId, repos] of reposByInstallation) {
+    tokenResults.set(
+      installationId,
+      deps
+        .createRepositoryReadTokenForRepositories(
+          installationId,
+          repos.map((repo) => repo.id),
+        )
+        .then(
+          (token) => ({ token, error: null }),
+          (error: unknown) => {
+            logger.warn(
+              {
+                err: error,
+                installationId,
+                repo_count: repos.length,
+              },
+              "failed to authorize GitHub repository candidates",
+            );
+            return { token: null, error };
+          },
+        ),
+    );
+  }
+
   const candidates = await Promise.all(
-    topScored.map(async (repo, index) =>
-      createRunnerRepoCandidate(repo, index < INSTRUCTION_FILE_PROBE_LIMIT, deps),
-    ),
+    topScored.map(async (repo, index) => {
+      const tokenResult = await tokenResults.get(repo.installation.installationId);
+      if (!tokenResult?.token) return null;
+      return createRunnerRepoCandidate(
+        repo,
+        tokenResult.token,
+        index < INSTRUCTION_FILE_PROBE_LIMIT,
+        deps,
+      );
+    }),
   );
-  return candidates.filter((repo): repo is AgentRunnerRepoCandidate => repo !== null);
+  const resolvedTokenResults = await Promise.all(tokenResults.values());
+  return {
+    candidates: candidates.filter((repo): repo is AgentRunnerRepoCandidate => repo !== null),
+    errors: resolvedTokenResults.flatMap((result) => (result.error === null ? [] : [result.error])),
+  };
 }
 
 // Each probe costs up to three GitHub contents-API requests, so only the
@@ -274,35 +341,19 @@ async function probeRepoInstructionFiles(
 
 async function createRunnerRepoCandidate(
   repo: ScoredGithubRepo,
+  installationToken: string,
   probeInstructionFiles: boolean,
   deps: StartQueuedAgentRunDeps,
-): Promise<AgentRunnerRepoCandidate | null> {
-  try {
-    const installationToken = await deps.createRepositoryReadToken(
-      repo.installation.installationId,
-      repo.id,
-    );
-    return {
-      fullName: repo.fullName,
-      cloneUrl: `https://github.com/${repo.fullName}`,
-      installationToken,
-      score: repo.score,
-      instructionFiles: probeInstructionFiles
-        ? await probeRepoInstructionFiles(repo, installationToken, deps)
-        : [],
-    };
-  } catch (err) {
-    logger.warn(
-      {
-        err,
-        installationId: repo.installation.installationId,
-        repo: repo.fullName,
-        repoId: repo.id,
-      },
-      "skipping inaccessible GitHub repo candidate",
-    );
-    return null;
-  }
+): Promise<AgentRunnerRepoCandidate> {
+  return {
+    fullName: repo.fullName,
+    cloneUrl: `https://github.com/${repo.fullName}`,
+    installationToken,
+    score: repo.score,
+    instructionFiles: probeInstructionFiles
+      ? await probeRepoInstructionFiles(repo, installationToken, deps)
+      : [],
+  };
 }
 
 async function startRunnerSession(

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -294,6 +294,9 @@ async function createRunnerRepoCandidates(
     for (const [repo, token] of result.tokens) tokenByRepo.set(repo, token);
     repoCandidateErrors.push(...result.errors);
   }
+  if (repoCandidateErrors.some(deps.isRetryableRepositoryError)) {
+    return { candidates: [], errors: repoCandidateErrors };
+  }
 
   const candidates = await Promise.all(
     topScored.map(async (repo, index) => {

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -268,57 +268,89 @@ async function createRunnerRepoCandidates(
   // Sharing each token across a bounded chunk preserves the run's aggregate
   // access while avoiding one token POST per repository (a 100-request burst
   // previously triggered GitHub's secondary rate limit).
-  type TokenResult = { token: string; error: null } | { token: null; error: unknown };
-  const tokenResults: Promise<TokenResult>[] = [];
-  const tokenResultByRepo = new Map<ScoredGithubRepo, Promise<TokenResult>>();
-  for (const [installationId, repos] of reposByInstallation) {
-    let previousChunk = Promise.resolve();
-    for (let offset = 0; offset < repos.length; offset += GITHUB_TOKEN_MAX_REPOSITORIES) {
-      const chunk = repos.slice(offset, offset + GITHUB_TOKEN_MAX_REPOSITORIES);
-      const tokenResult = previousChunk
-        .then(() =>
-          deps.createRepositoryReadTokenForRepositories(
-            installationId,
-            chunk.map((repo) => repo.id),
-          ),
-        )
-        .then<TokenResult, TokenResult>(
-          (token) => ({ token, error: null }),
-          (error: unknown) => {
-            logger.error(
-              {
-                err: error,
-                installationId,
-                repo_count: chunk.length,
-              },
-              "failed to authorize GitHub repository candidates",
-            );
-            return { token: null, error };
-          },
+  const installationResults = await Promise.all(
+    Array.from(reposByInstallation, async ([installationId, repos]) => {
+      const tokens = new Map<ScoredGithubRepo, string>();
+      const errors: unknown[] = [];
+      // Token requests for one installation stay sequential even when its
+      // selected repositories require multiple 500-repository chunks.
+      // Different installations may authorize concurrently.
+      for (let offset = 0; offset < repos.length; offset += GITHUB_TOKEN_MAX_REPOSITORIES) {
+        const result = await authorizeRepositoryChunk(
+          ctx,
+          installationId,
+          repos.slice(offset, offset + GITHUB_TOKEN_MAX_REPOSITORIES),
+          deps,
         );
-      previousChunk = tokenResult.then(() => undefined);
-      tokenResults.push(tokenResult);
-      for (const repo of chunk) tokenResultByRepo.set(repo, tokenResult);
-    }
+        for (const [repo, token] of result.tokens) tokens.set(repo, token);
+        errors.push(...result.errors);
+      }
+      return { tokens, errors };
+    }),
+  );
+  const tokenByRepo = new Map<ScoredGithubRepo, string>();
+  const repoCandidateErrors: unknown[] = [];
+  for (const result of installationResults) {
+    for (const [repo, token] of result.tokens) tokenByRepo.set(repo, token);
+    repoCandidateErrors.push(...result.errors);
   }
 
   const candidates = await Promise.all(
     topScored.map(async (repo, index) => {
-      const tokenResult = await tokenResultByRepo.get(repo);
-      if (!tokenResult?.token) return null;
-      return createRunnerRepoCandidate(
-        repo,
-        tokenResult.token,
-        index < INSTRUCTION_FILE_PROBE_LIMIT,
-        deps,
-      );
+      const token = tokenByRepo.get(repo);
+      if (!token) return null;
+      return createRunnerRepoCandidate(repo, token, index < INSTRUCTION_FILE_PROBE_LIMIT, deps);
     }),
   );
-  const resolvedTokenResults = await Promise.all(tokenResults);
   return {
     candidates: candidates.filter((repo): repo is AgentRunnerRepoCandidate => repo !== null),
-    errors: resolvedTokenResults.flatMap((result) => (result.error === null ? [] : [result.error])),
+    errors: repoCandidateErrors,
   };
+}
+
+async function authorizeRepositoryChunk(
+  ctx: AgentRunContext,
+  installationId: number,
+  repos: ScoredGithubRepo[],
+  deps: StartQueuedAgentRunDeps,
+): Promise<{ tokens: Map<ScoredGithubRepo, string>; errors: unknown[] }> {
+  try {
+    const token = await deps.createRepositoryReadTokenForRepositories(
+      installationId,
+      repos.map((repo) => repo.id),
+    );
+    return {
+      tokens: new Map(repos.map((repo) => [repo, token])),
+      errors: [],
+    };
+  } catch (error) {
+    logger.error(
+      {
+        err: error,
+        agent_run_id: ctx.agentRun.id,
+        incident_id: ctx.incident.id,
+        installationId,
+        repo_count: repos.length,
+      },
+      "failed to authorize GitHub repository candidates",
+    );
+    if (deps.isRetryableRepositoryError(error) || repos.length === 1) {
+      return { tokens: new Map(), errors: [error] };
+    }
+
+    const midpoint = Math.floor(repos.length / 2);
+    const left = await authorizeRepositoryChunk(
+      ctx,
+      installationId,
+      repos.slice(0, midpoint),
+      deps,
+    );
+    const right = await authorizeRepositoryChunk(ctx, installationId, repos.slice(midpoint), deps);
+    return {
+      tokens: new Map([...left.tokens, ...right.tokens]),
+      errors: [...left.errors, ...right.errors],
+    };
+  }
 }
 
 const GITHUB_TOKEN_MAX_REPOSITORIES = 500;

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -91,7 +91,7 @@ export async function startQueuedAgentRunWorkflow(
       await createRunnerRepoCandidates(ctx, runner, scored, deps);
     if (repoCandidates.length === 0) {
       if (repoCandidateErrors.some(deps.isRetryableRepositoryError)) {
-        logger.warn(
+        logger.error(
           {
             agent_run_id: ctx.agentRun.id,
             incident_id: ctx.incident.id,

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -33,6 +33,7 @@ export type StartQueuedAgentRunDeps = {
     installationId: number,
     repositoryIds: number[],
   ): Promise<string>;
+  isRepositorySelectionError(error: unknown): boolean;
   isRetryableRepositoryError(error: unknown): boolean;
   listRepositoryInstructionFiles(
     installationToken: string,
@@ -284,6 +285,14 @@ async function createRunnerRepoCandidates(
         );
         for (const [repo, token] of result.tokens) tokens.set(repo, token);
         errors.push(...result.errors);
+        if (
+          result.errors.some(
+            (error) =>
+              deps.isRetryableRepositoryError(error) || !deps.isRepositorySelectionError(error),
+          )
+        ) {
+          break;
+        }
       }
       return { tokens, errors };
     }),
@@ -337,7 +346,11 @@ async function authorizeRepositoryChunk(
       },
       "failed to authorize GitHub repository candidates",
     );
-    if (deps.isRetryableRepositoryError(error) || repos.length === 1) {
+    if (
+      deps.isRetryableRepositoryError(error) ||
+      !deps.isRepositorySelectionError(error) ||
+      repos.length === 1
+    ) {
       return { tokens: new Map(), errors: [error] };
     }
 

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -89,18 +89,18 @@ export async function startQueuedAgentRunWorkflow(
   try {
     const { candidates: repoCandidates, errors: repoCandidateErrors } =
       await createRunnerRepoCandidates(ctx, runner, scored, deps);
+    if (repoCandidateErrors.some(deps.isRetryableRepositoryError)) {
+      logger.error(
+        {
+          agent_run_id: ctx.agentRun.id,
+          incident_id: ctx.incident.id,
+          failed_installation_count: repoCandidateErrors.length,
+        },
+        "repository authorization temporarily unavailable; will retry on the next sweep",
+      );
+      return;
+    }
     if (repoCandidates.length === 0) {
-      if (repoCandidateErrors.some(deps.isRetryableRepositoryError)) {
-        logger.error(
-          {
-            agent_run_id: ctx.agentRun.id,
-            incident_id: ctx.incident.id,
-            failed_installation_count: repoCandidateErrors.length,
-          },
-          "repository authorization temporarily unavailable; will retry on the next sweep",
-        );
-        return;
-      }
       await deps.fail(
         ctx,
         "github_repo_token_failed",

--- a/apps/worker/src/agent-runs/start.ts
+++ b/apps/worker/src/agent-runs/start.ts
@@ -361,6 +361,7 @@ async function authorizeRepositoryChunk(
       repos.slice(0, midpoint),
       deps,
     );
+    if (left.errors.some(deps.isRetryableRepositoryError)) return left;
     const right = await authorizeRepositoryChunk(ctx, installationId, repos.slice(midpoint), deps);
     return {
       tokens: new Map([...left.tokens, ...right.tokens]),

--- a/apps/worker/src/github-app.test.ts
+++ b/apps/worker/src/github-app.test.ts
@@ -36,6 +36,10 @@ test("GitHub HTTP retry policy distinguishes transient provider failures", () =>
     true,
   );
   assert.equal(isRetryableGithubHttpFailure(429, '{"message":"API rate limit exceeded"}'), true);
+  assert.equal(
+    isRetryableGithubHttpFailure(403, '{"message":"API rate limit exceeded"}', "0"),
+    true,
+  );
   assert.equal(isRetryableGithubHttpFailure(503, "service unavailable"), true);
   assert.equal(isRetryableGithubHttpFailure(403, '{"message":"Resource not accessible"}'), false);
   assert.equal(isRetryableGithubHttpFailure(404, '{"message":"Not Found"}'), false);

--- a/apps/worker/src/github-app.test.ts
+++ b/apps/worker/src/github-app.test.ts
@@ -22,6 +22,7 @@ import {
   isRetryableGithubHttpFailure,
   loadGithubPullRequestProviderObservationWithToken,
   openedAgentPullRequest,
+  parseGithubRetryDelayMs,
   recoverPullRequestDelivery,
   redactGitSecrets,
   reopenGithubPullRequestWithToken,
@@ -43,6 +44,25 @@ test("GitHub HTTP retry policy distinguishes transient provider failures", () =>
   assert.equal(isRetryableGithubHttpFailure(503, "service unavailable"), true);
   assert.equal(isRetryableGithubHttpFailure(403, '{"message":"Resource not accessible"}'), false);
   assert.equal(isRetryableGithubHttpFailure(404, '{"message":"Not Found"}'), false);
+});
+
+test("GitHub retry delay honors the primary rate-limit reset window", () => {
+  assert.equal(
+    parseGithubRetryDelayMs({
+      retryAfter: null,
+      rateLimitReset: "1753366805",
+      now: () => 1_753_366_800_000,
+    }),
+    5_000,
+  );
+  assert.equal(
+    parseGithubRetryDelayMs({
+      retryAfter: "120",
+      rateLimitReset: "1753366805",
+      now: () => 1_753_366_800_000,
+    }),
+    120_000,
+  );
 });
 
 test("GitHub installation token gate honors a transient failure's retry window", async () => {

--- a/apps/worker/src/github-app.test.ts
+++ b/apps/worker/src/github-app.test.ts
@@ -6,6 +6,8 @@ import path from "node:path";
 import { test } from "node:test";
 import {
   type GithubDirEntry,
+  GithubInstallationTokenGate,
+  GithubRequestError,
   MAX_REPO_INSTRUCTION_FILES,
   applyAgentPatch,
   buildPullRequestDeliveryCommitMessage,
@@ -17,12 +19,50 @@ import {
   isGitPushBranchCollision,
   isMissingRemoteBranchFailure,
   isRetryableGitPushFailure,
+  isRetryableGithubHttpFailure,
   loadGithubPullRequestProviderObservationWithToken,
   openedAgentPullRequest,
   recoverPullRequestDelivery,
   redactGitSecrets,
   reopenGithubPullRequestWithToken,
 } from "./github-app.js";
+
+test("GitHub HTTP retry policy distinguishes transient provider failures", () => {
+  assert.equal(
+    isRetryableGithubHttpFailure(
+      403,
+      '{"message":"You have exceeded a secondary rate limit. Please wait a few minutes."}',
+    ),
+    true,
+  );
+  assert.equal(isRetryableGithubHttpFailure(429, '{"message":"API rate limit exceeded"}'), true);
+  assert.equal(isRetryableGithubHttpFailure(503, "service unavailable"), true);
+  assert.equal(isRetryableGithubHttpFailure(403, '{"message":"Resource not accessible"}'), false);
+  assert.equal(isRetryableGithubHttpFailure(404, '{"message":"Not Found"}'), false);
+});
+
+test("GitHub installation token gate honors a transient failure's retry window", async () => {
+  let now = 1_000;
+  let requests = 0;
+  const gate = new GithubInstallationTokenGate(() => now);
+  const request = async () => {
+    requests += 1;
+    throw new GithubRequestError("secondary rate limit", {
+      retryable: true,
+      status: 403,
+      retryAfterMs: 120_000,
+    });
+  };
+
+  await assert.rejects(() => gate.run(123, request));
+  now += 60_000;
+  await assert.rejects(() => gate.run(123, request));
+  assert.equal(requests, 1);
+
+  now += 60_001;
+  await assert.rejects(() => gate.run(123, request));
+  assert.equal(requests, 2);
+});
 
 test("PR review tokens are restricted to the queued repository", () => {
   assert.deepEqual(githubPullRequestReviewTokenScope(123, 456), {

--- a/apps/worker/src/github-app.test.ts
+++ b/apps/worker/src/github-app.test.ts
@@ -51,6 +51,7 @@ test("GitHub retry delay honors the primary rate-limit reset window", () => {
     parseGithubRetryDelayMs({
       retryAfter: null,
       rateLimitReset: "1753366805",
+      rateLimitRemaining: "0",
       now: () => 1_753_366_800_000,
     }),
     5_000,
@@ -59,9 +60,19 @@ test("GitHub retry delay honors the primary rate-limit reset window", () => {
     parseGithubRetryDelayMs({
       retryAfter: "120",
       rateLimitReset: "1753366805",
+      rateLimitRemaining: "0",
       now: () => 1_753_366_800_000,
     }),
     120_000,
+  );
+  assert.equal(
+    parseGithubRetryDelayMs({
+      retryAfter: null,
+      rateLimitReset: "1753370400",
+      rateLimitRemaining: "4999",
+      now: () => 1_753_366_800_000,
+    }),
+    undefined,
   );
 });
 

--- a/apps/worker/src/github-app.ts
+++ b/apps/worker/src/github-app.ts
@@ -378,7 +378,10 @@ async function githubRequest<T>(
   }
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    const retryAfterMs = parseRetryAfterMs(res.headers.get("retry-after"));
+    const retryAfterMs = parseGithubRetryDelayMs({
+      retryAfter: res.headers.get("retry-after"),
+      rateLimitReset: res.headers.get("x-ratelimit-reset"),
+    });
     throw new GithubRequestError(`github ${method} ${pathname} failed: ${res.status} ${text}`, {
       retryable: isRetryableGithubHttpFailure(
         res.status,
@@ -392,13 +395,28 @@ async function githubRequest<T>(
   return (await res.json()) as T;
 }
 
-function parseRetryAfterMs(value: string | null): number | undefined {
+export function parseGithubRetryDelayMs(opts: {
+  retryAfter: string | null;
+  rateLimitReset: string | null;
+  now?: () => number;
+}): number | undefined {
+  const now = opts.now ?? Date.now;
+  const retryAfterMs = parseRetryAfterMs(opts.retryAfter, now);
+  if (retryAfterMs !== undefined) return retryAfterMs;
+
+  if (!opts.rateLimitReset) return undefined;
+  const resetEpochSeconds = Number(opts.rateLimitReset);
+  if (!Number.isFinite(resetEpochSeconds) || resetEpochSeconds < 0) return undefined;
+  return Math.max(0, resetEpochSeconds * 1_000 - now());
+}
+
+function parseRetryAfterMs(value: string | null, now: () => number): number | undefined {
   if (!value) return undefined;
   const seconds = Number(value);
   if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
   const date = Date.parse(value);
   if (Number.isNaN(date)) return undefined;
-  return Math.max(0, date - Date.now());
+  return Math.max(0, date - now());
 }
 
 const installationTokenGate = new GithubInstallationTokenGate();

--- a/apps/worker/src/github-app.ts
+++ b/apps/worker/src/github-app.ts
@@ -72,11 +72,15 @@ export function isRetryableGithubRequestError(error: unknown): error is GithubRe
   return error instanceof GithubRequestError && error.retryable;
 }
 
-export function isRetryableGithubHttpFailure(status: number, responseBody: string): boolean {
+export function isRetryableGithubHttpFailure(
+  status: number,
+  responseBody: string,
+  rateLimitRemaining?: string | null,
+): boolean {
   return (
     status === 429 ||
     status >= 500 ||
-    (status === 403 && /secondary rate limit/i.test(responseBody))
+    (status === 403 && (rateLimitRemaining === "0" || /secondary rate limit/i.test(responseBody)))
   );
 }
 
@@ -376,7 +380,11 @@ async function githubRequest<T>(
     const text = await res.text().catch(() => "");
     const retryAfterMs = parseRetryAfterMs(res.headers.get("retry-after"));
     throw new GithubRequestError(`github ${method} ${pathname} failed: ${res.status} ${text}`, {
-      retryable: isRetryableGithubHttpFailure(res.status, text),
+      retryable: isRetryableGithubHttpFailure(
+        res.status,
+        text,
+        res.headers.get("x-ratelimit-remaining"),
+      ),
       status: res.status,
       retryAfterMs,
     });

--- a/apps/worker/src/github-app.ts
+++ b/apps/worker/src/github-app.ts
@@ -107,7 +107,7 @@ export class GithubInstallationTokenGate {
       const blockedUntil = this.blockedUntil.get(installationId) ?? 0;
       if (blockedUntil > now) {
         const retryAfterMs = blockedUntil - now;
-        logger.info(
+        logger.error(
           {
             installationId,
             retry_after_ms: retryAfterMs,

--- a/apps/worker/src/github-app.ts
+++ b/apps/worker/src/github-app.ts
@@ -46,6 +46,91 @@ const GITHUB_API = "https://api.github.com";
 const GIT_PUSH_MAX_ATTEMPTS = 3;
 const GIT_PUSH_RETRY_DELAYS_MS = [1_000, 3_000] as const;
 
+export class GithubRequestError extends Error {
+  readonly retryable: boolean;
+  readonly status: number | null;
+  readonly retryAfterMs: number | null;
+
+  constructor(
+    message: string,
+    options: {
+      retryable: boolean;
+      status?: number;
+      retryAfterMs?: number;
+      cause?: unknown;
+    },
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "GithubRequestError";
+    this.retryable = options.retryable;
+    this.status = options.status ?? null;
+    this.retryAfterMs = options.retryAfterMs ?? null;
+  }
+}
+
+export function isRetryableGithubRequestError(error: unknown): error is GithubRequestError {
+  return error instanceof GithubRequestError && error.retryable;
+}
+
+export function isRetryableGithubHttpFailure(status: number, responseBody: string): boolean {
+  return (
+    status === 429 ||
+    status >= 500 ||
+    (status === 403 && /secondary rate limit/i.test(responseBody))
+  );
+}
+
+const DEFAULT_GITHUB_RETRY_DELAY_MS = 60_000;
+
+export class GithubInstallationTokenGate {
+  private readonly blockedUntil = new Map<number, number>();
+  private readonly queueTails = new Map<number, Promise<void>>();
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  async run<T>(installationId: number, request: () => Promise<T>): Promise<T> {
+    const predecessor = this.queueTails.get(installationId) ?? Promise.resolve();
+    let release!: () => void;
+    const turn = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = predecessor.catch(() => undefined).then(() => turn);
+    this.queueTails.set(installationId, tail);
+    await predecessor.catch(() => undefined);
+
+    try {
+      const now = this.now();
+      const blockedUntil = this.blockedUntil.get(installationId) ?? 0;
+      if (blockedUntil > now) {
+        throw new GithubRequestError(
+          `GitHub installation ${installationId} is temporarily rate limited`,
+          {
+            retryable: true,
+            retryAfterMs: blockedUntil - now,
+          },
+        );
+      }
+      const result = await request();
+      this.blockedUntil.delete(installationId);
+      return result;
+    } catch (error) {
+      if (isRetryableGithubRequestError(error)) {
+        const retryAfterMs = error.retryAfterMs ?? DEFAULT_GITHUB_RETRY_DELAY_MS;
+        this.blockedUntil.set(
+          installationId,
+          Math.max(this.blockedUntil.get(installationId) ?? 0, this.now() + retryAfterMs),
+        );
+      }
+      throw error;
+    } finally {
+      release();
+      if (this.queueTails.get(installationId) === tail) {
+        this.queueTails.delete(installationId);
+      }
+    }
+  }
+}
+
 function formatGitCommand(args: string[]): string {
   return `git ${args.join(" ")}`;
 }
@@ -264,23 +349,51 @@ async function githubRequest<T>(
     bearerToken: string;
   },
 ): Promise<T> {
-  const res = await fetch(`${GITHUB_API}${pathname}`, {
-    method: opts.method ?? "GET",
-    headers: {
-      accept: "application/vnd.github+json",
-      authorization: `Bearer ${opts.bearerToken}`,
-      "content-type": "application/json; charset=utf-8",
-      "x-github-api-version": "2022-11-28",
-      "user-agent": "superlog-worker",
-    },
-    body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
-  });
+  const method = opts.method ?? "GET";
+  let res: Response;
+  try {
+    res = await fetch(`${GITHUB_API}${pathname}`, {
+      method,
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${opts.bearerToken}`,
+        "content-type": "application/json; charset=utf-8",
+        "x-github-api-version": "2022-11-28",
+        "user-agent": "superlog-worker",
+      },
+      body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
+    });
+  } catch (cause) {
+    throw new GithubRequestError(
+      `github ${method} ${pathname} failed before receiving a response`,
+      {
+        retryable: true,
+        cause,
+      },
+    );
+  }
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`github ${opts.method ?? "GET"} ${pathname} failed: ${res.status} ${text}`);
+    const retryAfterMs = parseRetryAfterMs(res.headers.get("retry-after"));
+    throw new GithubRequestError(`github ${method} ${pathname} failed: ${res.status} ${text}`, {
+      retryable: isRetryableGithubHttpFailure(res.status, text),
+      status: res.status,
+      retryAfterMs,
+    });
   }
   return (await res.json()) as T;
 }
+
+function parseRetryAfterMs(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
+  const date = Date.parse(value);
+  if (Number.isNaN(date)) return undefined;
+  return Math.max(0, date - Date.now());
+}
+
+const installationTokenGate = new GithubInstallationTokenGate();
 
 async function createInstallationToken(opts: {
   installationId: number;
@@ -289,19 +402,21 @@ async function createInstallationToken(opts: {
 }): Promise<string> {
   const cfg = getGithubAppConfig();
   if (!cfg) throw new Error("GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY are required");
-  const appJwt = signGithubAppJwt(cfg.appId, cfg.privateKey);
-  const data = await githubRequest<{ token: string }>(
-    `/app/installations/${opts.installationId}/access_tokens`,
-    {
-      method: "POST",
-      bearerToken: appJwt,
-      body: {
-        permissions: opts.permissions,
-        repository_ids: opts.repositoryIds,
+  return installationTokenGate.run(opts.installationId, async () => {
+    const appJwt = signGithubAppJwt(cfg.appId, cfg.privateKey);
+    const data = await githubRequest<{ token: string }>(
+      `/app/installations/${opts.installationId}/access_tokens`,
+      {
+        method: "POST",
+        bearerToken: appJwt,
+        body: {
+          permissions: opts.permissions,
+          repository_ids: opts.repositoryIds,
+        },
       },
-    },
-  );
-  return data.token;
+    );
+    return data.token;
+  });
 }
 
 export async function createGithubReadToken(
@@ -311,6 +426,17 @@ export async function createGithubReadToken(
   return createInstallationToken({
     installationId,
     repositoryIds: repositoryId ? [repositoryId] : undefined,
+    permissions: { contents: "read" },
+  });
+}
+
+export async function createGithubReadTokenForRepositories(
+  installationId: number,
+  repositoryIds: number[],
+): Promise<string> {
+  return createInstallationToken({
+    installationId,
+    repositoryIds,
     permissions: { contents: "read" },
   });
 }

--- a/apps/worker/src/github-app.ts
+++ b/apps/worker/src/github-app.ts
@@ -106,11 +106,19 @@ export class GithubInstallationTokenGate {
       const now = this.now();
       const blockedUntil = this.blockedUntil.get(installationId) ?? 0;
       if (blockedUntil > now) {
+        const retryAfterMs = blockedUntil - now;
+        logger.info(
+          {
+            installationId,
+            retry_after_ms: retryAfterMs,
+          },
+          "GitHub installation token gate is rate-limited; skipping request until window expires",
+        );
         throw new GithubRequestError(
           `GitHub installation ${installationId} is temporarily rate limited`,
           {
             retryable: true,
-            retryAfterMs: blockedUntil - now,
+            retryAfterMs,
           },
         );
       }

--- a/apps/worker/src/github-app.ts
+++ b/apps/worker/src/github-app.ts
@@ -389,6 +389,7 @@ async function githubRequest<T>(
     const retryAfterMs = parseGithubRetryDelayMs({
       retryAfter: res.headers.get("retry-after"),
       rateLimitReset: res.headers.get("x-ratelimit-reset"),
+      rateLimitRemaining: res.headers.get("x-ratelimit-remaining"),
     });
     throw new GithubRequestError(`github ${method} ${pathname} failed: ${res.status} ${text}`, {
       retryable: isRetryableGithubHttpFailure(
@@ -406,13 +407,14 @@ async function githubRequest<T>(
 export function parseGithubRetryDelayMs(opts: {
   retryAfter: string | null;
   rateLimitReset: string | null;
+  rateLimitRemaining: string | null;
   now?: () => number;
 }): number | undefined {
   const now = opts.now ?? Date.now;
   const retryAfterMs = parseRetryAfterMs(opts.retryAfter, now);
   if (retryAfterMs !== undefined) return retryAfterMs;
 
-  if (!opts.rateLimitReset) return undefined;
+  if (opts.rateLimitRemaining !== "0" || !opts.rateLimitReset) return undefined;
   const resetEpochSeconds = Number(opts.rateLimitReset);
   if (!Number.isFinite(resetEpochSeconds) || resetEpochSeconds < 0) return undefined;
   return Math.max(0, resetEpochSeconds * 1_000 - now());

--- a/apps/worker/src/github-app.ts
+++ b/apps/worker/src/github-app.ts
@@ -72,6 +72,15 @@ export function isRetryableGithubRequestError(error: unknown): error is GithubRe
   return error instanceof GithubRequestError && error.retryable;
 }
 
+export function isGithubRepositorySelectionError(error: unknown): error is GithubRequestError {
+  return (
+    error instanceof GithubRequestError &&
+    !error.retryable &&
+    error.status === 422 &&
+    /repositor(?:y|ies)|repository_ids/i.test(error.message)
+  );
+}
+
 export function isRetryableGithubHttpFailure(
   status: number,
   responseBody: string,

--- a/apps/worker/src/infra/github/repositories.ts
+++ b/apps/worker/src/infra/github/repositories.ts
@@ -1,5 +1,7 @@
 export {
+  isRetryableGithubRequestError,
   createGithubReadToken as createRepositoryReadToken,
+  createGithubReadTokenForRepositories as createRepositoryReadTokenForRepositories,
   listGithubInstallationRepositories as listInstallationRepositories,
   listGithubRepoInstructionFiles as listRepositoryInstructionFiles,
 } from "../../github-app.js";

--- a/apps/worker/src/infra/github/repositories.ts
+++ b/apps/worker/src/infra/github/repositories.ts
@@ -1,4 +1,5 @@
 export {
+  isGithubRepositorySelectionError,
   isRetryableGithubRequestError,
   createGithubReadToken as createRepositoryReadToken,
   createGithubReadTokenForRepositories as createRepositoryReadTokenForRepositories,

--- a/scripts/worktree-bootstrap.sh
+++ b/scripts/worktree-bootstrap.sh
@@ -132,6 +132,17 @@ echo "==> worktree:    $WT_NAME"
 echo "==> main repo:   $MAIN_REPO"
 echo "==> mode:        $MODE"
 
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required for worktree bootstrap but the CLI is not installed." >&2
+  echo "Install Docker Desktop, start it, then rerun this command." >&2
+  exit 1
+fi
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker is installed but its daemon is not running." >&2
+  echo "Start Docker Desktop, wait until it is ready, then rerun this command." >&2
+  exit 1
+fi
+
 # -----------------------------------------------------------------------------
 # 0. orphan Docker resource check
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- create one installation token scoped to all selected repositories instead of one token per repository
- classify network errors, rate limits, and GitHub 5xx responses as retryable across both discovery and token authorization
- serialize installation-token requests per installation and honor Retry-After with a bounded fallback circuit breaker
- keep transient failures in repository discovery without posting a terminal failure
- add a Docker-daemon preflight to worktree bootstrap

## Root cause

Large installations issued one concurrent access-token request per repository. A 100-repository run could therefore trigger GitHub secondary rate limiting. Separately, transient connect timeouts during repository listing were treated as permanent run failures. Both paths created avoidable terminal notifications and required manual restarts.

## Verification

- worker typecheck
- agent-run start workflow tests
- repository-discovery context tests
- GitHub integration boundary tests
- worktree bootstrap and full worktree verification
- formatting and shell validation

Supersedes #387 and #388.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes GitHub repo discovery and authorization resilient by sharing installation tokens across up to 500 repos, gating per installation with a token gate that honors retry windows, salvaging valid repos from invalid batches with bounded bisection that stops on retryable errors, and deferring runs on transient provider failures.

- **New Features**
  - Share installation‑scoped read tokens across repos with per‑installation gating; chunk to 500, skip during blocked windows, honor `Retry-After` and use `x-ratelimit-reset` only for primary limits; bisect invalid batches to salvage valid repo candidates and stop fallback once a half fails retryably; skip instruction‑file probes after retryable GitHub failures.
  - Classify network errors, 429/5xx, and secondary/primary rate limits as retryable for both discovery and token authorization. Add a Docker daemon preflight to `worktree-bootstrap.sh`.

- **Bug Fixes**
  - Defer repository authorization when any installation token request fails transiently and avoid bisecting on installation‑wide failures; retry on the next sweep without posting a terminal failure.
  - Preserve discovery progress and retry when all installations temporarily fail.

<sup>Written for commit 4f3f514f95282d105d308a9a19ce8b8d6d538374. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

