### PR TITLE
Prefill organization name from Google Workspace domain

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -128,6 +128,7 @@ import {
 } from "./mcp/clickhouse.js";
 import { mountMcpAuthed, mountMcpPublic } from "./mcp/index.js";
 import { mountNotionAuthed, mountNotionPublic } from "./notion.js";
+import { suggestOrgNameFromGoogleIdToken } from "./onboarding-org-suggestion.js";
 import { requireProjectManagerContext } from "./org-authorization-http.js";
 import { resolveActiveOrgContext, resolveMaybeActiveOrgContext } from "./org-context.js";
 import { ORG_NAME_MAX, createOrgWithDefaults, mountOrgCrud } from "./orgs.js";
@@ -500,6 +501,16 @@ app.get("/api/me", async (c) => {
   // null org/project so the web client can route them to the create-org step
   // in the onboarding wizard.
   if (!ctx.org) {
+    const googleAccount = await db.query.accounts.findFirst({
+      where: and(eq(schema.accounts.userId, user.id), eq(schema.accounts.providerId, "google")),
+      columns: { idToken: true },
+    });
+    // Better Auth validated this provider token before persisting it. The claim
+    // is used only as an editable onboarding suggestion, never for access.
+    const suggestedOrgName = googleAccount?.idToken
+      ? suggestOrgNameFromGoogleIdToken(googleAccount.idToken)
+      : null;
+
     return c.json({
       user: {
         id: user.id,
@@ -510,6 +521,7 @@ app.get("/api/me", async (c) => {
       },
       org: null,
       project: null,
+      suggestedOrgName,
       favorite: { orgId: user.favoriteOrgId, projectId: user.favoriteProjectId },
       billingEnforcement,
       features: { anomalyScanner: false },
@@ -571,6 +583,7 @@ app.get("/api/me", async (c) => {
       hasIngested,
       hasSentryIssues,
     },
+    suggestedOrgName: null,
     favorite: { orgId: user.favoriteOrgId, projectId: user.favoriteProjectId },
     demoMode,
     billingEnforcement,

--- a/apps/api/src/onboarding-org-suggestion.test.ts
+++ b/apps/api/src/onboarding-org-suggestion.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { suggestOrgNameFromGoogleIdToken } from "./onboarding-org-suggestion.js";
+
+function unsignedIdToken(payload: Record<string, unknown>): string {
+  return `header.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+}
+
+test("suggests the first Google Workspace domain label as the organization name", () => {
+  assert.equal(suggestOrgNameFromGoogleIdToken(unsignedIdToken({ hd: "acme.com" })), "Acme");
+});
+
+test("does not suggest an organization for a consumer Google account", () => {
+  assert.equal(suggestOrgNameFromGoogleIdToken(unsignedIdToken({ email: "jane@gmail.com" })), null);
+});

--- a/apps/api/src/onboarding-org-suggestion.ts
+++ b/apps/api/src/onboarding-org-suggestion.ts
@@ -1,0 +1,18 @@
+export function suggestOrgNameFromGoogleIdToken(idToken: string): string | null {
+  const encodedPayload = idToken.split(".")[1];
+  if (!encodedPayload) return null;
+
+  try {
+    const payload = JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf8")) as {
+      hd?: unknown;
+    };
+    if (typeof payload.hd !== "string") return null;
+
+    const domainLabel = payload.hd.trim().split(".")[0];
+    if (!domainLabel) return null;
+
+    return domainLabel.charAt(0).toUpperCase() + domainLabel.slice(1);
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -22,6 +22,7 @@ export type Me = {
     hasIngested: boolean;
     hasSentryIssues: boolean;
   } | null;
+  suggestedOrgName: string | null;
   // True when a shared demo project is configured and this project hasn't
   // ingested yet — the server is serving it read-only sample data. Drives the
   // demo-explore experience + the persistent install nudge. Flips false the

--- a/apps/web/src/onboarding/OnboardingGate.tsx
+++ b/apps/web/src/onboarding/OnboardingGate.tsx
@@ -82,6 +82,7 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
         hasSentryIssues={hasSentryIssues}
         userName={me.data.user.name}
         userEmail={me.data.user.email}
+        workspaceOrgName={me.data.suggestedOrgName}
         onComplete={() => {
           if (skillMode) finishSkillOnboarding();
           setDismissed(true);
@@ -99,6 +100,7 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
         hasSentryIssues={hasSentryIssues}
         userName={me.data.user.name}
         userEmail={me.data.user.email}
+        workspaceOrgName={me.data.suggestedOrgName}
         onComplete={() => {
           finishSkillOnboarding();
           setDismissed(true);
@@ -124,6 +126,7 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
       hasSentryIssues={hasSentryIssues}
       userName={me.data.user.name}
       userEmail={me.data.user.email}
+      workspaceOrgName={me.data.suggestedOrgName}
       onComplete={() => {
         setDismissed(true);
       }}

--- a/apps/web/src/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/onboarding/OnboardingWizard.tsx
@@ -34,6 +34,7 @@ import {
   initialWebViewFromSearch,
   stripHandledOnboardingParams,
 } from "./onboardingWebView.ts";
+import { suggestedOrgName } from "./orgNameSuggestion.ts";
 import {
   ExploreDemoLink,
   InstallPromptCard,
@@ -77,6 +78,7 @@ export function OnboardingWizard({
   hasSentryIssues,
   userName,
   userEmail,
+  workspaceOrgName,
   onComplete,
   onExploreDemo,
 }: {
@@ -92,6 +94,7 @@ export function OnboardingWizard({
   hasSentryIssues: boolean;
   userName: string;
   userEmail: string;
+  workspaceOrgName?: string | null;
   onComplete: () => void;
   // Present only when a shared demo project is configured. Lets the user skip
   // ahead and explore sample data instead of instrumenting first.
@@ -178,7 +181,11 @@ export function OnboardingWizard({
         <div className="w-full max-w-[640px]">
           {!projectId ? (
             <>
-              <CreateOrgStep userName={userName} userEmail={userEmail} />
+              <CreateOrgStep
+                userName={userName}
+                userEmail={userEmail}
+                workspaceOrgName={workspaceOrgName}
+              />
               <FounderCallCard />
             </>
           ) : mode === "agent" ? (
@@ -271,19 +278,18 @@ export function OnboardingWizard({
   );
 }
 
-// Suggest an org name from whatever we know about the user. Google sign-in
-// gives us a real display name ("Jane Doe"); email/password gives us nothing,
-// so we fall back to the email local part.
-function suggestedOrgName(userName: string, userEmail: string): string {
-  const trimmedName = userName.trim();
-  if (trimmedName) return `${trimmedName}'s org`;
-  const local = userEmail.split("@")[0] ?? "";
-  if (local) return `${local}'s org`;
-  return "";
-}
-
-function CreateOrgStep({ userName, userEmail }: { userName: string; userEmail: string }) {
-  const [name, setName] = useState(() => suggestedOrgName(userName, userEmail));
+function CreateOrgStep({
+  userName,
+  userEmail,
+  workspaceOrgName,
+}: {
+  userName: string;
+  userEmail: string;
+  workspaceOrgName?: string | null;
+}) {
+  const [name, setName] = useState(() =>
+    suggestedOrgName({ workspaceOrgName, userName, userEmail }),
+  );
   const inputRef = useRef<HTMLInputElement>(null);
   const createOrg = useCreateMyFirstOrg();
   const trimmed = name.trim();

--- a/apps/web/src/onboarding/orgNameSuggestion.test.ts
+++ b/apps/web/src/onboarding/orgNameSuggestion.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { suggestedOrgName } from "./orgNameSuggestion.ts";
+
+test("prefers a Google Workspace organization suggestion over the user's display name", () => {
+  assert.equal(
+    suggestedOrgName({
+      workspaceOrgName: "Acme",
+      userName: "Jane Doe",
+      userEmail: "jane@acme.com",
+    }),
+    "Acme",
+  );
+});
+
+test("falls back to the user's display name without a Workspace suggestion", () => {
+  assert.equal(
+    suggestedOrgName({
+      workspaceOrgName: null,
+      userName: "Jane Doe",
+      userEmail: "jane@gmail.com",
+    }),
+    "Jane Doe's org",
+  );
+});

--- a/apps/web/src/onboarding/orgNameSuggestion.ts
+++ b/apps/web/src/onboarding/orgNameSuggestion.ts
@@ -1,0 +1,20 @@
+export function suggestedOrgName({
+  workspaceOrgName,
+  userName,
+  userEmail,
+}: {
+  workspaceOrgName?: string | null;
+  userName: string;
+  userEmail: string;
+}): string {
+  const trimmedWorkspaceName = workspaceOrgName?.trim();
+  if (trimmedWorkspaceName) return trimmedWorkspaceName;
+
+  const trimmedName = userName.trim();
+  if (trimmedName) return `${trimmedName}'s org`;
+
+  const local = userEmail.split("@")[0] ?? "";
+  if (local) return `${local}'s org`;
+
+  return "";
+}

--- a/apps/web/src/org-name-suggestion.test.ts
+++ b/apps/web/src/org-name-suggestion.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { suggestedOrgName } from "./orgNameSuggestion.ts";
+import { suggestedOrgName } from "./onboarding/orgNameSuggestion.ts";
 
 test("prefers a Google Workspace organization suggestion over the user's display name", () => {
   assert.equal(


### PR DESCRIPTION
## What changed

- Read the validated Google Workspace `hd` claim from the stored Google OAuth ID token for users creating their first organization.
- Convert the first hosted-domain label into an editable organization-name suggestion (`acme.com` → `Acme`).
- Preserve the existing display-name/email fallback for consumer Google accounts and other sign-in methods.
- Add focused API and web behavior tests that run in the standard package test commands.

## Why

Google Workspace users currently see a personal organization suggestion such as `Jane Doe's org`. Their hosted domain is a better default while keeping the field editable and avoiding extra Google permissions.

## Validation

- `pnpm --dir superlog --filter @superlog/api exec tsx --test src/onboarding-org-suggestion.test.ts`
- `pnpm --dir superlog --filter @superlog/web test`
- `pnpm --dir superlog --filter @superlog/api typecheck`
- `pnpm --dir superlog --filter @superlog/web typecheck`
- `pnpm --dir superlog --filter @superlog/web build`
- `pnpm --dir superlog worktree:bootstrap --seed`