### PR TITLE
docs: Fix OTLP default port to 4000 (fixes #397)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Default local services:
 | ------------ | ------------------------- |
 | Web app      | http://localhost:5173     |
 | API          | http://localhost:4100     |
-| OTLP proxy   | http://localhost:4101     |
+| OTLP proxy   | http://localhost:4000     |
 | Sample app   | http://localhost:3005     |
 
 If something fails on first boot, run `pnpm dev:portless:status` to see what came up. For a clean restart:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The default local services are:
 
 - Web: `http://localhost:5173`
 - API: `http://localhost:4100`
-- OTLP intake: `http://localhost:4101`
+- OTLP intake: `http://localhost:4000`
 
 ## Development
 


### PR DESCRIPTION
Align quick-start OTLP endpoint documentation with the proxy's default listening port. Fixes #397.