### PR TITLE
Prevent login crash while billing data hydrates

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,3 @@
-import { hasClaimedPaygPromotion } from "@superlog/billing";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCustomer } from "autumn-js/react";
 import { usePostHog } from "posthog-js/react";
@@ -29,7 +28,7 @@ import { AnomalyScanDetail } from "./anomaly-scanner/AnomalyScanDetail.tsx";
 import { AnomalyScanner } from "./anomaly-scanner/AnomalyScanner.tsx";
 import { useMe } from "./api.ts";
 import { authClient, useSession } from "./auth-client.ts";
-import { signalAtHardCap } from "./billing.ts";
+import { isPaygPromotionAvailable, signalAtHardCap } from "./billing.ts";
 import { DashboardView } from "./dashboards/DashboardView.tsx";
 import { DashboardsList } from "./dashboards/DashboardsList.tsx";
 import { ProductShell } from "./design/ProductShell.tsx";
@@ -189,12 +188,7 @@ function AuthenticatedApp() {
     // signalAtHardCap swallows autumn-js check() throwing on a not-yet-hydrated
     // customer (e.g. a brand-new org) so billing state can't black-screen the app.
     ["spans", "logs", "metric_points"].some((f) => signalAtHardCap(check, f));
-  const paygPromotionAvailable =
-    !!billingCustomer &&
-    !hasClaimedPaygPromotion(
-      billingCustomer.id,
-      billingCustomer.balances.investigations?.breakdown,
-    );
+  const paygPromotionAvailable = isPaygPromotionAvailable(billingCustomer);
   if (isPending) return null;
   if (!data) return <Landing />;
   const scopedRoute = matchPath("/app/org/:orgSlug/project/:projectSlug/*", pathname);

--- a/apps/web/src/billing.test.ts
+++ b/apps/web/src/billing.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   type EntitlementBalance,
   isPaygPromotionAvailable,
+  paygPromotionStatus,
   signalAtHardCap,
 } from "./billing.ts";
 
@@ -74,5 +75,32 @@ test("PAYG promotion availability stays false while customer balances are not hy
       id: "org_123",
     }),
     false,
+  );
+  assert.equal(
+    paygPromotionStatus({
+      id: "org_123",
+    }),
+    "unknown",
+  );
+});
+
+test("PAYG promotion status distinguishes available and claimed hydrated balances", () => {
+  assert.equal(
+    paygPromotionStatus({
+      id: "org_123",
+      balances: { investigations: { breakdown: [] } },
+    }),
+    "available",
+  );
+  assert.equal(
+    paygPromotionStatus({
+      id: "org_123",
+      balances: {
+        investigations: {
+          breakdown: [{ id: "payg-welcome-investigations-org_123" }],
+        },
+      },
+    }),
+    "claimed",
   );
 });

--- a/apps/web/src/billing.test.ts
+++ b/apps/web/src/billing.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { type EntitlementBalance, signalAtHardCap } from "./billing.ts";
+import {
+  type EntitlementBalance,
+  isPaygPromotionAvailable,
+  signalAtHardCap,
+} from "./billing.ts";
 
 // A `check` stand-in that returns a fixed balance.
 const checkReturning = (balance: EntitlementBalance) => () => ({ balance });
@@ -57,4 +61,18 @@ test("signalAtHardCap returns false (never throws) when check() throws", () => {
   };
   assert.doesNotThrow(() => signalAtHardCap(throwingCheck, "spans"));
   assert.equal(signalAtHardCap(throwingCheck, "spans"), false);
+});
+
+test("PAYG promotion availability stays false while customer balances are not hydrated", () => {
+  assert.doesNotThrow(() =>
+    isPaygPromotionAvailable({
+      id: "org_123",
+    }),
+  );
+  assert.equal(
+    isPaygPromotionAvailable({
+      id: "org_123",
+    }),
+    false,
+  );
 });

