### PR TITLE
Bound agent trace context enrichment

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -28,7 +28,7 @@
     "test:recurring-steps": "tsx --test src/worker/recurring-steps.test.ts",
     "test:worker-tick": "tsx --test src/worker/tick.test.ts",
     "test:telemetry-ingest": "tsx --test src/telemetry/ingest.test.ts",
-    "test:agent-run-start": "tsx --test src/agent-runs/start.test.ts",
+    "test:agent-run-start": "tsx --test src/agent-runs/start.test.ts src/agent-runs/prompt-context.test.ts",
     "test:agent-run-status": "tsx --test src/agent-runs/status.test.ts",
     "test:agent-run-sync": "tsx --test src/agent-runs/sync.test.ts",
     "test:agent-run-merge": "tsx --test src/agent-runs/merge.test.ts",

--- a/apps/worker/src/agent-runs/prompt-context.test.ts
+++ b/apps/worker/src/agent-runs/prompt-context.test.ts
@@ -1,0 +1,114 @@
+import "../agent-run.test-env.js";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { schema } from "@superlog/db";
+import { buildAgentRunIssueSummaries } from "./prompt-context.js";
+
+test("agent run issue context retains every issue while enriching only the 50 newest traces", async () => {
+  const issues = Array.from({ length: 51 }, (_, index) => makeIssue(index + 1)).reverse();
+  const enrichedIssueIds: string[] = [];
+
+  const summaries = await buildAgentRunIssueSummaries("project-1", issues, {
+    async buildWithTrace(_projectId, issue) {
+      enrichedIssueIds.push(issue.id);
+      return {
+        id: issue.id,
+        title: issue.title,
+        exceptionType: issue.exceptionType,
+        message: issue.message,
+        topFrame: issue.topFrame,
+        normalizedFrames: issue.normalizedFrames,
+        stacktrace: null,
+        sessionId: null,
+        lastSample: issue.lastSample,
+        traceContext: `trace:${issue.id}`,
+        alertEpisode: null,
+      };
+    },
+  });
+
+  assert.equal(summaries.length, 51);
+  assert.equal(enrichedIssueIds.includes("issue-1"), true);
+  assert.equal(enrichedIssueIds.includes("issue-51"), false);
+  assert.equal(summaries[0]?.traceContext, null);
+  assert.equal(summaries[0]?.title, "Issue 51");
+  assert.equal(summaries[50]?.traceContext, "trace:issue-1");
+});
+
+test("agent run issue context enriches no more than eight traces concurrently", async () => {
+  const issues = Array.from({ length: 16 }, (_, index) => makeIssue(index + 1));
+  let activeEnrichments = 0;
+  let maxActiveEnrichments = 0;
+
+  await buildAgentRunIssueSummaries("project-1", issues, {
+    async buildWithTrace(_projectId, issue) {
+      activeEnrichments += 1;
+      maxActiveEnrichments = Math.max(maxActiveEnrichments, activeEnrichments);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      activeEnrichments -= 1;
+      return {
+        id: issue.id,
+        title: issue.title,
+        exceptionType: issue.exceptionType,
+        message: issue.message,
+        topFrame: issue.topFrame,
+        normalizedFrames: issue.normalizedFrames,
+        stacktrace: null,
+        sessionId: null,
+        lastSample: issue.lastSample,
+        traceContext: `trace:${issue.id}`,
+        alertEpisode: null,
+      };
+    },
+  });
+
+  assert.equal(maxActiveEnrichments, 8);
+});
+
+function makeIssue(index: number): schema.Issue {
+  const seenAt = new Date(2026, 7, 24, 20, 0, 0, -index);
+  return {
+    id: `issue-${index}`,
+    projectId: "project-1",
+    fingerprint: `fingerprint-${index}`,
+    kind: "span",
+    service: "api",
+    exceptionType: `Exception${index}`,
+    title: `Issue ${index}`,
+    message: `message-${index}`,
+    topFrame: `frame-${index}`,
+    normalizedFrames: [`frame-${index}`],
+    lastSample: {
+      kind: "span",
+      service: "api",
+      severity: "ERROR",
+      message: `message-${index}`,
+      body: null,
+      exceptionType: `Exception${index}`,
+      topFrame: `frame-${index}`,
+      normalizedFrames: [`frame-${index}`],
+      stacktrace: null,
+      traceId: `trace-${index}`,
+      spanId: `span-${index}`,
+      seenAt: seenAt.toISOString(),
+    },
+    firstSeen: seenAt,
+    lastSeen: seenAt,
+    status: "open",
+    silencedAt: null,
+    escalationTrigger: null,
+    observationStartedAt: null,
+    observationBaselineEventCount: null,
+    observationLastEvaluatedAt: null,
+    observationLastEventCount: null,
+    lastAlertedAt: null,
+    slackMessageTs: null,
+    eventCount: 1,
+    groupingState: "grouped",
+    groupingSource: null,
+    groupingReason: null,
+    groupingAttemptedAt: null,
+    groupingAttemptCount: 0,
+    createdAt: seenAt,
+  };
+}

