### PR TITLE
Prevent proxy keep-alive response drops

### DIFF
--- a/apps/proxy/src/http-server.test.ts
+++ b/apps/proxy/src/http-server.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { Agent, createServer, request } from "node:http";
+import test from "node:test";
+import { configureHttpServerTimeouts } from "./http-server.js";
+
+function getConnectionId(port: number, agent: Agent): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const req = request({ port, path: "/", agent }, (res) => {
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        body += chunk;
+      });
+      res.on("end", () => resolve(body));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+test("an upstream load balancer can own idle connection closure", async () => {
+  const connectionIds = new WeakMap<object, number>();
+  let nextConnectionId = 0;
+  const server = createServer((req, res) => {
+    let connectionId = connectionIds.get(req.socket);
+    if (connectionId === undefined) {
+      connectionId = ++nextConnectionId;
+      connectionIds.set(req.socket, connectionId);
+    }
+    res.end(String(connectionId));
+  });
+  server.keepAliveTimeout = 20;
+  configureHttpServerTimeouts(server, { HTTP_KEEP_ALIVE_TIMEOUT_MS: "0" });
+
+  const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    assert(address && typeof address === "object");
+
+    const firstConnection = await getConnectionId(address.port, agent);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const secondConnection = await getConnectionId(address.port, agent);
+
+    assert.equal(secondConnection, firstConnection);
+  } finally {
+    agent.destroy();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  }
+});

--- a/apps/proxy/src/http-server.test.ts
+++ b/apps/proxy/src/http-server.test.ts
@@ -64,3 +64,15 @@ test("an invalid keep-alive timeout cannot silently disable idle closure", () =>
     /HTTP_KEEP_ALIVE_TIMEOUT_MS must be a nonnegative integer/,
   );
 });
+
+test("an oversized keep-alive timeout cannot collapse to an immediate Node timer", () => {
+  const server = createServer();
+
+  assert.throws(
+    () =>
+      configureHttpServerTimeouts(server, {
+        HTTP_KEEP_ALIVE_TIMEOUT_MS: "2147482648",
+      }),
+    /HTTP_KEEP_ALIVE_TIMEOUT_MS must not exceed 2147482647/,
+  );
+});

--- a/apps/proxy/src/http-server.test.ts
+++ b/apps/proxy/src/http-server.test.ts
@@ -55,3 +55,12 @@ test("an upstream load balancer can own idle connection closure", async () => {
     });
   }
 });
+
+test("an invalid keep-alive timeout cannot silently disable idle closure", () => {
+  const server = createServer();
+
+  assert.throws(
+    () => configureHttpServerTimeouts(server, { HTTP_KEEP_ALIVE_TIMEOUT_MS: "" }),
+    /HTTP_KEEP_ALIVE_TIMEOUT_MS must be a nonnegative integer/,
+  );
+});

--- a/apps/proxy/src/http-server.ts
+++ b/apps/proxy/src/http-server.ts
@@ -1,6 +1,8 @@
 import type { Server } from "node:http";
 
 const DEFAULT_KEEP_ALIVE_TIMEOUT_MS = 75_000;