--- a/apps/web/src/billing.ts
+++ b/apps/web/src/billing.ts
@@ -1,3 +1,5 @@
+import { hasClaimedPaygPromotion } from "@superlog/billing";
+
 // Billing entitlement helpers shared by the app-wide "ingest paused" banner
 // (App.tsx) and the billing settings card (BillingCard.tsx).
 //
@@ -15,6 +17,26 @@ export type EntitlementBalance =
   | undefined;
 
 export type EntitlementCheck = (args: { featureId: string }) => { balance: EntitlementBalance };
+
+type PromotionCustomer =
+  | {
+      id?: string | null;
+      balances?: {
+        investigations?: {
+          breakdown?: ReadonlyArray<{ id: string }> | null;
+        };
+      } | null;
+    }
+  | null
+  | undefined;
+
+// Autumn briefly exposes a customer before its balances are hydrated. Treat
+// that intermediate state as unknown/unavailable so login can render without
+// advertising a promotion from incomplete billing data.
+export function isPaygPromotionAvailable(customer: PromotionCustomer): boolean {
+  if (!customer?.id || !customer.balances) return false;
+  return !hasClaimedPaygPromotion(customer.id, customer.balances.investigations?.breakdown);
+}
 
 // True when a signal is at a *hard* cap: a bounded (granted > 0), non-overage
 // feature whose usage has reached its allowance — the Free-tier state where

--- a/apps/web/src/billing.ts
+++ b/apps/web/src/billing.ts
@@ -30,12 +30,21 @@ type PromotionCustomer =
   | null
   | undefined;
 
-// Autumn briefly exposes a customer before its balances are hydrated. Treat
-// that intermediate state as unknown/unavailable so login can render without
-// advertising a promotion from incomplete billing data.
+export type PaygPromotionStatus = "unknown" | "available" | "claimed";
+
+// Autumn can expose a customer without balances while a new billing customer
+// is being populated or when a response is incomplete. Treat that state as
+// unknown/unavailable so login can render without advertising a promotion from
+// incomplete billing data.
+export function paygPromotionStatus(customer: PromotionCustomer): PaygPromotionStatus {
+  if (!customer?.id || !customer.balances) return "unknown";
+  return hasClaimedPaygPromotion(customer.id, customer.balances.investigations?.breakdown)
+    ? "claimed"
+    : "available";
+}
+
 export function isPaygPromotionAvailable(customer: PromotionCustomer): boolean {
-  if (!customer?.id || !customer.balances) return false;
-  return !hasClaimedPaygPromotion(customer.id, customer.balances.investigations?.breakdown);
+  return paygPromotionStatus(customer) === "available";
 }
 
 // True when a signal is at a *hard* cap: a bounded (granted > 0), non-overage