--- a/apps/worker/src/agent-runs/prompt-context.ts
+++ b/apps/worker/src/agent-runs/prompt-context.ts
@@ -5,6 +5,8 @@ import { fetchTraceContext } from "../infra/clickhouse/trace-context.js";
 import { findAlertEpisodeForIssue } from "../issues/repository.js";
 
 const STACKTRACE_PREVIEW_CHARS = 4_000;
+const MAX_TRACE_ENRICHED_ISSUES = 50;
+const TRACE_ENRICHMENT_CONCURRENCY = 8;
 
 function buildIssueSummary(issue: schema.Issue) {
   const sample = (issue.lastSample ?? null) as schema.IssueSample | null;
@@ -51,6 +53,30 @@ export async function buildIssueSummaryWithTrace(
       : (issue.lastSeen ?? null);
   const traceContext = await fetchTraceContext(projectId, traceId, spanId ?? null, hintTs);
   return { ...base, traceContext };
+}
+
+export async function buildAgentRunIssueSummaries(
+  projectId: string,
+  issues: schema.Issue[],
+  deps: {
+    buildWithTrace?: typeof buildIssueSummaryWithTrace;
+  } = {},
+): Promise<Array<ReturnType<typeof buildIssueSummary>>> {
+  const buildWithTrace = deps.buildWithTrace ?? buildIssueSummaryWithTrace;
+  const traceIssueIds = new Set(
+    issues
+      .filter((issue) => issue.kind !== "alert" && traceIdForIssue(issue) !== null)
+      .sort((left, right) => right.lastSeen.getTime() - left.lastSeen.getTime())
+      .slice(0, MAX_TRACE_ENRICHED_ISSUES)
+      .map((issue) => issue.id),
+  );
+
+  return mapWithConcurrency(issues, TRACE_ENRICHMENT_CONCURRENCY, (issue) => {
+    if (issue.kind === "alert" || traceIssueIds.has(issue.id)) {
+      return buildWithTrace(projectId, issue);
+    }
+    return buildIssueSummary(issue);
+  });
 }
 
 async function loadAlertEpisodeContext(issueId: string): Promise<AgentRunnerAlertEpisode | null> {
@@ -102,4 +128,29 @@ function sessionIdForSample(sample: schema.IssueSample | null): string | null {
     sample?.resourceAttrs?.["session.id"] ??
     null
   );
+}
+
+function traceIdForIssue(issue: schema.Issue): string | null {
+  const sample = (issue.lastSample ?? null) as schema.IssueSample | null;
+  return sample?.traceId ?? null;
+}
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  concurrency: number,
+  map: (value: T) => R | Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < values.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await map(values[index] as T);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, () => worker()));
+  return results;
 }

--- a/apps/worker/src/agent-runs/start-run.ts
+++ b/apps/worker/src/agent-runs/start-run.ts
@@ -16,7 +16,7 @@ import {
   updateIncidentMainMessage,
 } from "../infra/slack/incident-messages.js";
 import { logger } from "../logger.js";
-import { buildIssueSummaryWithTrace } from "./prompt-context.js";
+import { buildAgentRunIssueSummaries } from "./prompt-context.js";
 import { startQueuedAgentRunWorkflow } from "./start.js";
 import {
   failAgentRun,
@@ -37,8 +37,7 @@ export async function startQueuedAgentRun(ctx: AgentRunContext): Promise<void> {
     isRepositorySelectionError: isGithubRepositorySelectionError,
     isRetryableRepositoryError: isRetryableGithubRequestError,
     listRepositoryInstructionFiles,
-    buildIssueSummaries: (ctx) =>
-      Promise.all(ctx.issueRows.map((issue) => buildIssueSummaryWithTrace(ctx.project.id, issue))),
+    buildIssueSummaries: (ctx) => buildAgentRunIssueSummaries(ctx.project.id, ctx.issueRows),
     fail: failAgentRun,
     blockForGithub: moveAgentRunToBlockedNoGithub,
     pauseForRepositorySelection: moveAgentRunToAwaitingHuman,


### PR DESCRIPTION
## Summary

- retain metadata for every issue linked to an agent investigation
- enrich only the 50 most recently observed trace-bearing issues with full trace context
- bound context enrichment to eight concurrent operations
- include the new behavior tests in the agent-start test command

## Why

Large grouped incidents could start one telemetry query per linked issue at once. Sampling full trace context while retaining all issue metadata keeps investigations useful without allowing a single run to exhaust telemetry read capacity.

## Validation

- `pnpm --dir superlog --filter @superlog/worker test:agent-run-start`
- `pnpm --dir superlog --filter @superlog/worker typecheck`
- `pnpm --dir superlog exec biome check apps/worker/src/agent-runs/prompt-context.ts apps/worker/src/agent-runs/prompt-context.test.ts apps/worker/src/agent-runs/start-run.ts apps/worker/package.json`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds agent trace context enrichment to prevent read spikes in large incidents. Previously we enriched every linked issue at once; now we keep metadata for all issues but only enrich the 50 most recent and limit concurrency to eight.

- Sorts by lastSeen and only selects trace-bearing issues; alert issues always use the enriched path to include episode context.
- Replaces direct per-issue enrichment with buildAgentRunIssueSummaries in start-run.
- Adds unit tests for selection and concurrency; updates the test:agent-run-start script to run the new tests.

<sup>Written for commit 42ae3d2cf3573eb511cd91337f42ed97bf72e812. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

