### PR TITLE
Hide Google Cloud provider errors from customers

### DIFF
--- a/apps/api/src/gcp/gcp.test.ts
+++ b/apps/api/src/gcp/gcp.test.ts
@@ -279,6 +279,75 @@ test("a project owner discovers Google projects before choosing one to connect",
   assert.equal(connected.refreshToken, undefined);
 });
 
+test("failed Google Cloud provisioning hides provider details from customer responses", async () => {
+  const { org, user, project } = await seedProject();
+  const providerError =
+    "POST pubsub.googleapis.com/v1/projects/integration/topics/connection:setIamPolicy: " +
+    "One or more users named in the policy do not belong to a permitted customer.";
+  const gateway: GcpGateway = {
+    authorizationUrl({ state }) {
+      return `https://accounts.google.com/o/oauth2/v2/auth?state=${encodeURIComponent(state)}`;
+    },
+    async exchangeCode() {
+      return { accessToken: "temporary-user-token" };
+    },
+    async listProjects() {
+      return [
+        {
+          projectId: "acme-production",
+          projectNumber: "123456789012",
+          displayName: "Acme production",
+        },
+      ];
+    },
+    async provision() {
+      throw new Error(providerError);
+    },
+    async deprovision() {},
+  };
+  const app = new Hono<{
+    Variables: { userId: string; orgId: string | null };
+  }>();
+  app.use("/api/*", async (c, next) => {
+    c.set("userId", user.id);
+    c.set("orgId", org.id);
+    await next();
+  });
+  mountGcpPublic(app, { config, gateway });
+  mountGcpAuthed(app, { config, gateway });
+
+  const start = await app.request(`/api/projects/${project.id}/gcp/install-url`, {
+    method: "POST",
+  });
+  const { url } = (await start.json()) as { url: string };
+  const state = new URL(url).searchParams.get("state");
+  assert.ok(state);
+  const callback = await app.request(
+    `/gcp/oauth/callback?code=oauth-code&state=${encodeURIComponent(state)}`,
+  );
+  const authorizationId = new URL(callback.headers.get("location") ?? "").searchParams.get(
+    "authorization",
+  );
+  assert.ok(authorizationId);
+
+  const connect = await app.request(`/api/gcp/authorizations/${authorizationId}/connect`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ gcpProjectId: "acme-production" }),
+  });
+
+  assert.equal(connect.status, 502);
+  assert.deepEqual(await connect.json(), {
+    error: "Google Cloud setup failed. Please try again or contact support.",
+  });
+  const status = await app.request(`/api/projects/${project.id}/gcp/connection`);
+  assert.equal(status.status, 200);
+  assert.equal(
+    ((await status.json()) as { lastError: string | null }).lastError,
+    "Google Cloud setup failed. Please try again or contact support.",
+  );
+});
+
 test("denying Google consent marks the pending connection failed", async () => {
   const { org, user, project } = await seedProject();
   const gateway: GcpGateway = {

--- a/apps/api/src/gcp/gcp.test.ts
+++ b/apps/api/src/gcp/gcp.test.ts
@@ -281,6 +281,7 @@ test("a project owner discovers Google projects before choosing one to connect",
 
 test("failed Google Cloud provisioning hides provider details from customer responses", async () => {
   const { org, user, project } = await seedProject();
+  const loggedErrors: Array<{ fields: Record<string, unknown>; message: string }> = [];
   const providerError =
     "POST pubsub.googleapis.com/v1/projects/integration/topics/connection:setIamPolicy: " +
     "One or more users named in the policy do not belong to a permitted customer.";
@@ -314,7 +315,15 @@ test("failed Google Cloud provisioning hides provider details from customer resp
     await next();
   });
   mountGcpPublic(app, { config, gateway });
-  mountGcpAuthed(app, { config, gateway });
+  mountGcpAuthed(app, {
+    config,
+    gateway,
+    log: {
+      error(fields, message) {
+        loggedErrors.push({ fields, message });
+      },
+    },
+  });
 
   const start = await app.request(`/api/projects/${project.id}/gcp/install-url`, {
     method: "POST",
@@ -346,6 +355,11 @@ test("failed Google Cloud provisioning hides provider details from customer resp
     ((await status.json()) as { lastError: string | null }).lastError,
     "Google Cloud setup failed. Please try again or contact support.",
   );
+  assert.equal(loggedErrors.length, 1);
+  assert.equal(loggedErrors[0]?.message, "Google Cloud provisioning failed");
+  assert.equal(loggedErrors[0]?.fields.authorizationId, authorizationId);
+  assert.equal(loggedErrors[0]?.fields.gcpProjectId, "acme-production");
+  assert.equal((loggedErrors[0]?.fields.err as Error | undefined)?.message, providerError);
 });
 
 test("denying Google consent marks the pending connection failed", async () => {

--- a/apps/api/src/gcp/interfaces.ts
+++ b/apps/api/src/gcp/interfaces.ts
@@ -5,6 +5,7 @@ import { HTTPException } from "hono/http-exception";
 import { requireProjectManagerContext } from "../org-authorization-http.js";
 import { hasProjectManagerAccess } from "../org-authorization.js";
 import { resolveActiveOrgContext } from "../org-context.js";
+import { logger } from "../logger.js";
 import type { GcpApplicationConfig } from "./application.js";
 import {
   completeGcpAuthorization,
@@ -28,6 +29,11 @@ type Vars = { userId: string; orgId: string | null };
 
 const GCP_SETUP_FAILED_MESSAGE =
   "Google Cloud setup failed. Please try again or contact support.";
+const gcpLog = logger.child({ scope: "gcp" });
+
+type GcpConnectLog = {
+  error(fields: Record<string, unknown>, message: string): void;
+};
 
 export type GcpConnectConfig = GcpApplicationConfig & {
   clientId: string;
@@ -41,6 +47,7 @@ type Dependencies = {
   gateway?: GcpGateway;
   repository?: GcpConnectionRepository;
   authorizationRepository?: GcpAuthorizationRepository;
+  log?: GcpConnectLog;
 };
 
 export function gcpConfigFromEnv(env: NodeJS.ProcessEnv = process.env): GcpConnectConfig | null {
@@ -83,6 +90,7 @@ function dependencies(input: Dependencies): {
   gateway: GcpGateway | null;
   repository: GcpConnectionRepository;
   authorizationRepository: GcpAuthorizationRepository;
+  log: GcpConnectLog;
 } {
   const config = input.config !== undefined ? input.config : gcpConfigFromEnv();
   return {
@@ -91,6 +99,7 @@ function dependencies(input: Dependencies): {
     repository: input.repository ?? new DrizzleGcpConnectionRepository(),
     authorizationRepository:
       input.authorizationRepository ?? new DrizzleGcpAuthorizationRepository(),
+    log: input.log ?? gcpLog,
   };
 }
 
@@ -143,7 +152,7 @@ function toPublic(connection: GcpConnectionRecord | null) {
 }
 
 export function mountGcpAuthed(app: Hono<{ Variables: Vars }>, input: Dependencies = {}): void {
-  const { config, gateway, repository, authorizationRepository } = dependencies(input);
+  const { config, gateway, repository, authorizationRepository, log } = dependencies(input);
   const stateSecret = process.env.STATE_SIGNING_SECRET;
 
   app.get("/api/projects/:projectId/gcp/connection", async (c) => {
@@ -189,10 +198,11 @@ export function mountGcpAuthed(app: Hono<{ Variables: Vars }>, input: Dependenci
   app.post("/api/gcp/authorizations/:authorizationId/connect", async (c) => {
     if (!config || !gateway) return c.json({ error: "GCP connect not configured" }, 503);
     if (!c.var.userId) return c.json({ error: "unauthenticated" }, 401);
+    const authorizationId = c.req.param("authorizationId");
     const body = (await c.req.json().catch(() => ({}))) as { gcpProjectId?: unknown };
     try {
       const session = await getGcpAuthorizationSelection({
-        authorizationId: c.req.param("authorizationId"),
+        authorizationId,
         userId: c.var.userId,
         repository: authorizationRepository,
       });
@@ -211,6 +221,14 @@ export function mountGcpAuthed(app: Hono<{ Variables: Vars }>, input: Dependenci
       if (error instanceof GcpAuthorizationError) {
         return c.json({ error: error.message }, authorizationErrorStatus(error));
       }
+      log.error(
+        {
+          err: error,
+          authorizationId,
+          gcpProjectId: body.gcpProjectId,
+        },
+        "Google Cloud provisioning failed",
+      );
       return c.json({ error: GCP_SETUP_FAILED_MESSAGE }, 502);
     }
   });

--- a/apps/api/src/gcp/interfaces.ts
+++ b/apps/api/src/gcp/interfaces.ts
@@ -26,6 +26,9 @@ import { signGcpState, verifyGcpState } from "./state.js";
 
 type Vars = { userId: string; orgId: string | null };
 
+const GCP_SETUP_FAILED_MESSAGE =
+  "Google Cloud setup failed. Please try again or contact support.";
+
 export type GcpConnectConfig = GcpApplicationConfig & {
   clientId: string;
   clientSecret: string;
@@ -133,7 +136,7 @@ function toPublic(connection: GcpConnectionRecord | null) {
     metricsBudgetMonth: connection.metricsBudgetMonth,
     metricsSeriesRead: connection.metricsSeriesRead,
     metricsMonthlySeriesLimit: monthlySeriesLimit(),
-    lastError: connection.lastError,
+    lastError: connection.lastError ? GCP_SETUP_FAILED_MESSAGE : null,
     createdAt: connection.createdAt,
     updatedAt: connection.updatedAt,
   };
@@ -208,10 +211,7 @@ export function mountGcpAuthed(app: Hono<{ Variables: Vars }>, input: Dependenci
       if (error instanceof GcpAuthorizationError) {
         return c.json({ error: error.message }, authorizationErrorStatus(error));
       }
-      return c.json(
-        { error: error instanceof Error ? error.message : "GCP provisioning failed" },
-        502,
-      );
+      return c.json({ error: GCP_SETUP_FAILED_MESSAGE }, 502);
     }
   });
 }


### PR DESCRIPTION
## Summary

- return a stable customer-safe error when Google Cloud provisioning fails
- keep provider details out of connection status responses
- cover both the connect response and subsequent status reads

## Root cause

The connect endpoint returned upstream Google API messages verbatim. The callback page rendered those details directly, exposing implementation-specific request paths and IAM policy text to customers.

## Validation

- 30 Google Cloud API tests
- API TypeScript typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide upstream Google Cloud provider error details from customer responses and return a single safe message on provisioning failures. Also adds structured logging for internal debugging.

- **Bug Fixes**
  - Connect now returns 502 with: "Google Cloud setup failed. Please try again or contact support."
  - Connection status `lastError` is masked to the same message.
  - Provisioning failures are logged with `authorizationId`, `gcpProjectId`, and the upstream error.

<sup>Written for commit be627424d98fd6c1ec521ea12fceac81efdff8c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

