### PR TITLE
Classify Railway stderr from application evidence

### DIFF
--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -17,7 +17,8 @@ const POSTGRESQL_RECORD =
   /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)? [A-Z]+) \[(\d+)\] (?:(\S+?)@(\S+) )?([A-Z][A-Z0-9]*):\s*(.*)$/s;
 const EXPLICIT_TEXT_SEVERITY =
   /(?:^|[\s[\]():-])(trace|debug|info|notice|warn|warning|err|error|fatal|critical|panic)(?=$|[\s[\]():-])/i;
-const STRONG_TEXT_ERROR = /\bsending to (?:the )?(?:dlq|dead[- ]letter queue)\b/i;
+const STRONG_TEXT_ERROR =
+  /(?:\b(?:failed|failure|exception|unauthorized|econnreset|connection (?:refused|reset)|premature (?:stream )?close|timed? out|cannot|unable to)\b|\bsending to (?:the )?(?:dlq|dead[- ]letter queue)\b|\bsubquery uses ungrouped column\b|\b(?:relation|column|operator|function|type|constraint|database|schema) .+ does not exist\b|\bsyntax error at or near\b|\bduplicate key value violates\b|\bpermission denied for\b|\binvalid input syntax\b)/i;
 const DEPLOYMENT_SHUTDOWN_WRAPPER =
   /^(?:error: script .+ terminated by signal SIGTERM \(Polite quit request\)|npm error (?:A complete log of this run can be found in:|Lifecycle script |command (?:failed|sh -c )|location |path |signal |workspace ))/i;
 const MAX_PARSED_FIELDS = 32;
@@ -105,10 +106,10 @@ export function parseRailwayLogRecord(
         "text",
         [],
         providerSeverity,
-        textSeverity
-          ? "text"
-          : context.applicationError
-            ? "railway_error_attribute"
+        context.applicationError
+          ? "railway_error_attribute"
+          : textSeverity
+            ? "text"
             : severity
               ? "railway"
               : "unclassified",

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -7,10 +7,19 @@ export type ParsedRailwayLogRecord = {
   attributes: ParsedAttribute[];
 };
 
+export type RailwayLogRecordContext = {
+  applicationError: boolean;
+};
+
 const HTTP_ACCESS_RECORD =
   /^(\S+) \S+ \S+ \[([^\]]+)\] "([A-Z]+) (\S+) HTTP\/(\d(?:\.\d)?)" (\d{3}) (\d+|-)(?: ([\d.]+|-))?$/;
 const POSTGRESQL_RECORD =
   /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)? [A-Z]+) \[(\d+)\] (?:(\S+?)@(\S+) )?([A-Z][A-Z0-9]*):\s*(.*)$/s;
+const EXPLICIT_TEXT_SEVERITY =
+  /(?:^|[\s[\]():-])(trace|debug|info|notice|warn|warning|err|error|fatal|critical|panic)(?=$|[\s[\]():-])/i;
+const STRONG_TEXT_ERROR = /\bsending to (?:the )?(?:dlq|dead[- ]letter queue)\b/i;
+const DEPLOYMENT_SHUTDOWN_WRAPPER =
+  /^(?:error: script .+ terminated by signal SIGTERM \(Polite quit request\)|npm error (?:A complete log of this run can be found in:|Lifecycle script |command (?:failed|sh -c )|location |path |signal |workspace ))/i;
 const MAX_PARSED_FIELDS = 32;
 const MAX_PARSED_KEY_LENGTH = 128;
 const MAX_PARSED_STRING_LENGTH = 4096;
