### PR TITLE
Bound GCP log group discovery

### DIFF
--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -3212,18 +3212,21 @@ function GcpLogGroupFilter({
       )}
 
       <div className="max-h-52 overflow-y-auto p-1.5">
-        {discovered.isLoading && logNames.length === 0 ? (
-          <p className="px-2 py-3 text-[11.5px] text-muted">Discovering recent log groups…</p>
-        ) : discovered.isError && logNames.length === 0 ? (
+        {discovered.isError && (
           <p className="px-2 py-3 text-[11.5px] text-danger">
             Couldn’t load recent log groups. Close and reopen this integration to retry.
           </p>
+        )}
+        {discovered.isLoading && logNames.length === 0 ? (
+          <p className="px-2 py-3 text-[11.5px] text-muted">Discovering recent log groups…</p>
         ) : visibleLogNames.length === 0 ? (
-          <p className="px-2 py-3 text-[11.5px] text-muted">
-            {normalizedQuery
-              ? "No matching log groups."
-              : "Log groups will appear here after GCP logs arrive."}
-          </p>
+          !discovered.isError && (
+            <p className="px-2 py-3 text-[11.5px] text-muted">
+              {normalizedQuery
+                ? "No matching log groups."
+                : "Log groups will appear here after GCP logs arrive."}
+            </p>
+          )
         ) : (
           visibleLogNames.map((logName) => {
             const enabled = !draft.includes(logName);

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -135,6 +135,7 @@ import {
 import {
   canToggleGcpLogGroup,
   gcpConnectAction,
+  gcpLogDiscoveryRange,
   gcpLogGroupLabel,
   mergeGcpLogNames,
 } from "./gcp-settings-model.ts";
@@ -3141,13 +3142,7 @@ function GcpLogGroupFilter({
   connection: Extract<NonNullable<ReturnType<typeof useGcpConnection>["data"]>, { status: string }>;
   canManage: boolean;
 }) {
-  const range = useMemo(() => {
-    const until = new Date();
-    return {
-      since: new Date(until.getTime() - 30 * 24 * 60 * 60 * 1_000).toISOString(),
-      until: until.toISOString(),
-    };
-  }, []);
+  const range = useMemo(() => gcpLogDiscoveryRange(new Date()), []);
   const logNamePrefix = `projects/${connection.gcpProjectId}/logs/`;
   const discovered = useExploreAttributeValues(
     projectId,
@@ -3219,6 +3214,10 @@ function GcpLogGroupFilter({
       <div className="max-h-52 overflow-y-auto p-1.5">
         {discovered.isLoading && logNames.length === 0 ? (
           <p className="px-2 py-3 text-[11.5px] text-muted">Discovering recent log groups…</p>
+        ) : discovered.isError && logNames.length === 0 ? (
+          <p className="px-2 py-3 text-[11.5px] text-danger">
+            Couldn’t load recent log groups. Close and reopen this integration to retry.
+          </p>
         ) : visibleLogNames.length === 0 ? (
           <p className="px-2 py-3 text-[11.5px] text-muted">
             {normalizedQuery

--- a/apps/web/src/gcp-settings-model.test.ts
+++ b/apps/web/src/gcp-settings-model.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import {
   canToggleGcpLogGroup,
   gcpConnectAction,
+  gcpLogDiscoveryRange,
   gcpLogGroupLabel,
   mergeGcpLogNames,
 } from "./gcp-settings-model.js";
@@ -37,6 +38,13 @@ test("saved GCP exclusions stay editable when they are outside the discovery win
       "projects/acme-production/logs/run.googleapis.com%2Fstdout",
     ],
   );
+});
+
+test("GCP log group discovery stays within the latest day", () => {
+  assert.deepEqual(gcpLogDiscoveryRange(new Date("2026-08-07T12:00:00.000Z")), {
+    since: "2026-08-06T12:00:00.000Z",
+    until: "2026-08-07T12:00:00.000Z",
+  });
 });
 
 test("the exclusion cap blocks another disable but still allows re-enabling a group", () => {

--- a/apps/web/src/gcp-settings-model.ts
+++ b/apps/web/src/gcp-settings-model.ts
@@ -1,5 +1,7 @@
 type GcpConnectionStatus = "pending" | "provisioning" | "connected" | "failed" | null;
 
+const GCP_LOG_DISCOVERY_WINDOW_MS = 24 * 60 * 60 * 1_000;
+
 export function gcpConnectAction(status: GcpConnectionStatus) {
   return status === "connected"
     ? {
@@ -17,6 +19,13 @@ export function gcpLogGroupLabel(logName: string): string {
   } catch {
     return encoded;
   }
+}
+
+export function gcpLogDiscoveryRange(until: Date): { since: string; until: string } {
+  return {
+    since: new Date(until.getTime() - GCP_LOG_DISCOVERY_WINDOW_MS).toISOString(),
+    until: until.toISOString(),
+  };
 }
 
 export function mergeGcpLogNames(


### PR DESCRIPTION
## Summary

- bound GCP log-group discovery to the latest 24 hours
- keep saved exclusions visible even when a group falls outside the discovery window
- distinguish discovery failures from projects that genuinely have no recent logs

## Root cause

The settings panel scanned 30 days of raw log attributes. On a busy project that query exceeded the telemetry query budget, and the UI incorrectly rendered the failure as “Log groups will appear here after GCP logs arrive.”

## Validation

- GCP settings model tests pass (6/6)
- web typecheck passes
- production web build and prerender tests pass
- the bounded query returns the recent log groups on a production-scale dataset within the request budget

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound GCP log group discovery to the last 24 hours to keep queries within budget and show accurate status in settings. Kept saved exclusions visible and added explicit UI for partial discovery failures.

- **Bug Fixes**
  - Added `gcpLogDiscoveryRange()` and used it in settings to compute a 24h since/until window.
  - Kept excluded log groups visible even if not in recent discovery results.
  - Show a clear error state when discovery fails, instead of implying no logs exist.

<sup>Written for commit 400233aa1382360ebd4f2ea6d08addd607648dab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

