### PR TITLE
Acknowledge quota-dropped Vercel drain deliveries

### DIFF
--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -56,7 +56,11 @@ import { Semaphore } from "./semaphore.js";
 // tracing.ts, so the OTel flush can't race the ingest drain and exit early.
 import { shutdownTelemetry } from "./telemetry-shutdown.js";
 import { lookupOrgForProject, recordIngestRequest } from "./tenant-metrics.js";
-import { parseVercelLogDrainBody, vercelLogsToOtlp } from "./vercel-log-drain.js";
+import {
+  acknowledgeVercelDrainDelivery,
+  parseVercelLogDrainBody,
+  vercelLogsToOtlp,
+} from "./vercel-log-drain.js";
 
 const tracer = trace.getTracer("@superlog/proxy");
 
@@ -412,19 +416,23 @@ app.post("/v1/traces", (c) => forward(c, "/v1/traces", "resourceSpans"));
 app.post("/v1/logs", (c) => forward(c, "/v1/logs", "resourceLogs"));
 app.post("/v1/metrics", (c) => forward(c, "/v1/metrics", "resourceMetrics"));
 
-app.post("/vercel/drains/traces", (c) =>
-  forward(c, "/v1/traces", "resourceSpans", { source: "vercel" }),
+app.post("/vercel/drains/traces", async (c) =>
+  acknowledgeVercelDrainDelivery(
+    await forward(c, "/v1/traces", "resourceSpans", { source: "vercel" }),
+  ),
 );
-app.post("/vercel/drains/logs", (c) =>
-  forward(c, "/v1/logs", "resourceLogs", {
-    source: "vercel",
-    bodyTransform: (body, contentType) => ({
-      body: Buffer.from(
-        JSON.stringify(vercelLogsToOtlp(parseVercelLogDrainBody(body, contentType))),
-      ),
-      contentType: "application/json",
+app.post("/vercel/drains/logs", async (c) =>
+  acknowledgeVercelDrainDelivery(
+    await forward(c, "/v1/logs", "resourceLogs", {
+      source: "vercel",
+      bodyTransform: (body, contentType) => ({
+        body: Buffer.from(
+          JSON.stringify(vercelLogsToOtlp(parseVercelLogDrainBody(body, contentType))),
+        ),
+        contentType: "application/json",
+      }),
     }),
-  }),
+  ),
 );
 
 // Railway puller ingest: the worker-side puller reads logs/metrics from

--- a/apps/proxy/src/vercel-log-drain.test.ts
+++ b/apps/proxy/src/vercel-log-drain.test.ts
@@ -3,7 +3,11 @@ import { test } from "node:test";
 
 import { stampIssueFingerprints } from "./ingest-fingerprints.js";
 import { otlpLogsToRows } from "./otlp-clickhouse.js";
-import { parseVercelLogDrainBody, vercelLogsToOtlp } from "./vercel-log-drain.js";
+import {
+  acknowledgeVercelDrainDelivery,
+  parseVercelLogDrainBody,
+  vercelLogsToOtlp,
+} from "./vercel-log-drain.js";
 
 const vercelLogs = [
   {
@@ -32,6 +36,21 @@ const vercelLogs = [
     },
   },
 ];
+
+test("Vercel receives a successful acknowledgement when telemetry is over quota", () => {
+  const response = acknowledgeVercelDrainDelivery(
+    new Response("telemetry quota exceeded", { status: 402 }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("x-superlog-ingest-drop"), "quota_exceeded");
+});
+
+test("Vercel still receives retryable delivery failures", () => {
+  const response = new Response("collector unavailable", { status: 503 });
+
+  assert.equal(acknowledgeVercelDrainDelivery(response), response);
+});
 
 test("parseVercelLogDrainBody accepts JSON arrays", () => {
   assert.deepEqual(

--- a/apps/proxy/src/vercel-log-drain.ts
+++ b/apps/proxy/src/vercel-log-drain.ts
@@ -8,6 +8,14 @@ type OtlpAnyValue = {
 
 type OtlpKeyValue = { key: string; value: OtlpAnyValue };
 
+export function acknowledgeVercelDrainDelivery(response: Response): Response {
+  if (response.status !== 402) return response;
+  return new Response(null, {
+    status: 200,
+    headers: { "x-superlog-ingest-drop": "quota_exceeded" },
+  });
+}
+
 type VercelLogRecord = Record<string, unknown> & {
   timestamp?: unknown;
   level?: unknown;


### PR DESCRIPTION
## Summary

- acknowledge quota-dropped Vercel trace and log deliveries with HTTP 200
- expose the drop reason through `x-superlog-ingest-drop: quota_exceeded`
- preserve retryable failures so Vercel can retry real service outages

## Why

Vercel treats non-2xx drain responses as delivery failures. Returning HTTP 402 for an intentional quota drop marks otherwise correctly configured drains as unhealthy and causes repeated delivery attempts. The Vercel adapter now translates only that permanent quota outcome into a successful acknowledgement; authentication, payload, and retryable upstream failures retain their existing responses.

## Validation

- `pnpm --filter @superlog/proxy test`
- `pnpm --filter @superlog/proxy typecheck`
- `pnpm exec biome check apps/proxy/src/index.ts apps/proxy/src/vercel-log-drain.ts apps/proxy/src/vercel-log-drain.test.ts`
- `pnpm worktree:verify`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return HTTP 200 for Vercel drain deliveries dropped due to quota so drains stay healthy and Vercel stops retrying. Expose the drop via `x-superlog-ingest-drop: quota_exceeded` and keep retryable failures unchanged.

- **Bug Fixes**
  - Add `acknowledgeVercelDrainDelivery` to translate 402 responses for quota drops.
  - Wrap `/vercel/drains/traces` and `/vercel/drains/logs` to use the acknowledgement; other errors (auth, payload, 5xx) pass through for retries.
  - Add tests for acknowledgement and retry paths.

<sup>Written for commit 2740c4cad8c801d7d066cc9432ea2ba0930367be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

