### PR TITLE
Coalesce pending direct ingest batches

### DIFF
--- a/apps/proxy/src/clickhouse-writer.test.ts
+++ b/apps/proxy/src/clickhouse-writer.test.ts
@@ -60,6 +60,41 @@ test("concurrent trace deliveries share one durable ClickHouse insert", async ()
   await writer.close();
 });
 
+test("deliveries arriving during an insert coalesce into one following insert", async () => {
+  let finishFirstInsert: (() => void) | undefined;
+  const firstInsertFinished = new Promise<void>((resolve) => {
+    finishFirstInsert = resolve;
+  });
+  const inserts: OtelTraceRow[][] = [];
+  const client: ClickHouseInsertClient = {
+    async insert(input) {
+      inserts.push(input.values as OtelTraceRow[]);
+      if (inserts.length === 1) await firstInsertFinished;
+    },
+    async close() {},
+  };
+  const writer = new ClickHouseIngestWriter(config, client);
+
+  const first = writer.insert("otel_traces", [traceRow("trace-1")]);
+  await delay(20);
+  assert.equal(inserts.length, 1);
+
+  const second = writer.insert("otel_traces", [traceRow("trace-2")]);
+  await delay(20);
+  const third = writer.insert("otel_traces", [traceRow("trace-3")]);
+  await delay(20);
+
+  finishFirstInsert?.();
+  await Promise.all([first, second, third]);
+
+  assert.equal(inserts.length, 2);
+  assert.deepEqual(
+    inserts[1]?.map((row) => row.TraceId),
+    ["trace-2", "trace-3"],
+  );
+  await writer.close();
+});
+
 test("a failed shared insert rejects every delivery and a later batch can recover", async () => {
   let attempts = 0;
   const client: ClickHouseInsertClient = {

--- a/apps/proxy/src/clickhouse-writer.ts
+++ b/apps/proxy/src/clickhouse-writer.ts
@@ -6,9 +6,9 @@ import type { OtelLogRow, OtelTraceRow } from "./otlp-clickhouse.js";
 // rows, combines concurrent deliveries briefly per table, then INSERTs each batch
 // synchronously with insert_quorum. Every caller waits for the shared insert, so an
 // SQS message is only deleted once its rows are durably committed (the consume loop
-// deletes on success, leaves on throw). Per-table promise chains cap each task at one
-// trace and one log insert at a time instead of turning queue concurrency into a
-// ClickHouse small-part storm.
+// deletes on success, leaves on throw). Each table has at most one active insert; all
+// deliveries received while it runs become one following insert. This keeps concurrent
+// queue work from becoming a chain of tiny ClickHouse inserts.
 //
 // Durability note: quorum is preserved (default 2), and async_insert stays OFF, so a
 // successful insert means the rows are committed to a quorum of replicas before we ack.
@@ -72,15 +72,15 @@ type PendingInsert = {
 type TableBatch = {
   pending: PendingInsert[];
   timer: NodeJS.Timeout | undefined;
-  tail: Promise<void>;
+  running: Promise<void> | undefined;
 };
 
 export class ClickHouseIngestWriter implements IngestRowWriter {
   private readonly client: ClickHouseInsertClient;
   private readonly batchLingerMs: number;
   private readonly batches: Record<IngestTable, TableBatch> = {
-    otel_logs: { pending: [], timer: undefined, tail: Promise.resolve() },
-    otel_traces: { pending: [], timer: undefined, tail: Promise.resolve() },
+    otel_logs: { pending: [], timer: undefined, running: undefined },
+    otel_traces: { pending: [], timer: undefined, running: undefined },
   };
   private closed = false;
 
@@ -121,7 +121,7 @@ export class ClickHouseIngestWriter implements IngestRowWriter {
     return new Promise<void>((resolve, reject) => {
       const batch = this.batches[table];
       batch.pending.push({ rows: rows as IngestRow[], resolve, reject });
-      if (!batch.timer) {
+      if (!batch.running && !batch.timer) {
         batch.timer = setTimeout(() => this.flush(table), this.batchLingerMs);
       }
     });
@@ -131,32 +131,38 @@ export class ClickHouseIngestWriter implements IngestRowWriter {
     const batch = this.batches[table];
     if (batch.timer) clearTimeout(batch.timer);
     batch.timer = undefined;
-    if (batch.pending.length === 0) return;
+    if (batch.running || batch.pending.length === 0) return;
 
     const pending = batch.pending.splice(0);
     const rows = pending.flatMap((item) => item.rows);
-    batch.tail = batch.tail
-      .then(async () => {
-        try {
-          // Resolve every included queue delivery only after the shared insert is
-          // synchronously committed to the configured replica quorum.
-          await this.client.insert({ table, values: rows, format: "JSONEachRow" });
-          for (const item of pending) item.resolve();
-        } catch (error) {
-          for (const item of pending) item.reject(error);
-        }
-      })
-      .catch(() => {
-        // Every insert error is delivered to its pending callers above. Keep the
-        // per-table chain usable so a later SQS redelivery can succeed.
-      });
+    batch.running = (async () => {
+      try {
+        // Resolve every included queue delivery only after the shared insert is
+        // synchronously committed to the configured replica quorum.
+        await this.client.insert({ table, values: rows, format: "JSONEachRow" });
+        for (const item of pending) item.resolve();
+      } catch (error) {
+        for (const item of pending) item.reject(error);
+      }
+    })().finally(() => {
+      batch.running = undefined;
+      if (batch.pending.length > 0) {
+        // Anything received while ClickHouse was busy has already lingered. Drain
+        // all of it as one next insert instead of building a queue of tiny batches.
+        this.flush(table);
+      }
+    });
   }
 
   async close(): Promise<void> {
     this.closed = true;
     this.flush("otel_logs");
     this.flush("otel_traces");
-    await Promise.all(Object.values(this.batches).map((batch) => batch.tail));
+    await Promise.all(
+      Object.values(this.batches).map(async (batch) => {
+        while (batch.running) await batch.running;
+      }),
+    );
     await this.client.close();
   }
 }


### PR DESCRIPTION
## Summary

- keep at most one active direct ClickHouse insert per telemetry table
- merge every delivery received during that insert into one following batch
- preserve per-delivery durable completion and failure propagation

## Why

A timer could previously append multiple small batches behind a slow synchronous insert. Under sustained queue concurrency, that made the pending insert chain grow faster than it drained. Coalescing all waiting deliveries into the next insert bounds the client-side backlog and increases useful rows per write.

## Validation

- `pnpm --filter @superlog/proxy test` (138 passing)
- `pnpm --filter @superlog/proxy typecheck`
- `pnpm exec biome check apps/proxy/src/clickhouse-writer.ts apps/proxy/src/clickhouse-writer.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesces pending direct ingest inserts per telemetry table so deliveries arriving during a slow insert wait as one batch instead of forming a chain of tiny inserts. Per-delivery completion and failures are unchanged.

**What changed**
- Replaced the per-table promise chain with a single running insert pointer.
- All deliveries received while an insert is active are drained into one next insert.
- Callers still resolve only after quorum commit, and insert errors reject every delivery in that batch.

<sup>Written for commit 6abe2c5893da6e6150f059e4fea2968df0145bc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

