### PR TITLE
Batch direct ClickHouse ingest writes

### DIFF
--- a/apps/proxy/src/clickhouse-writer.test.ts
+++ b/apps/proxy/src/clickhouse-writer.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+
+import {
+  ClickHouseIngestWriter,
+  type ClickHouseInsertClient,
+  type IngestClickHouseConfig,
+} from "./clickhouse-writer.js";
+import type { OtelTraceRow } from "./otlp-clickhouse.js";
+
+const config: IngestClickHouseConfig = {
+  url: "http://clickhouse:8123",
+  database: "superlog",
+  username: "writer",
+  password: "secret",
+  insertQuorum: 2,
+  insertQuorumTimeoutMs: 30_000,
+  requestTimeoutMs: 30_000,
+  batchLingerMs: 5,
+};
+
+function traceRow(traceId: string): OtelTraceRow {
+  return { TraceId: traceId } as OtelTraceRow;
+}
+
+test("concurrent trace deliveries share one durable ClickHouse insert", async () => {
+  let finishInsert: (() => void) | undefined;
+  const insertFinished = new Promise<void>((resolve) => {
+    finishInsert = resolve;
+  });
+  const inserts: Array<{ table: string; values: unknown[] }> = [];
+  const client: ClickHouseInsertClient = {
+    async insert(input) {
+      inserts.push({ table: input.table, values: input.values });
+      await insertFinished;
+    },
+    async close() {},
+  };
+  const writer = new ClickHouseIngestWriter(config, client);
+
+  let firstResolved = false;
+  const first = writer.insert("otel_traces", [traceRow("trace-1")]).then(() => {
+    firstResolved = true;
+  });
+  const second = writer.insert("otel_traces", [traceRow("trace-2")]);
+
+  await delay(20);
+  assert.equal(inserts.length, 1);
+  assert.equal(inserts[0]?.table, "otel_traces");
+  assert.deepEqual(
+    inserts[0]?.values.map((row) => (row as OtelTraceRow).TraceId),
+    ["trace-1", "trace-2"],
+  );
+  assert.equal(firstResolved, false, "queue messages must wait for the durable insert");
+
+  finishInsert?.();
+  await Promise.all([first, second]);
+  assert.equal(firstResolved, true);
+  await writer.close();
+});
+
+test("a failed shared insert rejects every delivery and a later batch can recover", async () => {
+  let attempts = 0;
+  const client: ClickHouseInsertClient = {
+    async insert() {
+      attempts += 1;
+      if (attempts === 1) throw new Error("quorum unavailable");
+    },
+    async close() {},
+  };
+  const writer = new ClickHouseIngestWriter(config, client);
+
+  const first = writer.insert("otel_traces", [traceRow("trace-1")]);
+  const second = writer.insert("otel_traces", [traceRow("trace-2")]);
+  await assert.rejects(first, /quorum unavailable/);
+  await assert.rejects(second, /quorum unavailable/);
+  assert.equal(attempts, 1);
+
+  await writer.insert("otel_traces", [traceRow("trace-redelivery")]);
+  assert.equal(attempts, 2);
+  await writer.close();
+});

--- a/apps/proxy/src/clickhouse-writer.ts
+++ b/apps/proxy/src/clickhouse-writer.ts
@@ -1,12 +1,14 @@
-import { createClient, type ClickHouseClient } from "@clickhouse/client";
+import { createClient } from "@clickhouse/client";
 
 import type { OtelLogRow, OtelTraceRow } from "./otlp-clickhouse.js";
 
-// Direct-to-ClickHouse ingest writer. Each consumer worker maps an OTLP payload to
-// rows and INSERTs them synchronously with insert_quorum, so the SQS message is only
-// deleted once the write is durably committed (the consume loop deletes on success,
-// leaves on throw). This replaces forwarding through the collector, whose synchronous
-// exporter serializes to ~one insert per task — the global ingest ceiling.
+// Direct-to-ClickHouse ingest writer. Each consumer worker maps OTLP payloads to
+// rows, combines concurrent deliveries briefly per table, then INSERTs each batch
+// synchronously with insert_quorum. Every caller waits for the shared insert, so an
+// SQS message is only deleted once its rows are durably committed (the consume loop
+// deletes on success, leaves on throw). Per-table promise chains cap each task at one
+// trace and one log insert at a time instead of turning queue concurrency into a
+// ClickHouse small-part storm.
 //
 // Durability note: quorum is preserved (default 2), and async_insert stays OFF, so a
 // successful insert means the rows are committed to a quorum of replicas before we ack.
