### PR TITLE
Add shared Sentry callback and webhook routing

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -69,6 +69,8 @@ NOTION_OAUTH_REDIRECT_URL=http://localhost:4100/notion/oauth/callback
 SENTRY_APP_SLUG=
 SENTRY_CLIENT_ID=
 SENTRY_CLIENT_SECRET=
+SENTRY_OAUTH_FORWARD_CALLBACK_URL=
+SENTRY_WEBHOOK_FORWARD_URL=
 SENTRY_OAUTH_REDIRECT_URL=http://localhost:4100/sentry/oauth/callback
 # AWS connect (CloudFormation-based "connect your data" onboarding). When unset,
 # the "Connect AWS" flow returns 500 "AWS connect is not configured". The first

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -163,6 +163,7 @@ import { importOpenSentryIssues, receiveSentryIssueEvent } from "./sentry/applic
 import { startSentryAuthorizationCleanup } from "./sentry/authorization-cleanup.js";
 import { DrizzleSentryAuthorizationRepository } from "./sentry/authorization-repository.js";
 import { listOpenSentryIssues, listSentryProjects } from "./sentry/client.js";
+import { createSentryWebhookForwarder } from "./sentry/forwarder.js";
 import { mountSentryPublic } from "./sentry/http.js";
 import {
   type SentryInstallationDeps,
@@ -390,6 +391,9 @@ const sentryInstallationDeps: SentryInstallationDeps = {
 mountSentryInstallationPublic(app, sentryInstallationDeps);
 mountSentryPublic(app, {
   clientSecret: process.env.SENTRY_CLIENT_SECRET,
+  forwardWebhook: createSentryWebhookForwarder({
+    destinationUrl: process.env.SENTRY_WEBHOOK_FORWARD_URL,
+  }),
   receiveIssueEvent: (event) => receiveSentryIssueEvent(sentryWebhookInbox, event),
   revokeInstallation: (installationId) => sentryWebhookInbox.revokeInstallation(installationId),
 });

--- a/apps/api/src/sentry/application.ts
+++ b/apps/api/src/sentry/application.ts
@@ -1,6 +1,15 @@
 import crypto from "node:crypto";
 import type { SentryIssue, SentryIssueEvent } from "./domain.js";
 
+export const SENTRY_WEBHOOK_FORWARDED_HEADER = "x-superlog-sentry-webhook-forwarded";
+
+export type SentryWebhookDelivery = {
+  rawBody: Uint8Array;
+  headers: Record<string, string>;
+};
+
+export type SentryWebhookForwarder = (delivery: SentryWebhookDelivery) => Promise<void>;
+
 export type StoredSentryIssueDelivery = SentryIssueEvent & {
   dedupeKey: string;
   rawPayload: Record<string, unknown>;

--- a/apps/api/src/sentry/domain.ts
+++ b/apps/api/src/sentry/domain.ts
@@ -22,7 +22,7 @@ export type SentryIssueEvent = {
 };
 
 export function hasValidSentrySignature(args: {
-  rawBody: string;
+  rawBody: string | Uint8Array;
   signature: string;
   clientSecret: string;
 }): boolean {

--- a/apps/api/src/sentry/forwarder.test.ts
+++ b/apps/api/src/sentry/forwarder.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createSentryWebhookForwarder } from "./forwarder.js";
+
+test("rejects a malformed forwarding destination when the API starts", () => {
+  assert.throws(
+    () => createSentryWebhookForwarder({ destinationUrl: "private destination" }),
+    /Sentry webhook forwarding destination must be an HTTP URL/,
+  );
+});
+
+test("forwards the signed Sentry delivery to the configured private destination", async () => {
+  const requests: Array<{ url: string; init: RequestInit }> = [];
+  const forwardWebhook = createSentryWebhookForwarder({
+    destinationUrl: "https://other-app.example.test/sentry/webhook",
+    fetchImpl: async (input, init = {}) => {
+      requests.push({ url: String(input), init });
+      return new Response(null, { status: 202 });
+    },
+  });
+
+  assert.ok(forwardWebhook);
+  const rawBody = new Uint8Array([123, 10, 32, 32, 125]);
+  await forwardWebhook({
+    rawBody,
+    headers: {
+      "content-type": "application/json",
+      "request-id": "request-42",
+      "sentry-hook-resource": "issue",
+      "sentry-hook-signature": "signature",
+    },
+  });
+
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0]?.url, "https://other-app.example.test/sentry/webhook");
+  assert.equal(requests[0]?.init.method, "POST");
+  assert.deepEqual(requests[0]?.init.body, rawBody);
+  assert.deepEqual(requests[0]?.init.headers, {
+    "content-type": "application/json",
+    "request-id": "request-42",
+    "sentry-hook-resource": "issue",
+    "sentry-hook-signature": "signature",
+    "x-superlog-sentry-webhook-forwarded": "1",
+  });
+});
+
+test("fails the source delivery when the configured destination rejects the webhook", async () => {
+  const forwardWebhook = createSentryWebhookForwarder({
+    destinationUrl: "https://other-app.example.test/sentry/webhook",
+    fetchImpl: async () => new Response(null, { status: 503 }),
+  });
+
+  assert.ok(forwardWebhook);
+  await assert.rejects(
+    forwardWebhook({
+      rawBody: new TextEncoder().encode("{}"),
+      headers: { "sentry-hook-signature": "signature" },
+    }),
+    /Sentry webhook forwarding failed \(503\)/,
+  );
+});
+
+test("bounds how long the source delivery waits for the configured destination", async () => {
+  const forwardWebhook = createSentryWebhookForwarder({
+    destinationUrl: "https://other-app.example.test/sentry/webhook",
+    timeoutMs: 5,
+    fetchImpl: async (_input, init = {}) =>
+      new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+      }),
+  });
+
+  assert.ok(forwardWebhook);
+  await Promise.race([
+    assert.rejects(
+      forwardWebhook({
+        rawBody: new TextEncoder().encode("{}"),
+        headers: { "sentry-hook-signature": "signature" },
+      }),
+      { name: "TimeoutError" },
+    ),
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("forwarding did not time out")), 50);
+    }),
+  ]);
+});

