### PR TITLE
Redesign the landing hero with animated Slack cards

### DIFF
--- a/apps/web/src/FluidSignalField.tsx
+++ b/apps/web/src/FluidSignalField.tsx
@@ -1,0 +1,424 @@
+import { useEffect, useRef } from "react";
+
+const VERTEX_SHADER = `#version 300 es
+precision highp float;
+
+uniform mat4 u_view;
+uniform mat4 u_projection;
+uniform vec2 u_viewport;
+uniform float u_time;
+uniform vec2 u_grid;
+uniform float u_pixel_ratio;
+uniform float u_amplitude;
+uniform float u_frequency;
+uniform float u_speed;
+uniform float u_choppiness;
+uniform float u_point_size;
+
+out float v_height;
+out float v_foam;
+out float v_fresnel;
+out float v_fade;
+
+const float WORLD_SIZE = 280.0;
+
+float oceanHeight(vec2 p) {
+  p *= u_frequency;
+  float t = u_time * u_speed;
+  float h = 0.0;
+  h += sin(dot(p, normalize(vec2( 0.12, -1.00))) * 0.074 + t * 1.10) * 4.1;
+  h += sin(dot(p, normalize(vec2(-0.48, -0.88))) * 0.105 + t * 1.31 + 1.8) * 3.0;
+  h += sin(dot(p, normalize(vec2( 0.64, -0.77))) * 0.142 + t * 1.55 + 3.4) * 2.2;
+  h += sin(dot(p, normalize(vec2(-0.86, -0.51))) * 0.184 + t * 1.86 + 0.7) * 1.55;
+  h += sin(dot(p, normalize(vec2( 0.91, -0.42))) * 0.229 + t * 2.21 + 4.2) * 1.0;
+  h += sin(dot(p, normalize(vec2( 0.31, -0.95))) * 0.284 + t * 2.62 + 2.5) * 0.68;
+  h += sin(dot(p, normalize(vec2(-0.22, -0.98))) * 0.347 + t * 3.02 + 5.1) * 0.4;
+  h += sin(dot(p, normalize(vec2( 0.73, -0.68))) * 0.421 + t * 3.46 + 1.2) * 0.24;
+  return h * u_amplitude;
+}
+
+vec2 horizontalDisplacement(vec2 p) {
+  p *= u_frequency;
+  float t = u_time * u_speed;
+  vec2 displacement = vec2(0.0);
+  vec2 d1 = normalize(vec2( 0.12, -1.00));
+  vec2 d2 = normalize(vec2(-0.48, -0.88));
+  vec2 d3 = normalize(vec2( 0.64, -0.77));
+  vec2 d4 = normalize(vec2(-0.86, -0.51));
+  displacement += d1 * cos(dot(p, d1) * 0.074 + t * 1.10) * 2.7;
+  displacement += d2 * cos(dot(p, d2) * 0.105 + t * 1.31 + 1.8) * 1.9;
+  displacement += d3 * cos(dot(p, d3) * 0.142 + t * 1.55 + 3.4) * 1.25;
+  displacement += d4 * cos(dot(p, d4) * 0.184 + t * 1.86 + 0.7) * 0.72;
+  return displacement * u_choppiness;
+}
+
+void main() {
+  float column = mod(float(gl_VertexID), u_grid.x);
+  float row = floor(float(gl_VertexID) / u_grid.x);
+  vec2 uv = vec2(column, row) / max(u_grid - 1.0, vec2(1.0));
+  vec2 base = vec2(
+    (uv.x - 0.5) * WORLD_SIZE * 2.45,
+    (uv.y - 0.5) * WORLD_SIZE
+  );
+
+  float height = oceanHeight(base);
+  float epsilon = 0.7;
+  float heightX = oceanHeight(base + vec2(epsilon, 0.0));
+  float heightZ = oceanHeight(base + vec2(0.0, epsilon));
+  vec3 normal = normalize(vec3(height - heightX, epsilon, height - heightZ));
+  vec2 chop = horizontalDisplacement(base);
+  vec3 worldPosition = vec3(base.x + chop.x, height, base.y + chop.y);
+
+  vec4 viewPosition = u_view * vec4(worldPosition, 1.0);
+  vec3 viewDirection = normalize(-viewPosition.xyz);
+  float distanceToCamera = -viewPosition.z;
+  float distanceFade = 1.0 - smoothstep(80.0, 280.0, distanceToCamera);
+  v_fade = mix(0.34, 1.0, pow(clamp(distanceFade, 0.0, 1.0), 1.35));
+
+  v_height = height;
+  v_fresnel = pow(1.0 - clamp(dot(normal, viewDirection), 0.0, 1.0), 5.0);
+  float compression = 1.0 - normal.y;
+  float highCrest = smoothstep(5.0, 10.0, height);
+  v_foam = smoothstep(0.18, 0.5, compression + highCrest * 0.24);
+
+  vec4 clipPosition = u_projection * viewPosition;
+  vec2 ndc = clipPosition.xy / clipPosition.w;
+  float aspect = u_viewport.x / max(u_viewport.y, 1.0);
+  vec2 snapped = vec2(ndc.x * aspect, ndc.y);
+  snapped = floor(snapped * 50.0) / 50.0;
+  snapped.x /= aspect;
+
+  gl_Position = vec4(snapped * clipPosition.w, clipPosition.z, clipPosition.w);
+  gl_PointSize = max(1.0, u_point_size * u_pixel_ratio);
+}
+`;
+
+const FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+
+uniform vec2 u_viewport;
+uniform float u_intensity;
+
+in float v_height;
+in float v_foam;
+in float v_fresnel;
+in float v_fade;
+
+out vec4 out_color;
+
+void main() {
+  vec2 point = gl_PointCoord - vec2(0.5);
+  if (dot(point, point) > 0.25) discard;
+
+  float crest = smoothstep(-0.5, 1.5, v_height);
+  float alpha = 0.075 + crest * 0.11 + v_fresnel * 0.065;
+  alpha = mix(alpha, 0.92, v_foam);
+
+  float shade = 0.2 + crest * 0.4 + v_fresnel * 0.16;
+  shade = mix(shade, 1.0, v_foam);
+
+  float screenY = gl_FragCoord.y / max(u_viewport.y, 1.0);
+  float verticalFade =
+    smoothstep(0.0, 0.08, screenY) *
+    (1.0 - smoothstep(0.92, 1.0, screenY));
+  float finalAlpha = clamp(alpha * v_fade * verticalFade * u_intensity, 0.0, 1.0);
+  out_color = vec4(vec3(shade), finalAlpha);
+}
+`;
+
+export type FluidSignalSettings = {
+  amplitude: number;
+  frequency: number;
+  speed: number;
+  choppiness: number;
+  pointSize: number;
+  intensity: number;
+  paused: boolean;
+};
+
+export const DEFAULT_FLUID_SIGNAL_SETTINGS: FluidSignalSettings = {
+  amplitude: 1.3,
+  frequency: 0.7,
+  speed: 0.6,
+  choppiness: 2.5,
+  pointSize: 0.75,
+  intensity: 0.9,
+  paused: false,
+};
+
+function compileShader(gl: WebGL2RenderingContext, type: number, source: string) {
+  const shader = gl.createShader(type);
+  if (!shader) throw new Error("Unable to create the hero shader.");
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    const message = gl.getShaderInfoLog(shader) ?? "Unknown shader compilation error.";
+    gl.deleteShader(shader);
+    throw new Error(message);
+  }
+  return shader;
+}
+
+function createProgram(gl: WebGL2RenderingContext) {
+  const vertex = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER);
+  const fragment = compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
+  const program = gl.createProgram();
+  if (!program) throw new Error("Unable to create the hero shader program.");
+  gl.attachShader(program, vertex);
+  gl.attachShader(program, fragment);
+  gl.linkProgram(program);
+  gl.deleteShader(vertex);
+  gl.deleteShader(fragment);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const message = gl.getProgramInfoLog(program) ?? "Unknown shader link error.";
+    gl.deleteProgram(program);
+    throw new Error(message);
+  }
+  return program;
+}
+
+function normalize([x, y, z]: [number, number, number]): [number, number, number] {
+  const length = Math.hypot(x, y, z) || 1;
+  return [x / length, y / length, z / length];
+}
+
+function cross(
+  [ax, ay, az]: [number, number, number],
+  [bx, by, bz]: [number, number, number],
+): [number, number, number] {
+  return [ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx];
+}
+
+function dot(
+  [ax, ay, az]: [number, number, number],
+  [bx, by, bz]: [number, number, number],
+) {
+  return ax * bx + ay * by + az * bz;
+}
+
+function lookAt(
+  eye: [number, number, number],
+  target: [number, number, number],
+  up: [number, number, number],
+) {
+  const z = normalize([eye[0] - target[0], eye[1] - target[1], eye[2] - target[2]]);
+  const x = normalize(cross(up, z));
+  const y = cross(z, x);
+  return new Float32Array([
+    x[0],
+    y[0],
+    z[0],
+    0,
+    x[1],
+    y[1],
+    z[1],
+    0,
+    x[2],
+    y[2],
+    z[2],
+    0,
+    -dot(x, eye),
+    -dot(y, eye),
+    -dot(z, eye),
+    1,
+  ]);
+}
+
+function perspective(fieldOfView: number, aspect: number, near: number, far: number) {
+  const scale = 1 / Math.tan(fieldOfView / 2);
+  const range = 1 / (near - far);
+  return new Float32Array([
+    scale / aspect,
+    0,
+    0,
+    0,
+    0,
+    scale,
+    0,
+    0,
+    0,
+    0,
+    (far + near) * range,
+    -1,
+    0,
+    0,
+    2 * far * near * range,
+    0,
+  ]);
+}
+
+function uniform(gl: WebGL2RenderingContext, program: WebGLProgram, name: string) {
+  const location = gl.getUniformLocation(program, name);
+  if (!location) throw new Error(`Missing hero shader uniform: ${name}`);
+  return location;
+}
+
+export function FluidSignalField({
+  className = "",
+  settings = DEFAULT_FLUID_SIGNAL_SETTINGS,
+}: {
+  className?: string;
+  settings?: FluidSignalSettings;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const settingsRef = useRef(settings);
+  const restartRef = useRef<() => void>(() => {});
+  settingsRef.current = settings;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const gl = canvas.getContext("webgl2", {
+      alpha: true,
+      antialias: false,
+      depth: false,
+      powerPreference: "high-performance",
+      premultipliedAlpha: true,
+    });
+    if (!gl) return;
+    const targetCanvas = canvas;
+    const renderingContext = gl;
+
+    let program: WebGLProgram;
+    try {
+      program = createProgram(gl);
+    } catch (error) {
+      console.warn("Unable to render the landing-page signal field.", error);
+      return;
+    }
+
+    const vertexArray = gl.createVertexArray();
+    gl.bindVertexArray(vertexArray);
+    gl.useProgram(program);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+    gl.disable(gl.DEPTH_TEST);
+
+    const viewLocation = uniform(gl, program, "u_view");
+    const projectionLocation = uniform(gl, program, "u_projection");
+    const viewportLocation = uniform(gl, program, "u_viewport");
+    const timeLocation = uniform(gl, program, "u_time");
+    const gridLocation = uniform(gl, program, "u_grid");
+    const pixelRatioLocation = uniform(gl, program, "u_pixel_ratio");
+    const amplitudeLocation = uniform(gl, program, "u_amplitude");
+    const frequencyLocation = uniform(gl, program, "u_frequency");
+    const speedLocation = uniform(gl, program, "u_speed");
+    const choppinessLocation = uniform(gl, program, "u_choppiness");
+    const pointSizeLocation = uniform(gl, program, "u_point_size");
+    const intensityLocation = uniform(gl, program, "u_intensity");
+
+    const view = lookAt([0, 92, 82], [0, -6, -28], [0, 1, 0]);
+    gl.uniformMatrix4fv(viewLocation, false, view);
+
+    let width = 1;
+    let height = 1;
+    let pixelRatio = 1;
+    let gridColumns = 416;
+    let gridRows = 240;
+    let animationFrame = 0;
+    let visible = true;
+    let reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const motionPreference = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    function resize() {
+      const bounds = targetCanvas.getBoundingClientRect();
+      width = Math.max(1, Math.round(bounds.width));
+      height = Math.max(1, Math.round(bounds.height));
+      pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+      gridColumns = width < 720 ? 224 : 416;
+      gridRows = width < 720 ? 144 : 240;
+      targetCanvas.width = Math.round(width * pixelRatio);
+      targetCanvas.height = Math.round(height * pixelRatio);
+      renderingContext.viewport(0, 0, targetCanvas.width, targetCanvas.height);
+      renderingContext.uniformMatrix4fv(
+        projectionLocation,
+        false,
+        perspective((60 * Math.PI) / 180, width / height, 0.1, 2000),
+      );
+      renderingContext.uniform2f(viewportLocation, targetCanvas.width, targetCanvas.height);
+      renderingContext.uniform2f(gridLocation, gridColumns, gridRows);
+      renderingContext.uniform1f(pixelRatioLocation, pixelRatio);
+    }
+
+    function draw(timestamp: number) {
+      const currentSettings = settingsRef.current;
+      renderingContext.clearColor(0, 0, 0, 0);
+      renderingContext.clear(renderingContext.COLOR_BUFFER_BIT);
+      renderingContext.uniform1f(timeLocation, reducedMotion ? 3.6 : timestamp / 1000);
+      renderingContext.uniform1f(amplitudeLocation, currentSettings.amplitude);
+      renderingContext.uniform1f(frequencyLocation, currentSettings.frequency);
+      renderingContext.uniform1f(speedLocation, currentSettings.speed);
+      renderingContext.uniform1f(choppinessLocation, currentSettings.choppiness);
+      renderingContext.uniform1f(pointSizeLocation, currentSettings.pointSize);
+      renderingContext.uniform1f(intensityLocation, currentSettings.intensity);
+      renderingContext.drawArrays(
+        renderingContext.POINTS,
+        0,
+        gridColumns * gridRows,
+      );
+    }
+
+    function animate(timestamp: number) {
+      draw(timestamp);
+      if (visible && !reducedMotion && !settingsRef.current.paused) {
+        animationFrame = window.requestAnimationFrame(animate);
+      }
+    }
+
+    function restart() {
+      window.cancelAnimationFrame(animationFrame);
+      if (visible && !reducedMotion && !settingsRef.current.paused) {
+        animationFrame = window.requestAnimationFrame(animate);
+      } else {
+        draw(3600);
+      }
+    }
+    restartRef.current = restart;
+
+    const resizeObserver = new ResizeObserver(() => {
+      resize();
+      restart();
+    });
+    resizeObserver.observe(targetCanvas);
+
+    const intersectionObserver = new IntersectionObserver(
+      ([entry]) => {
+        visible = entry?.isIntersecting ?? true;
+        restart();
+      },
+      { rootMargin: "120px" },
+    );
+    intersectionObserver.observe(targetCanvas);
+
+    function onMotionPreferenceChange(event: MediaQueryListEvent) {
+      reducedMotion = event.matches;
+      restart();
+    }
+    motionPreference.addEventListener("change", onMotionPreferenceChange);
+
+    resize();
+    restart();
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      resizeObserver.disconnect();
+      intersectionObserver.disconnect();
+      motionPreference.removeEventListener("change", onMotionPreferenceChange);
+      restartRef.current = () => {};
+      gl.deleteVertexArray(vertexArray);
+      gl.deleteProgram(program);
+    };
+  }, []);
+
+  useEffect(() => {
+    restartRef.current();
+  }, [settings]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className={`pointer-events-none block h-full w-full select-none ${className}`}
+    />
+  );
+}

--- a/apps/web/src/Landing.test.ts
+++ b/apps/web/src/Landing.test.ts
@@ -67,7 +67,7 @@ test("landing renders the client-logo marquee between the hero and the first con
   const source = await readFile(new URL("./Landing.tsx", import.meta.url), "utf8");
   // The strip must sit just after the hero image and before the first text
   // section (id="install"), which is exactly where the design calls for it.
-  assert.match(source, /<Hero \/>[\s\S]*<ClientLogos \/>[\s\S]*id="install"/);
+  assert.match(source, /<Hero(?:\s[^>]*)? \/>[\s\S]*<ClientLogos \/>[\s\S]*id="install"/);
 });
 
 test("client-logo marquee is a masked, animated, duplicated track", async () => {

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -451,7 +451,7 @@ function HeroSlackMessage() {
   const [activeMessageIndex, setActiveMessageIndex] = useState(0);
   const message = HERO_SLACK_MESSAGES[activeMessageIndex] ?? HERO_SLACK_MESSAGES[0];
   const secondaryAction =
-    "inline-flex shrink-0 items-center gap-1 rounded-[4px] border border-black/30 bg-white px-[7px] py-[5px] text-[12px] font-bold leading-[17px] text-[#1d1c1d] transition-colors hover:bg-black/[0.04]";
+    "inline-flex shrink-0 items-center gap-1 rounded-[4px] border border-black/30 bg-white px-[7px] py-[5px] text-[12px] font-bold leading-[17px] text-[#1d1c1d]";
 
   return (
     <div className="landing-slack-card w-full max-w-[660px]">
@@ -510,33 +510,28 @@ function HeroSlackMessage() {
               </p>
 
               <div className="mt-auto flex flex-wrap items-center gap-1.5">
-                <button type="button" className={secondaryAction}>
-                  Open in Superlog
-                </button>
-                <button type="button" className={secondaryAction}>
-                  View PR
-                </button>
-                <button
-                  type="button"
-                  className="inline-flex shrink-0 items-center gap-1 rounded-[4px] bg-[#007a5a] px-[7px] py-[5px] text-[12px] font-bold leading-[17px] text-white transition-colors hover:bg-[#006b4f]"
+                <span className={secondaryAction}>Open in Superlog</span>
+                <span className={secondaryAction}>View PR</span>
+                <span
+                  className="inline-flex shrink-0 items-center gap-1 rounded-[4px] bg-[#007a5a] px-[7px] py-[5px] text-[12px] font-bold leading-[17px] text-white"
                 >
                   <span aria-hidden="true" className="font-['Apple_Color_Emoji'] text-[14px]">
                     🔀
                   </span>
                   Merge PR
-                </button>
-                <button type="button" className={secondaryAction}>
+                </span>
+                <span className={secondaryAction}>
                   <span aria-hidden="true" className="font-['Apple_Color_Emoji'] text-[14px]">
                     ✅
                   </span>
                   Problem resolved
-                </button>
-                <button type="button" className={secondaryAction}>
+                </span>
+                <span className={secondaryAction}>
                   <span aria-hidden="true" className="font-['Apple_Color_Emoji'] text-[14px]">
                     🔕
                   </span>
                   Not an issue
-                </button>
+                </span>
               </div>
             </div>
           </div>

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -1,7 +1,8 @@
 import { usePostHog } from "posthog-js/react";
 import { useEffect, useRef, useState } from "react";
 import { AuthForm } from "./AuthForm.tsx";
-import { Btn, Chip, Label, Tile, Wordmark } from "./design/ui.tsx";
+import { Arrow, Btn, Chip, Label, Tile, Wordmark } from "./design/ui.tsx";
+import { FluidSignalField } from "./FluidSignalField.tsx";
 import { formatStarCount } from "./githubStars.ts";
 import { INSTALL_PROMPT } from "./installPrompt.ts";
 import { LANDING_DOCS_URL, LANDING_GITHUB_REPO_URL } from "./landingLinks.ts";
@@ -31,7 +32,7 @@ export function Landing({ initialAuthMode }: { initialAuthMode?: AuthMode } = {}
       <TopNav onSignIn={openSignIn} onSignUp={openSignUp} />
 
       <main className="relative">
-        <Hero />
+        <Hero onSignUp={openSignUp} />
         <ClientLogos />
 
         <div className="mx-auto w-full max-w-[1400px] px-0 pb-24 md:px-8 xl:px-12">
@@ -132,19 +133,25 @@ export function TopNav({
       <div className="mx-auto w-full max-w-[1400px] px-4 md:px-8 xl:px-12">
         <nav className="grid grid-cols-[1fr_auto_1fr] items-center py-5">
           <div className="flex items-center justify-self-start">
-            <a href="/" aria-label="Superlog home" className="inline-flex items-center">
+            <a
+              href="/"
+              aria-label="Superlog home"
+              className="landing-nav-unblur inline-flex items-center"
+              style={{ animationDelay: "20ms" }}
+            >
               <Wordmark />
             </a>
           </div>
 
           <div className="hidden items-center gap-6 justify-self-center lg:flex">
-            {NAV_LINKS.map((link) => (
+            {NAV_LINKS.map((link, index) => (
               <a
                 key={link.href}
                 href={link.href}
                 target={link.external ? "_blank" : undefined}
                 rel={link.external ? "noreferrer" : undefined}
-                className="text-[12px] font-medium text-muted transition-colors hover:text-fg"
+                className="landing-nav-unblur text-[12px] font-medium text-muted transition-colors hover:text-fg"
+                style={{ animationDelay: `${80 + index * 55}ms` }}
               >
                 {link.label}
               </a>
@@ -164,16 +171,23 @@ export function TopNav({
               className="hidden items-center gap-1.5 text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline-flex"
             >
               <GitHubIcon />
-              <span className="tabular-nums">
+              <span className="landing-nav-unblur tabular-nums" style={{ animationDelay: "430ms" }}>
                 {stars != null ? formatStarCount(stars) : "GitHub"}
               </span>
             </a>
             <Btn variant="ghost" size="sm" onClick={onSignIn}>
-              Sign in
+              <span className="landing-nav-unblur" style={{ animationDelay: "485ms" }}>
+                Sign in
+              </span>
             </Btn>
-            <Btn variant="primary" size="sm" onClick={onSignUp}>
-              Get started
-            </Btn>
+            <span
+              className="landing-nav-unblur inline-flex"
+              style={{ animationDelay: "540ms" }}
+            >
+              <Btn variant="primary" size="sm" onClick={onSignUp}>
+                Get started
+              </Btn>
+            </span>
           </div>
         </nav>
       </div>
@@ -193,43 +207,51 @@ function GitHubIcon() {
 // Hero
 // ---------------------------------------------------------------------------
 
-function Hero() {
+function Hero({ onSignUp }: { onSignUp: () => void }) {
   return (
-    <section className="relative px-0 pb-8 pt-20 md:px-8 md:pt-24 xl:px-12">
-      <div className="mx-auto max-w-[1400px]">
-        <div className="px-4 text-center md:px-0">
-          <div className="mb-10 inline-flex items-center gap-2 text-[11px] font-medium text-muted md:text-[12px]">
+    <section className="relative overflow-hidden bg-bg px-4 md:px-8 xl:px-12">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute left-1/2 top-0 h-full w-[min(2800px,190vw)] -translate-x-1/2 overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_5%,black_95%,transparent)] [-webkit-mask-image:linear-gradient(to_right,transparent,black_5%,black_95%,transparent)]">
+          <FluidSignalField />
+        </div>
+        <div className="landing-fluid-hero-overlay absolute inset-0" />
+      </div>
+
+      <div className="relative mx-auto grid min-h-[calc(100svh-64px)] max-w-[1400px] items-center gap-10 pb-8 pt-12 md:pt-16 lg:grid-cols-[minmax(0,560px)_minmax(0,1fr)] lg:gap-[72px] lg:pb-10 lg:pt-24">
+        <div className="flex flex-col items-center text-center lg:items-start lg:text-left">
+          <div
+            className="landing-hero-unblur mb-10 inline-flex items-center gap-2 text-[11px] font-medium text-muted md:text-[12px]"
+            style={{ animationDelay: "180ms" }}
+          >
             <img src="/yc-logo-square.svg" alt="" aria-hidden="true" className="h-4 w-4" />
             <span>Backed by Y Combinator</span>
           </div>
           <h1
-            className="mx-auto max-w-4xl text-balance text-[2.4375rem] leading-[0.98] tracking-tight text-fg md:text-[4.3125rem] lg:text-[57px]"
-            style={{ fontWeight: 450 }}
+            className="landing-hero-unblur max-w-[410px] text-balance text-[2.4375rem] leading-[0.98] tracking-[-0.035em] text-fg md:text-[57px] md:leading-[56px]"
+            style={{ fontWeight: 450, animationDelay: "260ms" }}
           >
             Observability that fixes your bugs
           </h1>
-          <p className="mx-auto mt-4 max-w-2xl text-[13.5px] leading-relaxed text-muted md:text-[18px]">
+          <p
+            className="landing-hero-unblur mt-5 max-w-lg text-[13.5px] leading-relaxed text-muted md:text-[18px]"
+            style={{ animationDelay: "340ms" }}
+          >
             Install in one prompt, get PRs in Slack
           </p>
+          <div
+            className="landing-hero-unblur mt-8 flex flex-col items-center gap-3 sm:flex-row lg:items-start"
+            style={{ animationDelay: "420ms" }}
+          >
+            <Btn variant="primary" size="lg" onClick={onSignUp}>
+              Get started
+              <Arrow />
+            </Btn>
+            <HeroInstallCommand />
+          </div>
         </div>
 
-        <div className="relative mx-auto mt-14 rounded-none md:rounded-lg">
-          <div className="absolute inset-0 overflow-hidden rounded-none md:rounded-lg">
-            <img
-              src="/hero-rocket.webp"
-              srcSet="/hero-rocket-768.webp 768w, /hero-rocket.webp 1586w"
-              sizes="(max-width: 768px) 100vw, 1400px"
-              alt=""
-              aria-hidden="true"
-              width={1586}
-              height={992}
-              fetchPriority="high"
-              decoding="async"
-              className="absolute inset-0 h-full w-full object-cover object-top"
-            />
-            <div className="absolute inset-0 bg-[linear-gradient(0deg,rgba(8,9,11,0.72),rgba(8,9,11,0.08)_64%),linear-gradient(90deg,rgba(8,9,11,0.54),rgba(8,9,11,0.06)_56%,rgba(8,9,11,0.42))]" />
-          </div>
-          <CodingAgentWindow />
+        <div className="flex w-full items-center justify-center lg:justify-end">
+          <HeroSlackMessage />
         </div>
       </div>
     </section>
@@ -306,9 +328,10 @@ function ClientLogos() {
   );
 }
 
-function CodingAgentWindow() {
+function HeroInstallCommand() {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const command = "npx skills add superloglabs/skills --all";
 
   async function copy() {
     try {
@@ -322,129 +345,204 @@ function CodingAgentWindow() {
   }
 
   return (
-    <div className="relative flex min-h-[520px] flex-col items-center justify-center gap-4 p-5 md:min-h-[620px] md:gap-5 md:p-8">
-      <div className="mx-auto w-full overflow-hidden rounded-2xl border border-white/10 bg-[#050608] shadow-[0_28px_100px_rgba(0,0,0,0.65)] lg:max-w-[75%]">
-        <div className="flex items-center gap-2 bg-[#050608] px-4 py-3">
-          <span className="h-2.5 w-2.5 rounded-full bg-danger" />
-          <span className="h-2.5 w-2.5 rounded-full bg-warning" />
-          <span className="h-2.5 w-2.5 rounded-full bg-success" />
-          <span className="ml-3 font-mono text-[10px] uppercase tracking-[0.2em] text-subtle">
-            coding agent
-          </span>
-        </div>
-        <div className="grid gap-4 p-4 font-mono text-[12px] leading-relaxed md:p-5 md:text-[13px]">
-          <div className="bg-[#050608] p-4">
-            <div className="mb-2 text-subtle">prompt</div>
-            <div className="flex items-center justify-between gap-3">
-              <div className="min-w-0 break-words text-fg">
-                <span className="mr-1 text-subtle" aria-hidden="true">
-                  &gt;
+    <button
+      type="button"
+      onClick={copy}
+      aria-label={copied ? "Install command copied" : "Copy install command"}
+      className="inline-flex h-10 max-w-full items-center gap-3 rounded-md border border-border bg-surface-2 px-4 font-mono text-[12px] text-fg transition-colors hover:border-border-strong hover:bg-surface-3 md:text-[14px]"
+    >
+      <span className="text-muted" aria-hidden="true">
+        $
+      </span>
+      <code className="truncate">{command}</code>
+      {copied ? (
+        <svg
+          className="h-3.5 w-3.5 shrink-0 text-success"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="m3 8.5 3 3 7-7"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : (
+        <svg
+          className="h-3.5 w-3.5 shrink-0 text-muted"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <rect x="5.25" y="5.25" width="7.5" height="7.5" rx="1.25" stroke="currentColor" />
+          <path
+            d="M10.5 5.25V4.5A1.25 1.25 0 0 0 9.25 3.25H4.5A1.25 1.25 0 0 0 3.25 4.5v4.75A1.25 1.25 0 0 0 4.5 10.5h.75"
+            stroke="currentColor"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+const HERO_SLACK_MESSAGES = [
+  {
+    id: "review",
+    emoji: "⌛",
+    status: "Waiting on PR review",
+    title: "Onboarding advance jobs stuck up to 24h after retry exhaustion",
+    time: "10:01 AM",
+    body: (
+      <>
+        The pg-boss queue alert fired because a <SlackCode>growth.onboarding.advance</SlackCode> job
+        from July 25 08:00 was revived by the daily reconciliation on July 26 08:00, appearing 24h
+        old in the <SlackCode>oldest_pending_age_ms</SlackCode> metric and spiking the cross-queue
+        average to ~976K ms. The underlying defect is that the only recovery mechanism is the
+        once-daily <SlackCode>growth.onboarding.scan</SlackCode> cron at 8 AM UTC, so exhausted jobs
+        can be delayed by up to ~24 hours before onboarding resumes.
+      </>
+    ),
+  },
+  {
+    id: "ready",
+    emoji: "🔀",
+    status: "PR ready to merge",
+    title: "Prevent duplicate Stripe charges after worker lock timeouts",
+    time: "10:07 AM",
+    body: (
+      <>
+        Superlog traced duplicate charges to <SlackCode>billing.webhook.process</SlackCode> retrying
+        after <SlackCode>lock_timeout_ms</SlackCode> while the first attempt was still committing.
+        The PR records <SlackCode>stripe_event_id</SlackCode> before dispatch, adds an idempotency
+        guard at the application boundary, and includes a concurrency regression test. Production
+        replay now shows one charge per event.
+      </>
+    ),
+  },
+  {
+    id: "resolved",
+    emoji: "✅",
+    status: "Problem resolved",
+    title: "Checkout recovered after Stripe credential validation fix",
+    time: "10:14 AM",
+    body: (
+      <>
+        Deploy <SlackCode>api-2026.07.28.3</SlackCode> added startup validation for{" "}
+        <SlackCode>STRIPE_SECRET_KEY</SlackCode>, replaced the generic HTTP 400 with an actionable
+        configuration error, and added a health check for <SlackCode>checkout-api</SlackCode>. Error
+        rate returned to baseline within three minutes, and no failed payments remain in the current
+        window.
+      </>
+    ),
+  },
+] as const;
+
+function SlackCode({ children }: { children: string }) {
+  return (
+    <code className="whitespace-nowrap rounded-[4px] border border-[#d9d9d9] bg-[#f7f7f7] px-[5px] py-px font-mono text-[11px] not-italic leading-4 text-[#e01e5a]">
+      {children}
+    </code>
+  );
+}
+
+function HeroSlackMessage() {
+  const [activeMessageIndex, setActiveMessageIndex] = useState(0);
+  const message = HERO_SLACK_MESSAGES[activeMessageIndex] ?? HERO_SLACK_MESSAGES[0];
+  const secondaryAction =
+    "inline-flex shrink-0 items-center gap-1 rounded-[4px] border border-black/30 bg-white px-[7px] py-[5px] text-[12px] font-bold leading-[17px] text-[#1d1c1d] transition-colors hover:bg-black/[0.04]";
+
+  return (
+    <div className="landing-slack-card w-full max-w-[660px]">
+      <div className="landing-slack-float relative w-full">
+        <div
+          aria-hidden="true"
+          className="landing-slack-card-back landing-slack-card-back-two absolute inset-0 rounded-lg"
+        />
+        <div
+          aria-hidden="true"
+          className="landing-slack-card-back landing-slack-card-back-one absolute inset-0 rounded-lg"
+        />
+
+        <div
+          className="landing-slack-shuffle-card relative z-10 overflow-hidden rounded-lg border border-black/10 bg-white text-[#1d1c1d] shadow-[0_28px_90px_rgba(0,0,0,0.42)]"
+          onAnimationIteration={() =>
+            setActiveMessageIndex((index) => (index + 1) % HERO_SLACK_MESSAGES.length)
+          }
+        >
+          <div className="flex min-h-[269px] items-start gap-3.5 px-4 py-6 sm:px-5 lg:px-[26px]">
+            <div className="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-[10px] border border-black/[0.08] bg-white">
+              <img
+                src="/superlog-pictogram-dark.svg"
+                alt=""
+                aria-hidden="true"
+                className="h-[18px] w-[18px]"
+              />
+            </div>
+
+            <div className="flex min-w-0 flex-1 self-stretch flex-col">
+              <div className="flex flex-wrap items-center gap-[9px] pb-2.5">
+                <span className="text-[15px] font-bold leading-5">Superlog</span>
+                <span className="rounded-sm bg-[#eeeeee] px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-[14px] tracking-[0.04em] text-[#454245]">
+                  app
                 </span>
-                {INSTALL_PROMPT}
-                <span className="ml-1 inline-block h-4 w-2 translate-y-0.5 animate-pulse bg-accent" />
+                <span className="text-[12px] leading-4 text-[#616061]">{message.time}</span>
               </div>
-              <button
-                type="button"
-                onClick={copy}
-                className="shrink-0 rounded-md bg-accent px-3 py-1.5 font-sans text-[11px] font-semibold uppercase tracking-[0.12em] text-accent-ink transition-[filter] hover:brightness-110"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
+
+              <div className="pb-2.5">
+                <div className="flex items-center gap-[9px]">
+                  <span
+                    aria-hidden="true"
+                    className="w-4 shrink-0 font-['Apple_Color_Emoji'] text-[16px] leading-[18px]"
+                  >
+                    {message.emoji}
+                  </span>
+                  <span className="text-[16px] font-bold leading-[22px]">{message.status}</span>
+                </div>
+                <h2 className="mt-[5px] text-[14px] font-semibold leading-[21px]">
+                  {message.title}
+                </h2>
+              </div>
+
+              <p className="pb-3.5 text-[11.5px] italic leading-[18px] tracking-[-0.005em] text-[#2a282a]">
+                {message.body}
+              </p>
+
+              <div className="mt-auto flex flex-wrap items-center gap-1.5">
+                <button type="button" className={secondaryAction}>
+                  Open in Superlog
+                </button>
+                <button type="button" className={secondaryAction}>
+                  View PR
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex shrink-0 items-center gap-1 rounded-[4px] bg-[#007a5a] px-[7px] py-[5px] text-[12px] font-bold leading-[17px] text-white transition-colors hover:bg-[#006b4f]"
+                >
+                  <span aria-hidden="true" className="font-['Apple_Color_Emoji'] text-[14px]">
+                    🔀
+                  </span>
+                  Merge PR
+                </button>
+                <button type="button" className={secondaryAction}>
+                  <span aria-hidden="true" className="font-['Apple_Color_Emoji'] text-[14px]">
+                    ✅
+                  </span>
+                  Problem resolved
+                </button>
+                <button type="button" className={secondaryAction}>
+                  <span aria-hidden="true" className="font-['Apple_Color_Emoji'] text-[14px]">
+                    🔕
+                  </span>
+                  Not an issue
+                </button>
+              </div>
             </div>
           </div>
         </div>
       </div>
-      <OnboardingAgenda />
-    </div>
-  );
-}
-
-function OnboardingAgenda() {
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const steps = [
-    "Map every app, service, and edge function in your repo",
-    "Install native OpenTelemetry — traces, logs, metrics — per language",
-    "Open superlog.sh in a browser to finish signup in parallel",
-    "Add spans, counters, and structured logs around critical operations",
-    "Verify the app still runs and OTLP reaches /v1/traces, /logs, /metrics",
-  ];
-
-  useEffect(() => {
-    if (!open) return;
-    function onDocClick(e: MouseEvent) {
-      if (!containerRef.current) return;
-      if (e.target instanceof Node && containerRef.current.contains(e.target)) return;
-      setOpen(false);
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") setOpen(false);
-    }
-    document.addEventListener("mousedown", onDocClick);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDocClick);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
-
-  function toggle() {
-    setOpen((prev) => !prev);
-  }
-
-  return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        onClick={toggle}
-        aria-expanded={open}
-        aria-haspopup="dialog"
-        className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-bg/70 px-4 py-2 text-[12px] font-medium text-fg shadow-[0_12px_30px_rgba(0,0,0,0.32)] backdrop-blur-md transition-colors hover:border-white/30 hover:bg-bg/85 md:text-[13px]"
-      >
-        <span
-          aria-hidden="true"
-          className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-white/30 text-[10px] font-semibold text-subtle"
-        >
-          ?
-        </span>
-        <span>What will the agent do?</span>
-        <span
-          aria-hidden="true"
-          className={`text-subtle transition-transform ${open ? "rotate-180" : ""}`}
-        >
-          ▾
-        </span>
-      </button>
-
-      {open && (
-        <div
-          role="dialog"
-          aria-label="What the agent will do"
-          className="absolute left-1/2 top-[calc(100%+10px)] z-30 w-[min(92vw,520px)] -translate-x-1/2 rounded-2xl border border-white/15 bg-bg/95 p-5 text-left shadow-[0_28px_80px_rgba(0,0,0,0.55)] backdrop-blur-md md:p-6"
-        >
-          <span
-            aria-hidden="true"
-            className="absolute -top-1.5 left-1/2 h-3 w-3 -translate-x-1/2 rotate-45 border-l border-t border-white/15 bg-bg/95"
-          />
-          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-subtle">
-            via superloglabs/skills
-          </div>
-          <ol className="grid gap-2 text-[13px] leading-relaxed text-fg md:text-[14px]">
-            {steps.map((step, i) => (
-              <li key={step} className="flex gap-3">
-                <span className="w-5 shrink-0 font-mono text-subtle" aria-hidden="true">
-                  {String(i + 1).padStart(2, "0")}
-                </span>
-                <span className="min-w-0 break-words">{step}</span>
-              </li>
-            ))}
-          </ol>
-          <p className="mt-4 text-[12px] leading-relaxed text-muted md:text-[13px]">
-            Public ingest token is inlined in the bootstrap — no env vars, no .env edits. Existing
-            vendors (Sentry, Datadog, etc.) stay in place.
-          </p>
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -168,12 +168,11 @@ export function TopNav({
                   ? `Superlog on GitHub, ${stars.toLocaleString()} stars`
                   : "Superlog on GitHub"
               }
-              className="hidden items-center gap-1.5 text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline-flex"
+              className="landing-nav-unblur hidden items-center gap-1.5 text-[12px] font-medium text-muted transition-colors hover:text-fg md:inline-flex"
+              style={{ animationDelay: "430ms" }}
             >
               <GitHubIcon />
-              <span className="landing-nav-unblur tabular-nums" style={{ animationDelay: "430ms" }}>
-                {stars != null ? formatStarCount(stars) : "GitHub"}
-              </span>
+              <span className="tabular-nums">{stars != null ? formatStarCount(stars) : "GitHub"}</span>
             </a>
             <Btn variant="ghost" size="sm" onClick={onSignIn}>
               <span className="landing-nav-unblur" style={{ animationDelay: "485ms" }}>

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -334,7 +334,7 @@ function HeroInstallCommand() {
 
   async function copy() {
     try {
-      await navigator.clipboard.writeText(INSTALL_PROMPT);
+      await navigator.clipboard.writeText(command);
     } catch {
       return;
     }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -106,6 +106,162 @@ body {
   outline-offset: 2px;
 }
 
+@keyframes landing-nav-unblur {
+  from {
+    opacity: 0;
+    filter: blur(8px);
+    transform: translateY(3px);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+}
+
+@keyframes landing-slack-enter {
+  from {
+    opacity: 0;
+    filter: blur(14px);
+    transform: translate3d(0, 34px, 0) scale(0.965);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+@keyframes landing-slack-shuffle {
+  0% {
+    opacity: 0;
+    filter: blur(5px);
+    transform: translate3d(48px, 0, 0) rotate(2.4deg) scale(0.965);
+  }
+  16% {
+    opacity: 1;
+    filter: blur(0);
+    transform: translate3d(0, 0, 0) rotate(0) scale(1);
+  }
+  78% {
+    opacity: 1;
+    filter: blur(0);
+    transform: translate3d(0, 0, 0) rotate(0) scale(1);
+  }
+  88% {
+    opacity: 1;
+    filter: blur(0);
+    transform: translate3d(-14px, 0, 0) rotate(-0.7deg) scale(0.99);
+  }
+  100% {
+    opacity: 0;
+    filter: blur(5px);
+    transform: translate3d(-56px, 0, 0) rotate(-2.5deg) scale(0.96);
+  }
+}
+
+@keyframes landing-slack-deck-one {
+  0%,
+  100% {
+    transform: translate3d(12px, 9px, 0) rotate(1.1deg);
+  }
+  12%,
+  82% {
+    transform: translate3d(8px, 9px, 0) rotate(0.7deg);
+  }
+  94% {
+    transform: translate3d(16px, 9px, 0) rotate(1.5deg);
+  }
+}
+
+@keyframes landing-slack-deck-two {
+  0%,
+  100% {
+    transform: translate3d(22px, 16px, 0) rotate(2deg);
+  }
+  12%,
+  82% {
+    transform: translate3d(17px, 16px, 0) rotate(1.5deg);
+  }
+  94% {
+    transform: translate3d(25px, 16px, 0) rotate(2.4deg);
+  }
+}
+
+@keyframes landing-slack-stack-float {
+  0%,
+  100% {
+    transform: translate3d(0, -10px, 0) rotate(-0.42deg);
+  }
+  50% {
+    transform: translate3d(0, 10px, 0) rotate(0.42deg);
+  }
+}
+
+.landing-nav-unblur {
+  animation: landing-nav-unblur 680ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  will-change: filter, opacity, transform;
+}
+
+.landing-hero-unblur {
+  animation: landing-nav-unblur 820ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  will-change: filter, opacity, transform;
+}
+
+.landing-slack-card {
+  transform-origin: 50% 65%;
+  animation: landing-slack-enter 900ms 180ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  will-change: filter, opacity, transform;
+}
+
+.landing-slack-card-back {
+  pointer-events: none;
+  background: rgb(255 255 255 / 72%);
+  border: 1px solid rgb(0 0 0 / 8%);
+  box-shadow: 0 20px 56px rgb(0 0 0 / 18%);
+}
+
+.landing-slack-card-back-one {
+  z-index: 2;
+  transform: translate3d(12px, 9px, 0) rotate(1.1deg);
+  animation: landing-slack-deck-one 2.8s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+
+.landing-slack-card-back-two {
+  z-index: 1;
+  opacity: 0.48;
+  transform: translate3d(22px, 16px, 0) rotate(2deg);
+  animation: landing-slack-deck-two 2.8s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+
+.landing-slack-shuffle-card {
+  transform-origin: 50% 55%;
+  animation: landing-slack-shuffle 2.8s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+  will-change: filter, opacity, transform;
+}
+
+.landing-slack-float {
+  transform-origin: 50% 50%;
+  animation: landing-slack-stack-float 5.6s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+  will-change: transform;
+}
+
+.landing-fluid-hero-overlay {
+  background:
+    linear-gradient(
+      0deg,
+      var(--color-bg) 0%,
+      rgb(var(--color-bg-rgb) / 86%) 8%,
+      rgb(var(--color-bg-rgb) / 0%) 42%
+    ),
+    linear-gradient(
+      90deg,
+      rgb(var(--color-bg-rgb) / 54%) 0%,
+      rgb(var(--color-bg-rgb) / 8%) 58%,
+      rgb(var(--color-bg-rgb) / 22%) 100%
+    );
+}
+
 .superlog-code {
   margin: 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
@@ -709,6 +865,22 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .landing-nav-unblur,
+  .landing-hero-unblur,
+  .landing-slack-card,
+  .landing-slack-shuffle-card,
+  .landing-slack-float {
+    animation: none;
+    filter: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .landing-slack-card-back-one,
+  .landing-slack-card-back-two {
+    animation: none;
+  }
+
   .marquee-track {
     animation: none;
     transform: none;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -865,6 +865,11 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .marquee-track {
+    animation: none;
+    transform: none;
+  }
+
   .landing-nav-unblur,
   .landing-hero-unblur,
   .landing-slack-card,
@@ -879,10 +884,5 @@ body {
   .landing-slack-card-back-one,
   .landing-slack-card-back-two {
     animation: none;
-  }
-
-  .marquee-track {
-    animation: none;
-    transform: none;
   }
 }


### PR DESCRIPTION
## What changed

- rebuilds the landing hero as a two-column product story with staggered unblur entrances
- adds an animated, smoothly rocking stack of Slack incident and pull-request cards
- uses the signal-field visualization as the hero background while preserving the site color tokens
- animates the wordmark and full primary navigation button during initial load

## Why

The previous hero did not communicate the Slack-to-PR workflow directly. This makes that outcome the visual focus while keeping the existing landing-page shell and design language.

## Validation

- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web build`
- 11 prerender tests pass
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the landing hero into a two-column story with animated Slack cards and a WebGL signal-field background. This centers the Slack-to-PR workflow and keeps reduced‑motion-friendly polish.

- New Features
  - Added `FluidSignalField` WebGL background with responsive density, additive blending, resize/visibility observers, DPR cap, and reduced-motion support.
  - Introduced an animated Slack card stack cycling key states (waiting review, PR ready, resolved) with shuffle/float effects and non-interactive action chips; added staggered unblur entrances for the wordmark, nav (incl. GitHub stars), hero copy, and primary CTA.
  - Replaced the coding agent window with a compact install command next to “Get started”; clicking copies the visible command and shows a success state.
  - Kept landing checks working by updating the hero/logo test to allow `Hero` props in the marquee position assertion.

<sup>Written for commit 3f817c3a2e6ac8cbb79192087ce8aee2d9fd5ff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