+const HEADERS_TIMEOUT_MARGIN_MS = 1_000;
+const MAX_KEEP_ALIVE_TIMEOUT_MS = 2_147_483_647 - HEADERS_TIMEOUT_MARGIN_MS;
 
 type HttpServerTimeoutEnvironment = {
   HTTP_KEEP_ALIVE_TIMEOUT_MS?: string;
@@ -14,6 +16,9 @@ function keepAliveTimeoutMs(env: HttpServerTimeoutEnvironment): number {
   if (!/^(0|[1-9]\d*)$/.test(raw) || !Number.isSafeInteger(value)) {
     throw new Error("HTTP_KEEP_ALIVE_TIMEOUT_MS must be a nonnegative integer");
   }
+  if (value > MAX_KEEP_ALIVE_TIMEOUT_MS) {
+    throw new Error(`HTTP_KEEP_ALIVE_TIMEOUT_MS must not exceed ${MAX_KEEP_ALIVE_TIMEOUT_MS}`);
+  }
   return value;
 }
 
@@ -25,6 +30,6 @@ export function configureHttpServerTimeouts(
   server.keepAliveTimeout = timeoutMs;
 
   if (timeoutMs > 0) {
-    server.headersTimeout = timeoutMs + 1_000;
+    server.headersTimeout = timeoutMs + HEADERS_TIMEOUT_MARGIN_MS;
   }
 }

--- a/apps/proxy/src/http-server.ts
+++ b/apps/proxy/src/http-server.ts
@@ -6,16 +6,25 @@ type HttpServerTimeoutEnvironment = {
   HTTP_KEEP_ALIVE_TIMEOUT_MS?: string;
 };
 
+function keepAliveTimeoutMs(env: HttpServerTimeoutEnvironment): number {
+  const raw = env.HTTP_KEEP_ALIVE_TIMEOUT_MS;
+  if (raw === undefined) return DEFAULT_KEEP_ALIVE_TIMEOUT_MS;
+
+  const value = Number(raw);
+  if (!/^(0|[1-9]\d*)$/.test(raw) || !Number.isSafeInteger(value)) {
+    throw new Error("HTTP_KEEP_ALIVE_TIMEOUT_MS must be a nonnegative integer");
+  }
+  return value;
+}
+
 export function configureHttpServerTimeouts(
   server: Pick<Server, "headersTimeout" | "keepAliveTimeout">,
   env: HttpServerTimeoutEnvironment = process.env,
 ): void {
-  const keepAliveTimeoutMs = Number(
-    env.HTTP_KEEP_ALIVE_TIMEOUT_MS ?? DEFAULT_KEEP_ALIVE_TIMEOUT_MS,
-  );
-  server.keepAliveTimeout = keepAliveTimeoutMs;
+  const timeoutMs = keepAliveTimeoutMs(env);
+  server.keepAliveTimeout = timeoutMs;
 
-  if (keepAliveTimeoutMs > 0) {
-    server.headersTimeout = keepAliveTimeoutMs + 1_000;
+  if (timeoutMs > 0) {
+    server.headersTimeout = timeoutMs + 1_000;
   }
 }

--- a/apps/proxy/src/http-server.ts
+++ b/apps/proxy/src/http-server.ts
@@ -1,0 +1,21 @@
+import type { Server } from "node:http";
+
+const DEFAULT_KEEP_ALIVE_TIMEOUT_MS = 75_000;
+
+type HttpServerTimeoutEnvironment = {
+  HTTP_KEEP_ALIVE_TIMEOUT_MS?: string;
+};
+
+export function configureHttpServerTimeouts(
+  server: Pick<Server, "headersTimeout" | "keepAliveTimeout">,
+  env: HttpServerTimeoutEnvironment = process.env,
+): void {
+  const keepAliveTimeoutMs = Number(
+    env.HTTP_KEEP_ALIVE_TIMEOUT_MS ?? DEFAULT_KEEP_ALIVE_TIMEOUT_MS,
+  );
+  server.keepAliveTimeout = keepAliveTimeoutMs;
+
+  if (keepAliveTimeoutMs > 0) {
+    server.headersTimeout = keepAliveTimeoutMs + 1_000;
+  }
+}

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -36,6 +36,7 @@ import {
   resolveGcpPubSubPushAudience,
 } from "./gcp-pubsub.js";
 import { mountGcpMetricsPullRoute } from "./gcp-pull-routes.js";
+import { configureHttpServerTimeouts } from "./http-server.js";
 import { stampIssueFingerprintsFailOpen } from "./ingest-fingerprints.js";
 import { createIngestKeyCache, createLastUsedRecorder } from "./ingest-key-auth.js";
 import { IngestQueue, getIngestQueueConfig } from "./ingest-queue.js";
@@ -1094,18 +1095,11 @@ async function forwardFirehose(
 }
 
 const server = serve({ fetch: app.fetch, port: PORT });
-// When deployed behind a load balancer (typically a 60s idle timeout), Node's
-// default 5s keepAliveTimeout closes idle keep-alive sockets the balancer still
-// considers pooled; reusing one then gets a RST and surfaces as a 502 to the
-// client even though the app returned 200. Periodic OTLP metric exporters
-// (default ~60s interval) hit this race the hardest. Keep the keep-alive
-// comfortably above the balancer idle timeout: a thin (~5s) margin still leaks
-// 502s in bursts where many wall-clock-aligned exporters reuse pooled sockets at
-// once and the event loop is briefly busy, so we keep a wide margin. headersTimeout
-// stays above keepAliveTimeout per Node's required ordering.
-if ("keepAliveTimeout" in server) {
-  server.keepAliveTimeout = 75_000;
-  server.headersTimeout = 76_000;
+// Keep the backend timeout configurable independently from any upstream load
+// balancer. Setting HTTP_KEEP_ALIVE_TIMEOUT_MS=0 leaves idle-connection closure
+// to the upstream, preventing it from reusing a socket while Node closes it.
+if ("keepAliveTimeout" in server && "headersTimeout" in server) {
+  configureHttpServerTimeouts(server);
 }
 if (ingestQueue && ingestQueueConfig?.consumerEnabled) {
   ingestQueue.startConsumer(COLLECTOR_URL);


### PR DESCRIPTION
## Summary

- make the proxy HTTP keep-alive timeout configurable with `HTTP_KEEP_ALIVE_TIMEOUT_MS`
- allow deployments to disable the server-side idle timer so an upstream load balancer owns connection closure
- cover the disabled-timeout behavior with a real keep-alive socket reuse test

## Why

A finite server-side keep-alive timeout can race an upstream load balancer that still considers the backend connection reusable. If the server closes the socket while the load balancer sends the next request, the client receives a load-balancer-generated 502 without an application response.

Setting `HTTP_KEEP_ALIVE_TIMEOUT_MS=0` removes the competing server idle timer for deployments where the upstream already enforces an idle timeout. The existing 75-second default remains unchanged for other deployments.

## Validation

- `pnpm --filter @superlog/proxy test`
- `pnpm --filter @superlog/proxy typecheck`
- formatting check for the changed proxy files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent 502s from keep‑alive races behind an upstream load balancer by making the proxy keep‑alive timeout configurable, allowing it to be disabled, and validating and bounding the env config.

- **Bug Fixes**
  - Introduced `HTTP_KEEP_ALIVE_TIMEOUT_MS` (default 75s); set to `0` to remove the server idle timer so the upstream LB owns connection closure.
  - Added `configureHttpServerTimeouts` to set `keepAliveTimeout` and keep `headersTimeout` above it; only sets `headersTimeout` when the timeout > 0.
  - Validated and bounded config: reject non‑integer, negative, or oversized values to prevent misconfig and immediate timer expiry.
  - Added tests for keep‑alive reuse with disabled timeout and for invalid/oversized config.

<sup>Written for commit 09f924106a9960cd66f6a553477aba331286550c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

