### PR TITLE
mcp: add get_trace tool for fetching one trace by id

### DIFF
--- a/apps/api/src/mcp/clickhouse.test.ts
+++ b/apps/api/src/mcp/clickhouse.test.ts
@@ -4,6 +4,7 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import {
   countSeries,
   fieldColumnExpr,
+  getTraceDetail,
   listAttributeKeys,
   listAttributeValues,
   listMetricNames,
@@ -1182,4 +1183,32 @@ test("countSeries falls back to the raw table when the rollup table is absent", 
   );
 
   assert.match(capture.query ?? "", /FROM otel_traces/);
+});
+
+test("getTraceDetail queries spans and logs, bound by the trace-id index window", async () => {
+  const queries: string[] = [];
+
+  await getTraceDetail(fakeClickhouseMulti(queries), "project-1", "abc123");
+
+  assert.equal(queries.length, 2);
+  const spansQuery = queries.find((q) => /FROM otel_traces/.test(q));
+  const logsQuery = queries.find((q) => /FROM otel_logs/.test(q));
+  assert.ok(spansQuery, "expected a spans query");
+  assert.ok(logsQuery, "expected a logs query");
+
+  // Both legs must be pruned via otel_traces_trace_id_ts: a bare TraceId
+  // predicate cannot use the primary index and full-scans every partition.
+  for (const query of [spansQuery, logsQuery]) {
+    assert.match(query, /otel_traces_trace_id_ts/);
+    assert.match(query, /\{traceId:String\}/);
+  }
+});
+
+test("getTraceDetail passes the trace id as a bound parameter", async () => {
+  const capture: { query?: string; params?: Record<string, unknown> } = {};
+
+  await getTraceDetail(fakeClickhouse(capture), "project-1", "abc123");
+
+  assert.equal(capture.params?.traceId, "abc123");
+  assert.doesNotMatch(capture.query ?? "", /abc123/);
 });

