### PR TITLE
Show quota reset date in billing usage

### DIFF
--- a/apps/web/src/settings/BillingCard.tsx
+++ b/apps/web/src/settings/BillingCard.tsx
@@ -65,6 +65,14 @@ function formatUsd(n: number): string {
   return `$${n.toFixed(2)}`;
 }
 
+function formatResetDate(timestamp: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: new Date(timestamp).getFullYear() === new Date().getFullYear() ? undefined : "numeric",
+  }).format(new Date(timestamp));
+}
+
 // Metered rates + plan base fees / per-credit overage (mirror pricing.ts). Used
 // to estimate the current bill from this period's usage. Free is never billed
 // (hard caps), so its bill is always $0.
@@ -170,6 +178,17 @@ export function BillingCard() {
       return null;
     }
   };
+  const balances = {
+    investigations: balanceOf("investigations"),
+    spans: balanceOf("spans"),
+    logs: balanceOf("logs"),
+    metric_points: balanceOf("metric_points"),
+  };
+  const quotaResetAt =
+    Object.values(balances)
+      .map((balance) => balance?.nextResetAt)
+      .filter((timestamp): timestamp is number => timestamp != null)
+      .sort((a, b) => a - b)[0] ?? activeSub?.currentPeriodEnd ?? null;
 
   // True when any hard-capped signal (Free tier) is exhausted — ingest/usage is
   // paused, so we surface the upgrade CTA. signalAtHardCap guards against
@@ -294,18 +313,29 @@ export function BillingCard() {
 
       {/* Usage this period — one card with all meters + the running bill */}
       <div className="rounded-lg border border-border bg-surface/30 p-4">
-        <div className="mb-3 text-[11px] tracking-wide text-subtle">This period</div>
+        <div className="mb-3 flex items-baseline justify-between gap-3 text-[11px] tracking-wide text-subtle">
+          <span>This period</span>
+          {quotaResetAt && (
+            <time
+              dateTime={new Date(quotaResetAt).toISOString()}
+              title={new Date(quotaResetAt).toLocaleString()}
+              className="normal-case tracking-normal"
+            >
+              Quotas reset {formatResetDate(quotaResetAt)}
+            </time>
+          )}
+        </div>
         <div className="grid gap-2">
           <UsageMeter
             label="Investigation credits"
-            balance={balanceOf("investigations")}
+            balance={balances.investigations}
             format={(n) => n.toLocaleString()}
           />
-          <UsageMeter label="Spans" balance={balanceOf("spans")} format={formatCount} />
-          <UsageMeter label="Logs" balance={balanceOf("logs")} format={formatCount} />
+          <UsageMeter label="Spans" balance={balances.spans} format={formatCount} />
+          <UsageMeter label="Logs" balance={balances.logs} format={formatCount} />
           <UsageMeter
             label="Metric points"
-            balance={balanceOf("metric_points")}
+            balance={balances.metric_points}
             format={formatCount}
           />
         </div>

--- a/scripts/portless-stack.sh
+++ b/scripts/portless-stack.sh
@@ -17,7 +17,7 @@ Starts an isolated local stack:
   - separate Docker Compose project and volumes
   - separate host ports for Postgres, ClickHouse, and the collector
   - Drizzle migrations against that stack's Postgres
-  - api, web, and intake proxy behind portless .localhost routes
+  - api, web, and intake proxy behind the active portless routes
 USAGE
 }
 
@@ -138,18 +138,23 @@ else
   PROXY_ROUTE="intake.$STACK_NAME.superlog"
 fi
 
-# Detect the portless proxy endpoint. Portless persists the port and TLS mode
-# separately (`proxy.port` + optional `proxy.tls`), so URL generation must read
-# both. Embedding the port and matching scheme is required so every process —
-# including node fetch in seed scripts — reaches the same proxy that the CLI
-# starts.
+# Detect the portless proxy endpoint. Portless persists the port, TLS mode, and
+# active TLD separately, so URL generation must read all three. The TLD can be
+# `.local` when a shared proxy is in LAN mode, or a user-selected custom value.
+# Matching the running proxy is required so every process — including node fetch
+# in seed scripts — reaches the routes that the CLI actually registers.
 PORTLESS_PORT_FILE="$HOME/.portless/proxy.port"
 PORTLESS_TLS_FILE="$HOME/.portless/proxy.tls"
+PORTLESS_TLD_FILE="$HOME/.portless/proxy.tld"
 PORT_SUFFIX=""
 PROXY_PORT_VAL=""
 URL_SCHEME="https"
+URL_TLD="localhost"
 if [[ -s "$PORTLESS_PORT_FILE" ]]; then
   PROXY_PORT_VAL="$(tr -d '[:space:]' < "$PORTLESS_PORT_FILE")"
+fi
+if [[ -s "$PORTLESS_TLD_FILE" ]]; then
+  URL_TLD="$(tr -d '[:space:]' < "$PORTLESS_TLD_FILE")"
 fi
 # Preserve portless' native no-marker behavior: privileged installs bind 443.
 # Non-privileged setup can opt into a shared port explicitly; writing the marker