@@ -19,10 +21,11 @@ export type IngestClickHouseConfig = {
   insertQuorum: number;
   insertQuorumTimeoutMs: number;
   requestTimeoutMs: number;
+  batchLingerMs: number;
 };
 
 function readPositiveInt(value: string | undefined, fallback: number): number {
-  const n = value === undefined ? NaN : Number(value);
+  const n = value === undefined ? Number.NaN : Number(value);
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
 }
 
@@ -40,44 +43,120 @@ export function getIngestClickHouseConfig(env: NodeJS.ProcessEnv): IngestClickHo
     insertQuorum: readPositiveInt(env.INGEST_CLICKHOUSE_INSERT_QUORUM, 2),
     insertQuorumTimeoutMs: readPositiveInt(env.INGEST_CLICKHOUSE_INSERT_QUORUM_TIMEOUT_MS, 30_000),
     requestTimeoutMs: readPositiveInt(env.INGEST_CLICKHOUSE_REQUEST_TIMEOUT_MS, 30_000),
+    batchLingerMs: readPositiveInt(env.INGEST_CLICKHOUSE_BATCH_LINGER_MS, 10),
   };
 }
 
 export type IngestTable = "otel_logs" | "otel_traces";
+type IngestRow = OtelLogRow | OtelTraceRow;
 
 export interface IngestRowWriter {
   insert(table: IngestTable, rows: OtelLogRow[] | OtelTraceRow[]): Promise<void>;
 }
 
