### PR TITLE
Align incident detail header, breadcrumb, and content left edges

### DIFF
--- a/apps/web/src/Issues.tsx
+++ b/apps/web/src/Issues.tsx
@@ -1639,7 +1639,7 @@ export function IncidentDetailContent({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-bg text-fg">
-      <div className="flex shrink-0 items-center gap-2 border-b border-border bg-bg px-5 py-3">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border bg-bg px-5 py-3 sm:px-6 lg:px-8">
         <span className="text-[13px] text-muted">Incidents</span>
         <span className="text-subtle">›</span>
         <span className="min-w-0 flex-1 truncate text-[13px] text-fg">{incident.title}</span>
@@ -1676,7 +1676,7 @@ export function IncidentDetailContent({
 
       <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[390px_minmax(0,1fr)]">
         <aside className="flex min-w-0 flex-col border-b border-border bg-bg lg:border-b-0 lg:border-r">
-          <div className="px-7 pb-7 pt-7">
+          <div className="px-5 pb-7 pt-7 sm:px-6 lg:px-8">
             <div className="font-sans text-[11px] text-subtle">#{incident.codename}</div>
             <h2 className="mt-2 break-words text-[20px] font-semibold leading-[1.1] tracking-tight text-fg">
               {incident.title}

--- a/apps/web/src/skeletons.tsx
+++ b/apps/web/src/skeletons.tsx
@@ -152,14 +152,14 @@ export function IssueDetailSkeleton() {
 export function IncidentDetailSkeleton() {
   return (
     <SkeletonStatus label="Loading incident detail" className="flex min-h-0 flex-1 flex-col bg-bg">
-      <div className="flex shrink-0 items-center gap-2 border-b border-border px-5 py-3">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-5 py-3 sm:px-6 lg:px-8">
         <SkeletonBlock className="h-4 w-20" />
         <SkeletonBlock className="h-4 w-3/5" />
         <SkeletonBlock className="ml-auto h-7 w-28" />
         <SkeletonBlock className="h-7 w-7" />
       </div>
       <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[390px_minmax(0,1fr)]">
-        <aside className="border-b border-border px-7 py-7 lg:border-b-0 lg:border-r">
+        <aside className="border-b border-border px-5 py-7 sm:px-6 lg:border-b-0 lg:border-r lg:px-8">
           <div className="space-y-4">
             <SkeletonBlock className="h-3 w-28" />
             <SkeletonBlock className="h-7 w-4/5" />


### PR DESCRIPTION
The incident detail page rendered three stacked bands with three different left insets:

- the chrome header used the responsive page padding `px-5 sm:px-6 lg:px-8`
- the breadcrumb row ("Incidents › …") used a fixed `px-5`
- the content header (`#codename` + title + summary) used a fixed `px-7`

On wide viewports their left edges landed at 32 / 20 / 28px, so the breadcrumb and title didn't line up with the header above them.

This gives the breadcrumb row and the content header the same responsive page padding as the chrome header, so all three left edges align at every breakpoint.

Presentational only — no behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the left edges of the incident header, breadcrumb row, and content header by using the same responsive padding (`px-5 sm:px-6 lg:px-8`). Matches the loading skeleton’s breadcrumb and sidebar padding to prevent layout shifts at `sm`/`lg` breakpoints; visual-only change.

<sup>Written for commit 5ede4d9f0ef0f0f13a95c5d20bec015ac45a4aab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