--- a/apps/web/src/design/ui.tsx
+++ b/apps/web/src/design/ui.tsx
@@ -1,10 +1,10 @@
 import { CreditCardIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { hasClaimedPaygPromotion } from "@superlog/billing";
 import { useCustomer } from "autumn-js/react";
 import { type CSSProperties, type ReactNode, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useProjectPath } from "../ProjectRouteContext.tsx";
+import { isPaygPromotionAvailable } from "../billing.ts";
 
 // ---------------------------------------------------------------------------
 // Canonical shared primitives — used across the app and the /design sheet.
@@ -719,8 +719,6 @@ export function OutOfCreditsBanner({
 
 export function BillingAwareOutOfCreditsBanner() {
   const { data: customer } = useCustomer();
-  const promotionAvailable =
-    !!customer &&
-    !hasClaimedPaygPromotion(customer.id, customer.balances.investigations?.breakdown);
+  const promotionAvailable = isPaygPromotionAvailable(customer);
   return <OutOfCreditsBanner promotionAvailable={promotionAvailable} />;
 }

--- a/apps/web/src/settings/BillingCard.tsx
+++ b/apps/web/src/settings/BillingCard.tsx
@@ -1,4 +1,3 @@
-import { hasClaimedPaygPromotion } from "@superlog/billing";
 import { useAggregateEvents, useCustomer } from "autumn-js/react";
 import { useEffect, useRef, useState } from "react";
 import {
@@ -11,7 +10,7 @@ import {
   YAxis,
 } from "recharts";
 import { useCancelBilling, useEnsurePaygPromotion } from "../api.ts";
-import { signalAtHardCap } from "../billing.ts";
+import { isPaygPromotionAvailable, signalAtHardCap } from "../billing.ts";
 import { Btn } from "../design/ui.tsx";
 
 // Autumn plan ids → display names (must match autumn.config.ts / pricing.ts).
@@ -106,10 +105,7 @@ export function BillingCard() {
   const activeSub = customer?.subscriptions?.find((s) => s.status === "active");
   const planId = activeSub?.planId ?? "free";
   const promotionCustomerId = customer?.id ?? null;
-  const promotionAlreadyClaimed = hasClaimedPaygPromotion(
-    customer?.id,
-    customer?.balances?.investigations?.breakdown,
-  );
+  const promotionAvailable = isPaygPromotionAvailable(customer);
 
   useEffect(() => {
     if (planId !== "payg" || !promotionCustomerId) return;
@@ -140,8 +136,9 @@ export function BillingCard() {
   }
 
   const planName = PLAN_NAMES[planId] ?? planId;
-  const planOptions = promotionAlreadyClaimed
-    ? PLAN_OPTIONS.map((option) =>
+  const planOptions = promotionAvailable
+    ? PLAN_OPTIONS
+    : PLAN_OPTIONS.map((option) =>
         option.id === "payg"
           ? {
               ...option,
@@ -153,8 +150,7 @@ export function BillingCard() {
               ],
             }
           : option,
-      )
-    : PLAN_OPTIONS;
+      );
 
   // A scheduled downgrade (e.g. Pro → PAYG) shows up as a second subscription
   // with status "scheduled" that takes effect at the end of the current cycle.
@@ -268,9 +264,9 @@ export function BillingCard() {
           <div className="mt-3 border-t border-border pt-3 text-[12.5px] leading-relaxed text-fg">
             <span className="font-semibold">You’ve reached your Free plan limits.</span> Ingest is
             paused for capped signals.{" "}
-            {promotionAlreadyClaimed
-              ? "Switch to pay-as-you-go to resume with no caps — you’ll add a card at checkout."
-              : "Switch to pay-as-you-go to resume with no caps and receive a one-time grant of 100 promotional investigations — you’ll add a card at checkout."}
+            {promotionAvailable
+              ? "Switch to pay-as-you-go to resume with no caps and receive a one-time grant of 100 promotional investigations — you’ll add a card at checkout."
+              : "Switch to pay-as-you-go to resume with no caps — you’ll add a card at checkout."}
           </div>
         )}
       </div>

--- a/apps/web/src/settings/BillingCard.tsx
+++ b/apps/web/src/settings/BillingCard.tsx
@@ -108,7 +108,7 @@ export function BillingCard() {
   const promotionCustomerId = customer?.id ?? null;
   const promotionAlreadyClaimed = hasClaimedPaygPromotion(
     customer?.id,
-    customer?.balances.investigations?.breakdown,
+    customer?.balances?.investigations?.breakdown,
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- guard PAYG promotion state while the billing customer is only partially hydrated
- treat missing balances as an explicit unknown/unavailable promotion state
- apply the guard to the authenticated app, out-of-credits incident banner, and billing settings
- keep promotional copy hidden until claim status is known
- add regression coverage for missing, available, and claimed balances

## Root cause

The billing hook can expose a truthy customer before its `balances` field is available. Several authenticated render paths synchronously read `customer.balances.investigations`, producing `Cannot read properties of undefined (reading 'investigations')` and black-screening the app immediately after login or while opening an out-of-credits incident.

## User impact

Authenticated users can enter the app while billing data is incomplete. Promotion messaging remains generic until the balances payload is complete.

## Validation

- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web test` (267 passing)
- `pnpm --filter @superlog/web build`
- local worktree verification