### PR TITLE
Don't pre-fill the org name on the onboarding create-org step

### DIFF
--- a/apps/web/src/onboarding/OnboardingGate.tsx
+++ b/apps/web/src/onboarding/OnboardingGate.tsx
@@ -76,9 +76,6 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
         projectId={null}
         hasIngested={hasIngested}
         hasSentryIssues={hasSentryIssues}
-        userName={me.data.user.name}
-        userEmail={me.data.user.email}
-        workspaceOrgName={me.data.suggestedOrgName}
         onComplete={() => {
           if (skillMode) finishSkillOnboarding();
           setDismissed(true);
@@ -94,9 +91,6 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
         projectId={me.data.project.id}
         hasIngested={hasIngested}
         hasSentryIssues={hasSentryIssues}
-        userName={me.data.user.name}
-        userEmail={me.data.user.email}
-        workspaceOrgName={me.data.suggestedOrgName}
         onComplete={() => {
           finishSkillOnboarding();
           setDismissed(true);
@@ -120,9 +114,6 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
       projectId={me.data.project.id}
       hasIngested={hasIngested}
       hasSentryIssues={hasSentryIssues}
-      userName={me.data.user.name}
-      userEmail={me.data.user.email}
-      workspaceOrgName={me.data.suggestedOrgName}
       onComplete={() => {
         setDismissed(true);
       }}

--- a/apps/web/src/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/onboarding/OnboardingWizard.tsx
@@ -34,7 +34,6 @@ import {
   initialWebViewFromSearch,
   stripHandledOnboardingParams,
 } from "./onboardingWebView.ts";
-import { suggestedOrgName } from "./orgNameSuggestion.ts";
 import {
   ExploreDemoLink,
   InstallPromptCard,
@@ -76,9 +75,6 @@ export function OnboardingWizard({
   projectId,
   hasIngested,
   hasSentryIssues,
-  userName,
-  userEmail,
-  workspaceOrgName,
   onComplete,
   onExploreDemo,
 }: {
@@ -92,9 +88,6 @@ export function OnboardingWizard({
   // make the wizard claim "first events received" while showing demo data.
   hasIngested: boolean;
   hasSentryIssues: boolean;
-  userName: string;
-  userEmail: string;
-  workspaceOrgName?: string | null;
   onComplete: () => void;
   // Present only when a shared demo project is configured. Lets the user skip
   // ahead and explore sample data instead of instrumenting first.
@@ -181,11 +174,7 @@ export function OnboardingWizard({
         <div className="w-full max-w-[640px]">
           {!projectId ? (
             <>
-              <CreateOrgStep
-                userName={userName}
-                userEmail={userEmail}
-                workspaceOrgName={workspaceOrgName}
-              />
+              <CreateOrgStep />
               <FounderCallCard />
             </>
           ) : mode === "agent" ? (
@@ -278,18 +267,10 @@ export function OnboardingWizard({
   );
 }
 
-function CreateOrgStep({
-  userName,
-  userEmail,
-  workspaceOrgName,
-}: {
-  userName: string;
-  userEmail: string;
-  workspaceOrgName?: string | null;
-}) {
-  const [name, setName] = useState(() =>
-    suggestedOrgName({ workspaceOrgName, userName, userEmail }),
-  );
+function CreateOrgStep() {
+  // Start blank on purpose — no suggested/pre-filled name. We want the user to
+  // deliberately type their org name rather than accept an auto-generated one.
+  const [name, setName] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const createOrg = useCreateMyFirstOrg();
   const trimmed = name.trim();


### PR DESCRIPTION
## What

The first-org onboarding step ("Name your organization") pre-filled the organization-name input with an auto-generated suggestion — `"<user>'s org"`, derived from the user's name or email. This change starts the field **blank** so the user deliberately types their own org name instead of accepting a generated default.

The "Create organization" button stays disabled until a non-empty name is entered (that guard already existed), so a blank submit isn't possible.

## Changes

- `CreateOrgStep` now initializes its name state to `""` instead of `suggestedOrgName(...)`.
- Removed the now-unused suggestion plumbing: the `suggestedOrgName` import and the `userName` / `userEmail` / `workspaceOrgName` props that were threaded through `OnboardingWizard` into the create-org step (and the corresponding props at the `OnboardingGate` call sites).

## Notes

- The `suggestedOrgName` helper, its unit test, and the `me.suggestedOrgName` API field are intentionally left in place — they're no longer used by this UI but are harmless and could back a placeholder later. Happy to remove them in a follow-up if preferred.

## Testing

- `pnpm --filter @superlog/web typecheck` passes.
- Verified manually: a fresh sign-up now lands on the create-org step with an empty field and a disabled submit button (previously pre-filled + enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)