### PR TITLE
Parse structured Railway logs

### DIFF
--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -85,7 +85,7 @@ export function parseRailwayLogRecord(
   const body = fields?.msg ?? fields?.message;
   const nativeSeverity = fields?.level;
   const parsedSeverity = nativeSeverity ? normalizeNativeSeverity(nativeSeverity) : null;
-  if (!fields || (!body && !parsedSeverity)) {
+  if (!fields || (body === undefined && !parsedSeverity)) {
     return { body: message, severity: providerSeverity, attributes: [] };
   }
 

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -84,6 +84,7 @@ export function parseRailwayLogRecord(
       "logfmt",
       Object.entries(fields)
         .filter(([key, value]) => isBoundedField(key, value))
+        .slice(0, MAX_PARSED_FIELDS)
         .map(([key, value]) => ({
           key: `railway.log.${normalizeAttributeKey(key)}`,
           value,
@@ -188,8 +189,8 @@ function parseJson(
         ? record.msg
         : null;
   if (!body) return null;
-  const nativeSeverity = record.level ?? record.severity;
-  const parsedSeverity = normalizeJsonSeverity(nativeSeverity);
+  const parsedSeverity =
+    normalizeJsonSeverity(record.level) ?? normalizeJsonSeverity(record.severity);
 
   const parsedFields = Object.entries(record)
     .filter(
@@ -393,9 +394,10 @@ function parseLogfmt(message: string): Record<string, string> | null {
       value = message.slice(valueStart, cursor);
     }
 
-    fields[key] = value;
+    if (count < MAX_PARSED_FIELDS || key === "level" || key === "msg" || key === "message") {
+      fields[key] = value;
+    }
     count += 1;
-    if (count > MAX_PARSED_FIELDS) return null;
   }
 
   if (count < 2) return null;

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -166,15 +166,19 @@ function parseJson(
 ): ParsedRailwayLogRecord | null {
   let value: unknown;
   try {
-    value = JSON.parse(message, (_key: string, parsed: unknown, context?: { source?: string }) =>
-      preserveUnsafeInteger(parsed, context?.source),
-    );
+    value = JSON.parse(message);
   } catch {
     return null;
   }
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
 
-  const record = value as Record<string, unknown>;
+  const sources = parseTopLevelJsonSources(message);
+  const record = Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, fieldValue]) => [
+      key,
+      preserveUnsafeInteger(fieldValue, sources?.get(key)),
+    ]),
+  );
   const body =
     typeof record.message === "string"
       ? record.message
@@ -206,6 +210,91 @@ function parseJson(
       message,
     ),
   };
+}
+
+function parseTopLevelJsonSources(message: string): Map<string, string> | null {
+  const sources = new Map<string, string>();
+  let cursor = skipWhitespace(message, 0);
+  if (message[cursor] !== "{") return null;
+  cursor += 1;
+
+  while (cursor < message.length) {
+    cursor = skipWhitespace(message, cursor);
+    if (message[cursor] === "}") return sources;
+    if (message[cursor] !== '"') return null;
+
+    const keyEnd = scanJsonStringEnd(message, cursor);
+    if (keyEnd === null) return null;
+    const key: unknown = JSON.parse(message.slice(cursor, keyEnd));
+    if (typeof key !== "string") return null;
+    cursor = skipWhitespace(message, keyEnd);
+    if (message[cursor] !== ":") return null;
+
+    cursor = skipWhitespace(message, cursor + 1);
+    const valueStart = cursor;
+    const valueEnd = scanJsonValueEnd(message, valueStart);
+    if (valueEnd === null) return null;
+    sources.set(key, message.slice(valueStart, valueEnd).trim());
+
+    cursor = skipWhitespace(message, valueEnd);
+    if (message[cursor] === ",") {
+      cursor += 1;
+      continue;
+    }
+    if (message[cursor] === "}") return sources;
+    return null;
+  }
+
+  return null;
+}
+
+function scanJsonValueEnd(message: string, start: number): number | null {
+  const first = message[start];
+  if (first === '"') return scanJsonStringEnd(message, start);
+
+  if (first === "{" || first === "[") {
+    const stack = [first];
+    let cursor = start + 1;
+    while (cursor < message.length) {
+      const character = message[cursor];
+      if (character === '"') {
+        const stringEnd = scanJsonStringEnd(message, cursor);
+        if (stringEnd === null) return null;
+        cursor = stringEnd;
+        continue;
+      }
+      if (character === "{" || character === "[") stack.push(character);
+      if (character === "}" || character === "]") {
+        stack.pop();
+        if (stack.length === 0) return cursor + 1;
+      }
+      cursor += 1;
+    }
+    return null;
+  }
+
+  let cursor = start;
+  while (cursor < message.length && message[cursor] !== "," && message[cursor] !== "}") cursor += 1;
+  return cursor;
+}
+
+function scanJsonStringEnd(message: string, start: number): number | null {
+  let cursor = start + 1;
+  while (cursor < message.length) {
+    if (message[cursor] === "\\") {
+      cursor += 2;
+      continue;
+    }
+    if (message[cursor] === '"') return cursor + 1;
+    cursor += 1;
+  }
+  return null;
+}
+
+function skipWhitespace(message: string, start: number): number {
+  let cursor = start;
+  while (cursor < message.length && isWhitespace(message[cursor])) cursor += 1;
+  return cursor;
 }
 
 function parsePostgresql(

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -29,6 +29,14 @@ const NATIVE_SEVERITY: Record<string, string> = {
   alert: "fatal",
   emergency: "fatal",
 };
+const NUMERIC_JSON_SEVERITY: Record<number, string> = {
+  10: "trace",
+  20: "debug",
+  30: "info",
+  40: "warn",
+  50: "error",
+  60: "fatal",
+};
 const POSTGRESQL_SEVERITY: Record<string, string> = {
   DEBUG: "debug",
   DEBUG1: "debug",
@@ -90,6 +98,9 @@ export function parseRailwayLogRecord(
 export function parseRailwayAttributeValue(value: string): ParsedAttributeValue {
   try {
     const parsed: unknown = JSON.parse(value);
+    if (typeof parsed === "number" && Number.isInteger(parsed) && !Number.isSafeInteger(parsed)) {
+      return value;
+    }
     return isScalar(parsed) ? parsed : value;
   } catch {
     return value;
@@ -171,14 +182,8 @@ function parseJson(
         ? record.msg
         : null;
   if (!body) return null;
-  const nativeSeverity =
-    typeof record.level === "string"
-      ? record.level
-      : typeof record.severity === "string"
-        ? record.severity
-        : null;
-  const parsedSeverity =
-    typeof nativeSeverity === "string" ? normalizeNativeSeverity(nativeSeverity) : null;
+  const nativeSeverity = record.level ?? record.severity;
+  const parsedSeverity = normalizeJsonSeverity(nativeSeverity);
 
   const parsedFields = Object.entries(record)
     .filter(
@@ -332,6 +337,12 @@ function isScalar(value: unknown): value is ParsedAttributeValue {
 
 function normalizeNativeSeverity(value: string): string | null {
   return NATIVE_SEVERITY[value.trim().toLowerCase()] ?? null;
+}
+
+function normalizeJsonSeverity(value: unknown): string | null {
+  if (typeof value === "string") return normalizeNativeSeverity(value);
+  if (typeof value === "number") return NUMERIC_JSON_SEVERITY[value] ?? null;
+  return null;
 }
 
 function isBoundedField(key: string, value: ParsedAttributeValue): boolean {

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -390,7 +390,6 @@ function parseLogfmt(message: string): Record<string, string> | null {
     } else {
       const valueStart = cursor;
       while (cursor < message.length && !isWhitespace(message[cursor])) cursor += 1;
-      if (valueStart === cursor) return null;
       value = message.slice(valueStart, cursor);
     }
 

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -1,0 +1,299 @@
+type ParsedAttributeValue = string | number | boolean;
+type ParsedAttribute = { key: string; value: ParsedAttributeValue };
+
+export type ParsedRailwayLogRecord = {
+  body: string;
+  severity: string | null;
+  attributes: ParsedAttribute[];
+};
+
+const LOGFMT_FIELD = /([A-Za-z_][A-Za-z0-9_.-]*)=(?:"((?:\\.|[^"])*)"|(\S+))/g;
+const HTTP_ACCESS_RECORD =
+  /^(\S+) \S+ \S+ \[([^\]]+)\] "([A-Z]+) (\S+) HTTP\/(\d(?:\.\d)?)" (\d{3}) (\d+|-)(?: ([\d.]+|-))?$/;
+const POSTGRESQL_RECORD =
+  /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)? [A-Z]+) \[(\d+)\] (?:(\S+?)@(\S+) )?([A-Z][A-Z0-9]*):\s*(.*)$/s;
+const MAX_PARSED_FIELDS = 32;
+const MAX_PARSED_KEY_LENGTH = 128;
+const MAX_PARSED_STRING_LENGTH = 4096;
+const NATIVE_SEVERITY: Record<string, string> = {
+  trace: "trace",
+  debug: "debug",
+  info: "info",
+  information: "info",
+  notice: "info",
+  warn: "warn",
+  warning: "warn",
+  err: "error",
+  error: "error",
+  fatal: "fatal",
+  critical: "fatal",
+  alert: "fatal",
+  emergency: "fatal",
+};
+const POSTGRESQL_SEVERITY: Record<string, string> = {
+  DEBUG: "debug",
+  DEBUG1: "debug",
+  DEBUG2: "debug",
+  DEBUG3: "debug",
+  DEBUG4: "debug",
+  DEBUG5: "debug",
+  DETAIL: "info",
+  HINT: "info",
+  INFO: "info",
+  LOG: "info",
+  NOTICE: "info",
+  STATEMENT: "info",
+  WARNING: "warn",
+  ERROR: "error",
+  FATAL: "fatal",
+  PANIC: "fatal",
+};
+
+export function parseRailwayLogRecord(
+  message: string,
+  providerSeverity: string | null,
+): ParsedRailwayLogRecord {
+  const json = parseJson(message, providerSeverity);
+  if (json) return json;
+
+  const httpAccess = parseHttpAccess(message, providerSeverity);
+  if (httpAccess) return httpAccess;
+
+  const postgresql = parsePostgresql(message, providerSeverity);
+  if (postgresql) return postgresql;
+
+  const fields = parseLogfmt(message);
+  const body = fields?.msg ?? fields?.message;
+  const nativeSeverity = fields?.level;
+  if (!fields || !body) {
+    return { body: message, severity: providerSeverity, attributes: [] };
+  }
+  const parsedSeverity = nativeSeverity ? normalizeNativeSeverity(nativeSeverity) : null;
+
+  return {
+    body,
+    severity: parsedSeverity ?? providerSeverity,
+    attributes: parsedAttributes(
+      "logfmt",
+      Object.entries(fields)
+        .filter(([key, value]) => isBoundedField(key, value))
+        .map(([key, value]) => ({
+          key: `railway.log.${normalizeAttributeKey(key)}`,
+          value,
+        })),
+      providerSeverity,
+      parsedSeverity ? "logfmt" : "railway",
+      message,
+    ),
+  };
+}
+
+export function parseRailwayAttributeValue(value: string): ParsedAttributeValue {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isScalar(parsed) ? parsed : value;
+  } catch {
+    return value;
+  }
+}
+
+function parseHttpAccess(
+  message: string,
+  providerSeverity: string | null,
+): ParsedRailwayLogRecord | null {
+  const match = message.match(HTTP_ACCESS_RECORD);
+  if (!match) return null;
+  const [
+    ,
+    peerAddress,
+    timestamp,
+    method,
+    target,
+    protocolVersion,
+    statusText,
+    sizeText,
+    durationText,
+  ] = match;
+  if (!peerAddress || !timestamp || !method || !target || !protocolVersion || !statusText) {
+    return null;
+  }
+
+  const status = Number(statusText);
+  const [path, query] = target.split("?", 2);
+  if (!path || !Number.isInteger(status)) return null;
+  const responseSize = sizeText && sizeText !== "-" ? Number(sizeText) : null;
+  const durationSeconds = durationText && durationText !== "-" ? Number(durationText) : null;
+
+  return {
+    body: `${method} ${path} ${status}`,
+    severity: status >= 500 ? "error" : status >= 400 ? "warn" : "info",
+    attributes: parsedAttributes(
+      "http_access",
+      [
+        { key: "network.peer.address", value: peerAddress },
+        { key: "railway.log.timestamp", value: timestamp },
+        { key: "http.request.method", value: method },
+        { key: "url.path", value: path },
+        ...(query ? [{ key: "url.query", value: query }] : []),
+        { key: "network.protocol.name", value: "http" },
+        { key: "network.protocol.version", value: protocolVersion },
+        { key: "http.response.status_code", value: status },
+        ...(responseSize !== null && Number.isFinite(responseSize)
+          ? [{ key: "http.response.body.size", value: responseSize }]
+          : []),
+        ...(durationSeconds !== null && Number.isFinite(durationSeconds)
+          ? [{ key: "railway.log.duration_seconds", value: durationSeconds }]
+          : []),
+      ],
+      providerSeverity,
+      "http_status",
+      message,
+    ),
+  };
+}
+
+function parseJson(
+  message: string,
+  providerSeverity: string | null,
+): ParsedRailwayLogRecord | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(message);
+  } catch {
+    return null;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+
+  const record = value as Record<string, unknown>;
+  const body =
+    typeof record.message === "string"
+      ? record.message
+      : typeof record.msg === "string"
+        ? record.msg
+        : null;
+  if (!body) return null;
+  const nativeSeverity =
+    typeof record.level === "string"
+      ? record.level
+      : typeof record.severity === "string"
+        ? record.severity
+        : null;
+  const parsedSeverity =
+    typeof nativeSeverity === "string" ? normalizeNativeSeverity(nativeSeverity) : null;
+
+  const parsedFields = Object.entries(record)
+    .filter(
+      (entry): entry is [string, ParsedAttributeValue] =>
+        isScalar(entry[1]) && isBoundedField(entry[0], entry[1]),
+    )
+    .slice(0, MAX_PARSED_FIELDS)
+    .map(([key, fieldValue]) => ({
+      key: `railway.log.${normalizeAttributeKey(key)}`,
+      value: fieldValue,
+    }));
+  return {
+    body,
+    severity: parsedSeverity ?? providerSeverity,
+    attributes: parsedAttributes(
+      "json",
+      parsedFields,
+      providerSeverity,
+      parsedSeverity ? "json" : "railway",
+      message,
+    ),
+  };
+}
+
+function parsePostgresql(
+  message: string,
+  providerSeverity: string | null,
+): ParsedRailwayLogRecord | null {
+  const match = message.match(POSTGRESQL_RECORD);
+  if (!match) return null;
+  const [, timestamp, pid, user, database, level, body] = match;
+  if (!timestamp || !pid || !level || body === undefined) return null;
+  const severity = POSTGRESQL_SEVERITY[level];
+  if (!severity) return null;
+  return {
+    body,
+    severity,
+    attributes: parsedAttributes(
+      "postgresql",
+      [
+        { key: "railway.log.timestamp", value: timestamp },
+        { key: "railway.log.pid", value: pid },
+        ...(user ? [{ key: "railway.log.user", value: user }] : []),
+        ...(database ? [{ key: "railway.log.database", value: database }] : []),
+        { key: "railway.log.level", value: level },
+      ],
+      providerSeverity,
+      "postgresql",
+      message,
+    ),
+  };
+}
+
+function parsedAttributes(
+  format: string,
+  fields: ParsedAttribute[],
+  providerSeverity: string | null,
+  severitySource: string,
+  original: string,
+): ParsedAttribute[] {
+  return [
+    { key: "railway.log.format", value: format },
+    ...fields,
+    ...(providerSeverity
+      ? [{ key: "railway.log.provider_severity", value: providerSeverity }]
+      : []),
+    { key: "railway.log.severity_source", value: severitySource },
+    { key: "log.record.original", value: original },
+  ];
+}
+
+function parseLogfmt(message: string): Record<string, string> | null {
+  const fields: Record<string, string> = {};
+  let cursor = 0;
+  let count = 0;
+  for (const match of message.matchAll(LOGFMT_FIELD)) {
+    if (match.index === undefined || message.slice(cursor, match.index).trim() !== "") return null;
+    const key = match[1];
+    const value = match[2] !== undefined ? unescapeQuoted(match[2]) : match[3];
+    if (!key || value === undefined || (match[2] === undefined && value.startsWith('"'))) {
+      return null;
+    }
+    fields[key] = value;
+    cursor = match.index + match[0].length;
+    count += 1;
+    if (count > MAX_PARSED_FIELDS) return null;
+  }
+  if (count < 2 || message.slice(cursor).trim() !== "") return null;
+  return fields;
+}
+
+function unescapeQuoted(value: string): string {
+  return value.replace(/\\(["\\])/g, "$1");
+}
+
+function normalizeAttributeKey(key: string): string {
+  return key.toLowerCase().replace(/[^a-z0-9_.-]/g, "_");
+}
+
+function isScalar(value: unknown): value is ParsedAttributeValue {
+  return (
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
+  );
+}
+
+function normalizeNativeSeverity(value: string): string | null {
+  return NATIVE_SEVERITY[value.trim().toLowerCase()] ?? null;
+}
+
+function isBoundedField(key: string, value: ParsedAttributeValue): boolean {
+  return (
+    key.length <= MAX_PARSED_KEY_LENGTH &&
+    (typeof value !== "string" || value.length <= MAX_PARSED_STRING_LENGTH)
+  );
+}

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -7,7 +7,6 @@ export type ParsedRailwayLogRecord = {
   attributes: ParsedAttribute[];
 };
 
-const LOGFMT_FIELD = /([A-Za-z_][A-Za-z0-9_.-]*)=(?:"((?:\\.|[^"])*)"|(\S+))/g;
 const HTTP_ACCESS_RECORD =
   /^(\S+) \S+ \S+ \[([^\]]+)\] "([A-Z]+) (\S+) HTTP\/(\d(?:\.\d)?)" (\d{3}) (\d+|-)(?: ([\d.]+|-))?$/;
 const POSTGRESQL_RECORD =
@@ -255,24 +254,68 @@ function parseLogfmt(message: string): Record<string, string> | null {
   const fields: Record<string, string> = {};
   let cursor = 0;
   let count = 0;
-  for (const match of message.matchAll(LOGFMT_FIELD)) {
-    if (match.index === undefined || message.slice(cursor, match.index).trim() !== "") return null;
-    const key = match[1];
-    const value = match[2] !== undefined ? unescapeQuoted(match[2]) : match[3];
-    if (!key || value === undefined || (match[2] === undefined && value.startsWith('"'))) {
-      return null;
+
+  while (cursor < message.length) {
+    while (cursor < message.length && isWhitespace(message[cursor])) cursor += 1;
+    if (cursor === message.length) break;
+
+    const keyStart = cursor;
+    if (!isLogfmtKeyStart(message[cursor])) return null;
+    cursor += 1;
+    while (cursor < message.length && isLogfmtKeyPart(message[cursor])) cursor += 1;
+    const key = message.slice(keyStart, cursor);
+    if (message[cursor] !== "=") return null;
+    cursor += 1;
+
+    let value = "";
+    if (message[cursor] === '"') {
+      cursor += 1;
+      let closed = false;
+      while (cursor < message.length) {
+        const character = message[cursor];
+        if (character === '"') {
+          cursor += 1;
+          closed = true;
+          break;
+        }
+        if (character === "\\" && cursor + 1 < message.length) {
+          const escaped = message[cursor + 1];
+          if (escaped === '"' || escaped === "\\") {
+            value += escaped;
+            cursor += 2;
+            continue;
+          }
+        }
+        value += character;
+        cursor += 1;
+      }
+      if (!closed || (cursor < message.length && !isWhitespace(message[cursor]))) return null;
+    } else {
+      const valueStart = cursor;
+      while (cursor < message.length && !isWhitespace(message[cursor])) cursor += 1;
+      if (valueStart === cursor) return null;
+      value = message.slice(valueStart, cursor);
     }
+
     fields[key] = value;
-    cursor = match.index + match[0].length;
     count += 1;
     if (count > MAX_PARSED_FIELDS) return null;
   }
-  if (count < 2 || message.slice(cursor).trim() !== "") return null;
+
+  if (count < 2) return null;
   return fields;
 }
 
-function unescapeQuoted(value: string): string {
-  return value.replace(/\\(["\\])/g, "$1");
+function isWhitespace(character: string | undefined): boolean {
+  return character === " " || character === "\t" || character === "\n" || character === "\r";
+}
+
+function isLogfmtKeyStart(character: string | undefined): boolean {
+  return character !== undefined && /[A-Za-z_]/.test(character);
+}
+
+function isLogfmtKeyPart(character: string | undefined): boolean {
+  return character !== undefined && /[A-Za-z0-9_.-]/.test(character);
 }
 
 function normalizeAttributeKey(key: string): string {

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -127,7 +127,9 @@ function parseHttpAccess(
   }
 
   const status = Number(statusText);
-  const [path, query] = target.split("?", 2);
+  const queryStart = target.indexOf("?");
+  const path = queryStart === -1 ? target : target.slice(0, queryStart);
+  const query = queryStart === -1 ? null : target.slice(queryStart + 1);
   if (!path || !Number.isInteger(status)) return null;
   const responseSize = sizeText && sizeText !== "-" ? Number(sizeText) : null;
   const durationSeconds = durationText && durationText !== "-" ? Number(durationText) : null;

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -19,6 +19,13 @@ const RESERVED_STRUCTURED_ATTRIBUTE_KEYS = new Set([
   "provider_severity",
   "severity_source",
 ]);
+const LOGFMT_QUOTED_ESCAPES: Record<string, string> = {
+  '"': '"',
+  "\\": "\\",
+  n: "\n",
+  r: "\r",
+  t: "\t",
+};
 const NATIVE_SEVERITY: Record<string, string> = {
   trace: "trace",
   debug: "debug",
@@ -87,15 +94,7 @@ export function parseRailwayLogRecord(
     severity: parsedSeverity ?? providerSeverity,
     attributes: parsedAttributes(
       "logfmt",
-      Object.entries(fields)
-        .filter(
-          ([key, value]) => isBoundedField(key, value) && !isReservedStructuredAttributeKey(key),
-        )
-        .slice(0, MAX_PARSED_FIELDS)
-        .map(([key, value]) => ({
-          key: `railway.log.${normalizeAttributeKey(key)}`,
-          value,
-        })),
+      structuredFields(Object.entries(fields)),
       providerSeverity,
       parsedSeverity ? "logfmt" : "railway",
       message,
@@ -199,18 +198,7 @@ function parseJson(
   const parsedSeverity =
     normalizeJsonSeverity(record.level) ?? normalizeJsonSeverity(record.severity);
 
-  const parsedFields = Object.entries(record)
-    .filter(
-      (entry): entry is [string, ParsedAttributeValue] =>
-        isScalar(entry[1]) &&
-        isBoundedField(entry[0], entry[1]) &&
-        !isReservedStructuredAttributeKey(entry[0]),
-    )
-    .slice(0, MAX_PARSED_FIELDS)
-    .map(([key, fieldValue]) => ({
-      key: `railway.log.${normalizeAttributeKey(key)}`,
-      value: fieldValue,
-    }));
+  const parsedFields = structuredFields(Object.entries(record));
   return {
     body,
     severity: parsedSeverity ?? providerSeverity,
@@ -386,8 +374,9 @@ function parseLogfmt(message: string): Record<string, string> | null {
         }
         if (character === "\\" && cursor + 1 < message.length) {
           const escaped = message[cursor + 1];
-          if (escaped === '"' || escaped === "\\") {
-            value += escaped;
+          const decoded = escaped ? LOGFMT_QUOTED_ESCAPES[escaped] : undefined;
+          if (decoded !== undefined) {
+            value += decoded;
             cursor += 2;
             continue;
           }
@@ -428,8 +417,20 @@ function normalizeAttributeKey(key: string): string {
   return key.toLowerCase().replace(/[^a-z0-9_.-]/g, "_");
 }
 
-function isReservedStructuredAttributeKey(key: string): boolean {
-  return RESERVED_STRUCTURED_ATTRIBUTE_KEYS.has(normalizeAttributeKey(key));
+function structuredFields(entries: Array<[string, unknown]>): ParsedAttribute[] {
+  const attributes: ParsedAttribute[] = [];
+  const seenKeys = new Set<string>();
+  for (const [key, value] of entries) {
+    if (!isScalar(value) || !isBoundedField(key, value)) continue;
+    const normalizedKey = normalizeAttributeKey(key);
+    if (RESERVED_STRUCTURED_ATTRIBUTE_KEYS.has(normalizedKey) || seenKeys.has(normalizedKey)) {
+      continue;
+    }
+    seenKeys.add(normalizedKey);
+    attributes.push({ key: `railway.log.${normalizedKey}`, value });
+    if (attributes.length === MAX_PARSED_FIELDS) break;
+  }
+  return attributes;
 }
 
 function isScalar(value: unknown): value is ParsedAttributeValue {

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -98,10 +98,8 @@ export function parseRailwayLogRecord(
 export function parseRailwayAttributeValue(value: string): ParsedAttributeValue {
   try {
     const parsed: unknown = JSON.parse(value);
-    if (typeof parsed === "number" && Number.isInteger(parsed) && !Number.isSafeInteger(parsed)) {
-      return value;
-    }
-    return isScalar(parsed) ? parsed : value;
+    const lossless = preserveUnsafeInteger(parsed, value);
+    return isScalar(lossless) ? lossless : value;
   } catch {
     return value;
   }
@@ -168,7 +166,9 @@ function parseJson(
 ): ParsedRailwayLogRecord | null {
   let value: unknown;
   try {
-    value = JSON.parse(message);
+    value = JSON.parse(message, (_key: string, parsed: unknown, context?: { source?: string }) =>
+      preserveUnsafeInteger(parsed, context?.source),
+    );
   } catch {
     return null;
   }
@@ -333,6 +333,13 @@ function isScalar(value: unknown): value is ParsedAttributeValue {
     typeof value === "boolean" ||
     (typeof value === "number" && Number.isFinite(value))
   );
+}
+
+function preserveUnsafeInteger(value: unknown, source: string | undefined): unknown {
+  if (typeof value === "number" && Number.isInteger(value) && !Number.isSafeInteger(value)) {
+    return source ?? value;
+  }
+  return value;
 }
 
 function normalizeNativeSeverity(value: string): string | null {

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -72,13 +72,13 @@ export function parseRailwayLogRecord(
   const fields = parseLogfmt(message);
   const body = fields?.msg ?? fields?.message;
   const nativeSeverity = fields?.level;
-  if (!fields || !body) {
+  const parsedSeverity = nativeSeverity ? normalizeNativeSeverity(nativeSeverity) : null;
+  if (!fields || (!body && !parsedSeverity)) {
     return { body: message, severity: providerSeverity, attributes: [] };
   }
-  const parsedSeverity = nativeSeverity ? normalizeNativeSeverity(nativeSeverity) : null;
 
   return {
-    body,
+    body: body ?? message,
     severity: parsedSeverity ?? providerSeverity,
     attributes: parsedAttributes(
       "logfmt",

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -194,13 +194,13 @@ function parseJson(
       : typeof record.msg === "string"
         ? record.msg
         : null;
-  if (!body) return null;
   const parsedSeverity =
     normalizeJsonSeverity(record.level) ?? normalizeJsonSeverity(record.severity);
+  if (!body && !parsedSeverity) return null;
 
   const parsedFields = structuredFields(Object.entries(record));
   return {
-    body,
+    body: body || message,
     severity: parsedSeverity ?? providerSeverity,
     attributes: parsedAttributes(
       "json",

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -14,6 +14,11 @@ const POSTGRESQL_RECORD =
 const MAX_PARSED_FIELDS = 32;
 const MAX_PARSED_KEY_LENGTH = 128;
 const MAX_PARSED_STRING_LENGTH = 4096;
+const RESERVED_STRUCTURED_ATTRIBUTE_KEYS = new Set([
+  "format",
+  "provider_severity",
+  "severity_source",
+]);
 const NATIVE_SEVERITY: Record<string, string> = {
   trace: "trace",
   debug: "debug",
@@ -83,7 +88,9 @@ export function parseRailwayLogRecord(
     attributes: parsedAttributes(
       "logfmt",
       Object.entries(fields)
-        .filter(([key, value]) => isBoundedField(key, value))
+        .filter(
+          ([key, value]) => isBoundedField(key, value) && !isReservedStructuredAttributeKey(key),
+        )
         .slice(0, MAX_PARSED_FIELDS)
         .map(([key, value]) => ({
           key: `railway.log.${normalizeAttributeKey(key)}`,
@@ -195,7 +202,9 @@ function parseJson(
   const parsedFields = Object.entries(record)
     .filter(
       (entry): entry is [string, ParsedAttributeValue] =>
-        isScalar(entry[1]) && isBoundedField(entry[0], entry[1]),
+        isScalar(entry[1]) &&
+        isBoundedField(entry[0], entry[1]) &&
+        !isReservedStructuredAttributeKey(entry[0]),
     )
     .slice(0, MAX_PARSED_FIELDS)
     .map(([key, fieldValue]) => ({
@@ -417,6 +426,10 @@ function isLogfmtKeyPart(character: string | undefined): boolean {
 
 function normalizeAttributeKey(key: string): string {
   return key.toLowerCase().replace(/[^a-z0-9_.-]/g, "_");
+}
+
+function isReservedStructuredAttributeKey(key: string): boolean {
+  return RESERVED_STRUCTURED_ATTRIBUTE_KEYS.has(normalizeAttributeKey(key));
 }
 
 function isScalar(value: unknown): value is ParsedAttributeValue {

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -196,11 +196,11 @@ function parseJson(
         : null;
   const parsedSeverity =
     normalizeJsonSeverity(record.level) ?? normalizeJsonSeverity(record.severity);
-  if (!body && !parsedSeverity) return null;
+  if (body === null && !parsedSeverity) return null;
 
   const parsedFields = structuredFields(Object.entries(record));
   return {
-    body: body || message,
+    body: body ?? message,
     severity: parsedSeverity ?? providerSeverity,
     attributes: parsedAttributes(
       "json",

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -246,6 +246,24 @@ test("railwayLogsToOtlp structures logfmt without a native level", () => {
   assert.equal(attrs["log.record.original"], message);
 });
 
+test("railwayLogsToOtlp parses escaped logfmt values", () => {
+  const message = 'level=info msg="worker said \\"ready\\" at C:\\\\jobs" request_id=req-1';
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, 'worker said "ready" at C:\\jobs');
+  assert.equal(record.severityText, "INFO");
+});
+
+test("railwayLogsToOtlp safely rejects a long unterminated logfmt value", () => {
+  const message = `level=info msg="${"\\!".repeat(10_000)}`;
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "ERROR");
+});
+
 test("railwayLogsToOtlp bounds extracted structured attributes", () => {
   const longKey = "x".repeat(129);
   const message = JSON.stringify({

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -452,6 +452,19 @@ test("railwayLogsToOtlp accepts empty unquoted logfmt values", () => {
   assert.equal(record.severityText, "INFO");
 });
 
+test("railwayLogsToOtlp preserves explicit empty logfmt message bodies", () => {
+  const message = 'msg="" event=heartbeat';
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "");
+  assert.equal(record.severityText, "ERROR");
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["railway.log.format"], "logfmt");
+  assert.equal(attrs["railway.log.event"], "heartbeat");
+  assert.equal(attrs["log.record.original"], message);
+});
+
 test("railwayLogsToOtlp safely rejects a long unterminated logfmt value", () => {
   const message = `level=info msg="${"\\!".repeat(10_000)}`;
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -289,6 +289,23 @@ test("railwayLogsToOtlp uses a recognized JSON severity when level is unknown", 
   assert.equal(attrs["railway.log.severity_source"]?.stringValue, "json");
 });
 
+test("railwayLogsToOtlp preserves native severity for event-style JSON", () => {
+  const message = JSON.stringify({ level: "info", event: "heartbeat", request_id: "req-1" });
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "INFO");
+  assert.equal(record.severityNumber, 9);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["railway.log.format"], "json");
+  assert.equal(attrs["railway.log.event"], "heartbeat");
+  assert.equal(attrs["railway.log.request_id"], "req-1");
+  assert.equal(attrs["railway.log.provider_severity"], "error");
+  assert.equal(attrs["railway.log.severity_source"], "json");
+  assert.equal(attrs["log.record.original"], message);
+});
+
 test("railwayLogsToOtlp preserves unsafe JSON integer fields as exact strings", () => {
   const message = '{"level":30,"msg":"order accepted","order_id":9007199254740993}';
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -97,6 +97,16 @@ test("railwayLogsToOtlp uses native logfmt fields instead of Railway's stderr se
   assert.equal(attrs["log.record.original"], message);
 });
 
+test("railwayLogsToOtlp keeps the raw Railway payload as the original record", () => {
+  const message = 'level=info msg="\u001b[32mready\u001b[0m"';
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "ready");
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["log.record.original"], message);
+});
+
 test("railwayLogsToOtlp maps PostgreSQL LOG records to informational structured logs", () => {
   const message =
     "2026-07-24 09:24:40.055 UTC [59] LOG:  checkpoint complete: wrote 1114 buffers (6.8%)";
@@ -156,6 +166,29 @@ test("railwayLogsToOtlp preserves scalar fields from structured JSON logs", () =
   assert.equal(attrs["railway.log.provider_severity"]?.stringValue, "error");
   assert.equal(attrs["railway.log.severity_source"]?.stringValue, "json");
   assert.equal(attrs["log.record.original"]?.stringValue, message);
+});
+
+test("railwayLogsToOtlp reserves collector-owned structured attribute names", () => {
+  const message = JSON.stringify({
+    message: "request complete",
+    FORMAT: "text",
+    provider_severity: "info",
+    severity_source: "application",
+  });
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value]));
+  assert.equal(attrs["railway.log.format"]?.stringValue, "json");
+  assert.equal(attrs["railway.log.provider_severity"]?.stringValue, "error");
+  assert.equal(attrs["railway.log.severity_source"]?.stringValue, "railway");
+  for (const key of [
+    "railway.log.format",
+    "railway.log.provider_severity",
+    "railway.log.severity_source",
+  ]) {
+    assert.equal(record.attributes.filter((attribute) => attribute.key === key).length, 1);
+  }
 });
 
 test("railwayLogsToOtlp decodes Railway's JSON-encoded scalar attributes", () => {

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -212,6 +212,17 @@ test("railwayLogsToOtlp maps common numeric JSON levels", () => {
   assert.equal(attrs["railway.log.severity_source"]?.stringValue, "json");
 });
 
+test("railwayLogsToOtlp preserves unsafe JSON integer fields as exact strings", () => {
+  const message = '{"level":30,"msg":"order accepted","order_id":9007199254740993}';
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value]));
+  assert.equal(attrs["railway.log.order_id"]?.stringValue, "9007199254740993");
+  assert.equal(attrs["railway.log.order_id"]?.intValue, undefined);
+  assert.equal(attrs["log.record.original"]?.stringValue, message);
+});
+
 test("railwayLogsToOtlp maps successful common access logs to structured HTTP info", () => {
   const message =
     '100.64.0.6 - - [2026-07-22 20:25:33] "POST /v1/audio/speech HTTP/1.1" 200 10761 1.317203';

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -322,6 +322,15 @@ test("railwayLogsToOtlp parses escaped logfmt values", () => {
   assert.equal(record.severityText, "INFO");
 });
 
+test("railwayLogsToOtlp accepts empty unquoted logfmt values", () => {
+  const message = 'level=info msg="request complete" err=';
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "request complete");
+  assert.equal(record.severityText, "INFO");
+});
+
 test("railwayLogsToOtlp safely rejects a long unterminated logfmt value", () => {
   const message = `level=info msg="${"\\!".repeat(10_000)}`;
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -182,6 +182,36 @@ test("railwayLogsToOtlp decodes Railway's JSON-encoded scalar attributes", () =>
   assert.equal(attrs["railway.attr.metadata"]?.stringValue, '{"nested":true}');
 });
 
+test("railwayLogsToOtlp preserves unsafe integer attributes as exact strings", () => {
+  const out = railwayLogsToOtlp(
+    [
+      {
+        ...LOG,
+        attributes: [{ key: "order_id", value: "9007199254740993" }],
+      },
+    ],
+    NAMES,
+  );
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value]));
+  assert.equal(attrs["railway.attr.order_id"]?.stringValue, "9007199254740993");
+  assert.equal(attrs["railway.attr.order_id"]?.intValue, undefined);
+});
+
+test("railwayLogsToOtlp maps common numeric JSON levels", () => {
+  const message = JSON.stringify({ level: 30, msg: "worker started" });
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "worker started");
+  assert.equal(record.severityText, "INFO");
+  assert.equal(record.severityNumber, 9);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value]));
+  assert.equal(attrs["railway.log.level"]?.intValue, "30");
+  assert.equal(attrs["railway.log.severity_source"]?.stringValue, "json");
+});
+
 test("railwayLogsToOtlp maps successful common access logs to structured HTTP info", () => {
   const message =
     '100.64.0.6 - - [2026-07-22 20:25:33] "POST /v1/audio/speech HTTP/1.1" 200 10761 1.317203';

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -313,6 +313,24 @@ test("railwayLogsToOtlp structures logfmt without a native level", () => {
   assert.equal(attrs["log.record.original"], message);
 });
 
+test("railwayLogsToOtlp preserves native severity for event-style logfmt", () => {
+  const message = "level=info event=heartbeat request_id=req-1";
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "INFO");
+  assert.equal(record.severityNumber, 9);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["railway.log.format"], "logfmt");
+  assert.equal(attrs["railway.log.level"], "info");
+  assert.equal(attrs["railway.log.event"], "heartbeat");
+  assert.equal(attrs["railway.log.request_id"], "req-1");
+  assert.equal(attrs["railway.log.provider_severity"], "error");
+  assert.equal(attrs["railway.log.severity_source"], "logfmt");
+  assert.equal(attrs["log.record.original"], message);
+});
+
 test("railwayLogsToOtlp parses escaped logfmt values", () => {
   const message = 'level=info msg="worker said \\"ready\\" at C:\\\\jobs" request_id=req-1';
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -229,6 +229,7 @@ test("railwayLogsToOtlp decodes Railway's JSON-encoded scalar attributes", () =>
           { key: "level", value: '"info"' },
           { key: "attempt", value: "3" },
           { key: "healthy", value: "false" },
+          { key: "error", value: '""' },
           { key: "metadata", value: '{"nested":true}' },
         ],
       },
@@ -241,6 +242,7 @@ test("railwayLogsToOtlp decodes Railway's JSON-encoded scalar attributes", () =>
   assert.equal(attrs["railway.attr.level"]?.stringValue, "info");
   assert.equal(attrs["railway.attr.attempt"]?.intValue, "3");
   assert.equal(attrs["railway.attr.healthy"]?.boolValue, false);
+  assert.equal(attrs["railway.attr.error"]?.stringValue, "");
   assert.equal(attrs["railway.attr.metadata"]?.stringValue, '{"nested":true}');
 });
 

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -258,6 +258,17 @@ test("railwayLogsToOtlp keeps HTTP server failures at error severity", () => {
   assert.equal(record.severityNumber, 17);
 });
 
+test("railwayLogsToOtlp preserves question marks inside HTTP query strings", () => {
+  const message =
+    '100.64.0.6 - - [2026-07-22 20:25:33] "GET /login?redirect=https://example.com/a?b=c HTTP/1.1" 302 0 0.012';
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value]));
+  assert.equal(attrs["url.path"]?.stringValue, "/login");
+  assert.equal(attrs["url.query"]?.stringValue, "redirect=https://example.com/a?b=c");
+});
+
 test("railwayLogsToOtlp keeps Railway severity when a parsed native level is unknown", () => {
   const message = 'level=verbose msg="something happened" request_id=req-1';
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -212,6 +212,21 @@ test("railwayLogsToOtlp maps common numeric JSON levels", () => {
   assert.equal(attrs["railway.log.severity_source"]?.stringValue, "json");
 });
 
+test("railwayLogsToOtlp uses a recognized JSON severity when level is unknown", () => {
+  const message = JSON.stringify({
+    level: "verbose",
+    severity: "info",
+    message: "worker started",
+  });
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.severityText, "INFO");
+  assert.equal(record.severityNumber, 9);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value]));
+  assert.equal(attrs["railway.log.severity_source"]?.stringValue, "json");
+});
+
 test("railwayLogsToOtlp preserves unsafe JSON integer fields as exact strings", () => {
   const message = '{"level":30,"msg":"order accepted","order_id":9007199254740993}';
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
@@ -314,6 +329,19 @@ test("railwayLogsToOtlp safely rejects a long unterminated logfmt value", () => 
   const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
   assert.equal(record.body.stringValue, message);
   assert.equal(record.severityText, "ERROR");
+});
+
+test("railwayLogsToOtlp caps logfmt attributes without rejecting the record", () => {
+  const fields = Array.from({ length: 33 }, (_, index) => `field${index}=value${index}`).join(" ");
+  const message = `level=info msg="many fields" ${fields}`;
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "many fields");
+  assert.equal(record.severityText, "INFO");
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value]));
+  assert.equal(attrs["railway.log.field0"]?.stringValue, "value0");
+  assert.equal(attrs["railway.log.field32"], undefined);
 });
 
 test("railwayLogsToOtlp bounds extracted structured attributes", () => {

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -308,6 +308,19 @@ test("railwayLogsToOtlp preserves native severity for event-style JSON", () => {
   assert.equal(attrs["log.record.original"], message);
 });
 
+test("railwayLogsToOtlp preserves explicit empty JSON message bodies", () => {
+  const message = JSON.stringify({ message: "", event: "heartbeat" });
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "");
+  assert.equal(record.severityText, "ERROR");
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["railway.log.format"], "json");
+  assert.equal(attrs["railway.log.event"], "heartbeat");
+  assert.equal(attrs["log.record.original"], message);
+});
+
 test("railwayLogsToOtlp preserves unsafe JSON integer fields as exact strings", () => {
   const message = '{"level":30,"msg":"order accepted","order_id":9007199254740993}';
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -68,6 +68,215 @@ test("railwayLogsToOtlp maps a Railway log line to an OTLP log record", () => {
   assert.equal(attrs["railway.deployment_id"], "dep-1");
 });
 
+test("railwayLogsToOtlp uses native logfmt fields instead of Railway's stderr severity", () => {
+  const message =
+    'time="2026-07-22T13:57:21.842594391Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.healthcheck type=io.containerd.grpc.v1';
+  const out = railwayLogsToOtlp(
+    [
+      {
+        ...LOG,
+        severity: "error",
+        message,
+        attributes: [{ key: "level", value: '"error"' }],
+      },
+    ],
+    NAMES,
+  );
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "loading plugin");
+  assert.equal(record.severityText, "INFO");
+  assert.equal(record.severityNumber, 9);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["railway.log.format"], "logfmt");
+  assert.equal(attrs["railway.log.level"], "info");
+  assert.equal(attrs["railway.log.id"], "io.containerd.grpc.v1.healthcheck");
+  assert.equal(attrs["railway.log.type"], "io.containerd.grpc.v1");
+  assert.equal(attrs["railway.log.provider_severity"], "error");
+  assert.equal(attrs["railway.log.severity_source"], "logfmt");
+  assert.equal(attrs["log.record.original"], message);
+});
+
+test("railwayLogsToOtlp maps PostgreSQL LOG records to informational structured logs", () => {
+  const message =
+    "2026-07-24 09:24:40.055 UTC [59] LOG:  checkpoint complete: wrote 1114 buffers (6.8%)";
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "checkpoint complete: wrote 1114 buffers (6.8%)");
+  assert.equal(record.severityText, "INFO");
+  assert.equal(record.severityNumber, 9);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["railway.log.format"], "postgresql");
+  assert.equal(attrs["railway.log.level"], "LOG");
+  assert.equal(attrs["railway.log.timestamp"], "2026-07-24 09:24:40.055 UTC");
+  assert.equal(attrs["railway.log.pid"], "59");
+  assert.equal(attrs["railway.log.provider_severity"], "error");
+  assert.equal(attrs["railway.log.severity_source"], "postgresql");
+  assert.equal(attrs["log.record.original"], message);
+});
+
+test("railwayLogsToOtlp preserves PostgreSQL warning severity and connection fields", () => {
+  const message =
+    "2026-07-24 16:42:04.651 UTC [1386] app@railway WARNING:  there is no transaction in progress";
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "there is no transaction in progress");
+  assert.equal(record.severityText, "WARN");
+  assert.equal(record.severityNumber, 13);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["railway.log.level"], "WARNING");
+  assert.equal(attrs["railway.log.user"], "app");
+  assert.equal(attrs["railway.log.database"], "railway");
+});
+
+test("railwayLogsToOtlp preserves scalar fields from structured JSON logs", () => {
+  const message = JSON.stringify({
+    level: "warn",
+    message: "queue depth high",
+    job: "emails",
+    attempt: 3,
+    healthy: false,
+    nested: { ignored: true },
+  });
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "queue depth high");
+  assert.equal(record.severityText, "WARN");
+  assert.equal(record.severityNumber, 13);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value]));
+  assert.equal(attrs["railway.log.format"]?.stringValue, "json");
+  assert.equal(attrs["railway.log.level"]?.stringValue, "warn");
+  assert.equal(attrs["railway.log.job"]?.stringValue, "emails");
+  assert.equal(attrs["railway.log.attempt"]?.intValue, "3");
+  assert.equal(attrs["railway.log.healthy"]?.boolValue, false);
+  assert.equal(attrs["railway.log.nested"], undefined);
+  assert.equal(attrs["railway.log.provider_severity"]?.stringValue, "error");
+  assert.equal(attrs["railway.log.severity_source"]?.stringValue, "json");
+  assert.equal(attrs["log.record.original"]?.stringValue, message);
+});
+
+test("railwayLogsToOtlp decodes Railway's JSON-encoded scalar attributes", () => {
+  const out = railwayLogsToOtlp(
+    [
+      {
+        ...LOG,
+        attributes: [
+          { key: "level", value: '"info"' },
+          { key: "attempt", value: "3" },
+          { key: "healthy", value: "false" },
+          { key: "metadata", value: '{"nested":true}' },
+        ],
+      },
+    ],
+    NAMES,
+  );
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value]));
+  assert.equal(attrs["railway.attr.level"]?.stringValue, "info");
+  assert.equal(attrs["railway.attr.attempt"]?.intValue, "3");
+  assert.equal(attrs["railway.attr.healthy"]?.boolValue, false);
+  assert.equal(attrs["railway.attr.metadata"]?.stringValue, '{"nested":true}');
+});
+
+test("railwayLogsToOtlp maps successful common access logs to structured HTTP info", () => {
+  const message =
+    '100.64.0.6 - - [2026-07-22 20:25:33] "POST /v1/audio/speech HTTP/1.1" 200 10761 1.317203';
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "POST /v1/audio/speech 200");
+  assert.equal(record.severityText, "INFO");
+  assert.equal(record.severityNumber, 9);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value]));
+  assert.equal(attrs["railway.log.format"]?.stringValue, "http_access");
+  assert.equal(attrs["network.peer.address"]?.stringValue, "100.64.0.6");
+  assert.equal(attrs["railway.log.timestamp"]?.stringValue, "2026-07-22 20:25:33");
+  assert.equal(attrs["http.request.method"]?.stringValue, "POST");
+  assert.equal(attrs["url.path"]?.stringValue, "/v1/audio/speech");
+  assert.equal(attrs["network.protocol.name"]?.stringValue, "http");
+  assert.equal(attrs["network.protocol.version"]?.stringValue, "1.1");
+  assert.equal(attrs["http.response.status_code"]?.intValue, "200");
+  assert.equal(attrs["http.response.body.size"]?.intValue, "10761");
+  assert.equal(attrs["railway.log.duration_seconds"]?.doubleValue, 1.317203);
+  assert.equal(attrs["railway.log.provider_severity"]?.stringValue, "error");
+  assert.equal(attrs["railway.log.severity_source"]?.stringValue, "http_status");
+  assert.equal(attrs["log.record.original"]?.stringValue, message);
+});
+
+test("railwayLogsToOtlp keeps HTTP server failures at error severity", () => {
+  const message = '100.64.0.6 - - [2026-07-22 20:25:33] "GET /health HTTP/1.1" 503 19 0.012';
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "info", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "GET /health 503");
+  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityNumber, 17);
+});
+
+test("railwayLogsToOtlp keeps Railway severity when a parsed native level is unknown", () => {
+  const message = 'level=verbose msg="something happened" request_id=req-1';
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "something happened");
+  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityNumber, 17);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["railway.log.level"], "verbose");
+  assert.equal(attrs["railway.log.provider_severity"], "error");
+  assert.equal(attrs["railway.log.severity_source"], "railway");
+});
+
+test("railwayLogsToOtlp structures logfmt without a native level", () => {
+  const message = 'msg="request finished" request_id=req-1';
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "warning", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "request finished");
+  assert.equal(record.severityText, "WARN");
+  assert.equal(record.severityNumber, 13);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["railway.log.format"], "logfmt");
+  assert.equal(attrs["railway.log.request_id"], "req-1");
+  assert.equal(attrs["railway.log.severity_source"], "railway");
+  assert.equal(attrs["log.record.original"], message);
+});
+
+test("railwayLogsToOtlp bounds extracted structured attributes", () => {
+  const longKey = "x".repeat(129);
+  const message = JSON.stringify({
+    level: "info",
+    message: "bounded fields",
+    accepted: "yes",
+    oversized: "x".repeat(4097),
+    [longKey]: "too long",
+  });
+  const out = railwayLogsToOtlp([{ ...LOG, message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value]));
+  assert.equal(attrs["railway.log.accepted"]?.stringValue, "yes");
+  assert.equal(attrs["railway.log.oversized"], undefined);
+  assert.equal(attrs[`railway.log.${longKey}`], undefined);
+});
+
+test("railwayLogsToOtlp leaves malformed structured messages lossless", () => {
+  const message = 'level=info msg="unterminated';
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityNumber, 17);
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["railway.log.format"], undefined);
+  assert.equal(attrs["log.record.original"], undefined);
+});
+
 test("railwayLogsToOtlp falls back to a railway service name when unmapped", () => {
   const out = railwayLogsToOtlp(
     [{ ...LOG, tags: { ...LOG.tags, serviceId: "unknown-svc" } }],

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -107,6 +107,16 @@ test("railwayLogsToOtlp keeps the raw Railway payload as the original record", (
   assert.equal(attrs["log.record.original"], message);
 });
 
+test("railwayLogsToOtlp strips decoded ANSI controls from JSON bodies", () => {
+  const message = JSON.stringify({ level: "info", message: "\u001b[32mready\u001b[0m" });
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "ready");
+  const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
+  assert.equal(attrs["log.record.original"], message);
+});
+
 test("railwayLogsToOtlp maps PostgreSQL LOG records to informational structured logs", () => {
   const message =
     "2026-07-24 09:24:40.055 UTC [59] LOG:  checkpoint complete: wrote 1114 buffers (6.8%)";
@@ -189,6 +199,25 @@ test("railwayLogsToOtlp reserves collector-owned structured attribute names", ()
   ]) {
     assert.equal(record.attributes.filter((attribute) => attribute.key === key).length, 1);
   }
+});
+
+test("railwayLogsToOtlp deduplicates normalized structured attribute keys", () => {
+  const message = JSON.stringify({
+    message: "request complete",
+    userId: "first",
+    userid: "second",
+    "foo bar": "first punctuation",
+    "foo@bar": "second punctuation",
+  });
+  const out = railwayLogsToOtlp([{ ...LOG, message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  const userIds = record.attributes.filter((attribute) => attribute.key === "railway.log.userid");
+  assert.equal(userIds.length, 1);
+  assert.equal(at(userIds, 0).value.stringValue, "first");
+  const fooBars = record.attributes.filter((attribute) => attribute.key === "railway.log.foo_bar");
+  assert.equal(fooBars.length, 1);
+  assert.equal(at(fooBars, 0).value.stringValue, "first punctuation");
 });
 
 test("railwayLogsToOtlp decodes Railway's JSON-encoded scalar attributes", () => {
@@ -370,6 +399,15 @@ test("railwayLogsToOtlp parses escaped logfmt values", () => {
 
   const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
   assert.equal(record.body.stringValue, 'worker said "ready" at C:\\jobs');
+  assert.equal(record.severityText, "INFO");
+});
+
+test("railwayLogsToOtlp decodes common control escapes in quoted logfmt values", () => {
+  const message = String.raw`level=info msg="first\nsecond\tready\rnext"`;
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "first\nsecond\tready\rnext");
   assert.equal(record.severityText, "INFO");
 });
 

--- a/packages/railway/src/transform.ts
+++ b/packages/railway/src/transform.ts
@@ -120,7 +120,7 @@ export function railwayLogsToOtlp(
                 timeUnixNano: nanos.toString(),
                 observedTimeUnixNano: nanos.toString(),
                 ...severity(parsed.severity),
-                body: { stringValue: parsed.body },
+                body: { stringValue: stripAnsi(parsed.body) },
                 attributes: [
                   kv("railway.deployment_id", log.tags?.deploymentId),
                   kv("railway.deployment_instance_id", log.tags?.deploymentInstanceId),

--- a/packages/railway/src/transform.ts
+++ b/packages/railway/src/transform.ts
@@ -267,7 +267,7 @@ export function advanceMetricsCursor(
 
 function kv(key: string, value: unknown): OtlpKeyValue | null {
   if (value === undefined || value === null) return null;
-  if (typeof value === "string") return value ? { key, value: { stringValue: value } } : null;
+  if (typeof value === "string") return { key, value: { stringValue: value } };
   if (typeof value === "number") {
     return Number.isInteger(value)
       ? { key, value: { intValue: String(value) } }

--- a/packages/railway/src/transform.ts
+++ b/packages/railway/src/transform.ts
@@ -3,6 +3,7 @@
 // shapes mirror the Vercel log-drain adapter's.
 
 import type { RailwayLog, RailwayMetricsResult } from "./graphql.js";
+import { parseRailwayAttributeValue, parseRailwayLogRecord } from "./log-record.js";
 
 type OtlpAnyValue = {
   stringValue?: string;
@@ -95,6 +96,7 @@ export function railwayLogsToOtlp(
       const serviceId = log.tags?.serviceId ?? null;
       const serviceName = (serviceId && ctx.serviceNamesById[serviceId]) || "railway";
       const nanos = rfc3339ToNanos(log.timestamp) ?? 0n;
+      const parsed = parseRailwayLogRecord(stripAnsi(log.message), log.severity);
       return {
         resource: {
           attributes: [
@@ -114,13 +116,16 @@ export function railwayLogsToOtlp(
               {
                 timeUnixNano: nanos.toString(),
                 observedTimeUnixNano: nanos.toString(),
-                ...severity(log.severity),
-                body: { stringValue: stripAnsi(log.message) },
+                ...severity(parsed.severity),
+                body: { stringValue: parsed.body },
                 attributes: [
                   kv("railway.deployment_id", log.tags?.deploymentId),
                   kv("railway.deployment_instance_id", log.tags?.deploymentInstanceId),
                   kv("railway.snapshot_id", log.tags?.snapshotId),
-                  ...log.attributes.map((a) => kv(`railway.attr.${a.key}`, a.value)),
+                  ...log.attributes.map((a) =>
+                    kv(`railway.attr.${a.key}`, parseRailwayAttributeValue(a.value)),
+                  ),
+                  ...parsed.attributes.map((a) => kv(a.key, a.value)),
                 ].filter(isKv),
               },
             ],

--- a/packages/railway/src/transform.ts
+++ b/packages/railway/src/transform.ts
@@ -97,6 +97,9 @@ export function railwayLogsToOtlp(
       const serviceName = (serviceId && ctx.serviceNamesById[serviceId]) || "railway";
       const nanos = rfc3339ToNanos(log.timestamp) ?? 0n;
       const parsed = parseRailwayLogRecord(stripAnsi(log.message), log.severity);
+      const parsedAttributes = parsed.attributes.map((attribute) =>
+        attribute.key === "log.record.original" ? { ...attribute, value: log.message } : attribute,
+      );
       return {
         resource: {
           attributes: [
@@ -125,7 +128,7 @@ export function railwayLogsToOtlp(
                   ...log.attributes.map((a) =>
                     kv(`railway.attr.${a.key}`, parseRailwayAttributeValue(a.value)),
                   ),
-                  ...parsed.attributes.map((a) => kv(a.key, a.value)),
+                  ...parsedAttributes.map((a) => kv(a.key, a.value)),
                 ].filter(isKv),
               },
             ],


### PR DESCRIPTION
## Summary

- parse Railway log bodies emitted as structured JSON, logfmt/containerd, PostgreSQL, and common HTTP access logs
- extract bounded scalar fields into OTLP attributes while preserving the original record
- prefer reliable native severity or HTTP status over transport-derived severity, including common numeric JSON levels
- decode JSON-encoded scalar attributes returned by Railway without rounding unsafe integer identifiers
- preserve unsafe integer fields from JSON bodies using their exact source representation
- use a single-pass logfmt scanner so malformed input cannot trigger regular-expression backtracking

## Why

Railway assigns log severity from the output stream, so informational messages written to stderr can arrive as errors. Structured application logs also previously remained opaque strings. This caused noisy error telemetry and unnecessarily fragmented log bodies.

## Impact

Newly ingested Railway records have normalized bodies, typed fields, and more accurate severity. Existing stored records are unchanged.

## Validation

- `pnpm --filter @superlog/railway test` (38 tests)
- `pnpm --filter @superlog/railway typecheck`
- `pnpm exec tsx --test apps/worker/src/railway/puller.test.ts` (6 tests)
- `pnpm --filter @superlog/worker typecheck`
- `pnpm exec biome check packages/railway/src/log-record.ts packages/railway/src/transform.ts packages/railway/src/transform.test.ts`