### PR TITLE
fix(web): Add awaiting_events to incident poller active states (fixes #398)

### DIFF
--- a/apps/web/src/incidents/agent-run-polling.test.ts
+++ b/apps/web/src/incidents/agent-run-polling.test.ts
@@ -25,6 +25,10 @@ test("keeps polling while awaiting a human — a Slack reply elsewhere can resum
   assert.equal(incidentPollIntervalMs("awaiting_human"), INCIDENT_POLL_INTERVAL_MS);
 });
 
+test("keeps polling while awaiting events — PR events (comment/merge/close) can resume the run", () => {
+  assert.equal(incidentPollIntervalMs("awaiting_events"), INCIDENT_POLL_INTERVAL_MS);
+});
+
 test("stops polling in terminal states", () => {
   assert.equal(incidentPollIntervalMs("complete"), false);
   assert.equal(incidentPollIntervalMs("failed"), false);

--- a/apps/web/src/incidents/agent-run-polling.ts
+++ b/apps/web/src/incidents/agent-run-polling.ts
@@ -19,6 +19,7 @@ const ACTIVE_AGENT_RUN_STATES: ReadonlySet<string> = new Set([
   "repo_discovery",
   "running",
   "awaiting_human",
+  "awaiting_events",
   "resuming",
   "pr_retry_queued",
 ]);


### PR DESCRIPTION
This PR fixes a bug where the incident detail page would stop polling for updates while an agent run was in the \waiting_events\ state. Because the web poller's canonical active-state mirror omitted \waiting_events\, the page would not automatically observe subsequent PR-event-driven resume, status, or transcript updates without a manual refresh. Adding \waiting_events\ to the \ACTIVE_AGENT_RUN_STATES\ set ensures that polling continues as expected. A regression test has also been added. Fixes #398.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep polling on the incident page while an agent run is in the awaiting_events state, so PR comment/merge/close updates appear without a refresh. Adds awaiting_events to ACTIVE_AGENT_RUN_STATES and a regression test.

<sup>Written for commit 610bbdc09c08e829403e6e58a37045cababe5d68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

