### PR TITLE
Add acceptance-rate stat to the landing page

### DIFF
--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -41,6 +41,8 @@ export function Landing({ initialAuthMode }: { initialAuthMode?: AuthMode } = {}
         <Hero onSignUp={openSignUp} />
 
         <div className="mx-auto w-full max-w-[1400px] px-0 pb-24 md:px-8 xl:px-12">
+          <AcceptanceStat />
+
           <ErrorImportSection />
 
           <AgentContextSection />
@@ -910,6 +912,75 @@ function FixSection() {
         <div className="absolute inset-0 bg-[linear-gradient(90deg,rgba(8,9,11,0.48),rgba(8,9,11,0.18)),linear-gradient(0deg,rgba(8,9,11,0.68),rgba(8,9,11,0.04)_62%)]" />
         <div className="relative flex min-h-[420px] items-center p-5 md:min-h-[520px] md:p-8">
           <SlackPrNotification />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance stat — oversized pixel figure paired with a short claim.
+// The number renders in Geist Pixel with font-smoothing off so the pixels
+// stay crisp (same treatment as the home pulse widgets).
+// ---------------------------------------------------------------------------
+
+const PIXEL_NUMBER_STYLE: React.CSSProperties = {
+  fontFamily: '"Geist Pixel", ui-monospace, monospace',
+  fontSynthesis: "none",
+  WebkitFontSmoothing: "none",
+};
+
+function AcceptanceStat() {
+  const [count, setCount] = useState(0);
+  const ref = useRef<HTMLDivElement>(null);
+  const started = useRef(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry?.isIntersecting || started.current) return;
+        started.current = true;
+        const duration = 1400;
+        const start = performance.now();
+        const step = (now: number) => {
+          const t = Math.min(1, (now - start) / duration);
+          const eased = 1 - (1 - t) ** 3; // ease-out cubic
+          setCount(Math.round(eased * 90));
+          if (t < 1) requestAnimationFrame(step);
+        };
+        requestAnimationFrame(step);
+      },
+      { threshold: 0.5 },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <section id="acceptance" className="mt-24 scroll-mt-24">
+      <div
+        ref={ref}
+        className="flex flex-col items-center gap-6 px-4 py-16 text-center md:flex-row md:justify-center md:gap-16 md:px-0 md:py-28 md:text-left"
+      >
+        <div
+          className="relative text-[104px] leading-none tracking-tight text-fg tabular-nums md:text-[150px]"
+          style={PIXEL_NUMBER_STYLE}
+        >
+          {/* Invisible final value reserves the slot so counting up doesn't
+              reflow the adjacent copy. */}
+          <span aria-hidden="true" className="invisible">
+            90%
+          </span>
+          <span className="absolute inset-0">{count}%</span>
+        </div>
+        <div className="max-w-md">
+          <div className="text-[16px] font-semibold text-fg md:text-[18px]">Acceptance rate</div>
+          <p className="mt-2 text-[18px] leading-tight tracking-tight text-muted md:text-[26px]">
+            Leading teams merge 9 out of 10 Superlog PRs.
+          </p>
         </div>
       </div>
     </section>

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -930,14 +930,23 @@ const PIXEL_NUMBER_STYLE: React.CSSProperties = {
   WebkitFontSmoothing: "none",
 };
 
+const ACCEPTANCE_RATE = 90;
+
 function AcceptanceStat() {
-  const [count, setCount] = useState(0);
+  // Seed at the real value so the prerendered / no-JS HTML and the initial
+  // hydration render both show 90% (no crawler mis-statement, no hydration
+  // mismatch). The 0 -> 90 count-up is a client-only visual layer.
+  const [count, setCount] = useState(ACCEPTANCE_RATE);
   const ref = useRef<HTMLDivElement>(null);
   const started = useRef(false);
 
   useEffect(() => {
+    // Respect reduced-motion: skip the counter and leave the value at 90.
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+
     const node = ref.current;
     if (!node) return;
+    setCount(0);
     const observer = new IntersectionObserver(
       (entries) => {
         const entry = entries[0];
@@ -948,7 +957,7 @@ function AcceptanceStat() {
         const step = (now: number) => {
           const t = Math.min(1, (now - start) / duration);
           const eased = 1 - (1 - t) ** 3; // ease-out cubic
-          setCount(Math.round(eased * 90));
+          setCount(Math.round(eased * ACCEPTANCE_RATE));
           if (t < 1) requestAnimationFrame(step);
         };
         requestAnimationFrame(step);


### PR DESCRIPTION
Adds a new social-proof stat block to the landing page, directly under the "Trusted by teams at" client-logo marquee.

- Oversized **Geist Pixel** figure that animates **0 → 90%** with an ease-out cubic when the block first scrolls into view (IntersectionObserver, fires once).
- Paired with an **Acceptance rate** label and the line *"Leading teams merge 9 out of 10 Superlog PRs."*
- The number sits in a fixed-width slot (an invisible final-value placeholder reserves the space) so counting up never reflows the adjacent copy.
- `tabular-nums` + font-smoothing off keeps the pixel digits crisp and stable, matching the home pulse widgets.
- Generous vertical padding gives the figure room to breathe; the number+text pair is centered as a unit on desktop and stacks centered on mobile.

Purely presentational — verified with typecheck and in a local dev build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new acceptance-rate stat block to the landing page under the client logo marquee. Shows a large `Geist Pixel` counter that animates from 0% to 90% when scrolled into view, paired with an “Acceptance rate” label and short claim.

- **New Features**
  - Count-up animation on first viewport entry (IntersectionObserver, ease-out cubic) from 0 → 90%; seeded at 90 for SSR/no-JS and hydration correctness; runs client-only and is skipped when prefers-reduced-motion.
  - Fixed-width number slot to prevent layout shifts; `tabular-nums` with font smoothing off for crisp digits; centered layout on desktop, stacked and centered on mobile.

<sup>Written for commit b65962ec1050a0e0877f39a8949bc3839d6ec476. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

