### PR TITLE
Preserve alert incident correlation across queued intake

### DIFF
--- a/apps/worker/src/alerts/evaluate.test.ts
+++ b/apps/worker/src/alerts/evaluate.test.ts
@@ -48,7 +48,6 @@ function makeRepoFake(opts: {
   capturedUpserts?: EpisodeIssueUpsertInput[];
   capturedTouches?: EpisodeTouchInput[];
   dueAlerts?: schema.Alert[];
-  incidentIdForIssue?: string | null;
 }): AlertRepository {
   return {
     async listDueAlerts() {
@@ -74,18 +73,11 @@ function makeRepoFake(opts: {
         inserted: opts.upsertInserted ?? true,
       };
     },
-    async setEpisodeIncident(episodeId, incidentId) {
-      opts.calls.push(`setEpisodeIncident:${episodeId}:${incidentId}`);
-    },
     async recordFiring(record) {
       opts.calls.push(
         `recordFiring:${record.groupKey || "*"}:${record.state}:${record.issueId ?? "null"}`,
       );
       opts.capturedFirings?.push(record);
-    },
-    async findIncidentIdForIssue(issueId) {
-      opts.calls.push(`findIncidentIdForIssue:${issueId}`);
-      return opts.incidentIdForIssue ?? null;
     },
     async touchOpenEpisode(input) {
       opts.calls.push(`touchOpenEpisode:${input.groupKey || "*"}`);
@@ -150,7 +142,6 @@ test("evaluateAlertWorkflow: first-time firing opens the episode first, then rai
     "openOrContinueEpisode:*",
     "upsertEpisodeIssue:ep-1",
     "handleIssueTransition:issue-1:new",
-    "findIncidentIdForIssue:issue-1",
     "recordFiring:*:firing:issue-1",
     "markEvaluated:alert-1",
   ]);
@@ -158,17 +149,6 @@ test("evaluateAlertWorkflow: first-time firing opens the episode first, then rai
   assert.equal(opens[0]?.observedValue, 20);
   assert.equal(upserts[0]?.episodeId, "ep-1");
   assert.equal(upserts[0]?.title, "Errors > 10 (observed=20)");
-});
-
-test("evaluateAlertWorkflow: new firing points the episode at the issue's incident", async () => {
-  const calls: string[] = [];
-  const repo = makeRepoFake({ calls, incidentIdForIssue: "inc-1" });
-  const deps = makeDeps({ calls, repo });
-
-  await evaluateAlertWorkflow(makeAlert(), deps);
-
-  assert.ok(calls.includes("findIncidentIdForIssue:issue-1"));
-  assert.ok(calls.includes("setEpisodeIncident:ep-1:inc-1"));
 });
 
 test("evaluateAlertWorkflow: retried tick notifies again even when the issue upsert folded", async () => {

--- a/apps/worker/src/alerts/evaluate.ts
+++ b/apps/worker/src/alerts/evaluate.ts
@@ -118,8 +118,8 @@ async function processEvaluation(
 
 // The breach (episode) is the trigger entity: open it first — the partial
 // unique index over open rows makes that the dedup arbiter — then raise its
-// 1:1 issue and hand it to incident intake. Finally point the episode at the
-// incident the issue landed on.
+// 1:1 issue and hand it to incident intake. Intake may run asynchronously;
+// the incident lifecycle stamps the episode when it commits the Issue link.
 async function openEpisodeAndNotify(
   alert: schema.Alert,
   evalResult: EvaluationResult,
@@ -149,10 +149,6 @@ async function openEpisodeAndNotify(
   // per-issue advisory lock around the read-then-create section — see
   // incident-intake.ts), so both racers land on one incident.
   await deps.handleIssueTransition(upsert.issue, "new");
-  const incidentId = await deps.repo.findIncidentIdForIssue(upsert.issue.id);
-  if (incidentId) {
-    await deps.repo.setEpisodeIncident(episodeId, incidentId);
-  }
   return upsert.issue.id;
 }
 

--- a/apps/worker/src/alerts/repository.ts
+++ b/apps/worker/src/alerts/repository.ts
@@ -92,18 +92,6 @@ export function createAlertRepository(db: DB) {
       });
     },
 
-    // Resolve the incident an alert issue is currently linked to (if any), so a
-    // freshly-opened episode can point straight at it. An issue keeps one link
-    // per incident it has driven; the newest link is its current incident.
-    async findIncidentIdForIssue(issueId: string): Promise<string | null> {
-      const link = await db.query.incidentIssues.findFirst({
-        where: eq(schema.incidentIssues.issueId, issueId),
-        orderBy: [desc(schema.incidentIssues.createdAt)],
-        columns: { incidentId: true },
-      });
-      return link?.incidentId ?? null;
-    },
-
     // Open (or continue) the episode for an alert+group. The partial-unique
     // index over open rows is the dedup arbiter: there is never more than one
     // open row per (alert, group), so a single activation can't fragment into
@@ -213,13 +201,6 @@ export function createAlertRepository(db: DB) {
         .set({ issueId: issue.id, updatedAt: new Date() })
         .where(eq(schema.alertEpisodes.id, input.episodeId));
       return { issue, inserted: raw?.xmax === "0" };
-    },
-
-    async setEpisodeIncident(episodeId: string, incidentId: string): Promise<void> {
-      await db
-        .update(schema.alertEpisodes)
-        .set({ incidentId, updatedAt: new Date() })
-        .where(eq(schema.alertEpisodes.id, episodeId));
     },
 
     // Advance an open episode on a still-firing tick: update the latest value,

--- a/apps/worker/src/issues/repository.integration.test.ts
+++ b/apps/worker/src/issues/repository.integration.test.ts
@@ -11,7 +11,7 @@ import { type DB, schema } from "@superlog/db";
 import { eq } from "drizzle-orm";
 import { type PgliteDatabase, drizzle } from "drizzle-orm/pglite";
 import { migrate } from "drizzle-orm/pglite/migrator";
-import { updateIssueGrouping } from "./repository.js";
+import { findOpenIncidentForAlert, updateIssueGrouping } from "./repository.js";
 
 // Real-Postgres (pglite, in-process) coverage for the updateIssueGrouping
 // guards. The onlyIfUndecided guard is the one that keeps a losing
@@ -124,4 +124,55 @@ test("onlyIfUndecided re-marks a retryable 'failed' issue (the grouping sweep ca
     db as unknown as DB,
   );
   assert.equal((await groupingOf(issue.id)).state, "pending");
+});
+
+test("same-alert lookup follows the issue link when queued intake has not stamped the episode", async () => {
+  const [user] = await db
+    .insert(schema.users)
+    .values({ email: "queued-alert-owner@example.com", name: "Alert owner" })
+    .returning();
+  assert.ok(user);
+  const [alert] = await db
+    .insert(schema.alerts)
+    .values({
+      projectId,
+      name: "Slow requests",
+      source: "traces",
+      aggregation: "count",
+      comparator: "gt",
+      threshold: 0,
+      createdBy: user.id,
+    })
+    .returning();
+  assert.ok(alert);
+  const issue = await makeIssue();
+  const [incident] = await db
+    .insert(schema.incidents)
+    .values({
+      projectId,
+      title: issue.title,
+      codename: "queued-alert-incident",
+      status: "open",
+      firstSeen: issue.firstSeen,
+      lastSeen: issue.lastSeen,
+    })
+    .returning();
+  assert.ok(incident);
+  await db.insert(schema.incidentIssues).values({ incidentId: incident.id, issueId: issue.id });
+  await db.insert(schema.alertEpisodes).values({
+    alertId: alert.id,
+    projectId,
+    groupKey: "",
+    startedAt: issue.firstSeen,
+    openObservedValue: 2,
+    peakObservedValue: 2,
+    lastObservedValue: 2,
+    lastFiringAt: issue.lastSeen,
+    issueId: issue.id,
+    incidentId: null,
+  });
+
+  const found = await findOpenIncidentForAlert(alert.id, "", db as unknown as DB);
+
+  assert.equal(found?.id, incident.id);
 });

--- a/apps/worker/src/issues/repository.ts
+++ b/apps/worker/src/issues/repository.ts
@@ -199,17 +199,24 @@ export async function withIssueIntakeLock<T>(
 }
 
 // Newest incident driven by an episode of the same alert+group, optionally
-// restricted to open incidents. Single query shape so the open-join and
-// latest-predecessor lookups can't drift apart.
+// restricted to open incidents. Follow the episode Issue's authoritative
+// incident link rather than the episode's denormalized incident_id: queued
+// intake creates that link after the alert evaluation has already returned.
+// Single query shape keeps the open-join and latest-predecessor lookups aligned.
 async function findNewestIncidentForAlert(
   alertId: string,
   groupKey: string,
   opts: { openOnly: boolean },
+  database: DB = db,
 ): Promise<schema.Incident | undefined> {
-  const rows = await db
+  const rows = await database
     .select({ incident: schema.incidents })
     .from(schema.alertEpisodes)
-    .innerJoin(schema.incidents, eq(schema.incidents.id, schema.alertEpisodes.incidentId))
+    .innerJoin(
+      schema.incidentIssues,
+      eq(schema.incidentIssues.issueId, schema.alertEpisodes.issueId),
+    )
+    .innerJoin(schema.incidents, eq(schema.incidents.id, schema.incidentIssues.incidentId))
     .where(
       and(
         eq(schema.alertEpisodes.alertId, alertId),
@@ -217,7 +224,7 @@ async function findNewestIncidentForAlert(
         opts.openOnly ? eq(schema.incidents.status, "open") : undefined,
       ),
     )
-    .orderBy(desc(schema.alertEpisodes.startedAt))
+    .orderBy(desc(schema.alertEpisodes.startedAt), desc(schema.incidentIssues.createdAt))
     .limit(1);
   return rows[0]?.incident;
 }
@@ -227,8 +234,9 @@ async function findNewestIncidentForAlert(
 export async function findOpenIncidentForAlert(
   alertId: string,
   groupKey: string,
+  database: DB = db,
 ): Promise<schema.Incident | undefined> {
-  return findNewestIncidentForAlert(alertId, groupKey, { openOnly: true });
+  return findNewestIncidentForAlert(alertId, groupKey, { openOnly: true }, database);
 }
 
 // Newest incident (any status) driven by an episode of the same alert+group —
@@ -236,8 +244,9 @@ export async function findOpenIncidentForAlert(
 export async function findLatestIncidentForAlert(
   alertId: string,
   groupKey: string,
+  database: DB = db,
 ): Promise<schema.Incident | undefined> {
-  return findNewestIncidentForAlert(alertId, groupKey, { openOnly: false });
+  return findNewestIncidentForAlert(alertId, groupKey, { openOnly: false }, database);
 }
 
 export async function linkIssueToIncident(opts: {

--- a/packages/db/src/incident-repository.ts
+++ b/packages/db/src/incident-repository.ts
@@ -86,6 +86,10 @@ export function createIncidentRepository(database: DB) {
         .values({ incidentId: incident.id, issueId: issue.id })
         .onConflictDoNothing()
         .returning({ id: schema.incidentIssues.id });
+      await tx
+        .update(schema.alertEpisodes)
+        .set({ incidentId: incident.id, updatedAt })
+        .where(eq(schema.alertEpisodes.issueId, issue.id));
       if (!inserted[0]) return false;
 
       await tx

--- a/packages/db/src/issue-lifecycle.test.ts
+++ b/packages/db/src/issue-lifecycle.test.ts
@@ -90,6 +90,61 @@ async function seedIncidentWithIssue(
   return { issue, incident };
 }
 
+async function seedAlertEpisodeIssue(db: DB, projectId: string) {
+  const user = one(
+    await db
+      .insert(schema.users)
+      .values({ email: "alert-owner@example.com", name: "Alert owner" })
+      .returning(),
+  );
+  const alert = one(
+    await db
+      .insert(schema.alerts)
+      .values({
+        projectId,
+        name: "Slow requests",
+        source: "traces",
+        aggregation: "count",
+        comparator: "gt",
+        threshold: 0,
+        createdBy: user.id,
+      })
+      .returning(),
+  );
+  const now = new Date("2026-08-08T08:03:03.623Z");
+  const issue = one(
+    await db
+      .insert(schema.issues)
+      .values({
+        projectId,
+        fingerprint: "alert-episode:test-episode",
+        kind: "alert",
+        exceptionType: "AlertFired",
+        title: "Slow requests > 0 (observed=2)",
+        firstSeen: now,
+        lastSeen: now,
+      })
+      .returning(),
+  );
+  const episode = one(
+    await db
+      .insert(schema.alertEpisodes)
+      .values({
+        alertId: alert.id,
+        projectId,
+        groupKey: "",
+        startedAt: now,
+        openObservedValue: 2,
+        peakObservedValue: 2,
+        lastObservedValue: 2,
+        lastFiringAt: now,
+        issueId: issue.id,
+      })
+      .returning(),
+  );
+  return { episode, issue, now };
+}
+
 async function eventKinds(db: DB, incidentId: string): Promise<string[]> {
   const rows = await db.query.incidentEvents.findMany({
     where: eq(schema.incidentEvents.incidentId, incidentId),
@@ -1249,7 +1304,9 @@ test("hasCurrentSilencedIssues follows the issue's current incident link", async
     // The issue recurs into a NEW incident which later silences it. The old
     // incident's historical link must not resurface the silenced state (its
     // un-silence button could no longer touch the issue).
-    const reloaded = one(await db.select().from(schema.issues).where(eq(schema.issues.id, issue.id)));
+    const reloaded = one(
+      await db.select().from(schema.issues).where(eq(schema.issues.id, issue.id)),
+    );
     const successor = await lifecycle.openRecurrence({
       previousIncident: incident,
       issue: reloaded,
@@ -1478,6 +1535,74 @@ test("an Issue cannot be linked after Incident resolution wins the lifecycle loc
       where: eq(schema.incidentIssues.issueId, lateIssue.id),
     });
     assert.deepEqual(links, []);
+  } finally {
+    await client.close();
+  }
+});
+
+test("linking an alert issue records the incident on its episode after asynchronous intake", async () => {
+  const { db, client } = await freshDb();
+  try {
+    const project = await seedProject(db);
+    const { episode, issue, now } = await seedAlertEpisodeIssue(db, project.id);
+    const incident = one(
+      await db
+        .insert(schema.incidents)
+        .values({
+          projectId: project.id,
+          title: issue.title,
+          codename: "slow-requests",
+          status: "open",
+          firstSeen: now,
+          lastSeen: now,
+        })
+        .returning(),
+    );
+
+    const linked = await createIncidentLifecycle(db).linkIssueToOpenIncident({
+      incidentId: incident.id,
+      issue,
+    });
+
+    assert.equal(linked, "linked");
+    const episodeAfter = one(
+      await db.select().from(schema.alertEpisodes).where(eq(schema.alertEpisodes.id, episode.id)),
+    );
+    assert.equal(episodeAfter.incidentId, incident.id);
+  } finally {
+    await client.close();
+  }
+});
+
+test("opening an alert recurrence records the successor incident on its episode", async () => {
+  const { db, client } = await freshDb();
+  try {
+    const project = await seedProject(db);
+    const { episode, issue, now } = await seedAlertEpisodeIssue(db, project.id);
+    const previousIncident = one(
+      await db
+        .insert(schema.incidents)
+        .values({
+          projectId: project.id,
+          title: "Earlier slow requests",
+          codename: "earlier-slow-requests",
+          status: "resolved",
+          firstSeen: new Date(now.getTime() - 60_000),
+          lastSeen: new Date(now.getTime() - 30_000),
+        })
+        .returning(),
+    );
+
+    const recurrence = await createIncidentLifecycle(db).openRecurrence({
+      previousIncident,
+      issue,
+      origin: "alert_breached_again",
+    });
+
+    const episodeAfter = one(
+      await db.select().from(schema.alertEpisodes).where(eq(schema.alertEpisodes.id, episode.id)),
+    );
+    assert.equal(episodeAfter.incidentId, recurrence.id);
   } finally {
     await client.close();
   }

--- a/packages/db/src/resolve-incident.ts
+++ b/packages/db/src/resolve-incident.ts
@@ -872,14 +872,11 @@ export function createIncidentLifecycle(database: DB = db) {
         await repository.updateIncidentInTx(
           tx,
           incident.id,
-          { previousIncidentId: opts.previousIncident.id, issueCount: 1 },
+          { previousIncidentId: opts.previousIncident.id },
           now,
         );
         await repository.updateIssueInTx(tx, opts.issue.id, buildIssueReopenPatch());
-        await tx
-          .insert(schema.incidentIssues)
-          .values({ incidentId: incident.id, issueId: opts.issue.id })
-          .onConflictDoNothing();
+        await repository.linkIssueInTx(tx, incident, opts.issue, now);
 
         await repository.insertEventInTx(tx, {
           incidentId: incident.id,


### PR DESCRIPTION
## Summary

- preserve same-alert incident correlation when issue intake runs asynchronously
- resolve alert incidents through the authoritative issue-to-incident link
- stamp alert episodes atomically whenever their issue is linked, including recurrence creation

## Root cause

The alert evaluator handed issue intake to an asynchronous dispatcher, then immediately attempted to copy the resulting incident id onto the episode. The dispatch completed before intake, so the incident did not exist yet and the episode pointer remained empty. Later breaches could not take the deterministic same-alert path and could open parallel investigations.

## Validation

- `pnpm --filter @superlog/db typecheck`
- `pnpm --filter @superlog/worker typecheck`
- `pnpm --filter @superlog/db exec tsx --test src/issue-lifecycle.test.ts`
- `pnpm --filter @superlog/worker exec tsx --test src/issues/repository.integration.test.ts src/alerts/evaluate.test.ts src/incidents/intake.test.ts`
- `pnpm exec biome check` on changed files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep alert episodes correctly linked to their incidents even when incident intake runs asynchronously. Prevents parallel investigations by using the issue→incident link as the source of truth and stamping episodes atomically.

- **Bug Fixes**
  - Alert evaluator no longer sets episode incident during evaluation; lifecycle stamps it when the issue is linked.
  - Replaced episode-based incident lookup with a join via `incident_issues` (by `issue_id`) and deterministic ordering.
  - Linking an issue or opening a recurrence now updates `alert_episodes.incident_id` in the same transaction.
  - Removed `findIncidentIdForIssue` and `setEpisodeIncident` from the alerts repository; added integration tests for queued intake and recurrence stamping.

<sup>Written for commit c400da4b1e714f96662d2ae38e79d2a8967347df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

