### PR TITLE
Recover telemetry reads from transient ClickHouse resets

### DIFF
--- a/apps/api/src/clickhouse-client.test.ts
+++ b/apps/api/src/clickhouse-client.test.ts
@@ -1,0 +1,13 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { clickHouseClientConfig } from "./clickhouse-client.js";
+
+test("the API discards stale ClickHouse sockets before reusing them", () => {
+  const config = clickHouseClientConfig({});
+
+  assert.deepEqual(config.keep_alive, {
+    enabled: true,
+    idle_socket_ttl: 2_500,
+    eagerly_destroy_stale_sockets: true,
+  });
+});

--- a/apps/api/src/clickhouse-client.ts
+++ b/apps/api/src/clickhouse-client.ts
@@ -1,0 +1,27 @@
+import { type ClickHouseClientConfigOptions, createClient } from "@clickhouse/client";
+
+export function clickHouseClientConfig(env: NodeJS.ProcessEnv): ClickHouseClientConfigOptions {
+  return {
+    url: env.CLICKHOUSE_URL ?? "http://localhost:8123",
+    database: env.CLICKHOUSE_DB ?? "superlog",
+    username: env.CLICKHOUSE_USER ?? "default",
+    password: env.CLICKHOUSE_PASSWORD ?? "",
+    // Give heavy filtered queries room to finish. Stale pooled sockets are
+    // removed both by timer and immediately before reuse so an event-loop
+    // delay cannot race ClickHouse's keep-alive timeout.
+    request_timeout: 20_000,
+    keep_alive: {
+      enabled: true,
+      idle_socket_ttl: 2_500,
+      eagerly_destroy_stale_sockets: true,
+    },
+    clickhouse_settings: {
+      // Cancel abandoned SELECTs instead of letting them occupy a server slot.
+      cancel_http_readonly_queries_on_client_close: 1,
+    },
+  };
+}
+
+export function createApiClickHouseClient(env: NodeJS.ProcessEnv = process.env) {
+  return createClient(clickHouseClientConfig(env));
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,5 @@
 import "./env.js";
 import "./net.js";
-import { createClient } from "@clickhouse/client";
 import { serve } from "@hono/node-server";
 import { SpanStatusCode, trace } from "@opentelemetry/api";
 import { ensurePaygPromotion } from "@superlog/billing";
@@ -56,6 +55,7 @@ import { mountAnomalyScanner } from "./anomaly-scanner.js";
 import { auth } from "./auth.js";
 import { buildAutomationSettingsConflictUpdate } from "./automation-settings-update.js";
 import { shouldRunMigrationsOnBoot } from "./boot-migrations.js";
+import { createApiClickHouseClient } from "./clickhouse-client.js";
 import { mountCloudConnectionsAuthed } from "./cloud-connections.js";
 import { mountCloudflareAuthed, mountCloudflarePublic } from "./cloudflare.js";
 import { mountDashboards } from "./dashboards.js";
@@ -189,28 +189,7 @@ const WEB_CORS_ORIGINS = Array.from(
   new Set([WEB_ORIGIN, "http://localhost:5173", "http://127.0.0.1:5173"]),
 );
 
-const ch = createClient({
-  url: process.env.CLICKHOUSE_URL ?? "http://localhost:8123",
-  database: process.env.CLICKHOUSE_DB ?? "superlog",
-  username: process.env.CLICKHOUSE_USER ?? "default",
-  password: process.env.CLICKHOUSE_PASSWORD ?? "",
-  // idle_socket_ttl must stay below CH server's keep_alive_timeout (3s default)
-  // so we recycle before the server closes; request_timeout short-circuits
-  // stale sockets that slipped through instead of hanging forever. 20s gives
-  // heavy filtered/grouped widget queries on high-volume projects room to
-  // finish; cancel_http_readonly_queries_on_client_close below keeps a
-  // timed-out query from living on server-side.
-  request_timeout: 20_000,
-  keep_alive: { enabled: true, idle_socket_ttl: 2_500 },
-  clickhouse_settings: {
-    // When request_timeout (or a caller's abort signal) drops the HTTP
-    // connection, make the server cancel the SELECT instead of letting it
-    // run to completion. Without this, abandoned long scans pile up until
-    // the server hits max_concurrent_queries and rejects everyone
-    // (TOO_MANY_SIMULTANEOUS_QUERIES).
-    cancel_http_readonly_queries_on_client_close: 1,
-  },
-});
+const ch = createApiClickHouseClient();
 
 const tracer = trace.getTracer("@superlog/api");
 const SIGNUP_INTENT_TTL_MS = 30 * 60 * 1000;

--- a/packages/telemetry-query/src/index.ts
+++ b/packages/telemetry-query/src/index.ts
@@ -331,24 +331,26 @@ export async function queryTraces(
     ORDER BY Timestamp DESC
     LIMIT {limit:UInt32}
   `;
-  const r = await ch.query({
-    query,
-    query_params: {
-      projectId,
-      since: sinceSql,
-      until: untilSql,
-      service: params.service ?? "",
-      spanName: params.spanName ?? "",
-      statusCode: params.statusCode ?? "",
-      minDurationNs: Math.round((params.minDurationMs ?? 0) * 1_000_000),
-      limit: params.limit,
-      ...attr.params,
-      ...spanAttr.params,
-      ...field.params,
-    },
-    format: "JSONEachRow",
+  return retryOneConnectionReset(async () => {
+    const r = await ch.query({
+      query,
+      query_params: {
+        projectId,
+        since: sinceSql,
+        until: untilSql,
+        service: params.service ?? "",
+        spanName: params.spanName ?? "",
+        statusCode: params.statusCode ?? "",
+        minDurationNs: Math.round((params.minDurationMs ?? 0) * 1_000_000),
+        limit: params.limit,
+        ...attr.params,
+        ...spanAttr.params,
+        ...field.params,
+      },
+      format: "JSONEachRow",
+    });
+    return r.json();
   });
-  return r.json();
 }
 
 type TracesAggregatedParams = {
@@ -407,8 +409,9 @@ async function traceRollupCoversWindow(
   sinceExpr: string,
   sinceSql: string,
 ): Promise<boolean> {
-  const r = await ch.query({
-    query: `
+  const rows = await retryOneConnectionReset(async () => {
+    const r = await ch.query({
+      query: `
       SELECT count() AS c
       FROM (
         SELECT 1
@@ -417,10 +420,11 @@ async function traceRollupCoversWindow(
         LIMIT 1
       )
     `,
-    query_params: { projectId, since: sinceSql },
-    format: "JSONEachRow",
+      query_params: { projectId, since: sinceSql },
+      format: "JSONEachRow",
+    });
+    return (await r.json()) as { c: string | number }[];
   });
-  const rows = (await r.json()) as { c: string | number }[];
   return Number(rows[0]?.c ?? 0) > 0;
 }
 
@@ -480,12 +484,14 @@ async function queryTracesAggregatedFromSummary(
     ORDER BY start_time DESC
     LIMIT {limit:UInt32}
   `;
-  const r = await ch.query({
-    query,
-    query_params: { projectId, since: sinceSql, until: untilSql, limit: params.limit },
-    format: "JSONEachRow",
+  return retryOneConnectionReset(async () => {
+    const r = await ch.query({
+      query,
+      query_params: { projectId, since: sinceSql, until: untilSql, limit: params.limit },
+      format: "JSONEachRow",
+    });
+    return r.json();
   });
-  return r.json();
 }
 
 export async function queryTracesAggregated(
@@ -570,23 +576,25 @@ export async function queryTracesAggregated(
     ORDER BY min(Timestamp) DESC
     LIMIT {limit:UInt32}
   `;
-  const r = await ch.query({
-    query,
-    query_params: {
-      projectId,
-      since: sinceSql,
-      until: untilSql,
-      service: params.service ?? "",
-      spanName: params.spanName ?? "",
-      statusCode: params.statusCode ?? "",
-      limit: params.limit,
-      ...attr.params,
-      ...spanAttr.params,
-      ...field.params,
-    },
-    format: "JSONEachRow",
+  return retryOneConnectionReset(async () => {
+    const r = await ch.query({
+      query,
+      query_params: {
+        projectId,
+        since: sinceSql,
+        until: untilSql,
+        service: params.service ?? "",
+        spanName: params.spanName ?? "",
+        statusCode: params.statusCode ?? "",
+        limit: params.limit,
+        ...attr.params,
+        ...spanAttr.params,
+        ...field.params,
+      },
+      format: "JSONEachRow",
+    });
+    return r.json();
   });
-  return r.json();
 }
 
 export async function getTraceDetail(ch: ClickHouseClient, projectId: string, traceId: string) {
@@ -2168,8 +2176,10 @@ function tableExists(ch: ClickHouseClient, table: string): Promise<boolean> {
   if (cached) return cached;
   const probe = (async () => {
     try {
-      const r = await ch.query({ query: `EXISTS TABLE ${table}`, format: "JSONEachRow" });
-      const rows = (await r.json()) as { result: number | string }[];
+      const rows = await retryOneConnectionReset(async () => {
+        const r = await ch.query({ query: `EXISTS TABLE ${table}`, format: "JSONEachRow" });
+        return (await r.json()) as { result: number | string }[];
+      });
       return Number(rows[0]?.result) === 1;
     } catch {
       return false;

--- a/packages/telemetry-query/src/index.ts
+++ b/packages/telemetry-query/src/index.ts
@@ -18,6 +18,17 @@ type ParsedAttributeKey = { scope: AttributeScope; key: string };
 
 export type FieldFilterSource = "logs" | "traces";
 
+async function retryOneConnectionReset<T>(read: () => Promise<T>): Promise<T> {
+  try {
+    return await read();
+  } catch (error) {
+    if (!(error instanceof Error) || (error as Error & { code?: string }).code !== "ECONNRESET") {
+      throw error;
+    }
+    return read();
+  }
+}
+
 // Allowlist mapping a `field.<name>` filter key to the ClickHouse column
 // expression it compares against (as a String). Returns null for anything not
 // on the list so an arbitrary `field.*` key can never reach the query — the
@@ -237,24 +248,26 @@ export async function queryLogs(
     ORDER BY Timestamp DESC
     LIMIT {limit:UInt32}
   `;
-  const r = await ch.query({
-    query,
-    query_params: {
-      projectId,
-      since: sinceSql,
-      until: untilSql,
-      service: params.service ?? "",
-      severity: params.severity ?? "",
-      search: params.search ?? "",
-      traceId: params.traceId ?? "",
-      limit: params.limit,
-      ...attr.params,
-      ...logAttr.params,
-      ...field.params,
-    },
-    format: "JSONEachRow",
+  return retryOneConnectionReset(async () => {
+    const r = await ch.query({
+      query,
+      query_params: {
+        projectId,
+        since: sinceSql,
+        until: untilSql,
+        service: params.service ?? "",
+        severity: params.severity ?? "",
+        search: params.search ?? "",
+        traceId: params.traceId ?? "",
+        limit: params.limit,
+        ...attr.params,
+        ...logAttr.params,
+        ...field.params,
+      },
+      format: "JSONEachRow",
+    });
+    return r.json();
   });
-  return r.json();
 }
 
 export async function queryTraces(
@@ -615,8 +628,10 @@ export async function getTraceDetail(ch: ClickHouseClient, projectId: string, tr
         AND TimestampTime >= ${winStart}
         AND TimestampTime <= ${winEnd}`;
 
-  const spansQ = ch.query({
-    query: `
+  const readSpans = () =>
+    retryOneConnectionReset(async () => {
+      const result = await ch.query({
+        query: `
       SELECT
         toString(Timestamp) AS timestamp,
         toString(toUnixTimestamp64Nano(Timestamp)) AS start_ns,
@@ -642,12 +657,16 @@ export async function getTraceDetail(ch: ClickHouseClient, projectId: string, tr
       ORDER BY Timestamp ASC, SpanId ASC
       LIMIT 5000
     `,
-    query_params: { projectId, traceId },
-    format: "JSONEachRow",
-  });
+        query_params: { projectId, traceId },
+        format: "JSONEachRow",
+      });
+      return result.json();
+    });
 
-  const logsQ = ch.query({
-    query: `
+  const readLogs = () =>
+    retryOneConnectionReset(async () => {
+      const result = await ch.query({
+        query: `
       SELECT
         toString(Timestamp) AS timestamp,
         toString(toUnixTimestamp64Nano(Timestamp)) AS ts_ns,
@@ -667,13 +686,13 @@ export async function getTraceDetail(ch: ClickHouseClient, projectId: string, tr
       ORDER BY Timestamp ASC
       LIMIT 5000
     `,
-    query_params: { projectId, traceId },
-    format: "JSONEachRow",
-  });
+        query_params: { projectId, traceId },
+        format: "JSONEachRow",
+      });
+      return result.json();
+    });
 
-  const [spansR, logsR] = await Promise.all([spansQ, logsQ]);
-  const spans = await spansR.json();
-  const logs = await logsR.json();
+  const [spans, logs] = await Promise.all([readSpans(), readLogs()]);
   return { spans, logs };
 }
 
@@ -732,20 +751,22 @@ export async function queryMetrics(
     `;
 
       try {
-        const r = await ch.query({
-          query,
-          query_params: {
-            projectId,
-            since: sinceSql,
-            until: untilSql,
-            metricName: params.metricName ?? "",
-            service: params.service ?? "",
-            limit: params.limit,
-            ...attr.params,
-          },
-          format: "JSONEachRow",
+        return await retryOneConnectionReset(async () => {
+          const r = await ch.query({
+            query,
+            query_params: {
+              projectId,
+              since: sinceSql,
+              until: untilSql,
+              metricName: params.metricName ?? "",
+              service: params.service ?? "",
+              limit: params.limit,
+              ...attr.params,
+            },
+            format: "JSONEachRow",
+          });
+          return (await r.json()) as Record<string, unknown>[];
         });
-        return (await r.json()) as Record<string, unknown>[];
       } catch (err) {
         // metric tables may not exist if no metrics of this kind have been ingested yet
         if (!isMissingMetricTableError(err)) throw err;

--- a/packages/telemetry-query/src/transient-clickhouse-read.test.ts
+++ b/packages/telemetry-query/src/transient-clickhouse-read.test.ts
@@ -1,7 +1,13 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import type { ClickHouseClient } from "@clickhouse/client";
-import { getTraceDetail, queryLogs, queryMetrics } from "./index.js";
+import {
+  getTraceDetail,
+  queryLogs,
+  queryMetrics,
+  queryTraces,
+  queryTracesAggregated,
+} from "./index.js";
 
 test("a trace read recovers from one transient ClickHouse connection reset", async () => {
   let spanAttempts = 0;
@@ -69,6 +75,165 @@ test("a log read recovers from one transient ClickHouse connection reset", async
 
   assert.equal(attempts, 2);
   assert.deepEqual(logs, [{ body: "dialtone tick" }]);
+});
+
+test("a trace list recovers from one transient ClickHouse connection reset", async () => {
+  let attempts = 0;
+  const clickhouse = {
+    async query() {
+      if (++attempts === 1) {
+        throw Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+      }
+      return {
+        async json() {
+          return [{ trace_id: "trace-1" }];
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+
+  const traces = await queryTraces(clickhouse, "project-1", { limit: 10 });
+
+  assert.equal(attempts, 2);
+  assert.deepEqual(traces, [{ trace_id: "trace-1" }]);
+});
+
+test("an aggregated trace list retries a reset table-availability read", async () => {
+  let recentProbeAttempts = 0;
+  const clickhouse = {
+    async query(input: { query: string }) {
+      if (input.query.includes("EXISTS TABLE otel_traces_recent")) {
+        if (++recentProbeAttempts === 1) {
+          throw Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+        }
+        return {
+          async json() {
+            return [{ result: 1 }];
+          },
+        };
+      }
+      if (input.query.includes("EXISTS TABLE otel_traces_summary")) {
+        return {
+          async json() {
+            return [{ result: 1 }];
+          },
+        };
+      }
+      if (input.query.includes("SELECT count() AS c")) {
+        return {
+          async json() {
+            return [{ c: 0 }];
+          },
+        };
+      }
+      return {
+        async json() {
+          return [{ trace_id: "trace-1" }];
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+
+  const traces = await queryTracesAggregated(clickhouse, "project-1", { limit: 10 });
+
+  assert.equal(recentProbeAttempts, 2);
+  assert.deepEqual(traces, [{ trace_id: "trace-1" }]);
+});
+
+test("an aggregated trace list retries a reset rollup-coverage read", async () => {
+  let coverageAttempts = 0;
+  const clickhouse = {
+    async query(input: { query: string }) {
+      if (input.query.startsWith("EXISTS TABLE")) {
+        return {
+          async json() {
+            return [{ result: 1 }];
+          },
+        };
+      }
+      if (input.query.includes("SELECT count() AS c")) {
+        if (++coverageAttempts === 1) {
+          throw Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+        }
+        return {
+          async json() {
+            return [{ c: 0 }];
+          },
+        };
+      }
+      return {
+        async json() {
+          return [{ trace_id: "trace-1" }];
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+
+  const traces = await queryTracesAggregated(clickhouse, "project-1", { limit: 10 });
+
+  assert.equal(coverageAttempts, 2);
+  assert.deepEqual(traces, [{ trace_id: "trace-1" }]);
+});
+
+test("an aggregated trace list retries a reset summary read", async () => {
+  let summaryAttempts = 0;
+  const clickhouse = {
+    async query(input: { query: string }) {
+      if (input.query.startsWith("EXISTS TABLE")) {
+        return {
+          async json() {
+            return [{ result: 1 }];
+          },
+        };
+      }
+      if (input.query.includes("SELECT count() AS c")) {
+        return {
+          async json() {
+            return [{ c: 1 }];
+          },
+        };
+      }
+      if (input.query.includes("FROM otel_traces_summary")) {
+        if (++summaryAttempts === 1) {
+          throw Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+        }
+      }
+      return {
+        async json() {
+          return [{ trace_id: "trace-1" }];
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+
+  const traces = await queryTracesAggregated(clickhouse, "project-1", { limit: 10 });
+
+  assert.equal(summaryAttempts, 2);
+  assert.deepEqual(traces, [{ trace_id: "trace-1" }]);
+});
+
+test("a filtered aggregated trace list retries a reset raw read", async () => {
+  let attempts = 0;
+  const clickhouse = {
+    async query() {
+      if (++attempts === 1) {
+        throw Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+      }
+      return {
+        async json() {
+          return [{ trace_id: "trace-1" }];
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+
+  const traces = await queryTracesAggregated(clickhouse, "project-1", {
+    service: "api",
+    limit: 10,
+  });
+
+  assert.equal(attempts, 2);
+  assert.deepEqual(traces, [{ trace_id: "trace-1" }]);
 });
 
 test("a log read does not retry a ClickHouse query error", async () => {

--- a/packages/telemetry-query/src/transient-clickhouse-read.test.ts
+++ b/packages/telemetry-query/src/transient-clickhouse-read.test.ts
@@ -1,0 +1,98 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import type { ClickHouseClient } from "@clickhouse/client";
+import { getTraceDetail, queryLogs, queryMetrics } from "./index.js";
+
+test("a trace read recovers from one transient ClickHouse connection reset", async () => {
+  let spanAttempts = 0;
+  const clickhouse = {
+    async query(input: { query: string }) {
+      const readsSpans = /FROM otel_traces\s+WHERE/.test(input.query);
+      if (readsSpans && ++spanAttempts === 1) {
+        throw Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+      }
+      return {
+        async json() {
+          return readsSpans ? [{ span_id: "span-1" }] : [];
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+
+  const detail = await getTraceDetail(clickhouse, "project-1", "trace-1");
+
+  assert.equal(spanAttempts, 2);
+  assert.deepEqual(detail.spans, [{ span_id: "span-1" }]);
+});
+
+test("a metric read recovers from one transient ClickHouse connection reset", async () => {
+  let gaugeAttempts = 0;
+  const clickhouse = {
+    async query(input: { query: string }) {
+      const readsGauge = input.query.includes("FROM otel_metrics_gauge");
+      if (readsGauge && ++gaugeAttempts === 1) {
+        throw Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+      }
+      return {
+        async json() {
+          return readsGauge ? [{ kind: "gauge", timestamp: "2026-08-28 07:39:00" }] : [];
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+
+  const metrics = await queryMetrics(clickhouse, "project-1", {
+    metricName: "dialtone.tick.fly-primary",
+    limit: 10,
+  });
+
+  assert.equal(gaugeAttempts, 2);
+  assert.deepEqual(metrics, [{ kind: "gauge", timestamp: "2026-08-28 07:39:00" }]);
+});
+
+test("a log read recovers from one transient ClickHouse connection reset", async () => {
+  let attempts = 0;
+  const clickhouse = {
+    async query() {
+      if (++attempts === 1) {
+        throw Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+      }
+      return {
+        async json() {
+          return [{ body: "dialtone tick" }];
+        },
+      };
+    },
+  } as unknown as ClickHouseClient;
+
+  const logs = await queryLogs(clickhouse, "project-1", { traceId: "trace-1", limit: 1 });
+
+  assert.equal(attempts, 2);
+  assert.deepEqual(logs, [{ body: "dialtone tick" }]);
+});
+
+test("a log read does not retry a ClickHouse query error", async () => {
+  let attempts = 0;
+  const clickhouse = {
+    async query() {
+      attempts += 1;
+      throw Object.assign(new Error("unknown table"), { code: "60" });
+    },
+  } as unknown as ClickHouseClient;
+
+  await assert.rejects(queryLogs(clickhouse, "project-1", { limit: 1 }), /unknown table/);
+  assert.equal(attempts, 1);
+});
+
+test("a log read surfaces a second connection reset", async () => {
+  let attempts = 0;
+  const clickhouse = {
+    async query() {
+      attempts += 1;
+      throw Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    },
+  } as unknown as ClickHouseClient;
+
+  await assert.rejects(queryLogs(clickhouse, "project-1", { limit: 1 }), /read ECONNRESET/);
+  assert.equal(attempts, 2);
+});


### PR DESCRIPTION
## Summary

- discard stale pooled ClickHouse sockets immediately before reuse
- retry trace, log, and metric reads once when the connection is reset
- keep non-transient query failures and repeated resets visible to callers

## Why

A completed ClickHouse read can still surface as an API 500 when a pooled HTTP connection is reset while the response is returned. These read operations are idempotent, so one immediate retry provides recovery without hiding persistent failures.

## Validation

- 675 API tests
- telemetry-query tests
- API and telemetry-query typechecks
- seeded worktree end-to-end verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes transient ClickHouse connection resets that surfaced telemetry reads as API 500s. The API now discards stale pooled sockets before reuse and retries trace, log, and metric reads once when a connection is reset, including the table-availability and rollup-coverage probes behind aggregated trace reads.

**Bug Fixes**
- Adds one immediate retry for reads that fail with `ECONNRESET`; a second reset or non-transient query errors still propagate to callers.
- Configures the ClickHouse client to eagerly destroy stale idle sockets so a delayed event loop cannot race the server's keep-alive timeout.

<sup>Written for commit a0d1e1596c9df122a765381a004e1c195b77f9a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