@@ -71,8 +80,9 @@ const POSTGRESQL_SEVERITY: Record<string, string> = {
 export function parseRailwayLogRecord(
   message: string,
   providerSeverity: string | null,
+  context: RailwayLogRecordContext = { applicationError: false },
 ): ParsedRailwayLogRecord {
-  const json = parseJson(message, providerSeverity);
+  const json = parseJson(message, providerSeverity, context);
   if (json) return json;
 
   const httpAccess = parseHttpAccess(message, providerSeverity);
@@ -86,12 +96,30 @@ export function parseRailwayLogRecord(
   const nativeSeverity = fields?.level;
   const parsedSeverity = nativeSeverity ? normalizeNativeSeverity(nativeSeverity) : null;
   if (!fields || (body === undefined && !parsedSeverity)) {
-    return { body: message, severity: providerSeverity, attributes: [] };
+    const textSeverity = explicitTextSeverity(message);
+    const severity = textSeverity ?? unstructuredProviderSeverity(providerSeverity, context);
+    return {
+      body: message,
+      severity,
+      attributes: parsedAttributes(
+        "text",
+        [],
+        providerSeverity,
+        textSeverity
+          ? "text"
+          : context.applicationError
+            ? "railway_error_attribute"
+            : severity
+              ? "railway"
+              : "unclassified",
+        message,
+      ),
+    };
   }
 
   return {
     body: body ?? message,
-    severity: parsedSeverity ?? providerSeverity,
+    severity: parsedSeverity ?? unstructuredProviderSeverity(providerSeverity, context),
     attributes: parsedAttributes(
       "logfmt",
       structuredFields(Object.entries(fields)),
@@ -172,6 +200,7 @@ function parseHttpAccess(
 function parseJson(
   message: string,
   providerSeverity: string | null,
+  context: RailwayLogRecordContext,
 ): ParsedRailwayLogRecord | null {
   let value: unknown;
   try {
@@ -201,7 +230,7 @@ function parseJson(
   const parsedFields = structuredFields(Object.entries(record));
   return {
     body: body ?? message,
-    severity: parsedSeverity ?? providerSeverity,
+    severity: parsedSeverity ?? unstructuredProviderSeverity(providerSeverity, context),
     attributes: parsedAttributes(
       "json",
       parsedFields,
@@ -456,6 +485,22 @@ function normalizeJsonSeverity(value: unknown): string | null {
   if (typeof value === "string") return normalizeNativeSeverity(value);
   if (typeof value === "number") return NUMERIC_JSON_SEVERITY[value] ?? null;
   return null;
+}
+
+function explicitTextSeverity(message: string): string | null {
+  if (DEPLOYMENT_SHUTDOWN_WRAPPER.test(message)) return null;
+  const label = message.match(EXPLICIT_TEXT_SEVERITY)?.[1];
+  if (label) return normalizeNativeSeverity(label);
+  return STRONG_TEXT_ERROR.test(message) ? "error" : null;
+}
+
+function unstructuredProviderSeverity(
+  providerSeverity: string | null,
+  context: RailwayLogRecordContext,
+): string | null {
+  if (context.applicationError) return "error";
+  const normalized = providerSeverity?.trim().toLowerCase();
+  return normalized === "error" || normalized === "fatal" ? null : providerSeverity;
 }
 
 function isBoundedField(key: string, value: ParsedAttributeValue): boolean {

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -20,9 +20,9 @@ const LEADING_TEXT_SEVERITY =
 const BRACKETED_TEXT_SEVERITY =
   /\[(trace|debug|info|notice|warn|warning|err|error|fatal|critical|panic)\]/i;
 const TIMESTAMPED_TEXT_SEVERITY =
-  /^\s*\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\s+(trace|debug|info|notice|warn|warning|err|error|fatal|critical|panic)(?=$|[\s:=-])/i;
+  /^\s*\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?\s+(trace|debug|info|notice|warn|warning|err|error|fatal|critical|panic)(?=$|[\s:=-])/i;
 const STRONG_TEXT_ERROR =
-  /(?:\b(?:failed|failure|exception|unauthorized|econnreset|connection (?:refused|reset)|premature (?:stream )?close|timed? out|cannot|unable to)\b|\bSIG(?:ABRT|BUS|FPE|ILL|QUIT|SEGV|SYS|TRAP)\b|\bsending to (?:the )?(?:dlq|dead[- ]letter queue)\b|\bsubquery uses ungrouped column\b|\b(?:relation|column|operator|function|type|constraint|database|schema) .+ does not exist\b|\bsyntax error at or near\b|\bduplicate key value violates\b|\bpermission denied for\b|\binvalid input syntax\b)/i;
+  /(?:\b[A-Z][A-Za-z0-9_]*(?:Error|Exception)\b|\b(?:failed|failure|exception|unauthorized|econnreset|connection (?:refused|reset)|premature (?:stream )?close|timed? out|cannot|unable to)\b|\bSIG(?:ABRT|BUS|FPE|ILL|QUIT|SEGV|SYS|TRAP)\b|\bsending to (?:the )?(?:dlq|dead[- ]letter queue)\b|\bsubquery uses ungrouped column\b|\b(?:relation|column|operator|function|type|constraint|database|schema) .+ does not exist\b|\bsyntax error at or near\b|\bduplicate key value violates\b|\bpermission denied for\b|\binvalid input syntax\b)/i;
 const NEGATED_FAILURE_COUNT = /\b(?:0|no|zero)\s+(?:failed|failures?|errors?|exceptions?)\b/gi;
 const DEPLOYMENT_SHUTDOWN_WRAPPER =
   /^(?:error: script .+ terminated by signal SIGTERM \(Polite quit request\)|npm error (?:A complete log of this run can be found in:|command sh -c |location |path |signal SIGTERM(?:\s|$)|workspace ))/i;
@@ -515,13 +515,13 @@ function normalizeJsonSeverity(value: unknown): string | null {
 }
 
 function explicitTextSeverity(message: string): string | null {
-  if (DEPLOYMENT_SHUTDOWN_WRAPPER.test(message)) return null;
+  const evidenceMessage = message.replace(DEPLOYMENT_SHUTDOWN_WRAPPER, "");
   const label =
-    message.match(LEADING_TEXT_SEVERITY)?.[1] ??
-    message.match(TIMESTAMPED_TEXT_SEVERITY)?.[1] ??
-    message.match(BRACKETED_TEXT_SEVERITY)?.[1];
+    evidenceMessage.match(LEADING_TEXT_SEVERITY)?.[1] ??
+    evidenceMessage.match(TIMESTAMPED_TEXT_SEVERITY)?.[1] ??
+    evidenceMessage.match(BRACKETED_TEXT_SEVERITY)?.[1];
   if (label) return normalizeNativeSeverity(label);
-  const failureEvidenceText = message.replace(NEGATED_FAILURE_COUNT, "");
+  const failureEvidenceText = evidenceMessage.replace(NEGATED_FAILURE_COUNT, "");
   return STRONG_TEXT_ERROR.test(failureEvidenceText) ? "error" : null;
 }
 

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -453,7 +453,7 @@ function parseLogfmt(message: string): Record<string, string> | null {
     count += 1;
   }
 
-  if (count < 2) return null;
+  if (count < 2 && fields.level === undefined) return null;
   return fields;
 }
 
@@ -518,8 +518,8 @@ function explicitTextSeverity(message: string): string | null {
   if (DEPLOYMENT_SHUTDOWN_WRAPPER.test(message)) return null;
   const label =
     message.match(LEADING_TEXT_SEVERITY)?.[1] ??
-    message.match(BRACKETED_TEXT_SEVERITY)?.[1] ??
-    message.match(TIMESTAMPED_TEXT_SEVERITY)?.[1];
+    message.match(TIMESTAMPED_TEXT_SEVERITY)?.[1] ??
+    message.match(BRACKETED_TEXT_SEVERITY)?.[1];
   if (label) return normalizeNativeSeverity(label);
   const failureEvidenceText = message.replace(NEGATED_FAILURE_COUNT, "");
   return STRONG_TEXT_ERROR.test(failureEvidenceText) ? "error" : null;

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -23,7 +23,7 @@ const TIMESTAMPED_TEXT_SEVERITY =
   /^\s*\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\s+(trace|debug|info|notice|warn|warning|err|error|fatal|critical|panic)(?=$|[\s:=-])/i;
 const STRONG_TEXT_ERROR =
   /(?:\b(?:failed|failure|exception|unauthorized|econnreset|connection (?:refused|reset)|premature (?:stream )?close|timed? out|cannot|unable to)\b|\bSIG(?:ABRT|BUS|FPE|ILL|QUIT|SEGV|SYS|TRAP)\b|\bsending to (?:the )?(?:dlq|dead[- ]letter queue)\b|\bsubquery uses ungrouped column\b|\b(?:relation|column|operator|function|type|constraint|database|schema) .+ does not exist\b|\bsyntax error at or near\b|\bduplicate key value violates\b|\bpermission denied for\b|\binvalid input syntax\b)/i;
-const NEGATED_FAILURE_COUNT = /\b(?:0|no|zero)\s+(?:failed|failures?|errors?|exceptions?)\b/i;
+const NEGATED_FAILURE_COUNT = /\b(?:0|no|zero)\s+(?:failed|failures?|errors?|exceptions?)\b/gi;
 const DEPLOYMENT_SHUTDOWN_WRAPPER =
   /^(?:error: script .+ terminated by signal SIGTERM \(Polite quit request\)|npm error (?:A complete log of this run can be found in:|command sh -c |location |path |signal SIGTERM(?:\s|$)|workspace ))/i;
 const MAX_PARSED_FIELDS = 32;
@@ -53,6 +53,7 @@ const NATIVE_SEVERITY: Record<string, string> = {
   error: "error",
   fatal: "fatal",
   critical: "fatal",
+  panic: "fatal",
   alert: "fatal",
   emergency: "fatal",
 };
@@ -520,8 +521,8 @@ function explicitTextSeverity(message: string): string | null {
     message.match(BRACKETED_TEXT_SEVERITY)?.[1] ??
     message.match(TIMESTAMPED_TEXT_SEVERITY)?.[1];
   if (label) return normalizeNativeSeverity(label);
-  if (NEGATED_FAILURE_COUNT.test(message)) return null;
-  return STRONG_TEXT_ERROR.test(message) ? "error" : null;
+  const failureEvidenceText = message.replace(NEGATED_FAILURE_COUNT, "");
+  return STRONG_TEXT_ERROR.test(failureEvidenceText) ? "error" : null;
 }
 
 function unstructuredProviderSeverity(

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -23,8 +23,9 @@ const TIMESTAMPED_TEXT_SEVERITY =
   /^\s*\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\s+(trace|debug|info|notice|warn|warning|err|error|fatal|critical|panic)(?=$|[\s:=-])/i;
 const STRONG_TEXT_ERROR =
   /(?:\b(?:failed|failure|exception|unauthorized|econnreset|connection (?:refused|reset)|premature (?:stream )?close|timed? out|cannot|unable to)\b|\bSIG(?:ABRT|BUS|FPE|ILL|QUIT|SEGV|SYS|TRAP)\b|\bsending to (?:the )?(?:dlq|dead[- ]letter queue)\b|\bsubquery uses ungrouped column\b|\b(?:relation|column|operator|function|type|constraint|database|schema) .+ does not exist\b|\bsyntax error at or near\b|\bduplicate key value violates\b|\bpermission denied for\b|\binvalid input syntax\b)/i;
+const NEGATED_FAILURE_COUNT = /\b(?:0|no|zero)\s+(?:failed|failures?|errors?|exceptions?)\b/i;
 const DEPLOYMENT_SHUTDOWN_WRAPPER =
-  /^(?:error: script .+ terminated by signal SIGTERM \(Polite quit request\)|npm error (?:A complete log of this run can be found in:|Lifecycle script |command (?:failed|sh -c )|location |path |signal SIGTERM(?:\s|$)|workspace ))/i;
+  /^(?:error: script .+ terminated by signal SIGTERM \(Polite quit request\)|npm error (?:A complete log of this run can be found in:|command sh -c |location |path |signal SIGTERM(?:\s|$)|workspace ))/i;
 const MAX_PARSED_FIELDS = 32;
 const MAX_PARSED_KEY_LENGTH = 128;
 const MAX_PARSED_STRING_LENGTH = 4096;
@@ -110,10 +111,10 @@ export function parseRailwayLogRecord(
         "text",
         [],
         providerSeverity,
-        context.applicationError
-          ? "railway_error_attribute"
-          : textSeverity
-            ? "text"
+        textSeverity
+          ? "text"
+          : context.applicationError
+            ? "railway_error_attribute"
             : severity
               ? "railway"
               : "unclassified",
@@ -133,10 +134,10 @@ export function parseRailwayLogRecord(
       providerSeverity,
       parsedSeverity
         ? "logfmt"
-        : context.applicationError
-          ? "railway_error_attribute"
-          : bodySeverity
-            ? "logfmt_message"
+        : bodySeverity
+          ? "logfmt_message"
+          : context.applicationError
+            ? "railway_error_attribute"
             : unstructuredProviderSeverity(providerSeverity, context)
               ? "railway"
               : "unclassified",
@@ -254,10 +255,10 @@ function parseJson(
       providerSeverity,
       parsedSeverity
         ? "json"
-        : context.applicationError
-          ? "railway_error_attribute"
-          : bodySeverity
-            ? "json_message"
+        : bodySeverity
+          ? "json_message"
+          : context.applicationError
+            ? "railway_error_attribute"
             : unstructuredProviderSeverity(providerSeverity, context)
               ? "railway"
               : "unclassified",
@@ -519,6 +520,7 @@ function explicitTextSeverity(message: string): string | null {
     message.match(BRACKETED_TEXT_SEVERITY)?.[1] ??
     message.match(TIMESTAMPED_TEXT_SEVERITY)?.[1];
   if (label) return normalizeNativeSeverity(label);
+  if (NEGATED_FAILURE_COUNT.test(message)) return null;
   return STRONG_TEXT_ERROR.test(message) ? "error" : null;
 }
 

--- a/packages/railway/src/log-record.ts
+++ b/packages/railway/src/log-record.ts
@@ -15,12 +15,16 @@ const HTTP_ACCESS_RECORD =
   /^(\S+) \S+ \S+ \[([^\]]+)\] "([A-Z]+) (\S+) HTTP\/(\d(?:\.\d)?)" (\d{3}) (\d+|-)(?: ([\d.]+|-))?$/;
 const POSTGRESQL_RECORD =
   /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)? [A-Z]+) \[(\d+)\] (?:(\S+?)@(\S+) )?([A-Z][A-Z0-9]*):\s*(.*)$/s;
-const EXPLICIT_TEXT_SEVERITY =
-  /(?:^|[\s[\]():-])(trace|debug|info|notice|warn|warning|err|error|fatal|critical|panic)(?=$|[\s[\]():-])/i;
+const LEADING_TEXT_SEVERITY =
+  /^\s*(trace|debug|info|notice|warn|warning|err|error|fatal|critical|panic)(?=$|[\s:=-])/i;
+const BRACKETED_TEXT_SEVERITY =
+  /\[(trace|debug|info|notice|warn|warning|err|error|fatal|critical|panic)\]/i;
+const TIMESTAMPED_TEXT_SEVERITY =
+  /^\s*\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\s+(trace|debug|info|notice|warn|warning|err|error|fatal|critical|panic)(?=$|[\s:=-])/i;
 const STRONG_TEXT_ERROR =
-  /(?:\b(?:failed|failure|exception|unauthorized|econnreset|connection (?:refused|reset)|premature (?:stream )?close|timed? out|cannot|unable to)\b|\bsending to (?:the )?(?:dlq|dead[- ]letter queue)\b|\bsubquery uses ungrouped column\b|\b(?:relation|column|operator|function|type|constraint|database|schema) .+ does not exist\b|\bsyntax error at or near\b|\bduplicate key value violates\b|\bpermission denied for\b|\binvalid input syntax\b)/i;
+  /(?:\b(?:failed|failure|exception|unauthorized|econnreset|connection (?:refused|reset)|premature (?:stream )?close|timed? out|cannot|unable to)\b|\bSIG(?:ABRT|BUS|FPE|ILL|QUIT|SEGV|SYS|TRAP)\b|\bsending to (?:the )?(?:dlq|dead[- ]letter queue)\b|\bsubquery uses ungrouped column\b|\b(?:relation|column|operator|function|type|constraint|database|schema) .+ does not exist\b|\bsyntax error at or near\b|\bduplicate key value violates\b|\bpermission denied for\b|\binvalid input syntax\b)/i;
 const DEPLOYMENT_SHUTDOWN_WRAPPER =
-  /^(?:error: script .+ terminated by signal SIGTERM \(Polite quit request\)|npm error (?:A complete log of this run can be found in:|Lifecycle script |command (?:failed|sh -c )|location |path |signal |workspace ))/i;
+  /^(?:error: script .+ terminated by signal SIGTERM \(Polite quit request\)|npm error (?:A complete log of this run can be found in:|Lifecycle script |command (?:failed|sh -c )|location |path |signal SIGTERM(?:\s|$)|workspace ))/i;
 const MAX_PARSED_FIELDS = 32;
 const MAX_PARSED_KEY_LENGTH = 128;
 const MAX_PARSED_STRING_LENGTH = 4096;
@@ -118,14 +122,24 @@ export function parseRailwayLogRecord(
     };
   }
 
+  const bodySeverity = body === undefined ? null : explicitTextSeverity(body);
   return {
     body: body ?? message,
-    severity: parsedSeverity ?? unstructuredProviderSeverity(providerSeverity, context),
+    severity:
+      parsedSeverity ?? bodySeverity ?? unstructuredProviderSeverity(providerSeverity, context),
     attributes: parsedAttributes(
       "logfmt",
       structuredFields(Object.entries(fields)),
       providerSeverity,
-      parsedSeverity ? "logfmt" : "railway",
+      parsedSeverity
+        ? "logfmt"
+        : context.applicationError
+          ? "railway_error_attribute"
+          : bodySeverity
+            ? "logfmt_message"
+            : unstructuredProviderSeverity(providerSeverity, context)
+              ? "railway"
+              : "unclassified",
       message,
     ),
   };
@@ -228,15 +242,25 @@ function parseJson(
     normalizeJsonSeverity(record.level) ?? normalizeJsonSeverity(record.severity);
   if (body === null && !parsedSeverity) return null;
 
+  const bodySeverity = body === null ? null : explicitTextSeverity(body);
   const parsedFields = structuredFields(Object.entries(record));
   return {
     body: body ?? message,
-    severity: parsedSeverity ?? unstructuredProviderSeverity(providerSeverity, context),
+    severity:
+      parsedSeverity ?? bodySeverity ?? unstructuredProviderSeverity(providerSeverity, context),
     attributes: parsedAttributes(
       "json",
       parsedFields,
       providerSeverity,
-      parsedSeverity ? "json" : "railway",
+      parsedSeverity
+        ? "json"
+        : context.applicationError
+          ? "railway_error_attribute"
+          : bodySeverity
+            ? "json_message"
+            : unstructuredProviderSeverity(providerSeverity, context)
+              ? "railway"
+              : "unclassified",
       message,
     ),
   };
@@ -490,7 +514,10 @@ function normalizeJsonSeverity(value: unknown): string | null {
 
 function explicitTextSeverity(message: string): string | null {
   if (DEPLOYMENT_SHUTDOWN_WRAPPER.test(message)) return null;
-  const label = message.match(EXPLICIT_TEXT_SEVERITY)?.[1];
+  const label =
+    message.match(LEADING_TEXT_SEVERITY)?.[1] ??
+    message.match(BRACKETED_TEXT_SEVERITY)?.[1] ??
+    message.match(TIMESTAMPED_TEXT_SEVERITY)?.[1];
   if (label) return normalizeNativeSeverity(label);
   return STRONG_TEXT_ERROR.test(message) ? "error" : null;
 }

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -148,7 +148,7 @@ test("railwayLogsToOtlp keeps a raw line at error when Railway carries an applic
   const attrs = Object.fromEntries(
     record.attributes.map((attribute) => [attribute.key, attribute.value.stringValue]),
   );
-  assert.equal(attrs["railway.log.severity_source"], "railway_error_attribute");
+  assert.equal(attrs["railway.log.severity_source"], "text");
 });
 
 test("railwayLogsToOtlp preserves an explicit severity label in raw application text", () => {
@@ -168,6 +168,16 @@ test("railwayLogsToOtlp preserves an explicit severity label in raw application 
 
 test("railwayLogsToOtlp does not treat severity words in ordinary prose as labels", () => {
   const message = "Recovered from error and resumed processing";
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "");
+  assert.equal(record.severityNumber, 0);
+});
+
+test("railwayLogsToOtlp does not treat zero failure counts as errors", () => {
+  const message = "Tests: 10 passed, 0 failed";
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
 
   const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
@@ -204,14 +214,49 @@ test("railwayLogsToOtlp does not promote deployment shutdown wrapper lines to er
   }
 });
 
-test("railwayLogsToOtlp preserves crash signals as errors", () => {
-  const message = "npm error signal SIGSEGV";
-  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+test("railwayLogsToOtlp preserves genuine npm failures as errors", () => {
+  for (const message of ["npm error signal SIGSEGV", "npm error command failed"]) {
+    const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+    const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+    assert.equal(record.body.stringValue, message);
+    assert.equal(record.severityText, "ERROR");
+    assert.equal(record.severityNumber, 17);
+  }
+});
 
-  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
-  assert.equal(record.body.stringValue, message);
-  assert.equal(record.severityText, "ERROR");
-  assert.equal(record.severityNumber, 17);
+test("railwayLogsToOtlp attributes explicit labels ahead of application error fields", () => {
+  for (const message of [
+    "INFO request recovered",
+    JSON.stringify({ message: "INFO request recovered" }),
+    'message="INFO request recovered" event=recovery',
+  ]) {
+    const out = railwayLogsToOtlp(
+      [
+        {
+          ...LOG,
+          severity: "error",
+          message,
+          attributes: [
+            { key: "level", value: '"error"' },
+            { key: "err", value: '"previous request failed"' },
+          ],
+        },
+      ],
+      NAMES,
+    );
+    const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+    assert.equal(record.body.stringValue, "INFO request recovered");
+    assert.equal(record.severityText, "INFO");
+    assert.equal(record.severityNumber, 9);
+    const attrs = Object.fromEntries(
+      record.attributes.map((attribute) => [attribute.key, attribute.value.stringValue]),
+    );
+    assert.ok(
+      ["text", "json_message", "logfmt_message"].includes(
+        attrs["railway.log.severity_source"] ?? "",
+      ),
+    );
+  }
 });
 
 test("railwayLogsToOtlp keeps the raw Railway payload as the original record", () => {

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -166,6 +166,16 @@ test("railwayLogsToOtlp preserves an explicit severity label in raw application 
   assert.equal(attrs["railway.log.severity_source"], "text");
 });
 
+test("railwayLogsToOtlp does not treat severity words in ordinary prose as labels", () => {
+  const message = "Recovered from error and resumed processing";
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "");
+  assert.equal(record.severityNumber, 0);
+});
+
 test("railwayLogsToOtlp preserves strong failure evidence in raw application text", () => {
   for (const message of [
     "Task abc123 exceeded max rescues (0/0), sending to DLQ",
@@ -192,6 +202,16 @@ test("railwayLogsToOtlp does not promote deployment shutdown wrapper lines to er
     assert.equal(record.severityText, "");
     assert.equal(record.severityNumber, 0);
   }
+});
+
+test("railwayLogsToOtlp preserves crash signals as errors", () => {
+  const message = "npm error signal SIGSEGV";
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityNumber, 17);
 });
 
 test("railwayLogsToOtlp keeps the raw Railway payload as the original record", () => {
@@ -288,7 +308,7 @@ test("railwayLogsToOtlp reserves collector-owned structured attribute names", ()
   const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value]));
   assert.equal(attrs["railway.log.format"]?.stringValue, "json");
   assert.equal(attrs["railway.log.provider_severity"]?.stringValue, "error");
-  assert.equal(attrs["railway.log.severity_source"]?.stringValue, "railway");
+  assert.equal(attrs["railway.log.severity_source"]?.stringValue, "unclassified");
   for (const key of [
     "railway.log.format",
     "railway.log.provider_severity",
@@ -415,6 +435,19 @@ test("railwayLogsToOtlp does not inherit stderr severity for JSON without a nati
   assert.equal(record.severityNumber, 0);
 });
 
+test("railwayLogsToOtlp preserves explicit severity evidence in structured message bodies", () => {
+  for (const message of [
+    JSON.stringify({ message: "ERROR database unavailable" }),
+    'message="ERROR database unavailable" event=connection_check',
+  ]) {
+    const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+    const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+    assert.equal(record.body.stringValue, "ERROR database unavailable");
+    assert.equal(record.severityText, "ERROR");
+    assert.equal(record.severityNumber, 17);
+  }
+});
+
 test("railwayLogsToOtlp preserves explicit empty JSON message bodies", () => {
   const message = JSON.stringify({ message: "", event: "heartbeat" });
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
@@ -496,7 +529,7 @@ test("railwayLogsToOtlp leaves an unknown native level unclassified", () => {
   const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
   assert.equal(attrs["railway.log.level"], "verbose");
   assert.equal(attrs["railway.log.provider_severity"], "error");
-  assert.equal(attrs["railway.log.severity_source"], "railway");
+  assert.equal(attrs["railway.log.severity_source"], "unclassified");
 });
 
 test("railwayLogsToOtlp structures logfmt without a native level", () => {

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -176,6 +176,16 @@ test("railwayLogsToOtlp prefers timestamp-adjacent severity over later bracketed
   assert.equal(record.severityNumber, 9);
 });
 
+test("railwayLogsToOtlp accepts comma-delimited timestamp fractions", () => {
+  const message = "2026-07-20 22:55:36,155 ERROR worker stopped";
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityNumber, 17);
+});
+
 test("railwayLogsToOtlp does not treat severity words in ordinary prose as labels", () => {
   const message = "Recovered from error and resumed processing";
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
@@ -210,6 +220,9 @@ test("railwayLogsToOtlp preserves strong failure evidence in raw application tex
   for (const message of [
     "Task abc123 exceeded max rescues (0/0), sending to DLQ",
     'subquery uses ungrouped column "vft.visitor_id" from outer query at character 413',
+    "ValueError: invalid literal",
+    "KeyError: 'id'",
+    "TypeError: x is not a function",
   ]) {
     const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
     const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
@@ -217,6 +230,16 @@ test("railwayLogsToOtlp preserves strong failure evidence in raw application tex
     assert.equal(record.severityText, "ERROR");
     assert.equal(record.severityNumber, 17);
   }
+});
+
+test("railwayLogsToOtlp preserves failure evidence after an npm wrapper prefix", () => {
+  const message = "npm error command sh -c vite build failed";
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityNumber, 17);
 });
 
 test("railwayLogsToOtlp does not promote deployment shutdown wrapper lines to errors", () => {

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -97,6 +97,100 @@ test("railwayLogsToOtlp uses native logfmt fields instead of Railway's stderr se
   assert.equal(attrs["log.record.original"], message);
 });
 
+test("railwayLogsToOtlp does not treat raw Railway stderr as semantic error evidence", () => {
+  const message = "++++++++++++++++++++++++++++++++++++*.......";
+  const out = railwayLogsToOtlp(
+    [
+      {
+        ...LOG,
+        severity: "error",
+        message,
+        attributes: [{ key: "level", value: '"error"' }],
+      },
+    ],
+    NAMES,
+  );
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "");
+  assert.equal(record.severityNumber, 0);
+  const attrs = Object.fromEntries(
+    record.attributes.map((attribute) => [attribute.key, attribute.value.stringValue]),
+  );
+  assert.equal(attrs["railway.log.format"], "text");
+  assert.equal(attrs["railway.log.provider_severity"], "error");
+  assert.equal(attrs["railway.log.severity_source"], "unclassified");
+  assert.equal(attrs["log.record.original"], message);
+});
+
+test("railwayLogsToOtlp keeps a raw line at error when Railway carries an application error", () => {
+  const message = "nightly failed";
+  const out = railwayLogsToOtlp(
+    [
+      {
+        ...LOG,
+        severity: "error",
+        message,
+        attributes: [
+          { key: "level", value: '"error"' },
+          { key: "err", value: '"error: relation \\"events\\" does not exist"' },
+        ],
+      },
+    ],
+    NAMES,
+  );
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityNumber, 17);
+  const attrs = Object.fromEntries(
+    record.attributes.map((attribute) => [attribute.key, attribute.value.stringValue]),
+  );
+  assert.equal(attrs["railway.log.severity_source"], "railway_error_attribute");
+});
+
+test("railwayLogsToOtlp preserves an explicit severity label in raw application text", () => {
+  const message =
+    "2026-07-20T22:55:36.155Z ERROR [Better Auth]: Invalid callbackURL: https://example.com";
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityNumber, 17);
+  const attrs = Object.fromEntries(
+    record.attributes.map((attribute) => [attribute.key, attribute.value.stringValue]),
+  );
+  assert.equal(attrs["railway.log.severity_source"], "text");
+});
+
+test("railwayLogsToOtlp preserves strong failure evidence in raw application text", () => {
+  const message = "Task abc123 exceeded max rescues (0/0), sending to DLQ";
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityNumber, 17);
+});
+
+test("railwayLogsToOtlp does not promote deployment shutdown wrapper lines to errors", () => {
+  for (const message of [
+    'error: script "start" was terminated by signal SIGTERM (Polite quit request)',
+    "npm error signal SIGTERM",
+    "npm error command sh -c next start",
+    "npm error A complete log of this run can be found in: /root/.npm/_logs/debug-0.log",
+  ]) {
+    const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+    const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+    assert.equal(record.body.stringValue, message);
+    assert.equal(record.severityText, "");
+    assert.equal(record.severityNumber, 0);
+  }
+});
+
 test("railwayLogsToOtlp keeps the raw Railway payload as the original record", () => {
   const message = 'level=info msg="\u001b[32mready\u001b[0m"';
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
@@ -308,13 +402,23 @@ test("railwayLogsToOtlp preserves native severity for event-style JSON", () => {
   assert.equal(attrs["log.record.original"], message);
 });
 
+test("railwayLogsToOtlp does not inherit stderr severity for JSON without a native level", () => {
+  const message = JSON.stringify({ message: "worker ready", event: "heartbeat" });
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, "worker ready");
+  assert.equal(record.severityText, "");
+  assert.equal(record.severityNumber, 0);
+});
+
 test("railwayLogsToOtlp preserves explicit empty JSON message bodies", () => {
   const message = JSON.stringify({ message: "", event: "heartbeat" });
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
 
   const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
   assert.equal(record.body.stringValue, "");
-  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityText, "");
   const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
   assert.equal(attrs["railway.log.format"], "json");
   assert.equal(attrs["railway.log.event"], "heartbeat");
@@ -378,14 +482,14 @@ test("railwayLogsToOtlp preserves question marks inside HTTP query strings", () 
   assert.equal(attrs["url.query"]?.stringValue, "redirect=https://example.com/a?b=c");
 });
 
-test("railwayLogsToOtlp keeps Railway severity when a parsed native level is unknown", () => {
+test("railwayLogsToOtlp leaves an unknown native level unclassified", () => {
   const message = 'level=verbose msg="something happened" request_id=req-1';
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
 
   const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
   assert.equal(record.body.stringValue, "something happened");
-  assert.equal(record.severityText, "ERROR");
-  assert.equal(record.severityNumber, 17);
+  assert.equal(record.severityText, "");
+  assert.equal(record.severityNumber, 0);
   const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
   assert.equal(attrs["railway.log.level"], "verbose");
   assert.equal(attrs["railway.log.provider_severity"], "error");
@@ -458,7 +562,7 @@ test("railwayLogsToOtlp preserves explicit empty logfmt message bodies", () => {
 
   const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
   assert.equal(record.body.stringValue, "");
-  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityText, "");
   const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
   assert.equal(attrs["railway.log.format"], "logfmt");
   assert.equal(attrs["railway.log.event"], "heartbeat");
@@ -471,7 +575,7 @@ test("railwayLogsToOtlp safely rejects a long unterminated logfmt value", () => 
 
   const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
   assert.equal(record.body.stringValue, message);
-  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityText, "");
 });
 
 test("railwayLogsToOtlp caps logfmt attributes without rejecting the record", () => {
@@ -505,17 +609,18 @@ test("railwayLogsToOtlp bounds extracted structured attributes", () => {
   assert.equal(attrs[`railway.log.${longKey}`], undefined);
 });
 
-test("railwayLogsToOtlp leaves malformed structured messages lossless", () => {
+test("railwayLogsToOtlp leaves malformed structured messages lossless and unclassified", () => {
   const message = 'level=info msg="unterminated';
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
 
   const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
   assert.equal(record.body.stringValue, message);
-  assert.equal(record.severityText, "ERROR");
-  assert.equal(record.severityNumber, 17);
+  assert.equal(record.severityText, "");
+  assert.equal(record.severityNumber, 0);
   const attrs = Object.fromEntries(record.attributes.map((a) => [a.key, a.value.stringValue]));
-  assert.equal(attrs["railway.log.format"], undefined);
-  assert.equal(attrs["log.record.original"], undefined);
+  assert.equal(attrs["railway.log.format"], "text");
+  assert.equal(attrs["railway.log.severity_source"], "unclassified");
+  assert.equal(attrs["log.record.original"], message);
 });
 
 test("railwayLogsToOtlp falls back to a railway service name when unmapped", () => {

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -186,6 +186,16 @@ test("railwayLogsToOtlp does not treat zero failure counts as errors", () => {
   assert.equal(record.severityNumber, 0);
 });
 
+test("railwayLogsToOtlp preserves independent failure evidence after a zero count", () => {
+  const message = "0 failed health checks; connection refused while starting worker";
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityNumber, 17);
+});
+
 test("railwayLogsToOtlp preserves strong failure evidence in raw application text", () => {
   for (const message of [
     "Task abc123 exceeded max rescues (0/0), sending to DLQ",
@@ -221,6 +231,20 @@ test("railwayLogsToOtlp preserves genuine npm failures as errors", () => {
     assert.equal(record.body.stringValue, message);
     assert.equal(record.severityText, "ERROR");
     assert.equal(record.severityNumber, 17);
+  }
+});
+
+test("railwayLogsToOtlp maps explicit panic labels to fatal", () => {
+  for (const message of [
+    "PANIC unrecoverable worker state",
+    JSON.stringify({ message: "PANIC unrecoverable worker state" }),
+    'message="PANIC unrecoverable worker state" event=worker_crash',
+  ]) {
+    const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+    const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+    assert.equal(record.body.stringValue, "PANIC unrecoverable worker state");
+    assert.equal(record.severityText, "FATAL");
+    assert.equal(record.severityNumber, 21);
   }
 });
 

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -167,13 +167,16 @@ test("railwayLogsToOtlp preserves an explicit severity label in raw application 
 });
 
 test("railwayLogsToOtlp preserves strong failure evidence in raw application text", () => {
-  const message = "Task abc123 exceeded max rescues (0/0), sending to DLQ";
-  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
-
-  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
-  assert.equal(record.body.stringValue, message);
-  assert.equal(record.severityText, "ERROR");
-  assert.equal(record.severityNumber, 17);
+  for (const message of [
+    "Task abc123 exceeded max rescues (0/0), sending to DLQ",
+    'subquery uses ungrouped column "vft.visitor_id" from outer query at character 413',
+  ]) {
+    const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+    const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+    assert.equal(record.body.stringValue, message);
+    assert.equal(record.severityText, "ERROR");
+    assert.equal(record.severityNumber, 17);
+  }
 });
 
 test("railwayLogsToOtlp does not promote deployment shutdown wrapper lines to errors", () => {

--- a/packages/railway/src/transform.test.ts
+++ b/packages/railway/src/transform.test.ts
@@ -166,6 +166,16 @@ test("railwayLogsToOtlp preserves an explicit severity label in raw application 
   assert.equal(attrs["railway.log.severity_source"], "text");
 });
 
+test("railwayLogsToOtlp prefers timestamp-adjacent severity over later bracketed prose", () => {
+  const message = "2026-07-20T22:55:36Z INFO handler returned [ERROR] as a value";
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "INFO");
+  assert.equal(record.severityNumber, 9);
+});
+
 test("railwayLogsToOtlp does not treat severity words in ordinary prose as labels", () => {
   const message = "Recovered from error and resumed processing";
   const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
@@ -599,6 +609,21 @@ test("railwayLogsToOtlp leaves an unknown native level unclassified", () => {
   assert.equal(attrs["railway.log.level"], "verbose");
   assert.equal(attrs["railway.log.provider_severity"], "error");
   assert.equal(attrs["railway.log.severity_source"], "unclassified");
+});
+
+test("railwayLogsToOtlp preserves a standalone native logfmt level", () => {
+  const message = "level=error";
+  const out = railwayLogsToOtlp([{ ...LOG, severity: "error", message }], NAMES);
+
+  const record = at(at(at(out.resourceLogs, 0).scopeLogs, 0).logRecords, 0);
+  assert.equal(record.body.stringValue, message);
+  assert.equal(record.severityText, "ERROR");
+  assert.equal(record.severityNumber, 17);
+  const attrs = Object.fromEntries(
+    record.attributes.map((attribute) => [attribute.key, attribute.value.stringValue]),
+  );
+  assert.equal(attrs["railway.log.format"], "logfmt");
+  assert.equal(attrs["railway.log.severity_source"], "logfmt");
 });
 
 test("railwayLogsToOtlp structures logfmt without a native level", () => {

--- a/packages/railway/src/transform.ts
+++ b/packages/railway/src/transform.ts
@@ -96,7 +96,9 @@ export function railwayLogsToOtlp(
       const serviceId = log.tags?.serviceId ?? null;
       const serviceName = (serviceId && ctx.serviceNamesById[serviceId]) || "railway";
       const nanos = rfc3339ToNanos(log.timestamp) ?? 0n;
-      const parsed = parseRailwayLogRecord(stripAnsi(log.message), log.severity);
+      const parsed = parseRailwayLogRecord(stripAnsi(log.message), log.severity, {
+        applicationError: hasApplicationErrorAttribute(log.attributes),
+      });
       const parsedAttributes = parsed.attributes.map((attribute) =>
         attribute.key === "log.record.original" ? { ...attribute, value: log.message } : attribute,
       );
@@ -194,6 +196,17 @@ export function railwayMetricsToOtlp(
       },
     ],
   };
+}
+
+function hasApplicationErrorAttribute(attributes: RailwayLog["attributes"]): boolean {
+  return attributes.some((attribute) => {
+    if (!["err", "error"].includes(attribute.key.trim().toLowerCase())) return false;
+    const value = parseRailwayAttributeValue(attribute.value);
+    if (typeof value === "boolean") return value;
+    if (typeof value === "number") return value !== 0;
+    const normalized = value.trim().toLowerCase();
+    return normalized !== "" && normalized !== "false" && normalized !== "null";
+  });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- treat Railway stderr routing as transport metadata instead of semantic error evidence
- preserve error severity when structured fields, explicit text labels, HTTP/PostgreSQL semantics, or application error attributes support it
- record the parsed format, provider severity, severity source, and original message for explainability

## Validation

- `pnpm --filter @superlog/railway test`
- `pnpm --filter @superlog/railway typecheck`
- `biome check packages/railway/src/log-record.ts packages/railway/src/transform.ts packages/railway/src/transform.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reclassifies Railway stderr in `@superlog/railway` as transport metadata so we only surface errors when there’s real application evidence, while preserving raw failure diagnostics and explainability attributes.

- New Features
  - Don’t promote stderr to ERROR without evidence: native level; explicit labels in text or inside structured message bodies (leading, bracketed, or timestamped); strong failure phrases; truthy `err`/`error` attribute. Unknown native levels stay unclassified.
  - Text handling: preserve timestamp-adjacent and leading/bracketed severity labels; prefer explicit labels over later prose and over application error fields; ignore deployment shutdown wrappers and zero‑failure counts, but keep independent failure evidence; recognize common failure forms (e.g. DLQ sends, SIG* crashes, connection refused/reset, timeouts, and common PostgreSQL/exception patterns); map explicit PANIC to fatal; avoid treating severity words in prose as labels.
  - Structured logs: preserve native levels for JSON/logfmt and HTTP/PostgreSQL (including standalone `level=...` lines); infer severity from explicit labels in `message` bodies; don’t inherit stderr when structured logs lack a level; malformed or empty structured messages stay lossless and unclassified.
  - Add `railway.log.format`, `railway.log.provider_severity`, `railway.log.severity_source` (`text`, `json_message`, `logfmt_message`, `railway_error_attribute`, `unclassified`), and `log.record.original`.

<sup>Written for commit 63c30041049904a1583dfc889daa79fd88cbcd30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