--- a/apps/api/src/mcp/scope-authorization.test.ts
+++ b/apps/api/src/mcp/scope-authorization.test.ts
@@ -123,6 +123,7 @@ test("mcp:read sessions expose reads but not writes or deletes", async () => {
     "get_incident",
     "get_issue_filter",
     "get_project_context",
+    "get_trace",
     "list_agent_mcp_servers",
     "list_agent_memories",
     "list_alerts",

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -8,6 +8,7 @@ import { registerAgentConfigTools } from "./agent-config.js";
 import { registerAlertTools } from "./alerts.js";
 import { instrumentMcpToolAnalytics } from "./analytics.js";
 import {
+  getTraceDetail,
   listServices,
   queryLogs,
   queryMetrics,
@@ -272,6 +273,36 @@ export function createMcpServerForSession(session: McpSession): McpServer {
             spanAttrs: input.span_attrs,
             limit: input.limit,
           }),
+      );
+      return { content: [{ type: "text", text: JSON.stringify(result) }] };
+    },
+  );
+
+  server.registerTool(
+    "get_trace",
+    {
+      title: "Get trace",
+      description:
+        "Fetch every span of one trace by id, plus the log records correlated to that trace. " +
+        "Targets the session's active project unless project_id is given. " +
+        "Use this after query_traces surfaces an interesting trace_id: query_traces only returns spans " +
+        "matching its filters, so the fast child spans of a slow request fall below min_duration_ms and " +
+        "never appear, and it cannot be narrowed to a single trace. This returns the whole tree instead, " +
+        "each span carrying parent_span_id so the caller can rebuild the hierarchy and see where the " +
+        "time actually went.",
+      annotations: READ_ONLY_TOOL,
+      inputSchema: {
+        project_id: projectIdSchema,
+        trace_id: z
+          .string()
+          .regex(/^[a-fA-F0-9]{1,64}$/, "trace id must be hex")
+          .describe("Trace id as hex, e.g. the trace_id returned by query_traces or query_logs."),
+      },
+    },
+    async (input) => {
+      const projectId = await resolveProject(input.project_id);
+      const result = await executeTelemetryQuery("get_trace", input, projectId, () =>
+        getTraceDetail(session.ch, projectId, input.trace_id),
       );
       return { content: [{ type: "text", text: JSON.stringify(result) }] };
     },

--- a/apps/api/src/mcp/telemetry-recovery.ts
+++ b/apps/api/src/mcp/telemetry-recovery.ts
@@ -4,6 +4,7 @@ export type McpTelemetryToolName =
   | "query_logs"
   | "query_traces"
   | "query_metrics"
+  | "get_trace"
   | "list_services";
 
 export type TelemetryRetryRequired = {


### PR DESCRIPTION
## What & why

`query_traces` returns only the spans matching its filters and takes no `trace_id`, so an agent can find that a request was slow but cannot see its span tree: the fast children fall below `min_duration_ms`, and dropping the threshold just returns the most recent 500 spans (`ORDER BY Timestamp DESC`, no offset), which on a busy project is a fraction of a second of traffic.

`getTraceDetail` already solves this — it returns `{ spans, logs }` and resolves the trace window through `otel_traces_trace_id_ts` instead of full-scanning `otel_traces` — but it was only reachable from the REST API. This exposes it as a read-only MCP tool. No new query, no new index, no schema change.

Fixes #477

## How to test

Against a local stack with some traces ingested:

- [ ] `pnpm --filter @superlog/api exec tsx --test src/mcp/clickhouse.test.ts src/mcp/scope-authorization.test.ts`
- [ ] Call the tool over MCP and check the tree comes back whole, fast children included:

```bash
curl -s -X POST http://localhost:4100/mcp \
  -H "Authorization: Bearer $SUPERLOG_PAT" \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_trace","arguments":{"trace_id":"<id from query_traces>"}}}'
```

On a Traefik trace here, `query_traces` with `min_duration_ms: 500` returned only the 2963.7ms root span, while `get_trace` on the same id returned the root plus its `ReverseProxy` child at 0.5ms — the span that shows the backend was not the problem. On a trace with the middleware chain enabled it returns all 7 spans plus the correlated access log.

- [ ] A non-hex `trace_id` is rejected by the input schema rather than reaching ClickHouse.

## AI assistance

- [ ] None
- [x] Used AI for: exploring the codebase, drafting this implementation and its tests, and writing this description. I ran the stack, reproduced the gap, and verified the tool's output against ClickHouse directly.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation
- [ ] Tests only
- [ ] Refactor / cleanup

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm format` has been run on changed files
- [x] Added or updated tests where it makes sense
- [x] Branch is up to date with `main`
- [x] PR title follows the area-prefix style for the area being changed (e.g. `worker: …`, `fix(slack): …`)
- [x] Read [CONTRIBUTING.md](https://github.com/superloglabs/superlog/blob/main/CONTRIBUTING.md) (skim counts)

### Notes on the checklist

`pnpm lint` and the full `@superlog/api` test suite do not pass cleanly on `main` in my environment, so I scoped both to my change:

- Biome reports pre-existing findings in `apps/api/src/mcp/analytics.ts`, `analytics.test.ts`, `telemetry-recovery.test.ts` and `index.ts` on an unmodified checkout. My four changed files are clean, and I deliberately left the surrounding pre-existing formatting alone rather than reformatting whole files.
- The api suite has failures in the AWS/Google Cloud integration tests, which look credential- and network-dependent. The two suites covering this change (`clickhouse.test.ts`, `scope-authorization.test.ts`) are green: 65 tests, 65 pass.

Happy to widen either if you'd rather see a full green run.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an MCP `get_trace` tool that returns the complete span tree and correlated logs for a given trace id. Before, `query_traces` couldn’t target a single trace and dropped fast children; this reuses `getTraceDetail` (no schema/index changes) to fetch the whole trace efficiently.

**New Features**
- Validates `trace_id` as hex and binds it as a parameter.
- Uses the `otel_traces_trace_id_ts` index window for both spans and logs to avoid full scans.
- Exposed as read-only and available to `mcp:read` sessions.
- Supports optional `project_id`, defaulting to the session’s active project.
- Adds tests for query shape (index usage, parameter binding) and scope authorization.

<sup>Written for commit 609bf558b8761d59e671e2705e18dfed82beced4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

