### PR TITLE
Hide the sample-data demo link from onboarding

### DIFF
--- a/apps/web/src/onboarding/OnboardingGate.tsx
+++ b/apps/web/src/onboarding/OnboardingGate.tsx
@@ -49,10 +49,6 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
     }
   }, [me.data, demoMode, exploring]);
 
-  const startExploring = () => {
-    setExploring(true);
-    writeDemoExploring(true);
-  };
   const stopExploring = () => {
     setExploring(false);
     writeDemoExploring(false);
@@ -130,7 +126,6 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
       onComplete={() => {
         setDismissed(true);
       }}
-      onExploreDemo={demoMode ? startExploring : undefined}
     />
   );
 }


### PR DESCRIPTION
Removes the "Explore with sample data first →" affordance from the onboarding flow.

## What changed
`apps/web/src/onboarding/OnboardingGate.tsx`:
- Drop the `onExploreDemo` prop passed into `OnboardingWizard` (the wizard's only demo entry point).
- Remove the now-unused `startExploring` helper.

`ExploreDemoLink` already returns `null` when it has no `onExploreDemo` callback (`wizardChrome.tsx`), so this removes the link from every onboarding surface at once — the connect-data chooser and all connector flows (Sentry / AWS / Cloudflare / GCP / Vercel / Render / Railway).

## What stays intact
The `demoMode` flag, `DemoExplorationProvider`, and the teleport-on-real-telemetry effect are untouched. Anyone who previously opted into demo exploration (persisted locally) still exits cleanly once real telemetry lands — there's simply no new way to enter demo mode from onboarding.

## Verification
`pnpm --filter @superlog/web typecheck` passes. Purely presentational (removes a link entry point); no behavior/data changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the "Explore with sample data first" link across onboarding by removing the `onExploreDemo` wiring in the wizard. Demo mode infrastructure stays; users already in demo mode exit as before when real telemetry arrives.

<sup>Written for commit 22fdb2ecc84559e77b340ef5f67e980fe4aad227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

