### PR TITLE
Use one shared marketing nav across landing and pricing

### DIFF
--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -132,7 +132,9 @@ export function TopNav({
       <div className="mx-auto w-full max-w-[1400px] px-4 md:px-8 xl:px-12">
         <nav className="grid grid-cols-[1fr_auto_1fr] items-center py-5">
           <div className="flex items-center justify-self-start">
-            <Wordmark />
+            <a href="/" aria-label="Superlog home" className="inline-flex items-center">
+              <Wordmark />
+            </a>
           </div>
 
           <div className="hidden items-center gap-6 justify-self-center lg:flex">

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -119,7 +119,7 @@ const NAV_LINKS: { href: string; label: string; external?: boolean }[] = [
   { href: "/pricing", label: "Pricing" },
 ];
 
-function TopNav({
+export function TopNav({
   onSignIn,
   onSignUp,
 }: {

--- a/apps/web/src/Pricing.tsx
+++ b/apps/web/src/Pricing.tsx
@@ -1,10 +1,8 @@
 import { usePostHog } from "posthog-js/react";
 import { useEffect, useState } from "react";
 import { AuthForm } from "./AuthForm.tsx";
-import { Btn, Label, Tile, Wordmark } from "./design/ui.tsx";
-import { formatStarCount } from "./githubStars.ts";
-import { LANDING_DOCS_URL, LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
-import { useGithubStarCount } from "./useGithubStars.ts";
+import { Btn, Label, Tile } from "./design/ui.tsx";
+import { TopNav } from "./Landing.tsx";
 
 type AuthMode = "sign-in" | "sign-up" | null;
 
@@ -119,7 +117,7 @@ export function Pricing() {
 
   return (
     <div className="relative min-h-screen bg-bg font-sans text-fg">
-      <PricingNav onSignIn={openSignIn} onSignUp={openSignUp} />
+      <TopNav onSignIn={openSignIn} onSignUp={openSignUp} />
 
       <main>
         <section className="px-6 pb-8 pt-20 text-center md:px-8 md:pt-24 xl:px-12">
@@ -205,97 +203,6 @@ export function Pricing() {
 
       {authMode && <AuthModal mode={authMode} onClose={() => setAuthMode(null)} />}
     </div>
-  );
-}
-
-function PricingNav({
-  onSignIn,
-  onSignUp,
-}: {
-  onSignIn: () => void;
-  onSignUp: () => void;
-}) {
-  const stars = useGithubStarCount(LANDING_GITHUB_REPO_URL);
-  return (
-    <header className="sticky top-0 z-40 bg-bg">
-      <div className="mx-auto w-full max-w-[1400px] px-6 md:px-8 xl:px-12">
-        <nav className="flex items-center justify-between py-5">
-          <a href="/" aria-label="Superlog home" className="inline-flex items-center">
-            <Wordmark />
-          </a>
-          <div className="flex items-center gap-3">
-            <a
-              href={LANDING_GITHUB_REPO_URL}
-              target="_blank"
-              rel="noreferrer"
-              aria-label={
-                stars != null
-                  ? `Superlog on GitHub, ${stars.toLocaleString()} stars`
-                  : "Superlog on GitHub"
-              }
-              className="hidden items-center gap-1.5 text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline-flex"
-            >
-              <GitHubIcon />
-              <span className="tabular-nums">
-                {stars != null ? formatStarCount(stars) : "GitHub"}
-              </span>
-            </a>
-            <a
-              href={LANDING_DOCS_URL}
-              target="_blank"
-              rel="noreferrer"
-              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline"
-            >
-              Docs
-            </a>
-            <a
-              href="/blog"
-              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline"
-            >
-              Blog
-            </a>
-            <a
-              href="/changelog"
-              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline"
-            >
-              Changelog
-            </a>
-            <a
-              href="/roadmap"
-              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline"
-            >
-              Roadmap
-            </a>
-            <a
-              href="/team"
-              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline"
-            >
-              Team
-            </a>
-            <a
-              href="/pricing"
-              className="hidden text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline"
-            >
-              Pricing
-            </a>
-            <Btn variant="ghost" size="sm" onClick={onSignIn}>
-              Sign in
-            </Btn>
-            <Btn variant="primary" size="sm" onClick={onSignUp}>
-              Get started
-            </Btn>
-          </div>
-        </nav>
-      </div>
-    </header>
-  );
-}
-
-function GitHubIcon() {
-  return (
-    <svg className="h-3.5 w-3.5" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38v-1.33c-2.22.48-2.69-1.07-2.69-1.07-.36-.92-.89-1.17-.89-1.17-.73-.5.06-.49.06-.49.81.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.13 0 0 .67-.21 2.2.82A7.6 7.6 0 0 1 8 3.86c.68 0 1.36.09 2 .27 1.53-1.03 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.51.56.82 1.28.82 2.15 0 3.07-1.87 3.74-3.65 3.94.29.25.54.73.54 1.48v2.19c0 .21.15.46.55.38A8 8 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
-    </svg>
   );
 }
 


### PR DESCRIPTION
The pricing page rendered its own nav — a `justify-between` flex row with hardcoded links crammed on the right, hidden below `md` — instead of the landing page's nav, a 3-column grid with the wordmark left, centered links driven by a shared `NAV_LINKS` array, and actions right. The two drifted in layout, breakpoint, and padding.

This exports the landing page's `TopNav` and reuses it on the pricing page, deleting the divergent nav and its duplicated `GitHubIcon`. Every marketing page now renders the same header.

One intentional behavior change: the old pricing nav wrapped the wordmark in a link to `/`; `TopNav` doesn't, matching the landing page exactly.

Pure presentational change — typecheck passes; verified `/` and `/pricing` render the identical header in the dev server.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the marketing navigation by reusing the landing page `TopNav` on the pricing page. Also makes the wordmark a link to `/` across both pages for consistent behavior.

- **Refactors**
  - Export `TopNav` from `Landing.tsx` and use it in `Pricing.tsx`.
  - Wrap `Wordmark` with a home link inside `TopNav`.
  - Remove `PricingNav` and duplicated `GitHubIcon`; links now come from shared `NAV_LINKS`.

<sup>Written for commit dc2a5eb09cdc2634550f301d543b229130462cac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

