### PR TITLE
Landing: restructure top nav into three columns

### DIFF
--- a/apps/web/src/Landing.test.ts
+++ b/apps/web/src/Landing.test.ts
@@ -11,13 +11,17 @@ test("landing navbar uses the public Superlog docs URL", () => {
   assert.equal(LANDING_DOCS_URL, "https://docs.superlog.sh");
 });
 
-test("landing top nav renders a Docs link wired to the docs URL", async () => {
+test("landing top nav wires the Docs link to the docs URL in a new tab", async () => {
   const source = await readFile(new URL("./Landing.tsx", import.meta.url), "utf8");
 
+  // Docs is a data-driven nav link marked external so it opens in a new tab.
   assert.match(
     source,
-    /href=\{LANDING_DOCS_URL\}[\s\S]*?target="_blank"[\s\S]*?rel="noreferrer"[\s\S]*?Docs\s*<\/a>/,
+    /\{\s*href:\s*LANDING_DOCS_URL,\s*label:\s*"Docs",\s*external:\s*true\s*\}/,
   );
+  // External nav links render target="_blank" rel="noreferrer".
+  assert.match(source, /target=\{link\.external \? "_blank" : undefined\}/);
+  assert.match(source, /rel=\{link\.external \? "noreferrer" : undefined\}/);
 });
 
 test("landing top nav renders a GitHub link wired to the repository URL", async () => {

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -101,8 +101,19 @@ function CopyPromptCard({ prompt }: { prompt: string }) {
 }
 
 // ---------------------------------------------------------------------------
-// Nav — wordmark left, sign-in right
+// Nav — three columns: brand left · links center · auth actions right.
+// The center column is `hidden md:flex`, so below md the `1fr auto 1fr` grid
+// collapses to brand-left / actions-right and stays balanced at every width.
 // ---------------------------------------------------------------------------
+
+const NAV_LINKS: { href: string; label: string; external?: boolean }[] = [
+  { href: LANDING_DOCS_URL, label: "Docs", external: true },
+  { href: "/blog", label: "Blog" },
+  { href: "/changelog", label: "Changelog" },
+  { href: "/roadmap", label: "Roadmap" },
+  { href: "/team", label: "Team" },
+  { href: "/pricing", label: "Pricing" },
+];
 
 function TopNav({
   onSignIn,
@@ -115,9 +126,26 @@ function TopNav({
   return (
     <header className="sticky top-0 z-40 bg-bg">
       <div className="mx-auto w-full max-w-[1400px] px-4 md:px-8 xl:px-12">
-        <nav className="flex items-center justify-between py-5">
-          <Wordmark />
-          <div className="flex items-center gap-3">
+        <nav className="grid grid-cols-[1fr_auto_1fr] items-center py-5">
+          <div className="flex items-center justify-self-start">
+            <Wordmark />
+          </div>
+
+          <div className="hidden items-center gap-6 justify-self-center md:flex">
+            {NAV_LINKS.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                target={link.external ? "_blank" : undefined}
+                rel={link.external ? "noreferrer" : undefined}
+                className="text-[12px] font-medium text-muted transition-colors hover:text-fg"
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-3 justify-self-end">
             <a
               href={LANDING_GITHUB_REPO_URL}
               target="_blank"
@@ -133,44 +161,6 @@ function TopNav({
               <span className="tabular-nums">
                 {stars != null ? formatStarCount(stars) : "GitHub"}
               </span>
-            </a>
-            <a
-              href={LANDING_DOCS_URL}
-              target="_blank"
-              rel="noreferrer"
-              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline"
-            >
-              Docs
-            </a>
-            <a
-              href="/blog"
-              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline"
-            >
-              Blog
-            </a>
-            <a
-              href="/changelog"
-              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline"
-            >
-              Changelog
-            </a>
-            <a
-              href="/roadmap"
-              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline"
-            >
-              Roadmap
-            </a>
-            <a
-              href="/team"
-              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline"
-            >
-              Team
-            </a>
-            <a
-              href="/pricing"
-              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline"
-            >
-              Pricing
             </a>
             <Btn variant="ghost" size="sm" onClick={onSignIn}>
               Sign in

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -102,8 +102,12 @@ function CopyPromptCard({ prompt }: { prompt: string }) {
 
 // ---------------------------------------------------------------------------
 // Nav — three columns: brand left · links center · auth actions right.
-// The center column is `hidden md:flex`, so below md the `1fr auto 1fr` grid
-// collapses to brand-left / actions-right and stays balanced at every width.
+// The center column is `hidden lg:flex`. Below lg the `1fr auto 1fr` grid
+// collapses to brand-left / actions-right and stays balanced. We wait for lg
+// (not md) because at the ~704px md content width the six links plus the
+// wordmark and action group overflow, and grid can't keep the two 1fr side
+// tracks equal once the right track's min-content exceeds half the free space
+// — the center would drift and the links could butt against the buttons.
 // ---------------------------------------------------------------------------
 
 const NAV_LINKS: { href: string; label: string; external?: boolean }[] = [
@@ -131,7 +135,7 @@ function TopNav({
             <Wordmark />
           </div>
 
-          <div className="hidden items-center gap-6 justify-self-center md:flex">
+          <div className="hidden items-center gap-6 justify-self-center lg:flex">
             {NAV_LINKS.map((link) => (
               <a
                 key={link.href}


### PR DESCRIPTION
Restructures the landing top bar into a three-column layout.

## What changed
`TopNav` in `apps/web/src/Landing.tsx`:
- Was a two-column `flex justify-between` — brand left, all links + buttons crammed right.
- Now a `grid grid-cols-[1fr_auto_1fr]`:
  - **Left** — wordmark
  - **Center** — page links (Docs, Blog, Changelog, Roadmap, Team, Pricing)
  - **Right** — GitHub star chip, Sign in, Get started
- Page links are driven off a `NAV_LINKS` array instead of repeated `<a>` markup.

## Responsive behavior
- The center column is `hidden md:flex`. Below `md` the `auto` middle track collapses to zero width, so the `1fr … 1fr` grid degrades to brand-left / actions-right — no overlap.
- At `md`+ the links stay dead-centered in the bar regardless of the side groups' widths, because the two `1fr` side tracks stay equal. The GitHub chip remains `hidden md:inline-flex`.

Purely presentational; typecheck passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the landing top bar as a three‑column grid (brand left, links centered, actions right) with the center links only visible at lg+ so they fit and stay centered; below lg the grid collapses to brand-left / actions-right. Nav links now render from a `NAV_LINKS` array, with external links (Docs) opening in a new tab, and tests updated to assert the array wiring and target/rel.

<sup>Written for commit 145c621baa0cdaefa15c324108258856211236c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

