### PR TITLE
Capture browser render failures in telemetry

### DIFF
--- a/apps/web/src/BrowserErrorBoundary.tsx
+++ b/apps/web/src/BrowserErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { reportBrowserException } from "./instrumentation.ts";
+
+type BrowserErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type BrowserErrorBoundaryState = {
+  failed: boolean;
+};
+
+export class BrowserErrorBoundary extends Component<
+  BrowserErrorBoundaryProps,
+  BrowserErrorBoundaryState
+> {
+  state: BrowserErrorBoundaryState = { failed: false };
+
+  static getDerivedStateFromError(): BrowserErrorBoundaryState {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    reportBrowserException(error, "react.render", {
+      "react.component_stack": info.componentStack ?? "",
+    });
+  }
+
+  render(): ReactNode {
+    if (!this.state.failed) return this.props.children;
+
+    return (
+      <main className="grid min-h-screen place-items-center bg-bg px-6 text-fg">
+        <div className="max-w-md text-center">
+          <h1 className="text-lg font-semibold">Superlog hit an unexpected error</h1>
+          <p className="mt-2 text-[13px] text-muted">
+            We recorded the details. Reload the page to continue.
+          </p>
+          <button
+            type="button"
+            className="mt-4 inline-flex h-8 items-center justify-center rounded-md bg-fg px-3 text-[12px] font-medium text-bg transition-opacity hover:opacity-85"
+            onClick={() => window.location.reload()}
+          >
+            Reload
+          </button>
+        </div>
+      </main>
+    );
+  }
+}

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -1,5 +1,5 @@
 // OpenTelemetry browser instrumentation. Loaded as the first import in main.tsx.
-import { trace } from "@opentelemetry/api";
+import { SpanStatusCode, trace, type Attributes } from "@opentelemetry/api";
 import { ZoneContextManager } from "@opentelemetry/context-zone";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { registerInstrumentations } from "@opentelemetry/instrumentation";
@@ -15,6 +15,7 @@ const env = (import.meta.env ?? {}) as Record<string, string | undefined>;
 const endpoint = env.VITE_OTEL_EXPORTER_OTLP_ENDPOINT;
 const headersRaw = env.VITE_OTEL_EXPORTER_OTLP_HEADERS;
 const serviceName = env.VITE_OTEL_SERVICE_NAME ?? "@superlog/web";
+const serviceVersion = env.VITE_OTEL_SERVICE_VERSION;
 // Always stamp an `env` resource attribute so every browser span is filterable
 // by deployment environment. VITE_SUPERLOG_ENV is the explicit knob; MODE is
 // vite's build mode (production/development); "development" is the last resort.
@@ -36,11 +37,11 @@ function parseHeaders(raw: string | undefined): Record<string, string> {
     }, {});
 }
 