@@ -172,9 +177,9 @@ if [[ "$PROXY_PORT_VAL" =~ ^[0-9]+$ ]] && [[ ! -f "$PORTLESS_TLS_FILE" ]]; then
   URL_SCHEME="http"
 fi
 
-WEB_URL="$URL_SCHEME://$WEB_ROUTE.localhost$PORT_SUFFIX"
-API_URL="$URL_SCHEME://$API_ROUTE.localhost$PORT_SUFFIX"
-PROXY_URL="$URL_SCHEME://$PROXY_ROUTE.localhost$PORT_SUFFIX"
+WEB_URL="$URL_SCHEME://$WEB_ROUTE.$URL_TLD$PORT_SUFFIX"
+API_URL="$URL_SCHEME://$API_ROUTE.$URL_TLD$PORT_SUFFIX"
+PROXY_URL="$URL_SCHEME://$PROXY_ROUTE.$URL_TLD$PORT_SUFFIX"
 
 write_env_file() {
   mkdir -p "$STACK_DIR" "$LOG_DIR"
@@ -259,12 +264,12 @@ print_summary() {
 
 ensure_portless_routes_healthy() {
   # ~/.portless/routes.json is a shared JSON array that the portless proxy
-  # uses to dispatch <name>.superlog.localhost to a local port. Two failure
+  # uses to dispatch <name>.superlog.<tld> to a local port. Two failure
   # modes we've seen:
   #
   #   (a) `routes.json` is zero-bytes, missing, or non-array JSON. portless'
   #       loadRoutes() then treats the table as empty and the user gets the
-  #       "No app registered for <name>.superlog.localhost" landing page.
+  #       "No app registered for <name>.superlog.<tld>" landing page.
   #       Symptom shows up even when `overmind ps` says services are running.
   #
   #   (b) `routes.lock/` (a directory — portless uses mkdir-as-mutex) is
@@ -330,9 +335,9 @@ routes_registered() {
     }
     if (required.size > 0) process.exit(1);
   ' "$routes_file" \
-    "${WEB_ROUTE}.localhost" \
-    "${API_ROUTE}.localhost" \
-    "${PROXY_ROUTE}.localhost"
+    "${WEB_ROUTE}.${URL_TLD}" \
+    "${API_ROUTE}.${URL_TLD}" \
+    "${PROXY_ROUTE}.${URL_TLD}"
 }
 
 start_stack() {

--- a/scripts/portless-stack.test.sh
+++ b/scripts/portless-stack.test.sh
@@ -24,6 +24,16 @@ if [[ -e "$TMP_HOME/.portless/proxy.port" ]]; then
 fi
 
 mkdir -p "$TMP_HOME/.portless"
+printf 'local\n' > "$TMP_HOME/.portless/proxy.tld"
+output="$(HOME="$TMP_HOME" "$REPO_ROOT/scripts/portless-stack.sh" env --name "$STACK_NAME")"
+if ! grep -Fqx "web:        https://$STACK_NAME.superlog.local" <<< "$output"; then
+  echo "expected a persisted proxy TLD to be reflected in generated URLs" >&2
+  printf '%s\n' "$output" >&2
+  exit 1
+fi
+rm "$TMP_HOME/.portless/proxy.tld"
+
+mkdir -p "$TMP_HOME/.portless"
 printf '443\n' > "$TMP_HOME/.portless/proxy.port"
 output="$(HOME="$TMP_HOME" "$REPO_ROOT/scripts/portless-stack.sh" env --name "$STACK_NAME")"
 if ! grep -Fqx "web:        http://$STACK_NAME.superlog.localhost:443" <<< "$output"; then


### PR DESCRIPTION
## Summary

- show the next quota reset date beside the billing usage gauges
- source the date from feature reset metadata, with the subscription period end as a fallback
- keep worktree URLs and health checks aligned with the active persisted Portless TLD

## Why

The billing panel showed current usage without telling customers when their monthly allowances replenish. During local verification, a persisted LAN/custom TLD also exposed a mismatch between generated health-check URLs and the routes registered by the shared proxy.

## Validation

- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web build`
- `bash scripts/portless-stack.test.sh`
- `pnpm worktree:bootstrap --seed`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the next quota reset date in the billing usage card and aligns local Portless URLs with the active TLD to prevent health-check mismatches. This clarifies when allowances replenish and fixes local routing issues.

- New Features
  - Display “Quotas reset <date>” in the billing usage section, sourced from feature reset metadata with a fallback to the subscription period end.

- Bug Fixes
  - Update `scripts/portless-stack.sh` to read the persisted `proxy.tld` and use it in generated web/api/proxy URLs and health checks.
  - Extend `scripts/portless-stack.test.sh` to assert the TLD is reflected in URLs.

<sup>Written for commit c76a96e9cb140fba8fbbdd2226bedff4c3da2ebc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

