### PR TITLE
Add configurable fluid hero visualization

### DIFF
--- a/apps/web/src/FluidSignalField.tsx
+++ b/apps/web/src/FluidSignalField.tsx
@@ -1,0 +1,425 @@
+import { useEffect, useRef } from "react";
+
+const VERTEX_SHADER = `#version 300 es
+precision highp float;
+
+uniform mat4 u_view;
+uniform mat4 u_projection;
+uniform vec2 u_viewport;
+uniform float u_time;
+uniform vec2 u_grid;
+uniform float u_pixel_ratio;
+uniform float u_amplitude;
+uniform float u_frequency;
+uniform float u_speed;
+uniform float u_choppiness;
+uniform float u_point_size;
+
+out float v_height;
+out float v_foam;
+out float v_fresnel;
+out float v_fade;
+
+const float WORLD_SIZE = 280.0;
+const float PI = 3.141592653589793;
+
+float oceanHeight(vec2 p) {
+  p *= u_frequency;
+  float t = u_time * u_speed;
+  float h = 0.0;
+  h += sin(dot(p, normalize(vec2( 0.12, -1.00))) * 0.074 + t * 1.10) * 4.1;
+  h += sin(dot(p, normalize(vec2(-0.48, -0.88))) * 0.105 + t * 1.31 + 1.8) * 3.0;
+  h += sin(dot(p, normalize(vec2( 0.64, -0.77))) * 0.142 + t * 1.55 + 3.4) * 2.2;
+  h += sin(dot(p, normalize(vec2(-0.86, -0.51))) * 0.184 + t * 1.86 + 0.7) * 1.55;
+  h += sin(dot(p, normalize(vec2( 0.91, -0.42))) * 0.229 + t * 2.21 + 4.2) * 1.0;
+  h += sin(dot(p, normalize(vec2( 0.31, -0.95))) * 0.284 + t * 2.62 + 2.5) * 0.68;
+  h += sin(dot(p, normalize(vec2(-0.22, -0.98))) * 0.347 + t * 3.02 + 5.1) * 0.4;
+  h += sin(dot(p, normalize(vec2( 0.73, -0.68))) * 0.421 + t * 3.46 + 1.2) * 0.24;
+  return h * u_amplitude;
+}
+
+vec2 horizontalDisplacement(vec2 p) {
+  p *= u_frequency;
+  float t = u_time * u_speed;
+  vec2 displacement = vec2(0.0);
+  vec2 d1 = normalize(vec2( 0.12, -1.00));
+  vec2 d2 = normalize(vec2(-0.48, -0.88));
+  vec2 d3 = normalize(vec2( 0.64, -0.77));
+  vec2 d4 = normalize(vec2(-0.86, -0.51));
+  displacement += d1 * cos(dot(p, d1) * 0.074 + t * 1.10) * 2.7;
+  displacement += d2 * cos(dot(p, d2) * 0.105 + t * 1.31 + 1.8) * 1.9;
+  displacement += d3 * cos(dot(p, d3) * 0.142 + t * 1.55 + 3.4) * 1.25;
+  displacement += d4 * cos(dot(p, d4) * 0.184 + t * 1.86 + 0.7) * 0.72;
+  return displacement * u_choppiness;
+}
+
+void main() {
+  float column = mod(float(gl_VertexID), u_grid.x);
+  float row = floor(float(gl_VertexID) / u_grid.x);
+  vec2 uv = vec2(column, row) / max(u_grid - 1.0, vec2(1.0));
+  vec2 base = vec2(
+    (uv.x - 0.5) * WORLD_SIZE * 2.45,
+    (uv.y - 0.5) * WORLD_SIZE
+  );
+
+  float height = oceanHeight(base);
+  float epsilon = 0.7;
+  float heightX = oceanHeight(base + vec2(epsilon, 0.0));
+  float heightZ = oceanHeight(base + vec2(0.0, epsilon));
+  vec3 normal = normalize(vec3(height - heightX, epsilon, height - heightZ));
+  vec2 chop = horizontalDisplacement(base);
+  vec3 worldPosition = vec3(base.x + chop.x, height, base.y + chop.y);
+
+  vec4 viewPosition = u_view * vec4(worldPosition, 1.0);
+  vec3 viewDirection = normalize(-viewPosition.xyz);
+  float distanceToCamera = -viewPosition.z;
+  float distanceFade = 1.0 - smoothstep(80.0, 280.0, distanceToCamera);
+  v_fade = mix(0.34, 1.0, pow(clamp(distanceFade, 0.0, 1.0), 1.35));
+
+  v_height = height;
+  v_fresnel = pow(1.0 - clamp(dot(normal, viewDirection), 0.0, 1.0), 5.0);
+  float compression = 1.0 - normal.y;
+  float highCrest = smoothstep(5.0, 10.0, height);
+  v_foam = smoothstep(0.18, 0.5, compression + highCrest * 0.24);
+
+  vec4 clipPosition = u_projection * viewPosition;
+  vec2 ndc = clipPosition.xy / clipPosition.w;
+  float aspect = u_viewport.x / max(u_viewport.y, 1.0);
+  vec2 snapped = vec2(ndc.x * aspect, ndc.y);
+  snapped = floor(snapped * 50.0) / 50.0;
+  snapped.x /= aspect;
+
+  gl_Position = vec4(snapped * clipPosition.w, clipPosition.z, clipPosition.w);
+  gl_PointSize = max(1.0, u_point_size * u_pixel_ratio);
+}
+`;
+
+const FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+
+uniform vec2 u_viewport;
+uniform float u_intensity;
+
+in float v_height;
+in float v_foam;
+in float v_fresnel;
+in float v_fade;
+
+out vec4 out_color;
+
+void main() {
+  vec2 point = gl_PointCoord - vec2(0.5);
+  if (dot(point, point) > 0.25) discard;
+
+  float crest = smoothstep(-0.5, 1.5, v_height);
+  float alpha = 0.075 + crest * 0.11 + v_fresnel * 0.065;
+  alpha = mix(alpha, 0.92, v_foam);
+
+  float shade = 0.2 + crest * 0.4 + v_fresnel * 0.16;
+  shade = mix(shade, 1.0, v_foam);
+
+  float screenY = gl_FragCoord.y / max(u_viewport.y, 1.0);
+  float verticalFade =
+    smoothstep(0.0, 0.08, screenY) *
+    (1.0 - smoothstep(0.92, 1.0, screenY));
+  float finalAlpha = clamp(alpha * v_fade * verticalFade * u_intensity, 0.0, 1.0);
+  out_color = vec4(vec3(shade), finalAlpha);
+}
+`;
+
+export type FluidSignalSettings = {
+  amplitude: number;
+  frequency: number;
+  speed: number;
+  choppiness: number;
+  pointSize: number;
+  intensity: number;
+  paused: boolean;
+};
+
+export const DEFAULT_FLUID_SIGNAL_SETTINGS: FluidSignalSettings = {
+  amplitude: 1.3,
+  frequency: 0.7,
+  speed: 0.6,
+  choppiness: 2.5,
+  pointSize: 0.75,
+  intensity: 0.9,
+  paused: false,
+};
+
+function compileShader(gl: WebGL2RenderingContext, type: number, source: string) {
+  const shader = gl.createShader(type);
+  if (!shader) throw new Error("Unable to create the hero shader.");
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    const message = gl.getShaderInfoLog(shader) ?? "Unknown shader compilation error.";
+    gl.deleteShader(shader);
+    throw new Error(message);
+  }
+  return shader;
+}
+
+function createProgram(gl: WebGL2RenderingContext) {
+  const vertex = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER);
+  const fragment = compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
+  const program = gl.createProgram();
+  if (!program) throw new Error("Unable to create the hero shader program.");
+  gl.attachShader(program, vertex);
+  gl.attachShader(program, fragment);
+  gl.linkProgram(program);
+  gl.deleteShader(vertex);
+  gl.deleteShader(fragment);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const message = gl.getProgramInfoLog(program) ?? "Unknown shader link error.";
+    gl.deleteProgram(program);
+    throw new Error(message);
+  }
+  return program;
+}
+
+function normalize([x, y, z]: [number, number, number]): [number, number, number] {
+  const length = Math.hypot(x, y, z) || 1;
+  return [x / length, y / length, z / length];
+}
+
+function cross(
+  [ax, ay, az]: [number, number, number],
+  [bx, by, bz]: [number, number, number],
+): [number, number, number] {
+  return [ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx];
+}
+
+function dot(
+  [ax, ay, az]: [number, number, number],
+  [bx, by, bz]: [number, number, number],
+) {
+  return ax * bx + ay * by + az * bz;
+}
+
+function lookAt(
+  eye: [number, number, number],
+  target: [number, number, number],
+  up: [number, number, number],
+) {
+  const z = normalize([eye[0] - target[0], eye[1] - target[1], eye[2] - target[2]]);
+  const x = normalize(cross(up, z));
+  const y = cross(z, x);
+  return new Float32Array([
+    x[0],
+    y[0],
+    z[0],
+    0,
+    x[1],
+    y[1],
+    z[1],
+    0,
+    x[2],
+    y[2],
+    z[2],
+    0,
+    -dot(x, eye),
+    -dot(y, eye),
+    -dot(z, eye),
+    1,
+  ]);
+}
+
+function perspective(fieldOfView: number, aspect: number, near: number, far: number) {
+  const scale = 1 / Math.tan(fieldOfView / 2);
+  const range = 1 / (near - far);
+  return new Float32Array([
+    scale / aspect,
+    0,
+    0,
+    0,
+    0,
+    scale,
+    0,
+    0,
+    0,
+    0,
+    (far + near) * range,
+    -1,
+    0,
+    0,
+    2 * far * near * range,
+    0,
+  ]);
+}
+
+function uniform(gl: WebGL2RenderingContext, program: WebGLProgram, name: string) {
+  const location = gl.getUniformLocation(program, name);
+  if (!location) throw new Error(`Missing hero shader uniform: ${name}`);
+  return location;
+}
+
+export function FluidSignalField({
+  className = "",
+  settings = DEFAULT_FLUID_SIGNAL_SETTINGS,
+}: {
+  className?: string;
+  settings?: FluidSignalSettings;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const settingsRef = useRef(settings);
+  const restartRef = useRef<() => void>(() => {});
+  settingsRef.current = settings;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const gl = canvas.getContext("webgl2", {
+      alpha: true,
+      antialias: false,
+      depth: false,
+      powerPreference: "high-performance",
+      premultipliedAlpha: true,
+    });
+    if (!gl) return;
+    const targetCanvas = canvas;
+    const renderingContext = gl;
+
+    let program: WebGLProgram;
+    try {
+      program = createProgram(gl);
+    } catch (error) {
+      console.warn("Unable to render the landing-page signal field.", error);
+      return;
+    }
+
+    const vertexArray = gl.createVertexArray();
+    gl.bindVertexArray(vertexArray);
+    gl.useProgram(program);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+    gl.disable(gl.DEPTH_TEST);
+
+    const viewLocation = uniform(gl, program, "u_view");
+    const projectionLocation = uniform(gl, program, "u_projection");
+    const viewportLocation = uniform(gl, program, "u_viewport");
+    const timeLocation = uniform(gl, program, "u_time");
+    const gridLocation = uniform(gl, program, "u_grid");
+    const pixelRatioLocation = uniform(gl, program, "u_pixel_ratio");
+    const amplitudeLocation = uniform(gl, program, "u_amplitude");
+    const frequencyLocation = uniform(gl, program, "u_frequency");
+    const speedLocation = uniform(gl, program, "u_speed");
+    const choppinessLocation = uniform(gl, program, "u_choppiness");
+    const pointSizeLocation = uniform(gl, program, "u_point_size");
+    const intensityLocation = uniform(gl, program, "u_intensity");
+
+    const view = lookAt([0, 92, 82], [0, -6, -28], [0, 1, 0]);
+    gl.uniformMatrix4fv(viewLocation, false, view);
+
+    let width = 1;
+    let height = 1;
+    let pixelRatio = 1;
+    let gridColumns = 416;
+    let gridRows = 240;
+    let animationFrame = 0;
+    let visible = true;
+    let reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const motionPreference = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    function resize() {
+      const bounds = targetCanvas.getBoundingClientRect();
+      width = Math.max(1, Math.round(bounds.width));
+      height = Math.max(1, Math.round(bounds.height));
+      pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+      gridColumns = width < 720 ? 224 : 416;
+      gridRows = width < 720 ? 144 : 240;
+      targetCanvas.width = Math.round(width * pixelRatio);
+      targetCanvas.height = Math.round(height * pixelRatio);
+      renderingContext.viewport(0, 0, targetCanvas.width, targetCanvas.height);
+      renderingContext.uniformMatrix4fv(
+        projectionLocation,
+        false,
+        perspective((60 * Math.PI) / 180, width / height, 0.1, 2000),
+      );
+      renderingContext.uniform2f(viewportLocation, targetCanvas.width, targetCanvas.height);
+      renderingContext.uniform2f(gridLocation, gridColumns, gridRows);
+      renderingContext.uniform1f(pixelRatioLocation, pixelRatio);
+    }
+
+    function draw(timestamp: number) {
+      const currentSettings = settingsRef.current;
+      renderingContext.clearColor(0, 0, 0, 0);
+      renderingContext.clear(renderingContext.COLOR_BUFFER_BIT);
+      renderingContext.uniform1f(timeLocation, reducedMotion ? 3.6 : timestamp / 1000);
+      renderingContext.uniform1f(amplitudeLocation, currentSettings.amplitude);
+      renderingContext.uniform1f(frequencyLocation, currentSettings.frequency);
+      renderingContext.uniform1f(speedLocation, currentSettings.speed);
+      renderingContext.uniform1f(choppinessLocation, currentSettings.choppiness);
+      renderingContext.uniform1f(pointSizeLocation, currentSettings.pointSize);
+      renderingContext.uniform1f(intensityLocation, currentSettings.intensity);
+      renderingContext.drawArrays(
+        renderingContext.POINTS,
+        0,
+        gridColumns * gridRows,
+      );
+    }
+
+    function animate(timestamp: number) {
+      draw(timestamp);
+      if (visible && !reducedMotion && !settingsRef.current.paused) {
+        animationFrame = window.requestAnimationFrame(animate);
+      }
+    }
+
+    function restart() {
+      window.cancelAnimationFrame(animationFrame);
+      if (visible && !reducedMotion && !settingsRef.current.paused) {
+        animationFrame = window.requestAnimationFrame(animate);
+      } else {
+        draw(3600);
+      }
+    }
+    restartRef.current = restart;
+
+    const resizeObserver = new ResizeObserver(() => {
+      resize();
+      restart();
+    });
+    resizeObserver.observe(targetCanvas);
+
+    const intersectionObserver = new IntersectionObserver(
+      ([entry]) => {
+        visible = entry?.isIntersecting ?? true;
+        restart();
+      },
+      { rootMargin: "120px" },
+    );
+    intersectionObserver.observe(targetCanvas);
+
+    function onMotionPreferenceChange(event: MediaQueryListEvent) {
+      reducedMotion = event.matches;
+      restart();
+    }
+    motionPreference.addEventListener("change", onMotionPreferenceChange);
+
+    resize();
+    restart();
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      resizeObserver.disconnect();
+      intersectionObserver.disconnect();
+      motionPreference.removeEventListener("change", onMotionPreferenceChange);
+      restartRef.current = () => {};
+      gl.deleteVertexArray(vertexArray);
+      gl.deleteProgram(program);
+    };
+  }, []);
+
+  useEffect(() => {
+    restartRef.current();
+  }, [settings]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className={`pointer-events-none block h-full w-full select-none ${className}`}
+    />
+  );
+}

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -2,6 +2,11 @@ import { usePostHog } from "posthog-js/react";
 import { useEffect, useRef, useState } from "react";
 import { AuthForm } from "./AuthForm.tsx";
 import { Btn, Chip, Label, Tile, Wordmark } from "./design/ui.tsx";
+import {
+  DEFAULT_FLUID_SIGNAL_SETTINGS,
+  FluidSignalField,
+  type FluidSignalSettings,
+} from "./FluidSignalField.tsx";
 import { formatStarCount } from "./githubStars.ts";
 import { INSTALL_PROMPT } from "./installPrompt.ts";
 import { LANDING_DOCS_URL, LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
@@ -31,7 +36,7 @@ export function Landing({ initialAuthMode }: { initialAuthMode?: AuthMode } = {}
       <TopNav onSignIn={openSignIn} onSignUp={openSignUp} />
 
       <main className="relative">
-        <Hero />
+        <Hero onSignUp={openSignUp} />
         <ClientLogos />
 
         <div className="mx-auto w-full max-w-[1400px] px-0 pb-24 md:px-8 xl:px-12">
@@ -193,46 +198,221 @@ function GitHubIcon() {
 // Hero
 // ---------------------------------------------------------------------------
 
-function Hero() {
-  return (
-    <section className="relative px-0 pb-8 pt-20 md:px-8 md:pt-24 xl:px-12">
-      <div className="mx-auto max-w-[1400px]">
-        <div className="px-4 text-center md:px-0">
-          <div className="mb-10 inline-flex items-center gap-2 text-[11px] font-medium text-muted md:text-[12px]">
-            <img src="/yc-logo-square.svg" alt="" aria-hidden="true" className="h-4 w-4" />
-            <span>Backed by Y Combinator</span>
-          </div>
-          <h1
-            className="mx-auto max-w-4xl text-balance text-[2.4375rem] leading-[0.98] tracking-tight text-fg md:text-[4.3125rem] lg:text-[57px]"
-            style={{ fontWeight: 450 }}
-          >
-            Observability that fixes your bugs
-          </h1>
-          <p className="mx-auto mt-4 max-w-2xl text-[13.5px] leading-relaxed text-muted md:text-[18px]">
-            Install in one prompt, get PRs in Slack
-          </p>
-        </div>
+function Hero({ onSignUp }: { onSignUp: () => void }) {
+  const [signalSettings, setSignalSettings] = useState<FluidSignalSettings>(() => ({
+    ...DEFAULT_FLUID_SIGNAL_SETTINGS,
+  }));
 
-        <div className="relative mx-auto mt-14 rounded-none md:rounded-lg">
-          <div className="absolute inset-0 overflow-hidden rounded-none md:rounded-lg">
-            <img
-              src="/hero-rocket.webp"
-              srcSet="/hero-rocket-768.webp 768w, /hero-rocket.webp 1586w"
-              sizes="(max-width: 768px) 100vw, 1400px"
-              alt=""
-              aria-hidden="true"
-              width={1586}
-              height={992}
-              fetchPriority="high"
-              decoding="async"
-              className="absolute inset-0 h-full w-full object-cover object-top"
-            />
-            <div className="absolute inset-0 bg-[linear-gradient(0deg,rgba(8,9,11,0.72),rgba(8,9,11,0.08)_64%),linear-gradient(90deg,rgba(8,9,11,0.54),rgba(8,9,11,0.06)_56%,rgba(8,9,11,0.42))]" />
+  return (
+    <section className="relative isolate overflow-hidden px-0 md:px-8 xl:px-12">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute left-1/2 top-0 -z-10 h-full w-[min(2800px,190vw)] -translate-x-1/2 overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_5%,black_95%,transparent)] [-webkit-mask-image:linear-gradient(to_right,transparent,black_5%,black_95%,transparent)]"
+      >
+        <FluidSignalField settings={signalSettings} />
+      </div>
+
+      <div className="relative mx-auto max-w-[1400px]">
+        <WaveControls settings={signalSettings} onChange={setSignalSettings} />
+
+        <div className="grid min-h-[590px] grid-cols-1 content-end gap-10 px-4 pb-16 pt-28 md:min-h-[620px] md:px-0 md:pb-20 md:pt-36 lg:grid-cols-12 lg:items-end lg:gap-6">
+          <div className="lg:col-span-6">
+            <div className="mb-8 inline-flex items-center gap-2 text-[11px] font-medium text-muted md:text-[12px]">
+              <img src="/yc-logo-square.svg" alt="" aria-hidden="true" className="h-4 w-4" />
+              <span>Backed by Y Combinator</span>
+            </div>
+            <h1
+              className="max-w-[13ch] text-balance text-[2.75rem] leading-[0.98] tracking-tight text-fg md:text-[4rem] lg:text-[68px]"
+              style={{ fontWeight: 450 }}
+            >
+              Observability that fixes your bugs
+            </h1>
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={onSignUp}
+                className="inline-flex h-11 items-center justify-center rounded-full bg-fg px-5 text-[14px] font-semibold text-bg transition-colors hover:bg-white"
+              >
+                Get started
+              </button>
+              <HeroCopyPromptButton />
+            </div>
           </div>
-          <CodingAgentWindow />
+
+          <div className="lg:col-start-8 lg:col-end-13">
+            <p className="max-w-[38ch] text-balance text-[17px] leading-relaxed text-muted md:text-[19px]">
+              Install in one prompt. Superlog investigates production telemetry and sends
+              ready-to-review fixes to Slack.
+            </p>
+          </div>
         </div>
       </div>
     </section>
+  );
+}
+
+function WaveControls({
+  settings,
+  onChange,
+}: {
+  settings: FluidSignalSettings;
+  onChange: (settings: FluidSignalSettings) => void;
+}) {
+  const [open, setOpen] = useState(true);
+
+  function update<Key extends keyof FluidSignalSettings>(
+    key: Key,
+    value: FluidSignalSettings[Key],
+  ) {
+    onChange({ ...settings, [key]: value });
+  }
+
+  return (
+    <div className="absolute right-4 top-5 z-20 md:right-0 md:top-8">
+      <button
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        aria-expanded={open}
+        className="ml-auto flex h-9 items-center gap-2 rounded-full border border-white/15 bg-bg/75 px-3.5 text-[12px] font-medium text-fg shadow-[0_12px_32px_rgba(0,0,0,0.28)] backdrop-blur-md transition-colors hover:border-white/30 hover:bg-bg/90"
+      >
+        <span aria-hidden="true" className="text-[14px] text-muted">
+          ≋
+        </span>
+        Tune waves
+      </button>
+
+      {open && (
+        <div className="mt-2 w-[min(300px,calc(100vw-2rem))] rounded-2xl border border-white/15 bg-bg/88 p-4 shadow-[0_24px_70px_rgba(0,0,0,0.5)] backdrop-blur-xl">
+          <div className="grid gap-3.5">
+            <WaveRange
+              label="Amplitude"
+              value={settings.amplitude}
+              min={0.4}
+              max={3}
+              step={0.05}
+              onChange={(value) => update("amplitude", value)}
+            />
+            <WaveRange
+              label="Wave density"
+              value={settings.frequency}
+              min={0.45}
+              max={2}
+              step={0.05}
+              onChange={(value) => update("frequency", value)}
+            />
+            <WaveRange
+              label="Speed"
+              value={settings.speed}
+              min={0.1}
+              max={1.5}
+              step={0.05}
+              onChange={(value) => update("speed", value)}
+            />
+            <WaveRange
+              label="Choppiness"
+              value={settings.choppiness}
+              min={0}
+              max={2.5}
+              step={0.05}
+              onChange={(value) => update("choppiness", value)}
+            />
+            <WaveRange
+              label="Particle size"
+              value={settings.pointSize}
+              min={0.5}
+              max={2.4}
+              step={0.05}
+              onChange={(value) => update("pointSize", value)}
+            />
+            <WaveRange
+              label="Brightness"
+              value={settings.intensity}
+              min={0.35}
+              max={2}
+              step={0.05}
+              onChange={(value) => update("intensity", value)}
+            />
+          </div>
+
+          <div className="mt-4 flex items-center gap-2 border-t border-white/10 pt-3">
+            <button
+              type="button"
+              onClick={() => update("paused", !settings.paused)}
+              className="flex h-8 flex-1 items-center justify-center rounded-full border border-white/15 bg-white/[0.04] text-[11px] font-medium text-fg transition-colors hover:border-white/30 hover:bg-white/[0.08]"
+            >
+              {settings.paused ? "Play" : "Pause"}
+            </button>
+            <button
+              type="button"
+              onClick={() => onChange({ ...DEFAULT_FLUID_SIGNAL_SETTINGS })}
+              className="flex h-8 flex-1 items-center justify-center rounded-full border border-white/15 bg-white/[0.04] text-[11px] font-medium text-muted transition-colors hover:border-white/30 hover:bg-white/[0.08] hover:text-fg"
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WaveRange({
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <label className="grid gap-1.5">
+      <span className="flex items-center justify-between gap-4 text-[11px] font-medium text-muted">
+        <span>{label}</span>
+        <span className="font-mono tabular-nums text-fg">{value.toFixed(2)}</span>
+      </span>
+      <input
+        type="range"
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        onChange={(event) => onChange(Number(event.target.value))}
+        className="h-4 w-full cursor-pointer accent-accent"
+      />
+    </label>
+  );
+}
+
+function HeroCopyPromptButton() {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(INSTALL_PROMPT);
+    } catch {
+      return;
+    }
+    setCopied(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className="inline-flex h-11 items-center justify-center rounded-full border border-white/15 bg-bg/65 px-5 text-[14px] font-medium text-fg backdrop-blur-sm transition-colors hover:border-white/30 hover:bg-bg/80"
+    >
+      {copied ? "Copied" : "Copy install prompt"}
+    </button>
   );
 }
 
@@ -303,149 +483,6 @@ function ClientLogos() {
         </div>
       </div>
     </section>
-  );
-}
-
-function CodingAgentWindow() {
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  async function copy() {
-    try {
-      await navigator.clipboard.writeText(INSTALL_PROMPT);
-    } catch {
-      return;
-    }
-    setCopied(true);
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setCopied(false), 2000);
-  }
-
-  return (
-    <div className="relative flex min-h-[520px] flex-col items-center justify-center gap-4 p-5 md:min-h-[620px] md:gap-5 md:p-8">
-      <div className="mx-auto w-full overflow-hidden rounded-2xl border border-white/10 bg-[#050608] shadow-[0_28px_100px_rgba(0,0,0,0.65)] lg:max-w-[75%]">
-        <div className="flex items-center gap-2 bg-[#050608] px-4 py-3">
-          <span className="h-2.5 w-2.5 rounded-full bg-danger" />
-          <span className="h-2.5 w-2.5 rounded-full bg-warning" />
-          <span className="h-2.5 w-2.5 rounded-full bg-success" />
-          <span className="ml-3 font-mono text-[10px] uppercase tracking-[0.2em] text-subtle">
-            coding agent
-          </span>
-        </div>
-        <div className="grid gap-4 p-4 font-mono text-[12px] leading-relaxed md:p-5 md:text-[13px]">
-          <div className="bg-[#050608] p-4">
-            <div className="mb-2 text-subtle">prompt</div>
-            <div className="flex items-center justify-between gap-3">
-              <div className="min-w-0 break-words text-fg">
-                <span className="mr-1 text-subtle" aria-hidden="true">
-                  &gt;
-                </span>
-                {INSTALL_PROMPT}
-                <span className="ml-1 inline-block h-4 w-2 translate-y-0.5 animate-pulse bg-accent" />
-              </div>
-              <button
-                type="button"
-                onClick={copy}
-                className="shrink-0 rounded-md bg-accent px-3 py-1.5 font-sans text-[11px] font-semibold uppercase tracking-[0.12em] text-accent-ink transition-[filter] hover:brightness-110"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-      <OnboardingAgenda />
-    </div>
-  );
-}
-
-function OnboardingAgenda() {
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const steps = [
-    "Map every app, service, and edge function in your repo",
-    "Install native OpenTelemetry — traces, logs, metrics — per language",
-    "Open superlog.sh in a browser to finish signup in parallel",
-    "Add spans, counters, and structured logs around critical operations",
-    "Verify the app still runs and OTLP reaches /v1/traces, /logs, /metrics",
-  ];
-
-  useEffect(() => {
-    if (!open) return;
-    function onDocClick(e: MouseEvent) {
-      if (!containerRef.current) return;
-      if (e.target instanceof Node && containerRef.current.contains(e.target)) return;
-      setOpen(false);
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") setOpen(false);
-    }
-    document.addEventListener("mousedown", onDocClick);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDocClick);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
-
-  function toggle() {
-    setOpen((prev) => !prev);
-  }
-
-  return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        onClick={toggle}
-        aria-expanded={open}
-        aria-haspopup="dialog"
-        className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-bg/70 px-4 py-2 text-[12px] font-medium text-fg shadow-[0_12px_30px_rgba(0,0,0,0.32)] backdrop-blur-md transition-colors hover:border-white/30 hover:bg-bg/85 md:text-[13px]"
-      >
-        <span
-          aria-hidden="true"
-          className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-white/30 text-[10px] font-semibold text-subtle"
-        >
-          ?
-        </span>
-        <span>What will the agent do?</span>
-        <span
-          aria-hidden="true"
-          className={`text-subtle transition-transform ${open ? "rotate-180" : ""}`}
-        >
-          ▾
-        </span>
-      </button>
-
-      {open && (
-        <div
-          role="dialog"
-          aria-label="What the agent will do"
-          className="absolute left-1/2 top-[calc(100%+10px)] z-30 w-[min(92vw,520px)] -translate-x-1/2 rounded-2xl border border-white/15 bg-bg/95 p-5 text-left shadow-[0_28px_80px_rgba(0,0,0,0.55)] backdrop-blur-md md:p-6"
-        >
-          <span
-            aria-hidden="true"
-            className="absolute -top-1.5 left-1/2 h-3 w-3 -translate-x-1/2 rotate-45 border-l border-t border-white/15 bg-bg/95"
-          />
-          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-subtle">
-            via superloglabs/skills
-          </div>
-          <ol className="grid gap-2 text-[13px] leading-relaxed text-fg md:text-[14px]">
-            {steps.map((step, i) => (
-              <li key={step} className="flex gap-3">
-                <span className="w-5 shrink-0 font-mono text-subtle" aria-hidden="true">
-                  {String(i + 1).padStart(2, "0")}
-                </span>
-                <span className="min-w-0 break-words">{step}</span>
-              </li>
-            ))}
-          </ol>
-          <p className="mt-4 text-[12px] leading-relaxed text-muted md:text-[13px]">
-            Public ingest token is inlined in the bootstrap — no env vars, no .env edits. Existing
-            vendors (Sentry, Datadog, etc.) stay in place.
-          </p>
-        </div>
-      )}
-    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- replace the static landing-page hero artwork with a responsive WebGL2 particle-wave field
- update the hero composition while preserving the signup and install-prompt actions
- add live controls for amplitude, wave density, speed, choppiness, particle size, brightness, pause, and reset
- respect reduced-motion preferences and stop rendering while the field is offscreen

## Validation

- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the landing hero with a responsive WebGL2 fluid particle-wave field and a simple “Tune waves” panel. Keeps the signup and install-prompt actions while improving visuals and performance.

- **New Features**
  - Added `FluidSignalField` WebGL2 canvas with a GPU particle wave; adaptive grid and DPR-aware sizing.
  - Live controls: amplitude, wave density, speed, choppiness, particle size, brightness; pause/play; reset.
  - Performance/accessibility: respects `prefers-reduced-motion`, stops rendering offscreen, efficient resize handling.
  - Updated `Landing` hero layout; preserved “Get started” and “Copy install prompt” CTAs.

<sup>Written for commit a4572b9da02d86900a97243c569e2d8a99693601. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