--- a/apps/api/src/sentry/forwarder.ts
+++ b/apps/api/src/sentry/forwarder.ts
@@ -1,0 +1,36 @@
+import { SENTRY_WEBHOOK_FORWARDED_HEADER, type SentryWebhookForwarder } from "./application.js";
+
+export function createSentryWebhookForwarder(input: {
+  destinationUrl: string | undefined;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): SentryWebhookForwarder | undefined {
+  const destinationUrl = input.destinationUrl?.trim();
+  if (!destinationUrl) return undefined;
+  let destination: URL;
+  try {
+    destination = new URL(destinationUrl);
+  } catch {
+    throw new Error("Sentry webhook forwarding destination must be an HTTP URL");
+  }
+  if (destination.protocol !== "http:" && destination.protocol !== "https:") {
+    throw new Error("Sentry webhook forwarding destination must be an HTTP URL");
+  }
+  const fetchImpl = input.fetchImpl ?? fetch;
+
+  return async (delivery) => {
+    const response = await fetchImpl(destination, {
+      method: "POST",
+      headers: {
+        ...delivery.headers,
+        [SENTRY_WEBHOOK_FORWARDED_HEADER]: "1",
+      },
+      body: delivery.rawBody,
+      redirect: "error",
+      signal: AbortSignal.timeout(input.timeoutMs ?? 5_000),
+    });
+    if (!response.ok) {
+      throw new Error(`Sentry webhook forwarding failed (${response.status})`);
+    }
+  };
+}

--- a/apps/api/src/sentry/http.test.ts
+++ b/apps/api/src/sentry/http.test.ts
@@ -65,6 +65,196 @@ test("accepts a signed new Sentry issue without doing incident work inline", asy
   ]);
 });
 
