### PR TITLE
Attribute the server-side signup event at ingestion time

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -266,9 +266,11 @@ export const auth = betterAuth({
             context?.headers?.get("cookie"),
           );
           if (attribution.posthogDistinctId && attribution.posthogDistinctId !== user.id) {
+            // Argument order per posthog-node: distinctId is the existing
+            // (anonymous) id, alias is the new user id being linked to it.
             aliasServerDistinctId({
-              distinctId: user.id,
-              alias: attribution.posthogDistinctId,
+              distinctId: attribution.posthogDistinctId,
+              alias: user.id,
             });
           }
           const hasEventProps = Object.keys(attribution.eventProperties).length > 0;

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -1,4 +1,10 @@
-import { captureServerEvent, db, emitLifecycleEvent, schema } from "@superlog/db";
+import {
+  aliasServerDistinctId,
+  captureServerEvent,
+  db,
+  emitLifecycleEvent,
+  schema,
+} from "@superlog/db";
 import { autumn } from "autumn-js/better-auth";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
@@ -11,7 +17,7 @@ import {
   sendEmail,
   verificationEmailBody,
 } from "./email.js";
-import { readClickIdsFromCookieHeader } from "./signup-click-ids.js";
+import { readSignupAttributionFromCookieHeader } from "./signup-click-ids.js";
 import { enqueueUserCreated } from "./user-created-publisher.js";
 
 // Better Auth server config. Mounted at /api/auth/* by apps/api/src/index.ts.
@@ -248,16 +254,42 @@ export const auth = betterAuth({
           // server-side and can't be lost to a blocked or bounced browser. The
           // browser posthog-js event depended on the page actually running it.
           // Best-effort; captureServerEvent no-ops when analytics is unconfigured.
+          //
+          // First-touch attribution + the browser's PostHog ids ride in on a
+          // first-party cookie (see signup-click-ids.ts). With person-on-events,
+          // person properties are frozen per event at ingestion — the SPA's
+          // later identify() can't retroactively attribute this event — so the
+          // attribution goes on the event itself, the session id ties it to the
+          // web session for channel attribution, and the anonymous person is
+          // merged here rather than whenever the SPA next loads.
+          const attribution = readSignupAttributionFromCookieHeader(
+            context?.headers?.get("cookie"),
+          );
+          if (attribution.posthogDistinctId && attribution.posthogDistinctId !== user.id) {
+            aliasServerDistinctId({
+              distinctId: user.id,
+              alias: attribution.posthogDistinctId,
+            });
+          }
+          const hasEventProps = Object.keys(attribution.eventProperties).length > 0;
           captureServerEvent({
             distinctId: user.id,
             event: "user_signed_up",
+            properties: {
+              ...attribution.eventProperties,
+              ...(attribution.posthogSessionId
+                ? { $session_id: attribution.posthogSessionId }
+                : {}),
+            },
             set: { email: user.email, name: user.name },
+            // Also stamp attribution on the person, write-once — same shape the
+            // SPA's identify() uses, whichever lands first wins.
+            setOnce: hasEventProps ? attribution.eventProperties : undefined,
           });
-          // Ad-network click ids captured on the landing URL and carried here in
-          // a first-party cookie (see signup-click-ids.ts). Forwarded on the
-          // event so a sink can click-attribute the conversion; empty when the
-          // user didn't arrive from a tagged ad click.
-          const clickIds = readClickIdsFromCookieHeader(context?.headers?.get("cookie"));
+          // Ad-network click ids, forwarded on the lifecycle event so a sink
+          // can click-attribute the conversion; empty when the user didn't
+          // arrive from a tagged ad click.
+          const clickIds = attribution.clickIds;
           // Vendor-neutral growth seam: a deployment may forward this to
           // external destinations (see @superlog/db lifecycle-events). No-op
           // unless a sink was registered at boot; fire-and-forget so a slow

--- a/apps/api/src/signup-click-ids.test.ts
+++ b/apps/api/src/signup-click-ids.test.ts
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { CLICK_ID_COOKIE, readClickIdsFromCookieHeader } from "./signup-click-ids.js";
+import {
+  CLICK_ID_COOKIE,
+  SIGNUP_ATTRIBUTION_COOKIE,
+  readClickIdsFromCookieHeader,
+  readSignupAttributionFromCookieHeader,
+} from "./signup-click-ids.js";
+
+function attributionCookie(payload: unknown): string {
+  return `${SIGNUP_ATTRIBUTION_COOKIE}=${encodeURIComponent(JSON.stringify(payload))}`;
+}
 
 test("reads and JSON-decodes the click-id cookie", () => {
   const value = encodeURIComponent(JSON.stringify({ twclid: "tw123", gclid: "gg456" }));
@@ -25,4 +34,77 @@ test("drops non-string values from a tampered cookie", () => {
   assert.deepEqual(readClickIdsFromCookieHeader(`${CLICK_ID_COOKIE}=${value}`), {
     twclid: "tw123",
   });
+});
+
+test("reads attribution props, click ids, and posthog ids from the attribution cookie", () => {
+  const header = attributionCookie({
+    props: {
+      utm_source: "x",
+      utm_medium: "paid_social",
+      utm_campaign: "first_campaign",
+      referring_domain: "t.co",
+      landing_path: "/",
+      auth_method: "google",
+      twclid: "tw123",
+    },
+    ph: { did: "anon-123", sid: "sess-456" },
+  });
+  const got = readSignupAttributionFromCookieHeader(header);
+  assert.deepEqual(got.eventProperties, {
+    utm_source: "x",
+    utm_medium: "paid_social",
+    utm_campaign: "first_campaign",
+    referring_domain: "t.co",
+    landing_path: "/",
+    auth_method: "google",
+    twclid: "tw123",
+  });
+  assert.deepEqual(got.clickIds, { twclid: "tw123" });
+  assert.equal(got.posthogDistinctId, "anon-123");
+  assert.equal(got.posthogSessionId, "sess-456");
+});
+
+test("attribution cookie drops unknown keys, non-strings, and oversized values", () => {
+  const header = attributionCookie({
+    props: {
+      utm_source: "x",
+      not_allowlisted: "nope",
+      $set: "evil",
+      evil_obj: { a: 1 },
+      utm_term: "x".repeat(300),
+    },
+    ph: { did: 42, sid: "s\nid" },
+  });
+  const got = readSignupAttributionFromCookieHeader(header);
+  assert.deepEqual(got.eventProperties, { utm_source: "x" });
+  assert.equal(got.posthogDistinctId, undefined);
+  assert.equal(got.posthogSessionId, undefined);
+});
+
+test("attribution cookie tolerates malformed contents and missing sections", () => {
+  assert.deepEqual(readSignupAttributionFromCookieHeader(`${SIGNUP_ATTRIBUTION_COOKIE}=%7Bnope`), {
+    eventProperties: {},
+    clickIds: {},
+  });
+  const propsOnly = readSignupAttributionFromCookieHeader(attributionCookie({ props: { gclid: "g1" } }));
+  assert.deepEqual(propsOnly.eventProperties, { gclid: "g1" });
+  assert.deepEqual(propsOnly.clickIds, { gclid: "g1" });
+  const phOnly = readSignupAttributionFromCookieHeader(attributionCookie({ ph: { sid: "sess-1" } }));
+  assert.deepEqual(phOnly.eventProperties, {});
+  assert.equal(phOnly.posthogSessionId, "sess-1");
+});
+
+test("legacy click-id cookie fills click ids when the attribution cookie lacks them", () => {
+  const legacy = encodeURIComponent(JSON.stringify({ twclid: "tw-legacy" }));
+  const header = `${CLICK_ID_COOKIE}=${legacy}; ${attributionCookie({ props: { utm_source: "x" }, ph: { sid: "sess-1" } })}`;
+  const got = readSignupAttributionFromCookieHeader(header);
+  assert.deepEqual(got.clickIds, { twclid: "tw-legacy" });
+  assert.deepEqual(got.eventProperties, { utm_source: "x" });
+});
+
+test("legacy click-id cookie alone still yields click ids", () => {
+  const legacy = encodeURIComponent(JSON.stringify({ gclid: "gg1" }));
+  const got = readSignupAttributionFromCookieHeader(`${CLICK_ID_COOKIE}=${legacy}`);
+  assert.deepEqual(got.clickIds, { gclid: "gg1" });
+  assert.deepEqual(got.eventProperties, {});
 });

--- a/apps/api/src/signup-click-ids.ts
+++ b/apps/api/src/signup-click-ids.ts
@@ -1,13 +1,39 @@
-// Server side of the click-id attribution carrier. The web writes ad-network
-// click ids (twclid, gclid, …) captured from the landing URL into a first-party
-// cookie so they survive the sign-up request — including the OAuth redirect to
-// this API origin, which localStorage cannot cross. The user-create hook reads
-// them here and forwards them on the vendor-neutral lifecycle event; a
-// deployment's sink then attaches whichever its ad network wants.
+// Server side of the signup-attribution carriers. The web writes two
+// first-party cookies so attribution survives the sign-up request — including
+// the OAuth redirect to this API origin, which localStorage cannot cross:
 //
-// Cookie name must match the web (`superlog/apps/web/src/signupAttribution.ts`).
+// - `sl_click_ids` (legacy): ad-network click ids only, forwarded on the
+//   vendor-neutral lifecycle event for conversion sinks.
+// - `sl_signup_attr`: the full first-touch attribution as snake_case event
+//   properties, plus the browser's PostHog distinct/session ids. The
+//   user-create hook puts these on the server-side signup analytics event so
+//   channel/session attribution exists at ingestion time instead of waiting
+//   for the SPA to identify() later.
+//
+// Cookie names must match the web (`apps/web/src/signupAttribution.ts`). Both
+// cookies are user-writable, so everything read here is allowlisted, type- and
+// length-checked, and malformed input degrades to empty rather than throwing.
 
 export const CLICK_ID_COOKIE = "sl_click_ids";
+export const SIGNUP_ATTRIBUTION_COOKIE = "sl_signup_attr";
+
+/** Decode one cookie's JSON value out of a raw `Cookie` header, or null. */
+function readJsonCookie(header: string | null | undefined, name: string): unknown {
+  if (!header) return null;
+  const prefix = `${name}=`;
+  const cookie = header
+    .split(";")
+    .map((c) => c.trim())
+    .find((c) => c.startsWith(prefix));
+  if (!cookie) return null;
+  try {
+    const raw = decodeURIComponent(cookie.slice(prefix.length));
+    if (!raw) return null;
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Parse the click-id cookie out of a raw `Cookie` request header. Best-effort
@@ -17,24 +43,101 @@ export const CLICK_ID_COOKIE = "sl_click_ids";
 export function readClickIdsFromCookieHeader(
   header: string | null | undefined,
 ): Record<string, string> {
-  if (!header) return {};
-  const prefix = `${CLICK_ID_COOKIE}=`;
-  const cookie = header
-    .split(";")
-    .map((c) => c.trim())
-    .find((c) => c.startsWith(prefix));
-  if (!cookie) return {};
-  try {
-    const raw = decodeURIComponent(cookie.slice(prefix.length));
-    if (!raw) return {};
-    const parsed: unknown = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object") return {};
-    const out: Record<string, string> = {};
-    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
-      if (typeof v === "string" && v !== "") out[k] = v;
-    }
-    return out;
-  } catch {
-    return {};
+  const parsed = readJsonCookie(header, CLICK_ID_COOKIE);
+  if (!parsed || typeof parsed !== "object") return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof v === "string" && v !== "") out[k] = v;
   }
+  return out;
+}
+
+// Event-property keys the attribution cookie may set on the signup analytics
+// event. Mirrors the web's buildSignupEventProperties output; anything else in
+// a (user-writable) cookie is dropped so a tampered cookie can't inject
+// reserved PostHog keys like $set.
+const ATTRIBUTION_EVENT_PROPERTY_KEYS = [
+  "signup_source",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "referrer",
+  "referring_domain",
+  "landing_path",
+  "auth_method",
+  "twclid",
+  "gclid",
+  "fbclid",
+  "msclkid",
+  "li_fat_id",
+] as const;
+
+// Subset of the above that are ad-network click ids, forwarded to conversion
+// sinks via the lifecycle event. Keyed by their standard query-param names.
+const CLICK_ID_KEYS = ["twclid", "gclid", "fbclid", "msclkid", "li_fat_id"] as const;
+
+const MAX_ATTRIBUTION_VALUE_LENGTH = 256;
+// PostHog distinct/session ids are UUID-sized; anything much longer or with
+// control characters is not a plausible id.
+const POSTHOG_ID_RE = /^[\x21-\x7e]{1,128}$/;
+
+export type SignupAttribution = {
+  /** Allowlisted snake_case properties for the signup analytics event. */
+  eventProperties: Record<string, string>;
+  /** Ad-network click ids for the lifecycle-event conversion sinks. */
+  clickIds: Record<string, string>;
+  /** The browser's anonymous PostHog distinct id, to merge at signup. */
+  posthogDistinctId?: string;
+  /** The browser's PostHog session id, to session-attribute the signup. */
+  posthogSessionId?: string;
+};
+
+function cleanAttributionValue(v: unknown): string | undefined {
+  if (typeof v !== "string" || v === "" || v.length > MAX_ATTRIBUTION_VALUE_LENGTH) {
+    return undefined;
+  }
+  return v;
+}
+
+function cleanPosthogId(v: unknown): string | undefined {
+  return typeof v === "string" && POSTHOG_ID_RE.test(v) ? v : undefined;
+}
+
+/**
+ * Read the full signup attribution out of a raw `Cookie` request header:
+ * event properties + PostHog ids from `sl_signup_attr`, click ids from the
+ * same, falling back to the legacy `sl_click_ids` cookie for clients that
+ * only wrote that one. Never throws; missing/malformed input yields empties.
+ */
+export function readSignupAttributionFromCookieHeader(
+  header: string | null | undefined,
+): SignupAttribution {
+  const out: SignupAttribution = { eventProperties: {}, clickIds: {} };
+
+  const parsed = readJsonCookie(header, SIGNUP_ATTRIBUTION_COOKIE);
+  if (parsed && typeof parsed === "object") {
+    const { props, ph } = parsed as { props?: unknown; ph?: unknown };
+    if (props && typeof props === "object") {
+      for (const key of ATTRIBUTION_EVENT_PROPERTY_KEYS) {
+        const v = cleanAttributionValue((props as Record<string, unknown>)[key]);
+        if (v !== undefined) out.eventProperties[key] = v;
+      }
+    }
+    if (ph && typeof ph === "object") {
+      out.posthogDistinctId = cleanPosthogId((ph as Record<string, unknown>).did);
+      out.posthogSessionId = cleanPosthogId((ph as Record<string, unknown>).sid);
+    }
+  }
+
+  for (const key of CLICK_ID_KEYS) {
+    const v = out.eventProperties[key];
+    if (v !== undefined) out.clickIds[key] = v;
+  }
+  if (Object.keys(out.clickIds).length === 0) {
+    out.clickIds = readClickIdsFromCookieHeader(header);
+  }
+
+  return out;
 }

--- a/apps/web/src/AuthForm.test.ts
+++ b/apps/web/src/AuthForm.test.ts
@@ -2,6 +2,17 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
+test("every auth attempt refreshes the attribution cookie before it leaves the page", async () => {
+  // The API's user-create hook reads PostHog ids from this cookie to
+  // session-attribute the server-side signup event; each auth path must
+  // snapshot fresh ids first (a social "sign-in" can create a new user too).
+  const source = await readFile(new URL("./AuthForm.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /refreshSignupAttributionCookie\(posthog, \{ authMethod: "email" \}\)/);
+  assert.match(source, /refreshSignupAttributionCookie\(posthog, \{ authMethod: "google" \}\)/);
+  assert.match(source, /refreshSignupAttributionCookie\(posthog, \{ authMethod: "github" \}\)/);
+});
+
 test("social sign-in accepts a caller-provided callback URL", async () => {
   const source = await readFile(new URL("./AuthForm.tsx", import.meta.url), "utf8");
 

--- a/apps/web/src/AuthForm.tsx
+++ b/apps/web/src/AuthForm.tsx
@@ -1,11 +1,18 @@
 import { type FormEvent, useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { usePostHog } from "posthog-js/react";
 import { authClient } from "./auth-client.ts";
+import { refreshSignupAttributionCookie } from "./signupAttributionCookie.ts";
 
 // Two-step auth form. Step 1: enter email (or click a social provider). Step 2:
 // enter password (sign-in) or name + password (sign-up). The previously-used
 // provider gets a "Last used" pill so returning users land on the right
 // button. Replaces Clerk's prebuilt <SignIn> / <SignUp>.
+//
+// Funnel instrumentation: auth_form_viewed → auth_email_continued →
+// auth_submitted → (auth_error)* fills the previously-dark gap between the
+// landing CTA click and the server-side signup event, so drop-off inside the
+// form is attributable to a step and an error instead of being invisible.
 
 const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:4100";
 const LAST_PROVIDER_KEY = "superlog.auth.last_provider";
@@ -65,6 +72,7 @@ export function AuthForm({
   socialCallbackURL?: string;
 }) {
   const providers = useAuthProviders();
+  const posthog = usePostHog();
   const anySocial = providers.google || providers.github;
   const [mode, setMode] = useState<Mode>(initialMode);
   const [step, setStep] = useState<Step>("email");
@@ -82,6 +90,17 @@ export function AuthForm({
     else passwordRef.current?.focus();
   }, [step]);
 
+  useEffect(() => {
+    // Refires on mode switch so sign-in ↔ sign-up hops stay visible.
+    posthog?.capture("auth_form_viewed", { mode });
+  }, [posthog, mode]);
+
+  function trackAuthError(method: Provider, message: string) {
+    // Better Auth error messages are static, non-PII strings ("Invalid email
+    // or password", …) — safe to attach for a drop-off-by-reason breakdown.
+    posthog?.capture("auth_error", { mode, method, message });
+  }
+
   function onEmailSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setError(null);
@@ -89,6 +108,7 @@ export function AuthForm({
       setError("Enter a valid email address.");
       return;
     }
+    posthog?.capture("auth_email_continued", { mode });
     setStep("credentials");
   }
 
@@ -96,6 +116,10 @@ export function AuthForm({
     e.preventDefault();
     setError(null);
     setSubmitting(true);
+    // Snapshot fresh PostHog ids into the attribution cookie so the API's
+    // user-create hook can session-attribute the server-side signup event.
+    refreshSignupAttributionCookie(posthog, { authMethod: "email" });
+    posthog?.capture("auth_submitted", { mode, method: "email" });
     try {
       if (mode === "sign-up") {
         const result = await authClient.signUp.email({
@@ -104,20 +128,26 @@ export function AuthForm({
           name: name || email.split("@")[0] || "",
         });
         if (result.error) {
-          setError(result.error.message ?? "Sign-up failed");
+          const message = result.error.message ?? "Sign-up failed";
+          trackAuthError("email", message);
+          setError(message);
           return;
         }
       } else {
         const result = await authClient.signIn.email({ email, password });
         if (result.error) {
-          setError(result.error.message ?? "Sign-in failed");
+          const message = result.error.message ?? "Sign-in failed";
+          trackAuthError("email", message);
+          setError(message);
           return;
         }
       }
       rememberProvider("email");
       onSuccess?.();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Unexpected error");
+      const message = err instanceof Error ? err.message : "Unexpected error";
+      trackAuthError("email", message);
+      setError(message);
     } finally {
       setSubmitting(false);
     }
@@ -126,26 +156,36 @@ export function AuthForm({
   async function onGoogle() {
     setError(null);
     rememberProvider("google");
+    // A social "sign-in" click can create a brand-new user, so the attribution
+    // cookie must be fresh before the OAuth redirect leaves the page.
+    refreshSignupAttributionCookie(posthog, { authMethod: "google" });
+    posthog?.capture("auth_submitted", { mode, method: "google" });
     try {
       await authClient.signIn.social({
         provider: "google",
         callbackURL: socialCallbackURL ?? `${window.location.origin}/app`,
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Google sign-in failed");
+      const message = err instanceof Error ? err.message : "Google sign-in failed";
+      trackAuthError("google", message);
+      setError(message);
     }
   }
 
   async function onGithub() {
     setError(null);
     rememberProvider("github");
+    refreshSignupAttributionCookie(posthog, { authMethod: "github" });
+    posthog?.capture("auth_submitted", { mode, method: "github" });
     try {
       await authClient.signIn.social({
         provider: "github",
         callbackURL: socialCallbackURL ?? `${API_URL}/api/github/post-signin`,
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : "GitHub sign-in failed");
+      const message = err instanceof Error ? err.message : "GitHub sign-in failed";
+      trackAuthError("github", message);
+      setError(message);
     }
   }
 

--- a/apps/web/src/SignupSourceCapture.tsx
+++ b/apps/web/src/SignupSourceCapture.tsx
@@ -1,10 +1,12 @@
 import { useEffect } from "react";
+import { usePostHog } from "posthog-js/react";
 import {
   CLICK_ID_COOKIE,
   parseAttribution,
   persistFirstTouchAttribution,
   serializeClickIdsCookie,
 } from "./signupAttribution.ts";
+import { refreshSignupAttributionCookie } from "./signupAttributionCookie.ts";
 
 // How long the click-id cookie lives. Just long enough to survive landing →
 // "Get started" → sign up (including an OAuth round-trip), then it expires on
@@ -37,6 +39,8 @@ function writeClickIdCookie(value: string) {
 }
 
 export function SignupSourceCapture() {
+  const posthog = usePostHog();
+
   useEffect(() => {
     const attr = parseAttribution(window.location.search, document.referrer);
     if (attr.source) {
@@ -52,9 +56,14 @@ export function SignupSourceCapture() {
       landingPath: window.location.pathname,
     });
     // Carry any ad-network click ids to the server for the sign-up conversion.
+    // Legacy carrier — kept during the transition to the attribution cookie
+    // below so an older API still finds the click ids.
     const clickIds = serializeClickIdsCookie(attr);
     if (clickIds) writeClickIdCookie(clickIds);
-  }, []);
+    // Full attribution + PostHog ids for the server-side signup event. Also
+    // refreshed at auth time (AuthForm) so the ids are current at sign-up.
+    refreshSignupAttributionCookie(posthog);
+  }, [posthog]);
 
   return null;
 }

--- a/apps/web/src/signupAttribution.test.ts
+++ b/apps/web/src/signupAttribution.test.ts
@@ -7,6 +7,7 @@ import {
   parseAttribution,
   persistFirstTouchAttribution,
   readFirstTouchAttribution,
+  readPosthogClientIds,
   serializeClickIdsCookie,
   serializeSignupAttributionCookie,
 } from "./signupAttribution.ts";
@@ -199,4 +200,84 @@ test("serializeSignupAttributionCookie drops blank posthog ids", () => {
 
 test("serializeSignupAttributionCookie yields null when there is nothing to carry", () => {
   assert.equal(serializeSignupAttributionCookie({}, {}), null);
+});
+
+test("serializeSignupAttributionCookie truncates oversized values instead of dropping them", () => {
+  // The server drops any value longer than 256 chars, so the client must
+  // truncate (an unbounded landing pathname would otherwise kill the field).
+  const value = serializeSignupAttributionCookie({ landing_path: "/" + "x".repeat(400) }, {});
+  assert.ok(value);
+  const parsed = JSON.parse(value) as { props: Record<string, string> };
+  assert.equal(parsed.props.landing_path?.length, 256);
+});
+
+test("serializeSignupAttributionCookie keeps the payload under the cookie size budget", () => {
+  const long = (c: string) => c.repeat(256);
+  const props: Record<string, string> = {
+    utm_source: long("a"),
+    utm_medium: long("b"),
+    utm_campaign: long("c"),
+    signup_source: long("d"),
+    referring_domain: long("e"),
+    auth_method: long("f"),
+    twclid: long("g"),
+    gclid: long("h"),
+    fbclid: long("i"),
+    msclkid: long("j"),
+    li_fat_id: long("k"),
+    utm_term: long("l"),
+    utm_content: long("m"),
+    landing_path: long("n"),
+    referrer: long("o"),
+  };
+  const value = serializeSignupAttributionCookie(props, {
+    distinctId: "anon-123",
+    sessionId: "sess-456",
+  });
+  assert.ok(value);
+  assert.ok(encodeURIComponent(value).length <= 3072, "encoded cookie must fit the budget");
+  const parsed = JSON.parse(value) as { props: Record<string, string>; ph: { did: string } };
+  // The ids and the highest-priority channel fields must survive the trim;
+  // the long free-text tail (referrer) is what gets dropped.
+  assert.equal(parsed.ph.did, "anon-123");
+  assert.equal(parsed.props.utm_source, long("a"));
+  assert.equal(parsed.props.referrer, undefined);
+});
+
+test("readPosthogClientIds returns both ids for an anonymous browser", () => {
+  const ids = readPosthogClientIds({
+    get_distinct_id: () => "anon-123",
+    get_session_id: () => "sess-456",
+    get_property: () => "anonymous",
+  });
+  assert.deepEqual(ids, { distinctId: "anon-123", sessionId: "sess-456" });
+});
+
+test("readPosthogClientIds omits the distinct id when the browser is already identified", () => {
+  // A stale identified state (previous account, expired server session) must
+  // not be aliased onto a new signup — that would merge two real users.
+  const ids = readPosthogClientIds({
+    get_distinct_id: () => "previous-user-id",
+    get_session_id: () => "sess-456",
+    get_property: (key: string) => (key === "$user_state" ? "identified" : undefined),
+  });
+  assert.deepEqual(ids, { distinctId: undefined, sessionId: "sess-456" });
+});
+
+test("readPosthogClientIds tolerates a missing or throwing posthog", () => {
+  assert.deepEqual(readPosthogClientIds(null), {
+    distinctId: undefined,
+    sessionId: undefined,
+  });
+  assert.deepEqual(
+    readPosthogClientIds({
+      get_distinct_id: () => {
+        throw new Error("not booted");
+      },
+      get_session_id: () => {
+        throw new Error("not booted");
+      },
+    }),
+    { distinctId: undefined, sessionId: undefined },
+  );
 });

--- a/apps/web/src/signupAttribution.test.ts
+++ b/apps/web/src/signupAttribution.test.ts
@@ -8,6 +8,7 @@ import {
   persistFirstTouchAttribution,
   readFirstTouchAttribution,
   serializeClickIdsCookie,
+  serializeSignupAttributionCookie,
 } from "./signupAttribution.ts";
 
 // A tiny in-memory localStorage stand-in so the storage helpers can be tested
@@ -170,4 +171,32 @@ test("buildSignupEventProperties emits snake_case keys and omits undefined", () 
 
 test("buildSignupEventProperties yields an empty object for empty inputs", () => {
   assert.deepEqual(buildSignupEventProperties({}, {}), {});
+});
+
+test("serializeSignupAttributionCookie carries props and posthog ids", () => {
+  const value = serializeSignupAttributionCookie(
+    { utm_source: "x", utm_medium: "paid_social" },
+    { distinctId: "anon-123", sessionId: "sess-456" },
+  );
+  assert.ok(value);
+  assert.deepEqual(JSON.parse(value), {
+    props: { utm_source: "x", utm_medium: "paid_social" },
+    ph: { did: "anon-123", sid: "sess-456" },
+  });
+});
+
+test("serializeSignupAttributionCookie omits empty props and absent ids", () => {
+  const value = serializeSignupAttributionCookie({}, { sessionId: "sess-456" });
+  assert.ok(value);
+  assert.deepEqual(JSON.parse(value), { ph: { sid: "sess-456" } });
+});
+
+test("serializeSignupAttributionCookie drops blank posthog ids", () => {
+  const value = serializeSignupAttributionCookie({ utm_source: "x" }, { distinctId: "" });
+  assert.ok(value);
+  assert.deepEqual(JSON.parse(value), { props: { utm_source: "x" } });
+});
+
+test("serializeSignupAttributionCookie yields null when there is nothing to carry", () => {
+  assert.equal(serializeSignupAttributionCookie({}, {}), null);
 });

--- a/apps/web/src/signupAttribution.ts
+++ b/apps/web/src/signupAttribution.ts
@@ -211,6 +211,37 @@ export function buildSignupEventProperties(
 // reads it in the user-create path; keep this name in sync there.
 export const CLICK_ID_COOKIE = "sl_click_ids";
 
+// Successor carrier: the full first-touch attribution (as snake_case event
+// properties) plus the browser's PostHog ids. The server puts the attribution
+// on the server-side signup event itself and uses the ids to merge the
+// anonymous web person / tie the event to the web session at ingestion time —
+// person-on-events freezes person properties per event, so attribution that
+// only arrives with the SPA's later identify() is invisible on the signup
+// event. Keep the name in sync with the API's reader.
+export const SIGNUP_ATTRIBUTION_COOKIE = "sl_signup_attr";
+
+export type PosthogClientIds = {
+  distinctId?: string;
+  sessionId?: string;
+};
+
+/**
+ * JSON body for the signup-attribution cookie, or null when there is nothing
+ * to carry. Compact keys (`ph.did` / `ph.sid`) keep the cookie small.
+ */
+export function serializeSignupAttributionCookie(
+  props: Record<string, string>,
+  ids: PosthogClientIds,
+): string | null {
+  const payload: { props?: Record<string, string>; ph?: { did?: string; sid?: string } } = {};
+  if (Object.keys(props).length > 0) payload.props = props;
+  const ph: { did?: string; sid?: string } = {};
+  if (ids.distinctId) ph.did = ids.distinctId;
+  if (ids.sessionId) ph.sid = ids.sessionId;
+  if (Object.keys(ph).length > 0) payload.ph = ph;
+  return Object.keys(payload).length > 0 ? JSON.stringify(payload) : null;
+}
+
 /** Present click ids, keyed by their standard query-param name. */
 export function clickIdsFromAttribution(attr: SignupAttribution): Record<string, string> {
   const out: Record<string, string> = {};

--- a/apps/web/src/signupAttribution.ts
+++ b/apps/web/src/signupAttribution.ts
@@ -225,20 +225,93 @@ export type PosthogClientIds = {
   sessionId?: string;
 };
 
+// The slice of posthog-js we read. Structural so callers can pass the
+// uninitialized global instance (methods present but inert) or nothing.
+export type PosthogIdSource = {
+  get_distinct_id?: () => string;
+  get_session_id?: () => string;
+  get_property?: (key: string) => unknown;
+} | null;
+
+/**
+ * Snapshot the PostHog ids worth carrying to the server. The distinct id is
+ * only carried while the browser is anonymous: after identify(), the current
+ * distinct id belongs to a real account, and aliasing it onto a *different*
+ * new signup (stale identified state — previous account, expired server
+ * session) would merge two real users. The session id is always safe — it
+ * names the physical browsing session, not a person.
+ */
+export function readPosthogClientIds(posthog: PosthogIdSource): PosthogClientIds {
+  let distinctId: string | undefined;
+  let sessionId: string | undefined;
+  try {
+    const identified = posthog?.get_property?.("$user_state") === "identified";
+    if (!identified) distinctId = posthog?.get_distinct_id?.();
+    sessionId = posthog?.get_session_id?.();
+  } catch {
+    /* posthog not booted — attribution still rides without the ids */
+  }
+  return { distinctId, sessionId };
+}
+
+// Each value is truncated to what the server-side reader accepts (it drops
+// anything longer), and the whole encoded cookie must stay under common
+// browser per-cookie limits (~4 KB) or the write is silently rejected.
+const MAX_ATTRIBUTION_VALUE_LENGTH = 256;
+const MAX_COOKIE_ENCODED_LENGTH = 3072;
+
+// Order in which attribution fields are fitted into the size budget: the
+// coarse channel fields and click ids matter most; long free-text fields
+// (full referrer URL, landing path) go last and are dropped first.
+const COOKIE_PROP_PRIORITY = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "signup_source",
+  "referring_domain",
+  "auth_method",
+  "twclid",
+  "gclid",
+  "fbclid",
+  "msclkid",
+  "li_fat_id",
+  "utm_term",
+  "utm_content",
+  "landing_path",
+  "referrer",
+] as const;
+
+type CookiePayload = { props?: Record<string, string>; ph?: { did?: string; sid?: string } };
+
+function encodedLength(payload: CookiePayload): number {
+  return encodeURIComponent(JSON.stringify(payload)).length;
+}
+
 /**
  * JSON body for the signup-attribution cookie, or null when there is nothing
- * to carry. Compact keys (`ph.did` / `ph.sid`) keep the cookie small.
+ * to carry. Compact keys (`ph.did` / `ph.sid`) keep the cookie small; fields
+ * are added in priority order and dropped once the size budget is exhausted
+ * (the PostHog ids always fit — they're first and bounded).
  */
 export function serializeSignupAttributionCookie(
   props: Record<string, string>,
   ids: PosthogClientIds,
 ): string | null {
-  const payload: { props?: Record<string, string>; ph?: { did?: string; sid?: string } } = {};
-  if (Object.keys(props).length > 0) payload.props = props;
+  const payload: CookiePayload = {};
   const ph: { did?: string; sid?: string } = {};
   if (ids.distinctId) ph.did = ids.distinctId;
   if (ids.sessionId) ph.sid = ids.sessionId;
   if (Object.keys(ph).length > 0) payload.ph = ph;
+
+  for (const key of COOKIE_PROP_PRIORITY) {
+    const raw = props[key];
+    if (typeof raw !== "string" || raw === "") continue;
+    const value = raw.slice(0, MAX_ATTRIBUTION_VALUE_LENGTH);
+    const next: CookiePayload = { ...payload, props: { ...payload.props, [key]: value } };
+    if (encodedLength(next) > MAX_COOKIE_ENCODED_LENGTH) continue;
+    payload.props = next.props;
+  }
+
   return Object.keys(payload).length > 0 ? JSON.stringify(payload) : null;
 }
 

--- a/apps/web/src/signupAttributionCookie.ts
+++ b/apps/web/src/signupAttributionCookie.ts
@@ -1,0 +1,69 @@
+// Browser side of the signup-attribution carrier cookie. Reads the stashed
+// first-touch attribution from localStorage, snapshots the live PostHog
+// distinct/session ids, and writes both into a short-lived first-party cookie
+// the API reads in its user-create hook. Written at landing and refreshed at
+// auth time so the PostHog ids are current when the sign-up request happens —
+// the session id rotates after 30 minutes of inactivity, so a landing-time
+// snapshot alone can go stale before the user signs up.
+
+import {
+  SIGNUP_ATTRIBUTION_COOKIE,
+  buildSignupEventProperties,
+  readFirstTouchAttribution,
+  serializeSignupAttributionCookie,
+} from "./signupAttribution.ts";
+
+// Long enough to survive landing → "Get started" → sign up (including an OAuth
+// round-trip), then it expires on its own. Not a durable tracking cookie.
+const COOKIE_MAX_AGE_SECONDS = 30 * 60;
+
+// Optional parent domain so the cookie reaches the API on a sibling subdomain
+// (e.g. api.example.com). Unset in dev / self-host → host-only, which is fine
+// when web and api share a host.
+const COOKIE_DOMAIN = import.meta.env.VITE_ATTRIBUTION_COOKIE_DOMAIN as string | undefined;
+
+// The slice of posthog-js we read. Structural so callers can pass the
+// uninitialized global instance (methods present but inert) or nothing at all.
+type PosthogLike = {
+  get_distinct_id?: () => string;
+  get_session_id?: () => string;
+} | null;
+
+/**
+ * Write (or refresh) the signup-attribution cookie. Unlike the legacy
+ * click-id cookie this overwrites on every call: the attribution part is
+ * already first-touch-stable via localStorage, and the PostHog ids must be
+ * fresh at auth time. No-op outside a DOM or when there's nothing to carry.
+ */
+export function refreshSignupAttributionCookie(
+  posthog: PosthogLike,
+  opts: { authMethod?: string } = {},
+): void {
+  if (typeof document === "undefined") return;
+  let attr = {};
+  try {
+    attr = readFirstTouchAttribution(window.localStorage) ?? {};
+  } catch {
+    /* storage unavailable — carry the PostHog ids alone */
+  }
+  const props = buildSignupEventProperties(attr, { authMethod: opts.authMethod });
+  let distinctId: string | undefined;
+  let sessionId: string | undefined;
+  try {
+    distinctId = posthog?.get_distinct_id?.();
+    sessionId = posthog?.get_session_id?.();
+  } catch {
+    /* posthog not booted — attribution still rides without the ids */
+  }
+  const value = serializeSignupAttributionCookie(props, { distinctId, sessionId });
+  if (!value) return;
+  const parts = [
+    `${SIGNUP_ATTRIBUTION_COOKIE}=${encodeURIComponent(value)}`,
+    "path=/",
+    `max-age=${COOKIE_MAX_AGE_SECONDS}`,
+    "samesite=lax",
+  ];
+  if (COOKIE_DOMAIN) parts.push(`domain=${COOKIE_DOMAIN}`);
+  if (typeof location !== "undefined" && location.protocol === "https:") parts.push("secure");
+  document.cookie = parts.join("; ");
+}

--- a/apps/web/src/signupAttributionCookie.ts
+++ b/apps/web/src/signupAttributionCookie.ts
@@ -7,9 +7,11 @@
 // snapshot alone can go stale before the user signs up.
 
 import {
+  type PosthogIdSource,
   SIGNUP_ATTRIBUTION_COOKIE,
   buildSignupEventProperties,
   readFirstTouchAttribution,
+  readPosthogClientIds,
   serializeSignupAttributionCookie,
 } from "./signupAttribution.ts";
 
@@ -22,13 +24,6 @@ const COOKIE_MAX_AGE_SECONDS = 30 * 60;
 // when web and api share a host.
 const COOKIE_DOMAIN = import.meta.env.VITE_ATTRIBUTION_COOKIE_DOMAIN as string | undefined;
 
-// The slice of posthog-js we read. Structural so callers can pass the
-// uninitialized global instance (methods present but inert) or nothing at all.
-type PosthogLike = {
-  get_distinct_id?: () => string;
-  get_session_id?: () => string;
-} | null;
-
 /**
  * Write (or refresh) the signup-attribution cookie. Unlike the legacy
  * click-id cookie this overwrites on every call: the attribution part is
@@ -36,7 +31,7 @@ type PosthogLike = {
  * fresh at auth time. No-op outside a DOM or when there's nothing to carry.
  */
 export function refreshSignupAttributionCookie(
-  posthog: PosthogLike,
+  posthog: PosthogIdSource,
   opts: { authMethod?: string } = {},
 ): void {
   if (typeof document === "undefined") return;
@@ -47,15 +42,7 @@ export function refreshSignupAttributionCookie(
     /* storage unavailable — carry the PostHog ids alone */
   }
   const props = buildSignupEventProperties(attr, { authMethod: opts.authMethod });
-  let distinctId: string | undefined;
-  let sessionId: string | undefined;
-  try {
-    distinctId = posthog?.get_distinct_id?.();
-    sessionId = posthog?.get_session_id?.();
-  } catch {
-    /* posthog not booted — attribution still rides without the ids */
-  }
-  const value = serializeSignupAttributionCookie(props, { distinctId, sessionId });
+  const value = serializeSignupAttributionCookie(props, readPosthogClientIds(posthog));
   if (!value) return;
   const parts = [
     `${SIGNUP_ATTRIBUTION_COOKIE}=${encodeURIComponent(value)}`,

--- a/packages/db/src/analytics.test.ts
+++ b/packages/db/src/analytics.test.ts
@@ -106,8 +106,9 @@ test("aliasServerDistinctId forwards to the client's alias", () => {
       aliases.push(args);
     },
   });
-  aliasServerDistinctId({ distinctId: "user-1", alias: "anon-123" });
-  assert.deepEqual(aliases, [{ distinctId: "user-1", alias: "anon-123" }]);
+  // distinctId = the existing (anonymous) id, alias = the new id linked to it.
+  aliasServerDistinctId({ distinctId: "anon-123", alias: "user-1" });
+  assert.deepEqual(aliases, [{ distinctId: "anon-123", alias: "user-1" }]);
 });
 
 test("aliasServerDistinctId no-ops when unconfigured or the client lacks alias", () => {

--- a/packages/db/src/analytics.test.ts
+++ b/packages/db/src/analytics.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { after, beforeEach, test } from "node:test";
-import { captureServerEvent, setAnalyticsClientForTests, shutdownAnalytics } from "./analytics.js";
+import {
+  aliasServerDistinctId,
+  captureServerEvent,
+  setAnalyticsClientForTests,
+  shutdownAnalytics,
+} from "./analytics.js";
 
 type Captured = { distinctId: string; event: string; properties?: Record<string, unknown> };
 
@@ -91,4 +96,34 @@ test("shutdownAnalytics no-ops when unconfigured or the client can't shut down",
   await assert.doesNotReject(() => shutdownAnalytics());
   setAnalyticsClientForTests({ capture() {} });
   await assert.doesNotReject(() => shutdownAnalytics());
+});
+
+test("aliasServerDistinctId forwards to the client's alias", () => {
+  const aliases: Array<{ distinctId: string; alias: string }> = [];
+  setAnalyticsClientForTests({
+    capture() {},
+    alias(args: { distinctId: string; alias: string }) {
+      aliases.push(args);
+    },
+  });
+  aliasServerDistinctId({ distinctId: "user-1", alias: "anon-123" });
+  assert.deepEqual(aliases, [{ distinctId: "user-1", alias: "anon-123" }]);
+});
+
+test("aliasServerDistinctId no-ops when unconfigured or the client lacks alias", () => {
+  setAnalyticsClientForTests(null);
+  assert.doesNotThrow(() => aliasServerDistinctId({ distinctId: "u", alias: "a" }));
+  // A recorder without alias() (older seam) must not crash the caller.
+  setAnalyticsClientForTests({ capture() {} });
+  assert.doesNotThrow(() => aliasServerDistinctId({ distinctId: "u", alias: "a" }));
+});
+
+test("aliasServerDistinctId swallows client errors", () => {
+  setAnalyticsClientForTests({
+    capture() {},
+    alias() {
+      throw new Error("network down");
+    },
+  });
+  assert.doesNotThrow(() => aliasServerDistinctId({ distinctId: "u", alias: "a" }));
 });

--- a/packages/db/src/analytics.ts
+++ b/packages/db/src/analytics.ts
@@ -81,10 +81,11 @@ export function captureServerEvent(input: CaptureServerEventInput): void {
 }
 
 /**
- * Merge another distinct id (typically the browser's anonymous PostHog id)
- * into `distinctId`'s person. Lets the server-side signup event land on an
- * already-merged person instead of waiting for the SPA to identify() later.
- * No-op when analytics isn't configured; never throws.
+ * Link a new distinct id (`alias`) to an existing person (`distinctId`) —
+ * e.g. `distinctId` = the browser's anonymous PostHog id, `alias` = the new
+ * user id, per posthog-node's alias semantics. Lets the server-side signup
+ * event land on an already-merged person instead of waiting for the SPA to
+ * identify() later. No-op when analytics isn't configured; never throws.
  */
 export function aliasServerDistinctId(input: { distinctId: string; alias: string }): void {
   const client = activeClient();

--- a/packages/db/src/analytics.ts
+++ b/packages/db/src/analytics.ts
@@ -18,9 +18,11 @@ import { PostHog } from "posthog-node";
 const DEFAULT_POSTHOG_HOST = "https://eu.i.posthog.com";
 
 // The slice of the PostHog client we use. Narrowed so tests can pass a plain
-// recorder and callers can inject one.
+// recorder and callers can inject one. `alias` is optional so existing
+// recorders that only capture keep working.
 export type AnalyticsClient = {
   capture(args: { distinctId: string; event: string; properties?: Record<string, unknown> }): void;
+  alias?(args: { distinctId: string; alias: string }): void;
 };
 
 export type CaptureServerEventInput = {
@@ -73,6 +75,22 @@ export function captureServerEvent(input: CaptureServerEventInput): void {
     if (input.set) properties.$set = input.set;
     if (input.setOnce) properties.$set_once = input.setOnce;
     client.capture({ distinctId: input.distinctId, event: input.event, properties });
+  } catch {
+    /* analytics is best-effort */
+  }
+}
+
+/**
+ * Merge another distinct id (typically the browser's anonymous PostHog id)
+ * into `distinctId`'s person. Lets the server-side signup event land on an
+ * already-merged person instead of waiting for the SPA to identify() later.
+ * No-op when analytics isn't configured; never throws.
+ */
+export function aliasServerDistinctId(input: { distinctId: string; alias: string }): void {
+  const client = activeClient();
+  if (!client?.alias) return;
+  try {
+    client.alias({ distinctId: input.distinctId, alias: input.alias });
   } catch {
     /* analytics is best-effort */
   }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -16,6 +16,7 @@ export {
 export {
   type AnalyticsClient,
   type CaptureServerEventInput,
+  aliasServerDistinctId,
   captureServerEvent,
   setAnalyticsClientForTests,
   shutdownAnalytics,


### PR DESCRIPTION
## Problem

The signup analytics event is captured server-side in the Better Auth user-create hook, which fires before the SPA ever runs `identify()`. With person-on-events, person properties are frozen per event at ingestion time — so the signup event landed with no attribution, no session id, and an unmerged person. Channel-level conversion reporting (web analytics conversion goals, UTM breakdowns) could not see roughly half of signups, and first-touch attribution silently depended on the user's browser loading the app again after signup.

## Fix

Carry attribution to the server on a short-lived first-party cookie (`sl_signup_attr`) holding the full first-touch attribution (snake_case event properties) plus the browser's PostHog distinct and session ids. The user-create hook now:

- **merges the anonymous web person** into the user id via server-side `alias`, instead of waiting for the SPA to `identify()` later;
- **puts attribution on the signup event itself** and stamps `$session_id`, so web analytics can session/channel-attribute the conversion at ingestion;
- stamps the same attribution on the person as `$set_once` (same shape the SPA's `identify()` uses — whichever lands first wins).

The cookie is written at landing (`SignupSourceCapture`) and refreshed on every auth attempt (`AuthForm`) — the PostHog session id rotates after 30 idle minutes, so a landing-time snapshot alone can go stale before sign-up. The legacy `sl_click_ids` cookie is still written and read as a fallback during the transition.

## Auth funnel instrumentation

Adds `auth_form_viewed` → `auth_email_continued` → `auth_submitted` → `auth_error` events in the auth form, so drop-off between the landing CTA and the completed signup is attributable to a step and a (static, non-PII) error message.

## Testing

- New unit tests for the cookie serializer (web), the allowlisting cookie reader (api), and `aliasServerDistinctId` (db) — cookie input is user-writable, so the reader drops unknown keys, non-strings, oversized values, and implausible PostHog ids.
- `tsc --noEmit` clean on web/api/db; full suites pass (the 16 failing api suites fail identically on `main` — pre-existing, environment-dependent).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes the server-side signup event at ingestion by carrying first-touch attribution and PostHog IDs in a short-lived cookie, merging the anonymous web person into the user, and stamping `$session_id` for accurate channel/session reporting. Adds auth funnel events and hardens the cookie to avoid wrong merges and size overflows.

- **New Features**
  - Add `sl_signup_attr` cookie (first-touch attribution + PostHog distinct/session IDs). Written at landing (`SignupSourceCapture`) and refreshed before each auth attempt in `AuthForm` (email, Google, GitHub). Hardening: only carry the PostHog distinct ID while the browser is anonymous; always carry the session ID; truncate values to 256 chars; fit payload under a ~3 KB encoded budget with priority ordering.
  - API (`apps/api`): allowlisted read of `sl_signup_attr`; call `aliasServerDistinctId` to merge anon → user (distinctId=anon, alias=user); attach attribution and `$session_id` to `user_signed_up`; `$set_once` attribution on the person; keep legacy `sl_click_ids` as a fallback. Robust parsing drops unknown keys, non-strings, and oversized values.
  - Funnel events: `auth_form_viewed` → `auth_email_continued` → `auth_submitted` → `auth_error` (static, non-PII).
  - New tests across web/api/`@superlog/db` cover cookie serialization/bounds, allowlisted reading, PostHog ID rules, and alias behavior.

- **Migration**
  - Set `VITE_ATTRIBUTION_COOKIE_DOMAIN` when web and API are on different subdomains.
  - If you use a custom analytics client with `@superlog/db`, implement optional `alias({ distinctId, alias })`; otherwise it no-ops.

<sup>Written for commit acdedd5f7bbd095fb4f05f2e51096a4a84fc9ea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

