### PR TITLE
Restore MCP authoring tools with write scopes

### DIFF
--- a/apps/api/src/mcp/index.ts
+++ b/apps/api/src/mcp/index.ts
@@ -13,7 +13,7 @@ import type { Hono } from "hono";
 import { logger } from "../logger.js";
 import { type McpConfig, loadMcpConfig } from "./config.js";
 import { mountOauthDecision, mountOauthEndpoints, mountOauthMetadata } from "./oauth.js";
-import { resolveMcpOauthScope } from "./scope-authorization.js";
+import { resolveStoredMcpOauthScope } from "./scope-authorization.js";
 import { createMcpServerForSession } from "./server.js";
 
 const log = logger.child({ scope: "mcp-bearer" });
@@ -118,7 +118,7 @@ async function resolveToken(
   if (stored !== cfg.resource && stored !== cfg.apiBaseUrl) {
     return { reason: `resource mismatch (stored=${row.resource})` };
   }
-  const resolvedScope = resolveMcpOauthScope(row.scope);
+  const resolvedScope = resolveStoredMcpOauthScope(row.scope);
   if ("error" in resolvedScope) return { reason: resolvedScope.error };
   return {
     tokenId: row.id,

--- a/apps/api/src/mcp/index.ts
+++ b/apps/api/src/mcp/index.ts
@@ -13,7 +13,7 @@ import type { Hono } from "hono";
 import { logger } from "../logger.js";
 import { type McpConfig, loadMcpConfig } from "./config.js";
 import { mountOauthDecision, mountOauthEndpoints, mountOauthMetadata } from "./oauth.js";
-import { resolveStoredMcpOauthScope } from "./scope-authorization.js";
+import { isLegacyStoredMcpOauthScope, resolveStoredMcpOauthScope } from "./scope-authorization.js";
 import { createMcpServerForSession } from "./server.js";
 
 const log = logger.child({ scope: "mcp-bearer" });
@@ -119,6 +119,17 @@ async function resolveToken(
     return { reason: `resource mismatch (stored=${row.resource})` };
   }
   const resolvedScope = resolveStoredMcpOauthScope(row.scope);
+  if (isLegacyStoredMcpOauthScope(row.scope) && "scope" in resolvedScope) {
+    log.info(
+      {
+        tokenId: row.id,
+        storedScope: row.scope,
+        resolvedScope: resolvedScope.scope,
+        reason: "legacy_scope_default",
+      },
+      "MCP legacy token scope normalized to read-only",
+    );
+  }
   if ("error" in resolvedScope) {
     log.info(
       {

--- a/apps/api/src/mcp/index.ts
+++ b/apps/api/src/mcp/index.ts
@@ -119,7 +119,18 @@ async function resolveToken(
     return { reason: `resource mismatch (stored=${row.resource})` };
   }
   const resolvedScope = resolveStoredMcpOauthScope(row.scope);
-  if ("error" in resolvedScope) return { reason: resolvedScope.error };
+  if ("error" in resolvedScope) {
+    log.info(
+      {
+        tokenId: row.id,
+        storedScope: row.scope,
+        reason: resolvedScope.reason,
+        error: resolvedScope.error,
+      },
+      "MCP token rejected: scope resolution failed",
+    );
+    return { reason: resolvedScope.error };
+  }
   return {
     tokenId: row.id,
     tokenKind: "oauth",

--- a/apps/api/src/mcp/index.ts
+++ b/apps/api/src/mcp/index.ts
@@ -13,10 +13,15 @@ import type { Hono } from "hono";
 import { logger } from "../logger.js";
 import { type McpConfig, loadMcpConfig } from "./config.js";
 import { mountOauthDecision, mountOauthEndpoints, mountOauthMetadata } from "./oauth.js";
-import { isLegacyStoredMcpOauthScope, resolveStoredMcpOauthScope } from "./scope-authorization.js";
+import {
+  createBoundedTokenObservationTracker,
+  isLegacyStoredMcpOauthScope,
+  resolveStoredMcpOauthScope,
+} from "./scope-authorization.js";
 import { createMcpServerForSession } from "./server.js";
 
 const log = logger.child({ scope: "mcp-bearer" });
+const shouldLogLegacyScopeFallback = createBoundedTokenObservationTracker();
 
 type TokenContext = {
   tokenId: string;
@@ -119,7 +124,11 @@ async function resolveToken(
     return { reason: `resource mismatch (stored=${row.resource})` };
   }
   const resolvedScope = resolveStoredMcpOauthScope(row.scope);
-  if (isLegacyStoredMcpOauthScope(row.scope) && "scope" in resolvedScope) {
+  if (
+    isLegacyStoredMcpOauthScope(row.scope) &&
+    "scope" in resolvedScope &&
+    shouldLogLegacyScopeFallback(row.id)
+  ) {
     log.info(
       {
         tokenId: row.id,

--- a/apps/api/src/mcp/oauth-metadata.test.ts
+++ b/apps/api/src/mcp/oauth-metadata.test.ts
@@ -1,0 +1,23 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { Hono } from "hono";
+
+process.env.DATABASE_URL ??= "postgres://localhost:5434/superlog";
+process.env.BETTER_AUTH_SECRET ??= "test-better-auth-secret";
+
+test("OAuth discovery advertises read and write MCP scopes", async () => {
+  const { mountOauthMetadata } = await import("./oauth.js");
+  const { loadMcpConfig } = await import("./config.js");
+  const app = new Hono();
+  mountOauthMetadata(app, loadMcpConfig());
+
+  for (const path of [
+    "/.well-known/oauth-protected-resource",
+    "/.well-known/oauth-authorization-server",
+  ]) {
+    const response = await app.request(path);
+    assert.equal(response.status, 200);
+    const metadata = (await response.json()) as { scopes_supported?: string[] };
+    assert.deepEqual(metadata.scopes_supported, ["mcp:read", "mcp:write"]);
+  }
+});

--- a/apps/api/src/mcp/oauth-refresh-rotation.test.ts
+++ b/apps/api/src/mcp/oauth-refresh-rotation.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { after, before, test } from "node:test";
 import { closeDb, db, runMigrations, schema } from "@superlog/db";
 import { eq } from "drizzle-orm";
-import { claimMcpOauthRefreshTokenRotation } from "./oauth.js";
+import { rotateMcpOauthRefreshToken } from "./oauth.js";
 
 const orgIds: string[] = [];
 const userIds: string[] = [];
@@ -29,7 +29,7 @@ after(async () => {
   }
 });
 
-test("only one concurrent refresh can claim a token for rotation", async () => {
+async function seedRefreshToken() {
   const tag = `mcp-refresh-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
   const [user] = await db
     .insert(schema.users)
@@ -72,10 +72,43 @@ test("only one concurrent refresh can claim a token for rotation", async () => {
     .returning();
   if (!token) throw new Error("seed OAuth token failed");
 
-  const claims = await Promise.all([
-    claimMcpOauthRefreshTokenRotation(token.id),
-    claimMcpOauthRefreshTokenRotation(token.id),
+  return {
+    token,
+    params: {
+      tokenId: token.id,
+      clientId: client.id,
+      userId: user.id,
+      projectId: project.id,
+      resource: token.resource,
+      scope: token.scope,
+    },
+  };
+}
+
+test("only one concurrent refresh can claim and replace a token", async () => {
+  const { params } = await seedRefreshToken();
+  const rotations = await Promise.all([
+    rotateMcpOauthRefreshToken(params),
+    rotateMcpOauthRefreshToken(params),
   ]);
 
-  assert.deepEqual(claims.sort(), [false, true]);
+  assert.equal(rotations.filter(Boolean).length, 1);
+});
+
+test("failed replacement issuance rolls back the refresh-token claim", async () => {
+  const { token, params } = await seedRefreshToken();
+
+  await assert.rejects(
+    rotateMcpOauthRefreshToken(params, () => ({
+      access: { plaintext: "duplicate-access", hash: token.accessHash, prefix: "duplicate" },
+      refresh: { plaintext: "new-refresh", hash: `${token.refreshHash}-new`, prefix: "new" },
+    })),
+  );
+
+  const afterFailure = await db.query.mcpOauthTokens.findFirst({
+    where: eq(schema.mcpOauthTokens.id, token.id),
+  });
+  assert.equal(afterFailure?.revokedAt, null);
+
+  assert.ok(await rotateMcpOauthRefreshToken(params));
 });

--- a/apps/api/src/mcp/oauth-refresh-rotation.test.ts
+++ b/apps/api/src/mcp/oauth-refresh-rotation.test.ts
@@ -1,0 +1,81 @@
+import "dotenv/config";
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+import { closeDb, db, runMigrations, schema } from "@superlog/db";
+import { eq } from "drizzle-orm";
+import { claimMcpOauthRefreshTokenRotation } from "./oauth.js";
+
+const orgIds: string[] = [];
+const userIds: string[] = [];
+const clientIds: string[] = [];
+
+before(async () => {
+  await runMigrations();
+});
+
+after(async () => {
+  try {
+    for (const orgId of orgIds.reverse()) {
+      await db.delete(schema.orgs).where(eq(schema.orgs.id, orgId));
+    }
+    for (const userId of userIds.reverse()) {
+      await db.delete(schema.users).where(eq(schema.users.id, userId));
+    }
+    for (const clientId of clientIds.reverse()) {
+      await db.delete(schema.mcpOauthClients).where(eq(schema.mcpOauthClients.id, clientId));
+    }
+  } finally {
+    await closeDb();
+  }
+});
+
+test("only one concurrent refresh can claim a token for rotation", async () => {
+  const tag = `mcp-refresh-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+  const [user] = await db
+    .insert(schema.users)
+    .values({ email: `${tag}@example.com` })
+    .returning();
+  if (!user) throw new Error("seed user failed");
+  userIds.push(user.id);
+
+  const [org] = await db.insert(schema.orgs).values({ name: tag, slug: tag }).returning();
+  if (!org) throw new Error("seed org failed");
+  orgIds.push(org.id);
+  await db.insert(schema.orgMembers).values({ orgId: org.id, userId: user.id, role: "owner" });
+
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ orgId: org.id, name: "Default", slug: "default" })
+    .returning();
+  if (!project) throw new Error("seed project failed");
+
+  const [client] = await db
+    .insert(schema.mcpOauthClients)
+    .values({ name: tag, redirectUris: ["http://127.0.0.1/callback"] })
+    .returning();
+  if (!client) throw new Error("seed OAuth client failed");
+  clientIds.push(client.id);
+
+  const [token] = await db
+    .insert(schema.mcpOauthTokens)
+    .values({
+      accessHash: `${tag}-access`,
+      refreshHash: `${tag}-refresh`,
+      clientId: client.id,
+      userId: user.id,
+      projectId: project.id,
+      resource: "https://api.example.com/mcp",
+      scope: "mcp:read mcp:write",
+      accessExpiresAt: new Date(Date.now() + 60_000),
+      refreshExpiresAt: new Date(Date.now() + 120_000),
+    })
+    .returning();
+  if (!token) throw new Error("seed OAuth token failed");
+
+  const claims = await Promise.all([
+    claimMcpOauthRefreshTokenRotation(token.id),
+    claimMcpOauthRefreshTokenRotation(token.id),
+  ]);
+
+  assert.deepEqual(claims.sort(), [false, true]);
+});

--- a/apps/api/src/mcp/oauth.ts
+++ b/apps/api/src/mcp/oauth.ts
@@ -360,6 +360,16 @@ async function handleRefreshGrant(c: Context, cfg: McpConfig, form: Record<strin
     resource: row.resource,
     scope: resolvedScope.scope,
   });
+  log.info(
+    {
+      tokenId: row.id,
+      userId: row.userId,
+      storedScope: row.scope,
+      requestedScope,
+      resolvedScope: resolvedScope.scope,
+    },
+    "MCP refresh token rotated",
+  );
   return c.json(tokens);
 }
 

--- a/apps/api/src/mcp/oauth.ts
+++ b/apps/api/src/mcp/oauth.ts
@@ -7,7 +7,7 @@ import {
   schema,
   syncLoopsContactForUserProject,
 } from "@superlog/db";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import type { Hono } from "hono";
 import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -348,10 +348,10 @@ async function handleRefreshGrant(c: Context, cfg: McpConfig, form: Record<strin
     return oauthError(c, 400, "invalid_scope", resolvedScope.error);
   }
 
-  await db
-    .update(schema.mcpOauthTokens)
-    .set({ revokedAt: new Date() })
-    .where(eq(schema.mcpOauthTokens.id, row.id));
+  const claimedRotation = await claimMcpOauthRefreshTokenRotation(row.id);
+  if (!claimedRotation) {
+    return oauthError(c, 400, "invalid_grant", "refresh token already used");
+  }
 
   const tokens = await issueTokens({
     clientId: row.clientId,
@@ -361,6 +361,15 @@ async function handleRefreshGrant(c: Context, cfg: McpConfig, form: Record<strin
     scope: resolvedScope.scope,
   });
   return c.json(tokens);
+}
+
+export async function claimMcpOauthRefreshTokenRotation(tokenId: string): Promise<boolean> {
+  const [claimed] = await db
+    .update(schema.mcpOauthTokens)
+    .set({ revokedAt: new Date() })
+    .where(and(eq(schema.mcpOauthTokens.id, tokenId), isNull(schema.mcpOauthTokens.revokedAt)))
+    .returning({ id: schema.mcpOauthTokens.id });
+  return claimed !== undefined;
 }
 
 async function issueTokens(params: {

--- a/apps/api/src/mcp/oauth.ts
+++ b/apps/api/src/mcp/oauth.ts
@@ -14,7 +14,7 @@ import { HTTPException } from "hono/http-exception";
 import { logger } from "../logger.js";
 import { resolveActiveOrgContext } from "../org-context.js";
 import type { McpConfig } from "./config.js";
-import { resolveMcpOauthScope } from "./scope-authorization.js";
+import { MCP_SUPPORTED_SCOPES, resolveMcpOauthScope } from "./scope-authorization.js";
 
 const log = logger.child({ scope: "mcp-oauth" });
 
@@ -72,7 +72,7 @@ export function mountOauthMetadata(app: Hono, cfg: McpConfig) {
       resource: cfg.resource,
       authorization_servers: [cfg.apiBaseUrl],
       bearer_methods_supported: ["header"],
-      scopes_supported: ["mcp:read"],
+      scopes_supported: MCP_SUPPORTED_SCOPES,
     }),
   );
 
@@ -86,7 +86,7 @@ export function mountOauthMetadata(app: Hono, cfg: McpConfig) {
       grant_types_supported: ["authorization_code", "refresh_token"],
       code_challenge_methods_supported: ["S256"],
       token_endpoint_auth_methods_supported: ["none"],
-      scopes_supported: ["mcp:read"],
+      scopes_supported: MCP_SUPPORTED_SCOPES,
     }),
   );
 }

--- a/apps/api/src/mcp/oauth.ts
+++ b/apps/api/src/mcp/oauth.ts
@@ -14,7 +14,11 @@ import { HTTPException } from "hono/http-exception";
 import { logger } from "../logger.js";
 import { resolveActiveOrgContext } from "../org-context.js";
 import type { McpConfig } from "./config.js";
-import { MCP_SUPPORTED_SCOPES, resolveMcpOauthScope } from "./scope-authorization.js";
+import {
+  MCP_SUPPORTED_SCOPES,
+  resolveMcpOauthScope,
+  resolveRefreshMcpOauthScope,
+} from "./scope-authorization.js";
 
 const log = logger.child({ scope: "mcp-oauth" });
 
@@ -305,6 +309,7 @@ async function handleRefreshGrant(c: Context, cfg: McpConfig, form: Record<strin
   const refreshToken = stringField(form, "refresh_token");
   const clientId = stringField(form, "client_id");
   const resource = stringField(form, "resource");
+  const requestedScope = stringField(form, "scope") || null;
   if (!refreshToken || !clientId) {
     return oauthError(c, 400, "invalid_request", "missing refresh_token or client_id");
   }
@@ -328,6 +333,21 @@ async function handleRefreshGrant(c: Context, cfg: McpConfig, form: Record<strin
     return oauthError(c, 400, "invalid_grant", "refresh token expired");
   }
 
+  const resolvedScope = resolveRefreshMcpOauthScope(requestedScope, row.scope);
+  if ("error" in resolvedScope) {
+    log.info(
+      {
+        tokenId: row.id,
+        requestedScope,
+        storedScope: row.scope,
+        reason: resolvedScope.reason,
+        error: resolvedScope.error,
+      },
+      "MCP refresh rejected: scope resolution failed",
+    );
+    return oauthError(c, 400, "invalid_scope", resolvedScope.error);
+  }
+
   await db
     .update(schema.mcpOauthTokens)
     .set({ revokedAt: new Date() })
@@ -338,7 +358,7 @@ async function handleRefreshGrant(c: Context, cfg: McpConfig, form: Record<strin
     userId: row.userId,
     projectId: row.projectId,
     resource: row.resource,
-    scope: row.scope,
+    scope: resolvedScope.scope,
   });
   return c.json(tokens);
 }

--- a/apps/api/src/mcp/oauth.ts
+++ b/apps/api/src/mcp/oauth.ts
@@ -358,13 +358,22 @@ async function handleRefreshGrant(c: Context, cfg: McpConfig, form: Record<strin
     return oauthError(c, 400, "invalid_grant", "refresh token already used");
   }
 
-  const tokens = await issueTokens({
-    clientId: row.clientId,
-    userId: row.userId,
-    projectId: row.projectId,
-    resource: row.resource,
-    scope: resolvedScope.scope,
-  });
+  let tokens: Awaited<ReturnType<typeof issueTokens>>;
+  try {
+    tokens = await issueTokens({
+      clientId: row.clientId,
+      userId: row.userId,
+      projectId: row.projectId,
+      resource: row.resource,
+      scope: resolvedScope.scope,
+    });
+  } catch (error) {
+    log.error(
+      { tokenId: row.id, userId: row.userId, error },
+      "MCP refresh token rotation claimed but replacement issuance failed",
+    );
+    throw error;
+  }
   log.info(
     {
       tokenId: row.id,

--- a/apps/api/src/mcp/oauth.ts
+++ b/apps/api/src/mcp/oauth.ts
@@ -349,18 +349,10 @@ async function handleRefreshGrant(c: Context, cfg: McpConfig, form: Record<strin
     return oauthError(c, 400, "invalid_scope", resolvedScope.error);
   }
 
-  const claimedRotation = await claimMcpOauthRefreshTokenRotation(row.id);
-  if (!claimedRotation) {
-    log.error(
-      { tokenId: row.id, userId: row.userId, clientId: row.clientId },
-      "MCP refresh token already claimed: possible replay or concurrent rotation",
-    );
-    return oauthError(c, 400, "invalid_grant", "refresh token already used");
-  }
-
-  let tokens: Awaited<ReturnType<typeof issueTokens>>;
+  let tokens: Awaited<ReturnType<typeof rotateMcpOauthRefreshToken>>;
   try {
-    tokens = await issueTokens({
+    tokens = await rotateMcpOauthRefreshToken({
+      tokenId: row.id,
       clientId: row.clientId,
       userId: row.userId,
       projectId: row.projectId,
@@ -369,11 +361,25 @@ async function handleRefreshGrant(c: Context, cfg: McpConfig, form: Record<strin
     });
   } catch (error) {
     log.error(
-      { tokenId: row.id, userId: row.userId, error },
-      "MCP refresh token rotation claimed but replacement issuance failed",
+      {
+        tokenId: row.id,
+        userId: row.userId,
+        requestedScope,
+        resolvedScope: resolvedScope.scope,
+        error,
+      },
+      "MCP refresh token rotation transaction failed",
     );
     throw error;
   }
+  if (!tokens) {
+    log.error(
+      { tokenId: row.id, userId: row.userId, clientId: row.clientId },
+      "MCP refresh token already claimed: possible replay or concurrent rotation",
+    );
+    return oauthError(c, 400, "invalid_grant", "refresh token already used");
+  }
+  syncMcpInstall(row.userId, row.projectId);
   log.info(
     {
       tokenId: row.id,
@@ -387,33 +393,61 @@ async function handleRefreshGrant(c: Context, cfg: McpConfig, form: Record<strin
   return c.json(tokens);
 }
 
-export async function claimMcpOauthRefreshTokenRotation(tokenId: string): Promise<boolean> {
-  try {
-    const [claimed] = await db
-      .update(schema.mcpOauthTokens)
-      .set({ revokedAt: new Date() })
-      .where(and(eq(schema.mcpOauthTokens.id, tokenId), isNull(schema.mcpOauthTokens.revokedAt)))
-      .returning({ id: schema.mcpOauthTokens.id });
-    return claimed !== undefined;
-  } catch (error) {
-    log.error({ tokenId, error }, "MCP refresh token rotation claim failed");
-    throw error;
-  }
-}
+type McpTokenPair = {
+  access: ReturnType<typeof generateMcpAccessToken>;
+  refresh: ReturnType<typeof generateMcpRefreshToken>;
+};
 
-async function issueTokens(params: {
+type McpTokenIssueParams = {
   clientId: string;
   userId: string;
   projectId: string;
   resource: string;
   scope: string | null;
-}): Promise<{
+};
+
+type McpTokenResponse = {
   access_token: string;
   refresh_token: string;
   token_type: "Bearer";
   expires_in: number;
   scope?: string;
-}> {
+};
+
+export async function rotateMcpOauthRefreshToken(
+  params: McpTokenIssueParams & { tokenId: string },
+  generateTokens: () => McpTokenPair = () => ({
+    access: generateMcpAccessToken(),
+    refresh: generateMcpRefreshToken(),
+  }),
+): Promise<McpTokenResponse | null> {
+  return db.transaction(async (tx) => {
+    const [claimed] = await tx
+      .update(schema.mcpOauthTokens)
+      .set({ revokedAt: new Date() })
+      .where(
+        and(eq(schema.mcpOauthTokens.id, params.tokenId), isNull(schema.mcpOauthTokens.revokedAt)),
+      )
+      .returning({ id: schema.mcpOauthTokens.id });
+    if (!claimed) return null;
+
+    const { access, refresh } = generateTokens();
+    await tx.insert(schema.mcpOauthTokens).values({
+      accessHash: access.hash,
+      refreshHash: refresh.hash,
+      clientId: params.clientId,
+      userId: params.userId,
+      projectId: params.projectId,
+      resource: params.resource,
+      scope: params.scope,
+      accessExpiresAt: new Date(Date.now() + ACCESS_TTL_SECONDS * 1000),
+      refreshExpiresAt: new Date(Date.now() + REFRESH_TTL_SECONDS * 1000),
+    });
+    return tokenResponse(access, refresh, params.scope);
+  });
+}
+
+async function issueTokens(params: McpTokenIssueParams): Promise<McpTokenResponse> {
   const access = generateMcpAccessToken();
   const refresh = generateMcpRefreshToken();
   await db.insert(schema.mcpOauthTokens).values({
@@ -427,18 +461,30 @@ async function issueTokens(params: {
     accessExpiresAt: new Date(Date.now() + ACCESS_TTL_SECONDS * 1000),
     refreshExpiresAt: new Date(Date.now() + REFRESH_TTL_SECONDS * 1000),
   });
+  syncMcpInstall(params.userId, params.projectId);
+  return tokenResponse(access, refresh, params.scope);
+}
+
+function syncMcpInstall(userId: string, projectId: string): void {
   void syncLoopsContactForUserProject({
-    userId: params.userId,
-    projectId: params.projectId,
+    userId,
+    projectId,
   }).catch((err) =>
-    log.warn({ err, user_id: params.userId }, "loops contact sync failed after mcp install"),
+    log.warn({ err, user_id: userId }, "loops contact sync failed after mcp install"),
   );
+}
+
+function tokenResponse(
+  access: ReturnType<typeof generateMcpAccessToken>,
+  refresh: ReturnType<typeof generateMcpRefreshToken>,
+  scope: string | null,
+): McpTokenResponse {
   return {
     access_token: access.plaintext,
     refresh_token: refresh.plaintext,
     token_type: "Bearer",
     expires_in: ACCESS_TTL_SECONDS,
-    ...(params.scope ? { scope: params.scope } : {}),
+    ...(scope ? { scope } : {}),
   };
 }
 

--- a/apps/api/src/mcp/oauth.ts
+++ b/apps/api/src/mcp/oauth.ts
@@ -16,6 +16,7 @@ import { resolveActiveOrgContext } from "../org-context.js";
 import type { McpConfig } from "./config.js";
 import {
   MCP_SUPPORTED_SCOPES,
+  mcpRefreshScopeRejectionLogLevel,
   resolveMcpOauthScope,
   resolveRefreshMcpOauthScope,
 } from "./scope-authorization.js";
@@ -335,7 +336,7 @@ async function handleRefreshGrant(c: Context, cfg: McpConfig, form: Record<strin
 
   const resolvedScope = resolveRefreshMcpOauthScope(requestedScope, row.scope);
   if ("error" in resolvedScope) {
-    log.info(
+    log[mcpRefreshScopeRejectionLogLevel(resolvedScope.reason)](
       {
         tokenId: row.id,
         requestedScope,
@@ -350,6 +351,10 @@ async function handleRefreshGrant(c: Context, cfg: McpConfig, form: Record<strin
 
   const claimedRotation = await claimMcpOauthRefreshTokenRotation(row.id);
   if (!claimedRotation) {
+    log.error(
+      { tokenId: row.id, userId: row.userId, clientId: row.clientId },
+      "MCP refresh token already claimed: possible replay or concurrent rotation",
+    );
     return oauthError(c, 400, "invalid_grant", "refresh token already used");
   }
 

--- a/apps/api/src/mcp/oauth.ts
+++ b/apps/api/src/mcp/oauth.ts
@@ -379,12 +379,17 @@ async function handleRefreshGrant(c: Context, cfg: McpConfig, form: Record<strin
 }
 
 export async function claimMcpOauthRefreshTokenRotation(tokenId: string): Promise<boolean> {
-  const [claimed] = await db
-    .update(schema.mcpOauthTokens)
-    .set({ revokedAt: new Date() })
-    .where(and(eq(schema.mcpOauthTokens.id, tokenId), isNull(schema.mcpOauthTokens.revokedAt)))
-    .returning({ id: schema.mcpOauthTokens.id });
-  return claimed !== undefined;
+  try {
+    const [claimed] = await db
+      .update(schema.mcpOauthTokens)
+      .set({ revokedAt: new Date() })
+      .where(and(eq(schema.mcpOauthTokens.id, tokenId), isNull(schema.mcpOauthTokens.revokedAt)))
+      .returning({ id: schema.mcpOauthTokens.id });
+    return claimed !== undefined;
+  } catch (error) {
+    log.error({ tokenId, error }, "MCP refresh token rotation claim failed");
+    throw error;
+  }
 }
 
 async function issueTokens(params: {

--- a/apps/api/src/mcp/oauth.ts
+++ b/apps/api/src/mcp/oauth.ts
@@ -420,6 +420,14 @@ async function validateAuthorizeParams(
   }
   const resolvedScope = resolveMcpOauthScope(params.scope);
   if ("error" in resolvedScope) {
+    log.info(
+      {
+        requestedScope: params.scope,
+        reason: resolvedScope.reason,
+        error: resolvedScope.error,
+      },
+      "MCP authorization rejected: scope resolution failed",
+    );
     return { code: "invalid_scope", description: resolvedScope.error };
   }
   params.scope = resolvedScope.scope;

--- a/apps/api/src/mcp/scope-authorization.test.ts
+++ b/apps/api/src/mcp/scope-authorization.test.ts
@@ -38,6 +38,10 @@ test("legacy OAuth tokens stored without a scope remain read-only", () => {
   assert.deepEqual(resolveStoredMcpOauthScope(null), { scope: "mcp:read" });
 });
 
+test("legacy OAuth tokens stored with a blank scope remain read-only", () => {
+  assert.deepEqual(resolveStoredMcpOauthScope("   "), { scope: "mcp:read" });
+});
+
 test("OAuth accepts read and write scopes", () => {
   assert.deepEqual(resolveMcpOauthScope("  mcp:write   mcp:read  "), {
     scope: "mcp:read mcp:write",

--- a/apps/api/src/mcp/scope-authorization.test.ts
+++ b/apps/api/src/mcp/scope-authorization.test.ts
@@ -5,6 +5,7 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import {
+  createBoundedTokenObservationTracker,
   isLegacyStoredMcpOauthScope,
   resolveMcpOauthScope,
   resolveRefreshMcpOauthScope,
@@ -52,6 +53,16 @@ test("legacy stored OAuth scopes are classified for observability", () => {
   assert.equal(isLegacyStoredMcpOauthScope(""), true);
   assert.equal(isLegacyStoredMcpOauthScope("   "), true);
   assert.equal(isLegacyStoredMcpOauthScope("mcp:read"), false);
+});
+
+test("legacy token observations emit once per token with bounded memory", () => {
+  const shouldObserve = createBoundedTokenObservationTracker(2);
+
+  assert.equal(shouldObserve("token-a"), true);
+  assert.equal(shouldObserve("token-a"), false);
+  assert.equal(shouldObserve("token-b"), true);
+  assert.equal(shouldObserve("token-c"), true);
+  assert.equal(shouldObserve("token-a"), true);
 });
 
 test("OAuth accepts read and write scopes", () => {

--- a/apps/api/src/mcp/scope-authorization.test.ts
+++ b/apps/api/src/mcp/scope-authorization.test.ts
@@ -5,6 +5,7 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import {
+  isLegacyStoredMcpOauthScope,
   resolveMcpOauthScope,
   resolveRefreshMcpOauthScope,
   resolveStoredMcpOauthScope,
@@ -44,6 +45,13 @@ test("legacy OAuth tokens stored without a scope remain read-only", () => {
 
 test("legacy OAuth tokens stored with a blank scope remain read-only", () => {
   assert.deepEqual(resolveStoredMcpOauthScope("   "), { scope: "mcp:read" });
+});
+
+test("legacy stored OAuth scopes are classified for observability", () => {
+  assert.equal(isLegacyStoredMcpOauthScope(null), true);
+  assert.equal(isLegacyStoredMcpOauthScope(""), true);
+  assert.equal(isLegacyStoredMcpOauthScope("   "), true);
+  assert.equal(isLegacyStoredMcpOauthScope("mcp:read"), false);
 });
 
 test("OAuth accepts read and write scopes", () => {

--- a/apps/api/src/mcp/scope-authorization.test.ts
+++ b/apps/api/src/mcp/scope-authorization.test.ts
@@ -4,7 +4,11 @@ import { test } from "node:test";
 import type { ClickHouseClient } from "@clickhouse/client";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { resolveMcpOauthScope, resolveStoredMcpOauthScope } from "./scope-authorization.js";
+import {
+  resolveMcpOauthScope,
+  resolveRefreshMcpOauthScope,
+  resolveStoredMcpOauthScope,
+} from "./scope-authorization.js";
 import { createMcpServerForSession } from "./server.js";
 
 const fakeCh = {} as ClickHouseClient;
@@ -59,6 +63,25 @@ test("OAuth rejects unsupported scopes", () => {
   assert.deepEqual(resolveMcpOauthScope("mcp:read profile"), {
     error: "unsupported MCP scope: profile",
     reason: "unsupported_scope",
+  });
+});
+
+test("refresh requests can narrow an existing read/write grant", () => {
+  assert.deepEqual(resolveRefreshMcpOauthScope("mcp:read", "mcp:read mcp:write"), {
+    scope: "mcp:read",
+  });
+});
+
+test("refresh requests cannot expand the existing grant", () => {
+  assert.deepEqual(resolveRefreshMcpOauthScope("mcp:read mcp:write", "mcp:read"), {
+    error: "requested refresh scope exceeds the original grant: mcp:write",
+    reason: "scope_escalation",
+  });
+});
+
+test("refresh requests preserve the existing grant when scope is omitted", () => {
+  assert.deepEqual(resolveRefreshMcpOauthScope(null, "mcp:read mcp:write"), {
+    scope: "mcp:read mcp:write",
   });
 });
 

--- a/apps/api/src/mcp/scope-authorization.test.ts
+++ b/apps/api/src/mcp/scope-authorization.test.ts
@@ -7,6 +7,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import {
   createBoundedTokenObservationTracker,
   isLegacyStoredMcpOauthScope,
+  mcpRefreshScopeRejectionLogLevel,
   resolveMcpOauthScope,
   resolveRefreshMcpOauthScope,
   resolveStoredMcpOauthScope,
@@ -96,6 +97,12 @@ test("refresh requests cannot expand the existing grant", () => {
     error: "requested refresh scope exceeds the original grant: mcp:write",
     reason: "scope_escalation",
   });
+});
+
+test("refresh scope escalation is error-level while malformed requests remain info-level", () => {
+  assert.equal(mcpRefreshScopeRejectionLogLevel("scope_escalation"), "error");
+  assert.equal(mcpRefreshScopeRejectionLogLevel("unsupported_scope"), "info");
+  assert.equal(mcpRefreshScopeRejectionLogLevel("write_requires_read"), "info");
 });
 
 test("refresh requests preserve the existing grant when scope is omitted", () => {

--- a/apps/api/src/mcp/scope-authorization.test.ts
+++ b/apps/api/src/mcp/scope-authorization.test.ts
@@ -47,12 +47,14 @@ test("OAuth accepts read and write scopes", () => {
 test("OAuth write access requires read access", () => {
   assert.deepEqual(resolveMcpOauthScope("mcp:write"), {
     error: "mcp:write requires mcp:read",
+    reason: "write_requires_read",
   });
 });
 
 test("OAuth rejects unsupported scopes", () => {
   assert.deepEqual(resolveMcpOauthScope("mcp:read profile"), {
     error: "unsupported MCP scope: profile",
+    reason: "unsupported_scope",
   });
 });
 

--- a/apps/api/src/mcp/scope-authorization.test.ts
+++ b/apps/api/src/mcp/scope-authorization.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import type { ClickHouseClient } from "@clickhouse/client";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { resolveMcpOauthScope } from "./scope-authorization.js";
+import { resolveMcpOauthScope, resolveStoredMcpOauthScope } from "./scope-authorization.js";
 import { createMcpServerForSession } from "./server.js";
 
 const fakeCh = {} as ClickHouseClient;
@@ -32,6 +32,10 @@ const session = {
 
 test("OAuth defaults to read and write access when the client omits scopes", () => {
   assert.deepEqual(resolveMcpOauthScope(null), { scope: "mcp:read mcp:write" });
+});
+
+test("legacy OAuth tokens stored without a scope remain read-only", () => {
+  assert.deepEqual(resolveStoredMcpOauthScope(null), { scope: "mcp:read" });
 });
 
 test("OAuth accepts read and write scopes", () => {

--- a/apps/api/src/mcp/scope-authorization.test.ts
+++ b/apps/api/src/mcp/scope-authorization.test.ts
@@ -30,10 +30,25 @@ const session = {
   activeProjectId: "00000000-0000-4000-8000-000000000002",
 };
 
-test("OAuth defaults to mcp:read and rejects unsupported scopes", () => {
-  assert.deepEqual(resolveMcpOauthScope(null), { scope: "mcp:read" });
-  assert.deepEqual(resolveMcpOauthScope("  mcp:read   mcp:write  "), {
-    error: "unsupported MCP scope: mcp:write",
+test("OAuth defaults to read and write access when the client omits scopes", () => {
+  assert.deepEqual(resolveMcpOauthScope(null), { scope: "mcp:read mcp:write" });
+});
+
+test("OAuth accepts read and write scopes", () => {
+  assert.deepEqual(resolveMcpOauthScope("  mcp:write   mcp:read  "), {
+    scope: "mcp:read mcp:write",
+  });
+});
+
+test("OAuth write access requires read access", () => {
+  assert.deepEqual(resolveMcpOauthScope("mcp:write"), {
+    error: "mcp:write requires mcp:read",
+  });
+});
+
+test("OAuth rejects unsupported scopes", () => {
+  assert.deepEqual(resolveMcpOauthScope("mcp:read profile"), {
+    error: "unsupported MCP scope: profile",
   });
 });
 
@@ -65,6 +80,16 @@ test("mcp:read sessions expose reads but not writes or deletes", async () => {
   ]);
 });
 
+test("mcp:read sessions do not instruct clients to call unavailable write tools", async () => {
+  const client = await connectedClient({ ...session, scopes: ["mcp:read"] });
+  const instructions = client.getInstructions() ?? "";
+
+  assert.match(instructions, /read-only/i);
+  assert.doesNotMatch(instructions, /create_agent_memory/);
+  assert.doesNotMatch(instructions, /set_project_context/);
+  assert.doesNotMatch(instructions, /update_issue_filter/);
+});
+
 test("mcp:read sessions reject direct calls to mutation tools", async () => {
   const client = await connectedClient({ ...session, scopes: ["mcp:read"] });
 
@@ -77,6 +102,25 @@ test("mcp:read sessions reject direct calls to mutation tools", async () => {
 
   assert.equal(result.isError, true);
   assert.match(JSON.stringify(result.content), /not found/i);
+});
+
+test("mcp:write sessions expose project authoring tools", async () => {
+  const client = await connectedClient({
+    ...session,
+    scopes: ["mcp:read", "mcp:write"],
+  });
+  const tools = await client.listTools();
+  const names = tools.tools.map((tool) => tool.name);
+
+  assert.ok(names.includes("create_agent_memory"));
+  assert.ok(names.includes("set_project_context"));
+  assert.ok(names.includes("update_issue_filter"));
+  assert.ok(names.includes("create_alert"));
+
+  const instructions = client.getInstructions() ?? "";
+  for (const name of ["create_agent_memory", "set_project_context", "update_issue_filter"]) {
+    assert.match(instructions, new RegExp(name));
+  }
 });
 
 test("unscoped personal tokens retain full MCP tool access", async () => {

--- a/apps/api/src/mcp/scope-authorization.ts
+++ b/apps/api/src/mcp/scope-authorization.ts
@@ -15,19 +15,28 @@ export const MCP_WRITE_SCOPE = "mcp:write";
 export const MCP_SUPPORTED_SCOPES = [MCP_READ_SCOPE, MCP_WRITE_SCOPE] as const;
 export const MCP_DEFAULT_SCOPE = MCP_SUPPORTED_SCOPES.join(" ");
 
-export function resolveMcpOauthScope(
-  requestedScope: string | null,
-): { scope: string } | { error: string } {
+type McpScopeResolution =
+  | { scope: string }
+  | {
+      error: string;
+      reason: "unsupported_scope" | "write_requires_read";
+    };
+
+export function resolveMcpOauthScope(requestedScope: string | null): McpScopeResolution {
   const requested = requestedScope?.split(/\s+/).filter(Boolean) ?? [];
   const supported = new Set<string>(MCP_SUPPORTED_SCOPES);
   const unsupported = [...new Set(requested.filter((scope) => !supported.has(scope)))];
   if (unsupported.length > 0) {
     return {
       error: `unsupported MCP scope${unsupported.length === 1 ? "" : "s"}: ${unsupported.join(", ")}`,
+      reason: "unsupported_scope",
     };
   }
   if (requested.includes(MCP_WRITE_SCOPE) && !requested.includes(MCP_READ_SCOPE)) {
-    return { error: `${MCP_WRITE_SCOPE} requires ${MCP_READ_SCOPE}` };
+    return {
+      error: `${MCP_WRITE_SCOPE} requires ${MCP_READ_SCOPE}`,
+      reason: "write_requires_read",
+    };
   }
   if (requested.length === 0) return { scope: MCP_DEFAULT_SCOPE };
   return {

--- a/apps/api/src/mcp/scope-authorization.ts
+++ b/apps/api/src/mcp/scope-authorization.ts
@@ -35,6 +35,12 @@ export function resolveMcpOauthScope(
   };
 }
 
+export function resolveStoredMcpOauthScope(
+  storedScope: string | null,
+): ReturnType<typeof resolveMcpOauthScope> {
+  return resolveMcpOauthScope(storedScope ?? MCP_READ_SCOPE);
+}
+
 export function hasMcpWriteAccess(scopes: readonly string[]): boolean {
   return (
     scopes.length === 0 || (scopes.includes(MCP_READ_SCOPE) && scopes.includes(MCP_WRITE_SCOPE))

--- a/apps/api/src/mcp/scope-authorization.ts
+++ b/apps/api/src/mcp/scope-authorization.ts
@@ -22,6 +22,14 @@ type McpScopeResolution =
       reason: "scope_escalation" | "unsupported_scope" | "write_requires_read";
     };
 
+type McpScopeRejectionReason = Extract<McpScopeResolution, { error: string }>["reason"];
+
+export function mcpRefreshScopeRejectionLogLevel(
+  reason: McpScopeRejectionReason,
+): "error" | "info" {
+  return reason === "scope_escalation" ? "error" : "info";
+}
+
 export function resolveMcpOauthScope(requestedScope: string | null): McpScopeResolution {
   const requested = requestedScope?.split(/\s+/).filter(Boolean) ?? [];
   const supported = new Set<string>(MCP_SUPPORTED_SCOPES);

--- a/apps/api/src/mcp/scope-authorization.ts
+++ b/apps/api/src/mcp/scope-authorization.ts
@@ -47,7 +47,13 @@ export function resolveMcpOauthScope(requestedScope: string | null): McpScopeRes
 export function resolveStoredMcpOauthScope(
   storedScope: string | null,
 ): ReturnType<typeof resolveMcpOauthScope> {
-  return resolveMcpOauthScope(storedScope?.trim() ? storedScope : MCP_READ_SCOPE);
+  return resolveMcpOauthScope(
+    isLegacyStoredMcpOauthScope(storedScope) ? MCP_READ_SCOPE : storedScope,
+  );
+}
+
+export function isLegacyStoredMcpOauthScope(storedScope: string | null): boolean {
+  return !storedScope?.trim();
 }
 
 export function resolveRefreshMcpOauthScope(

--- a/apps/api/src/mcp/scope-authorization.ts
+++ b/apps/api/src/mcp/scope-authorization.ts
@@ -47,7 +47,7 @@ export function resolveMcpOauthScope(requestedScope: string | null): McpScopeRes
 export function resolveStoredMcpOauthScope(
   storedScope: string | null,
 ): ReturnType<typeof resolveMcpOauthScope> {
-  return resolveMcpOauthScope(storedScope ?? MCP_READ_SCOPE);
+  return resolveMcpOauthScope(storedScope?.trim() ? storedScope : MCP_READ_SCOPE);
 }
 
 export function hasMcpWriteAccess(scopes: readonly string[]): boolean {

--- a/apps/api/src/mcp/scope-authorization.ts
+++ b/apps/api/src/mcp/scope-authorization.ts
@@ -10,29 +10,47 @@ export const READ_ONLY_TOOL = {
   readOnlyHint: true,
 } as const;
 
-const MCP_READ_SCOPE = "mcp:read";
+export const MCP_READ_SCOPE = "mcp:read";
+export const MCP_WRITE_SCOPE = "mcp:write";
+export const MCP_SUPPORTED_SCOPES = [MCP_READ_SCOPE, MCP_WRITE_SCOPE] as const;
+export const MCP_DEFAULT_SCOPE = MCP_SUPPORTED_SCOPES.join(" ");
 
 export function resolveMcpOauthScope(
   requestedScope: string | null,
-): { scope: typeof MCP_READ_SCOPE } | { error: string } {
+): { scope: string } | { error: string } {
   const requested = requestedScope?.split(/\s+/).filter(Boolean) ?? [];
-  const unsupported = [...new Set(requested.filter((scope) => scope !== MCP_READ_SCOPE))];
+  const supported = new Set<string>(MCP_SUPPORTED_SCOPES);
+  const unsupported = [...new Set(requested.filter((scope) => !supported.has(scope)))];
   if (unsupported.length > 0) {
     return {
       error: `unsupported MCP scope${unsupported.length === 1 ? "" : "s"}: ${unsupported.join(", ")}`,
     };
   }
-  return { scope: MCP_READ_SCOPE };
+  if (requested.includes(MCP_WRITE_SCOPE) && !requested.includes(MCP_READ_SCOPE)) {
+    return { error: `${MCP_WRITE_SCOPE} requires ${MCP_READ_SCOPE}` };
+  }
+  if (requested.length === 0) return { scope: MCP_DEFAULT_SCOPE };
+  return {
+    scope: MCP_SUPPORTED_SCOPES.filter((scope) => requested.includes(scope)).join(" "),
+  };
+}
+
+export function hasMcpWriteAccess(scopes: readonly string[]): boolean {
+  return (
+    scopes.length === 0 || (scopes.includes(MCP_READ_SCOPE) && scopes.includes(MCP_WRITE_SCOPE))
+  );
 }
 
 /**
- * Restrict an `mcp:read` session to tools explicitly classified as read-only.
+ * Restrict scoped sessions without the complete read/write grant to tools
+ * explicitly classified as read-only. Empty scopes are legacy personal tokens
+ * and intentionally retain full access.
  *
  * The default is intentionally deny: a newly added tool is unavailable to
  * read-scoped tokens until its registration opts in with READ_ONLY_TOOL.
  */
 export function enforceMcpToolScopes(server: McpServer, scopes: readonly string[]): void {
-  if (!scopes.includes(MCP_READ_SCOPE)) return;
+  if (hasMcpWriteAccess(scopes)) return;
 
   const original = (server.registerTool as AnyRegisterTool).bind(server);
   (server as unknown as { registerTool: AnyRegisterTool }).registerTool = (

--- a/apps/api/src/mcp/scope-authorization.ts
+++ b/apps/api/src/mcp/scope-authorization.ts
@@ -56,6 +56,19 @@ export function isLegacyStoredMcpOauthScope(storedScope: string | null): boolean
   return !storedScope?.trim();
 }
 
+export function createBoundedTokenObservationTracker(limit = 10_000) {
+  const observed = new Set<string>();
+  return (tokenId: string): boolean => {
+    if (observed.has(tokenId)) return false;
+    observed.add(tokenId);
+    if (observed.size > limit) {
+      const oldest = observed.values().next().value;
+      if (oldest !== undefined) observed.delete(oldest);
+    }
+    return true;
+  };
+}
+
 export function resolveRefreshMcpOauthScope(
   requestedScope: string | null,
   storedScope: string | null,

--- a/apps/api/src/mcp/scope-authorization.ts
+++ b/apps/api/src/mcp/scope-authorization.ts
@@ -19,7 +19,7 @@ type McpScopeResolution =
   | { scope: string }
   | {
       error: string;
-      reason: "unsupported_scope" | "write_requires_read";
+      reason: "scope_escalation" | "unsupported_scope" | "write_requires_read";
     };
 
 export function resolveMcpOauthScope(requestedScope: string | null): McpScopeResolution {
@@ -48,6 +48,27 @@ export function resolveStoredMcpOauthScope(
   storedScope: string | null,
 ): ReturnType<typeof resolveMcpOauthScope> {
   return resolveMcpOauthScope(storedScope?.trim() ? storedScope : MCP_READ_SCOPE);
+}
+
+export function resolveRefreshMcpOauthScope(
+  requestedScope: string | null,
+  storedScope: string | null,
+): McpScopeResolution {
+  const current = resolveStoredMcpOauthScope(storedScope);
+  if ("error" in current || !requestedScope?.trim()) return current;
+
+  const requested = resolveMcpOauthScope(requestedScope);
+  if ("error" in requested) return requested;
+
+  const currentScopes = new Set(current.scope.split(/\s+/));
+  const expandedScopes = requested.scope.split(/\s+/).filter((scope) => !currentScopes.has(scope));
+  if (expandedScopes.length > 0) {
+    return {
+      error: `requested refresh scope exceeds the original grant: ${expandedScopes.join(", ")}`,
+      reason: "scope_escalation",
+    };
+  }
+  return requested;
 }
 
 export function hasMcpWriteAccess(scopes: readonly string[]): boolean {

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -20,7 +20,11 @@ import {
   listAccessibleProjects,
   setActiveProjectForToken,
 } from "./projects.js";
-import { READ_ONLY_TOOL, enforceMcpToolScopes } from "./scope-authorization.js";
+import {
+  READ_ONLY_TOOL,
+  enforceMcpToolScopes,
+  hasMcpWriteAccess,
+} from "./scope-authorization.js";
 import {
   type McpTelemetryToolName,
   executeRecoverableTelemetryQuery,
@@ -105,13 +109,24 @@ const SERVER_INSTRUCTIONS = [
   "Tune the issue filter to control noise. When the user describes recurring noise or wants investigations scoped to certain services/routes, use get_issue_filter / preview_issue_filter / update_issue_filter — excludes drop matching events, non-empty includes restrict to matching events. Always preview before saving.",
 ].join("\n");
 
+const READ_ONLY_SERVER_INSTRUCTIONS = [
+  "Superlog is an observability + investigation platform. This connection is read-only.",
+  "Query logs, traces, metrics, incidents, alerts, dashboards, project context, agent memories, and the current issue filter to investigate the active project.",
+].join("\n\n");
+
 export function createMcpServerForSession(session: McpSession): McpServer {
   // Telemetry-only sessions don't get the agent-config / alert / dashboard /
   // incident tools, so the guidance below (which is all about them) would
   // advertise tools that aren't registered. Omit instructions in that case.
   const server = new McpServer(
     { name: "superlog", version: "0.1.0" },
-    session.telemetryOnly ? undefined : { instructions: SERVER_INSTRUCTIONS },
+    session.telemetryOnly
+      ? undefined
+      : {
+          instructions: hasMcpWriteAccess(session.scopes)
+            ? SERVER_INSTRUCTIONS
+            : READ_ONLY_SERVER_INSTRUCTIONS,
+        },
   );
 
   // Before any registerTool call so every tool below (and in the register*

--- a/apps/web/src/OauthConsent.tsx
+++ b/apps/web/src/OauthConsent.tsx
@@ -72,7 +72,10 @@ function ConsentCard({ params }: { params: AuthorizeParams }) {
   const [me, setMe] = useState<MeResponse | null>(null);
   const [client, setClient] = useState<ClientInfo | null>(null);
   const [state, setState] = useState<
-    { kind: "loading" } | { kind: "ready" } | { kind: "working" } | { kind: "error"; message: string }
+    | { kind: "loading" }
+    | { kind: "ready" }
+    | { kind: "working" }
+    | { kind: "error"; message: string }
   >({ kind: "loading" });
 
   useEffect(() => {
@@ -167,11 +170,11 @@ function ConsentCard({ params }: { params: AuthorizeParams }) {
             will access
           </span>
           <div className="text-[13px] text-fg">
-            Read logs, traces, metrics, and saved investigation data for project{" "}
-            <span className="font-medium">{me?.project.name}</span> in org{" "}
+            Read logs, traces, metrics, and saved investigation data across projects you can access,
+            starting with project <span className="font-medium">{me?.project.name}</span> in org{" "}
             <span className="font-medium">{me?.org.name}</span>
             {grantsWriteAccess
-              ? ", and create or change alerts, dashboards, investigation settings, and agent memories."
+              ? ", and create or change alerts, dashboards, investigation settings, and agent memories in any project you can access."
               : ". This client requested read-only access."}
           </div>
         </div>

--- a/apps/web/src/OauthConsent.tsx
+++ b/apps/web/src/OauthConsent.tsx
@@ -67,6 +67,8 @@ type MeResponse = {
 type ClientInfo = { id: string; name: string };
 
 function ConsentCard({ params }: { params: AuthorizeParams }) {
+  const requestedScopes = params.scope?.split(/\s+/).filter(Boolean) ?? [];
+  const grantsWriteAccess = requestedScopes.length === 0 || requestedScopes.includes("mcp:write");
   const [me, setMe] = useState<MeResponse | null>(null);
   const [client, setClient] = useState<ClientInfo | null>(null);
   const [state, setState] = useState<
@@ -165,9 +167,12 @@ function ConsentCard({ params }: { params: AuthorizeParams }) {
             will access
           </span>
           <div className="text-[13px] text-fg">
-            Read logs, traces, and metrics for project{" "}
+            Read logs, traces, metrics, and saved investigation data for project{" "}
             <span className="font-medium">{me?.project.name}</span> in org{" "}
-            <span className="font-medium">{me?.org.name}</span>.
+            <span className="font-medium">{me?.org.name}</span>
+            {grantsWriteAccess
+              ? ", and create or change alerts, dashboards, investigation settings, and agent memories."
+              : ". This client requested read-only access."}
           </div>
         </div>
 

--- a/apps/web/src/OauthConsent.tsx
+++ b/apps/web/src/OauthConsent.tsx
@@ -174,7 +174,7 @@ function ConsentCard({ params }: { params: AuthorizeParams }) {
             starting with project <span className="font-medium">{me?.project.name}</span> in org{" "}
             <span className="font-medium">{me?.org.name}</span>
             {grantsWriteAccess
-              ? ", and create or change alerts, dashboards, investigation settings, and agent memories in any project you can access."
+              ? ", create or change alerts, dashboards, investigation settings, and agent memories in any project you can access, and manage external MCP integrations and their credentials."
               : ". This client requested read-only access."}
           </div>
         </div>


### PR DESCRIPTION
## Summary

- advertise and grant `mcp:write` alongside `mcp:read` for normal OAuth connections
- preserve explicit read-only connections and give them instructions that only reference available tools
- disclose write access on the OAuth consent screen
- cover OAuth discovery, scope resolution, tool exposure, and instruction/tool consistency

Existing OAuth connections that hold only `mcp:read` remain read-only and must reconnect to grant the new write scope.

## Validation

- `pnpm --filter @superlog/api test` (629 passed)
- `pnpm --filter @superlog/api typecheck`
- `pnpm --filter @superlog/web typecheck`
- `pnpm --filter @superlog/web build`
- `pnpm worktree:verify`
- live OAuth discovery returned `mcp:read` and `mcp:write`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores MCP authoring tools behind `mcp:write` and makes OAuth scopes explicit with transactional refresh rotation. Defaults to `mcp:read mcp:write`, keeps legacy tokens read-only, updates discovery, consent, and in-app instructions.

- **New Features**
  - OAuth discovery advertises `mcp:read` and `mcp:write` on `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`.
  - Scope handling: defaults to `mcp:read mcp:write` when omitted; `mcp:write` requires `mcp:read`; rejects unsupported scopes with reason-tagged logs.
  - Refresh grants: allow narrowing; reject escalation (error-level); preserve current scope when omitted; rotate refresh tokens transactionally with single-claim checks, return `invalid_grant` on reuse, roll back on issuance errors, and log failures.
  - Legacy tokens: null/blank stored scopes normalize to `mcp:read`; emit one-time per-token legacy normalization with bounded memory; unscoped personal tokens keep full tool access.
  - Server/UI: write tools only when both scopes are present; read-only sessions expose only read tools and show read-only instructions; consent clarifies read vs write access, project/org scope, and external MCP integration management.

- **Migration**
  - Existing OAuth tokens with `mcp:read` only or no/blank stored scope stay read-only; reconnect to grant `mcp:write`.
  - Unscoped personal tokens retain full tool access.

<sup>Written for commit 07725bf79c31bb5a2a17f64532c0e825f5af1814. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

