### PR TITLE
Support log attribute alert filters

### DIFF
--- a/apps/api/src/alerts-service.test.ts
+++ b/apps/api/src/alerts-service.test.ts
@@ -87,6 +87,19 @@ test("validateAlertInput requires groupBy when groupMode = per_group", () => {
   );
 });
 
+test("validateAlertInput rejects log attributes for non-log alerts", () => {
+  expectBadRequest(
+    () =>
+      validateAlertInput(
+        baseInput({
+          source: "traces",
+          filter: { logAttrs: [{ key: "gcp.http_request.status", value: "422" }] },
+        }),
+      ),
+    "logAttrs can only be used when source = logs",
+  );
+});
+
 test("alertInputToFilter keeps only the filter fields", () => {
   const filter = alertInputToFilter(
     baseInput({
@@ -94,6 +107,7 @@ test("alertInputToFilter keeps only the filter fields", () => {
       groupMode: "per_group",
       filter: {
         resourceAttrs: [{ key: "deployment.environment", value: "prod" }],
+        logAttrs: [{ key: "gcp.http_request.status", value: "422" }],
         service: "checkout",
         severity: "ERROR",
         spanName: "POST /pay",
@@ -105,6 +119,7 @@ test("alertInputToFilter keeps only the filter fields", () => {
 
   assert.deepEqual(filter, {
     resourceAttrs: [{ key: "deployment.environment", value: "prod" }],
+    logAttrs: [{ key: "gcp.http_request.status", value: "422" }],
     service: "checkout",
     severity: "ERROR",
     spanName: "POST /pay",
@@ -117,6 +132,7 @@ test("alertInputToFilter returns undefined fields when no filter is provided", (
   const filter = alertInputToFilter(baseInput());
   assert.deepEqual(filter, {
     resourceAttrs: undefined,
+    logAttrs: undefined,
     service: undefined,
     severity: undefined,
     spanName: undefined,
@@ -222,6 +238,7 @@ test("alertRecordToInput maps a metric alert row to the preview input shape", ()
   // Round-trips through the filter extractor the series builder uses.
   assert.deepEqual(alertInputToFilter(input), {
     resourceAttrs: [{ key: "env", value: "prod" }],
+    logAttrs: undefined,
     service: "worker",
     severity: undefined,
     spanName: undefined,

--- a/apps/api/src/alerts-service.test.ts
+++ b/apps/api/src/alerts-service.test.ts
@@ -100,6 +100,17 @@ test("validateAlertInput rejects log attributes for non-log alerts", () => {
   );
 });
 
+test("validateAlertInput rejects group attributes incompatible with the source", () => {
+  expectBadRequest(
+    () => validateAlertInput(baseInput({ source: "traces", groupBy: "log.http.status_code" })),
+    "log groupBy can only be used when source = logs",
+  );
+  expectBadRequest(
+    () => validateAlertInput(baseInput({ source: "logs", groupBy: "span.http.route" })),
+    "span groupBy can only be used when source = traces",
+  );
+});
+
 test("alertInputToFilter keeps only the filter fields", () => {
   const filter = alertInputToFilter(
     baseInput({

--- a/apps/api/src/alerts-service.ts
+++ b/apps/api/src/alerts-service.ts
@@ -76,6 +76,12 @@ export function validateAlertInput(input: AlertInput): void {
   if (input.source !== "logs" && input.filter?.logAttrs?.length) {
     throw new HTTPException(400, { message: "logAttrs can only be used when source = logs" });
   }
+  if (input.source !== "logs" && input.groupBy?.startsWith("log.")) {
+    throw new HTTPException(400, { message: "log groupBy can only be used when source = logs" });
+  }
+  if (input.source !== "traces" && input.groupBy?.startsWith("span.")) {
+    throw new HTTPException(400, { message: "span groupBy can only be used when source = traces" });
+  }
 }
 
 export function alertInputToFilter(input: AlertInput): schema.AlertFilter {

--- a/apps/api/src/alerts-service.ts
+++ b/apps/api/src/alerts-service.ts
@@ -27,6 +27,11 @@ const resourceAttrSchema = z.object({
 
 export const alertFilterSchema = z.object({
   resourceAttrs: z.array(resourceAttrSchema).max(50).optional(),
+  logAttrs: z
+    .array(resourceAttrSchema)
+    .max(50)
+    .optional()
+    .describe("Equality filters on per-log-record attributes; valid only for logs alerts"),
   service: z.string().max(200).optional(),
   severity: z.string().max(50).optional(),
   spanName: z.string().max(200).optional(),
@@ -68,11 +73,15 @@ export function validateAlertInput(input: AlertInput): void {
   if (input.groupMode === "per_group" && !input.groupBy) {
     throw new HTTPException(400, { message: "groupBy required when groupMode = per_group" });
   }
+  if (input.source !== "logs" && input.filter?.logAttrs?.length) {
+    throw new HTTPException(400, { message: "logAttrs can only be used when source = logs" });
+  }
 }
 
 export function alertInputToFilter(input: AlertInput): schema.AlertFilter {
   return {
     resourceAttrs: input.filter?.resourceAttrs,
+    logAttrs: input.filter?.logAttrs,
     service: input.filter?.service,
     severity: input.filter?.severity,
     spanName: input.filter?.spanName,
@@ -142,6 +151,7 @@ export async function evaluateAlertQuery(
         range,
         service: alert.filter.service,
         resourceAttrs,
+        logAttrs: alert.filter.logAttrs,
         severity: alert.filter.severity,
         spanName: alert.filter.spanName,
         statusCode: alert.filter.statusCode,
@@ -481,6 +491,7 @@ export async function previewAlertSeries(
         range,
         service: filter.service,
         resourceAttrs: filter.resourceAttrs,
+        logAttrs: filter.logAttrs,
         severity: filter.severity,
         spanName: filter.spanName,
         statusCode: filter.statusCode,

--- a/apps/api/src/mcp/alerts.ts
+++ b/apps/api/src/mcp/alerts.ts
@@ -56,7 +56,9 @@ const alertInputShape = {
     .max(200)
     .nullable()
     .optional()
-    .describe("Resource attribute to group by, e.g. 'service.name'"),
+    .describe(
+      "Attribute to group by, e.g. 'service.name', 'resource.deployment.environment', or 'log.gcp.http_request.status'",
+    ),
   group_mode: alertGroupModeSchema
     .optional()
     .describe("'single' rolls up everything; 'per_group' fires per distinct group_by value"),

--- a/apps/web/src/Explore.tsx
+++ b/apps/web/src/Explore.tsx
@@ -1305,6 +1305,7 @@ export function AddFilter({
   existing,
   hasSeverity,
   hasStatus,
+  hideFacets,
   onPick,
   onClose,
 }: {
@@ -1314,6 +1315,7 @@ export function AddFilter({
   existing: ResourceAttr[];
   hasSeverity?: boolean;
   hasStatus?: boolean;
+  hideFacets?: boolean;
   onPick: (f: AddedFilter) => void;
   onClose: () => void;
 }) {
@@ -1489,7 +1491,7 @@ export function AddFilter({
   }
 
   const facetRows: FacetRow[] = [];
-  if (source === "logs") {
+  if (source === "logs" && !hideFacets) {
     facetRows.push({
       kind: "severity",
       label: "severity",
@@ -1497,7 +1499,7 @@ export function AddFilter({
       disabled: !!hasSeverity,
     });
   }
-  if (source === "traces") {
+  if (source === "traces" && !hideFacets) {
     facetRows.push({
       kind: "status",
       label: "status",

--- a/apps/web/src/alerts/AlertEdit.tsx
+++ b/apps/web/src/alerts/AlertEdit.tsx
@@ -75,7 +75,8 @@ function AlertEditInner({
   const [enabled, setEnabled] = useState(true);
   const [source, setSource] = useState<AlertSource>("logs");
   const [metricName, setMetricName] = useState("");
-  const [attrs, setAttrs] = useState<ResourceAttr[]>([]);
+  const [resourceAttrs, setResourceAttrs] = useState<ResourceAttr[]>([]);
+  const [logAttrs, setLogAttrs] = useState<ResourceAttr[]>([]);
   const [filterOpen, setFilterOpen] = useState(false);
   const [groupBy, setGroupBy] = useState("");
   const [groupMode, setGroupMode] = useState<AlertGroupMode>("single");
@@ -92,8 +93,20 @@ function AlertEditInner({
     setEnabled(a.enabled);
     setSource(a.source);
     setMetricName(a.metricName ?? "");
-    setAttrs(a.filter.resourceAttrs ?? []);
-    setGroupBy(a.groupBy ?? "");
+    setResourceAttrs(a.filter.resourceAttrs ?? []);
+    setLogAttrs(a.filter.logAttrs ?? []);
+    const storedGroupBy = a.groupBy ?? "";
+    setGroupBy(
+      a.source === "logs" &&
+        storedGroupBy &&
+        storedGroupBy !== "service" &&
+        storedGroupBy !== "service.name" &&
+        !storedGroupBy.startsWith("resource.") &&
+        !storedGroupBy.startsWith("log.") &&
+        !storedGroupBy.startsWith("attr:")
+        ? `resource.${storedGroupBy}`
+        : storedGroupBy,
+    );
     setGroupMode(a.groupMode);
     setAggregation(a.aggregation);
     setComparator(a.comparator);
@@ -114,7 +127,17 @@ function AlertEditInner({
   }, [groupBy, groupMode]);
 
   const range = useMemo(defaultRange, []);
-  const keys = useExploreAttributeKeys(projectId, range);
+  const keys = useExploreAttributeKeys(projectId, range, source === "logs" ? "logs" : undefined);
+  const visibleAttrs = useMemo(
+    () =>
+      source === "logs"
+        ? [
+            ...resourceAttrs.map((attr) => ({ ...attr, key: `resource.${attr.key}` })),
+            ...logAttrs.map((attr) => ({ ...attr, key: `log.${attr.key}` })),
+          ]
+        : resourceAttrs,
+    [source, resourceAttrs, logAttrs],
+  );
 
   const create = useCreateAlert(projectId);
   const update = useUpdateAlert(projectId, alertId ?? "");
@@ -127,7 +150,10 @@ function AlertEditInner({
       enabled,
       source,
       metricName: source === "metric" ? metricName : null,
-      filter: { resourceAttrs: attrs.length ? attrs : undefined },
+      filter: {
+        resourceAttrs: resourceAttrs.length ? resourceAttrs : undefined,
+        logAttrs: source === "logs" && logAttrs.length ? logAttrs : undefined,
+      },
       groupBy: groupBy || null,
       groupMode,
       aggregation,
@@ -141,7 +167,8 @@ function AlertEditInner({
       enabled,
       source,
       metricName,
-      attrs,
+      resourceAttrs,
+      logAttrs,
       groupBy,
       groupMode,
       aggregation,
@@ -178,7 +205,8 @@ function AlertEditInner({
       JSON.stringify({
         source,
         metricName: source === "metric" ? metricName : null,
-        attrs,
+        resourceAttrs,
+        logAttrs: source === "logs" ? logAttrs : undefined,
         groupBy,
         groupMode,
         aggregation,
@@ -186,7 +214,18 @@ function AlertEditInner({
         threshold,
         windowMinutes,
       }),
-    [source, metricName, attrs, groupBy, groupMode, aggregation, comparator, threshold, windowMinutes],
+    [
+      source,
+      metricName,
+      resourceAttrs,
+      logAttrs,
+      groupBy,
+      groupMode,
+      aggregation,
+      comparator,
+      threshold,
+      windowMinutes,
+    ],
   );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-run is keyed by previewKey; body/mutations are read fresh.
@@ -263,7 +302,11 @@ function AlertEditInner({
           ) : previewSeries.data || preview.data ? (
             <div className="flex flex-col gap-4">
               {preview.data && (
-                <PreviewResult result={preview.data} threshold={threshold} comparator={comparator} />
+                <PreviewResult
+                  result={preview.data}
+                  threshold={threshold}
+                  comparator={comparator}
+                />
               )}
               {previewSeries.data && <AlertPreviewChart series={previewSeries.data} />}
             </div>
@@ -291,10 +334,25 @@ function AlertEditInner({
 
         <SettingsRow title="Filters" description="Narrow down the data this rule looks at">
           <div className="flex flex-wrap items-center gap-2">
-            {attrs.map((a, i) => (
+            {visibleAttrs.map((a, i) => (
               <button
+                type="button"
                 key={`${a.key}=${a.value}-${i}`}
-                onClick={() => setAttrs(attrs.filter((_, j) => j !== i))}
+                onClick={() => {
+                  if (source === "logs" && a.key.startsWith("log.")) {
+                    const key = a.key.slice("log.".length);
+                    setLogAttrs(
+                      logAttrs.filter((attr) => attr.key !== key || attr.value !== a.value),
+                    );
+                  } else {
+                    const key = a.key.startsWith("resource.")
+                      ? a.key.slice("resource.".length)
+                      : a.key;
+                    setResourceAttrs(
+                      resourceAttrs.filter((attr) => attr.key !== key || attr.value !== a.value),
+                    );
+                  }
+                }}
               >
                 <Chip tone="accent">
                   <span className="opacity-70">{a.key}</span>
@@ -312,10 +370,29 @@ function AlertEditInner({
                 <AddFilter
                   projectId={projectId}
                   range={range}
-                  existing={attrs}
+                  source={source === "logs" ? "logs" : undefined}
+                  hideFacets
+                  existing={visibleAttrs}
                   onClose={() => setFilterOpen(false)}
                   onPick={(f) => {
-                    if (f.kind === "attr") setAttrs([...attrs, { key: f.key, value: f.value }]);
+                    if (f.kind === "attr") {
+                      if (source === "logs" && f.key.startsWith("log.")) {
+                        setLogAttrs([
+                          ...logAttrs,
+                          { key: f.key.slice("log.".length), value: f.value },
+                        ]);
+                      } else {
+                        setResourceAttrs([
+                          ...resourceAttrs,
+                          {
+                            key: f.key.startsWith("resource.")
+                              ? f.key.slice("resource.".length)
+                              : f.key,
+                            value: f.value,
+                          },
+                        ]);
+                      }
+                    }
                     setFilterOpen(false);
                   }}
                 />
@@ -634,8 +711,8 @@ function PreviewResult({
           label={result.breaches > 0 ? "Firing" : "OK"}
         />
         <span className="text-[12px] text-muted">
-          value{" "}
-          <span className="tabular-nums text-fg">{result.value.toFixed(2)}</span> {op} {threshold}
+          value <span className="tabular-nums text-fg">{result.value.toFixed(2)}</span> {op}{" "}
+          {threshold}
         </span>
       </div>
     );
@@ -651,7 +728,10 @@ function PreviewResult({
         )}
         {result.groups.map((g) => (
           <div key={g.key} className="flex items-center gap-3 px-3 py-2">
-            <StatusDot tone={g.breaching ? "danger" : "success"} label={g.breaching ? "Firing" : "OK"} />
+            <StatusDot
+              tone={g.breaching ? "danger" : "success"}
+              label={g.breaching ? "Firing" : "OK"}
+            />
             <span className="flex-1 truncate text-[12.5px] text-fg">{g.key || "(empty)"}</span>
             <span className="tabular-nums text-[12.5px] text-muted">{g.value.toFixed(2)}</span>
           </div>

--- a/apps/web/src/alerts/AlertEdit.tsx
+++ b/apps/web/src/alerts/AlertEdit.tsx
@@ -97,8 +97,7 @@ function AlertEditInner({
     setLogAttrs(a.filter.logAttrs ?? []);
     const storedGroupBy = a.groupBy ?? "";
     setGroupBy(
-      a.source === "logs" &&
-        storedGroupBy &&
+      storedGroupBy &&
         storedGroupBy !== "service" &&
         storedGroupBy !== "service.name" &&
         !storedGroupBy.startsWith("resource.") &&
@@ -133,7 +132,11 @@ function AlertEditInner({
   }, [groupBy, groupMode]);
 
   const range = useMemo(defaultRange, []);
-  const keys = useExploreAttributeKeys(projectId, range, source === "logs" ? "logs" : undefined);
+  const keys = useExploreAttributeKeys(
+    projectId,
+    range,
+    source === "metric" ? "metrics" : source,
+  );
   const visibleAttrs = useMemo(
     () =>
       source === "logs"

--- a/apps/web/src/alerts/AlertEdit.tsx
+++ b/apps/web/src/alerts/AlertEdit.tsx
@@ -121,6 +121,12 @@ function AlertEditInner({
     if (source !== "metric" && aggregation !== "count") setAggregation("count");
   }, [source, aggregation]);
 
+  // Scoped event attributes only exist on their matching telemetry source.
+  useEffect(() => {
+    if (source !== "logs" && groupBy.startsWith("log.")) setGroupBy("");
+    if (source !== "traces" && groupBy.startsWith("span.")) setGroupBy("");
+  }, [source, groupBy]);
+
   // Reset groupMode if groupBy is cleared
   useEffect(() => {
     if (!groupBy && groupMode === "per_group") setGroupMode("single");

--- a/apps/web/src/alerts/AlertEdit.tsx
+++ b/apps/web/src/alerts/AlertEdit.tsx
@@ -102,6 +102,7 @@ function AlertEditInner({
         storedGroupBy !== "service.name" &&
         !storedGroupBy.startsWith("resource.") &&
         !storedGroupBy.startsWith("log.") &&
+        !storedGroupBy.startsWith("span.") &&
         !storedGroupBy.startsWith("attr:")
         ? `resource.${storedGroupBy}`
         : storedGroupBy,

--- a/apps/web/src/alerts/types.ts
+++ b/apps/web/src/alerts/types.ts
@@ -5,6 +5,7 @@ export type AlertGroupMode = "per_group" | "single";
 
 export type AlertFilter = {
   resourceAttrs?: { key: string; value: string }[];
+  logAttrs?: { key: string; value: string }[];
   service?: string;
   severity?: string;
   spanName?: string;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -46,7 +46,13 @@ export default defineConfig(({ mode }) => {
       port: Number(env.PORT ?? env.WEB_PORT ?? 5173),
       strictPort: true,
       watch: inWorktree ? { usePolling: true, interval: 150 } : undefined,
-      allowedHosts: [".localhost", ".ngrok-free.app", ".ngrok.app", ".trycloudflare.com"],
+      allowedHosts: [
+        ".localhost",
+        ...(env.VITE_PORTLESS_TLD ? [`.${env.VITE_PORTLESS_TLD}`] : []),
+        ".ngrok-free.app",
+        ".ngrok.app",
+        ".trycloudflare.com",
+      ],
     },
   };
 });

--- a/apps/worker/src/alerts/metrics-repository.test.ts
+++ b/apps/worker/src/alerts/metrics-repository.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ClickHouseClient } from "@clickhouse/client";
+import type { schema } from "@superlog/db";
+import { createAlertMetricsRepository } from "./metrics-repository.js";
+
+function makeAlert(overrides: Partial<schema.Alert> = {}): schema.Alert {
+  return {
+    id: "alert-1",
+    projectId: "project-1",
+    name: "Nginx 422s",
+    enabled: true,
+    source: "logs",
+    metricName: null,
+    filter: {},
+    groupBy: null,
+    groupMode: "single",
+    aggregation: "count",
+    comparator: "gt",
+    threshold: 2,
+    windowMinutes: 15,
+    evaluationIntervalSeconds: 60,
+    createdBy: "user-1",
+    lastEvaluatedAt: null,
+    createdAt: new Date("2026-08-06T09:00:00.000Z"),
+    updatedAt: new Date("2026-08-06T09:00:00.000Z"),
+    ...overrides,
+  } satisfies schema.Alert;
+}
+
+test("live alert evaluation counts logs matching per-record attributes", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+  const ch = {
+    async query(input: { query: string; query_params?: Record<string, unknown> }) {
+      capture.query = input.query;
+      capture.params = input.query_params;
+      return { json: async () => [{ group_key: "", v: "3" }] };
+    },
+  } as unknown as ClickHouseClient;
+  const repo = createAlertMetricsRepository(ch);
+
+  const counts = await repo.aggregateCount(
+    makeAlert({
+      filter: {
+        logAttrs: [
+          { key: "gcp.http_request.status", value: "422" },
+          { key: "gcp.http_request.requestUrl", value: "/api/captains/stripe/connect" },
+        ],
+      },
+    } as Partial<schema.Alert>),
+    { since: "2026-08-06T10:00:00.000Z", until: "2026-08-06T10:15:00.000Z" },
+  );
+
+  assert.equal(counts.get(""), 3);
+  assert.match(capture.query ?? "", /LogAttributes\[\{aalert_log_k_0:String\}\]/);
+  assert.match(capture.query ?? "", /LogAttributes\[\{aalert_log_k_1:String\}\]/);
+  assert.equal(capture.params?.aalert_log_k_0, "gcp.http_request.status");
+  assert.equal(capture.params?.aalert_log_v_0, "422");
+  assert.equal(capture.params?.aalert_log_k_1, "gcp.http_request.requestUrl");
+});
+
+test("live alert evaluation groups logs by a per-record attribute", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+  const ch = {
+    async query(input: { query: string; query_params?: Record<string, unknown> }) {
+      capture.query = input.query;
+      capture.params = input.query_params;
+      return { json: async () => [{ group_key: "422", v: "3" }] };
+    },
+  } as unknown as ClickHouseClient;
+  const repo = createAlertMetricsRepository(ch);
+
+  const counts = await repo.aggregateCount(
+    makeAlert({ groupBy: "log.gcp.http_request.status", groupMode: "per_group" }),
+    { since: "2026-08-06T10:00:00.000Z", until: "2026-08-06T10:15:00.000Z" },
+  );
+
+  assert.equal(counts.get("422"), 3);
+  assert.match(capture.query ?? "", /LogAttributes\[\{aalert_groupKey:String\}\]/);
+  assert.equal(capture.params?.aalert_groupKey, "gcp.http_request.status");
+});

--- a/apps/worker/src/alerts/metrics-repository.test.ts
+++ b/apps/worker/src/alerts/metrics-repository.test.ts
@@ -79,3 +79,23 @@ test("live alert evaluation groups logs by a per-record attribute", async () => 
   assert.match(capture.query ?? "", /LogAttributes\[\{aalert_groupKey:String\}\]/);
   assert.equal(capture.params?.aalert_groupKey, "gcp.http_request.status");
 });
+
+test("live alert evaluation does not reinterpret an incompatible scoped group as a resource", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+  const ch = {
+    async query(input: { query: string; query_params?: Record<string, unknown> }) {
+      capture.query = input.query;
+      capture.params = input.query_params;
+      return { json: async () => [{ group_key: "", v: "3" }] };
+    },
+  } as unknown as ClickHouseClient;
+  const repo = createAlertMetricsRepository(ch);
+
+  await repo.aggregateCount(
+    makeAlert({ source: "traces", groupBy: "log.gcp.http_request.status" }),
+    { since: "2026-08-06T10:00:00.000Z", until: "2026-08-06T10:15:00.000Z" },
+  );
+
+  assert.match(capture.query ?? "", /'' AS group_key/);
+  assert.equal(capture.params?.aalert_groupKey, undefined);
+});

--- a/apps/worker/src/alerts/metrics-repository.ts
+++ b/apps/worker/src/alerts/metrics-repository.ts
@@ -5,7 +5,11 @@ import type { EvaluationRange } from "./domain.js";
 
 export type AlertMetricsRepository = ReturnType<typeof createAlertMetricsRepository>;
 
-function attrConds(attrs: { key: string; value: string }[] | undefined): {
+function attrConds(
+  attrs: { key: string; value: string }[] | undefined,
+  column = "ResourceAttributes",
+  prefix = "aalert",
+): {
   conds: string[];
   params: Record<string, string>;
 } {
@@ -13,16 +17,19 @@ function attrConds(attrs: { key: string; value: string }[] | undefined): {
   const params: Record<string, string> = {};
   if (!attrs) return { conds, params };
   attrs.forEach((a, i) => {
-    const k = `aalert_k_${i}`;
-    const v = `aalert_v_${i}`;
-    conds.push(`ResourceAttributes[{${k}:String}] = {${v}:String}`);
+    const k = `${prefix}_k_${i}`;
+    const v = `${prefix}_v_${i}`;
+    conds.push(`${column}[{${k}:String}] = {${v}:String}`);
     params[k] = a.key;
     params[v] = a.value;
   });
   return { conds, params };
 }
 
-function groupExprFor(groupBy: string | null | undefined): {
+function groupExprFor(
+  groupBy: string | null | undefined,
+  source: schema.AlertSource,
+): {
   expr: string;
   params: Record<string, string>;
 } {
@@ -30,9 +37,31 @@ function groupExprFor(groupBy: string | null | undefined): {
   if (groupBy === "service.name" || groupBy === "service") {
     return { expr: "ServiceName", params: {} };
   }
+  if (groupBy.startsWith("log.") && source === "logs") {
+    return {
+      expr: "LogAttributes[{aalert_groupKey:String}]",
+      params: { aalert_groupKey: groupBy.slice("log.".length) },
+    };
+  }
+  if (groupBy.startsWith("span.") && source === "traces") {
+    return {
+      expr: "SpanAttributes[{aalert_groupKey:String}]",
+      params: { aalert_groupKey: groupBy.slice("span.".length) },
+    };
+  }
+  if (groupBy.startsWith("attr:")) {
+    return {
+      expr:
+        source === "logs"
+          ? "LogAttributes[{aalert_groupKey:String}]"
+          : "SpanAttributes[{aalert_groupKey:String}]",
+      params: { aalert_groupKey: groupBy.slice("attr:".length) },
+    };
+  }
+  const resourceKey = groupBy.startsWith("resource.") ? groupBy.slice("resource.".length) : groupBy;
   return {
     expr: "ResourceAttributes[{aalert_groupKey:String}]",
-    params: { aalert_groupKey: groupBy },
+    params: { aalert_groupKey: resourceKey },
   };
 }
 
@@ -43,12 +72,14 @@ export function createAlertMetricsRepository(ch: ClickHouseClient) {
   ): Promise<Map<string, number>> {
     const table = alert.source === "logs" ? "otel_logs" : "otel_traces";
     const attr = attrConds(alert.filter.resourceAttrs);
-    const group = groupExprFor(alert.groupBy);
+    const logAttr = attrConds(alert.filter.logAttrs, "LogAttributes", "aalert_log");
+    const group = groupExprFor(alert.groupBy, alert.source);
     const conds: string[] = [
       "ResourceAttributes['superlog.project_id'] = {projectId:String}",
       "Timestamp >= parseDateTime64BestEffortOrZero({since:String})",
       "Timestamp <= parseDateTime64BestEffortOrZero({until:String})",
       ...attr.conds,
+      ...(alert.source === "logs" ? logAttr.conds : []),
     ];
     if (alert.filter.service) conds.push("ServiceName = {service:String}");
     if (alert.source === "logs") {
@@ -78,6 +109,7 @@ export function createAlertMetricsRepository(ch: ClickHouseClient) {
         statusCode: alert.filter.statusCode ?? "",
         minDurationNs: Math.round((alert.filter.minDurationMs ?? 0) * 1_000_000),
         ...attr.params,
+        ...(alert.source === "logs" ? logAttr.params : {}),
         ...group.params,
       },
       format: "JSONEachRow",

--- a/apps/worker/src/alerts/metrics-repository.ts
+++ b/apps/worker/src/alerts/metrics-repository.ts
@@ -49,6 +49,9 @@ function groupExprFor(
       params: { aalert_groupKey: groupBy.slice("span.".length) },
     };
   }
+  if (groupBy.startsWith("log.") || groupBy.startsWith("span.")) {
+    return { expr: "''", params: {} };
+  }
   if (groupBy.startsWith("attr:")) {
     return {
       expr:

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2646,6 +2646,7 @@ export type AlertGroupMode = "per_group" | "single";
 
 export type AlertFilter = {
   resourceAttrs?: { key: string; value: string }[];
+  logAttrs?: { key: string; value: string }[];
   service?: string;
   severity?: string;
   spanName?: string;

--- a/packages/telemetry-query/src/event-attribute-filter.test.ts
+++ b/packages/telemetry-query/src/event-attribute-filter.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ClickHouseClient } from "@clickhouse/client";
+import { countSeries } from "./index.js";
+
+test("countSeries filters log counts by per-record attributes", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+  const ch = {
+    async query(input: { query: string; query_params?: Record<string, unknown> }) {
+      capture.query = input.query;
+      capture.params = input.query_params;
+      return { json: async () => [] };
+    },
+  } as unknown as ClickHouseClient;
+
+  await countSeries(
+    ch,
+    "project-1",
+    "logs",
+    {
+      range: { since: "2026-08-06T10:00:00.000Z", until: "2026-08-06T10:15:00.000Z" },
+      logAttrs: [
+        { key: "gcp.http_request.status", value: "422" },
+        { key: "gcp.http_request.requestUrl", value: "/api/captains/stripe/connect" },
+      ],
+    },
+    undefined,
+    { n: 15, unit: "MINUTE" },
+  );
+
+  assert.match(capture.query ?? "", /LogAttributes\[\{event_attr_k_0:String\}\]/);
+  assert.match(capture.query ?? "", /LogAttributes\[\{event_attr_k_1:String\}\]/);
+  assert.equal(capture.params?.event_attr_k_0, "gcp.http_request.status");
+  assert.equal(capture.params?.event_attr_v_0, "422");
+  assert.equal(capture.params?.event_attr_k_1, "gcp.http_request.requestUrl");
+  assert.equal(capture.params?.event_attr_v_1, "/api/captains/stripe/connect");
+});

--- a/packages/telemetry-query/src/index.ts
+++ b/packages/telemetry-query/src/index.ts
@@ -1838,7 +1838,9 @@ export async function metricSeries(
     groupParams.groupKey = groupBy.slice("attr:".length);
   } else if (groupBy) {
     groupExpr = "ResourceAttributes[{groupKey:String}]";
-    groupParams.groupKey = groupBy;
+    groupParams.groupKey = groupBy.startsWith("resource.")
+      ? groupBy.slice("resource.".length)
+      : groupBy;
   }
 
   const perTable = await Promise.all(

--- a/packages/telemetry-query/src/index.ts
+++ b/packages/telemetry-query/src/index.ts
@@ -2060,6 +2060,7 @@ export type SeriesFilter = {
   range?: TimeRange;
   service?: string;
   resourceAttrs?: ResourceAttrFilter[];
+  logAttrs?: ResourceAttrFilter[];
   search?: string;
   severity?: string;
   spanName?: string;
@@ -2178,6 +2179,7 @@ function foldServiceAttrFilter(filter: SeriesFilter): SeriesFilter | null {
 function rollupEligible(filter: SeriesFilter, groupBy: string | undefined, step: Step): boolean {
   if (step.unit === "SECOND") return false; // rollup resolution is one minute
   if (filter.resourceAttrs?.length) return false;
+  if (filter.logAttrs?.length) return false;
   if (filter.search) return false;
   if (filter.spanName) return false;
   if (filter.minDurationMs) return false;
@@ -2263,7 +2265,7 @@ export async function countSeries(
   const attr = attrConds(split.resource);
   const eventAttr =
     source === "logs"
-      ? attrConds(split.log, "LogAttributes", "event_attr")
+      ? attrConds([...split.log, ...(filter.logAttrs ?? [])], "LogAttributes", "event_attr")
       : attrConds(split.span, "SpanAttributes", "event_attr");
   const field = fieldConds(split.field, source === "logs" ? "logs" : "traces");
   const table = source === "logs" ? "otel_logs" : "otel_traces";

--- a/packages/telemetry-query/src/metric-grouping.test.ts
+++ b/packages/telemetry-query/src/metric-grouping.test.ts
@@ -1,0 +1,29 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import type { ClickHouseClient } from "@clickhouse/client";
+import { metricSeries } from "./index.js";
+
+test("metric series strips the resource scope from a group key", async () => {
+  const queryParams: Record<string, unknown>[] = [];
+  const ch = {
+    async query(input: { query_params?: Record<string, unknown> }) {
+      queryParams.push(input.query_params ?? {});
+      return { json: async () => [] };
+    },
+  } as unknown as ClickHouseClient;
+
+  await metricSeries(
+    ch,
+    "project-1",
+    "requests.total",
+    {},
+    "resource.deployment.environment",
+    { n: 1, unit: "MINUTE" },
+    "sum",
+  );
+
+  assert.ok(queryParams.length > 0);
+  for (const params of queryParams) {
+    assert.equal(params.groupKey, "deployment.environment");
+  }
+});

--- a/scripts/portless-stack.sh
+++ b/scripts/portless-stack.sh
@@ -17,7 +17,7 @@ Starts an isolated local stack:
   - separate Docker Compose project and volumes
   - separate host ports for Postgres, ClickHouse, and the collector
   - Drizzle migrations against that stack's Postgres
-  - api, web, and intake proxy behind portless .localhost routes
+  - api, web, and intake proxy behind portless named routes
 USAGE
 }
 
@@ -145,9 +145,11 @@ fi
 # starts.
 PORTLESS_PORT_FILE="$HOME/.portless/proxy.port"
 PORTLESS_TLS_FILE="$HOME/.portless/proxy.tls"
+PORTLESS_TLD_FILE="$HOME/.portless/proxy.tld"
 PORT_SUFFIX=""
 PROXY_PORT_VAL=""
 URL_SCHEME="https"
+URL_TLD="localhost"
 if [[ -s "$PORTLESS_PORT_FILE" ]]; then
   PROXY_PORT_VAL="$(tr -d '[:space:]' < "$PORTLESS_PORT_FILE")"
 fi
@@ -171,10 +173,17 @@ fi
 if [[ "$PROXY_PORT_VAL" =~ ^[0-9]+$ ]] && [[ ! -f "$PORTLESS_TLS_FILE" ]]; then
   URL_SCHEME="http"
 fi
+if [[ -s "$PORTLESS_TLD_FILE" ]]; then
+  URL_TLD="$(tr -d '[:space:]' < "$PORTLESS_TLD_FILE")"
+  if [[ ! "$URL_TLD" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ ]]; then
+    echo "invalid portless proxy TLD in $PORTLESS_TLD_FILE: $URL_TLD" >&2
+    exit 1
+  fi
+fi
 
-WEB_URL="$URL_SCHEME://$WEB_ROUTE.localhost$PORT_SUFFIX"
-API_URL="$URL_SCHEME://$API_ROUTE.localhost$PORT_SUFFIX"
-PROXY_URL="$URL_SCHEME://$PROXY_ROUTE.localhost$PORT_SUFFIX"
+WEB_URL="$URL_SCHEME://$WEB_ROUTE.$URL_TLD$PORT_SUFFIX"
+API_URL="$URL_SCHEME://$API_ROUTE.$URL_TLD$PORT_SUFFIX"
+PROXY_URL="$URL_SCHEME://$PROXY_ROUTE.$URL_TLD$PORT_SUFFIX"
 
 write_env_file() {
   mkdir -p "$STACK_DIR" "$LOG_DIR"
@@ -259,12 +268,14 @@ print_summary() {
 
 ensure_portless_routes_healthy() {
   # ~/.portless/routes.json is a shared JSON array that the portless proxy
-  # uses to dispatch <name>.superlog.localhost to a local port. Two failure
+  # uses to dispatch the generated <name>.superlog.<tld> host to a local port.
+  # The persisted proxy.tld controls that suffix (`localhost` by default,
+  # `local` in LAN mode). Two failure
   # modes we've seen:
   #
   #   (a) `routes.json` is zero-bytes, missing, or non-array JSON. portless'
   #       loadRoutes() then treats the table as empty and the user gets the
-  #       "No app registered for <name>.superlog.localhost" landing page.
+  #       "No app registered for <name>.superlog.<tld>" landing page.
   #       Symptom shows up even when `overmind ps` says services are running.
   #
   #   (b) `routes.lock/` (a directory — portless uses mkdir-as-mutex) is
@@ -330,9 +341,9 @@ routes_registered() {
     }
     if (required.size > 0) process.exit(1);
   ' "$routes_file" \
-    "${WEB_ROUTE}.localhost" \
-    "${API_ROUTE}.localhost" \
-    "${PROXY_ROUTE}.localhost"
+    "${WEB_ROUTE}.${URL_TLD}" \
+    "${API_ROUTE}.${URL_TLD}" \
+    "${PROXY_ROUTE}.${URL_TLD}"
 }
 
 start_stack() {

--- a/scripts/portless-stack.sh
+++ b/scripts/portless-stack.sh
@@ -211,6 +211,7 @@ write_env_file() {
     printf 'GATEWAY_PUBLIC_URL=%s\n' "$API_URL"
     printf 'API_BASE_URL=%s\n' "$API_URL"
     printf 'VITE_API_URL=%s\n' "$API_URL"
+    printf 'VITE_PORTLESS_TLD=%s\n' "$URL_TLD"
     # Better Auth's baseURL has to match the actual origin serving /api/auth/*
     # or state cookies get scoped to the wrong host. Without this, the worktree
     # falls back to apps/api/.env's localhost:4100 and every OAuth attempt

--- a/scripts/portless-stack.test.sh
+++ b/scripts/portless-stack.test.sh
@@ -24,6 +24,15 @@ if [[ -e "$TMP_HOME/.portless/proxy.port" ]]; then
 fi
 
 mkdir -p "$TMP_HOME/.portless"
+printf 'local\n' > "$TMP_HOME/.portless/proxy.tld"
+output="$(HOME="$TMP_HOME" "$REPO_ROOT/scripts/portless-stack.sh" env --name "$STACK_NAME")"
+if ! grep -Fqx "web:        https://$STACK_NAME.superlog.local" <<< "$output"; then
+  echo "expected URL generation to follow portless' persisted TLD" >&2
+  printf '%s\n' "$output" >&2
+  exit 1
+fi
+rm "$TMP_HOME/.portless/proxy.tld"
+
 printf '443\n' > "$TMP_HOME/.portless/proxy.port"
 output="$(HOME="$TMP_HOME" "$REPO_ROOT/scripts/portless-stack.sh" env --name "$STACK_NAME")"
 if ! grep -Fqx "web:        http://$STACK_NAME.superlog.localhost:443" <<< "$output"; then

--- a/scripts/portless-stack.test.sh
+++ b/scripts/portless-stack.test.sh
@@ -31,6 +31,10 @@ if ! grep -Fqx "web:        https://$STACK_NAME.superlog.local" <<< "$output"; t
   printf '%s\n' "$output" >&2
   exit 1
 fi
+if ! grep -Fqx 'VITE_PORTLESS_TLD=local' "$REPO_ROOT/tmp/portless-stacks/$STACK_NAME/env"; then
+  echo "expected the active portless TLD to be passed to Vite's host allowlist" >&2
+  exit 1
+fi
 rm "$TMP_HOME/.portless/proxy.tld"
 
 printf '443\n' > "$TMP_HOME/.portless/proxy.port"


### PR DESCRIPTION
## Summary

- let log alerts filter and group by event-level log attributes
- keep metric, trace, and resource-attribute alert behavior unchanged
- expose separate resource and log attribute controls in the alert editor
- make worktree URLs follow the active local proxy TLD

## Why

Log queries already support event attributes, but alert evaluation only applied resource attributes. That made source-specific fields such as `gcp.http_request.status` unavailable to alerts even when the logs explorer could query them.

## Validation

- API test suite (619 tests)
- worker alert suite (28 tests)
- telemetry query filter tests
- typechecks for database, telemetry query, API, worker, and web packages
- production web build
- portless stack tests
- local runtime preview against a GCP-shaped Nginx log matched the expected event

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-log attribute filtering and grouping for log alerts, with strict group-by scope validation and consistently scoped group keys across API, UI, and backend. Preserves span-scoped group keys for trace alerts, and the dev server host allowlist follows the active proxy TLD.

- **New Features**
  - API: Add `filter.logAttrs` for logs; reject on non-log sources. Enforce scoped `groupBy` (`log.<key>` for logs, `span.<key>` for traces). MCP help text now includes resource/log examples. `alertInputToFilter` passes `logAttrs` through to evaluation and preview.
  - Grouping: Support `groupBy` on `log.<key>` and `span.<key>` only on matching sources; ignore incompatible scoped groups. Preserve span group scopes and normalize resource `groupBy` keys so metrics strip `resource.`. UI prefixes bare keys to `resource.<key>` and clears incompatible scoped groups on source change.
  - Backend: `apps/worker` counts and groups logs by per-record attributes; passes `logAttrs` to ClickHouse; disables rollup when `logAttrs` exist; preserves span grouping only for traces and avoids reinterpretation of incompatible groups. `packages/telemetry-query` accepts `logAttrs` in `SeriesFilter`, applies them in `countSeries`, and strips `resource.` in metric grouping. Tests cover event filters, scoped grouping, and metric resource key normalization.
  - UI: `apps/web` alert editor splits Resource and Log filters, shows prefixed chips, and fetches attribute keys per source; `AddFilter` respects `source="logs"` and `hideFacets`. Types include `logAttrs` in `AlertFilter`.

- **Dev tooling**
  - Portless stack: `scripts/portless-stack.sh` reads and validates `~/.portless/proxy.tld`, writes `VITE_PORTLESS_TLD`, and updates URLs. `apps/web/vite.config.ts` allows `.${env.VITE_PORTLESS_TLD}`. Tests verify TLD propagation.

<sup>Written for commit f1c941b5399f2101e143dd2c8270110bca896ce7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

