### PR TITLE
Allow configured Portless web hosts

### DIFF
--- a/apps/web/vite.config.test.ts
+++ b/apps/web/vite.config.test.ts
@@ -1,0 +1,22 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { viteAllowedHosts } from "./vite.config.ts";
+
+test("vite allows the generated Portless web host", () => {
+  assert.deepEqual(viteAllowedHosts({ SUPERLOG_PORTLESS_WEB_HOST: "feature.superlog.local" }), [
+    ".localhost",
+    ".ngrok-free.app",
+    ".ngrok.app",
+    ".trycloudflare.com",
+    "feature.superlog.local",
+  ]);
+});
+
+test("vite keeps the default host allowlist outside Portless", () => {
+  assert.deepEqual(viteAllowedHosts({}), [
+    ".localhost",
+    ".ngrok-free.app",
+    ".ngrok.app",
+    ".trycloudflare.com",
+  ]);
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,20 @@ import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv } from "vite";
 
+const DEFAULT_ALLOWED_HOSTS = [
+  ".localhost",
+  ".ngrok-free.app",
+  ".ngrok.app",
+  ".trycloudflare.com",
+];
+
+export function viteAllowedHosts(
+  env: Partial<Record<"SUPERLOG_PORTLESS_WEB_HOST", string>>,
+): string[] {
+  const portlessHost = env.SUPERLOG_PORTLESS_WEB_HOST?.trim();
+  return portlessHost ? [...DEFAULT_ALLOWED_HOSTS, portlessHost] : [...DEFAULT_ALLOWED_HOSTS];
+}
+
 export default defineConfig(({ mode }) => {
   const env = { ...loadEnv(mode, process.cwd(), ""), ...process.env };
 
@@ -46,7 +60,7 @@ export default defineConfig(({ mode }) => {
       port: Number(env.PORT ?? env.WEB_PORT ?? 5173),
       strictPort: true,
       watch: inWorktree ? { usePolling: true, interval: 150 } : undefined,
-      allowedHosts: [".localhost", ".ngrok-free.app", ".ngrok.app", ".trycloudflare.com"],
+      allowedHosts: viteAllowedHosts(env),
     },
   };
 });

--- a/scripts/portless-stack.sh
+++ b/scripts/portless-stack.sh
@@ -217,6 +217,7 @@ write_env_file() {
     printf 'SLACK_OAUTH_REDIRECT_URL=%s/slack/oauth/callback\n' "$API_URL"
     printf 'LINEAR_OAUTH_REDIRECT_URL=%s/linear/oauth/callback\n' "$API_URL"
     printf 'SUPERLOG_PORTLESS_WEB_NAME=%s\n' "$WEB_ROUTE"
+    printf 'SUPERLOG_PORTLESS_WEB_HOST=%s.%s\n' "$WEB_ROUTE" "$URL_TLD"
     printf 'SUPERLOG_PORTLESS_API_NAME=%s\n' "$API_ROUTE"
     printf 'SUPERLOG_PORTLESS_PROXY_NAME=%s\n' "$PROXY_ROUTE"
     printf 'SUPERLOG_PORTLESS_WEB_URL=%s\n' "$WEB_URL"

--- a/scripts/portless-stack.test.sh
+++ b/scripts/portless-stack.test.sh
@@ -31,6 +31,11 @@ if ! grep -Fqx "web:        https://$STACK_NAME.superlog.local" <<< "$output"; t
   printf '%s\n' "$output" >&2
   exit 1
 fi
+if ! grep -Fqx "SUPERLOG_PORTLESS_WEB_HOST=$STACK_NAME.superlog.local" \
+  "$REPO_ROOT/tmp/portless-stacks/$STACK_NAME/env"; then
+  echo "expected the generated web host to be available to Vite" >&2
+  exit 1
+fi
 rm "$TMP_HOME/.portless/proxy.tld"
 
 mkdir -p "$TMP_HOME/.portless"


### PR DESCRIPTION
## Summary

- expose the generated Portless web hostname to the web development process
- allow that exact hostname through Vite's development-server host check
- retain the existing default and tunnel host allowlist outside Portless

## Validation

- `bash scripts/portless-stack.test.sh`
- `pnpm --filter @superlog/web exec tsx --test vite.config.test.ts`
- `pnpm --filter @superlog/web typecheck`
