### PR TITLE
fix(worker): Centralize ClickHouse configuration (fixes #286)

### DIFF
--- a/apps/worker/scripts/backfill-issue-activity-daily.ts
+++ b/apps/worker/scripts/backfill-issue-activity-daily.ts
@@ -18,11 +18,13 @@ type Args = {
 };
 
 const args = parseArgs(process.argv.slice(2));
+import { CLICKHOUSE_DB, CLICKHOUSE_PASSWORD, CLICKHOUSE_URL, CLICKHOUSE_USER } from "../src/infra/clickhouse/config.js";
+
 const clickhouse = createClient({
-  url: process.env.CLICKHOUSE_URL ?? "http://localhost:8123",
-  username: process.env.CLICKHOUSE_USER ?? "default",
-  password: process.env.CLICKHOUSE_PASSWORD ?? "",
-  database: process.env.CLICKHOUSE_DB ?? "superlog",
+  url: CLICKHOUSE_URL,
+  username: CLICKHOUSE_USER,
+  password: CLICKHOUSE_PASSWORD,
+  database: CLICKHOUSE_DB,
 });
 
 let scannedTraceGroups = 0;

--- a/apps/worker/scripts/backfill-otel-exceptions.ts
+++ b/apps/worker/scripts/backfill-otel-exceptions.ts
@@ -31,11 +31,13 @@ type Args = {
 };
 
 const args = parseArgs(process.argv.slice(2));
+import { CLICKHOUSE_DB, CLICKHOUSE_PASSWORD, CLICKHOUSE_URL, CLICKHOUSE_USER } from "../src/infra/clickhouse/config.js";
+
 const clickhouse = createClient({
-  url: process.env.CLICKHOUSE_URL ?? "http://localhost:8123",
-  username: process.env.CLICKHOUSE_USER ?? "default",
-  password: process.env.CLICKHOUSE_PASSWORD ?? "",
-  database: process.env.CLICKHOUSE_DB ?? "superlog",
+  url: CLICKHOUSE_URL,
+  username: CLICKHOUSE_USER,
+  password: CLICKHOUSE_PASSWORD,
+  database: CLICKHOUSE_DB,
 });
 
 // Column projections shared by the dry-run count and the INSERT, kept identical

--- a/apps/worker/scripts/backfill-otel-traces-summary.ts
+++ b/apps/worker/scripts/backfill-otel-traces-summary.ts
@@ -35,11 +35,13 @@ type Args = {
 };
 
 const args = parseArgs(process.argv.slice(2));
+import { CLICKHOUSE_DB, CLICKHOUSE_PASSWORD, CLICKHOUSE_URL, CLICKHOUSE_USER } from "../src/infra/clickhouse/config.js";
+
 const clickhouse = createClient({
-  url: process.env.CLICKHOUSE_URL ?? "http://localhost:8123",
-  username: process.env.CLICKHOUSE_USER ?? "default",
-  password: process.env.CLICKHOUSE_PASSWORD ?? "",
-  database: process.env.CLICKHOUSE_DB ?? "superlog",
+  url: CLICKHOUSE_URL,
+  username: CLICKHOUSE_USER,
+  password: CLICKHOUSE_PASSWORD,
+  database: CLICKHOUSE_DB,
 });
 
 const windowFilter = `

--- a/apps/worker/scripts/materialize-metric-usage-projections.ts
+++ b/apps/worker/scripts/materialize-metric-usage-projections.ts
@@ -16,11 +16,13 @@ import { METRIC_TABLES } from "../src/billing/metric-usage-schema.js";
 type Args = { from: string; to: string; apply: boolean };
 
 const args = parseArgs(process.argv.slice(2));
+import { CLICKHOUSE_DB, CLICKHOUSE_PASSWORD, CLICKHOUSE_URL, CLICKHOUSE_USER } from "../src/infra/clickhouse/config.js";
+
 const clickhouse = createClient({
-  url: process.env.CLICKHOUSE_URL ?? "http://localhost:8123",
-  username: process.env.CLICKHOUSE_USER ?? "default",
-  password: process.env.CLICKHOUSE_PASSWORD ?? "",
-  database: process.env.CLICKHOUSE_DB ?? "superlog",
+  url: CLICKHOUSE_URL,
+  username: CLICKHOUSE_USER,
+  password: CLICKHOUSE_PASSWORD,
+  database: CLICKHOUSE_DB,
   // This is an explicit maintenance command that waits for replicated
   // mutations. The normal worker query deadline remains 30 seconds.
   request_timeout: 6 * 60 * 60 * 1000,

--- a/apps/worker/src/autorecovery/metrics-repository.ts
+++ b/apps/worker/src/autorecovery/metrics-repository.ts
@@ -197,13 +197,14 @@ let cachedClient: ClickHouseClient | null = null;
 export async function defaultClickhouseClient(): Promise<ClickHouseClient> {
   if (cachedClient) return cachedClient;
   const { createClient } = await import("@clickhouse/client");
+  const { CLICKHOUSE_DB, CLICKHOUSE_PASSWORD, CLICKHOUSE_URL, CLICKHOUSE_USER } = await import(
+    "../infra/clickhouse/config.js"
+  );
   cachedClient = createClient({
-    url: process.env.CLICKHOUSE_URL ?? "http://localhost:8123",
-    username: process.env.CLICKHOUSE_USER ?? "default",
-    password: process.env.CLICKHOUSE_PASSWORD ?? "",
-    // Local portless stacks ship a `superlog` database; prod uses `olly`.
-    // `CLICKHOUSE_DB` is the env name `scripts/portless-stack.sh` writes.
-    database: process.env.CLICKHOUSE_DATABASE ?? process.env.CLICKHOUSE_DB ?? "olly",
+    url: CLICKHOUSE_URL,
+    username: CLICKHOUSE_USER,
+    password: CLICKHOUSE_PASSWORD,
+    database: CLICKHOUSE_DB,
   });
   return cachedClient;
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -31,16 +31,16 @@ registerTenantMetrics();
 registerAgentRunHealthMetrics();
 registerQueueHealthMetrics();
 
-const CLICKHOUSE_URL = process.env.CLICKHOUSE_URL ?? "http://localhost:8123";
-const CLICKHOUSE_DB = process.env.CLICKHOUSE_DB ?? "superlog";
+import { CLICKHOUSE_DB, CLICKHOUSE_PASSWORD, CLICKHOUSE_URL, CLICKHOUSE_USER } from "./infra/clickhouse/config.js";
+
 const POLL_INTERVAL_MS = Number(process.env.POLL_INTERVAL_MS ?? 3000);
 const BATCH_SIZE = Number(process.env.BATCH_SIZE ?? 500);
 const TELEMETRY_DISCOVERY_WINDOW_MS = Number(process.env.TELEMETRY_DISCOVERY_WINDOW_MS);
 
 const ch = createClient({
   url: CLICKHOUSE_URL,
-  username: process.env.CLICKHOUSE_USER ?? "default",
-  password: process.env.CLICKHOUSE_PASSWORD ?? "",
+  username: CLICKHOUSE_USER,
+  password: CLICKHOUSE_PASSWORD,
   database: CLICKHOUSE_DB,
 });
 

--- a/apps/worker/src/infra/clickhouse/config.ts
+++ b/apps/worker/src/infra/clickhouse/config.ts
@@ -1,0 +1,4 @@
+export const CLICKHOUSE_URL = process.env.CLICKHOUSE_URL ?? "http://localhost:8123";
+export const CLICKHOUSE_USER = process.env.CLICKHOUSE_USER ?? "default";
+export const CLICKHOUSE_PASSWORD = process.env.CLICKHOUSE_PASSWORD ?? "";
+export const CLICKHOUSE_DB = process.env.CLICKHOUSE_DB ?? "superlog";

--- a/apps/worker/src/infra/clickhouse/trace-context.ts
+++ b/apps/worker/src/infra/clickhouse/trace-context.ts
@@ -1,12 +1,12 @@
 import { createClient } from "@clickhouse/client";
 import { logger } from "../../logger.js";
 
-const CLICKHOUSE_URL = process.env.CLICKHOUSE_URL ?? "http://localhost:8123";
-const CLICKHOUSE_DB = process.env.CLICKHOUSE_DB ?? "superlog";
+import { CLICKHOUSE_DB, CLICKHOUSE_PASSWORD, CLICKHOUSE_URL, CLICKHOUSE_USER } from "./config.js";
+
 const ch = createClient({
   url: CLICKHOUSE_URL,
-  username: process.env.CLICKHOUSE_USER ?? "default",
-  password: process.env.CLICKHOUSE_PASSWORD ?? "",
+  username: CLICKHOUSE_USER,
+  password: CLICKHOUSE_PASSWORD,
   database: CLICKHOUSE_DB,
 });
 


### PR DESCRIPTION
This PR centralizes the ClickHouse connection configuration into a single module, \infra/clickhouse/config.ts\. Previously, the autorecovery agent read a different database (falling back to \olly\) while the primary worker and backfill scripts read from \superlog\. By routing all ClickHouse connections through the same environment resolution logic, this guarantees that all modules correctly resolve the same target database, fixing Issue #286.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized ClickHouse connection config in `apps/worker/src/infra/clickhouse/config.ts` and updated all worker components to use it. This aligns autorecovery, worker, and backfill scripts to the same DB resolution and fixes #286.

- **Bug Fixes**
  - Autorecovery no longer falls back to `olly`; all modules now read the same DB via shared envs (`CLICKHOUSE_URL`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`, `CLICKHOUSE_DB`).

- **Migration**
  - If you used `CLICKHOUSE_DATABASE`, switch to `CLICKHOUSE_DB` (default remains `superlog`).

<sup>Written for commit 5a8524e2e00813ce9bb68ee361e5518b0298dd22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

