### PR TITLE
Fit three incidents in the active-incidents home widget, with an animated scroll shadow

### DIFF
--- a/apps/api/src/dashboards-service.ts
+++ b/apps/api/src/dashboards-service.ts
@@ -77,7 +77,7 @@ export function defaultWidgetLayout(type: DashboardWidgetType): DashboardWidgetL
     case "setup_todos":
       return { x: 0, y: 0, w: 12, h: 5 };
     case "active_incidents":
-      return { x: 0, y: 5, w: 6, h: 3 };
+      return { x: 0, y: 5, w: 6, h: 5 };
     case "service_map":
       return { x: 6, y: 5, w: 6, h: 8 };
     case "incoming_signals":

--- a/apps/web/src/home/HomeDashboard.tsx
+++ b/apps/web/src/home/HomeDashboard.tsx
@@ -326,6 +326,12 @@ function HomeItemTile({
 }) {
   const presentation = homeWidgetPresentation(widget.type);
   const { scrollRef, edges } = useScrollEdges<HTMLDivElement>();
+  // The edge shadow only belongs on widgets that scroll in this outer body — the
+  // builtin list widgets (active_incidents et al.). Framed widgets (trace/log
+  // tables, markdown, charts) own their scrolling via an inner overflow-auto, so
+  // the outer element never scrolls; attaching the shadow there would leave dead
+  // overlays over a container that never moves.
+  const showScrollShadow = !presentation.innerShell;
   return (
     <section
       className={`flex h-full flex-col overflow-hidden rounded-xl border bg-surface ${
@@ -370,23 +376,27 @@ function HomeItemTile({
       </div>
       <div className="relative min-h-0 flex-1">
         <div
-          ref={scrollRef}
+          ref={showScrollShadow ? scrollRef : undefined}
           className={`h-full overflow-auto ${presentation.bodyPadding ? "p-4" : ""}`}
         >
           <HomeItemBody projectId={projectId} slugs={slugs} range={range} widget={widget} />
         </div>
-        <div
-          aria-hidden="true"
-          className={`pointer-events-none absolute inset-x-0 top-0 h-10 bg-gradient-to-b from-black/55 to-transparent transition-opacity duration-500 ease-out ${
-            edges.top ? "opacity-100" : "opacity-0"
-          }`}
-        />
-        <div
-          aria-hidden="true"
-          className={`pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-black/55 to-transparent transition-opacity duration-500 ease-out ${
-            edges.bottom ? "opacity-100" : "opacity-0"
-          }`}
-        />
+        {showScrollShadow && (
+          <>
+            <div
+              aria-hidden="true"
+              className={`pointer-events-none absolute inset-x-0 top-0 h-10 bg-gradient-to-b from-black/55 to-transparent transition-opacity duration-500 ease-out ${
+                edges.top ? "opacity-100" : "opacity-0"
+              }`}
+            />
+            <div
+              aria-hidden="true"
+              className={`pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-black/55 to-transparent transition-opacity duration-500 ease-out ${
+                edges.bottom ? "opacity-100" : "opacity-0"
+              }`}
+            />
+          </>
+        )}
       </div>
     </section>
   );

--- a/apps/web/src/home/HomeDashboard.tsx
+++ b/apps/web/src/home/HomeDashboard.tsx
@@ -32,7 +32,12 @@ import {
   IncidentCountHomeWidget,
   IncomingSignalsHomeWidget,
 } from "./HomePulseWidgets.tsx";
-import { homeWidgetMinWidth, homeWidgetPresentation, splitHomeWidgets } from "./home-layout.ts";
+import {
+  homeWidgetMinHeight,
+  homeWidgetMinWidth,
+  homeWidgetPresentation,
+  splitHomeWidgets,
+} from "./home-layout.ts";
 
 const GRID_CONFIG = {
   cols: 12,
@@ -189,7 +194,7 @@ function HomeGrid({
         i: widget.id,
         ...widget.layout,
         minW: homeWidgetMinWidth(widget.type),
-        minH: widget.type === "link" ? 2 : 3,
+        minH: homeWidgetMinHeight(widget.type),
       })),
     [widgets],
   );
@@ -248,6 +253,36 @@ function HomeGrid({
   );
 }
 
+// Reports whether content is hidden above/below the viewport, so the tile can
+// fade its edge shadows in and out. The fade itself is a slow, eased CSS opacity
+// transition on the overlays (see below) rather than tracking scroll position, so
+// crossing an edge animates gently instead of snapping. Driven by real scroll
+// position (not a background-attachment trick, which slid with the content here)
+// and re-measured when the body resizes or its data loads in.
+function useScrollEdges<T extends HTMLElement>() {
+  const ref = useRef<T | null>(null);
+  const [edges, setEdges] = useState({ top: false, bottom: false });
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const measure = () => {
+      const top = el.scrollTop > 1;
+      const bottom = el.scrollTop + el.clientHeight < el.scrollHeight - 1;
+      setEdges((prev) => (prev.top === top && prev.bottom === bottom ? prev : { top, bottom }));
+    };
+    measure();
+    el.addEventListener("scroll", measure, { passive: true });
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    if (el.firstElementChild) observer.observe(el.firstElementChild);
+    return () => {
+      el.removeEventListener("scroll", measure);
+      observer.disconnect();
+    };
+  }, []);
+  return { ref, edges };
+}
+
 function HomeItemTile({
   projectId,
   slugs,
@@ -264,6 +299,7 @@ function HomeItemTile({
   onRemove: () => void;
 }) {
   const presentation = homeWidgetPresentation(widget.type);
+  const { ref: scrollRef, edges } = useScrollEdges<HTMLDivElement>();
   return (
     <section
       className={`flex h-full flex-col overflow-hidden rounded-xl border bg-surface ${
@@ -306,8 +342,25 @@ function HomeItemTile({
           </button>
         )}
       </div>
-      <div className={`min-h-0 flex-1 overflow-auto ${presentation.bodyPadding ? "p-4" : ""}`}>
-        <HomeItemBody projectId={projectId} slugs={slugs} range={range} widget={widget} />
+      <div className="relative min-h-0 flex-1">
+        <div
+          ref={scrollRef}
+          className={`h-full overflow-auto ${presentation.bodyPadding ? "p-4" : ""}`}
+        >
+          <HomeItemBody projectId={projectId} slugs={slugs} range={range} widget={widget} />
+        </div>
+        <div
+          aria-hidden="true"
+          className={`pointer-events-none absolute inset-x-0 top-0 h-10 bg-gradient-to-b from-black/55 to-transparent transition-opacity duration-500 ease-out ${
+            edges.top ? "opacity-100" : "opacity-0"
+          }`}
+        />
+        <div
+          aria-hidden="true"
+          className={`pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-black/55 to-transparent transition-opacity duration-500 ease-out ${
+            edges.bottom ? "opacity-100" : "opacity-0"
+          }`}
+        />
       </div>
     </section>
   );

--- a/apps/web/src/home/HomeDashboard.tsx
+++ b/apps/web/src/home/HomeDashboard.tsx
@@ -267,9 +267,8 @@ function HomeGrid({
 // crossing an edge animates gently instead of snapping. Driven by real scroll
 // position (not a background-attachment trick, which slid with the content here)
 // and re-measured when the body resizes or its data loads in.
-function useScrollEdges<S extends HTMLElement, C extends HTMLElement>() {
+function useScrollEdges<S extends HTMLElement>() {
   const scrollRef = useRef<S | null>(null);
-  const contentRef = useRef<C | null>(null);
   const [edges, setEdges] = useState({ top: false, bottom: false });
   useEffect(() => {
     const el = scrollRef.current;
@@ -281,19 +280,33 @@ function useScrollEdges<S extends HTMLElement, C extends HTMLElement>() {
     };
     measure();
     el.addEventListener("scroll", measure, { passive: true });
+    // The fixed-height scroll container doesn't resize when its content's
+    // scrollHeight grows, so watch the content node too. It's observed directly
+    // (no layout wrapper — that would break widgets whose body relies on h-full).
+    // An async widget can swap that node when it goes from loading to loaded, so a
+    // MutationObserver re-points the ResizeObserver to the live child and
+    // re-measures, keeping the overflow shadow correct on load.
     const observer = new ResizeObserver(measure);
     observer.observe(el);
-    // Observe a stable content wrapper (not el.firstElementChild) so the observer
-    // survives an async widget swapping its loading node for loaded content — the
-    // fixed-height scroll container itself doesn't resize when scrollHeight grows,
-    // so this is what re-fires measure and reveals the overflow shadow on load.
-    if (contentRef.current) observer.observe(contentRef.current);
+    let child = el.firstElementChild;
+    if (child) observer.observe(child);
+    const mutations = new MutationObserver(() => {
+      const next = el.firstElementChild;
+      if (next !== child) {
+        if (child) observer.unobserve(child);
+        if (next) observer.observe(next);
+        child = next;
+      }
+      measure();
+    });
+    mutations.observe(el, { childList: true });
     return () => {
       el.removeEventListener("scroll", measure);
       observer.disconnect();
+      mutations.disconnect();
     };
   }, []);
-  return { scrollRef, contentRef, edges };
+  return { scrollRef, edges };
 }
 
 function HomeItemTile({
@@ -312,7 +325,7 @@ function HomeItemTile({
   onRemove: () => void;
 }) {
   const presentation = homeWidgetPresentation(widget.type);
-  const { scrollRef, contentRef, edges } = useScrollEdges<HTMLDivElement, HTMLDivElement>();
+  const { scrollRef, edges } = useScrollEdges<HTMLDivElement>();
   return (
     <section
       className={`flex h-full flex-col overflow-hidden rounded-xl border bg-surface ${
@@ -360,9 +373,7 @@ function HomeItemTile({
           ref={scrollRef}
           className={`h-full overflow-auto ${presentation.bodyPadding ? "p-4" : ""}`}
         >
-          <div ref={contentRef}>
-            <HomeItemBody projectId={projectId} slugs={slugs} range={range} widget={widget} />
-          </div>
+          <HomeItemBody projectId={projectId} slugs={slugs} range={range} widget={widget} />
         </div>
         <div
           aria-hidden="true"

--- a/apps/web/src/home/HomeDashboard.tsx
+++ b/apps/web/src/home/HomeDashboard.tsx
@@ -190,12 +190,20 @@ function HomeGrid({
 
   const layout: Layout = useMemo(
     () =>
-      widgets.map((widget) => ({
-        i: widget.id,
-        ...widget.layout,
-        minW: homeWidgetMinWidth(widget.type),
-        minH: homeWidgetMinHeight(widget.type),
-      })),
+      widgets.map((widget) => {
+        const minH = homeWidgetMinHeight(widget.type);
+        return {
+          i: widget.id,
+          ...widget.layout,
+          // minH only constrains interactive resizing — it does not enlarge an
+          // already-persisted item. Widgets saved before a min bump (e.g. an
+          // active_incidents that stored h:3) would still render clipped, so
+          // clamp the rendered height up to the current minimum.
+          h: Math.max(widget.layout.h, minH),
+          minW: homeWidgetMinWidth(widget.type),
+          minH,
+        };
+      }),
     [widgets],
   );
 
@@ -259,11 +267,12 @@ function HomeGrid({
 // crossing an edge animates gently instead of snapping. Driven by real scroll
 // position (not a background-attachment trick, which slid with the content here)
 // and re-measured when the body resizes or its data loads in.
-function useScrollEdges<T extends HTMLElement>() {
-  const ref = useRef<T | null>(null);
+function useScrollEdges<S extends HTMLElement, C extends HTMLElement>() {
+  const scrollRef = useRef<S | null>(null);
+  const contentRef = useRef<C | null>(null);
   const [edges, setEdges] = useState({ top: false, bottom: false });
   useEffect(() => {
-    const el = ref.current;
+    const el = scrollRef.current;
     if (!el) return;
     const measure = () => {
       const top = el.scrollTop > 1;
@@ -274,13 +283,17 @@ function useScrollEdges<T extends HTMLElement>() {
     el.addEventListener("scroll", measure, { passive: true });
     const observer = new ResizeObserver(measure);
     observer.observe(el);
-    if (el.firstElementChild) observer.observe(el.firstElementChild);
+    // Observe a stable content wrapper (not el.firstElementChild) so the observer
+    // survives an async widget swapping its loading node for loaded content — the
+    // fixed-height scroll container itself doesn't resize when scrollHeight grows,
+    // so this is what re-fires measure and reveals the overflow shadow on load.
+    if (contentRef.current) observer.observe(contentRef.current);
     return () => {
       el.removeEventListener("scroll", measure);
       observer.disconnect();
     };
   }, []);
-  return { ref, edges };
+  return { scrollRef, contentRef, edges };
 }
 
 function HomeItemTile({
@@ -299,7 +312,7 @@ function HomeItemTile({
   onRemove: () => void;
 }) {
   const presentation = homeWidgetPresentation(widget.type);
-  const { ref: scrollRef, edges } = useScrollEdges<HTMLDivElement>();
+  const { scrollRef, contentRef, edges } = useScrollEdges<HTMLDivElement, HTMLDivElement>();
   return (
     <section
       className={`flex h-full flex-col overflow-hidden rounded-xl border bg-surface ${
@@ -347,7 +360,9 @@ function HomeItemTile({
           ref={scrollRef}
           className={`h-full overflow-auto ${presentation.bodyPadding ? "p-4" : ""}`}
         >
-          <HomeItemBody projectId={projectId} slugs={slugs} range={range} widget={widget} />
+          <div ref={contentRef}>
+            <HomeItemBody projectId={projectId} slugs={slugs} range={range} widget={widget} />
+          </div>
         </div>
         <div
           aria-hidden="true"

--- a/apps/web/src/home/home-layout.test.ts
+++ b/apps/web/src/home/home-layout.test.ts
@@ -1,13 +1,23 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { homeWidgetPresentation, splitHomeWidgets } from "./home-layout.ts";
+import {
+  homeWidgetMinHeight,
+  homeWidgetPresentation,
+  splitHomeWidgets,
+} from "./home-layout.ts";
 
 test("active incidents use the home tile as their only shell", () => {
   const presentation = homeWidgetPresentation("active_incidents");
 
   assert.equal(presentation.bodyPadding, false);
   assert.equal(presentation.innerShell, false);
-  assert.equal(presentation.defaultHeight, 3);
+  assert.equal(presentation.defaultHeight, 5);
+});
+
+test("active incidents floor at five rows so three incidents show before scrolling", () => {
+  assert.equal(homeWidgetMinHeight("active_incidents"), 5);
+  assert.equal(homeWidgetMinHeight("link"), 2);
+  assert.equal(homeWidgetMinHeight("incoming_signals"), 3);
 });
 
 test("setup stays outside the framed home widget grid", () => {

--- a/apps/web/src/home/home-layout.ts
+++ b/apps/web/src/home/home-layout.ts
@@ -15,8 +15,10 @@ export function homeWidgetPresentation(type: string): {
   innerShell: boolean;
   defaultHeight: number | undefined;
 } {
+  if (type === "active_incidents") {
+    return { bodyPadding: false, innerShell: false, defaultHeight: 5 };
+  }
   if (
-    type === "active_incidents" ||
     type === "incoming_signals" ||
     type === "incident_count" ||
     type === "agent_pull_requests"
@@ -32,5 +34,15 @@ export function homeWidgetMinWidth(type: string): number {
     return 4;
   }
   if (type === "setup_todos" || type === "active_incidents" || type === "service_map") return 6;
+  return 3;
+}
+
+// Minimum grid-row height per widget. The incident list packs ~84px per row plus
+// a 44px header, so a 3-row default (~200px) clipped the second incident. Floor
+// active_incidents at 5 rows (~344px) so at least three incidents show before the
+// body scrolls; other widgets keep the generic 3-row minimum (links 2).
+export function homeWidgetMinHeight(type: string): number {
+  if (type === "link") return 2;
+  if (type === "active_incidents") return 5;
   return 3;
 }


### PR DESCRIPTION
## What

The **Active critical incidents** home widget was seeded at 3 grid rows (~200px), which only fits ~1.5 incident rows. The second incident clipped mid-content with no signal that the list scrolled.

## Changes

- **Height** — raise the widget's seed layout height and add `homeWidgetMinHeight`, flooring `active_incidents` at 5 grid rows so at least three incidents are visible before the body scrolls. 5 rows also matches the pulse widgets sharing its row band.
- **Scroll shadow** — add edge fades to the shared home-widget body. A small `useScrollEdges` hook reads the real scroll position (re-measuring on resize and when data loads in via `ResizeObserver`) and fades top/bottom gradient overlays in/out with a slow eased opacity transition, only on the side that has more content. Overlays are `pointer-events-none` and driven by scroll state rather than a `background-attachment` trick (which slid with the content).

## Testing

- `pnpm --filter @superlog/web typecheck` and `pnpm --filter @superlog/api typecheck` clean.
- `home-layout` unit tests updated/added and passing.
- Verified in a running stack with 10 seeded active incidents: three show, the rest scroll, and the fades ease in/out at the edges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show at least three incidents in the Active critical incidents widget and add animated scroll-edge shadows that track real scroll. Shadows apply only to list widgets, stay accurate on resize/async loads, and don’t affect layout.

- **New Features**
  - `active_incidents` height: default and floor at 5 grid rows so three incidents show before scroll; clamp rendered `h` up to `homeWidgetMinHeight` to fix existing dashboards (links 2, others 3).
  - Scroll shadows: top/bottom fades via a `useScrollEdges` hook that reads real scroll and observes the container + live content; a `MutationObserver` re-points after async swaps; smooth opacity, no pointer events.

- **Bug Fixes**
  - Scoped edge shadows to widgets that scroll the outer body (builtin list widgets) so framed widgets with inner scrolling don’t show dead overlays.
  - Removed an unsized wrapper that shrank `h-full` widget bodies; the observer now attaches to the scroll container and re-points to its current child to preserve layout.

<sup>Written for commit e9c71104dfaf3bd60069a2243633f10fd7c704aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