+let browserTracerProvider: WebTracerProvider | undefined;
+
 if (!endpoint) {
   // eslint-disable-next-line no-console
-  console.warn(
-    "[otel] VITE_OTEL_EXPORTER_OTLP_ENDPOINT not set; tracing disabled",
-  );
+  console.warn("[otel] VITE_OTEL_EXPORTER_OTLP_ENDPOINT not set; tracing disabled");
 } else {
   try {
     const headers = parseHeaders(headersRaw);
@@ -50,16 +51,17 @@ if (!endpoint) {
       headers,
     });
 
-    const provider = new WebTracerProvider({
+    browserTracerProvider = new WebTracerProvider({
       resource: resourceFromAttributes({
         [ATTR_SERVICE_NAME]: serviceName,
         "deployment.environment.name": deploymentEnv,
         env: deploymentEnv,
+        ...(serviceVersion ? { "service.version": serviceVersion } : {}),
       }),
       spanProcessors: [new BatchSpanProcessor(exporter)],
     });
 
-    provider.register({
+    browserTracerProvider.register({
       contextManager: new ZoneContextManager(),
     });
 
@@ -83,3 +85,60 @@ if (!endpoint) {
 }
 
 export const tracer = trace.getTracer("@superlog/web");
+
+type BrowserExceptionSource =
+  | "bootstrap"
+  | "react.render"
+  | "window.error"
+  | "window.unhandledrejection";
+
+const reportedErrors = new WeakSet<object>();
+
+function normalizeError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  if (typeof error === "string") return new Error(error);
+  try {
+    return new Error(JSON.stringify(error));
+  } catch {
+    return new Error(String(error));
+  }
+}
+
+export function reportBrowserException(
+  error: unknown,
+  source: BrowserExceptionSource,
+  attributes: Attributes = {},
+): void {
+  if (typeof error === "object" && error !== null) {
+    if (reportedErrors.has(error)) return;
+    reportedErrors.add(error);
+  }
+
+  const normalized = normalizeError(error);
+  const span = tracer.startSpan("browser.exception", {
+    attributes: {
+      "app.path": window.location.pathname,
+      "error.source": source,
+      ...attributes,
+    },
+  });
+  span.recordException(normalized);
+  span.setStatus({ code: SpanStatusCode.ERROR, message: normalized.message });
+  span.end();
+  void browserTracerProvider?.forceFlush().catch(() => {
+    // The exception is already recorded locally. Telemetry export failures must
+    // never replace the original browser error or break the recovery screen.
+  });
+}
+
+window.addEventListener("error", (event) => {
+  reportBrowserException(event.error ?? event.message, "window.error", {
+    "code.file": event.filename,
+    "code.line.number": event.lineno,
+    "code.column.number": event.colno,
+  });
+});
+
+window.addEventListener("unhandledrejection", (event) => {
+  reportBrowserException(event.reason, "window.unhandledrejection");
+});

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,4 +1,4 @@
-import "./instrumentation";
+import { reportBrowserException, tracer } from "./instrumentation";
 import { initGtm } from "./gtm";
 import "@fontsource/geist-pixel/latin.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -7,8 +7,8 @@ import { PostHogProvider } from "posthog-js/react";
 import React, { type ReactNode } from "react";
 import { createRoot, hydrateRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { BrowserErrorBoundary } from "./BrowserErrorBoundary.tsx";
 import { surfaceForPath } from "./entry-surface.ts";
-import { tracer } from "./instrumentation";
 import "./index.css";
 import "react-grid-layout/css/styles.css";
 import "./dashboards/grid.css";
@@ -62,15 +62,17 @@ async function renderDesign() {
   // gracefully against the unauthenticated /design origin.
   createRoot(rootElement).render(
     <React.StrictMode>
-      <BrowserRouter>
-        <QueryClientProvider client={queryClient()}>
-          {window.location.pathname === "/design/home-dashboard-mockups" ? (
-            <HomeDashboardMockups />
-          ) : (
-            <DesignLanguage />
-          )}
-        </QueryClientProvider>
-      </BrowserRouter>
+      <BrowserErrorBoundary>
+        <BrowserRouter>
+          <QueryClientProvider client={queryClient()}>
+            {window.location.pathname === "/design/home-dashboard-mockups" ? (
+              <HomeDashboardMockups />
+            ) : (
+              <DesignLanguage />
+            )}
+          </QueryClientProvider>
+        </BrowserRouter>
+      </BrowserErrorBoundary>
     </React.StrictMode>,
   );
   bootSpan.setAttribute("app.mode", "design");
@@ -80,13 +82,15 @@ async function renderMarketing() {
   const { MarketingApp } = await import("./marketing/MarketingApp.tsx");
   const tree = (
     <React.StrictMode>
-      <Analytics>
-        <BrowserRouter>
-          <QueryClientProvider client={queryClient()}>
-            <MarketingApp />
-          </QueryClientProvider>
-        </BrowserRouter>
-      </Analytics>
+      <BrowserErrorBoundary>
+        <Analytics>
+          <BrowserRouter>
+            <QueryClientProvider client={queryClient()}>
+              <MarketingApp />
+            </QueryClientProvider>
+          </BrowserRouter>
+        </Analytics>
+      </BrowserErrorBoundary>
     </React.StrictMode>
   );
   if (rootElement.hasChildNodes()) hydrateRoot(rootElement, tree);
@@ -98,21 +102,23 @@ async function renderProduct() {
   const { App } = await import("./App.tsx");
   createRoot(rootElement).render(
     <React.StrictMode>
-      <Analytics>
-        <BrowserRouter>
-          <QueryClientProvider client={queryClient()}>
-            {/* Billing context. Web and API are separate origins, so point
-                Autumn at the API; useBetterAuth routes through /api/auth/autumn
-                with the session cookie. Harmless when billing is unconfigured. */}
-            <AutumnProvider
-              backendUrl={import.meta.env.VITE_API_URL ?? "http://localhost:4100"}
-              useBetterAuth
-            >
-              <App />
-            </AutumnProvider>
-          </QueryClientProvider>
-        </BrowserRouter>
-      </Analytics>
+      <BrowserErrorBoundary>
+        <Analytics>
+          <BrowserRouter>
+            <QueryClientProvider client={queryClient()}>
+              {/* Billing context. Web and API are separate origins, so point
+                  Autumn at the API; useBetterAuth routes through /api/auth/autumn
+                  with the session cookie. Harmless when billing is unconfigured. */}
+              <AutumnProvider
+                backendUrl={import.meta.env.VITE_API_URL ?? "http://localhost:4100"}
+                useBetterAuth
+              >
+                <App />
+              </AutumnProvider>
+            </QueryClientProvider>
+          </BrowserRouter>
+        </Analytics>
+      </BrowserErrorBoundary>
     </React.StrictMode>,
   );
   bootSpan.setAttribute("app.mode", "product");
@@ -128,7 +134,7 @@ async function bootstrap() {
 }
 
 void bootstrap().catch((error: unknown) => {
-  bootSpan.recordException(error instanceof Error ? error : new Error(String(error)));
+  reportBrowserException(error, "bootstrap");
   bootSpan.end();
   throw error;
 });


### PR DESCRIPTION
## What changed

- record React render failures, uncaught browser errors, and unhandled promise rejections as OpenTelemetry ERROR spans
- deduplicate the same exception across capture paths and flush it immediately
- show a reload recovery screen instead of leaving the page blank
- accept an optional browser `service.version` build value for deploy correlation

## Why

The browser tracing setup covered page loads, interactions, fetches, and bootstrap failures, but React render failures after bootstrap could blank the page without producing an error span or incident.

## Validation

- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture React render and browser runtime failures as OpenTelemetry ERROR spans and show a simple reload screen instead of a blank page. Also adds optional `service.version` tagging for deploy correlation.

- **New Features**
  - Record React render errors, uncaught `window.error`, and `unhandledrejection` as error spans; deduplicate the same exception and force-flush telemetry.
  - Wrap all app roots with a `BrowserErrorBoundary` that reports the error and displays a “Reload” recovery UI.
  - Add `reportBrowserException` and use it in bootstrap for consistent handling.
  - Support optional release tagging via `VITE_OTEL_SERVICE_VERSION` to set the `service.version` resource attribute.

<sup>Written for commit edf9c4f6639d89a6dd1dc2beb8a36614d676054f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

