### PR TITLE
fix: sanitize untrusted attributes and preserve fingerprints

### DIFF
--- a/apps/proxy/src/ingest-fingerprints.ts
+++ b/apps/proxy/src/ingest-fingerprints.ts
@@ -93,8 +93,10 @@ export function stampIssueFingerprints(input: StampInput): StampedIngestPayload 
 function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
   const payload = JSON.parse(body.toString("utf8")) as {
     resourceSpans?: Array<{
+      resource?: { attributes?: OtlpKeyValue[] };
       scopeSpans?: Array<{
         spans?: Array<{
+          attributes?: OtlpKeyValue[];
           events?: Array<{
             name?: string;
             attributes?: OtlpKeyValue[];
@@ -105,10 +107,26 @@ function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
   };
 
   let stampedCount = 0;
+  let sanitizedCount = 0;
   for (const resourceSpan of payload.resourceSpans ?? []) {
+    if (resourceSpan.resource?.attributes) {
+      const before = resourceSpan.resource.attributes.length;
+      resourceSpan.resource.attributes = sanitizeSuperlog(resourceSpan.resource.attributes);
+      sanitizedCount += before - resourceSpan.resource.attributes.length;
+    }
     for (const scopeSpan of resourceSpan.scopeSpans ?? []) {
       for (const span of scopeSpan.spans ?? []) {
+        if (span.attributes) {
+          const before = span.attributes.length;
+          span.attributes = sanitizeSuperlog(span.attributes);
+          sanitizedCount += before - span.attributes.length;
+        }
         for (const event of span.events ?? []) {
+          if (event.attributes) {
+            const before = event.attributes.length;
+            event.attributes = sanitizeSuperlog(event.attributes);
+            sanitizedCount += before - event.attributes.length;
+          }
           if (event.name !== "exception") continue;
           const attrs = event.attributes ?? [];
           const fp = fingerprint({
@@ -123,15 +141,17 @@ function stampJsonTraceFingerprints(body: Buffer): StampedIngestPayload {
     }
   }
 
-  if (stampedCount === 0) return { body, stampedCount };
+  if (stampedCount === 0 && sanitizedCount === 0) return { body, stampedCount };
   return { body: Buffer.from(JSON.stringify(payload)), stampedCount };
 }
 
 function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
   const payload = ExportTraceServiceRequest.decode(body) as {
     resourceSpans?: Array<{
+      resource?: { attributes?: OtlpKeyValue[] };
       scopeSpans?: Array<{
         spans?: Array<{
+          attributes?: OtlpKeyValue[];
           events?: Array<{
             name?: string;
             attributes?: OtlpKeyValue[];
@@ -142,10 +162,26 @@ function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
   };
 
   let stampedCount = 0;
+  let sanitizedCount = 0;
   for (const resourceSpan of payload.resourceSpans ?? []) {
+    if (resourceSpan.resource?.attributes) {
+      const before = resourceSpan.resource.attributes.length;
+      resourceSpan.resource.attributes = sanitizeSuperlog(resourceSpan.resource.attributes);
+      sanitizedCount += before - resourceSpan.resource.attributes.length;
+    }
     for (const scopeSpan of resourceSpan.scopeSpans ?? []) {
       for (const span of scopeSpan.spans ?? []) {
+        if (span.attributes) {
+          const before = span.attributes.length;
+          span.attributes = sanitizeSuperlog(span.attributes);
+          sanitizedCount += before - span.attributes.length;
+        }
         for (const event of span.events ?? []) {
+          if (event.attributes) {
+            const before = event.attributes.length;
+            event.attributes = sanitizeSuperlog(event.attributes);
+            sanitizedCount += before - event.attributes.length;
+          }
           if (event.name !== "exception") continue;
           const attrs = event.attributes ?? [];
           const fp = fingerprint({
@@ -160,7 +196,7 @@ function stampProtobufTraceFingerprints(body: Buffer): StampedIngestPayload {
     }
   }
 
-  if (stampedCount === 0) return { body, stampedCount };
+  if (stampedCount === 0 && sanitizedCount === 0) return { body, stampedCount };
   return { body: Buffer.from(ExportTraceServiceRequest.encode(payload).finish()), stampedCount };
 }
 
@@ -180,11 +216,22 @@ function stampJsonLogFingerprints(body: Buffer): StampedIngestPayload {
   };
 
   let stampedCount = 0;
+  let sanitizedCount = 0;
   for (const resourceLog of payload.resourceLogs ?? []) {
+    if (resourceLog.resource?.attributes) {
+      const before = resourceLog.resource.attributes.length;
+      resourceLog.resource.attributes = sanitizeSuperlog(resourceLog.resource.attributes);
+      sanitizedCount += before - resourceLog.resource.attributes.length;
+    }
     const service =
       stringAttribute(resourceLog.resource?.attributes ?? [], "service.name") || "unknown";
     for (const scopeLog of resourceLog.scopeLogs ?? []) {
       for (const logRecord of scopeLog.logRecords ?? []) {
+        if (logRecord.attributes) {
+          const before = logRecord.attributes.length;
+          logRecord.attributes = sanitizeSuperlog(logRecord.attributes);
+          sanitizedCount += before - logRecord.attributes.length;
+        }
         const attrs = logRecord.attributes ?? [];
         if (!isErrorLog(logRecord.severityNumber, logRecord.severityText, attrs)) continue;
         const fp = fingerprintLog({
@@ -200,7 +247,7 @@ function stampJsonLogFingerprints(body: Buffer): StampedIngestPayload {
     }
   }
 
-  if (stampedCount === 0) return { body, stampedCount };
+  if (stampedCount === 0 && sanitizedCount === 0) return { body, stampedCount };
   return { body: Buffer.from(JSON.stringify(payload)), stampedCount };
 }
 
@@ -235,6 +282,18 @@ function setStringAttribute(attrs: OtlpKeyValue[], key: string, value: string): 
   const next = attrs.filter((attr) => attr.key !== key);
   next.push({ key, value: { stringValue: value } });
   return next;
+}
+
+function sanitizeSuperlog(attrs: OtlpKeyValue[]): OtlpKeyValue[] {
+  let hasSuperlog = false;
+  for (let i = 0; i < attrs.length; i++) {
+    if (attrs[i].key?.startsWith("superlog.")) {
+      hasSuperlog = true;
+      break;
+    }
+  }
+  if (!hasSuperlog) return attrs;
+  return attrs.filter((attr) => !(attr.key || "").startsWith("superlog."));
 }
 
 function stringAttribute(attrs: OtlpKeyValue[], key: string): string | null {

--- a/apps/proxy/src/otlp-clickhouse.test.ts
+++ b/apps/proxy/src/otlp-clickhouse.test.ts
@@ -85,11 +85,10 @@ test("otlpLogsToRows strips superlog.* from resource attrs and stamps the real p
   // no stray superlog.* keys other than the stamped project id
   const superlogKeys = Object.keys(rows[0]!.ResourceAttributes).filter((k) => k.startsWith("superlog."));
   assert.deepEqual(superlogKeys, ["superlog.project_id"]);
-  // superlog.* is stripped from log record attributes too (matches the collector's
-  // transform/strip_superlog on log.attributes); project id lives only on resource attrs.
-  assert.equal(rows[0]!.LogAttributes["superlog.issue_fingerprint"], undefined);
+  // superlog.issue_fingerprint is preserved for issue-activity rollups
+  assert.equal(rows[0]!.LogAttributes["superlog.issue_fingerprint"], "deadbeef");
   assert.equal(
-    Object.keys(rows[0]!.LogAttributes).some((k) => k.startsWith("superlog.")),
+    Object.keys(rows[0]!.LogAttributes).some((k) => k.startsWith("superlog.") && k !== "superlog.issue_fingerprint"),
     false,
   );
 });
@@ -197,8 +196,8 @@ test("otlpTracesToRows strips superlog.* from resource and span attrs, stamps pr
   assert.equal(r.ResourceAttributes["superlog.project_id"], "proj-xyz");
   assert.equal(r.ResourceAttributes["service.name"], "api");
   assert.equal(r.SpanAttributes["http.method"], "GET");
-  // span-level superlog.* stripped (matches collector transform/strip_superlog)
-  assert.equal(r.SpanAttributes["superlog.issue_fingerprint"], undefined);
+  // span-level superlog.* stripped except for the fingerprint
+  assert.equal(r.SpanAttributes["superlog.issue_fingerprint"], "deadbeef");
 });
 
 test("otlpTracesToRows flattens events and links into parallel arrays", () => {

--- a/apps/proxy/src/otlp-clickhouse.ts
+++ b/apps/proxy/src/otlp-clickhouse.ts
@@ -251,7 +251,7 @@ function kvListToMap(attrs: OtlpKeyValue[] | undefined): Record<string, string> 
 function stripSuperlog(map: Record<string, string>): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(map)) {
-    if (k.startsWith("superlog.")) continue;
+    if (k.startsWith("superlog.") && k !== "superlog.issue_fingerprint") continue;
     out[k] = v;
   }
   return out;

--- a/infra/collector/config.yaml
+++ b/infra/collector/config.yaml
@@ -42,8 +42,11 @@ processors:
       - delete_matching_keys(span.attributes, "^superlog\\..*")
       - delete_matching_keys(resource.attributes, "^superlog\\..*")
     log_statements:
+      - set(log.attributes["__tmp_superlog_issue_fingerprint"], log.attributes["superlog.issue_fingerprint"]) where log.attributes["superlog.issue_fingerprint"] != nil
       - delete_matching_keys(log.attributes, "^superlog\\..*")
       - delete_matching_keys(resource.attributes, "^superlog\\..*")
+      - set(log.attributes["superlog.issue_fingerprint"], log.attributes["__tmp_superlog_issue_fingerprint"]) where log.attributes["__tmp_superlog_issue_fingerprint"] != nil
+      - delete_key(log.attributes, "__tmp_superlog_issue_fingerprint")
     metric_statements:
       - delete_matching_keys(datapoint.attributes, "^superlog\\..*")
       - delete_matching_keys(resource.attributes, "^superlog\\..*")


### PR DESCRIPTION
Resolves #285.

### What was causing the issue?
1. The proxy enriches incoming traces and logs with superlog.issue_fingerprint by evaluating exception attributes.
2. The proxy then routes the payload either to the collector or maps it directly to ClickHouse.
3. However, the direct ClickHouse mapper (otlp-clickhouse.ts) stripped every superlog.* attribute, including the proxy's newly minted fingerprint.
4. Similarly, the collector (infra/collector/config.yaml) stripped all superlog.* attributes from logs, thus scrubbing the log fingerprint before it ever reached the database.

### The Solution
1. **Pre-Enrichment Sanitization (apps/proxy/src/ingest-fingerprints.ts)**: Added a highly optimized zero-allocation fast-path scanner to sanitize untrusted superlog.* attributes from the payload prior to trusted enrichment.
2. **Direct Mapper Preservation (apps/proxy/src/otlp-clickhouse.ts)**: Updated stripSuperlog to preserve the superlog.issue_fingerprint key.
3. **Collector Preservation (infra/collector/config.yaml)**: Updated the OTTL transformations to cache and restore the fingerprint before/after stripping other keys.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes untrusted `superlog.*` attributes before enrichment and preserves `superlog.issue_fingerprint` through both the direct ClickHouse path and the collector. Fixes #285 so fingerprints persist while other `superlog.*` keys are stripped.

- **Bug Fixes**
  - Proxy: Added `sanitizeSuperlog` in `ingest-fingerprints.ts` to drop untrusted `superlog.*` attrs on traces and logs before stamping fingerprints.
  - Direct mapper: Updated `stripSuperlog` in `otlp-clickhouse.ts` to keep `superlog.issue_fingerprint`; tests adjusted to reflect preservation.
  - Collector: Added OTTL steps to stash and restore `superlog.issue_fingerprint` around key stripping and remove the temp key.

<sup>Written for commit aab9e20979c97b9f2575f1590e905df427e87b02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

