### PR TITLE
fix(docs): align quick-start OTLP port

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,8 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Check CI workflow security
-        run: pnpm test:ci-workflows
+      - name: Check repository contracts
+        run: pnpm test:repository-contracts
       - name: typecheck
         run: pnpm typecheck
       - name: build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Default local services:
 | ------------ | ------------------------- |
 | Web app      | http://localhost:5173     |
 | API          | http://localhost:4100     |
-| OTLP proxy   | http://localhost:4101     |
+| OTLP proxy   | http://localhost:4000     |
 | Sample app   | http://localhost:3005     |
 
 If something fails on first boot, run `pnpm dev:portless:status` to see what came up. For a clean restart:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The default local services are:
 
 - Web: `http://localhost:5173`
 - API: `http://localhost:4100`
-- OTLP intake: `http://localhost:4101`
+- OTLP intake: `http://localhost:4000`
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "demo:provision": "tsx scripts/demo/provision-demo-project.ts",
     "demo:verify-isolation": "tsx scripts/demo/verify-demo-isolation.ts",
     "test:ci-workflows": "tsx --test scripts/ci-workflow-security.test.ts",
+    "test:repository-contracts": "tsx --test scripts/*.test.ts",
     "lint": "biome check .",
     "format": "biome format --write .",
     "typecheck": "turbo run typecheck"

--- a/scripts/quick-start-defaults.test.ts
+++ b/scripts/quick-start-defaults.test.ts
@@ -1,0 +1,15 @@
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const proxyEnv = readFileSync(new URL("../apps/proxy/.env.example", import.meta.url), "utf8");
+const readme = readFileSync(new URL("../README.md", import.meta.url), "utf8");
+const contributing = readFileSync(new URL("../CONTRIBUTING.md", import.meta.url), "utf8");
+
+test("quick-start guides use the proxy's default OTLP port", () => {
+  const proxyPort = proxyEnv.match(/^PORT=(\d+)$/m)?.[1];
+
+  assert.ok(proxyPort, "expected apps/proxy/.env.example to define PORT");
+  assert.match(readme, new RegExp(`OTLP intake: \`http://localhost:${proxyPort}\``));
+  assert.match(contributing, new RegExp(`OTLP proxy\\s+\\| http://localhost:${proxyPort}`));
+});


### PR DESCRIPTION
## What & why

Align both quick-start guides with the proxy's actual default port (`4000`). The previous `4101` URLs sent new contributors to a port where the OTLP proxy does not listen.

The new repository contract test derives the expected port from `apps/proxy/.env.example`, so future runtime-default changes must update the public setup instructions too.

Fixes #397

## How to test

- [x] `pnpm test:repository-contracts`
- [x] `pnpm test:ci-workflows`
- [x] `pnpm typecheck`
- [x] `pnpm exec biome check scripts/quick-start-defaults.test.ts package.json`

## AI assistance

- [ ] None
- [x] Used AI for: reproducing the documentation/runtime mismatch, drafting the fix, and adding the repository contract test

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [x] Documentation
- [ ] Tests only
- [ ] Refactor / cleanup

## Checklist

- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes (current `main` has unrelated existing Biome diagnostics; all changed Biome-supported files pass targeted checks)
- [x] `pnpm format` has been run on changed files
- [x] Added or updated tests where it makes sense
- [x] Branch is up to date with `main`
- [x] PR title follows the area-prefix style for the area being changed
- [x] Read [CONTRIBUTING.md](https://github.com/superloglabs/superlog/blob/main/CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes quick-start docs that pointed OTLP traffic to port 4101 by aligning them to the proxy’s actual default port, 4000. Adds a repository contract test and CI check to keep docs in sync with `apps/proxy/.env.example`. Fixes #397.

- **Bug Fixes**
  - Updated `README.md` and `CONTRIBUTING.md` to use `http://localhost:4000` for the OTLP proxy.
  - Added `scripts/quick-start-defaults.test.ts` and a `test:repository-contracts` script; CI now runs it to ensure docs match the port in `apps/proxy/.env.example`.

<sup>Written for commit 983e9570e564260335a5b78b79623ab9d66e5bde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