-export class ClickHouseIngestWriter implements IngestRowWriter {
-  private readonly client: ClickHouseClient;
+export interface ClickHouseInsertClient {
+  insert(input: {
+    table: IngestTable;
+    values: IngestRow[];
+    format: "JSONEachRow";
+  }): Promise<void>;
+  close(): Promise<void>;
+}
 
-  constructor(config: IngestClickHouseConfig) {
-    this.client = createClient({
-      url: config.url,
-      database: config.database,
-      username: config.username,
-      password: config.password,
-      request_timeout: config.requestTimeoutMs,
-      keep_alive: { enabled: true },
-      clickhouse_settings: {
-        // Mirror the collector's durability: commit to a quorum of replicas before
-        // the insert resolves, and keep inserts synchronous (no server-side buffering).
-        insert_quorum: String(config.insertQuorum),
-        insert_quorum_timeout: config.insertQuorumTimeoutMs,
-        async_insert: 0,
-        wait_for_async_insert: 1,
-      },
-    });
+type PendingInsert = {
+  rows: IngestRow[];
+  resolve: () => void;
+  reject: (error: unknown) => void;
+};
+
+type TableBatch = {
+  pending: PendingInsert[];
+  timer: NodeJS.Timeout | undefined;
+  tail: Promise<void>;
+};
+
+export class ClickHouseIngestWriter implements IngestRowWriter {
+  private readonly client: ClickHouseInsertClient;
+  private readonly batchLingerMs: number;
+  private readonly batches: Record<IngestTable, TableBatch> = {
+    otel_logs: { pending: [], timer: undefined, tail: Promise.resolve() },
+    otel_traces: { pending: [], timer: undefined, tail: Promise.resolve() },
+  };
+  private closed = false;
+
+  constructor(config: IngestClickHouseConfig, client?: ClickHouseInsertClient) {
+    this.batchLingerMs = config.batchLingerMs;
+    if (client) {
+      this.client = client;
+    } else {
+      const clickhouse = createClient({
+        url: config.url,
+        database: config.database,
+        username: config.username,
+        password: config.password,
+        request_timeout: config.requestTimeoutMs,
+        keep_alive: { enabled: true },
+        clickhouse_settings: {
+          // Mirror the collector's durability: commit to a quorum of replicas before
+          // the insert resolves, and keep inserts synchronous (no server-side buffering).
+          insert_quorum: String(config.insertQuorum),
+          insert_quorum_timeout: config.insertQuorumTimeoutMs,
+          async_insert: 0,
+          wait_for_async_insert: 1,
+        },
+      });
+      this.client = {
+        insert: async ({ table, values, format }) => {
+          await clickhouse.insert({ table, values: values as OtelLogRow[], format });
+        },
+        close: () => clickhouse.close(),
+      };
+    }
   }
 
   async insert(table: IngestTable, rows: OtelLogRow[] | OtelTraceRow[]): Promise<void> {
     if (rows.length === 0) return;
-    // Both row shapes are plain JSON objects; the client just serializes JSONEachRow.
-    await this.client.insert({ table, values: rows as OtelLogRow[], format: "JSONEachRow" });
+    if (this.closed) throw new Error("ClickHouse ingest writer is closed");
+
+    return new Promise<void>((resolve, reject) => {
+      const batch = this.batches[table];
+      batch.pending.push({ rows: rows as IngestRow[], resolve, reject });
+      if (!batch.timer) {
+        batch.timer = setTimeout(() => this.flush(table), this.batchLingerMs);
+      }
+    });
+  }
+
+  private flush(table: IngestTable): void {
+    const batch = this.batches[table];
+    if (batch.timer) clearTimeout(batch.timer);
+    batch.timer = undefined;
+    if (batch.pending.length === 0) return;
+
+    const pending = batch.pending.splice(0);
+    const rows = pending.flatMap((item) => item.rows);
+    batch.tail = batch.tail
+      .then(async () => {
+        try {
+          // Resolve every included queue delivery only after the shared insert is
+          // synchronously committed to the configured replica quorum.
+          await this.client.insert({ table, values: rows, format: "JSONEachRow" });
+          for (const item of pending) item.resolve();
+        } catch (error) {
+          for (const item of pending) item.reject(error);
+        }
+      })
+      .catch(() => {
+        // Every insert error is delivered to its pending callers above. Keep the
+        // per-table chain usable so a later SQS redelivery can succeed.
+      });
   }
 
   async close(): Promise<void> {
+    this.closed = true;
+    this.flush("otel_logs");
+    this.flush("otel_traces");
+    await Promise.all(Object.values(this.batches).map((batch) => batch.tail));
     await this.client.close();
   }
 }

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -82,7 +82,7 @@ const FIREHOSE_LOGS_COLLECTOR_URL =
 const PORT = Number(process.env.PORT ?? 4000);
 const ingestQueueConfig = getIngestQueueConfig(process.env);
 // When INGEST_CLICKHOUSE_DIRECT=true, the consumer writes logs/traces straight to
-// ClickHouse (parallel synchronous quorum inserts, acked on success) instead of
+// ClickHouse (briefly batched synchronous quorum inserts, acked on success) instead of
 // forwarding every message through the collector. Metrics and undecodable bodies
 // still fall through to the collector. Disabled (null) otherwise.
 const ingestClickHouseConfig = getIngestClickHouseConfig(process.env);


### PR DESCRIPTION
## Summary

- combine concurrent direct-ingest deliveries into a short per-table batch
- serialize synchronous ClickHouse inserts per table and process while retaining replica-quorum durability
- resolve or reject every included delivery only after the shared insert completes, so queue acknowledgements remain safe
- keep the writer usable after an insert failure for later redelivery

This bounds ClickHouse insert concurrency and avoids creating one small part per concurrent queue message.

## Validation

- `pnpm --filter @superlog/proxy test` (137 passed)
- `pnpm --filter @superlog/proxy typecheck`
- `pnpm exec biome check apps/proxy/src/clickhouse-writer.ts apps/proxy/src/clickhouse-writer.test.ts apps/proxy/src/index.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batches concurrent direct ClickHouse ingest writes per table so queue concurrency no longer turns every message into a separate small ClickHouse part.

- Combines concurrent deliveries for a table into one synchronous insert within a short window.
- Preserves the existing `insert_quorum` durability guarantee; each delivery resolves only after the shared insert commits.
- A failed insert rejects all deliveries in that batch and leaves the writer usable for SQS redelivery.
- Adds `INGEST_CLICKHOUSE_BATCH_LINGER_MS` (default 10 ms) to tune the trade-off between insert concurrency and added latency.
- Adds tests covering shared-insert batching and failure recovery.

<sup>Written for commit 6ac49bf0e8693429034547f135b29402b62d7b10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

