### PR TITLE
Add Google Cloud integration disconnect

### DIFF
--- a/apps/api/src/gcp/application.test.ts
+++ b/apps/api/src/gcp/application.test.ts
@@ -469,6 +469,67 @@ test("a failed disconnect recovery row can retry cleanup", async () => {
   assert.deepEqual(events, ["claim-disconnect", "deprovision-connection", "revoke-connection"]);
 });
 
+test("a failed disconnect claim release becomes retryable", async () => {
+  const connected: GcpConnectionRecord = {
+    ...connection,
+    ...provisioned,
+    status: "connected",
+  };
+  const events: string[] = [];
+  const repository = {
+    async findCurrent() {
+      return connected;
+    },
+    async findById() {
+      return { ...connected, status: "disconnecting" as const };
+    },
+    async claimDisconnect() {
+      events.push("claim-disconnect");
+      return { ...connected, status: "disconnecting" as const };
+    },
+    async prepareMonitoringGrantRemoval() {
+      return true;
+    },
+    async releaseDisconnect() {
+      events.push("release-disconnect");
+      throw new Error("database unavailable");
+    },
+    async failDisconnect(_id: string, error: string) {
+      assert.match(error, /disconnect claim release failed: database unavailable/);
+      events.push("fail-disconnect");
+    },
+  } as unknown as GcpConnectionRepository;
+  const gateway = {
+    async deprovision() {
+      events.push("deprovision-connection");
+      throw new Error("partial cleanup failure");
+    },
+    async provision() {
+      events.push("restore-connection");
+      return provisioned;
+    },
+  } as unknown as GcpGateway;
+
+  await assert.rejects(
+    disconnectGcpConnection({
+      projectId: connected.projectId,
+      userAccessToken: "temporary-user-token",
+      repository,
+      gateway,
+      config,
+    }),
+    /disconnect claim release failed: database unavailable/,
+  );
+
+  assert.deepEqual(events, [
+    "claim-disconnect",
+    "deprovision-connection",
+    "restore-connection",
+    "release-disconnect",
+    "fail-disconnect",
+  ]);
+});
+
 test("a local persistence failure removes newly provisioned Google resources", async () => {
   const cleanupCalls: unknown[] = [];
   const repository = {

--- a/apps/api/src/gcp/application.test.ts
+++ b/apps/api/src/gcp/application.test.ts
@@ -145,6 +145,9 @@ test("a failed disconnect revocation restores the connected GCP resources", asyn
     async findCurrent() {
       return connected;
     },
+    async findById() {
+      return connected;
+    },
     async prepareMonitoringGrantRemoval() {
       return true;
     },
@@ -177,6 +180,101 @@ test("a failed disconnect revocation restores the connected GCP resources", asyn
   );
 
   assert.deepEqual(events, ["deprovision-connection", "revoke-connection", "restore-connection"]);
+});
+
+test("a partially failed cloud cleanup restores the connected GCP resources", async () => {
+  const events: string[] = [];
+  const connected: GcpConnectionRecord = {
+    ...connection,
+    ...provisioned,
+    status: "connected",
+  };
+  const repository = {
+    async findCurrent() {
+      return connected;
+    },
+    async findById() {
+      return connected;
+    },
+    async prepareMonitoringGrantRemoval() {
+      return true;
+    },
+    async revoke() {
+      events.push("revoke-connection");
+      return { ...connected, revokedAt: new Date() };
+    },
+  } as unknown as GcpConnectionRepository;
+  const gateway = {
+    async deprovision() {
+      events.push("deprovision-connection");
+      throw new Error("partial cleanup failure");
+    },
+    async provision(input: GcpProvisioningInput) {
+      assert.equal(input.connectionId, connected.id);
+      events.push("restore-connection");
+      return provisioned;
+    },
+  } as unknown as GcpGateway;
+
+  await assert.rejects(
+    disconnectGcpConnection({
+      projectId: connected.projectId,
+      userAccessToken: "temporary-user-token",
+      repository,
+      gateway,
+      config,
+    }),
+    /partial cleanup failure/,
+  );
+
+  assert.deepEqual(events, ["deprovision-connection", "restore-connection"]);
+});
+
+test("an overlapping disconnect does not restore an already revoked connection", async () => {
+  const events: string[] = [];
+  const connected: GcpConnectionRecord = {
+    ...connection,
+    ...provisioned,
+    status: "connected",
+  };
+  const revoked = { ...connected, revokedAt: new Date("2026-08-21T12:00:00.000Z") };
+  const repository = {
+    async findCurrent() {
+      return connected;
+    },
+    async findById() {
+      return revoked;
+    },
+    async prepareMonitoringGrantRemoval() {
+      return true;
+    },
+    async revoke() {
+      events.push("revoke-connection");
+      throw new Error("Connected GCP project not found");
+    },
+  } as unknown as GcpConnectionRepository;
+  const gateway = {
+    async deprovision() {
+      events.push("deprovision-connection");
+    },
+    async provision() {
+      events.push("restore-connection");
+      return provisioned;
+    },
+  } as unknown as GcpGateway;
+
+  await assert.rejects(
+    disconnectGcpConnection({
+      projectId: connected.projectId,
+      userAccessToken: "temporary-user-token",
+      repository,
+      gateway,
+      config,
+    }),
+    /Connected GCP project not found/,
+  );
+
+  assert.deepEqual(events, ["deprovision-connection", "revoke-connection"]);
 });
 
 test("a local persistence failure removes newly provisioned Google resources", async () => {

--- a/apps/api/src/gcp/application.test.ts
+++ b/apps/api/src/gcp/application.test.ts
@@ -430,7 +430,7 @@ test("a failed disconnect recovery row can retry cleanup", async () => {
   const failed: GcpConnectionRecord = {
     ...connection,
     ...provisioned,
-    status: "failed",
+    status: "disconnect_failed",
     lastError: "partial cleanup failure; connection restore failed",
   };
   const events: string[] = [];
@@ -608,24 +608,8 @@ test("replaying a completed OAuth callback leaves the connected connection uncha
   assert.equal(exchangeCalls, 0);
 });
 
-test("an OAuth callback cannot reclaim a connection while disconnect is in progress", async () => {
+test("an OAuth callback cannot reclaim a connection during disconnect or recovery", async () => {
   let provisioningCalls = 0;
-  const disconnecting = {
-    ...connection,
-    ...provisioned,
-    status: "disconnecting" as const,
-  };
-  const repository = {
-    async findById() {
-      return disconnecting;
-    },
-    async findCurrent() {
-      return disconnecting;
-    },
-    async markProvisioning() {
-      provisioningCalls += 1;
-    },
-  } as unknown as GcpConnectionRepository;
   const gateway = {
     async provision() {
       provisioningCalls += 1;
@@ -633,16 +617,31 @@ test("an OAuth callback cannot reclaim a connection while disconnect is in progr
     },
   } as unknown as GcpGateway;
 
-  await assert.rejects(
-    completeGcpConnect({
-      connectionId: disconnecting.id,
-      userAccessToken: "temporary-user-token",
-      repository,
-      gateway,
-      config,
-    }),
-    /disconnect is in progress/,
-  );
+  for (const status of ["disconnecting", "disconnect_failed"] as const) {
+    const disconnecting = { ...connection, ...provisioned, status };
+    const repository = {
+      async findById() {
+        return disconnecting;
+      },
+      async findCurrent() {
+        return disconnecting;
+      },
+      async markProvisioning() {
+        provisioningCalls += 1;
+      },
+    } as unknown as GcpConnectionRepository;
+
+    await assert.rejects(
+      completeGcpConnect({
+        connectionId: disconnecting.id,
+        userAccessToken: "temporary-user-token",
+        repository,
+        gateway,
+        config,
+      }),
+      /disconnect is in progress or requires recovery/,
+    );
+  }
 
   assert.equal(provisioningCalls, 0);
 });

--- a/apps/api/src/gcp/application.test.ts
+++ b/apps/api/src/gcp/application.test.ts
@@ -643,13 +643,11 @@ test("replacement preserves a monitoring grant shared by another active connecti
     async prepareMonitoringGrantRemoval(input: {
       connectionId: string;
       gcpProjectId: string;
-      grantCreated: boolean;
     }) {
       assert.deepEqual(input, {
         connectionId: oldConnection.id,
         gcpProjectId: oldConnection.gcpProjectId,
         readerServiceAccountEmail: oldConnection.readerServiceAccountEmail,
-        grantCreated: true,
       });
       return false;
     },

--- a/apps/api/src/gcp/application.test.ts
+++ b/apps/api/src/gcp/application.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import {
   type GcpApplicationConfig,
   completeGcpConnect,
+  disconnectGcpConnection,
   updateGcpLogExclusions,
 } from "./application.js";
 import type {
@@ -10,6 +11,7 @@ import type {
   GcpConnectionRepository,
   GcpDeprovisioningInput,
   GcpGateway,
+  GcpProvisioningInput,
   ProvisionedGcpConnection,
 } from "./domain.js";
 
@@ -84,6 +86,98 @@ const provisioned: ProvisionedGcpConnection = {
   logSinkWriterIdentity: "serviceAccount:cloud-logs@system.gserviceaccount.com",
   monitoringViewerGrantCreated: true,
 };
+
+test("disconnecting a connected GCP project removes its cloud resources before revoking it", async () => {
+  const events: string[] = [];
+  const connected: GcpConnectionRecord = {
+    ...connection,
+    ...provisioned,
+    status: "connected",
+  };
+  const repository = {
+    async findCurrent(projectId: string) {
+      assert.equal(projectId, connected.projectId);
+      return connected;
+    },
+    async prepareMonitoringGrantRemoval() {
+      return true;
+    },
+    async revoke(id: string) {
+      assert.equal(id, connected.id);
+      events.push("revoke-connection");
+      return { ...connected, revokedAt: new Date("2026-08-21T12:00:00.000Z") };
+    },
+  } as unknown as GcpConnectionRepository;
+  const gateway = {
+    async deprovision(input: GcpDeprovisioningInput) {
+      assert.deepEqual(input, {
+        connectionId: connected.id,
+        gcpProjectId: connected.gcpProjectId,
+        userAccessToken: "temporary-user-token",
+        integrationProjectId: config.integrationProjectId,
+        readerServiceAccountEmail: connected.readerServiceAccountEmail,
+        provisioned,
+      });
+      events.push("deprovision-connection");
+    },
+  } as unknown as GcpGateway;
+
+  const result = await disconnectGcpConnection({
+    projectId: connected.projectId,
+    userAccessToken: "temporary-user-token",
+    repository,
+    gateway,
+    config,
+  });
+
+  assert.ok(result.revokedAt);
+  assert.deepEqual(events, ["deprovision-connection", "revoke-connection"]);
+});
+
+test("a failed disconnect revocation restores the connected GCP resources", async () => {
+  const events: string[] = [];
+  const connected: GcpConnectionRecord = {
+    ...connection,
+    ...provisioned,
+    status: "connected",
+  };
+  const repository = {
+    async findCurrent() {
+      return connected;
+    },
+    async prepareMonitoringGrantRemoval() {
+      return true;
+    },
+    async revoke() {
+      events.push("revoke-connection");
+      throw new Error("database unavailable");
+    },
+  } as unknown as GcpConnectionRepository;
+  const gateway = {
+    async deprovision() {
+      events.push("deprovision-connection");
+    },
+    async provision(input: GcpProvisioningInput) {
+      assert.equal(input.connectionId, connected.id);
+      assert.equal(input.userAccessToken, "temporary-user-token");
+      events.push("restore-connection");
+      return provisioned;
+    },
+  } as unknown as GcpGateway;
+
+  await assert.rejects(
+    disconnectGcpConnection({
+      projectId: connected.projectId,
+      userAccessToken: "temporary-user-token",
+      repository,
+      gateway,
+      config,
+    }),
+    /database unavailable/,
+  );
+
+  assert.deepEqual(events, ["deprovision-connection", "revoke-connection", "restore-connection"]);
+});
 
 test("a local persistence failure removes newly provisioned Google resources", async () => {
   const cleanupCalls: unknown[] = [];

--- a/apps/api/src/gcp/application.test.ts
+++ b/apps/api/src/gcp/application.test.ts
@@ -361,6 +361,71 @@ test("a failed disconnect restoration persists a retryable connection state", as
   ]);
 });
 
+test("a superseded disconnect recovery removes the restored cloud resources", async () => {
+  const events: string[] = [];
+  const connected: GcpConnectionRecord = {
+    ...connection,
+    ...provisioned,
+    status: "connected",
+  };
+  let deprovisionCalls = 0;
+  const repository = {
+    async findCurrent() {
+      return connected;
+    },
+    async findById() {
+      return { ...connected, status: "disconnecting" as const };
+    },
+    async prepareMonitoringGrantRemoval() {
+      return true;
+    },
+    async claimDisconnect() {
+      events.push("claim-disconnect");
+      return { ...connected, status: "disconnecting" as const };
+    },
+    async revoke() {
+      events.push("revoke-connection");
+      throw new Error("database unavailable");
+    },
+    async releaseDisconnect() {
+      events.push("release-disconnect");
+      return false;
+    },
+  } as unknown as GcpConnectionRepository;
+  const gateway = {
+    async deprovision() {
+      deprovisionCalls += 1;
+      events.push(
+        deprovisionCalls === 1 ? "deprovision-connection" : "discard-restored-connection",
+      );
+    },
+    async provision() {
+      events.push("restore-connection");
+      return provisioned;
+    },
+  } as unknown as GcpGateway;
+
+  await assert.rejects(
+    disconnectGcpConnection({
+      projectId: connected.projectId,
+      userAccessToken: "temporary-user-token",
+      repository,
+      gateway,
+      config,
+    }),
+    /connection recovery was superseded/,
+  );
+
+  assert.deepEqual(events, [
+    "claim-disconnect",
+    "deprovision-connection",
+    "revoke-connection",
+    "restore-connection",
+    "release-disconnect",
+    "discard-restored-connection",
+  ]);
+});
+
 test("a local persistence failure removes newly provisioned Google resources", async () => {
   const cleanupCalls: unknown[] = [];
   const repository = {

--- a/apps/api/src/gcp/application.test.ts
+++ b/apps/api/src/gcp/application.test.ts
@@ -102,6 +102,11 @@ test("disconnecting a connected GCP project removes its cloud resources before r
     async prepareMonitoringGrantRemoval() {
       return true;
     },
+    async claimDisconnect(id: string) {
+      assert.equal(id, connected.id);
+      events.push("claim-disconnect");
+      return { ...connected, status: "disconnecting" as const };
+    },
     async revoke(id: string) {
       assert.equal(id, connected.id);
       events.push("revoke-connection");
@@ -131,7 +136,7 @@ test("disconnecting a connected GCP project removes its cloud resources before r
   });
 
   assert.ok(result.revokedAt);
-  assert.deepEqual(events, ["deprovision-connection", "revoke-connection"]);
+  assert.deepEqual(events, ["claim-disconnect", "deprovision-connection", "revoke-connection"]);
 });
 
 test("a failed disconnect revocation restores the connected GCP resources", async () => {
@@ -146,14 +151,21 @@ test("a failed disconnect revocation restores the connected GCP resources", asyn
       return connected;
     },
     async findById() {
-      return connected;
+      return { ...connected, status: "disconnecting" as const };
     },
     async prepareMonitoringGrantRemoval() {
       return true;
     },
+    async claimDisconnect() {
+      events.push("claim-disconnect");
+      return { ...connected, status: "disconnecting" as const };
+    },
     async revoke() {
       events.push("revoke-connection");
       throw new Error("database unavailable");
+    },
+    async releaseDisconnect() {
+      events.push("release-disconnect");
     },
   } as unknown as GcpConnectionRepository;
   const gateway = {
@@ -179,7 +191,13 @@ test("a failed disconnect revocation restores the connected GCP resources", asyn
     /database unavailable/,
   );
 
-  assert.deepEqual(events, ["deprovision-connection", "revoke-connection", "restore-connection"]);
+  assert.deepEqual(events, [
+    "claim-disconnect",
+    "deprovision-connection",
+    "revoke-connection",
+    "restore-connection",
+    "release-disconnect",
+  ]);
 });
 
 test("a partially failed cloud cleanup restores the connected GCP resources", async () => {
@@ -194,14 +212,21 @@ test("a partially failed cloud cleanup restores the connected GCP resources", as
       return connected;
     },
     async findById() {
-      return connected;
+      return { ...connected, status: "disconnecting" as const };
     },
     async prepareMonitoringGrantRemoval() {
       return true;
     },
+    async claimDisconnect() {
+      events.push("claim-disconnect");
+      return { ...connected, status: "disconnecting" as const };
+    },
     async revoke() {
       events.push("revoke-connection");
       return { ...connected, revokedAt: new Date() };
+    },
+    async releaseDisconnect() {
+      events.push("release-disconnect");
     },
   } as unknown as GcpConnectionRepository;
   const gateway = {
@@ -227,30 +252,31 @@ test("a partially failed cloud cleanup restores the connected GCP resources", as
     /partial cleanup failure/,
   );
 
-  assert.deepEqual(events, ["deprovision-connection", "restore-connection"]);
+  assert.deepEqual(events, [
+    "claim-disconnect",
+    "deprovision-connection",
+    "restore-connection",
+    "release-disconnect",
+  ]);
 });
 
-test("an overlapping disconnect does not restore an already revoked connection", async () => {
+test("an overlapping disconnect cannot clean up a connection claimed by another request", async () => {
   const events: string[] = [];
   const connected: GcpConnectionRecord = {
     ...connection,
     ...provisioned,
     status: "connected",
   };
-  const revoked = { ...connected, revokedAt: new Date("2026-08-21T12:00:00.000Z") };
   const repository = {
     async findCurrent() {
       return connected;
     },
-    async findById() {
-      return revoked;
-    },
     async prepareMonitoringGrantRemoval() {
       return true;
     },
-    async revoke() {
-      events.push("revoke-connection");
-      throw new Error("Connected GCP project not found");
+    async claimDisconnect() {
+      events.push("claim-disconnect");
+      throw new Error("GCP disconnect is already in progress");
     },
   } as unknown as GcpConnectionRepository;
   const gateway = {
@@ -271,10 +297,10 @@ test("an overlapping disconnect does not restore an already revoked connection",
       gateway,
       config,
     }),
-    /Connected GCP project not found/,
+    /already in progress/,
   );
 
-  assert.deepEqual(events, ["deprovision-connection", "revoke-connection"]);
+  assert.deepEqual(events, ["claim-disconnect"]);
 });
 
 test("a local persistence failure removes newly provisioned Google resources", async () => {
@@ -353,6 +379,45 @@ test("replaying a completed OAuth callback leaves the connected connection uncha
   assert.equal(result, connected);
   assert.equal(provisioningCalls, 0);
   assert.equal(exchangeCalls, 0);
+});
+
+test("an OAuth callback cannot reclaim a connection while disconnect is in progress", async () => {
+  let provisioningCalls = 0;
+  const disconnecting = {
+    ...connection,
+    ...provisioned,
+    status: "disconnecting" as const,
+  };
+  const repository = {
+    async findById() {
+      return disconnecting;
+    },
+    async findCurrent() {
+      return disconnecting;
+    },
+    async markProvisioning() {
+      provisioningCalls += 1;
+    },
+  } as unknown as GcpConnectionRepository;
+  const gateway = {
+    async provision() {
+      provisioningCalls += 1;
+      return provisioned;
+    },
+  } as unknown as GcpGateway;
+
+  await assert.rejects(
+    completeGcpConnect({
+      connectionId: disconnecting.id,
+      userAccessToken: "temporary-user-token",
+      repository,
+      gateway,
+      config,
+    }),
+    /disconnect is in progress/,
+  );
+
+  assert.equal(provisioningCalls, 0);
 });
 
 test("replacing a connected GCP project removes its cloud resources before superseding it", async () => {

--- a/apps/api/src/gcp/application.test.ts
+++ b/apps/api/src/gcp/application.test.ts
@@ -166,6 +166,7 @@ test("a failed disconnect revocation restores the connected GCP resources", asyn
     },
     async releaseDisconnect() {
       events.push("release-disconnect");
+      return true;
     },
   } as unknown as GcpConnectionRepository;
   const gateway = {
@@ -227,6 +228,7 @@ test("a partially failed cloud cleanup restores the connected GCP resources", as
     },
     async releaseDisconnect() {
       events.push("release-disconnect");
+      return true;
     },
   } as unknown as GcpConnectionRepository;
   const gateway = {
@@ -301,6 +303,62 @@ test("an overlapping disconnect cannot clean up a connection claimed by another 
   );
 
   assert.deepEqual(events, ["claim-disconnect"]);
+});
+
+test("a failed disconnect restoration persists a retryable connection state", async () => {
+  const events: string[] = [];
+  const connected: GcpConnectionRecord = {
+    ...connection,
+    ...provisioned,
+    status: "connected",
+  };
+  const repository = {
+    async findCurrent() {
+      return connected;
+    },
+    async findById() {
+      return { ...connected, status: "disconnecting" as const };
+    },
+    async claimDisconnect() {
+      events.push("claim-disconnect");
+      return { ...connected, status: "disconnecting" as const };
+    },
+    async prepareMonitoringGrantRemoval() {
+      return true;
+    },
+    async failDisconnect(_id: string, error: string) {
+      assert.match(error, /connection restore failed: restore unavailable/);
+      events.push("fail-disconnect");
+    },
+  } as unknown as GcpConnectionRepository;
+  const gateway = {
+    async deprovision() {
+      events.push("deprovision-connection");
+      throw new Error("partial cleanup failure");
+    },
+    async provision() {
+      events.push("restore-connection");
+      throw new Error("restore unavailable");
+    },
+  } as unknown as GcpGateway;
+
+  await assert.rejects(
+    disconnectGcpConnection({
+      projectId: connected.projectId,
+      userAccessToken: "temporary-user-token",
+      repository,
+      gateway,
+      config,
+    }),
+    /connection restore failed: restore unavailable/,
+  );
+
+  assert.deepEqual(events, [
+    "claim-disconnect",
+    "deprovision-connection",
+    "restore-connection",
+    "fail-disconnect",
+  ]);
 });
 
 test("a local persistence failure removes newly provisioned Google resources", async () => {

--- a/apps/api/src/gcp/application.test.ts
+++ b/apps/api/src/gcp/application.test.ts
@@ -426,6 +426,49 @@ test("a superseded disconnect recovery removes the restored cloud resources", as
   ]);
 });
 
+test("a failed disconnect recovery row can retry cleanup", async () => {
+  const failed: GcpConnectionRecord = {
+    ...connection,
+    ...provisioned,
+    status: "failed",
+    lastError: "partial cleanup failure; connection restore failed",
+  };
+  const events: string[] = [];
+  const repository = {
+    async findById() {
+      return failed;
+    },
+    async claimDisconnect() {
+      events.push("claim-disconnect");
+      return { ...failed, status: "disconnecting" as const };
+    },
+    async prepareMonitoringGrantRemoval() {
+      return true;
+    },
+    async revoke() {
+      events.push("revoke-connection");
+      return { ...failed, status: "disconnecting" as const, revokedAt: new Date() };
+    },
+  } as unknown as GcpConnectionRepository;
+  const gateway = {
+    async deprovision() {
+      events.push("deprovision-connection");
+    },
+  } as unknown as GcpGateway;
+
+  const result = await disconnectGcpConnection({
+    projectId: failed.projectId,
+    expectedConnectionId: failed.id,
+    userAccessToken: "temporary-user-token",
+    repository,
+    gateway,
+    config,
+  });
+
+  assert.ok(result.revokedAt);
+  assert.deepEqual(events, ["claim-disconnect", "deprovision-connection", "revoke-connection"]);
+});
+
 test("a local persistence failure removes newly provisioned Google resources", async () => {
   const cleanupCalls: unknown[] = [];
   const repository = {

--- a/apps/api/src/gcp/application.ts
+++ b/apps/api/src/gcp/application.ts
@@ -274,12 +274,10 @@ async function cleanupProvisioningResult(
   provisioned: ProvisionedGcpConnection,
   repository: GcpConnectionRepository,
 ): Promise<ProvisionedGcpConnection> {
-  if (!provisioned.monitoringViewerGrantCreated) return provisioned;
   const removeGrant = await repository.prepareMonitoringGrantRemoval({
     connectionId: connection.id,
     gcpProjectId: connection.gcpProjectId,
     readerServiceAccountEmail: connection.readerServiceAccountEmail,
-    grantCreated: provisioned.monitoringViewerGrantCreated,
   });
   return { ...provisioned, monitoringViewerGrantCreated: removeGrant };
 }

--- a/apps/api/src/gcp/application.ts
+++ b/apps/api/src/gcp/application.ts
@@ -160,6 +160,58 @@ export async function completeGcpConnect(input: {
   }
 }
 
+export async function disconnectGcpConnection(input: {
+  projectId: string;
+  expectedConnectionId?: string;
+  userAccessToken: string;
+  repository: GcpConnectionRepository;
+  gateway: GcpGateway;
+  config: GcpApplicationConfig;
+}): Promise<GcpConnectionRecord> {
+  const connection = await input.repository.findCurrent(input.projectId);
+  if (!connection || connection.status !== "connected" || connection.revokedAt) {
+    throw new Error("Connected GCP project not found");
+  }
+  if (input.expectedConnectionId && connection.id !== input.expectedConnectionId) {
+    throw new Error("Connected GCP project changed during authorization");
+  }
+  const provisioned = await cleanupProvisioningResult(
+    connection,
+    persistedProvisioningResult(connection),
+    input.repository,
+  );
+  await input.gateway.deprovision({
+    connectionId: connection.id,
+    gcpProjectId: connection.gcpProjectId,
+    userAccessToken: input.userAccessToken,
+    integrationProjectId: input.config.integrationProjectId,
+    readerServiceAccountEmail: connection.readerServiceAccountEmail,
+    provisioned,
+  });
+  try {
+    return await input.repository.revoke(connection.id);
+  } catch (error) {
+    try {
+      await input.gateway.provision(
+        provisioningInput(
+          connection,
+          input.userAccessToken,
+          input.config,
+          connection.gcpProjectNumber ?? undefined,
+        ),
+      );
+    } catch (restoreError) {
+      const originalMessage = error instanceof Error ? error.message : "GCP disconnect failed";
+      const restoreMessage =
+        restoreError instanceof Error ? restoreError.message : "unknown restore error";
+      throw new Error(`${originalMessage}; connection restore failed: ${restoreMessage}`, {
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}
+
 async function cleanupProvisioningResult(
   connection: GcpConnectionRecord,
   provisioned: ProvisionedGcpConnection,

--- a/apps/api/src/gcp/application.ts
+++ b/apps/api/src/gcp/application.ts
@@ -83,8 +83,8 @@ export async function completeGcpConnect(input: {
   const connection = await input.repository.findById(input.connectionId);
   if (!connection || connection.revokedAt) throw new Error("GCP connection not found");
   if (connection.status === "connected") return connection;
-  if (connection.status === "disconnecting") {
-    throw new Error("GCP disconnect is in progress");
+  if (connection.status === "disconnecting" || connection.status === "disconnect_failed") {
+    throw new Error("GCP disconnect is in progress or requires recovery");
   }
   const current = await input.repository.findCurrent(connection.projectId);
   const superseded =
@@ -175,7 +175,9 @@ export async function disconnectGcpConnection(input: {
     ? await input.repository.findById(input.expectedConnectionId)
     : await input.repository.findCurrent(input.projectId);
   const isRetryableFailure = Boolean(
-    input.expectedConnectionId && connection?.status === "failed" && !connection.revokedAt,
+    input.expectedConnectionId &&
+      connection?.status === "disconnect_failed" &&
+      !connection.revokedAt,
   );
   if (
     !connection ||
@@ -251,7 +253,7 @@ export async function disconnectGcpConnection(input: {
       try {
         const restored = await input.repository.releaseDisconnect(
           connection.id,
-          connection.status === "failed" ? "failed" : "connected",
+          connection.status === "disconnect_failed" ? "disconnect_failed" : "connected",
         );
         if (!restored) {
           if (restoredProvisioning) {

--- a/apps/api/src/gcp/application.ts
+++ b/apps/api/src/gcp/application.ts
@@ -226,13 +226,23 @@ export async function disconnectGcpConnection(input: {
           const originalMessage = error instanceof Error ? error.message : "GCP disconnect failed";
           const restoreMessage =
             restoreError instanceof Error ? restoreError.message : "unknown restore error";
-          throw new Error(`${originalMessage}; connection restore failed: ${restoreMessage}`, {
-            cause: error,
-          });
+          const failureMessage = `${originalMessage}; connection restore failed: ${restoreMessage}`;
+          try {
+            await input.repository.failDisconnect(connection.id, failureMessage);
+          } catch (persistError) {
+            const persistMessage =
+              persistError instanceof Error ? persistError.message : "unknown persistence error";
+            throw new Error(
+              `${failureMessage}; disconnect failure state persistence failed: ${persistMessage}`,
+              { cause: error },
+            );
+          }
+          throw new Error(failureMessage, { cause: error });
         }
       }
       try {
-        await input.repository.releaseDisconnect(connection.id);
+        const restored = await input.repository.releaseDisconnect(connection.id);
+        if (!restored) throw new Error("connection recovery was superseded");
       } catch (releaseError) {
         const originalMessage = error instanceof Error ? error.message : "GCP disconnect failed";
         const releaseMessage =

--- a/apps/api/src/gcp/application.ts
+++ b/apps/api/src/gcp/application.ts
@@ -249,7 +249,10 @@ export async function disconnectGcpConnection(input: {
         }
       }
       try {
-        const restored = await input.repository.releaseDisconnect(connection.id);
+        const restored = await input.repository.releaseDisconnect(
+          connection.id,
+          connection.status === "failed" ? "failed" : "connected",
+        );
         if (!restored) {
           if (restoredProvisioning) {
             await input.gateway.deprovision({
@@ -267,9 +270,18 @@ export async function disconnectGcpConnection(input: {
         const originalMessage = error instanceof Error ? error.message : "GCP disconnect failed";
         const releaseMessage =
           releaseError instanceof Error ? releaseError.message : "unknown release error";
-        throw new Error(`${originalMessage}; disconnect claim release failed: ${releaseMessage}`, {
-          cause: error,
-        });
+        const failureMessage = `${originalMessage}; disconnect claim release failed: ${releaseMessage}`;
+        try {
+          await input.repository.failDisconnect(connection.id, failureMessage);
+        } catch (persistError) {
+          const persistMessage =
+            persistError instanceof Error ? persistError.message : "unknown persistence error";
+          throw new Error(
+            `${failureMessage}; disconnect recovery state persistence failed: ${persistMessage}`,
+            { cause: error },
+          );
+        }
+        throw new Error(failureMessage, { cause: error });
       }
     }
     throw error;

--- a/apps/api/src/gcp/application.ts
+++ b/apps/api/src/gcp/application.ts
@@ -180,33 +180,43 @@ export async function disconnectGcpConnection(input: {
     persistedProvisioningResult(connection),
     input.repository,
   );
-  await input.gateway.deprovision({
-    connectionId: connection.id,
-    gcpProjectId: connection.gcpProjectId,
-    userAccessToken: input.userAccessToken,
-    integrationProjectId: input.config.integrationProjectId,
-    readerServiceAccountEmail: connection.readerServiceAccountEmail,
-    provisioned,
-  });
   try {
+    await input.gateway.deprovision({
+      connectionId: connection.id,
+      gcpProjectId: connection.gcpProjectId,
+      userAccessToken: input.userAccessToken,
+      integrationProjectId: input.config.integrationProjectId,
+      readerServiceAccountEmail: connection.readerServiceAccountEmail,
+      provisioned,
+    });
     return await input.repository.revoke(connection.id);
   } catch (error) {
+    let restoreConnection = true;
     try {
-      await input.gateway.provision(
-        provisioningInput(
-          connection,
-          input.userAccessToken,
-          input.config,
-          connection.gcpProjectNumber ?? undefined,
-        ),
-      );
-    } catch (restoreError) {
-      const originalMessage = error instanceof Error ? error.message : "GCP disconnect failed";
-      const restoreMessage =
-        restoreError instanceof Error ? restoreError.message : "unknown restore error";
-      throw new Error(`${originalMessage}; connection restore failed: ${restoreMessage}`, {
-        cause: error,
-      });
+      const latest = await input.repository.findById(connection.id);
+      restoreConnection = latest?.status === "connected" && !latest.revokedAt;
+    } catch {
+      // If persistence is unavailable, prefer restoring the resources for the
+      // connection that the database most likely still considers active.
+    }
+    if (restoreConnection) {
+      try {
+        await input.gateway.provision(
+          provisioningInput(
+            connection,
+            input.userAccessToken,
+            input.config,
+            connection.gcpProjectNumber ?? undefined,
+          ),
+        );
+      } catch (restoreError) {
+        const originalMessage = error instanceof Error ? error.message : "GCP disconnect failed";
+        const restoreMessage =
+          restoreError instanceof Error ? restoreError.message : "unknown restore error";
+        throw new Error(`${originalMessage}; connection restore failed: ${restoreMessage}`, {
+          cause: error,
+        });
+      }
     }
     throw error;
   }

--- a/apps/api/src/gcp/application.ts
+++ b/apps/api/src/gcp/application.ts
@@ -83,6 +83,9 @@ export async function completeGcpConnect(input: {
   const connection = await input.repository.findById(input.connectionId);
   if (!connection || connection.revokedAt) throw new Error("GCP connection not found");
   if (connection.status === "connected") return connection;
+  if (connection.status === "disconnecting") {
+    throw new Error("GCP disconnect is in progress");
+  }
   const current = await input.repository.findCurrent(connection.projectId);
   const superseded =
     current?.status === "connected" && current.id !== connection.id ? current : null;
@@ -168,19 +171,28 @@ export async function disconnectGcpConnection(input: {
   gateway: GcpGateway;
   config: GcpApplicationConfig;
 }): Promise<GcpConnectionRecord> {
-  const connection = await input.repository.findCurrent(input.projectId);
+  const connection = input.expectedConnectionId
+    ? await input.repository.findById(input.expectedConnectionId)
+    : await input.repository.findCurrent(input.projectId);
   if (!connection || connection.status !== "connected" || connection.revokedAt) {
+    throw new Error("Connected GCP project not found");
+  }
+  if (connection.projectId !== input.projectId) {
     throw new Error("Connected GCP project not found");
   }
   if (input.expectedConnectionId && connection.id !== input.expectedConnectionId) {
     throw new Error("Connected GCP project changed during authorization");
   }
-  const provisioned = await cleanupProvisioningResult(
-    connection,
-    persistedProvisioningResult(connection),
-    input.repository,
-  );
+  const persistedProvisioning = persistedProvisioningResult(connection);
+  await input.repository.claimDisconnect(connection.id);
+  let cleanupAttempted = false;
   try {
+    const provisioned = await cleanupProvisioningResult(
+      connection,
+      persistedProvisioning,
+      input.repository,
+    );
+    cleanupAttempted = true;
     await input.gateway.deprovision({
       connectionId: connection.id,
       gcpProjectId: connection.gcpProjectId,
@@ -194,26 +206,38 @@ export async function disconnectGcpConnection(input: {
     let restoreConnection = true;
     try {
       const latest = await input.repository.findById(connection.id);
-      restoreConnection = latest?.status === "connected" && !latest.revokedAt;
+      restoreConnection = latest?.status === "disconnecting" && !latest.revokedAt;
     } catch {
       // If persistence is unavailable, prefer restoring the resources for the
       // connection that the database most likely still considers active.
     }
     if (restoreConnection) {
+      if (cleanupAttempted) {
+        try {
+          await input.gateway.provision(
+            provisioningInput(
+              connection,
+              input.userAccessToken,
+              input.config,
+              connection.gcpProjectNumber ?? undefined,
+            ),
+          );
+        } catch (restoreError) {
+          const originalMessage = error instanceof Error ? error.message : "GCP disconnect failed";
+          const restoreMessage =
+            restoreError instanceof Error ? restoreError.message : "unknown restore error";
+          throw new Error(`${originalMessage}; connection restore failed: ${restoreMessage}`, {
+            cause: error,
+          });
+        }
+      }
       try {
-        await input.gateway.provision(
-          provisioningInput(
-            connection,
-            input.userAccessToken,
-            input.config,
-            connection.gcpProjectNumber ?? undefined,
-          ),
-        );
-      } catch (restoreError) {
+        await input.repository.releaseDisconnect(connection.id);
+      } catch (releaseError) {
         const originalMessage = error instanceof Error ? error.message : "GCP disconnect failed";
-        const restoreMessage =
-          restoreError instanceof Error ? restoreError.message : "unknown restore error";
-        throw new Error(`${originalMessage}; connection restore failed: ${restoreMessage}`, {
+        const releaseMessage =
+          releaseError instanceof Error ? releaseError.message : "unknown release error";
+        throw new Error(`${originalMessage}; disconnect claim release failed: ${releaseMessage}`, {
           cause: error,
         });
       }

--- a/apps/api/src/gcp/application.ts
+++ b/apps/api/src/gcp/application.ts
@@ -174,7 +174,14 @@ export async function disconnectGcpConnection(input: {
   const connection = input.expectedConnectionId
     ? await input.repository.findById(input.expectedConnectionId)
     : await input.repository.findCurrent(input.projectId);
-  if (!connection || connection.status !== "connected" || connection.revokedAt) {
+  const isRetryableFailure = Boolean(
+    input.expectedConnectionId && connection?.status === "failed" && !connection.revokedAt,
+  );
+  if (
+    !connection ||
+    (connection.status !== "connected" && !isRetryableFailure) ||
+    connection.revokedAt
+  ) {
     throw new Error("Connected GCP project not found");
   }
   if (connection.projectId !== input.projectId) {

--- a/apps/api/src/gcp/application.ts
+++ b/apps/api/src/gcp/application.ts
@@ -212,9 +212,10 @@ export async function disconnectGcpConnection(input: {
       // connection that the database most likely still considers active.
     }
     if (restoreConnection) {
+      let restoredProvisioning: ProvisionedGcpConnection | null = null;
       if (cleanupAttempted) {
         try {
-          await input.gateway.provision(
+          restoredProvisioning = await input.gateway.provision(
             provisioningInput(
               connection,
               input.userAccessToken,
@@ -242,7 +243,19 @@ export async function disconnectGcpConnection(input: {
       }
       try {
         const restored = await input.repository.releaseDisconnect(connection.id);
-        if (!restored) throw new Error("connection recovery was superseded");
+        if (!restored) {
+          if (restoredProvisioning) {
+            await input.gateway.deprovision({
+              connectionId: connection.id,
+              gcpProjectId: connection.gcpProjectId,
+              userAccessToken: input.userAccessToken,
+              integrationProjectId: input.config.integrationProjectId,
+              readerServiceAccountEmail: connection.readerServiceAccountEmail,
+              provisioned: restoredProvisioning,
+            });
+          }
+          throw new Error("connection recovery was superseded");
+        }
       } catch (releaseError) {
         const originalMessage = error instanceof Error ? error.message : "GCP disconnect failed";
         const releaseMessage =

--- a/apps/api/src/gcp/authorization-application.test.ts
+++ b/apps/api/src/gcp/authorization-application.test.ts
@@ -104,8 +104,11 @@ test("a ready Google authorization disconnects the project's current GCP connect
     },
   } as unknown as GcpAuthorizationRepository;
   const connectionRepository = {
-    async findCurrent() {
+    async findById() {
       return connection;
+    },
+    async claimDisconnect() {
+      return { ...connection, status: "disconnecting" as const };
     },
     async prepareMonitoringGrantRemoval() {
       return true;
@@ -131,6 +134,7 @@ test("a ready Google authorization disconnects the project's current GCP connect
   const result = await disconnectGcpAuthorization({
     authorizationId: session.id,
     userId: session.userId,
+    expectedConnectionId: connection.id,
     authorizationRepository,
     connectionRepository,
     gateway,
@@ -140,4 +144,98 @@ test("a ready Google authorization disconnects the project's current GCP connect
 
   assert.ok(result.revokedAt);
   assert.equal(deprovisioned, true);
+});
+
+test("a disconnect authorization cannot target a replacement connection", async () => {
+  const now = new Date("2026-08-21T12:00:00.000Z");
+  const session: GcpAuthorizationSessionRecord = {
+    id: "authorization-id",
+    projectId: "project-id",
+    userId: "user-id",
+    status: "ready",
+    projects: [
+      {
+        projectId: "acme-production",
+        projectNumber: "123456789012",
+        displayName: "Acme production",
+      },
+    ],
+    expiresAt: new Date("2026-08-21T12:10:00.000Z"),
+    consumedAt: null,
+    lastError: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const original = {
+    id: "original-connection-id",
+    projectId: session.projectId,
+    gcpProjectId: "acme-production",
+    gcpProjectNumber: "123456789012",
+    status: "connected" as const,
+    topicName: "superlog-original-connection-id",
+    subscriptionName: "superlog-original-connection-id",
+    logSinkName: "superlog-original-connection-id",
+    logSinkWriterIdentity: "serviceAccount:cloud-logs@system.gserviceaccount.com",
+    excludedLogNames: [],
+    monitoringViewerGrantCreated: true,
+    readerServiceAccountEmail: "reader@example.iam.gserviceaccount.com",
+    lastVerifiedAt: now,
+    lastLogReceivedAt: null,
+    lastMetricsReceivedAt: null,
+    metricsBudgetMonth: null,
+    metricsSeriesRead: 0,
+    lastError: null,
+    createdBy: session.userId,
+    revokedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  } satisfies GcpConnectionRecord;
+  let claimCalls = 0;
+  let deprovisionCalls = 0;
+  const authorizationRepository = {
+    async findById() {
+      return session;
+    },
+    async claim() {
+      claimCalls += 1;
+      throw new Error("stale authorization must not be claimed");
+    },
+  } as unknown as GcpAuthorizationRepository;
+  const connectionRepository = {
+    async findById(id: string) {
+      assert.equal(id, original.id);
+      return original;
+    },
+    async findCurrent() {
+      throw new Error("the current replacement connection must not be selected");
+    },
+  } as unknown as GcpConnectionRepository;
+  const gateway = {
+    async deprovision() {
+      deprovisionCalls += 1;
+    },
+  } as unknown as GcpGateway;
+
+  await assert.rejects(
+    disconnectGcpAuthorization({
+      authorizationId: session.id,
+      userId: session.userId,
+      expectedConnectionId: original.id,
+      authorizationRepository,
+      connectionRepository,
+      gateway,
+      config: {
+        integrationProjectId: "superlog-observability",
+        readerServiceAccountEmail: original.readerServiceAccountEmail,
+        pushServiceAccountEmail: "push@example.iam.gserviceaccount.com",
+        pushAudience: "https://intake.example.com/gcp/pubsub",
+        pushEndpoint: "https://intake.example.com/gcp/pubsub",
+      },
+      now,
+    }),
+    /Connected GCP project not found/,
+  );
+
+  assert.equal(claimCalls, 0);
+  assert.equal(deprovisionCalls, 0);
 });

--- a/apps/api/src/gcp/authorization-application.test.ts
+++ b/apps/api/src/gcp/authorization-application.test.ts
@@ -239,3 +239,134 @@ test("a disconnect authorization cannot target a replacement connection", async 
   assert.equal(claimCalls, 0);
   assert.equal(deprovisionCalls, 0);
 });
+
+test("a failed disconnect restores its Google authorization for retry", async () => {
+  const now = new Date("2026-08-21T12:00:00.000Z");
+  const session: GcpAuthorizationSessionRecord = {
+    id: "authorization-id",
+    projectId: "project-id",
+    userId: "user-id",
+    status: "ready",
+    projects: [
+      {
+        projectId: "acme-production",
+        projectNumber: "123456789012",
+        displayName: "Acme production",
+      },
+    ],
+    expiresAt: new Date("2026-08-21T12:10:00.000Z"),
+    consumedAt: null,
+    lastError: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const connection = {
+    id: "connection-id",
+    projectId: session.projectId,
+    gcpProjectId: "acme-production",
+    gcpProjectNumber: "123456789012",
+    status: "connected" as const,
+    topicName: "superlog-connection-id",
+    subscriptionName: "superlog-connection-id",
+    logSinkName: "superlog-connection-id",
+    logSinkWriterIdentity: "serviceAccount:cloud-logs@system.gserviceaccount.com",
+    excludedLogNames: [],
+    monitoringViewerGrantCreated: true,
+    readerServiceAccountEmail: "reader@example.iam.gserviceaccount.com",
+    lastVerifiedAt: now,
+    lastLogReceivedAt: null,
+    lastMetricsReceivedAt: null,
+    metricsBudgetMonth: null,
+    metricsSeriesRead: 0,
+    lastError: null,
+    createdBy: session.userId,
+    revokedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  } satisfies GcpConnectionRecord;
+  const events: string[] = [];
+  const authorizationRepository = {
+    async findById() {
+      return session;
+    },
+    async claim() {
+      events.push("claim-authorization");
+      return {
+        session: { ...session, status: "consumed" as const, consumedAt: now },
+        project: session.projects[0],
+        accessToken: "temporary-user-token",
+      };
+    },
+    async restoreClaim(input: { accessToken: string; expiresAt: Date }) {
+      assert.equal(input.accessToken, "temporary-user-token");
+      assert.equal(input.expiresAt.getTime(), now.getTime() + GCP_AUTHORIZATION_TTL_MS);
+      events.push("restore-authorization");
+    },
+  } as unknown as GcpAuthorizationRepository;
+  let connectionReads = 0;
+  const connectionRepository = {
+    async findById() {
+      connectionReads += 1;
+      return connectionReads <= 2
+        ? connection
+        : { ...connection, status: "disconnecting" as const };
+    },
+    async claimDisconnect() {
+      events.push("claim-disconnect");
+      return { ...connection, status: "disconnecting" as const };
+    },
+    async prepareMonitoringGrantRemoval() {
+      return true;
+    },
+    async releaseDisconnect() {
+      events.push("release-disconnect");
+      return true;
+    },
+  } as unknown as GcpConnectionRepository;
+  const gateway = {
+    async deprovision() {
+      events.push("deprovision");
+      throw new Error("transient Google error");
+    },
+    async provision() {
+      events.push("restore-resources");
+      return {
+        gcpProjectNumber: connection.gcpProjectNumber,
+        topicName: connection.topicName,
+        subscriptionName: connection.subscriptionName,
+        logSinkName: connection.logSinkName,
+        logSinkWriterIdentity: connection.logSinkWriterIdentity,
+        monitoringViewerGrantCreated: connection.monitoringViewerGrantCreated,
+      };
+    },
+  } as unknown as GcpGateway;
+
+  await assert.rejects(
+    disconnectGcpAuthorization({
+      authorizationId: session.id,
+      userId: session.userId,
+      expectedConnectionId: connection.id,
+      authorizationRepository,
+      connectionRepository,
+      gateway,
+      config: {
+        integrationProjectId: "superlog-observability",
+        readerServiceAccountEmail: connection.readerServiceAccountEmail,
+        pushServiceAccountEmail: "push@example.iam.gserviceaccount.com",
+        pushAudience: "https://intake.example.com/gcp/pubsub",
+        pushEndpoint: "https://intake.example.com/gcp/pubsub",
+      },
+      now,
+    }),
+    /transient Google error/,
+  );
+
+  assert.deepEqual(events, [
+    "claim-authorization",
+    "claim-disconnect",
+    "deprovision",
+    "restore-resources",
+    "release-disconnect",
+    "restore-authorization",
+  ]);
+});

--- a/apps/api/src/gcp/authorization-application.test.ts
+++ b/apps/api/src/gcp/authorization-application.test.ts
@@ -1,10 +1,13 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
-import { startGcpAuthorization } from "./authorization-application.js";
+import type { GcpApplicationConfig } from "./application.js";
+import { disconnectGcpAuthorization, startGcpAuthorization } from "./authorization-application.js";
 import {
   GCP_AUTHORIZATION_TTL_MS,
   type GcpAuthorizationRepository,
   type GcpAuthorizationSessionRecord,
+  type GcpConnectionRecord,
+  type GcpConnectionRepository,
   type GcpGateway,
 } from "./domain.js";
 
@@ -41,4 +44,100 @@ test("a pending Google authorization and its signed state share one lifetime", a
   });
 
   assert.equal(createCalled, true);
+});
+
+test("a ready Google authorization disconnects the project's current GCP connection", async () => {
+  const now = new Date("2026-08-21T12:00:00.000Z");
+  const session: GcpAuthorizationSessionRecord = {
+    id: "authorization-id",
+    projectId: "project-id",
+    userId: "user-id",
+    status: "ready",
+    projects: [
+      {
+        projectId: "acme-production",
+        projectNumber: "123456789012",
+        displayName: "Acme production",
+      },
+    ],
+    expiresAt: new Date("2026-08-21T12:10:00.000Z"),
+    consumedAt: null,
+    lastError: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const connection: GcpConnectionRecord = {
+    id: "connection-id",
+    projectId: session.projectId,
+    gcpProjectId: "acme-production",
+    gcpProjectNumber: "123456789012",
+    status: "connected",
+    topicName: "superlog-connection-id",
+    subscriptionName: "superlog-connection-id",
+    logSinkName: "superlog-connection-id",
+    logSinkWriterIdentity: "serviceAccount:cloud-logs@system.gserviceaccount.com",
+    excludedLogNames: [],
+    monitoringViewerGrantCreated: true,
+    readerServiceAccountEmail: "reader@example.iam.gserviceaccount.com",
+    lastVerifiedAt: now,
+    lastLogReceivedAt: null,
+    lastMetricsReceivedAt: null,
+    metricsBudgetMonth: null,
+    metricsSeriesRead: 0,
+    lastError: null,
+    createdBy: session.userId,
+    revokedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const authorizationRepository = {
+    async findById() {
+      return session;
+    },
+    async claim(input: { gcpProjectId: string }) {
+      assert.equal(input.gcpProjectId, connection.gcpProjectId);
+      return {
+        session: { ...session, status: "consumed" as const, consumedAt: now },
+        project: session.projects[0],
+        accessToken: "temporary-user-token",
+      };
+    },
+  } as unknown as GcpAuthorizationRepository;
+  const connectionRepository = {
+    async findCurrent() {
+      return connection;
+    },
+    async prepareMonitoringGrantRemoval() {
+      return true;
+    },
+    async revoke() {
+      return { ...connection, revokedAt: now };
+    },
+  } as unknown as GcpConnectionRepository;
+  let deprovisioned = false;
+  const gateway = {
+    async deprovision() {
+      deprovisioned = true;
+    },
+  } as unknown as GcpGateway;
+  const config: GcpApplicationConfig = {
+    integrationProjectId: "superlog-observability",
+    readerServiceAccountEmail: connection.readerServiceAccountEmail,
+    pushServiceAccountEmail: "push@example.iam.gserviceaccount.com",
+    pushAudience: "https://intake.example.com/gcp/pubsub",
+    pushEndpoint: "https://intake.example.com/gcp/pubsub",
+  };
+
+  const result = await disconnectGcpAuthorization({
+    authorizationId: session.id,
+    userId: session.userId,
+    authorizationRepository,
+    connectionRepository,
+    gateway,
+    config,
+    now,
+  });
+
+  assert.ok(result.revokedAt);
+  assert.equal(deprovisioned, true);
 });

--- a/apps/api/src/gcp/authorization-application.test.ts
+++ b/apps/api/src/gcp/authorization-application.test.ts
@@ -242,6 +242,7 @@ test("a disconnect authorization cannot target a replacement connection", async 
 
 test("a failed disconnect restores its Google authorization for retry", async () => {
   const now = new Date("2026-08-21T12:00:00.000Z");
+  const retryExpiresAt = new Date("2026-08-21T12:03:00.000Z");
   const session: GcpAuthorizationSessionRecord = {
     id: "authorization-id",
     projectId: "project-id",
@@ -299,27 +300,26 @@ test("a failed disconnect restores its Google authorization for retry", async ()
     },
     async restoreClaim(input: { accessToken: string; expiresAt: Date }) {
       assert.equal(input.accessToken, "temporary-user-token");
-      assert.equal(input.expiresAt.getTime(), now.getTime() + GCP_AUTHORIZATION_TTL_MS);
+      assert.equal(input.expiresAt.getTime(), retryExpiresAt.getTime());
       events.push("restore-authorization");
     },
   } as unknown as GcpAuthorizationRepository;
-  let connectionReads = 0;
+  let connectionStatus: GcpConnectionRecord["status"] = "connected";
   const connectionRepository = {
     async findById() {
-      connectionReads += 1;
-      return connectionReads <= 2
-        ? connection
-        : { ...connection, status: "disconnecting" as const };
+      return { ...connection, status: connectionStatus };
     },
     async claimDisconnect() {
       events.push("claim-disconnect");
-      return { ...connection, status: "disconnecting" as const };
+      connectionStatus = "disconnecting";
+      return { ...connection, status: connectionStatus };
     },
     async prepareMonitoringGrantRemoval() {
       return true;
     },
     async releaseDisconnect() {
       events.push("release-disconnect");
+      connectionStatus = "connected";
       return true;
     },
   } as unknown as GcpConnectionRepository;
@@ -346,6 +346,7 @@ test("a failed disconnect restores its Google authorization for retry", async ()
       authorizationId: session.id,
       userId: session.userId,
       expectedConnectionId: connection.id,
+      retryExpiresAt,
       authorizationRepository,
       connectionRepository,
       gateway,
@@ -369,4 +370,106 @@ test("a failed disconnect restores its Google authorization for retry", async ()
     "release-disconnect",
     "restore-authorization",
   ]);
+});
+
+test("a disconnect whose revoke committed is returned as terminal success", async () => {
+  const now = new Date("2026-08-21T12:00:00.000Z");
+  const session: GcpAuthorizationSessionRecord = {
+    id: "authorization-id",
+    projectId: "project-id",
+    userId: "user-id",
+    status: "ready",
+    projects: [
+      {
+        projectId: "acme-production",
+        projectNumber: "123456789012",
+        displayName: "Acme production",
+      },
+    ],
+    expiresAt: new Date("2026-08-21T12:10:00.000Z"),
+    consumedAt: null,
+    lastError: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const connection = {
+    id: "connection-id",
+    projectId: session.projectId,
+    gcpProjectId: "acme-production",
+    gcpProjectNumber: "123456789012",
+    status: "connected" as const,
+    topicName: "superlog-connection-id",
+    subscriptionName: "superlog-connection-id",
+    logSinkName: "superlog-connection-id",
+    logSinkWriterIdentity: "serviceAccount:cloud-logs@system.gserviceaccount.com",
+    excludedLogNames: [],
+    monitoringViewerGrantCreated: true,
+    readerServiceAccountEmail: "reader@example.iam.gserviceaccount.com",
+    lastVerifiedAt: now,
+    lastLogReceivedAt: null,
+    lastMetricsReceivedAt: null,
+    metricsBudgetMonth: null,
+    metricsSeriesRead: 0,
+    lastError: null,
+    createdBy: session.userId,
+    revokedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  } satisfies GcpConnectionRecord;
+  let latest = connection as GcpConnectionRecord;
+  let restoreClaimCalls = 0;
+  const authorizationRepository = {
+    async findById() {
+      return session;
+    },
+    async claim() {
+      return {
+        session: { ...session, status: "consumed" as const, consumedAt: now },
+        project: session.projects[0],
+        accessToken: "temporary-user-token",
+      };
+    },
+    async restoreClaim() {
+      restoreClaimCalls += 1;
+    },
+  } as unknown as GcpAuthorizationRepository;
+  const connectionRepository = {
+    async findById() {
+      return latest;
+    },
+    async claimDisconnect() {
+      latest = { ...connection, status: "disconnecting" };
+      return latest;
+    },
+    async prepareMonitoringGrantRemoval() {
+      return true;
+    },
+    async revoke() {
+      latest = { ...latest, revokedAt: now };
+      throw new Error("database response lost after commit");
+    },
+  } as unknown as GcpConnectionRepository;
+  const gateway = {
+    async deprovision() {},
+  } as unknown as GcpGateway;
+
+  const result = await disconnectGcpAuthorization({
+    authorizationId: session.id,
+    userId: session.userId,
+    expectedConnectionId: connection.id,
+    authorizationRepository,
+    connectionRepository,
+    gateway,
+    config: {
+      integrationProjectId: "superlog-observability",
+      readerServiceAccountEmail: connection.readerServiceAccountEmail,
+      pushServiceAccountEmail: "push@example.iam.gserviceaccount.com",
+      pushAudience: "https://intake.example.com/gcp/pubsub",
+      pushEndpoint: "https://intake.example.com/gcp/pubsub",
+    },
+    now,
+  });
+
+  assert.ok(result.revokedAt);
+  assert.equal(restoreClaimCalls, 0);
 });

--- a/apps/api/src/gcp/authorization-application.ts
+++ b/apps/api/src/gcp/authorization-application.ts
@@ -1,4 +1,8 @@
-import { type GcpApplicationConfig, completeGcpConnect } from "./application.js";
+import {
+  type GcpApplicationConfig,
+  completeGcpConnect,
+  disconnectGcpConnection,
+} from "./application.js";
 import type {
   GcpAuthorizationRepository,
   GcpAuthorizationSessionRecord,
@@ -127,6 +131,43 @@ export async function connectGcpAuthorization(input: {
     connectionId: connection.id,
     userAccessToken: claim.accessToken,
     gcpProjectNumber: claim.project.projectNumber,
+    repository: input.connectionRepository,
+    gateway: input.gateway,
+    config: input.config,
+  });
+}
+
+export async function disconnectGcpAuthorization(input: {
+  authorizationId: string;
+  userId: string;
+  authorizationRepository: GcpAuthorizationRepository;
+  connectionRepository: GcpConnectionRepository;
+  gateway: GcpGateway;
+  config: GcpApplicationConfig;
+  now?: Date;
+}): Promise<GcpConnectionRecord> {
+  const now = input.now ?? new Date();
+  const session = await getGcpAuthorizationSelection({
+    authorizationId: input.authorizationId,
+    userId: input.userId,
+    repository: input.authorizationRepository,
+    now,
+  });
+  const connection = await input.connectionRepository.findCurrent(session.projectId);
+  if (!connection || connection.status !== "connected" || connection.revokedAt) {
+    throw new Error("Connected GCP project not found");
+  }
+  const claim = await input.authorizationRepository.claim({
+    id: session.id,
+    projectId: session.projectId,
+    userId: session.userId,
+    gcpProjectId: connection.gcpProjectId,
+    now,
+  });
+  return disconnectGcpConnection({
+    projectId: session.projectId,
+    expectedConnectionId: connection.id,
+    userAccessToken: claim.accessToken,
     repository: input.connectionRepository,
     gateway: input.gateway,
     config: input.config,

--- a/apps/api/src/gcp/authorization-application.ts
+++ b/apps/api/src/gcp/authorization-application.ts
@@ -141,6 +141,7 @@ export async function disconnectGcpAuthorization(input: {
   authorizationId: string;
   userId: string;
   expectedConnectionId: string;
+  retryExpiresAt?: Date;
   authorizationRepository: GcpAuthorizationRepository;
   connectionRepository: GcpConnectionRepository;
   gateway: GcpGateway;
@@ -158,7 +159,7 @@ export async function disconnectGcpAuthorization(input: {
   if (
     !connection ||
     connection.projectId !== session.projectId ||
-    connection.status !== "connected" ||
+    (connection.status !== "connected" && connection.status !== "failed") ||
     connection.revokedAt
   ) {
     throw new Error("Connected GCP project not found");
@@ -180,11 +181,26 @@ export async function disconnectGcpAuthorization(input: {
       config: input.config,
     });
   } catch (error) {
+    let latest: GcpConnectionRecord | null;
+    try {
+      latest = await input.connectionRepository.findById(connection.id);
+    } catch {
+      throw error;
+    }
+    if (latest?.revokedAt) return latest;
+    if (!latest || (latest.status !== "connected" && latest.status !== "failed")) {
+      throw error;
+    }
     try {
       await input.authorizationRepository.restoreClaim({
         id: session.id,
         accessToken: claim.accessToken,
-        expiresAt: new Date(now.getTime() + GCP_AUTHORIZATION_TTL_MS),
+        expiresAt: new Date(
+          Math.min(
+            session.expiresAt.getTime(),
+            input.retryExpiresAt?.getTime() ?? session.expiresAt.getTime(),
+          ),
+        ),
       });
     } catch (restoreError) {
       const message =

--- a/apps/api/src/gcp/authorization-application.ts
+++ b/apps/api/src/gcp/authorization-application.ts
@@ -159,7 +159,7 @@ export async function disconnectGcpAuthorization(input: {
   if (
     !connection ||
     connection.projectId !== session.projectId ||
-    (connection.status !== "connected" && connection.status !== "failed") ||
+    (connection.status !== "connected" && connection.status !== "disconnect_failed") ||
     connection.revokedAt
   ) {
     throw new Error("Connected GCP project not found");
@@ -188,7 +188,7 @@ export async function disconnectGcpAuthorization(input: {
       throw error;
     }
     if (latest?.revokedAt) return latest;
-    if (!latest || (latest.status !== "connected" && latest.status !== "failed")) {
+    if (!latest || (latest.status !== "connected" && latest.status !== "disconnect_failed")) {
       throw error;
     }
     try {

--- a/apps/api/src/gcp/authorization-application.ts
+++ b/apps/api/src/gcp/authorization-application.ts
@@ -170,12 +170,29 @@ export async function disconnectGcpAuthorization(input: {
     gcpProjectId: connection.gcpProjectId,
     now,
   });
-  return disconnectGcpConnection({
-    projectId: session.projectId,
-    expectedConnectionId: connection.id,
-    userAccessToken: claim.accessToken,
-    repository: input.connectionRepository,
-    gateway: input.gateway,
-    config: input.config,
-  });
+  try {
+    return await disconnectGcpConnection({
+      projectId: session.projectId,
+      expectedConnectionId: connection.id,
+      userAccessToken: claim.accessToken,
+      repository: input.connectionRepository,
+      gateway: input.gateway,
+      config: input.config,
+    });
+  } catch (error) {
+    try {
+      await input.authorizationRepository.restoreClaim({
+        id: session.id,
+        accessToken: claim.accessToken,
+        expiresAt: new Date(now.getTime() + GCP_AUTHORIZATION_TTL_MS),
+      });
+    } catch (restoreError) {
+      const message =
+        restoreError instanceof Error ? restoreError.message : "unknown authorization error";
+      throw new Error(`GCP disconnect failed; authorization recovery failed: ${message}`, {
+        cause: error,
+      });
+    }
+    throw error;
+  }
 }

--- a/apps/api/src/gcp/authorization-application.ts
+++ b/apps/api/src/gcp/authorization-application.ts
@@ -140,6 +140,7 @@ export async function connectGcpAuthorization(input: {
 export async function disconnectGcpAuthorization(input: {
   authorizationId: string;
   userId: string;
+  expectedConnectionId: string;
   authorizationRepository: GcpAuthorizationRepository;
   connectionRepository: GcpConnectionRepository;
   gateway: GcpGateway;
@@ -153,8 +154,13 @@ export async function disconnectGcpAuthorization(input: {
     repository: input.authorizationRepository,
     now,
   });
-  const connection = await input.connectionRepository.findCurrent(session.projectId);
-  if (!connection || connection.status !== "connected" || connection.revokedAt) {
+  const connection = await input.connectionRepository.findById(input.expectedConnectionId);
+  if (
+    !connection ||
+    connection.projectId !== session.projectId ||
+    connection.status !== "connected" ||
+    connection.revokedAt
+  ) {
     throw new Error("Connected GCP project not found");
   }
   const claim = await input.authorizationRepository.claim({

--- a/apps/api/src/gcp/authorization-repository.ts
+++ b/apps/api/src/gcp/authorization-repository.ts
@@ -189,4 +189,34 @@ export class DrizzleGcpAuthorizationRepository implements GcpAuthorizationReposi
     if ("error" in result) throw result.error;
     return result.claim;
   }
+
+  async restoreClaim(input: {
+    id: string;
+    accessToken: string;
+    expiresAt: Date;
+  }): Promise<void> {
+    const encrypted = encryptIntegrationSecret(input.accessToken);
+    const [restored] = await db
+      .update(schema.gcpAuthorizationSessions)
+      .set({
+        status: "ready",
+        accessTokenCiphertext: encrypted.ciphertext,
+        accessTokenNonce: encrypted.nonce,
+        accessTokenKeyVersion: encrypted.keyVersion,
+        expiresAt: input.expiresAt,
+        consumedAt: null,
+        lastError: null,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(schema.gcpAuthorizationSessions.id, input.id),
+          eq(schema.gcpAuthorizationSessions.status, "consumed"),
+        ),
+      )
+      .returning({ id: schema.gcpAuthorizationSessions.id });
+    if (!restored) {
+      throw new GcpAuthorizationError("unavailable", "GCP authorization is unavailable");
+    }
+  }
 }

--- a/apps/api/src/gcp/domain.ts
+++ b/apps/api/src/gcp/domain.ts
@@ -136,7 +136,7 @@ export interface GcpConnectionRepository {
   ): Promise<GcpConnectionRecord>;
   markFailed(id: string, error: string): Promise<void>;
   claimDisconnect(id: string): Promise<GcpConnectionRecord>;
-  releaseDisconnect(id: string): Promise<boolean>;
+  releaseDisconnect(id: string, previousStatus: "connected" | "failed"): Promise<boolean>;
   failDisconnect(id: string, error: string): Promise<void>;
   revoke(id: string): Promise<GcpConnectionRecord>;
   updateExcludedLogNames(id: string, excludedLogNames: string[]): Promise<GcpConnectionRecord>;

--- a/apps/api/src/gcp/domain.ts
+++ b/apps/api/src/gcp/domain.ts
@@ -137,7 +137,8 @@ export interface GcpConnectionRepository {
   ): Promise<GcpConnectionRecord>;
   markFailed(id: string, error: string): Promise<void>;
   claimDisconnect(id: string): Promise<GcpConnectionRecord>;
-  releaseDisconnect(id: string): Promise<void>;
+  releaseDisconnect(id: string): Promise<boolean>;
+  failDisconnect(id: string, error: string): Promise<void>;
   revoke(id: string): Promise<GcpConnectionRecord>;
   updateExcludedLogNames(id: string, excludedLogNames: string[]): Promise<GcpConnectionRecord>;
 }

--- a/apps/api/src/gcp/domain.ts
+++ b/apps/api/src/gcp/domain.ts
@@ -3,6 +3,7 @@ export type GcpConnectionStatus =
   | "provisioning"
   | "connected"
   | "disconnecting"
+  | "disconnect_failed"
   | "failed";
 
 export type GcpConnectionRecord = {
@@ -136,7 +137,10 @@ export interface GcpConnectionRepository {
   ): Promise<GcpConnectionRecord>;
   markFailed(id: string, error: string): Promise<void>;
   claimDisconnect(id: string): Promise<GcpConnectionRecord>;
-  releaseDisconnect(id: string, previousStatus: "connected" | "failed"): Promise<boolean>;
+  releaseDisconnect(
+    id: string,
+    previousStatus: "connected" | "disconnect_failed",
+  ): Promise<boolean>;
   failDisconnect(id: string, error: string): Promise<void>;
   revoke(id: string): Promise<GcpConnectionRecord>;
   updateExcludedLogNames(id: string, excludedLogNames: string[]): Promise<GcpConnectionRecord>;

--- a/apps/api/src/gcp/domain.ts
+++ b/apps/api/src/gcp/domain.ts
@@ -131,6 +131,7 @@ export interface GcpConnectionRepository {
     supersededConnectionId: string | null,
   ): Promise<GcpConnectionRecord>;
   markFailed(id: string, error: string): Promise<void>;
+  revoke(id: string): Promise<GcpConnectionRecord>;
   updateExcludedLogNames(id: string, excludedLogNames: string[]): Promise<GcpConnectionRecord>;
 }
 

--- a/apps/api/src/gcp/domain.ts
+++ b/apps/api/src/gcp/domain.ts
@@ -126,7 +126,6 @@ export interface GcpConnectionRepository {
     connectionId: string;
     gcpProjectId: string;
     readerServiceAccountEmail: string;
-    grantCreated: boolean;
   }): Promise<boolean>;
   markProvisioning(id: string): Promise<void>;
   ensureIngestKey(id: string, projectId: string): Promise<void>;
@@ -165,6 +164,7 @@ export interface GcpAuthorizationRepository {
     gcpProjectId: string;
     now: Date;
   }): Promise<GcpAuthorizationClaim>;
+  restoreClaim(input: { id: string; accessToken: string; expiresAt: Date }): Promise<void>;
 }
 
 export function parseGcpProjectId(value: unknown): string {

--- a/apps/api/src/gcp/domain.ts
+++ b/apps/api/src/gcp/domain.ts
@@ -1,4 +1,9 @@
-export type GcpConnectionStatus = "pending" | "provisioning" | "connected" | "failed";
+export type GcpConnectionStatus =
+  | "pending"
+  | "provisioning"
+  | "connected"
+  | "disconnecting"
+  | "failed";
 
 export type GcpConnectionRecord = {
   id: string;
@@ -131,6 +136,8 @@ export interface GcpConnectionRepository {
     supersededConnectionId: string | null,
   ): Promise<GcpConnectionRecord>;
   markFailed(id: string, error: string): Promise<void>;
+  claimDisconnect(id: string): Promise<GcpConnectionRecord>;
+  releaseDisconnect(id: string): Promise<void>;
   revoke(id: string): Promise<GcpConnectionRecord>;
   updateExcludedLogNames(id: string, excludedLogNames: string[]): Promise<GcpConnectionRecord>;
 }

--- a/apps/api/src/gcp/gcp.test.ts
+++ b/apps/api/src/gcp/gcp.test.ts
@@ -6,7 +6,8 @@ import { closeDb, db, runMigrations, schema } from "@superlog/db";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { projectHasIngested } from "../demo.js";
-import type { GcpGateway } from "./domain.js";
+import { DrizzleGcpAuthorizationRepository } from "./authorization-repository.js";
+import { GCP_AUTHORIZATION_TTL_MS, type GcpGateway } from "./domain.js";
 import {
   type GcpConnectConfig,
   gcpConfigFromEnv,
@@ -14,6 +15,7 @@ import {
   mountGcpPublic,
 } from "./interfaces.js";
 import { DrizzleGcpConnectionRepository } from "./repository.js";
+import { signGcpState, verifyGcpState } from "./state.js";
 
 process.env.STATE_SIGNING_SECRET ||= "gcp-test-state-secret";
 process.env.AGENT_SECRETS_KEY ||= randomBytes(32).toString("base64");
@@ -349,9 +351,19 @@ test("a project owner reauthorizes with Google before disconnecting the current 
   const { url } = (await start.json()) as { url: string };
   const state = new URL(url).searchParams.get("state");
   assert.ok(state);
+  const stateSecret = process.env.STATE_SIGNING_SECRET;
+  assert.ok(stateSecret);
+  const disconnectIntent = verifyGcpState(state, stateSecret);
+  assert.ok(disconnectIntent?.connectionId);
+  const nearlyExpiredState = signGcpState(
+    disconnectIntent.authorizationId,
+    stateSecret,
+    Date.now() - GCP_AUTHORIZATION_TTL_MS + 1_000,
+    { action: "disconnect", connectionId: disconnectIntent.connectionId },
+  );
 
   const callback = await app.request(
-    `/gcp/oauth/callback?code=oauth-code&state=${encodeURIComponent(state)}`,
+    `/gcp/oauth/callback?code=oauth-code&state=${encodeURIComponent(nearlyExpiredState)}`,
   );
   assert.equal(callback.status, 302);
   const selectionUrl = new URL(callback.headers.get("location") ?? "");
@@ -360,6 +372,19 @@ test("a project owner reauthorizes with Google before disconnecting the current 
   const authorizationState = selectionUrl.searchParams.get("authorization_state");
   assert.ok(authorizationId);
   assert.ok(authorizationState);
+  const readyAuthorization = await db.query.gcpAuthorizationSessions.findFirst({
+    where: eq(schema.gcpAuthorizationSessions.id, authorizationId),
+  });
+  assert.ok(readyAuthorization);
+  const refreshedIntent = verifyGcpState(
+    authorizationState,
+    stateSecret,
+    readyAuthorization.expiresAt.getTime() - 1,
+  );
+  assert.equal(
+    refreshedIntent?.issuedAt,
+    readyAuthorization.expiresAt.getTime() - GCP_AUTHORIZATION_TTL_MS,
+  );
 
   const disconnect = await app.request(`/api/gcp/authorizations/${authorizationId}/disconnect`, {
     method: "POST",
@@ -852,11 +877,13 @@ test("preserving a shared monitoring grant transfers cleanup ownership", async (
     .returning();
   assert.ok(owner && remaining);
 
-  const shouldRemove = await new DrizzleGcpConnectionRepository().prepareMonitoringGrantRemoval({
+  const repository = new DrizzleGcpConnectionRepository();
+  await repository.claimDisconnect(owner.id);
+
+  const shouldRemove = await repository.prepareMonitoringGrantRemoval({
     connectionId: owner.id,
     gcpProjectId: owner.gcpProjectId,
     readerServiceAccountEmail: owner.readerServiceAccountEmail,
-    grantCreated: true,
   });
 
   assert.equal(shouldRemove, false);
@@ -864,6 +891,55 @@ test("preserving a shared monitoring grant transfers cleanup ownership", async (
     where: eq(schema.gcpConnections.id, remaining.id),
   });
   assert.equal(transferred?.monitoringViewerGrantCreated, true);
+
+  await repository.revoke(owner.id);
+  await repository.claimDisconnect(remaining.id);
+  const shouldRemoveAfterStaleSnapshot = await repository.prepareMonitoringGrantRemoval({
+    connectionId: remaining.id,
+    gcpProjectId: remaining.gcpProjectId,
+    readerServiceAccountEmail: remaining.readerServiceAccountEmail,
+  });
+  assert.equal(shouldRemoveAfterStaleSnapshot, true);
+});
+
+test("a consumed Google authorization can be restored and claimed again", async () => {
+  const { user, project } = await seedProject();
+  const repository = new DrizzleGcpAuthorizationRepository();
+  const now = new Date("2026-08-21T12:00:00.000Z");
+  const session = await repository.create({
+    projectId: project.id,
+    userId: user.id,
+    expiresAt: new Date(now.getTime() + GCP_AUTHORIZATION_TTL_MS),
+  });
+  await repository.markReady({
+    id: session.id,
+    accessToken: "temporary-user-token",
+    projects: [
+      {
+        projectId: "acme-production",
+        projectNumber: "123456789012",
+        displayName: "Acme production",
+      },
+    ],
+    expiresAt: new Date(now.getTime() + GCP_AUTHORIZATION_TTL_MS),
+  });
+  const claimInput = {
+    id: session.id,
+    projectId: project.id,
+    userId: user.id,
+    gcpProjectId: "acme-production",
+    now,
+  };
+  await repository.claim(claimInput);
+
+  await repository.restoreClaim({
+    id: session.id,
+    accessToken: "temporary-user-token",
+    expiresAt: new Date(now.getTime() + GCP_AUTHORIZATION_TTL_MS),
+  });
+
+  assert.equal((await repository.findById(session.id))?.status, "ready");
+  assert.equal((await repository.claim(claimInput)).accessToken, "temporary-user-token");
 });
 
 test("a monitoring grant is not transferred to a different reader principal", async () => {
@@ -897,7 +973,6 @@ test("a monitoring grant is not transferred to a different reader principal", as
     connectionId: owner.id,
     gcpProjectId: owner.gcpProjectId,
     readerServiceAccountEmail: owner.readerServiceAccountEmail,
-    grantCreated: true,
   });
 
   assert.equal(shouldRemove, true);

--- a/apps/api/src/gcp/gcp.test.ts
+++ b/apps/api/src/gcp/gcp.test.ts
@@ -772,6 +772,16 @@ test("a replacement cannot complete while the current connection is disconnectin
 
 test("releasing a disconnect claim cannot restore a second active connection", async () => {
   const { user, project } = await seedProject();
+  const [ingestKey] = await db
+    .insert(schema.apiKeys)
+    .values({
+      projectId: project.id,
+      name: "GCP metrics puller",
+      keyPrefix: "sl_public_recovery",
+      keyHash: `gcp-recovery-${crypto.randomUUID()}`,
+    })
+    .returning();
+  assert.ok(ingestKey);
   const [disconnecting, replacement] = await db
     .insert(schema.gcpConnections)
     .values([
@@ -781,6 +791,7 @@ test("releasing a disconnect claim cannot restore a second active connection", a
         readerServiceAccountEmail: config.readerServiceAccountEmail,
         createdBy: user.id,
         status: "disconnecting",
+        apiKeyId: ingestKey.id,
       },
       {
         projectId: project.id,
@@ -805,6 +816,13 @@ test("releasing a disconnect claim cannot restore a second active connection", a
     /replacement completed during disconnect recovery/,
   );
   assert.equal(rows.find((row) => row.id === replacement.id)?.status, "connected");
+  assert.ok(
+    (
+      await db.query.apiKeys.findFirst({
+        where: eq(schema.apiKeys.id, ingestKey.id),
+      })
+    )?.revokedAt,
+  );
 });
 
 test("preserving a shared monitoring grant transfers cleanup ownership", async () => {

--- a/apps/api/src/gcp/gcp.test.ts
+++ b/apps/api/src/gcp/gcp.test.ts
@@ -691,6 +691,26 @@ test("only one request can claim a connected GCP project for disconnect", async 
   assert.equal((await repository.findById(connection.id))?.status, "connected");
 });
 
+test("a failed disconnect recovery can be claimed for another cleanup attempt", async () => {
+  const { user, project } = await seedProject();
+  const [connection] = await db
+    .insert(schema.gcpConnections)
+    .values({
+      projectId: project.id,
+      gcpProjectId: "acme-retry-disconnect",
+      readerServiceAccountEmail: config.readerServiceAccountEmail,
+      createdBy: user.id,
+      status: "failed",
+      lastError: "partial cleanup failure; connection restore failed",
+    })
+    .returning();
+  assert.ok(connection);
+
+  const claimed = await new DrizzleGcpConnectionRepository().claimDisconnect(connection.id);
+
+  assert.equal(claimed.status, "disconnecting");
+});
+
 test("connecting after an overlapping callback cannot create a second active connection", async () => {
   const { user, project } = await seedProject();
   const inserted = await db

--- a/apps/api/src/gcp/gcp.test.ts
+++ b/apps/api/src/gcp/gcp.test.ts
@@ -687,7 +687,7 @@ test("only one request can claim a connected GCP project for disconnect", async 
   assert.equal(attempts.filter((attempt) => attempt.status === "fulfilled").length, 1);
   assert.equal(attempts.filter((attempt) => attempt.status === "rejected").length, 1);
   assert.equal((await repository.findById(connection.id))?.status, "disconnecting");
-  await repository.releaseDisconnect(connection.id);
+  await repository.releaseDisconnect(connection.id, "connected");
   assert.equal((await repository.findById(connection.id))?.status, "connected");
 });
 
@@ -709,6 +709,11 @@ test("a failed disconnect recovery can be claimed for another cleanup attempt", 
   const claimed = await new DrizzleGcpConnectionRepository().claimDisconnect(connection.id);
 
   assert.equal(claimed.status, "disconnecting");
+  await new DrizzleGcpConnectionRepository().releaseDisconnect(connection.id, "failed");
+  assert.equal(
+    (await new DrizzleGcpConnectionRepository().findById(connection.id))?.status,
+    "failed",
+  );
 });
 
 test("connecting after an overlapping callback cannot create a second active connection", async () => {
@@ -850,7 +855,7 @@ test("releasing a disconnect claim cannot restore a second active connection", a
   assert.ok(disconnecting && replacement);
   const repository = new DrizzleGcpConnectionRepository();
 
-  assert.equal(await repository.releaseDisconnect(disconnecting.id), false);
+  assert.equal(await repository.releaseDisconnect(disconnecting.id, "connected"), false);
 
   const rows = await db.query.gcpConnections.findMany({
     where: eq(schema.gcpConnections.projectId, project.id),

--- a/apps/api/src/gcp/gcp.test.ts
+++ b/apps/api/src/gcp/gcp.test.ts
@@ -722,6 +722,91 @@ test("connecting after an overlapping callback cannot create a second active con
   assert.equal(rows.find((row) => row.id === candidate.id)?.status, "pending");
 });
 
+test("a replacement cannot complete while the current connection is disconnecting", async () => {
+  const { user, project } = await seedProject();
+  const [current, candidate] = await db
+    .insert(schema.gcpConnections)
+    .values([
+      {
+        projectId: project.id,
+        gcpProjectId: "acme-current",
+        readerServiceAccountEmail: config.readerServiceAccountEmail,
+        createdBy: user.id,
+        status: "disconnecting",
+      },
+      {
+        projectId: project.id,
+        gcpProjectId: "acme-replacement",
+        readerServiceAccountEmail: config.readerServiceAccountEmail,
+        createdBy: user.id,
+      },
+    ])
+    .returning();
+  assert.ok(current && candidate);
+
+  await assert.rejects(
+    new DrizzleGcpConnectionRepository().markConnected(
+      candidate.id,
+      {
+        gcpProjectNumber: "123456789012",
+        topicName: `superlog-${candidate.id}`,
+        subscriptionName: `superlog-${candidate.id}`,
+        logSinkName: `superlog-${candidate.id}`,
+        logSinkWriterIdentity: "serviceAccount:cloud-logs@system.gserviceaccount.com",
+        monitoringViewerGrantCreated: true,
+      },
+      current.id,
+    ),
+    /another GCP connection is disconnecting/,
+  );
+
+  assert.equal(
+    (await new DrizzleGcpConnectionRepository().findById(current.id))?.status,
+    "disconnecting",
+  );
+  assert.equal(
+    (await new DrizzleGcpConnectionRepository().findById(candidate.id))?.status,
+    "pending",
+  );
+});
+
+test("releasing a disconnect claim cannot restore a second active connection", async () => {
+  const { user, project } = await seedProject();
+  const [disconnecting, replacement] = await db
+    .insert(schema.gcpConnections)
+    .values([
+      {
+        projectId: project.id,
+        gcpProjectId: "acme-disconnecting",
+        readerServiceAccountEmail: config.readerServiceAccountEmail,
+        createdBy: user.id,
+        status: "disconnecting",
+      },
+      {
+        projectId: project.id,
+        gcpProjectId: "acme-connected-replacement",
+        readerServiceAccountEmail: config.readerServiceAccountEmail,
+        createdBy: user.id,
+        status: "connected",
+      },
+    ])
+    .returning();
+  assert.ok(disconnecting && replacement);
+  const repository = new DrizzleGcpConnectionRepository();
+
+  assert.equal(await repository.releaseDisconnect(disconnecting.id), false);
+
+  const rows = await db.query.gcpConnections.findMany({
+    where: eq(schema.gcpConnections.projectId, project.id),
+  });
+  assert.equal(rows.find((row) => row.id === disconnecting.id)?.status, "failed");
+  assert.match(
+    rows.find((row) => row.id === disconnecting.id)?.lastError ?? "",
+    /replacement completed during disconnect recovery/,
+  );
+  assert.equal(rows.find((row) => row.id === replacement.id)?.status, "connected");
+});
+
 test("preserving a shared monitoring grant transfers cleanup ownership", async () => {
   const first = await seedProject();
   const second = await seedProject();

--- a/apps/api/src/gcp/gcp.test.ts
+++ b/apps/api/src/gcp/gcp.test.ts
@@ -179,6 +179,17 @@ test("a project owner discovers Google projects before choosing one to connect",
   assert.ok(authorizationId);
   assert.equal(calls.length, 0);
 
+  const invalidDisconnect = await app.request(
+    `/api/gcp/authorizations/${authorizationId}/disconnect`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ authorizationState: authorizationUrl.searchParams.get("state") }),
+    },
+  );
+  assert.equal(invalidDisconnect.status, 400);
+  assert.equal(calls.length, 0);
+
   const projects = await app.request(`/api/gcp/authorizations/${authorizationId}`);
   assert.equal(projects.status, 200);
   const readyAuthorization = await db.query.gcpAuthorizationSessions.findFirst({
@@ -346,10 +357,14 @@ test("a project owner reauthorizes with Google before disconnecting the current 
   const selectionUrl = new URL(callback.headers.get("location") ?? "");
   assert.equal(selectionUrl.searchParams.get("action"), "disconnect");
   const authorizationId = selectionUrl.searchParams.get("authorization");
+  const authorizationState = selectionUrl.searchParams.get("authorization_state");
   assert.ok(authorizationId);
+  assert.ok(authorizationState);
 
   const disconnect = await app.request(`/api/gcp/authorizations/${authorizationId}/disconnect`, {
     method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ authorizationState }),
   });
 
   assert.equal(disconnect.status, 200);
@@ -613,13 +628,42 @@ test("revoking a GCP connection also revokes its ingest key", async () => {
     .returning();
   assert.ok(connection);
 
-  const revoked = await new DrizzleGcpConnectionRepository().revoke(connection.id);
+  const repository = new DrizzleGcpConnectionRepository();
+  await repository.claimDisconnect(connection.id);
+  const revoked = await repository.revoke(connection.id);
 
   assert.ok(revoked.revokedAt);
   const revokedKey = await db.query.apiKeys.findFirst({
     where: eq(schema.apiKeys.id, ingestKey.id),
   });
   assert.ok(revokedKey?.revokedAt);
+});
+
+test("only one request can claim a connected GCP project for disconnect", async () => {
+  const { user, project } = await seedProject();
+  const [connection] = await db
+    .insert(schema.gcpConnections)
+    .values({
+      projectId: project.id,
+      gcpProjectId: "acme-concurrent-disconnect",
+      readerServiceAccountEmail: config.readerServiceAccountEmail,
+      createdBy: user.id,
+      status: "connected",
+    })
+    .returning();
+  assert.ok(connection);
+  const repository = new DrizzleGcpConnectionRepository();
+
+  const attempts = await Promise.allSettled([
+    repository.claimDisconnect(connection.id),
+    repository.claimDisconnect(connection.id),
+  ]);
+
+  assert.equal(attempts.filter((attempt) => attempt.status === "fulfilled").length, 1);
+  assert.equal(attempts.filter((attempt) => attempt.status === "rejected").length, 1);
+  assert.equal((await repository.findById(connection.id))?.status, "disconnecting");
+  await repository.releaseDisconnect(connection.id);
+  assert.equal((await repository.findById(connection.id))?.status, "connected");
 });
 
 test("connecting after an overlapping callback cannot create a second active connection", async () => {
@@ -810,6 +854,29 @@ test("a stale callback failure cannot demote an already connected row", async ()
 
   const current = await repository.findById(connection.id);
   assert.equal(current?.status, "connected");
+  assert.equal(current?.lastError, null);
+});
+
+test("a stale callback cannot overwrite an active disconnect claim", async () => {
+  const { user, project } = await seedProject();
+  const [connection] = await db
+    .insert(schema.gcpConnections)
+    .values({
+      projectId: project.id,
+      gcpProjectId: "acme-production",
+      readerServiceAccountEmail: config.readerServiceAccountEmail,
+      createdBy: user.id,
+      status: "disconnecting",
+    })
+    .returning();
+  assert.ok(connection);
+  const repository = new DrizzleGcpConnectionRepository();
+
+  await repository.markProvisioning(connection.id);
+  await repository.markFailed(connection.id, "late OAuth callback failed");
+
+  const current = await repository.findById(connection.id);
+  assert.equal(current?.status, "disconnecting");
   assert.equal(current?.lastError, null);
 });
 

--- a/apps/api/src/gcp/gcp.test.ts
+++ b/apps/api/src/gcp/gcp.test.ts
@@ -279,6 +279,88 @@ test("a project owner discovers Google projects before choosing one to connect",
   assert.equal(connected.refreshToken, undefined);
 });
 
+test("a project owner reauthorizes with Google before disconnecting the current project", async () => {
+  const { org, user, project } = await seedProject();
+  const [connection] = await db
+    .insert(schema.gcpConnections)
+    .values({
+      projectId: project.id,
+      gcpProjectId: "acme-production",
+      gcpProjectNumber: "123456789012",
+      readerServiceAccountEmail: config.readerServiceAccountEmail,
+      createdBy: user.id,
+      status: "connected",
+      topicName: "superlog-disconnect",
+      subscriptionName: "superlog-disconnect",
+      logSinkName: "superlog-disconnect",
+      logSinkWriterIdentity: "serviceAccount:cloud-logs@system.gserviceaccount.com",
+      monitoringViewerGrantCreated: true,
+    })
+    .returning();
+  assert.ok(connection);
+  let deprovisionedConnectionId: string | null = null;
+  const gateway: GcpGateway = {
+    authorizationUrl({ state }) {
+      return `https://accounts.google.com/o/oauth2/v2/auth?state=${encodeURIComponent(state)}`;
+    },
+    async exchangeCode() {
+      return { accessToken: "temporary-user-token" };
+    },
+    async listProjects() {
+      return [
+        {
+          projectId: connection.gcpProjectId,
+          projectNumber: connection.gcpProjectNumber ?? "",
+          displayName: "Acme production",
+        },
+      ];
+    },
+    async provision() {
+      throw new Error("restore should not be needed");
+    },
+    async deprovision(input) {
+      deprovisionedConnectionId = input.connectionId;
+    },
+  };
+  const app = new Hono<{ Variables: { userId: string; orgId: string | null } }>();
+  app.use("/api/*", async (c, next) => {
+    c.set("userId", user.id);
+    c.set("orgId", org.id);
+    await next();
+  });
+  mountGcpAuthed(app, { config, gateway });
+  mountGcpPublic(app, { config, gateway });
+
+  const start = await app.request(`/api/projects/${project.id}/gcp/disconnect-url`, {
+    method: "POST",
+  });
+  assert.equal(start.status, 200);
+  const { url } = (await start.json()) as { url: string };
+  const state = new URL(url).searchParams.get("state");
+  assert.ok(state);
+
+  const callback = await app.request(
+    `/gcp/oauth/callback?code=oauth-code&state=${encodeURIComponent(state)}`,
+  );
+  assert.equal(callback.status, 302);
+  const selectionUrl = new URL(callback.headers.get("location") ?? "");
+  assert.equal(selectionUrl.searchParams.get("action"), "disconnect");
+  const authorizationId = selectionUrl.searchParams.get("authorization");
+  assert.ok(authorizationId);
+
+  const disconnect = await app.request(`/api/gcp/authorizations/${authorizationId}/disconnect`, {
+    method: "POST",
+  });
+
+  assert.equal(disconnect.status, 200);
+  assert.deepEqual(await disconnect.json(), { disconnected: true });
+  assert.equal(deprovisionedConnectionId, connection.id);
+  const revoked = await db.query.gcpConnections.findFirst({
+    where: eq(schema.gcpConnections.id, connection.id),
+  });
+  assert.ok(revoked?.revokedAt);
+});
+
 test("failed Google Cloud provisioning hides provider details from customer responses", async () => {
   const { org, user, project } = await seedProject();
   const loggedErrors: Array<{ fields: Record<string, unknown>; message: string }> = [];
@@ -500,6 +582,40 @@ test("superseding a GCP connection revokes its ingest key", async () => {
     old.id,
   );
 
+  const revokedKey = await db.query.apiKeys.findFirst({
+    where: eq(schema.apiKeys.id, ingestKey.id),
+  });
+  assert.ok(revokedKey?.revokedAt);
+});
+
+test("revoking a GCP connection also revokes its ingest key", async () => {
+  const { user, project } = await seedProject();
+  const [ingestKey] = await db
+    .insert(schema.apiKeys)
+    .values({
+      projectId: project.id,
+      name: "GCP metrics puller",
+      keyPrefix: "sl_public_disconnect",
+      keyHash: `gcp-disconnect-${crypto.randomUUID()}`,
+    })
+    .returning();
+  assert.ok(ingestKey);
+  const [connection] = await db
+    .insert(schema.gcpConnections)
+    .values({
+      projectId: project.id,
+      gcpProjectId: "acme-disconnect",
+      readerServiceAccountEmail: config.readerServiceAccountEmail,
+      createdBy: user.id,
+      status: "connected",
+      apiKeyId: ingestKey.id,
+    })
+    .returning();
+  assert.ok(connection);
+
+  const revoked = await new DrizzleGcpConnectionRepository().revoke(connection.id);
+
+  assert.ok(revoked.revokedAt);
   const revokedKey = await db.query.apiKeys.findFirst({
     where: eq(schema.apiKeys.id, ingestKey.id),
   });

--- a/apps/api/src/gcp/gcp.test.ts
+++ b/apps/api/src/gcp/gcp.test.ts
@@ -820,6 +820,55 @@ test("a replacement cannot complete while the current connection is disconnectin
   );
 });
 
+test("a replacement cannot complete while another connection requires recovery", async () => {
+  const { user, project } = await seedProject();
+  const [recovering, candidate] = await db
+    .insert(schema.gcpConnections)
+    .values([
+      {
+        projectId: project.id,
+        gcpProjectId: "acme-recovering",
+        readerServiceAccountEmail: config.readerServiceAccountEmail,
+        createdBy: user.id,
+        status: "failed",
+        lastError: "partial cleanup failure; connection restore failed",
+      },
+      {
+        projectId: project.id,
+        gcpProjectId: "acme-replacement",
+        readerServiceAccountEmail: config.readerServiceAccountEmail,
+        createdBy: user.id,
+      },
+    ])
+    .returning();
+  assert.ok(recovering && candidate);
+
+  await assert.rejects(
+    new DrizzleGcpConnectionRepository().markConnected(
+      candidate.id,
+      {
+        gcpProjectNumber: "123456789012",
+        topicName: `superlog-${candidate.id}`,
+        subscriptionName: `superlog-${candidate.id}`,
+        logSinkName: `superlog-${candidate.id}`,
+        logSinkWriterIdentity: "serviceAccount:cloud-logs@system.gserviceaccount.com",
+        monitoringViewerGrantCreated: true,
+      },
+      null,
+    ),
+    /another GCP connection requires recovery/,
+  );
+
+  assert.equal(
+    (await new DrizzleGcpConnectionRepository().findById(recovering.id))?.status,
+    "failed",
+  );
+  assert.equal(
+    (await new DrizzleGcpConnectionRepository().findById(candidate.id))?.status,
+    "pending",
+  );
+});
+
 test("releasing a disconnect claim cannot restore a second active connection", async () => {
   const { user, project } = await seedProject();
   const [ingestKey] = await db

--- a/apps/api/src/gcp/gcp.test.ts
+++ b/apps/api/src/gcp/gcp.test.ts
@@ -700,7 +700,7 @@ test("a failed disconnect recovery can be claimed for another cleanup attempt", 
       gcpProjectId: "acme-retry-disconnect",
       readerServiceAccountEmail: config.readerServiceAccountEmail,
       createdBy: user.id,
-      status: "failed",
+      status: "disconnect_failed",
       lastError: "partial cleanup failure; connection restore failed",
     })
     .returning();
@@ -709,10 +709,10 @@ test("a failed disconnect recovery can be claimed for another cleanup attempt", 
   const claimed = await new DrizzleGcpConnectionRepository().claimDisconnect(connection.id);
 
   assert.equal(claimed.status, "disconnecting");
-  await new DrizzleGcpConnectionRepository().releaseDisconnect(connection.id, "failed");
+  await new DrizzleGcpConnectionRepository().releaseDisconnect(connection.id, "disconnect_failed");
   assert.equal(
     (await new DrizzleGcpConnectionRepository().findById(connection.id))?.status,
-    "failed",
+    "disconnect_failed",
   );
 });
 
@@ -830,7 +830,7 @@ test("a replacement cannot complete while another connection requires recovery",
         gcpProjectId: "acme-recovering",
         readerServiceAccountEmail: config.readerServiceAccountEmail,
         createdBy: user.id,
-        status: "failed",
+        status: "disconnect_failed",
         lastError: "partial cleanup failure; connection restore failed",
       },
       {
@@ -861,11 +861,54 @@ test("a replacement cannot complete while another connection requires recovery",
 
   assert.equal(
     (await new DrizzleGcpConnectionRepository().findById(recovering.id))?.status,
-    "failed",
+    "disconnect_failed",
   );
   assert.equal(
     (await new DrizzleGcpConnectionRepository().findById(candidate.id))?.status,
     "pending",
+  );
+});
+
+test("a replacement can complete after an ordinary setup failure", async () => {
+  const { user, project } = await seedProject();
+  const [failedSetup, candidate] = await db
+    .insert(schema.gcpConnections)
+    .values([
+      {
+        projectId: project.id,
+        gcpProjectId: "acme-failed-setup",
+        readerServiceAccountEmail: config.readerServiceAccountEmail,
+        createdBy: user.id,
+        status: "failed",
+        lastError: "Google Cloud provisioning failed",
+      },
+      {
+        projectId: project.id,
+        gcpProjectId: "acme-replacement",
+        readerServiceAccountEmail: config.readerServiceAccountEmail,
+        createdBy: user.id,
+      },
+    ])
+    .returning();
+  assert.ok(failedSetup && candidate);
+
+  const connected = await new DrizzleGcpConnectionRepository().markConnected(
+    candidate.id,
+    {
+      gcpProjectNumber: "123456789012",
+      topicName: `superlog-${candidate.id}`,
+      subscriptionName: `superlog-${candidate.id}`,
+      logSinkName: `superlog-${candidate.id}`,
+      logSinkWriterIdentity: "serviceAccount:cloud-logs@system.gserviceaccount.com",
+      monitoringViewerGrantCreated: true,
+    },
+    null,
+  );
+
+  assert.equal(connected.status, "connected");
+  assert.equal(
+    (await new DrizzleGcpConnectionRepository().findById(failedSetup.id))?.status,
+    "failed",
   );
 });
 
@@ -1084,6 +1127,37 @@ test("a failed reconnect does not hide an older working GCP connection", async (
 
   assert.equal(current?.id, connected.id);
   assert.equal(current?.status, "connected");
+});
+
+test("an ordinary setup failure does not hide a disconnect recovery", async () => {
+  const { user, project } = await seedProject();
+  const [recovering] = await db
+    .insert(schema.gcpConnections)
+    .values({
+      projectId: project.id,
+      gcpProjectId: "acme-production",
+      readerServiceAccountEmail: config.readerServiceAccountEmail,
+      createdBy: user.id,
+      status: "disconnect_failed",
+      lastError: "partial cleanup failure; connection restore failed",
+      createdAt: new Date("2026-07-13T00:00:00Z"),
+    })
+    .returning();
+  await db.insert(schema.gcpConnections).values({
+    projectId: project.id,
+    gcpProjectId: "acme-staging",
+    readerServiceAccountEmail: config.readerServiceAccountEmail,
+    createdBy: user.id,
+    status: "failed",
+    lastError: "Google Cloud provisioning failed",
+    createdAt: new Date("2026-07-14T00:00:00Z"),
+  });
+  assert.ok(recovering);
+
+  const current = await new DrizzleGcpConnectionRepository().findCurrent(project.id);
+
+  assert.equal(current?.id, recovering.id);
+  assert.equal(current?.status, "disconnect_failed");
 });
 
 test("a stale callback failure cannot demote an already connected row", async () => {

--- a/apps/api/src/gcp/google-gateway.test.ts
+++ b/apps/api/src/gcp/google-gateway.test.ts
@@ -548,6 +548,67 @@ test("a recovery cleanup failure removes the new canonical subscription", async 
   assert.equal(canonicalDeleteCount, 2);
 });
 
+test("a stale recovery cleanup failure removes a newly created canonical subscription", async () => {
+  const requests: Array<{ url: URL; method: string }> = [];
+  const fetchImpl: typeof fetch = async (input, init = {}) => {
+    const url = new URL(
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+    );
+    const method = init.method ?? "GET";
+    const body = init.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+    requests.push({ url, method });
+    if (url.pathname === "/v1/projects/acme-production") {
+      return Response.json({ projectNumber: "123456789012" });
+    }
+    if (url.pathname.endsWith(":getIamPolicy")) {
+      return Response.json({ bindings: [], etag: "etag" });
+    }
+    if (url.pathname.endsWith(":setIamPolicy")) return Response.json(body.policy ?? {});
+    if (url.pathname.endsWith("/sinks")) {
+      return Response.json({
+        name: "superlog-connection-id",
+        writerIdentity: "serviceAccount:cloud-logs@system.gserviceaccount.com",
+      });
+    }
+    if (
+      url.pathname.endsWith("/subscriptions/superlog-connection-id-recovery") &&
+      method === "DELETE"
+    ) {
+      return Response.json({ error: { message: "cleanup failed" } }, { status: 500 });
+    }
+    return Response.json({});
+  };
+  const gateway = new GoogleGcpGateway(config, fetchImpl, async () => "service-access-token");
+
+  await assert.rejects(
+    gateway.provision({
+      connectionId: "connection-id",
+      gcpProjectId: "acme-production",
+      userAccessToken: "temporary-user-token",
+      integrationProjectId: config.integrationProjectId,
+      readerServiceAccountEmail: config.readerServiceAccountEmail,
+      pushServiceAccountEmail: config.pushServiceAccountEmail,
+      pushAudience: config.pushAudience,
+      pushEndpoint: `${config.pushEndpoint}/connection-id`,
+    }),
+    /cleanup failed/,
+  );
+
+  assert.deepEqual(
+    requests
+      .filter((request) => request.url.pathname.includes("/subscriptions/"))
+      .map((request) => ({
+        name: request.url.pathname.split("/").at(-1),
+        method: request.method,
+      })),
+    [
+      { name: "superlog-connection-id", method: "PUT" },
+      { name: "superlog-connection-id-recovery", method: "DELETE" },
+      { name: "superlog-connection-id", method: "DELETE" },
+    ],
+  );
+});
+
 test("deprovisioning preserves a monitoring viewer grant that predates the connection", async () => {
   const requests: Array<{ url: URL; init: RequestInit; body: Record<string, unknown> }> = [];
   const readerMember = `serviceAccount:${config.readerServiceAccountEmail}`;

--- a/apps/api/src/gcp/google-gateway.test.ts
+++ b/apps/api/src/gcp/google-gateway.test.ts
@@ -342,8 +342,84 @@ test("provisioning recreates a subscription detached by an earlier topic deletio
   assert.deepEqual(
     requests
       .filter((request) => request.url.pathname.includes("/subscriptions/"))
-      .map((request) => request.method),
-    ["PUT", "GET", "DELETE", "PUT"],
+      .map((request) => ({
+        name: request.url.pathname.split("/").at(-1),
+        method: request.method,
+      })),
+    [
+      { name: "superlog-connection-id", method: "PUT" },
+      { name: "superlog-connection-id", method: "GET" },
+      { name: "superlog-connection-id-recovery", method: "PUT" },
+      { name: "superlog-connection-id", method: "DELETE" },
+      { name: "superlog-connection-id", method: "PUT" },
+      { name: "superlog-connection-id-recovery", method: "DELETE" },
+    ],
+  );
+});
+
+test("a failed canonical replacement keeps the recovery subscription active", async () => {
+  const requests: Array<{ url: URL; method: string }> = [];
+  let canonicalPutCount = 0;
+  const fetchImpl: typeof fetch = async (input, init = {}) => {
+    const url = new URL(
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+    );
+    const method = init.method ?? "GET";
+    const body = init.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+    requests.push({ url, method });
+    if (url.pathname === "/v1/projects/acme-production") {
+      return Response.json({ projectNumber: "123456789012" });
+    }
+    if (url.pathname.endsWith(":getIamPolicy")) {
+      return Response.json({ bindings: [], etag: "etag" });
+    }
+    if (url.pathname.endsWith(":setIamPolicy")) return Response.json(body.policy ?? {});
+    if (url.pathname.endsWith("/sinks")) {
+      return Response.json({
+        name: "superlog-connection-id",
+        writerIdentity: "serviceAccount:cloud-logs@system.gserviceaccount.com",
+      });
+    }
+    if (url.pathname.endsWith("/subscriptions/superlog-connection-id") && method === "PUT") {
+      canonicalPutCount += 1;
+      return canonicalPutCount === 1
+        ? Response.json({ error: { message: "already exists" } }, { status: 409 })
+        : Response.json({ error: { message: "replacement failed" } }, { status: 500 });
+    }
+    if (url.pathname.endsWith("/subscriptions/superlog-connection-id") && method === "GET") {
+      return Response.json({ topic: "_deleted-topic_" });
+    }
+    return Response.json({});
+  };
+  const gateway = new GoogleGcpGateway(config, fetchImpl, async () => "service-access-token");
+
+  const provisioned = await gateway.provision({
+    connectionId: "connection-id",
+    gcpProjectId: "acme-production",
+    userAccessToken: "temporary-user-token",
+    integrationProjectId: config.integrationProjectId,
+    readerServiceAccountEmail: config.readerServiceAccountEmail,
+    pushServiceAccountEmail: config.pushServiceAccountEmail,
+    pushAudience: config.pushAudience,
+    pushEndpoint: `${config.pushEndpoint}/connection-id`,
+  });
+
+  assert.equal(provisioned.subscriptionName, "superlog-connection-id-recovery");
+
+  assert.deepEqual(
+    requests
+      .filter((request) => request.url.pathname.includes("/subscriptions/"))
+      .map((request) => ({
+        name: request.url.pathname.split("/").at(-1),
+        method: request.method,
+      })),
+    [
+      { name: "superlog-connection-id", method: "PUT" },
+      { name: "superlog-connection-id", method: "GET" },
+      { name: "superlog-connection-id-recovery", method: "PUT" },
+      { name: "superlog-connection-id", method: "DELETE" },
+      { name: "superlog-connection-id", method: "PUT" },
+    ],
   );
 });
 

--- a/apps/api/src/gcp/google-gateway.test.ts
+++ b/apps/api/src/gcp/google-gateway.test.ts
@@ -248,6 +248,11 @@ test("provisioning reconciles an existing subscription push configuration", asyn
     if (url.pathname.includes("/subscriptions/") && method === "PUT") {
       return Response.json({ error: { message: "already exists" } }, { status: 409 });
     }
+    if (url.pathname.includes("/subscriptions/") && method === "GET") {
+      return Response.json({
+        topic: "projects/superlog-observability/topics/superlog-connection-id",
+      });
+    }
     return Response.json({});
   };
   const gateway = new GoogleGcpGateway(config, fetchImpl, async () => "service-access-token");
@@ -284,6 +289,62 @@ test("provisioning reconciles an existing subscription push configuration", asyn
       retryPolicy: { minimumBackoff: "10s", maximumBackoff: "600s" },
     },
   });
+});
+
+test("provisioning recreates a subscription detached by an earlier topic deletion", async () => {
+  const requests: Array<{ url: URL; method: string }> = [];
+  let subscriptionPutCount = 0;
+  const fetchImpl: typeof fetch = async (input, init = {}) => {
+    const url = new URL(
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+    );
+    const method = init.method ?? "GET";
+    const body = init.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+    requests.push({ url, method });
+    if (url.pathname === "/v1/projects/acme-production") {
+      return Response.json({ projectNumber: "123456789012" });
+    }
+    if (url.pathname.endsWith(":getIamPolicy")) {
+      return Response.json({ bindings: [], etag: "etag" });
+    }
+    if (url.pathname.endsWith(":setIamPolicy")) return Response.json(body.policy ?? {});
+    if (url.pathname.endsWith("/sinks")) {
+      return Response.json({
+        name: "superlog-connection-id",
+        writerIdentity: "serviceAccount:cloud-logs@system.gserviceaccount.com",
+      });
+    }
+    if (url.pathname.includes("/subscriptions/") && method === "PUT") {
+      subscriptionPutCount += 1;
+      if (subscriptionPutCount === 1) {
+        return Response.json({ error: { message: "already exists" } }, { status: 409 });
+      }
+      return Response.json({});
+    }
+    if (url.pathname.includes("/subscriptions/") && method === "GET") {
+      return Response.json({ topic: "_deleted-topic_" });
+    }
+    return Response.json({});
+  };
+  const gateway = new GoogleGcpGateway(config, fetchImpl, async () => "service-access-token");
+
+  await gateway.provision({
+    connectionId: "connection-id",
+    gcpProjectId: "acme-production",
+    userAccessToken: "temporary-user-token",
+    integrationProjectId: config.integrationProjectId,
+    readerServiceAccountEmail: config.readerServiceAccountEmail,
+    pushServiceAccountEmail: config.pushServiceAccountEmail,
+    pushAudience: config.pushAudience,
+    pushEndpoint: `${config.pushEndpoint}/connection-id`,
+  });
+
+  assert.deepEqual(
+    requests
+      .filter((request) => request.url.pathname.includes("/subscriptions/"))
+      .map((request) => request.method),
+    ["PUT", "GET", "DELETE", "PUT"],
+  );
 });
 
 test("deprovisioning preserves a monitoring viewer grant that predates the connection", async () => {

--- a/apps/api/src/gcp/google-gateway.test.ts
+++ b/apps/api/src/gcp/google-gateway.test.ts
@@ -423,6 +423,131 @@ test("a failed canonical replacement keeps the recovery subscription active", as
   );
 });
 
+test("a stale canonical deletion failure returns the recovery subscription as active", async () => {
+  const requests: Array<{ url: URL; method: string }> = [];
+  const fetchImpl: typeof fetch = async (input, init = {}) => {
+    const url = new URL(
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+    );
+    const method = init.method ?? "GET";
+    const body = init.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+    requests.push({ url, method });
+    if (url.pathname === "/v1/projects/acme-production") {
+      return Response.json({ projectNumber: "123456789012" });
+    }
+    if (url.pathname.endsWith(":getIamPolicy")) {
+      return Response.json({ bindings: [], etag: "etag" });
+    }
+    if (url.pathname.endsWith(":setIamPolicy")) return Response.json(body.policy ?? {});
+    if (url.pathname.endsWith("/sinks")) {
+      return Response.json({
+        name: "superlog-connection-id",
+        writerIdentity: "serviceAccount:cloud-logs@system.gserviceaccount.com",
+      });
+    }
+    if (url.pathname.endsWith("/subscriptions/superlog-connection-id")) {
+      if (method === "PUT") {
+        return Response.json({ error: { message: "already exists" } }, { status: 409 });
+      }
+      if (method === "GET") return Response.json({ topic: "_deleted-topic_" });
+      if (method === "DELETE") {
+        return Response.json({ error: { message: "delete failed" } }, { status: 500 });
+      }
+    }
+    return Response.json({});
+  };
+  const gateway = new GoogleGcpGateway(config, fetchImpl, async () => "service-access-token");
+
+  const provisioned = await gateway.provision({
+    connectionId: "connection-id",
+    gcpProjectId: "acme-production",
+    userAccessToken: "temporary-user-token",
+    integrationProjectId: config.integrationProjectId,
+    readerServiceAccountEmail: config.readerServiceAccountEmail,
+    pushServiceAccountEmail: config.pushServiceAccountEmail,
+    pushAudience: config.pushAudience,
+    pushEndpoint: `${config.pushEndpoint}/connection-id`,
+  });
+
+  assert.equal(provisioned.subscriptionName, "superlog-connection-id-recovery");
+  assert.deepEqual(
+    requests
+      .filter((request) => request.url.pathname.includes("/subscriptions/"))
+      .map((request) => ({
+        name: request.url.pathname.split("/").at(-1),
+        method: request.method,
+      })),
+    [
+      { name: "superlog-connection-id", method: "PUT" },
+      { name: "superlog-connection-id", method: "GET" },
+      { name: "superlog-connection-id-recovery", method: "PUT" },
+      { name: "superlog-connection-id", method: "DELETE" },
+    ],
+  );
+});
+
+test("a recovery cleanup failure removes the new canonical subscription", async () => {
+  const requests: Array<{ url: URL; method: string }> = [];
+  let canonicalPutCount = 0;
+  let canonicalDeleteCount = 0;
+  const fetchImpl: typeof fetch = async (input, init = {}) => {
+    const url = new URL(
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+    );
+    const method = init.method ?? "GET";
+    const body = init.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+    requests.push({ url, method });
+    if (url.pathname === "/v1/projects/acme-production") {
+      return Response.json({ projectNumber: "123456789012" });
+    }
+    if (url.pathname.endsWith(":getIamPolicy")) {
+      return Response.json({ bindings: [], etag: "etag" });
+    }
+    if (url.pathname.endsWith(":setIamPolicy")) return Response.json(body.policy ?? {});
+    if (url.pathname.endsWith("/sinks")) {
+      return Response.json({
+        name: "superlog-connection-id",
+        writerIdentity: "serviceAccount:cloud-logs@system.gserviceaccount.com",
+      });
+    }
+    if (url.pathname.endsWith("/subscriptions/superlog-connection-id")) {
+      if (method === "PUT") {
+        canonicalPutCount += 1;
+        return canonicalPutCount === 1
+          ? Response.json({ error: { message: "already exists" } }, { status: 409 })
+          : Response.json({});
+      }
+      if (method === "GET") return Response.json({ topic: "_deleted-topic_" });
+      if (method === "DELETE") {
+        canonicalDeleteCount += 1;
+        return Response.json({});
+      }
+    }
+    if (
+      url.pathname.endsWith("/subscriptions/superlog-connection-id-recovery") &&
+      method === "DELETE"
+    ) {
+      return Response.json({ error: { message: "cleanup failed" } }, { status: 500 });
+    }
+    return Response.json({});
+  };
+  const gateway = new GoogleGcpGateway(config, fetchImpl, async () => "service-access-token");
+
+  const provisioned = await gateway.provision({
+    connectionId: "connection-id",
+    gcpProjectId: "acme-production",
+    userAccessToken: "temporary-user-token",
+    integrationProjectId: config.integrationProjectId,
+    readerServiceAccountEmail: config.readerServiceAccountEmail,
+    pushServiceAccountEmail: config.pushServiceAccountEmail,
+    pushAudience: config.pushAudience,
+    pushEndpoint: `${config.pushEndpoint}/connection-id`,
+  });
+
+  assert.equal(provisioned.subscriptionName, "superlog-connection-id-recovery");
+  assert.equal(canonicalDeleteCount, 2);
+});
+
 test("deprovisioning preserves a monitoring viewer grant that predates the connection", async () => {
   const requests: Array<{ url: URL; init: RequestInit; body: Record<string, unknown> }> = [];
   const readerMember = `serviceAccount:${config.readerServiceAccountEmail}`;

--- a/apps/api/src/gcp/google-gateway.ts
+++ b/apps/api/src/gcp/google-gateway.ts
@@ -425,28 +425,57 @@ export class GoogleGcpGateway implements GcpGateway {
               );
             }
           }
-          await deleteResource(
-            this.fetchImpl,
-            subscriptionUrl,
-            serviceToken,
-            input.integrationProjectId,
-          );
+          let canonicalRemoved = false;
           try {
-            await requestJson(
+            await deleteResource(
               this.fetchImpl,
               subscriptionUrl,
               serviceToken,
-              { method: "PUT", body: JSON.stringify(subscription) },
               input.integrationProjectId,
             );
-            await deleteResource(
-              this.fetchImpl,
-              recoverySubscriptionUrl,
-              serviceToken,
-              input.integrationProjectId,
-            );
+            canonicalRemoved = true;
           } catch {
             activeSubscriptionName = recoverySubscriptionName;
+          }
+          if (canonicalRemoved) {
+            let canonicalCreated = false;
+            try {
+              await requestJson(
+                this.fetchImpl,
+                subscriptionUrl,
+                serviceToken,
+                { method: "PUT", body: JSON.stringify(subscription) },
+                input.integrationProjectId,
+              );
+              canonicalCreated = true;
+            } catch {
+              activeSubscriptionName = recoverySubscriptionName;
+            }
+            if (canonicalCreated) {
+              try {
+                await deleteResource(
+                  this.fetchImpl,
+                  recoverySubscriptionUrl,
+                  serviceToken,
+                  input.integrationProjectId,
+                );
+              } catch (recoveryCleanupError) {
+                try {
+                  await deleteResource(
+                    this.fetchImpl,
+                    subscriptionUrl,
+                    serviceToken,
+                    input.integrationProjectId,
+                  );
+                  activeSubscriptionName = recoverySubscriptionName;
+                } catch (canonicalCleanupError) {
+                  throw new AggregateError(
+                    [recoveryCleanupError, canonicalCleanupError],
+                    "GCP subscription cleanup failed",
+                  );
+                }
+              }
+            }
           }
         } else {
           await updateSubscription(

--- a/apps/api/src/gcp/google-gateway.ts
+++ b/apps/api/src/gcp/google-gateway.ts
@@ -350,23 +350,46 @@ export class GoogleGcpGateway implements GcpGateway {
         input.integrationProjectId,
       );
       if (!subscriptionCreated) {
-        const updateMask = "pushConfig,ackDeadlineSeconds,retryPolicy";
-        await requestJson(
+        const existingSubscription = await requestJson<{ topic?: string }>(
           this.fetchImpl,
           subscriptionUrl,
           serviceToken,
-          {
-            method: "PATCH",
-            body: JSON.stringify({
-              subscription: {
-                name: subscriptionPath,
-                ...subscription,
-              },
-              updateMask,
-            }),
-          },
+          {},
           input.integrationProjectId,
         );
+        if (existingSubscription.topic !== topicPath) {
+          await deleteResource(
+            this.fetchImpl,
+            subscriptionUrl,
+            serviceToken,
+            input.integrationProjectId,
+          );
+          await requestJson(
+            this.fetchImpl,
+            subscriptionUrl,
+            serviceToken,
+            { method: "PUT", body: JSON.stringify(subscription) },
+            input.integrationProjectId,
+          );
+        } else {
+          const updateMask = "pushConfig,ackDeadlineSeconds,retryPolicy";
+          await requestJson(
+            this.fetchImpl,
+            subscriptionUrl,
+            serviceToken,
+            {
+              method: "PATCH",
+              body: JSON.stringify({
+                subscription: {
+                  name: subscriptionPath,
+                  ...subscription,
+                },
+                updateMask,
+              }),
+            },
+            input.integrationProjectId,
+          );
+        }
       }
 
       return {

--- a/apps/api/src/gcp/google-gateway.ts
+++ b/apps/api/src/gcp/google-gateway.ts
@@ -494,12 +494,29 @@ export class GoogleGcpGateway implements GcpGateway {
           );
         }
       } else {
-        await deleteResource(
-          this.fetchImpl,
-          recoverySubscriptionUrl,
-          serviceToken,
-          input.integrationProjectId,
-        );
+        try {
+          await deleteResource(
+            this.fetchImpl,
+            recoverySubscriptionUrl,
+            serviceToken,
+            input.integrationProjectId,
+          );
+        } catch (recoveryCleanupError) {
+          try {
+            await deleteResource(
+              this.fetchImpl,
+              subscriptionUrl,
+              serviceToken,
+              input.integrationProjectId,
+            );
+          } catch (canonicalCleanupError) {
+            throw new AggregateError(
+              [recoveryCleanupError, canonicalCleanupError],
+              "GCP subscription cleanup failed",
+            );
+          }
+          throw recoveryCleanupError;
+        }
       }
 
       return {

--- a/apps/api/src/gcp/google-gateway.ts
+++ b/apps/api/src/gcp/google-gateway.ts
@@ -89,6 +89,29 @@ async function deleteResource(
   }
 }
 
+async function updateSubscription(
+  fetchImpl: typeof fetch,
+  url: string,
+  path: string,
+  accessToken: string,
+  subscription: Record<string, unknown>,
+  quotaProject: string,
+): Promise<void> {
+  await requestJson(
+    fetchImpl,
+    url,
+    accessToken,
+    {
+      method: "PATCH",
+      body: JSON.stringify({
+        subscription: { name: path, ...subscription },
+        updateMask: "pushConfig,ackDeadlineSeconds,retryPolicy",
+      }),
+    },
+    quotaProject,
+  );
+}
+
 type IamPolicy = {
   bindings?: Array<{
     role: string;
@@ -330,6 +353,9 @@ export class GoogleGcpGateway implements GcpGateway {
       }
 
       const subscriptionUrl = `https://pubsub.googleapis.com/v1/${subscriptionPath}`;
+      const recoverySubscriptionName = `${resourceSlug}-recovery`;
+      const recoverySubscriptionPath = `projects/${input.integrationProjectId}/subscriptions/${recoverySubscriptionName}`;
+      const recoverySubscriptionUrl = `https://pubsub.googleapis.com/v1/${recoverySubscriptionPath}`;
       const subscription = {
         topic: topicPath,
         ackDeadlineSeconds: 30,
@@ -349,6 +375,7 @@ export class GoogleGcpGateway implements GcpGateway {
         subscription,
         input.integrationProjectId,
       );
+      let activeSubscriptionName = resourceSlug;
       if (!subscriptionCreated) {
         const existingSubscription = await requestJson<{ topic?: string }>(
           this.fetchImpl,
@@ -358,44 +385,98 @@ export class GoogleGcpGateway implements GcpGateway {
           input.integrationProjectId,
         );
         if (existingSubscription.topic !== topicPath) {
+          const recoveryCreated = await ensureResource(
+            this.fetchImpl,
+            recoverySubscriptionUrl,
+            serviceToken,
+            subscription,
+            input.integrationProjectId,
+          );
+          if (!recoveryCreated) {
+            const existingRecovery = await requestJson<{ topic?: string }>(
+              this.fetchImpl,
+              recoverySubscriptionUrl,
+              serviceToken,
+              {},
+              input.integrationProjectId,
+            );
+            if (existingRecovery.topic !== topicPath) {
+              await deleteResource(
+                this.fetchImpl,
+                recoverySubscriptionUrl,
+                serviceToken,
+                input.integrationProjectId,
+              );
+              await requestJson(
+                this.fetchImpl,
+                recoverySubscriptionUrl,
+                serviceToken,
+                { method: "PUT", body: JSON.stringify(subscription) },
+                input.integrationProjectId,
+              );
+            } else {
+              await updateSubscription(
+                this.fetchImpl,
+                recoverySubscriptionUrl,
+                recoverySubscriptionPath,
+                serviceToken,
+                subscription,
+                input.integrationProjectId,
+              );
+            }
+          }
           await deleteResource(
             this.fetchImpl,
             subscriptionUrl,
             serviceToken,
             input.integrationProjectId,
           );
-          await requestJson(
+          try {
+            await requestJson(
+              this.fetchImpl,
+              subscriptionUrl,
+              serviceToken,
+              { method: "PUT", body: JSON.stringify(subscription) },
+              input.integrationProjectId,
+            );
+            await deleteResource(
+              this.fetchImpl,
+              recoverySubscriptionUrl,
+              serviceToken,
+              input.integrationProjectId,
+            );
+          } catch {
+            activeSubscriptionName = recoverySubscriptionName;
+          }
+        } else {
+          await updateSubscription(
             this.fetchImpl,
             subscriptionUrl,
+            subscriptionPath,
             serviceToken,
-            { method: "PUT", body: JSON.stringify(subscription) },
+            subscription,
             input.integrationProjectId,
           );
-        } else {
-          const updateMask = "pushConfig,ackDeadlineSeconds,retryPolicy";
-          await requestJson(
+          await deleteResource(
             this.fetchImpl,
-            subscriptionUrl,
+            recoverySubscriptionUrl,
             serviceToken,
-            {
-              method: "PATCH",
-              body: JSON.stringify({
-                subscription: {
-                  name: subscriptionPath,
-                  ...subscription,
-                },
-                updateMask,
-              }),
-            },
             input.integrationProjectId,
           );
         }
+      } else {
+        await deleteResource(
+          this.fetchImpl,
+          recoverySubscriptionUrl,
+          serviceToken,
+          input.integrationProjectId,
+        );
       }
 
       return {
         gcpProjectNumber,
         topicName: resourceSlug,
-        subscriptionName: resourceSlug,
+        subscriptionName: activeSubscriptionName,
         logSinkName: sink.name,
         logSinkWriterIdentity: sink.writerIdentity,
         monitoringViewerGrantCreated: projectPolicyChanged,
@@ -470,14 +551,22 @@ export class GoogleGcpGateway implements GcpGateway {
       `https://logging.googleapis.com/v2/projects/${encodeURIComponent(input.gcpProjectId)}/sinks/${input.provisioned.logSinkName}`,
       input.userAccessToken,
     );
+    const subscriptionNames = new Set([
+      input.provisioned.subscriptionName,
+      resourceSlug,
+      `${resourceSlug}-recovery`,
+    ]);
     const actions: Array<() => Promise<void>> = [
-      () =>
-        deleteResource(
-          this.fetchImpl,
-          `https://pubsub.googleapis.com/v1/projects/${input.integrationProjectId}/subscriptions/${resourceSlug}`,
-          serviceToken,
-          input.integrationProjectId,
-        ),
+      ...Array.from(
+        subscriptionNames,
+        (subscriptionName) => () =>
+          deleteResource(
+            this.fetchImpl,
+            `https://pubsub.googleapis.com/v1/projects/${input.integrationProjectId}/subscriptions/${encodeURIComponent(subscriptionName)}`,
+            serviceToken,
+            input.integrationProjectId,
+          ),
+      ),
       () =>
         deleteResource(
           this.fetchImpl,

--- a/apps/api/src/gcp/interfaces.ts
+++ b/apps/api/src/gcp/interfaces.ts
@@ -26,7 +26,7 @@ import type {
   GcpConnectionRepository,
   GcpGateway,
 } from "./domain.js";
-import { GcpAuthorizationError } from "./domain.js";
+import { GCP_AUTHORIZATION_TTL_MS, GcpAuthorizationError } from "./domain.js";
 import { GoogleGcpGateway } from "./google-gateway.js";
 import { DrizzleGcpConnectionRepository } from "./repository.js";
 import { signGcpState, verifyGcpState } from "./state.js";
@@ -417,20 +417,22 @@ export function mountGcpPublic(app: Hono<{ Variables: Vars }>, input: Dependenci
       return c.redirect(outcomeUrl("error"), 302);
     }
     try {
-      await completeGcpAuthorization({
+      const completed = await completeGcpAuthorization({
         authorizationId: state.authorizationId,
         code,
         repository: authorizationRepository,
         gateway,
       });
-      return c.redirect(
-        outcomeUrl(
-          "select",
-          state.authorizationId,
-          state.action === "disconnect" ? stateParam : undefined,
-        ),
-        302,
-      );
+      const refreshedDisconnectState =
+        state.action === "disconnect" && state.connectionId
+          ? signGcpState(
+              state.authorizationId,
+              stateSecret,
+              completed.expiresAt.getTime() - GCP_AUTHORIZATION_TTL_MS,
+              { action: "disconnect", connectionId: state.connectionId },
+            )
+          : undefined;
+      return c.redirect(outcomeUrl("select", state.authorizationId, refreshedDisconnectState), 302);
     } catch {
       return c.redirect(outcomeUrl("error"), 302);
     }

--- a/apps/api/src/gcp/interfaces.ts
+++ b/apps/api/src/gcp/interfaces.ts
@@ -152,7 +152,11 @@ function toPublic(connection: GcpConnectionRecord | null, canManage: boolean) {
     metricsBudgetMonth: connection.metricsBudgetMonth,
     metricsSeriesRead: connection.metricsSeriesRead,
     metricsMonthlySeriesLimit: monthlySeriesLimit(),
-    lastError: connection.lastError ? GCP_SETUP_FAILED_MESSAGE : null,
+    lastError: connection.lastError
+      ? connection.status === "disconnect_failed"
+        ? "Google Cloud disconnect needs to be retried."
+        : GCP_SETUP_FAILED_MESSAGE
+      : null,
     createdAt: connection.createdAt,
     updatedAt: connection.updatedAt,
     canManage,
@@ -233,7 +237,11 @@ export function mountGcpAuthed(app: Hono<{ Variables: Vars }>, input: Dependenci
       return c.json({ error: "GCP connect not configured" }, 503);
     const context = await requireProjectManager(c, c.req.param("projectId"));
     const connection = await repository.findCurrent(context.projectId);
-    if (!connection || connection.status !== "connected" || connection.revokedAt) {
+    if (
+      !connection ||
+      (connection.status !== "connected" && connection.status !== "disconnect_failed") ||
+      connection.revokedAt
+    ) {
       return c.json({ error: "Connected GCP project not found" }, 404);
     }
     const result = await startGcpAuthorization({

--- a/apps/api/src/gcp/interfaces.ts
+++ b/apps/api/src/gcp/interfaces.ts
@@ -342,6 +342,7 @@ export function mountGcpAuthed(app: Hono<{ Variables: Vars }>, input: Dependenci
         authorizationId: session.id,
         userId: c.var.userId,
         expectedConnectionId: disconnectIntent.connectionId,
+        retryExpiresAt: new Date(disconnectIntent.issuedAt + GCP_AUTHORIZATION_TTL_MS),
         authorizationRepository,
         connectionRepository: repository,
         gateway,

--- a/apps/api/src/gcp/interfaces.ts
+++ b/apps/api/src/gcp/interfaces.ts
@@ -241,7 +241,10 @@ export function mountGcpAuthed(app: Hono<{ Variables: Vars }>, input: Dependenci
       repository: authorizationRepository,
       gateway,
       signState: (authorizationId) =>
-        signGcpState(authorizationId, stateSecret, Date.now(), "disconnect"),
+        signGcpState(authorizationId, stateSecret, Date.now(), {
+          action: "disconnect",
+          connectionId: connection.id,
+        }),
     });
     return c.json({ url: result.url });
   });
@@ -307,9 +310,27 @@ export function mountGcpAuthed(app: Hono<{ Variables: Vars }>, input: Dependenci
   });
 
   app.post("/api/gcp/authorizations/:authorizationId/disconnect", async (c) => {
-    if (!config || !gateway) return c.json({ error: "GCP connect not configured" }, 503);
+    if (!config || !gateway || !stateSecret)
+      return c.json({ error: "GCP connect not configured" }, 503);
     if (!c.var.userId) return c.json({ error: "unauthenticated" }, 401);
     const authorizationId = c.req.param("authorizationId");
+    const parsedBody: unknown = await c.req.json().catch(() => ({}));
+    const authorizationState =
+      parsedBody && typeof parsedBody === "object" && !Array.isArray(parsedBody)
+        ? (parsedBody as { authorizationState?: unknown }).authorizationState
+        : undefined;
+    const disconnectIntent =
+      typeof authorizationState === "string"
+        ? verifyGcpState(authorizationState, stateSecret)
+        : null;
+    if (
+      !disconnectIntent ||
+      disconnectIntent.action !== "disconnect" ||
+      disconnectIntent.authorizationId !== authorizationId ||
+      !disconnectIntent.connectionId
+    ) {
+      return c.json({ error: "Invalid Google Cloud disconnect authorization" }, 400);
+    }
     try {
       const session = await getGcpAuthorizationSelection({
         authorizationId,
@@ -320,6 +341,7 @@ export function mountGcpAuthed(app: Hono<{ Variables: Vars }>, input: Dependenci
       const connection = await disconnectGcpAuthorization({
         authorizationId: session.id,
         userId: c.var.userId,
+        expectedConnectionId: disconnectIntent.connectionId,
         authorizationRepository,
         connectionRepository: repository,
         gateway,
@@ -358,12 +380,15 @@ export function mountGcpPublic(app: Hono<{ Variables: Vars }>, input: Dependenci
     const outcomeUrl = (
       outcome: "select" | "denied" | "error",
       authorizationId?: string,
-      action?: "disconnect",
+      authorizationState?: string,
     ) => {
       const url = new URL("/connect/gcp", config.webOrigin);
       url.searchParams.set("gcp", outcome);
       if (authorizationId) url.searchParams.set("authorization", authorizationId);
-      if (action) url.searchParams.set("action", action);
+      if (authorizationState) {
+        url.searchParams.set("action", "disconnect");
+        url.searchParams.set("authorization_state", authorizationState);
+      }
       return url.toString();
     };
     if (c.req.query("error")) {
@@ -377,7 +402,8 @@ export function mountGcpPublic(app: Hono<{ Variables: Vars }>, input: Dependenci
       return c.redirect(outcomeUrl("denied"), 302);
     }
     const code = c.req.query("code");
-    const state = verifyGcpState(c.req.query("state") ?? "", stateSecret);
+    const stateParam = c.req.query("state") ?? "";
+    const state = verifyGcpState(stateParam, stateSecret);
     if (!code || !state) return c.redirect(outcomeUrl("error"), 302);
     const authorization = await authorizationRepository.findById(state.authorizationId);
     if (
@@ -397,7 +423,14 @@ export function mountGcpPublic(app: Hono<{ Variables: Vars }>, input: Dependenci
         repository: authorizationRepository,
         gateway,
       });
-      return c.redirect(outcomeUrl("select", state.authorizationId, state.action), 302);
+      return c.redirect(
+        outcomeUrl(
+          "select",
+          state.authorizationId,
+          state.action === "disconnect" ? stateParam : undefined,
+        ),
+        302,
+      );
     } catch {
       return c.redirect(outcomeUrl("error"), 302);
     }

--- a/apps/api/src/gcp/interfaces.ts
+++ b/apps/api/src/gcp/interfaces.ts
@@ -15,6 +15,7 @@ import {
 import {
   completeGcpAuthorization,
   connectGcpAuthorization,
+  disconnectGcpAuthorization,
   getGcpAuthorizationSelection,
   startGcpAuthorization,
 } from "./authorization-application.js";
@@ -227,6 +228,24 @@ export function mountGcpAuthed(app: Hono<{ Variables: Vars }>, input: Dependenci
     return c.json({ url: result.url });
   });
 
+  app.post("/api/projects/:projectId/gcp/disconnect-url", async (c) => {
+    if (!config || !gateway || !stateSecret)
+      return c.json({ error: "GCP connect not configured" }, 503);
+    const context = await requireProjectManager(c, c.req.param("projectId"));
+    const connection = await repository.findCurrent(context.projectId);
+    if (!connection || connection.status !== "connected" || connection.revokedAt) {
+      return c.json({ error: "Connected GCP project not found" }, 404);
+    }
+    const result = await startGcpAuthorization({
+      ...context,
+      repository: authorizationRepository,
+      gateway,
+      signState: (authorizationId) =>
+        signGcpState(authorizationId, stateSecret, Date.now(), "disconnect"),
+    });
+    return c.json({ url: result.url });
+  });
+
   app.get("/api/gcp/authorizations/:authorizationId", async (c) => {
     if (!c.var.userId) return c.json({ error: "unauthenticated" }, 401);
     try {
@@ -286,6 +305,47 @@ export function mountGcpAuthed(app: Hono<{ Variables: Vars }>, input: Dependenci
       return c.json({ error: GCP_SETUP_FAILED_MESSAGE }, 502);
     }
   });
+
+  app.post("/api/gcp/authorizations/:authorizationId/disconnect", async (c) => {
+    if (!config || !gateway) return c.json({ error: "GCP connect not configured" }, 503);
+    if (!c.var.userId) return c.json({ error: "unauthenticated" }, 401);
+    const authorizationId = c.req.param("authorizationId");
+    try {
+      const session = await getGcpAuthorizationSelection({
+        authorizationId,
+        userId: c.var.userId,
+        repository: authorizationRepository,
+      });
+      const context = await requireProjectManager(c, session.projectId);
+      const connection = await disconnectGcpAuthorization({
+        authorizationId: session.id,
+        userId: c.var.userId,
+        authorizationRepository,
+        connectionRepository: repository,
+        gateway,
+        config,
+      });
+      log.info(
+        {
+          projectId: context.projectId,
+          userId: context.userId,
+          gcpConnectionId: connection.id,
+          gcpProjectId: connection.gcpProjectId,
+        },
+        "Google Cloud connection disconnected",
+      );
+      return c.json({ disconnected: true as const });
+    } catch (error) {
+      if (error instanceof GcpAuthorizationError) {
+        return c.json({ error: error.message }, authorizationErrorStatus(error));
+      }
+      log.error(
+        { err: error, authorizationId, userId: c.var.userId },
+        "Google Cloud disconnection failed",
+      );
+      return c.json({ error: "Google Cloud disconnect failed. Please try again." }, 502);
+    }
+  });
 }
 
 export function mountGcpPublic(app: Hono<{ Variables: Vars }>, input: Dependencies = {}): void {
@@ -295,10 +355,15 @@ export function mountGcpPublic(app: Hono<{ Variables: Vars }>, input: Dependenci
   app.get("/gcp/oauth/callback", async (c) => {
     if (!config || !gateway || !stateSecret)
       return c.json({ error: "GCP connect not configured" }, 503);
-    const outcomeUrl = (outcome: "select" | "denied" | "error", authorizationId?: string) => {
+    const outcomeUrl = (
+      outcome: "select" | "denied" | "error",
+      authorizationId?: string,
+      action?: "disconnect",
+    ) => {
       const url = new URL("/connect/gcp", config.webOrigin);
       url.searchParams.set("gcp", outcome);
       if (authorizationId) url.searchParams.set("authorization", authorizationId);
+      if (action) url.searchParams.set("action", action);
       return url.toString();
     };
     if (c.req.query("error")) {
@@ -332,7 +397,7 @@ export function mountGcpPublic(app: Hono<{ Variables: Vars }>, input: Dependenci
         repository: authorizationRepository,
         gateway,
       });
-      return c.redirect(outcomeUrl("select", state.authorizationId), 302);
+      return c.redirect(outcomeUrl("select", state.authorizationId, state.action), 302);
     } catch {
       return c.redirect(outcomeUrl("error"), 302);
     }

--- a/apps/api/src/gcp/repository.ts
+++ b/apps/api/src/gcp/repository.ts
@@ -59,10 +59,24 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
     connectionId: string;
     gcpProjectId: string;
     readerServiceAccountEmail: string;
-    grantCreated: boolean;
   }): Promise<boolean> {
-    if (!input.grantCreated) return false;
     return db.transaction(async (tx) => {
+      const [connection] = await tx
+        .select({
+          monitoringViewerGrantCreated: schema.gcpConnections.monitoringViewerGrantCreated,
+        })
+        .from(schema.gcpConnections)
+        .where(
+          and(
+            eq(schema.gcpConnections.id, input.connectionId),
+            eq(schema.gcpConnections.gcpProjectId, input.gcpProjectId),
+            eq(schema.gcpConnections.readerServiceAccountEmail, input.readerServiceAccountEmail),
+            isNull(schema.gcpConnections.revokedAt),
+          ),
+        )
+        .limit(1)
+        .for("update");
+      if (!connection?.monitoringViewerGrantCreated) return false;
       const [remaining] = await tx
         .select({ id: schema.gcpConnections.id })
         .from(schema.gcpConnections)

--- a/apps/api/src/gcp/repository.ts
+++ b/apps/api/src/gcp/repository.ts
@@ -49,6 +49,7 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
       ),
       orderBy: [
         desc(sql`${schema.gcpConnections.status} = 'connected'`),
+        desc(sql`${schema.gcpConnections.status} IN ('disconnecting', 'disconnect_failed')`),
         desc(schema.gcpConnections.createdAt),
       ],
     });
@@ -108,7 +109,11 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
       .where(
         and(
           eq(schema.gcpConnections.id, id),
-          notInArray(schema.gcpConnections.status, ["connected", "disconnecting"]),
+          notInArray(schema.gcpConnections.status, [
+            "connected",
+            "disconnecting",
+            "disconnect_failed",
+          ]),
         ),
       );
   }
@@ -160,14 +165,18 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
           and(
             eq(schema.gcpConnections.projectId, candidate.projectId),
             ne(schema.gcpConnections.id, id),
-            inArray(schema.gcpConnections.status, ["connected", "disconnecting", "failed"]),
+            inArray(schema.gcpConnections.status, [
+              "connected",
+              "disconnecting",
+              "disconnect_failed",
+            ]),
             isNull(schema.gcpConnections.revokedAt),
           ),
         );
       if (active.some((connection) => connection.status === "disconnecting")) {
         throw new Error("another GCP connection is disconnecting");
       }
-      if (active.some((connection) => connection.status === "failed")) {
+      if (active.some((connection) => connection.status === "disconnect_failed")) {
         throw new Error("another GCP connection requires recovery");
       }
       if (active.some((connection) => connection.id !== supersededConnectionId)) {
@@ -221,7 +230,11 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
       .where(
         and(
           eq(schema.gcpConnections.id, id),
-          notInArray(schema.gcpConnections.status, ["connected", "disconnecting"]),
+          notInArray(schema.gcpConnections.status, [
+            "connected",
+            "disconnecting",
+            "disconnect_failed",
+          ]),
         ),
       );
   }
@@ -233,7 +246,7 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
       .where(
         and(
           eq(schema.gcpConnections.id, id),
-          inArray(schema.gcpConnections.status, ["connected", "failed"]),
+          inArray(schema.gcpConnections.status, ["connected", "disconnect_failed"]),
           isNull(schema.gcpConnections.revokedAt),
         ),
       )
@@ -242,7 +255,10 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
     return toDomain(row);
   }
 
-  async releaseDisconnect(id: string, previousStatus: "connected" | "failed"): Promise<boolean> {
+  async releaseDisconnect(
+    id: string,
+    previousStatus: "connected" | "disconnect_failed",
+  ): Promise<boolean> {
     return db.transaction(async (tx) => {
       const [connection] = await tx
         .select({
@@ -325,7 +341,11 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
   async failDisconnect(id: string, error: string): Promise<void> {
     await db
       .update(schema.gcpConnections)
-      .set({ status: "failed", lastError: error.slice(0, 2_000), updatedAt: new Date() })
+      .set({
+        status: "disconnect_failed",
+        lastError: error.slice(0, 2_000),
+        updatedAt: new Date(),
+      })
       .where(
         and(
           eq(schema.gcpConnections.id, id),

--- a/apps/api/src/gcp/repository.ts
+++ b/apps/api/src/gcp/repository.ts
@@ -239,7 +239,7 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
     return toDomain(row);
   }
 
-  async releaseDisconnect(id: string): Promise<boolean> {
+  async releaseDisconnect(id: string, previousStatus: "connected" | "failed"): Promise<boolean> {
     return db.transaction(async (tx) => {
       const [connection] = await tx
         .select({
@@ -302,7 +302,11 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
       }
       const [restored] = await tx
         .update(schema.gcpConnections)
-        .set({ status: "connected", lastError: null, updatedAt: new Date() })
+        .set({
+          status: previousStatus,
+          ...(previousStatus === "connected" ? { lastError: null } : {}),
+          updatedAt: new Date(),
+        })
         .where(
           and(
             eq(schema.gcpConnections.id, id),

--- a/apps/api/src/gcp/repository.ts
+++ b/apps/api/src/gcp/repository.ts
@@ -196,6 +196,31 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
       .where(and(eq(schema.gcpConnections.id, id), ne(schema.gcpConnections.status, "connected")));
   }
 
+  async revoke(id: string): Promise<GcpConnectionRecord> {
+    return db.transaction(async (tx) => {
+      const revokedAt = new Date();
+      const [row] = await tx
+        .update(schema.gcpConnections)
+        .set({ revokedAt, updatedAt: revokedAt })
+        .where(
+          and(
+            eq(schema.gcpConnections.id, id),
+            eq(schema.gcpConnections.status, "connected"),
+            isNull(schema.gcpConnections.revokedAt),
+          ),
+        )
+        .returning();
+      if (!row) throw new Error("Connected GCP project not found");
+      if (row.apiKeyId) {
+        await tx
+          .update(schema.apiKeys)
+          .set({ revokedAt })
+          .where(and(eq(schema.apiKeys.id, row.apiKeyId), isNull(schema.apiKeys.revokedAt)));
+      }
+      return toDomain(row);
+    });
+  }
+
   async updateExcludedLogNames(
     id: string,
     excludedLogNames: string[],

--- a/apps/api/src/gcp/repository.ts
+++ b/apps/api/src/gcp/repository.ts
@@ -232,6 +232,7 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
           projectId: schema.gcpConnections.projectId,
           status: schema.gcpConnections.status,
           revokedAt: schema.gcpConnections.revokedAt,
+          apiKeyId: schema.gcpConnections.apiKeyId,
         })
         .from(schema.gcpConnections)
         .where(eq(schema.gcpConnections.id, id))
@@ -260,12 +261,13 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
         )
         .limit(1);
       if (replacement) {
+        const failedAt = new Date();
         await tx
           .update(schema.gcpConnections)
           .set({
             status: "failed",
             lastError: "replacement completed during disconnect recovery",
-            updatedAt: new Date(),
+            updatedAt: failedAt,
           })
           .where(
             and(
@@ -274,6 +276,14 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
               isNull(schema.gcpConnections.revokedAt),
             ),
           );
+        if (connection.apiKeyId) {
+          await tx
+            .update(schema.apiKeys)
+            .set({ revokedAt: failedAt })
+            .where(
+              and(eq(schema.apiKeys.id, connection.apiKeyId), isNull(schema.apiKeys.revokedAt)),
+            );
+        }
         return false;
       }
       const [restored] = await tx

--- a/apps/api/src/gcp/repository.ts
+++ b/apps/api/src/gcp/repository.ts
@@ -1,5 +1,5 @@
 import { db, encryptIntegrationSecret, mintApiKey, schema } from "@superlog/db";
-import { and, desc, eq, isNull, ne, notInArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, ne, notInArray, sql } from "drizzle-orm";
 import type {
   GcpConnectionRecord,
   GcpConnectionRepository,
@@ -140,16 +140,19 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
         .for("update");
       if (!project) throw new Error("GCP project not found");
       const active = await tx
-        .select({ id: schema.gcpConnections.id })
+        .select({ id: schema.gcpConnections.id, status: schema.gcpConnections.status })
         .from(schema.gcpConnections)
         .where(
           and(
             eq(schema.gcpConnections.projectId, candidate.projectId),
             ne(schema.gcpConnections.id, id),
-            eq(schema.gcpConnections.status, "connected"),
+            inArray(schema.gcpConnections.status, ["connected", "disconnecting"]),
             isNull(schema.gcpConnections.revokedAt),
           ),
         );
+      if (active.some((connection) => connection.status === "disconnecting")) {
+        throw new Error("another GCP connection is disconnecting");
+      }
       if (active.some((connection) => connection.id !== supersededConnectionId)) {
         throw new Error("another GCP connection completed first");
       }
@@ -222,10 +225,76 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
     return toDomain(row);
   }
 
-  async releaseDisconnect(id: string): Promise<void> {
+  async releaseDisconnect(id: string): Promise<boolean> {
+    return db.transaction(async (tx) => {
+      const [connection] = await tx
+        .select({
+          projectId: schema.gcpConnections.projectId,
+          status: schema.gcpConnections.status,
+          revokedAt: schema.gcpConnections.revokedAt,
+        })
+        .from(schema.gcpConnections)
+        .where(eq(schema.gcpConnections.id, id))
+        .limit(1)
+        .for("update");
+      if (!connection || connection.status !== "disconnecting" || connection.revokedAt) {
+        return false;
+      }
+      const [project] = await tx
+        .select({ id: schema.projects.id })
+        .from(schema.projects)
+        .where(eq(schema.projects.id, connection.projectId))
+        .limit(1)
+        .for("update");
+      if (!project) throw new Error("GCP project not found");
+      const [replacement] = await tx
+        .select({ id: schema.gcpConnections.id })
+        .from(schema.gcpConnections)
+        .where(
+          and(
+            eq(schema.gcpConnections.projectId, connection.projectId),
+            ne(schema.gcpConnections.id, id),
+            eq(schema.gcpConnections.status, "connected"),
+            isNull(schema.gcpConnections.revokedAt),
+          ),
+        )
+        .limit(1);
+      if (replacement) {
+        await tx
+          .update(schema.gcpConnections)
+          .set({
+            status: "failed",
+            lastError: "replacement completed during disconnect recovery",
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(schema.gcpConnections.id, id),
+              eq(schema.gcpConnections.status, "disconnecting"),
+              isNull(schema.gcpConnections.revokedAt),
+            ),
+          );
+        return false;
+      }
+      const [restored] = await tx
+        .update(schema.gcpConnections)
+        .set({ status: "connected", lastError: null, updatedAt: new Date() })
+        .where(
+          and(
+            eq(schema.gcpConnections.id, id),
+            eq(schema.gcpConnections.status, "disconnecting"),
+            isNull(schema.gcpConnections.revokedAt),
+          ),
+        )
+        .returning({ id: schema.gcpConnections.id });
+      return Boolean(restored);
+    });
+  }
+
+  async failDisconnect(id: string, error: string): Promise<void> {
     await db
       .update(schema.gcpConnections)
-      .set({ status: "connected", updatedAt: new Date() })
+      .set({ status: "failed", lastError: error.slice(0, 2_000), updatedAt: new Date() })
       .where(
         and(
           eq(schema.gcpConnections.id, id),

--- a/apps/api/src/gcp/repository.ts
+++ b/apps/api/src/gcp/repository.ts
@@ -160,12 +160,15 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
           and(
             eq(schema.gcpConnections.projectId, candidate.projectId),
             ne(schema.gcpConnections.id, id),
-            inArray(schema.gcpConnections.status, ["connected", "disconnecting"]),
+            inArray(schema.gcpConnections.status, ["connected", "disconnecting", "failed"]),
             isNull(schema.gcpConnections.revokedAt),
           ),
         );
       if (active.some((connection) => connection.status === "disconnecting")) {
         throw new Error("another GCP connection is disconnecting");
+      }
+      if (active.some((connection) => connection.status === "failed")) {
+        throw new Error("another GCP connection requires recovery");
       }
       if (active.some((connection) => connection.id !== supersededConnectionId)) {
         throw new Error("another GCP connection completed first");

--- a/apps/api/src/gcp/repository.ts
+++ b/apps/api/src/gcp/repository.ts
@@ -230,7 +230,7 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
       .where(
         and(
           eq(schema.gcpConnections.id, id),
-          eq(schema.gcpConnections.status, "connected"),
+          inArray(schema.gcpConnections.status, ["connected", "failed"]),
           isNull(schema.gcpConnections.revokedAt),
         ),
       )

--- a/apps/api/src/gcp/repository.ts
+++ b/apps/api/src/gcp/repository.ts
@@ -1,5 +1,5 @@
 import { db, encryptIntegrationSecret, mintApiKey, schema } from "@superlog/db";
-import { and, desc, eq, isNull, ne, sql } from "drizzle-orm";
+import { and, desc, eq, isNull, ne, notInArray, sql } from "drizzle-orm";
 import type {
   GcpConnectionRecord,
   GcpConnectionRepository,
@@ -91,7 +91,12 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
     await db
       .update(schema.gcpConnections)
       .set({ status: "provisioning", lastError: null, updatedAt: new Date() })
-      .where(and(eq(schema.gcpConnections.id, id), ne(schema.gcpConnections.status, "connected")));
+      .where(
+        and(
+          eq(schema.gcpConnections.id, id),
+          notInArray(schema.gcpConnections.status, ["connected", "disconnecting"]),
+        ),
+      );
   }
 
   async ensureIngestKey(id: string, projectId: string): Promise<void> {
@@ -193,7 +198,41 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
     await db
       .update(schema.gcpConnections)
       .set({ status: "failed", lastError: error.slice(0, 2_000), updatedAt: new Date() })
-      .where(and(eq(schema.gcpConnections.id, id), ne(schema.gcpConnections.status, "connected")));
+      .where(
+        and(
+          eq(schema.gcpConnections.id, id),
+          notInArray(schema.gcpConnections.status, ["connected", "disconnecting"]),
+        ),
+      );
+  }
+
+  async claimDisconnect(id: string): Promise<GcpConnectionRecord> {
+    const [row] = await db
+      .update(schema.gcpConnections)
+      .set({ status: "disconnecting", updatedAt: new Date() })
+      .where(
+        and(
+          eq(schema.gcpConnections.id, id),
+          eq(schema.gcpConnections.status, "connected"),
+          isNull(schema.gcpConnections.revokedAt),
+        ),
+      )
+      .returning();
+    if (!row) throw new Error("GCP disconnect is already in progress or unavailable");
+    return toDomain(row);
+  }
+
+  async releaseDisconnect(id: string): Promise<void> {
+    await db
+      .update(schema.gcpConnections)
+      .set({ status: "connected", updatedAt: new Date() })
+      .where(
+        and(
+          eq(schema.gcpConnections.id, id),
+          eq(schema.gcpConnections.status, "disconnecting"),
+          isNull(schema.gcpConnections.revokedAt),
+        ),
+      );
   }
 
   async revoke(id: string): Promise<GcpConnectionRecord> {
@@ -205,7 +244,7 @@ export class DrizzleGcpConnectionRepository implements GcpConnectionRepository {
         .where(
           and(
             eq(schema.gcpConnections.id, id),
-            eq(schema.gcpConnections.status, "connected"),
+            eq(schema.gcpConnections.status, "disconnecting"),
             isNull(schema.gcpConnections.revokedAt),
           ),
         )

--- a/apps/api/src/gcp/state.test.ts
+++ b/apps/api/src/gcp/state.test.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from "node:assert";
+import crypto from "node:crypto";
 import { test } from "node:test";
 import { GCP_AUTHORIZATION_TTL_MS } from "./domain.js";
 import { signGcpState, verifyGcpState } from "./state.js";
@@ -11,13 +12,28 @@ test("signed Google authorization state expires at the shared authorization life
   assert.equal(verifyGcpState(state, "secret", issuedAt + GCP_AUTHORIZATION_TTL_MS + 1), null);
 });
 
-test("signed Google authorization state preserves a disconnect action", () => {
+test("signed Google authorization state binds a disconnect to its original connection", () => {
   const issuedAt = Date.parse("2026-08-21T12:00:00.000Z");
-  const state = signGcpState("authorization-id", "secret", issuedAt, "disconnect");
+  const state = signGcpState("authorization-id", "secret", issuedAt, {
+    action: "disconnect",
+    connectionId: "connection-id",
+  });
 
   assert.deepEqual(verifyGcpState(state, "secret", issuedAt), {
     authorizationId: "authorization-id",
     issuedAt,
     action: "disconnect",
+    connectionId: "connection-id",
   });
+});
+
+test("signed Google authorization state rejects an incomplete disconnect intent", () => {
+  const issuedAt = Date.parse("2026-08-21T12:00:00.000Z");
+  const body = Buffer.from(
+    JSON.stringify({ authorizationId: "authorization-id", issuedAt, action: "disconnect" }),
+    "utf8",
+  ).toString("base64url");
+  const signature = crypto.createHmac("sha256", "secret").update(body).digest("base64url");
+
+  assert.equal(verifyGcpState(`${body}.${signature}`, "secret", issuedAt), null);
 });

--- a/apps/api/src/gcp/state.test.ts
+++ b/apps/api/src/gcp/state.test.ts
@@ -10,3 +10,14 @@ test("signed Google authorization state expires at the shared authorization life
   assert.ok(verifyGcpState(state, "secret", issuedAt + GCP_AUTHORIZATION_TTL_MS));
   assert.equal(verifyGcpState(state, "secret", issuedAt + GCP_AUTHORIZATION_TTL_MS + 1), null);
 });
+
+test("signed Google authorization state preserves a disconnect action", () => {
+  const issuedAt = Date.parse("2026-08-21T12:00:00.000Z");
+  const state = signGcpState("authorization-id", "secret", issuedAt, "disconnect");
+
+  assert.deepEqual(verifyGcpState(state, "secret", issuedAt), {
+    authorizationId: "authorization-id",
+    issuedAt,
+    action: "disconnect",
+  });
+});

--- a/apps/api/src/gcp/state.ts
+++ b/apps/api/src/gcp/state.ts
@@ -1,22 +1,24 @@
 import crypto from "node:crypto";
 import { GCP_AUTHORIZATION_TTL_MS } from "./domain.js";
 
-export type GcpAuthorizationAction = "disconnect";
+export type GcpAuthorizationIntent = {
+  action: "disconnect";
+  connectionId: string;
+};
 
 type GcpState = {
   authorizationId: string;
   issuedAt: number;
-  action?: GcpAuthorizationAction;
-};
+} & Partial<GcpAuthorizationIntent>;
 
 export function signGcpState(
   authorizationId: string,
   secret: string,
   issuedAt = Date.now(),
-  action?: GcpAuthorizationAction,
+  intent?: GcpAuthorizationIntent,
 ): string {
   const body = Buffer.from(
-    JSON.stringify({ authorizationId, issuedAt, ...(action ? { action } : {}) } satisfies GcpState),
+    JSON.stringify({ authorizationId, issuedAt, ...intent } satisfies GcpState),
     "utf8",
   ).toString("base64url");
   const signature = crypto.createHmac("sha256", secret).update(body).digest("base64url");
@@ -40,12 +42,22 @@ export function verifyGcpState(state: string, secret: string, now = Date.now()):
     if (typeof parsed.authorizationId !== "string" || typeof parsed.issuedAt !== "number") {
       return null;
     }
-    if (parsed.action !== undefined && parsed.action !== "disconnect") return null;
+    const hasIntent = parsed.action !== undefined || parsed.connectionId !== undefined;
+    if (
+      hasIntent &&
+      (parsed.action !== "disconnect" ||
+        typeof parsed.connectionId !== "string" ||
+        parsed.connectionId.length === 0)
+    ) {
+      return null;
+    }
     if (now - parsed.issuedAt > GCP_AUTHORIZATION_TTL_MS) return null;
     return {
       authorizationId: parsed.authorizationId,
       issuedAt: parsed.issuedAt,
-      ...(parsed.action ? { action: parsed.action } : {}),
+      ...(hasIntent
+        ? { action: parsed.action as "disconnect", connectionId: parsed.connectionId as string }
+        : {}),
     };
   } catch {
     return null;

--- a/apps/api/src/gcp/state.ts
+++ b/apps/api/src/gcp/state.ts
@@ -1,15 +1,22 @@
 import crypto from "node:crypto";
 import { GCP_AUTHORIZATION_TTL_MS } from "./domain.js";
 
-type GcpState = { authorizationId: string; issuedAt: number };
+export type GcpAuthorizationAction = "disconnect";
+
+type GcpState = {
+  authorizationId: string;
+  issuedAt: number;
+  action?: GcpAuthorizationAction;
+};
 
 export function signGcpState(
   authorizationId: string,
   secret: string,
   issuedAt = Date.now(),
+  action?: GcpAuthorizationAction,
 ): string {
   const body = Buffer.from(
-    JSON.stringify({ authorizationId, issuedAt } satisfies GcpState),
+    JSON.stringify({ authorizationId, issuedAt, ...(action ? { action } : {}) } satisfies GcpState),
     "utf8",
   ).toString("base64url");
   const signature = crypto.createHmac("sha256", secret).update(body).digest("base64url");
@@ -33,8 +40,13 @@ export function verifyGcpState(state: string, secret: string, now = Date.now()):
     if (typeof parsed.authorizationId !== "string" || typeof parsed.issuedAt !== "number") {
       return null;
     }
+    if (parsed.action !== undefined && parsed.action !== "disconnect") return null;
     if (now - parsed.issuedAt > GCP_AUTHORIZATION_TTL_MS) return null;
-    return { authorizationId: parsed.authorizationId, issuedAt: parsed.issuedAt };
+    return {
+      authorizationId: parsed.authorizationId,
+      issuedAt: parsed.issuedAt,
+      ...(parsed.action ? { action: parsed.action } : {}),
+    };
   } catch {
     return null;
   }

--- a/apps/proxy/src/gcp-pubsub.test.ts
+++ b/apps/proxy/src/gcp-pubsub.test.ts
@@ -27,7 +27,11 @@ test("the Pub/Sub verifier defaults its audience to the configured push endpoint
 });
 
 test("Pub/Sub delivery remains ingestible while disconnect is provisional", () => {
-  assert.deepEqual(GCP_PUBSUB_INGESTIBLE_STATUSES, ["connected", "disconnecting", "failed"]);
+  assert.deepEqual(GCP_PUBSUB_INGESTIBLE_STATUSES, [
+    "connected",
+    "disconnecting",
+    "disconnect_failed",
+  ]);
 });
 
 test("Pub/Sub acknowledges permanent ingest rejects but preserves retryable failures", () => {

--- a/apps/proxy/src/gcp-pubsub.test.ts
+++ b/apps/proxy/src/gcp-pubsub.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import {
+  GCP_PUBSUB_INGESTIBLE_STATUSES,
   acknowledgeGcpPubSubDelivery,
   authenticateGcpPubSubPush,
   gcpPubSubLogToOtlp,
@@ -23,6 +24,10 @@ test("the Pub/Sub verifier defaults its audience to the configured push endpoint
     }),
     "https://audience.example.com/gcp",
   );
+});
+
+test("Pub/Sub delivery remains ingestible while disconnect is provisional", () => {
+  assert.deepEqual(GCP_PUBSUB_INGESTIBLE_STATUSES, ["connected", "disconnecting"]);
 });
 
 test("Pub/Sub acknowledges permanent ingest rejects but preserves retryable failures", () => {

--- a/apps/proxy/src/gcp-pubsub.test.ts
+++ b/apps/proxy/src/gcp-pubsub.test.ts
@@ -27,7 +27,7 @@ test("the Pub/Sub verifier defaults its audience to the configured push endpoint
 });
 
 test("Pub/Sub delivery remains ingestible while disconnect is provisional", () => {
-  assert.deepEqual(GCP_PUBSUB_INGESTIBLE_STATUSES, ["connected", "disconnecting"]);
+  assert.deepEqual(GCP_PUBSUB_INGESTIBLE_STATUSES, ["connected", "disconnecting", "failed"]);
 });
 
 test("Pub/Sub acknowledges permanent ingest rejects but preserves retryable failures", () => {

--- a/apps/proxy/src/gcp-pubsub.ts
+++ b/apps/proxy/src/gcp-pubsub.ts
@@ -29,7 +29,11 @@ type PubSubPush = {
   subscription?: unknown;
 };
 
-export const GCP_PUBSUB_INGESTIBLE_STATUSES = ["connected", "disconnecting", "failed"] as const;
+export const GCP_PUBSUB_INGESTIBLE_STATUSES = [
+  "connected",
+  "disconnecting",
+  "disconnect_failed",
+] as const;
 
 export type GcpIdTokenVerifier = {
   verify(input: { idToken: string; audience: string }): Promise<{

--- a/apps/proxy/src/gcp-pubsub.ts
+++ b/apps/proxy/src/gcp-pubsub.ts
@@ -29,6 +29,8 @@ type PubSubPush = {
   subscription?: unknown;
 };
 
+export const GCP_PUBSUB_INGESTIBLE_STATUSES = ["connected", "disconnecting"] as const;
+
 export type GcpIdTokenVerifier = {
   verify(input: { idToken: string; audience: string }): Promise<{
     email: string | null;

--- a/apps/proxy/src/gcp-pubsub.ts
+++ b/apps/proxy/src/gcp-pubsub.ts
@@ -29,7 +29,7 @@ type PubSubPush = {
   subscription?: unknown;
 };
 
-export const GCP_PUBSUB_INGESTIBLE_STATUSES = ["connected", "disconnecting"] as const;
+export const GCP_PUBSUB_INGESTIBLE_STATUSES = ["connected", "disconnecting", "failed"] as const;
 
 export type GcpIdTokenVerifier = {
   verify(input: { idToken: string; audience: string }): Promise<{

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -11,7 +11,7 @@ import {
   syncLoopsContactsForProject,
 } from "@superlog/db";
 import { db } from "@superlog/db";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import { OAuth2Client } from "google-auth-library";
 import { Hono } from "hono";
 import type { Context } from "hono";
@@ -29,6 +29,7 @@ import {
   parseAccountIdFromFirehoseArn,
 } from "./firehose.js";
 import {
+  GCP_PUBSUB_INGESTIBLE_STATUSES,
   type GcpIdTokenVerifier,
   acknowledgeGcpPubSubDelivery,
   authenticateGcpPubSubPush,
@@ -518,7 +519,7 @@ app.post("/gcp/pubsub/:connectionId", async (c) => {
   const connection = await db.query.gcpConnections.findFirst({
     where: and(
       eq(schema.gcpConnections.id, c.req.param("connectionId")),
-      eq(schema.gcpConnections.status, "connected"),
+      inArray(schema.gcpConnections.status, [...GCP_PUBSUB_INGESTIBLE_STATUSES]),
       isNull(schema.gcpConnections.revokedAt),
     ),
   });

--- a/apps/web/src/GcpCallback.tsx
+++ b/apps/web/src/GcpCallback.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
-import { useConnectGcpAuthorization, useGcpAuthorizationSelection } from "./api.ts";
+import {
+  useConnectGcpAuthorization,
+  useDisconnectGcpAuthorization,
+  useGcpAuthorizationSelection,
+} from "./api.ts";
 import { Dropdown } from "./design/Dropdown.tsx";
 import { Btn, Wordmark } from "./design/ui.tsx";
 import { gcpCallbackView } from "./gcpCallbackModel.ts";
@@ -11,12 +15,58 @@ export function GcpCallback() {
   const authorizationId = params.get("authorization");
   if (outcome === "select") {
     return authorizationId ? (
-      <GcpProjectPicker authorizationId={authorizationId} />
+      params.get("action") === "disconnect" ? (
+        <GcpDisconnect authorizationId={authorizationId} />
+      ) : (
+        <GcpProjectPicker authorizationId={authorizationId} />
+      )
     ) : (
       <GcpCallbackMessage outcome="error" />
     );
   }
   return <GcpCallbackMessage outcome={outcome} />;
+}
+
+function GcpDisconnect({ authorizationId }: { authorizationId: string }) {
+  const selection = useGcpAuthorizationSelection(authorizationId);
+  const disconnect = useDisconnectGcpAuthorization(authorizationId);
+
+  if (selection.isError) return <GcpCallbackMessage outcome="error" />;
+
+  return (
+    <PageFrame>
+      <h1 className="mb-2 text-[22px] font-semibold tracking-[-0.015em]">
+        Disconnect Google Cloud
+      </h1>
+      <p className="mb-7 text-[13px] leading-[1.55] text-muted">
+        This removes the Cloud Logging sink, delivery resources, and metric access created by
+        Superlog. Telemetry already stored in Superlog is kept.
+      </p>
+      <div className="rounded-[10px] border border-[rgba(240,98,98,0.35)] bg-[rgba(240,98,98,0.06)] px-4 py-3 text-[13px] leading-[1.55] text-fg">
+        New logs and metrics from the connected Google Cloud project will stop arriving.
+      </div>
+      {disconnect.error && (
+        <p className="mt-3 text-[12.5px] text-danger">{String(disconnect.error)}</p>
+      )}
+      <div className="mt-9 flex items-center justify-between border-t border-[rgba(255,255,255,0.07)] pt-5">
+        <Btn size="md" onClick={() => window.location.assign("/app/settings")}>
+          Cancel
+        </Btn>
+        <Btn
+          variant="danger"
+          size="md"
+          loading={selection.isPending || disconnect.isPending}
+          disabled={selection.isPending || disconnect.isPending}
+          onClick={async () => {
+            await disconnect.mutateAsync();
+            window.location.assign("/connect/gcp?gcp=disconnected");
+          }}
+        >
+          Disconnect project
+        </Btn>
+      </div>
+    </PageFrame>
+  );
 }
 
 function PageFrame({ children }: { children: React.ReactNode }) {

--- a/apps/web/src/GcpCallback.tsx
+++ b/apps/web/src/GcpCallback.tsx
@@ -16,7 +16,14 @@ export function GcpCallback() {
   if (outcome === "select") {
     return authorizationId ? (
       params.get("action") === "disconnect" ? (
-        <GcpDisconnect authorizationId={authorizationId} />
+        params.get("authorization_state") ? (
+          <GcpDisconnect
+            authorizationId={authorizationId}
+            authorizationState={params.get("authorization_state") ?? ""}
+          />
+        ) : (
+          <GcpCallbackMessage outcome="error" />
+        )
       ) : (
         <GcpProjectPicker authorizationId={authorizationId} />
       )
@@ -27,9 +34,15 @@ export function GcpCallback() {
   return <GcpCallbackMessage outcome={outcome} />;
 }
 
-function GcpDisconnect({ authorizationId }: { authorizationId: string }) {
+function GcpDisconnect({
+  authorizationId,
+  authorizationState,
+}: {
+  authorizationId: string;
+  authorizationState: string;
+}) {
   const selection = useGcpAuthorizationSelection(authorizationId);
-  const disconnect = useDisconnectGcpAuthorization(authorizationId);
+  const disconnect = useDisconnectGcpAuthorization(authorizationId, authorizationState);
 
   if (selection.isError) return <GcpCallbackMessage outcome="error" />;
 

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -3097,8 +3097,17 @@ function GcpCard({ projectId }: { projectId: string | undefined }) {
               {row.gcpProjectId}
             </Chip>
           ) : row ? (
-            <Chip tone={row.status === "failed" ? "danger" : "muted"} dot>
-              {row.status === "failed" ? "Setup failed" : "Setup in progress"}
+            <Chip
+              tone={
+                row.status === "failed" || row.status === "disconnect_failed" ? "danger" : "muted"
+              }
+              dot
+            >
+              {row.status === "failed"
+                ? "Setup failed"
+                : row.status === "disconnect_failed"
+                  ? "Disconnect needs retry"
+                  : "Setup in progress"}
             </Chip>
           ) : (
             <Chip tone="muted" dot>
@@ -3116,7 +3125,7 @@ function GcpCard({ projectId }: { projectId: string | undefined }) {
           </p>
         )}
         <div className="flex justify-end gap-2">
-          {row?.status === "connected" && canManage && (
+          {(row?.status === "connected" || row?.status === "disconnect_failed") && canManage && (
             <Btn
               size="sm"
               variant="danger"
@@ -3127,21 +3136,23 @@ function GcpCard({ projectId }: { projectId: string | undefined }) {
                 window.location.href = url;
               }}
             >
-              Disconnect
+              {row.status === "disconnect_failed" ? "Retry disconnect" : "Disconnect"}
             </Btn>
           )}
-          <Btn
-            size="sm"
-            variant="primary"
-            loading={start.isPending}
-            disabled={!projectId || !configured || !canManage || start.isPending}
-            onClick={async () => {
-              const { url } = await start.mutateAsync();
-              window.location.href = url;
-            }}
-          >
-            {connectAction.buttonLabel}
-          </Btn>
+          {row?.status !== "disconnect_failed" && (
+            <Btn
+              size="sm"
+              variant="primary"
+              loading={start.isPending}
+              disabled={!projectId || !configured || !canManage || start.isPending}
+              onClick={async () => {
+                const { url } = await start.mutateAsync();
+                window.location.href = url;
+              }}
+            >
+              {connectAction.buttonLabel}
+            </Btn>
+          )}
         </div>
         {disconnect.error && (
           <p className="text-[12.5px] text-danger">{String(disconnect.error)}</p>

--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -84,6 +84,7 @@ import {
   useSlackRoute,
   useStartCloudflareInstall,
   useStartGcpConnect,
+  useStartGcpDisconnect,
   useStartGithubAccessLogin,
   useStartGithubAuthorLogin,
   useStartGithubInstall,
@@ -3065,6 +3066,7 @@ function IngestSourcesCard({ projectId }: { projectId: string | undefined }) {
 function GcpCard({ projectId }: { projectId: string | undefined }) {
   const connection = useGcpConnection(projectId);
   const start = useStartGcpConnect(projectId);
+  const disconnect = useStartGcpDisconnect(projectId);
   const capabilities = useSystemCapabilities();
   const row =
     connection.data?.connected !== undefined && "status" in connection.data
@@ -3113,7 +3115,21 @@ function GcpCard({ projectId }: { projectId: string | undefined }) {
             GCP connect is not configured on this deployment.
           </p>
         )}
-        <div className="flex justify-end">
+        <div className="flex justify-end gap-2">
+          {row?.status === "connected" && canManage && (
+            <Btn
+              size="sm"
+              variant="danger"
+              loading={disconnect.isPending}
+              disabled={!projectId || !configured || disconnect.isPending}
+              onClick={async () => {
+                const { url } = await disconnect.mutateAsync();
+                window.location.href = url;
+              }}
+            >
+              Disconnect
+            </Btn>
+          )}
           <Btn
             size="sm"
             variant="primary"
@@ -3127,6 +3143,9 @@ function GcpCard({ projectId }: { projectId: string | undefined }) {
             {connectAction.buttonLabel}
           </Btn>
         </div>
+        {disconnect.error && (
+          <p className="text-[12.5px] text-danger">{String(disconnect.error)}</p>
+        )}
         {start.error && <p className="text-[12.5px] text-danger">{String(start.error)}</p>}
       </div>
     </Tile>

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1221,13 +1221,17 @@ export function useConnectGcpAuthorization(authorizationId: string | null) {
   });
 }
 
-export function useDisconnectGcpAuthorization(authorizationId: string | null) {
+export function useDisconnectGcpAuthorization(
+  authorizationId: string | null,
+  authorizationState: string,
+) {
   const fetcher = useFetcher();
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () =>
       fetcher<{ disconnected: true }>(`/api/gcp/authorizations/${authorizationId}/disconnect`, {
         method: "POST",
+        body: JSON.stringify({ authorizationState }),
       }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["gcp-connection"] });

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1173,6 +1173,16 @@ export function useStartGcpConnect(projectId: string | undefined) {
   });
 }
 
+export function useStartGcpDisconnect(projectId: string | undefined) {
+  const fetcher = useFetcher();
+  return useMutation({
+    mutationFn: () =>
+      fetcher<{ url: string }>(`/api/projects/${projectId}/gcp/disconnect-url`, {
+        method: "POST",
+      }),
+  });
+}
+
 export type GcpProjectOption = {
   projectId: string;
   projectNumber: string;
@@ -1203,6 +1213,21 @@ export function useConnectGcpAuthorization(authorizationId: string | null) {
       fetcher<{ connected: true }>(`/api/gcp/authorizations/${authorizationId}/connect`, {
         method: "POST",
         body: JSON.stringify({ gcpProjectId }),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["gcp-connection"] });
+      qc.removeQueries({ queryKey: ["gcp-authorization", authorizationId] });
+    },
+  });
+}
+
+export function useDisconnectGcpAuthorization(authorizationId: string | null) {
+  const fetcher = useFetcher();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      fetcher<{ disconnected: true }>(`/api/gcp/authorizations/${authorizationId}/disconnect`, {
+        method: "POST",
       }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["gcp-connection"] });

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1123,7 +1123,13 @@ export type GcpConnection =
       projectId: string;
       gcpProjectId: string;
       gcpProjectNumber: string | null;
-      status: "pending" | "provisioning" | "connected" | "failed";
+      status:
+        | "pending"
+        | "provisioning"
+        | "connected"
+        | "disconnecting"
+        | "disconnect_failed"
+        | "failed";
       lastVerifiedAt: string | null;
       lastLogReceivedAt: string | null;
       lastMetricsReceivedAt: string | null;

--- a/apps/web/src/gcp-settings-model.ts
+++ b/apps/web/src/gcp-settings-model.ts
@@ -3,6 +3,7 @@ type GcpConnectionStatus =
   | "provisioning"
   | "connected"
   | "disconnecting"
+  | "disconnect_failed"
   | "failed"
   | null;
 

--- a/apps/web/src/gcp-settings-model.ts
+++ b/apps/web/src/gcp-settings-model.ts
@@ -1,4 +1,10 @@
-type GcpConnectionStatus = "pending" | "provisioning" | "connected" | "failed" | null;
+type GcpConnectionStatus =
+  | "pending"
+  | "provisioning"
+  | "connected"
+  | "disconnecting"
+  | "failed"
+  | null;
 
 const GCP_LOG_DISCOVERY_WINDOW_MS = 24 * 60 * 60 * 1_000;
 

--- a/apps/web/src/gcpCallbackModel.ts
+++ b/apps/web/src/gcpCallbackModel.ts
@@ -25,6 +25,15 @@ export function gcpCallbackView(outcome: string | null | undefined): GcpCallback
       backHref: "/app/settings",
     };
   }
+  if (outcome === "disconnected") {
+    return {
+      tone: "success",
+      title: "Google Cloud disconnected",
+      body: "New logs and metrics have stopped. Telemetry already stored in Superlog was kept.",
+      backLabel: "Back to settings",
+      backHref: "/app/settings",
+    };
+  }
   if (outcome === "denied") {
     return {
       tone: "error",

--- a/apps/web/src/onboarding/GcpConnectFlow.tsx
+++ b/apps/web/src/onboarding/GcpConnectFlow.tsx
@@ -119,6 +119,7 @@ export function GcpConnectFlow({
           onRetry={retryDisconnect}
           retrying={disconnect.isPending}
           error={disconnect.error ? String(disconnect.error) : null}
+          canManage={row?.canManage ?? false}
         />
       )}
 
@@ -172,11 +173,13 @@ function DisconnectRecoveryPanel({
   onRetry,
   retrying,
   error,
+  canManage,
 }: {
   lastError: string | null;
   onRetry: () => void;
   retrying: boolean;
   error: string | null;
+  canManage: boolean;
 }) {
   return (
     <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
@@ -189,16 +192,22 @@ function DisconnectRecoveryPanel({
         <span className="text-[12.5px] text-muted">
           Logs remain protected while cleanup is waiting.
         </span>
-        <Btn
-          variant="primary"
-          size="md"
-          onClick={onRetry}
-          loading={retrying}
-          className="!h-[36px] !rounded-[8px] !px-[14px] !text-[13px]"
-        >
-          {retrying ? "Preparing…" : "Retry disconnect"}
-          {!retrying && <ExternalLinkIcon size={13} />}
-        </Btn>
+        {canManage ? (
+          <Btn
+            variant="primary"
+            size="md"
+            onClick={onRetry}
+            loading={retrying}
+            className="!h-[36px] !rounded-[8px] !px-[14px] !text-[13px]"
+          >
+            {retrying ? "Preparing…" : "Retry disconnect"}
+            {!retrying && <ExternalLinkIcon size={13} />}
+          </Btn>
+        ) : (
+          <span className="text-[12.5px] font-medium text-fg">
+            Ask a project manager to retry the disconnect.
+          </span>
+        )}
       </div>
       {error && (
         <div className={`border-t px-[22px] py-[12px] ${SOFT_LINE}`}>

--- a/apps/web/src/onboarding/GcpConnectFlow.tsx
+++ b/apps/web/src/onboarding/GcpConnectFlow.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useGcpConnection, useStartGcpConnect } from "../api.ts";
+import { useGcpConnection, useStartGcpConnect, useStartGcpDisconnect } from "../api.ts";
 import { Btn } from "../design/ui.tsx";
 import { type GcpPhase, canContinueGcp, gcpPhase, gcpStatusText } from "./gcpConnectModel.ts";
 import { CheckIcon, ExternalLinkIcon, SpinnerIcon } from "./icons.tsx";
@@ -53,6 +53,7 @@ export function GcpConnectFlow({
 
   const connection = useGcpConnection(projectId);
   const start = useStartGcpConnect(projectId);
+  const disconnect = useStartGcpDisconnect(projectId);
 
   const row = connection.data && "status" in connection.data ? connection.data : null;
   const phase = gcpPhase({ status: row?.status ?? null, launched });
@@ -66,6 +67,16 @@ export function GcpConnectFlow({
       openConsent(url);
     } catch {
       // The mutation error surfaces via start.error below.
+    }
+  };
+
+  const retryDisconnect = async () => {
+    if (disconnect.isPending) return;
+    try {
+      const { url } = await disconnect.mutateAsync();
+      window.location.href = url;
+    } catch {
+      // The mutation error surfaces in the recovery panel below.
     }
   };
 
@@ -102,6 +113,15 @@ export function GcpConnectFlow({
         />
       )}
 
+      {phase === "disconnect_recovery" && (
+        <DisconnectRecoveryPanel
+          lastError={row?.lastError ?? null}
+          onRetry={retryDisconnect}
+          retrying={disconnect.isPending}
+          error={disconnect.error ? String(disconnect.error) : null}
+        />
+      )}
+
       {phase === "connected" && row && (
         <ConnectedPanel gcpProjectId={row.gcpProjectId} eventsArrived={eventsArrived} />
       )}
@@ -134,12 +154,59 @@ function headerForPhase(phase: GcpPhase): { title: string; sub: string } {
         title: "Connection didn't finish",
         sub: "Something went wrong provisioning the connection. Reconnect to try again.",
       };
+    case "disconnect_recovery":
+      return {
+        title: "Finish disconnecting Google Cloud",
+        sub: "Cleanup was interrupted before it could finish. Reauthorize Google Cloud to retry safely.",
+      };
     default:
       return {
         title: "You're connected",
         sub: "We're routing Cloud Logging and reading bounded Cloud Monitoring metrics. First events typically appear within a minute.",
       };
   }
+}
+
+function DisconnectRecoveryPanel({
+  lastError,
+  onRetry,
+  retrying,
+  error,
+}: {
+  lastError: string | null;
+  onRetry: () => void;
+  retrying: boolean;
+  error: string | null;
+}) {
+  return (
+    <div className={`overflow-hidden rounded-[14px] border bg-surface ${SOFT_LINE}`}>
+      <div className={`border-b px-[22px] py-[18px] ${SOFT_LINE}`}>
+        <p className="m-0 text-[13px] leading-[1.55] text-danger">
+          {lastError ?? "Google Cloud cleanup needs to be retried."}
+        </p>
+      </div>
+      <div className="flex items-center justify-between gap-3 px-[22px] py-[16px]">
+        <span className="text-[12.5px] text-muted">
+          Logs remain protected while cleanup is waiting.
+        </span>
+        <Btn
+          variant="primary"
+          size="md"
+          onClick={onRetry}
+          loading={retrying}
+          className="!h-[36px] !rounded-[8px] !px-[14px] !text-[13px]"
+        >
+          {retrying ? "Preparing…" : "Retry disconnect"}
+          {!retrying && <ExternalLinkIcon size={13} />}
+        </Btn>
+      </div>
+      {error && (
+        <div className={`border-t px-[22px] py-[12px] ${SOFT_LINE}`}>
+          <p className="m-0 text-[12.5px] text-danger">{error}</p>
+        </div>
+      )}
+    </div>
+  );
 }
 
 function StartPanel({

--- a/apps/web/src/onboarding/gcpConnectModel.test.ts
+++ b/apps/web/src/onboarding/gcpConnectModel.test.ts
@@ -25,10 +25,15 @@ test("gcpPhase surfaces 'failed' regardless of launch state", () => {
   assert.equal(gcpPhase({ status: "failed", launched: false }), "failed");
 });
 
+test("gcpPhase keeps disconnect recovery out of the generic reconnect flow", () => {
+  assert.equal(gcpPhase({ status: "disconnect_failed", launched: false }), "disconnect_recovery");
+});
+
 test("canContinueGcp only unlocks on 'connected'", () => {
   assert.equal(canContinueGcp("start"), false);
   assert.equal(canContinueGcp("connecting"), false);
   assert.equal(canContinueGcp("failed"), false);
+  assert.equal(canContinueGcp("disconnect_recovery"), false);
   assert.equal(canContinueGcp("connected"), true);
 });
 

--- a/apps/web/src/onboarding/gcpConnectModel.ts
+++ b/apps/web/src/onboarding/gcpConnectModel.ts
@@ -18,7 +18,7 @@ export type GcpStatus =
   | "disconnect_failed"
   | "failed";
 
-export type GcpPhase = "start" | "connecting" | "connected" | "failed";
+export type GcpPhase = "start" | "connecting" | "connected" | "disconnect_recovery" | "failed";
 
 /**
  * Resolve the flow phase from the polled connection status and whether the user
@@ -30,7 +30,8 @@ export type GcpPhase = "start" | "connecting" | "connected" | "failed";
  */
 export function gcpPhase(input: { status: GcpStatus | null; launched: boolean }): GcpPhase {
   if (input.status === "connected") return "connected";
-  if (input.status === "failed" || input.status === "disconnect_failed") return "failed";
+  if (input.status === "disconnect_failed") return "disconnect_recovery";
+  if (input.status === "failed") return "failed";
   if (input.launched || input.status === "pending" || input.status === "provisioning") {
     return "connecting";
   }
@@ -51,6 +52,8 @@ export function gcpStatusText(phase: GcpPhase, eventsArrived: boolean): string {
       return "Waiting for you to authorize Google Cloud and pick a project in the other tab…";
     case "failed":
       return "The connection didn't finish. Reconnect to try again.";
+    case "disconnect_recovery":
+      return "The previous disconnect needs another authorization to finish safely.";
     default:
       return eventsArrived
         ? "Connected — telemetry from Google Cloud is arriving."

--- a/apps/web/src/onboarding/gcpConnectModel.ts
+++ b/apps/web/src/onboarding/gcpConnectModel.ts
@@ -10,7 +10,13 @@
 // connection endpoint; the milestone that unlocks "Continue" is `connected`.
 // Telemetry arrival is surfaced as a bonus but never blocks.
 
-export type GcpStatus = "pending" | "provisioning" | "connected" | "failed";
+export type GcpStatus =
+  | "pending"
+  | "provisioning"
+  | "connected"
+  | "disconnecting"
+  | "disconnect_failed"
+  | "failed";
 
 export type GcpPhase = "start" | "connecting" | "connected" | "failed";
 
@@ -24,7 +30,7 @@ export type GcpPhase = "start" | "connecting" | "connected" | "failed";
  */
 export function gcpPhase(input: { status: GcpStatus | null; launched: boolean }): GcpPhase {
   if (input.status === "connected") return "connected";
-  if (input.status === "failed") return "failed";
+  if (input.status === "failed" || input.status === "disconnect_failed") return "failed";
   if (input.launched || input.status === "pending" || input.status === "provisioning") {
     return "connecting";
   }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -3050,6 +3050,7 @@ export type GcpConnectionStatus =
   | "provisioning"
   | "connected"
   | "disconnecting"
+  | "disconnect_failed"
   | "failed";
 
 export const gcpConnections = pgTable(

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -3045,7 +3045,12 @@ export type GcpAuthorizationSession = typeof gcpAuthorizationSessions.$inferSele
  * resources live in the integration operator's GCP project, so their metered
  * usage is not charged to the customer project.
  */
-export type GcpConnectionStatus = "pending" | "provisioning" | "connected" | "failed";
+export type GcpConnectionStatus =
+  | "pending"
+  | "provisioning"
+  | "connected"
+  | "disconnecting"
+  | "failed";
 
 export const gcpConnections = pgTable(
   "gcp_connections",


### PR DESCRIPTION
## Summary

- add a manager-only, re-authenticated Google Cloud disconnect flow
- remove only the sink, delivery resources, and monitoring access provisioned for the connection
- revoke the connection ingest key while preserving previously stored telemetry
- restore provisioned resources if the final persistence step fails
- add a deliberate confirmation screen before destructive cleanup

## Validation

- focused API tests: 59 passed
- API typecheck
- web production build and prerender tests
- full worktree verification, including OTLP ingest and ClickHouse persistence

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manager‑only, re‑authenticated Google Cloud disconnect with recovery‑safe rollback, durable retries, and a dedicated recovery state. Previously you could not disconnect; now managers can remove provisioned resources, revoke the connection and its ingest key, preserve stored telemetry, and keep Pub/Sub ingest during recovery. Recovery actions are also manager‑gated.

- API: Adds POST `/api/projects/:projectId/gcp/disconnect-url` and POST `/api/gcp/authorizations/:authorizationId/disconnect`. The OAuth callback accepts `action=disconnect`, returns a refreshed `authorization_state` bound to an `expectedConnectionId` with the same TTL, and rejects invalid or expired state.
- Disconnect flow: Introduces `status="disconnecting"` and `status="disconnect_failed"`. Serializes teardown, removes sink/delivery/monitoring grant before revocation, revokes the linked API key last, returns 502 on provider failures, and allows only one claim. Blocks connect callbacks and prevents replacement connections while disconnecting or in recovery. Verifies `expectedConnectionId`.
- Pub/Sub: Reconciles push config; if the subscription was detached by a deleted/different topic, recreates a `-recovery` subscription and swaps it in. Deprovision deletes canonical, recovery, and the stored subscription name. The proxy ingests Pub/Sub while status is `connected`, `disconnecting`, or `disconnect_failed` and not revoked.
- UI and access control: Settings adds a Disconnect button with confirmation; the callback shows a “disconnected” success. Onboarding shows a `disconnect_recovery` phase, disables Continue until reconnected, and adds a Retry Disconnect action. Only project managers can start or retry disconnect; others can view status only.
- Migration: Add `disconnecting` and `disconnect_failed` to `gcp_connections.status`.

<sup>Written for commit 4d5f0158e8e0d8d7cb4f80fcc63399ea8d797491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