+test("forwards a signed Sentry webhook even when the local receiver has no matching installation", async () => {
+  const secret = "test-sentry-client-secret";
+  const rawBody = new TextEncoder().encode(
+    JSON.stringify({
+      action: "created",
+      installation: { uuid: "external-only" },
+      data: {
+        issue: {
+          id: "issue-42",
+          title: "External app issue",
+          project: { slug: "external-project" },
+        },
+      },
+    }),
+  );
+  const signature = crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+  const forwarded: unknown[] = [];
+  const app = new Hono();
+  mountSentryPublic(app, {
+    clientSecret: secret,
+    receiveIssueEvent: async () => undefined,
+    forwardWebhook: async (delivery) => {
+      forwarded.push(delivery);
+    },
+  });
+
+  const response = await app.request("/sentry/webhook", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "request-id": "request-42",
+      "sentry-hook-id": "hook-42",
+      "sentry-hook-resource": "issue",
+      "sentry-hook-signature": signature,
+    },
+    body: rawBody,
+  });
+
+  assert.equal(response.status, 202);
+  assert.deepEqual(forwarded, [
+    {
+      rawBody,
+      headers: {
+        "content-type": "application/json",
+        "request-id": "request-42",
+        "sentry-hook-id": "hook-42",
+        "sentry-hook-resource": "issue",
+        "sentry-hook-signature": signature,
+      },
+    },
+  ]);
+});
+
+test("does not forward a webhook that already came from the multiplexer", async () => {
+  const secret = "test-sentry-client-secret";
+  const body = JSON.stringify({ action: "assigned", installation: { uuid: "external-only" } });
+  const signature = crypto.createHmac("sha256", secret).update(body).digest("hex");
+  let forwardAttempts = 0;
+  const app = new Hono();
+  mountSentryPublic(app, {
+    clientSecret: secret,
+    receiveIssueEvent: async () =>
+      assert.fail("unsupported issue action must not be handled locally"),
+    forwardWebhook: async () => {
+      forwardAttempts += 1;
+    },
+  });
+
+  const response = await app.request("/sentry/webhook", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "sentry-hook-resource": "issue",
+      "sentry-hook-signature": signature,
+      "x-superlog-sentry-webhook-forwarded": "1",
+    },
+    body,
+  });
+
+  assert.equal(response.status, 202);
+  assert.equal(forwardAttempts, 0);
+});
+
+test("does not forward a webhook whose Sentry signature is invalid", async () => {
+  let forwardAttempts = 0;
+  const app = new Hono();
+  mountSentryPublic(app, {
+    clientSecret: "test-sentry-client-secret",
+    receiveIssueEvent: async () => assert.fail("invalid webhook must not be handled locally"),
+    forwardWebhook: async () => {
+      forwardAttempts += 1;
+    },
+  });
+
+  const response = await app.request("/sentry/webhook", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "sentry-hook-resource": "issue",
+      "sentry-hook-signature": "invalid",
+    },
+    body: "{}",
+  });
+
+  assert.equal(response.status, 401);
+  assert.equal(forwardAttempts, 0);
+});
+
+test("still delivers locally when the forwarded webhook fails", async () => {
+  const secret = "test-sentry-client-secret";
+  const rawBody = JSON.stringify({
+    action: "created",
+    installation: { uuid: "installation-1" },
+    data: {
+      issue: {
+        id: "issue-42",
+        title: "Checkout failed",
+        project: { slug: "storefront" },
+      },
+    },
+  });
+  const signature = crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+  let deliveredLocally = false;
+  const app = new Hono();
+  app.onError((_error, c) => c.json({ error: "delivery failed" }, 502));
+  mountSentryPublic(app, {
+    clientSecret: secret,
+    receiveIssueEvent: async () => {
+      deliveredLocally = true;
+    },
+    forwardWebhook: async () => {
+      throw new Error("Responder unavailable");
+    },
+  });
+
+  const response = await app.request("/sentry/webhook", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "sentry-hook-resource": "issue",
+      "sentry-hook-signature": signature,
+    },
+    body: rawBody,
+  });
+
+  assert.equal(response.status, 502);
+  assert.equal(deliveredLocally, true);
+});
+
+test("still forwards the webhook when local delivery fails", async () => {
+  const secret = "test-sentry-client-secret";
+  const rawBody = JSON.stringify({
+    action: "created",
+    installation: { uuid: "installation-1" },
+    data: {
+      issue: {
+        id: "issue-42",
+        title: "Checkout failed",
+        project: { slug: "storefront" },
+      },
+    },
+  });
+  const signature = crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+  let forwarded = false;
+  const app = new Hono();
+  app.onError((_error, c) => c.json({ error: "delivery failed" }, 502));
+  mountSentryPublic(app, {
+    clientSecret: secret,
+    receiveIssueEvent: async () => {
+      throw new Error("Superlog delivery failed");
+    },
+    forwardWebhook: async () => {
+      forwarded = true;
+    },
+  });
+
+  const response = await app.request("/sentry/webhook", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "sentry-hook-resource": "issue",
+      "sentry-hook-signature": signature,
+    },
+    body: rawBody,
+  });
+
+  assert.equal(response.status, 502);
+  assert.equal(forwarded, true);
+});
+
 test("accepts a signed Sentry App uninstall so stale project connections are revoked", async () => {
   const secret = "test-sentry-client-secret";
   const body = JSON.stringify({ action: "deleted", installation: { uuid: "installation-1" } });

--- a/apps/api/src/sentry/http.ts
+++ b/apps/api/src/sentry/http.ts
@@ -1,5 +1,6 @@
 import type { Hono } from "hono";
 import { requestBodyLimit } from "../request-body-limits.js";
+import { SENTRY_WEBHOOK_FORWARDED_HEADER, type SentryWebhookForwarder } from "./application.js";
 import { type SentryIssueEvent, hasValidSentrySignature, parseSentryIssueEvent } from "./domain.js";
 
 export const SENTRY_WEBHOOK_BODY_BYTES = 2 * 1024 * 1024;
@@ -8,6 +9,7 @@ export type SentryPublicDependencies = {
   clientSecret: string | undefined;
   receiveIssueEvent: (event: SentryIssueEvent) => Promise<void>;
   revokeInstallation?: (installationId: string) => Promise<void>;
+  forwardWebhook?: SentryWebhookForwarder;
 };
 
 // biome-ignore lint/suspicious/noExplicitAny: Hono Variables invariance.
@@ -15,24 +17,63 @@ export function mountSentryPublic(app: Hono<any>, deps: SentryPublicDependencies
   app.use("/sentry/webhook", requestBodyLimit(SENTRY_WEBHOOK_BODY_BYTES));
   app.post("/sentry/webhook", async (c) => {
     if (!deps.clientSecret) return c.json({ error: "sentry not configured" }, 503);
-    const rawBody = await c.req.text();
+    const rawBody = new Uint8Array(await c.req.arrayBuffer());
+    const decodedBody = new TextDecoder().decode(rawBody);
     const signature = c.req.header("sentry-hook-signature") ?? "";
     if (!hasValidSentrySignature({ rawBody, signature, clientSecret: deps.clientSecret })) {
       return c.json({ error: "invalid signature" }, 401);
     }
-    if (c.req.header("sentry-hook-resource") === "installation") {
-      const payload = parseInstallationDeleted(rawBody);
-      if (payload && deps.revokeInstallation) await deps.revokeInstallation(payload);
-      return c.json({ accepted: !!payload }, 202);
+    const localDelivery = receiveSentryWebhookLocally({
+      rawBody: decodedBody,
+      resource: c.req.header("sentry-hook-resource"),
+      deps,
+    });
+    const forwardedDelivery =
+      c.req.header(SENTRY_WEBHOOK_FORWARDED_HEADER) !== "1" && deps.forwardWebhook
+        ? deps.forwardWebhook({ rawBody, headers: sentryWebhookHeaders(c.req.raw.headers) })
+        : Promise.resolve();
+
+    const [localResult, forwardedResult] = await Promise.allSettled([
+      localDelivery,
+      forwardedDelivery,
+    ]);
+    if (localResult.status === "rejected" || forwardedResult.status === "rejected") {
+      const failures = [localResult, forwardedResult].flatMap((delivery) =>
+        delivery.status === "rejected" ? [delivery.reason] : [],
+      );
+      throw new AggregateError(failures, "Sentry webhook delivery failed");
     }
-    if (c.req.header("sentry-hook-resource") !== "issue") {
-      return c.json({ accepted: false }, 202);
-    }
-    const event = parseSentryIssueEvent(rawBody);
-    if (!event) return c.json({ accepted: false }, 202);
-    await deps.receiveIssueEvent(event);
-    return c.json({ accepted: true }, 202);
+    return c.json({ accepted: localResult.value }, 202);
   });
+}
+
+async function receiveSentryWebhookLocally(input: {
+  rawBody: string;
+  resource: string | undefined;
+  deps: SentryPublicDependencies;
+}): Promise<boolean> {
+  if (input.resource === "installation") {
+    const installationId = parseInstallationDeleted(input.rawBody);
+    if (installationId && input.deps.revokeInstallation) {
+      await input.deps.revokeInstallation(installationId);
+    }
+    return !!installationId;
+  }
+  if (input.resource !== "issue") return false;
+
+  const event = parseSentryIssueEvent(input.rawBody);
+  if (!event) return false;
+  await input.deps.receiveIssueEvent(event);
+  return true;
+}
+
+function sentryWebhookHeaders(headers: Headers): Record<string, string> {
+  return Object.fromEntries(
+    [...headers.entries()].filter(
+      ([name]) =>
+        name === "content-type" || name === "request-id" || name.startsWith("sentry-hook-"),
+    ),
+  );
 }
 
 function parseInstallationDeleted(rawBody: string): string | null {

--- a/apps/api/src/sentry/installation.test.ts
+++ b/apps/api/src/sentry/installation.test.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
+import { Hono } from "hono";
 import { listOpenSentryIssues, listSentryProjects, sentryProjectIsAccessible } from "./client.js";
 import { signSentryState } from "./oauth.js";
 
@@ -7,9 +8,97 @@ process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
 const {
   completeSentryInstallation,
   exchangeSentryInstallationGrant,
+  mountSentryInstallationPublic,
   parseSentryInstallationCallback,
   startSentryOpenIssueImport,
 } = await import("./installation.js");
+
+test("routes a Responder callback with every incoming query parameter preserved", async () => {
+  const previousDestination = process.env.SENTRY_OAUTH_FORWARD_CALLBACK_URL;
+  const destination = "https://responder.example.test/api/integrations/sentry/callback";
+  process.env.SENTRY_OAUTH_FORWARD_CALLBACK_URL = destination;
+  try {
+    const encodedDestination = Buffer.from(destination, "utf8").toString("base64url");
+    const state = `responder-v1.${encodedDestination}.one-time-nonce`;
+    const rawQuery = `state=${state}&code=grant%2Bcode&installationId=installation-1&orgSlug=acme&extra=one&extra=two`;
+    const app = new Hono();
+    mountSentryInstallationPublic(app, {
+      authorizations: {} as never,
+      listProjects: async () => assert.fail("Responder callback must not enter Superlog OAuth"),
+      importOpenIssues: async () => assert.fail("Responder callback must not import issues"),
+      getActiveCredential: async () => null,
+    });
+
+    const response = await app.request(`/sentry/oauth/callback?${rawQuery}`);
+
+    assert.equal(response.status, 302);
+    assert.equal(response.headers.get("location"), `${destination}?${rawQuery}`);
+  } finally {
+    if (previousDestination === undefined) {
+      Reflect.deleteProperty(process.env, "SENTRY_OAUTH_FORWARD_CALLBACK_URL");
+    } else process.env.SENTRY_OAUTH_FORWARD_CALLBACK_URL = previousDestination;
+  }
+});
+
+test("continues through the Superlog callback flow for an ordinary state", async () => {
+  const keys = [
+    "SENTRY_APP_SLUG",
+    "SENTRY_CLIENT_ID",
+    "SENTRY_CLIENT_SECRET",
+    "STATE_SIGNING_SECRET",
+  ] as const;
+  const previous = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+  try {
+    for (const key of keys) delete process.env[key];
+    const app = new Hono();
+    mountSentryInstallationPublic(app, {
+      authorizations: {} as never,
+      listProjects: async () => [],
+      importOpenIssues: async () => 0,
+      getActiveCredential: async () => null,
+    });
+
+    const response = await app.request(
+      "/sentry/oauth/callback?state=ordinary-superlog-state&code=code&installationId=install",
+    );
+
+    assert.equal(response.status, 503);
+    assert.deepEqual(await response.json(), { error: "sentry not configured" });
+  } finally {
+    for (const key of keys) {
+      const value = previous[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+});
+
+test("rejects an invalid Responder state before entering the Superlog callback flow", async () => {
+  const previousDestination = process.env.SENTRY_OAUTH_FORWARD_CALLBACK_URL;
+  process.env.SENTRY_OAUTH_FORWARD_CALLBACK_URL =
+    "https://responder.example.test/api/integrations/sentry/callback";
+  try {
+    const app = new Hono();
+    mountSentryInstallationPublic(app, {
+      authorizations: {} as never,
+      listProjects: async () =>
+        assert.fail("invalid Responder state must not enter Superlog OAuth"),
+      importOpenIssues: async () => assert.fail("invalid Responder state must not import issues"),
+      getActiveCredential: async () => null,
+    });
+
+    const response = await app.request(
+      "/sentry/oauth/callback?state=responder-v1.invalid!.nonce&code=code&installationId=install",
+    );
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { error: "invalid callback" });
+  } finally {
+    if (previousDestination === undefined) {
+      Reflect.deleteProperty(process.env, "SENTRY_OAUTH_FORWARD_CALLBACK_URL");
+    } else process.env.SENTRY_OAUTH_FORWARD_CALLBACK_URL = previousDestination;
+  }
+});
 
 test("accepts the documented Sentry App callback without an organization slug", () => {
   const state = signSentryState(

--- a/apps/api/src/sentry/installation.ts
+++ b/apps/api/src/sentry/installation.ts
@@ -11,6 +11,7 @@ import {
 } from "./authorization-session.js";
 import { type SentryInstallationToken, requestSentryInstallationToken } from "./authorization.js";
 import type { SentryProject } from "./client.js";
+import { routeSentryOAuthCallback } from "./oauth-routing.js";
 import {
   type SentryOAuthState,
   buildSentryAuthorizeUrl,
@@ -53,15 +54,23 @@ function config() {
     clientSecret: process.env.SENTRY_CLIENT_SECRET,
     appSlug: process.env.SENTRY_APP_SLUG,
     stateSecret: process.env.STATE_SIGNING_SECRET,
+    forwardCallbackUrl: process.env.SENTRY_OAUTH_FORWARD_CALLBACK_URL,
     webOrigin: process.env.WEB_ORIGIN ?? "http://localhost:5173",
   };
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: Hono Variables invariance.
 export function mountSentryInstallationPublic(app: Hono<any>, deps: SentryInstallationDeps): void {
-  const { clientId, clientSecret, appSlug, stateSecret, webOrigin } = config();
+  const { clientId, clientSecret, appSlug, stateSecret, forwardCallbackUrl, webOrigin } = config();
 
   app.get("/sentry/oauth/callback", async (c) => {
+    const route = routeSentryOAuthCallback({
+      state: c.req.query("state"),
+      requestUrl: c.req.url,
+      allowedDestination: forwardCallbackUrl,
+    });
+    if (route.kind === "redirect") return c.redirect(route.location, 302);
+    if (route.kind === "invalid") return c.json({ error: "invalid callback" }, 400);
     if (!clientId || !clientSecret || !appSlug || !stateSecret) {
       return c.json({ error: "sentry not configured" }, 503);
     }

--- a/apps/api/src/sentry/oauth-routing.test.ts
+++ b/apps/api/src/sentry/oauth-routing.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { routeSentryOAuthCallback } from "./oauth-routing.js";
+
+const allowedDestination = "https://responder.example.test/api/integrations/sentry/callback";
+
+function responderState(destination: string): string {
+  return `responder-v1.${Buffer.from(destination, "utf8").toString("base64url")}.nonce`;
+}
+
+test("rejects malformed and disallowed Responder callback destinations", () => {
+  const cases = [
+    "responder-v1.%%%.nonce",
+    responderState("https://attacker.example.test/api/integrations/sentry/callback"),
+    responderState("https://responder.example.test/api/integrations/sentry/other"),
+    responderState("https://user:password@responder.example.test/api/integrations/sentry/callback"),
+    responderState(
+      "https://responder.example.test/api/integrations/sentry/callback?next=https://attacker.example.test",
+    ),
+    responderState("https://responder.example.test/api/integrations/sentry/callback#attacker"),
+    responderState(
+      "https://responder.example.test@attacker.example.test/api/integrations/sentry/callback",
+    ),
+  ];
+
+  for (const state of cases) {
+    assert.deepEqual(
+      routeSentryOAuthCallback({
+        state,
+        requestUrl: `https://api.example.test/sentry/oauth/callback?state=${state}`,
+        allowedDestination,
+      }),
+      { kind: "invalid" },
+      state,
+    );
+  }
+});

--- a/apps/api/src/sentry/oauth-routing.ts
+++ b/apps/api/src/sentry/oauth-routing.ts
@@ -1,0 +1,59 @@
+const RESPONDER_STATE_PREFIX = "responder-v1.";
+
+export type SentryOAuthCallbackRoute =
+  | { kind: "superlog" }
+  | { kind: "redirect"; location: string }
+  | { kind: "invalid" };
+
+export function routeSentryOAuthCallback(input: {
+  state: string | undefined;
+  requestUrl: string;
+  allowedDestination: string | undefined;
+}): SentryOAuthCallbackRoute {
+  if (!input.state?.startsWith(RESPONDER_STATE_PREFIX)) return { kind: "superlog" };
+
+  const segments = input.state.split(".");
+  if (segments.length !== 3 || segments[0] !== "responder-v1" || !segments[2]) {
+    return { kind: "invalid" };
+  }
+  const encodedDestination = segments[1];
+  if (!encodedDestination || !/^[A-Za-z0-9_-]+$/.test(encodedDestination)) {
+    return { kind: "invalid" };
+  }
+
+  let destinationText: string;
+  try {
+    const bytes = Buffer.from(encodedDestination, "base64url");
+    if (bytes.toString("base64url") !== encodedDestination) return { kind: "invalid" };
+    destinationText = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return { kind: "invalid" };
+  }
+  if (!input.allowedDestination || destinationText !== input.allowedDestination) {
+    return { kind: "invalid" };
+  }
+
+  let destination: URL;
+  let allowed: URL;
+  try {
+    destination = new URL(destinationText);
+    allowed = new URL(input.allowedDestination);
+  } catch {
+    return { kind: "invalid" };
+  }
+  if (
+    destination.protocol !== "https:" ||
+    destination.username !== "" ||
+    destination.password !== "" ||
+    destination.search !== "" ||
+    destination.hash !== "" ||
+    destination.origin !== allowed.origin ||
+    destination.pathname !== allowed.pathname
+  ) {
+    return { kind: "invalid" };
+  }
+
+  const queryIndex = input.requestUrl.indexOf("?");
+  const rawQuery = queryIndex === -1 ? "" : input.requestUrl.slice(queryIndex);
+  return { kind: "redirect", location: `${destinationText}${rawQuery}` };
+}

--- a/scripts/worktree-env.sh
+++ b/scripts/worktree-env.sh
@@ -6,7 +6,8 @@
 # branch migrations don't pollute main's pg ledger. ClickHouse + collector
 # stay shared — data isolation there happens at project_id, not db.
 #
-# Run from a worktree root, e.g.:
+# Run from a worktree root, including when this repo is checked out as a
+# submodule inside a superproject worktree, e.g.:
 #   ./scripts/worktree-env.sh
 #
 # Main repo (no worktree): writes nothing and exits 0 — the default ports are
@@ -22,15 +23,26 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
-case "$REPO_ROOT" in
-  */.claude/worktrees/*) ;;
-  *)
-    echo "not in a worktree — nothing to do (main repo uses default ports)"
-    exit 0
-    ;;
-esac
+# Detect linked worktrees from Git metadata instead of assuming a particular
+# tool's directory layout. When checked out as a submodule, ports and database
+# identity belong to the superproject worktree rather than the submodule clone.
+SUPERPROJECT="$(git -C "$REPO_ROOT" rev-parse --show-superproject-working-tree 2>/dev/null || true)"
+if [[ -n "$SUPERPROJECT" ]]; then
+  IDENTITY_ROOT="$SUPERPROJECT"
+else
+  IDENTITY_ROOT="$REPO_ROOT"
+fi
+IDENTITY_GIT_COMMON_DIR="$(git -C "$IDENTITY_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+if [[ -z "$IDENTITY_GIT_COMMON_DIR" ]]; then
+  echo "not inside a git repo at $IDENTITY_ROOT — bailing." >&2
+  exit 1
+fi
+if [[ "$IDENTITY_GIT_COMMON_DIR" == "$IDENTITY_ROOT/.git" ]]; then
+  echo "not in a worktree — nothing to do (main repo uses default ports)"
+  exit 0
+fi
 
-WT_NAME="$(basename "$REPO_ROOT")"
+WT_NAME="$(basename "$IDENTITY_ROOT")"
 
 # Slug for use in postgres database names (alnum + underscore only).
 WT_SLUG="$(printf '%s' "$WT_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/_/g; s/^_+//; s/_+$//')"


### PR DESCRIPTION
## Summary

- route versioned external Sentry OAuth states through a strict HTTPS callback allowlist while preserving the callback query string byte-for-byte
- fan out verified Sentry webhooks using the original request bytes and signed headers, with independent local and forwarded delivery attempts
- reject malformed callback destinations and bound forwarding requests with retryable failures
- detect linked worktrees from Git metadata when this repository is checked out as a submodule

## Why

A single Sentry App/OAuth client can serve more than one application only if its callback and webhook entrypoints safely multiplex deliveries. The callback destination must not become an open redirect, and webhook signatures require forwarding the exact request body rather than parsed JSON.

## Validation

- 24 focused Sentry tests
- 617 API tests
- API typecheck
- Biome checks
- live worktree verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds secure multiplexing for Sentry OAuth callbacks and webhooks so a single Sentry App can serve multiple apps without open redirects or broken signatures. Also fixes worktree detection when this repo is used as a submodule.

- **New Features**
  - Routes `responder-v1` OAuth states to a strict HTTPS allowlist and preserves the callback query string exactly.
  - Forwards verified Sentry webhooks using the original raw body and signed headers, and adds `x-superlog-sentry-webhook-forwarded` to prevent loops.
  - Delivers locally and forwards in parallel; failures are aggregated and bounded by a timeout.
  - Rejects malformed callback destinations and invalid webhook signatures.

- **Migration**
  - Set `SENTRY_OAUTH_FORWARD_CALLBACK_URL` to the exact Responder callback (HTTPS, no auth, no query/hash).
  - Set `SENTRY_WEBHOOK_FORWARD_URL` to your private webhook destination.
  - No changes needed if you’re not multiplexing callbacks or webhooks.

<sup>Written for commit 669307ae7d43d3af71e1051f83648af773d76868. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

