### PR TITLE
fix(db): resolve DATABASE_URL from packages/db/.env for self-hosting

### DIFF
--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -6,11 +6,15 @@ import { defineConfig } from "drizzle-kit";
 //   1. process.env (explicit caller override always wins)
 //   2. <repo-root>/tmp/worktree.json (written by worktree-bootstrap.sh)
 //   3. <repo-root>/apps/api/.env.local (port-offset shared mode)
+//   4. packages/db/.env (self-host path — copy .env.example here)
 //
-// Without this, `pnpm --filter @superlog/db db:migrate` run by hand from a
-// worktree fails with "Please provide required params for Postgres driver:
-// url: ''". The bootstrap script inlines DATABASE_URL when it runs migrate
-// itself, so historically only manual reruns hit this.
+// The worktree sources must stay ahead of the self-host fallback so a worktree
+// that also has a packages/db/.env keeps targeting its own database. Without
+// any of these, `pnpm --filter @superlog/db db:migrate` — e.g. during
+// self-hosting per docs.superlog.sh/self-hosting after `docker compose up -d` —
+// fails with "Please provide required params for Postgres driver: url: ''".
+// The self-host instructions create Postgres on port 5434, so pull the URL from
+// this package's local .env file when no other source is available.
 function findRepoRoot(start: string): string {
   let dir = start;
   while (dir !== "/") {
@@ -20,12 +24,25 @@ function findRepoRoot(start: string): string {
   return start;
 }
 
+const ROOT = findRepoRoot(resolve(process.cwd()));
+
+// Safely parse a DATABASE_URL= line from an env-style file: tolerate
+// whitespace around "=", strip surrounding single/double quotes, and drop
+// any trailing inline comment.
+function readDatabaseUrlFromEnvFile(path: string): string | undefined {
+  if (!existsSync(path)) return undefined;
+  const m = readFileSync(path, "utf8").match(/^\s*DATABASE_URL\s*=\s*(.*)$/m);
+  if (!m) return undefined;
+  const v = m[1].trim().split(/\s+#/)[0].replace(/^['"]|['"]$/g, "").trim();
+  return v || undefined;
+}
+
+const DB_PACKAGE_ENV = join(ROOT, "packages", "db", ".env");
+
 function readDatabaseUrl(): string {
   if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
 
-  const root = findRepoRoot(resolve(process.cwd()));
-
-  const summary = join(root, "tmp", "worktree.json");
+  const summary = join(ROOT, "tmp", "worktree.json");
   if (existsSync(summary)) {
     try {
       const j = JSON.parse(readFileSync(summary, "utf8"));
@@ -35,11 +52,11 @@ function readDatabaseUrl(): string {
     }
   }
 
-  const envLocal = join(root, "apps", "api", ".env.local");
-  if (existsSync(envLocal)) {
-    const m = readFileSync(envLocal, "utf8").match(/^DATABASE_URL=(.+)$/m);
-    if (m) return m[1].trim();
-  }
+  const envLocal = readDatabaseUrlFromEnvFile(join(ROOT, "apps", "api", ".env.local"));
+  if (envLocal) return envLocal;
+
+  const selfHost = readDatabaseUrlFromEnvFile(DB_PACKAGE_ENV);
+  if (selfHost) return selfHost;
 
   return "";
 }


### PR DESCRIPTION
## What

Fixes self-host database migrations failing with:

```
Error  Please provide required params for Postgres driver:
    [x] url: ''
```

following the [self-hosting docs](https://docs.superlog.sh/self-hosting) flow (`docker compose up -d`, then `pnpm --filter @superlog/db db:migrate`).

## Why

`packages/db/drizzle.config.ts` resolved `DATABASE_URL` from three sources only:
1. `process.env`
2. `<repo-root>/tmp/worktree.json` (worktree bootstrap helper)
3. `<repo-root>/apps/api/.env.local` (worktree dev shared-mode)

None of these exist in a plain self-hosted checkout, so `readDatabaseUrl()` returned an empty string and drizzle-kit errored out.

## Fix

Added `packages/db/.env` as a final fallback source: the package already ships a `.env.example` whose `DATABASE_URL` points exactly at the compose-managed Postgres on port 5434, but the config never read it. The env files are parsed with a shared `readDatabaseUrlFromEnvFile()` helper that tolerates whitespace around `=`, strips surrounding single/double quotes and trailing inline comments, and the config path is resolved from the repo root so it works regardless of cwd.

Self-hosters now just need:

```bash
cp packages/db/.env.example packages/db/.env
pnpm --filter @superlog/db db:migrate
```

`.env` is gitignored, so this is safe and matches the normal env-file pattern used across the repo.

## Precedence

`DATABASE_URL` is now resolved in this order:

1. `process.env` (explicit caller override always wins)
2. `<repo-root>/tmp/worktree.json` (worktree bootstrap)
3. `<repo-root>/apps/api/.env.local` (worktree port-offset shared mode)
4. `packages/db/.env` (self-host fallback)

The worktree sources stay ahead of the self-host fallback so a worktree that also has a `packages/db/.env` keeps targeting its own database.

## Verification

- Reproduced the original `url: ''` failure on a fresh checkout.
- With `packages/db/.env` present (compose Postgres up), `pnpm --filter @superlog/db db:migrate` completes: `migrations applied successfully!`
- Edge-case env parsing (plain / quoted / single-quoted / inline-comment / whitespace / empty) verified.
- `drizzle.config.ts` typechecks (`tsc --noEmit`).

## Docs

Adds the matching setup step to the self-hosting guide in [superloglabs/mintlify-docs#2](https://github.com/superloglabs/mintlify-docs/pull/2).
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes self-host database migrations failing with `url: ''` by reading `DATABASE_URL` from `packages/db/.env` when no other source is set. Self-hosters must copy `packages/db/.env.example` to `packages/db/.env` before running `pnpm --filter @superlog/db db:migrate`; `.env` is gitignored.

<sup>Written for commit 5a61bf5b12d712e5ba5a7400f8b131dbadaf7fbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


