### PR TITLE
Enforce read-only MCP token scopes

### DIFF
--- a/apps/api/src/mcp/agent-config.ts
+++ b/apps/api/src/mcp/agent-config.ts
@@ -35,6 +35,7 @@ import {
 import { parseProjectMcpServerAuthInput } from "../project-mcp-servers.js";
 import { testProjectMcpServerConnection } from "../project-mcp-test.js";
 import { previewIssueFilterMatches } from "./clickhouse.js";
+import { READ_ONLY_TOOL } from "./scope-authorization.js";
 
 const projectIdSchema = z
   .string()
@@ -146,6 +147,7 @@ export function registerAgentConfigTools(
       title: "List agent MCP servers",
       description:
         "List the custom MCP servers available to new investigation and Slack-agent sessions for this project. Credentials are always redacted.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: { project_id: projectIdSchema },
     },
     async (input) => {
@@ -340,6 +342,7 @@ export function registerAgentConfigTools(
       title: "Get issue filter",
       description:
         "Read the project's issue filter: per-kind include/exclude attribute clauses that decide which ERROR events become issues/incidents. Excludes win; a non-empty include list means an event must match at least one clause.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: { project_id: projectIdSchema },
     },
     async (input) => {
@@ -389,6 +392,7 @@ export function registerAgentConfigTools(
       title: "Preview issue filter",
       description:
         "Preview which recent ERROR events (last 24h) would still become issues under a candidate filter, WITHOUT saving. Buckets you pass are merged over the project's current filter (same semantics as update_issue_filter); omit all buckets to preview the current saved filter. Returns sample matching events.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: {
         project_id: projectIdSchema,
         includeLogs: clauseListSchema.optional(),
@@ -428,6 +432,7 @@ export function registerAgentConfigTools(
       title: "Get project context",
       description:
         "Read the project's freeform context — the human-written description of the system (architecture, conventions, key services) that the investigation agent reads on every run.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: { project_id: projectIdSchema },
     },
     async (input) => {
@@ -466,6 +471,7 @@ export function registerAgentConfigTools(
       title: "List agent memories",
       description:
         "List the investigation agent's stored memories for the project — durable learnings (feedback, terminology, infra, project facts) that are injected into future investigations.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: { project_id: projectIdSchema },
     },
     async (input) => {

--- a/apps/api/src/mcp/alerts.ts
+++ b/apps/api/src/mcp/alerts.ts
@@ -18,6 +18,7 @@ import {
   updateAlertRecord,
 } from "../alerts-service.js";
 import { assertProjectAccess } from "./projects.js";
+import { READ_ONLY_TOOL } from "./scope-authorization.js";
 
 const projectIdSchema = z
   .string()
@@ -139,6 +140,7 @@ export function registerAlertTools(
     {
       title: "List alerts",
       description: "List all alerts in the active project (or the project_id you pass).",
+      annotations: READ_ONLY_TOOL,
       inputSchema: { project_id: projectIdSchema },
     },
     async (input) => text(await listAlertsForProject(await resolve(input.project_id))),
@@ -149,6 +151,7 @@ export function registerAlertTools(
     {
       title: "Get alert",
       description: "Fetch a single alert plus its 50 most recent firings.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: { project_id: projectIdSchema, id: alertIdSchema },
     },
     async (input) => {
@@ -225,6 +228,7 @@ export function registerAlertTools(
       title: "Preview alert",
       description:
         "Evaluate a draft alert spec against current data without saving. Returns whether it would breach right now.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: { project_id: projectIdSchema, ...alertInputShape },
     },
     async (input) => {
@@ -238,6 +242,7 @@ export function registerAlertTools(
     {
       title: "Test alert",
       description: "Re-evaluate a saved alert against current data and return the result.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: { project_id: projectIdSchema, id: alertIdSchema },
     },
     async (input) => {

--- a/apps/api/src/mcp/analytics.test.ts
+++ b/apps/api/src/mcp/analytics.test.ts
@@ -95,6 +95,7 @@ test("tool calls emit mcp_tool_called with user + org context", async () => {
     tokenId: "tok-analytics-1",
     tokenKind: "pat",
     activeProjectId: project.id,
+    scopes: [],
   });
 
   const result = await client.callTool({ name: "list_projects", arguments: {} });
@@ -123,6 +124,7 @@ test("failed tool calls emit mcp_tool_called with success=false and the error", 
     tokenId: "tok-analytics-2",
     tokenKind: "oauth",
     activeProjectId: outsideProject,
+    scopes: [],
   });
 
   const result = await client.callTool({ name: "get_active_project", arguments: {} });
@@ -155,6 +157,7 @@ test("org context is omitted for projects the user is not a member of", async ()
     tokenId: "tok-analytics-3",
     tokenKind: "pat",
     activeProjectId: other.project.id,
+    scopes: [],
   });
 
   const failed = await client.callTool({
@@ -186,6 +189,7 @@ test("isError results carry the error text without a throw", async () => {
     tokenId: "tok-analytics-4",
     tokenKind: "pat",
     activeProjectId: project.id,
+    scopes: [],
   });
   server.registerTool("soft_fail", { inputSchema: {} }, async () => ({
     content: [{ type: "text" as const, text: "budget exceeded" }],

--- a/apps/api/src/mcp/dashboards.ts
+++ b/apps/api/src/mcp/dashboards.ts
@@ -25,6 +25,7 @@ import {
   updateHomeLayout,
 } from "../dashboards-service.js";
 import { assertProjectAccess } from "./projects.js";
+import { READ_ONLY_TOOL } from "./scope-authorization.js";
 
 const projectIdSchema = z
   .string()
@@ -194,6 +195,7 @@ export function registerDashboardTools(
     {
       title: "List dashboards",
       description: "List dashboards in the active project (or project_id).",
+      annotations: READ_ONLY_TOOL,
       inputSchema: { project_id: projectIdSchema },
     },
     async (input) => text(await listDashboardsForProject(await resolve(input.project_id))),
@@ -204,6 +206,7 @@ export function registerDashboardTools(
     {
       title: "Get dashboard",
       description: "Fetch a dashboard with its widgets.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: { project_id: projectIdSchema, id: z.string().uuid() },
     },
     async (input) => {

--- a/apps/api/src/mcp/incidents.ts
+++ b/apps/api/src/mcp/incidents.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { getIncidentDetail } from "../incidents/detail.js";
 import { searchIncidents } from "../incidents/search.js";
 import { assertProjectAccess } from "./projects.js";
+import { READ_ONLY_TOOL } from "./scope-authorization.js";
 
 const projectIdSchema = z
   .string()
@@ -51,6 +52,7 @@ export function registerIncidentTools(
         "Fetch one incident by its id — the uuid at the end of a superlog.sh/app/org/<org>/project/<project>/incidents/<id> link — and everything needed to explain it. " +
         "No project_id is required; the project is resolved from the incident. Returns: the incident summary with the agent's findings (root_cause_text, agent_summary, estimated_impact_text) and its project_id; every linked issue with a stored telemetry `sample` (trace_id, span_id, stacktrace, span/log/resource attributes); and a pointer to the latest investigation run. " +
         "To pull live telemetry, take a sample's trace_id and call query_traces, or filter query_logs/query_traces by the issue's service + exception type — passing the returned project_id.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: {
         incident_id: z.string().uuid().describe("Incident id (the uuid from the incident URL)."),
       },
@@ -73,6 +75,7 @@ export function registerIncidentTools(
         "Filter by status, severity, service, a free-text substring over title/codename, and a last_seen time window. Results are newest-activity-first. " +
         "By default agent-classified noise (status='autoresolved_noise') is hidden; pass status='all' to include it or status='autoresolved_noise' to inspect just the noise pile. " +
         "Use get_incident to drill into a single incident's linked issues and telemetry.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: {
         project_id: projectIdSchema,
         status: z

--- a/apps/api/src/mcp/index.ts
+++ b/apps/api/src/mcp/index.ts
@@ -13,6 +13,7 @@ import type { Hono } from "hono";
 import { logger } from "../logger.js";
 import { type McpConfig, loadMcpConfig } from "./config.js";
 import { mountOauthDecision, mountOauthEndpoints, mountOauthMetadata } from "./oauth.js";
+import { resolveMcpOauthScope } from "./scope-authorization.js";
 import { createMcpServerForSession } from "./server.js";
 
 const log = logger.child({ scope: "mcp-bearer" });
@@ -66,6 +67,7 @@ export function mountMcpPublic<T extends Hono<any, any, any>>(app: T, ch: ClickH
       activeProjectId: tokenCtx.projectId,
       allowedOrgId: tokenCtx.allowedOrgId,
       telemetryOnly: tokenCtx.telemetryOnly,
+      scopes: tokenCtx.scope?.split(/\s+/).filter(Boolean) ?? [],
     });
     // handleRequest returns immediately with a Response wrapping a ReadableStream
     // (Content-Type: text/event-stream). The server writes JSON-RPC responses
@@ -116,13 +118,15 @@ async function resolveToken(
   if (stored !== cfg.resource && stored !== cfg.apiBaseUrl) {
     return { reason: `resource mismatch (stored=${row.resource})` };
   }
+  const resolvedScope = resolveMcpOauthScope(row.scope);
+  if ("error" in resolvedScope) return { reason: resolvedScope.error };
   return {
     tokenId: row.id,
     tokenKind: "oauth",
     projectId: row.projectId,
     userId: row.userId,
     clientId: row.clientId,
-    scope: row.scope,
+    scope: resolvedScope.scope,
     resource: row.resource,
     allowedOrgId: parseOrgScope(row.scope),
     telemetryOnly: hasScopePart(row.scope, "superlog:telemetry"),

--- a/apps/api/src/mcp/oauth.ts
+++ b/apps/api/src/mcp/oauth.ts
@@ -14,6 +14,7 @@ import { HTTPException } from "hono/http-exception";
 import { logger } from "../logger.js";
 import { resolveActiveOrgContext } from "../org-context.js";
 import type { McpConfig } from "./config.js";
+import { resolveMcpOauthScope } from "./scope-authorization.js";
 
 const log = logger.child({ scope: "mcp-oauth" });
 
@@ -417,6 +418,11 @@ async function validateAuthorizeParams(
   if (!params.codeChallenge) {
     return { code: "invalid_request", description: "code_challenge is required" };
   }
+  const resolvedScope = resolveMcpOauthScope(params.scope);
+  if ("error" in resolvedScope) {
+    return { code: "invalid_scope", description: resolvedScope.error };
+  }
+  params.scope = resolvedScope.scope;
   const matched = pickMatchingResource(params.receivedResources, cfg);
   if (!matched) {
     return {

--- a/apps/api/src/mcp/scope-authorization.test.ts
+++ b/apps/api/src/mcp/scope-authorization.test.ts
@@ -1,0 +1,94 @@
+import "../project-mcp-test-env.js";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ClickHouseClient } from "@clickhouse/client";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { resolveMcpOauthScope } from "./scope-authorization.js";
+import { createMcpServerForSession } from "./server.js";
+
+const fakeCh = {} as ClickHouseClient;
+
+async function connectedClient(
+  session: Parameters<typeof createMcpServerForSession>[0],
+): Promise<Client> {
+  const server = createMcpServerForSession({
+    ...session,
+    ch: fakeCh,
+  });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "scope-test-client", version: "0.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+const session = {
+  ch: fakeCh,
+  userId: "00000000-0000-4000-8000-000000000001",
+  tokenId: "scope-test-token",
+  tokenKind: "oauth" as const,
+  activeProjectId: "00000000-0000-4000-8000-000000000002",
+};
+
+test("OAuth defaults to mcp:read and rejects unsupported scopes", () => {
+  assert.deepEqual(resolveMcpOauthScope(null), { scope: "mcp:read" });
+  assert.deepEqual(resolveMcpOauthScope("  mcp:read   mcp:write  "), {
+    error: "unsupported MCP scope: mcp:write",
+  });
+});
+
+test("mcp:read sessions expose reads but not writes or deletes", async () => {
+  const client = await connectedClient({ ...session, scopes: ["mcp:read"] });
+  const tools = await client.listTools();
+  const names = tools.tools.map((tool) => tool.name).sort();
+
+  assert.deepEqual(names, [
+    "get_active_project",
+    "get_alert",
+    "get_dashboard",
+    "get_incident",
+    "get_issue_filter",
+    "get_project_context",
+    "list_agent_mcp_servers",
+    "list_agent_memories",
+    "list_alerts",
+    "list_dashboards",
+    "list_projects",
+    "list_services",
+    "preview_alert",
+    "preview_issue_filter",
+    "query_logs",
+    "query_metrics",
+    "query_traces",
+    "search_incidents",
+    "test_alert",
+  ]);
+});
+
+test("mcp:read sessions reject direct calls to mutation tools", async () => {
+  const client = await connectedClient({ ...session, scopes: ["mcp:read"] });
+
+  const result = await client.callTool({
+    name: "delete_agent_memory",
+    arguments: {
+      id: "00000000-0000-4000-8000-000000000003",
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.match(JSON.stringify(result.content), /not found/i);
+});
+
+test("unscoped personal tokens retain full MCP tool access", async () => {
+  const client = await connectedClient({
+    ...session,
+    tokenKind: "pat",
+    scopes: [],
+  });
+  const tools = await client.listTools();
+  const names = tools.tools.map((tool) => tool.name);
+
+  assert.ok(names.includes("query_logs"));
+  assert.ok(names.includes("create_agent_memory"));
+  assert.ok(names.includes("delete_agent_memory"));
+});

--- a/apps/api/src/mcp/scope-authorization.ts
+++ b/apps/api/src/mcp/scope-authorization.ts
@@ -1,0 +1,46 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+type AnyToolHandler = (...args: unknown[]) => unknown;
+type ToolConfig = {
+  annotations?: { readOnlyHint?: boolean };
+};
+type AnyRegisterTool = (name: string, config: ToolConfig, handler: AnyToolHandler) => unknown;
+
+export const READ_ONLY_TOOL = {
+  readOnlyHint: true,
+} as const;
+
+const MCP_READ_SCOPE = "mcp:read";
+
+export function resolveMcpOauthScope(
+  requestedScope: string | null,
+): { scope: typeof MCP_READ_SCOPE } | { error: string } {
+  const requested = requestedScope?.split(/\s+/).filter(Boolean) ?? [];
+  const unsupported = [...new Set(requested.filter((scope) => scope !== MCP_READ_SCOPE))];
+  if (unsupported.length > 0) {
+    return {
+      error: `unsupported MCP scope${unsupported.length === 1 ? "" : "s"}: ${unsupported.join(", ")}`,
+    };
+  }
+  return { scope: MCP_READ_SCOPE };
+}
+
+/**
+ * Restrict an `mcp:read` session to tools explicitly classified as read-only.
+ *
+ * The default is intentionally deny: a newly added tool is unavailable to
+ * read-scoped tokens until its registration opts in with READ_ONLY_TOOL.
+ */
+export function enforceMcpToolScopes(server: McpServer, scopes: readonly string[]): void {
+  if (!scopes.includes(MCP_READ_SCOPE)) return;
+
+  const original = (server.registerTool as AnyRegisterTool).bind(server);
+  (server as unknown as { registerTool: AnyRegisterTool }).registerTool = (
+    name,
+    config,
+    handler,
+  ) => {
+    if (config.annotations?.readOnlyHint !== true) return undefined;
+    return original(name, config, handler);
+  };
+}

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -20,6 +20,7 @@ import {
   listAccessibleProjects,
   setActiveProjectForToken,
 } from "./projects.js";
+import { READ_ONLY_TOOL, enforceMcpToolScopes } from "./scope-authorization.js";
 import {
   type McpTelemetryToolName,
   executeRecoverableTelemetryQuery,
@@ -87,6 +88,7 @@ export type McpSession = {
   activeProjectId: string;
   allowedOrgId?: string;
   telemetryOnly?: boolean;
+  scopes: string[];
 };
 
 // Advisory guidance surfaced to compatible MCP clients in the initialize
@@ -115,6 +117,7 @@ export function createMcpServerForSession(session: McpSession): McpServer {
   // Before any registerTool call so every tool below (and in the register*
   // modules) emits a per-invocation analytics event.
   instrumentMcpToolAnalytics(server, session);
+  enforceMcpToolScopes(server, session.scopes);
 
   const assertTokenScope = async (projectId: string): Promise<void> => {
     if (!session.allowedOrgId) return;
@@ -174,6 +177,7 @@ export function createMcpServerForSession(session: McpSession): McpServer {
       title: "Query logs",
       description:
         "Search OpenTelemetry logs. Targets the session's active project unless project_id is given. Error rows include flattened exception_type, exception_message, and exception_stacktrace fields when present.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: {
         project_id: projectIdSchema,
         range: timeRangeSchema,
@@ -218,6 +222,7 @@ export function createMcpServerForSession(session: McpSession): McpServer {
       title: "Query traces",
       description:
         "Search OpenTelemetry spans. Targets the session's active project unless project_id is given. Spans with exception events include flattened exception_type, exception_message, and exception_stacktrace fields when present.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: {
         project_id: projectIdSchema,
         range: timeRangeSchema,
@@ -263,6 +268,7 @@ export function createMcpServerForSession(session: McpSession): McpServer {
       title: "Query metrics",
       description:
         "Fetch recent metric points across gauge, sum, explicit-histogram, exponential-histogram, and summary tables. Targets the session's active project unless project_id is given. Each point includes its data-point `attributes` (the per-series dimensions like route/status/tenant), `resource_attrs`, start time, and aggregation temporality where applicable. Gauge/sum points carry a scalar `value`; histogram/summary points carry `count` and `sum` (plus `min`/`max` for histograms) instead, since they have no scalar value.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: {
         project_id: projectIdSchema,
         metric_name: z.string().optional(),
@@ -297,6 +303,7 @@ export function createMcpServerForSession(session: McpSession): McpServer {
       title: "List services",
       description:
         "List distinct service.name values emitting telemetry in the given window.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: {
         project_id: projectIdSchema,
         range: timeRangeSchema,
@@ -320,6 +327,7 @@ export function createMcpServerForSession(session: McpSession): McpServer {
       title: "List projects",
       description:
         "List every project the authenticated user can access, across all of their orgs. The active project is marked.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: {},
     },
     async () => {
@@ -340,6 +348,7 @@ export function createMcpServerForSession(session: McpSession): McpServer {
       title: "Get active project",
       description:
         "Return the project that tools default to when project_id is omitted.",
+      annotations: READ_ONLY_TOOL,
       inputSchema: {},
     },
     async () => {

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -131,14 +131,16 @@ export function reportBrowserException(
   });
 }
 
-window.addEventListener("error", (event) => {
-  reportBrowserException(event.error ?? event.message, "window.error", {
-    "code.file": event.filename,
-    "code.line.number": event.lineno,
-    "code.column.number": event.colno,
+if (typeof window !== "undefined") {
+  window.addEventListener("error", (event) => {
+    reportBrowserException(event.error ?? event.message, "window.error", {
+      "code.file": event.filename,
+      "code.line.number": event.lineno,
+      "code.column.number": event.colno,
+    });
   });
-});
 
-window.addEventListener("unhandledrejection", (event) => {
-  reportBrowserException(event.reason, "window.unhandledrejection");
-});
+  window.addEventListener("unhandledrejection", (event) => {
+    reportBrowserException(event.reason, "window.unhandledrejection");
+  });
+}


### PR DESCRIPTION
## What changed

- enforce `mcp:read` at MCP tool registration with an explicit, fail-closed read-only classification
- hide mutation and deletion tools from read-scoped sessions and reject direct calls to them
- default missing OAuth scope requests to `mcp:read` and reject unsupported scopes
- preserve full tool access for intentionally unscoped personal access tokens

## Why

The OAuth server advertised `mcp:read`, but the granted scope was only forwarded as metadata and did not constrain the registered tool set. A read-scoped bearer token could therefore invoke persistent writes and deletes.

## Impact

OAuth MCP sessions can query telemetry and other explicitly read-only resources, but cannot mutate project configuration, dashboards, alerts, memories, or token state. Newly added tools are denied to read-scoped sessions until explicitly classified as read-only.

## Validation

- `pnpm --dir superlog --filter @superlog/api test` — 604 passed
- `pnpm --dir superlog --filter @superlog/api typecheck`
- `pnpm --dir superlog worktree:verify`
- focused MCP scope and analytics tests — 8 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces read-only MCP OAuth scopes so `mcp:read` sessions can query data but cannot write or delete. Read-scoped sessions only see tools explicitly marked read-only; unsupported scopes are rejected.

- **Bug Fixes**
  - Added `READ_ONLY_TOOL` and `enforceMcpToolScopes` to limit `mcp:read` sessions to explicitly read-only tools.
  - Annotated read-only tools across alerts, dashboards, incidents, telemetry, and agent config.
  - OAuth: default missing scopes to `mcp:read`; reject unsupported scopes; pass the resolved scope through `/oauth` and token resolution.
  - Read-scoped sessions hide mutation/deletion tools and reject direct calls; unscoped personal access tokens keep full access.
  - Web: guard `window` error and unhandledrejection listeners behind `typeof window !== "undefined"` to prevent crashes in non-DOM/SSR contexts.

<sup>Written for commit 07e17b53bd2b772bded95ff365fd7016f9295a04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

