### PR TITLE
fix(web): poll agent runs awaiting PR events

### DIFF
--- a/apps/web/src/incidents/agent-run-polling.test.ts
+++ b/apps/web/src/incidents/agent-run-polling.test.ts
@@ -25,6 +25,10 @@ test("keeps polling while awaiting a human — a Slack reply elsewhere can resum
   assert.equal(incidentPollIntervalMs("awaiting_human"), INCIDENT_POLL_INTERVAL_MS);
 });
 
+test("keeps polling while awaiting PR events — an external event can resume the run", () => {
+  assert.equal(incidentPollIntervalMs("awaiting_events"), INCIDENT_POLL_INTERVAL_MS);
+});
+
 test("stops polling in terminal states", () => {
   assert.equal(incidentPollIntervalMs("complete"), false);
   assert.equal(incidentPollIntervalMs("failed"), false);

--- a/apps/web/src/incidents/agent-run-polling.ts
+++ b/apps/web/src/incidents/agent-run-polling.ts
@@ -11,14 +11,16 @@ export const INCIDENT_POLL_INTERVAL_MS = 3000;
 // These are the states where the worker is still ticking the run, so new events
 // can still land. `awaiting_human` is included on purpose: a reply arriving on
 // another channel (e.g. Slack) flips it back to `resuming`, and we want the page
-// to catch that without a manual refresh. Terminal (`complete`/`failed`) and
-// dormant (`blocked_no_github`) states are omitted — they won't produce more
-// events until an external event requeues them, so we let the poll stop.
+// to catch that without a manual refresh. `awaiting_events` is also active: PR
+// events can resume the durable run and append status or transcript updates.
+// Terminal (`complete`/`failed`) and dormant (`blocked_no_github`) states are
+// omitted — they won't produce more events until explicitly requeued.
 const ACTIVE_AGENT_RUN_STATES: ReadonlySet<string> = new Set([
   "queued",
   "repo_discovery",
   "running",
   "awaiting_human",
+  "awaiting_events",
   "resuming",
   "pr_retry_queued",
 ]);


### PR DESCRIPTION
## What & why

Keep the incident detail query polling while an agent run is in `awaiting_events`. PR comments, merges, and closes can resume this durable state, so stopping the poll left status and transcript updates stale until a manual refresh.

Fixes #398

## How to test

- [x] `pnpm --filter @superlog/web test`
- [x] `pnpm typecheck`
- [x] `pnpm exec biome check apps/web/src/incidents/agent-run-polling.ts apps/web/src/incidents/agent-run-polling.test.ts`

## AI assistance

- [ ] None
- [x] Used AI for: reproducing the polling-state mismatch, drafting the focused fix, and adding the regression test

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / cleanup

## Checklist

- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes (current `main` has unrelated existing Biome diagnostics; the changed files pass targeted Biome checks)
- [x] `pnpm format` has been run on changed files
- [x] Added or updated tests where it makes sense
- [x] Branch is up to date with `main`
- [x] PR title follows the area-prefix style for the area being changed
- [x] Read [CONTRIBUTING.md](https://github.com/superloglabs/superlog/blob/main/CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep incident detail polling active while an agent run is in `awaiting_events`. This lets PR comments, merges, or closes resume the run and update status/transcript without a manual refresh, with a regression test added to cover the state.

<sup>Written for commit 889816fad26b636c393bfc662bdeef0add6554e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

