### PR TITLE
Increase HTTP accept backlog for bursty ingest

### DIFF
--- a/apps/proxy/src/http-server.test.ts
+++ b/apps/proxy/src/http-server.test.ts
@@ -2,7 +2,23 @@ import assert from "node:assert/strict";
 import { once } from "node:events";
 import { Agent, createServer, request } from "node:http";
 import test from "node:test";
-import { configureHttpServerTimeouts } from "./http-server.js";
+import { configureHttpServerTimeouts, serverBacklog } from "./http-server.js";
+
+test("the HTTP listener uses a burst-sized accept backlog by default", () => {
+  assert.equal(serverBacklog({}), 4096);
+  assert.equal(serverBacklog({ HTTP_SERVER_BACKLOG: "8192" }), 8192);
+});
+
+test("an invalid listener backlog is rejected instead of silently disabling backpressure", () => {
+  assert.throws(
+    () => serverBacklog({ HTTP_SERVER_BACKLOG: "0" }),
+    /HTTP_SERVER_BACKLOG must be a positive integer/,
+  );
+  assert.throws(
+    () => serverBacklog({ HTTP_SERVER_BACKLOG: "not-a-number" }),
+    /HTTP_SERVER_BACKLOG must be a positive integer/,
+  );
+});
 
 function getConnectionId(port: number, agent: Agent): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/apps/proxy/src/http-server.ts
+++ b/apps/proxy/src/http-server.ts
@@ -1,12 +1,28 @@
 import type { Server } from "node:http";
 
 const DEFAULT_KEEP_ALIVE_TIMEOUT_MS = 75_000;
+const DEFAULT_SERVER_BACKLOG = 4096;
 const HEADERS_TIMEOUT_MARGIN_MS = 1_000;
 const MAX_KEEP_ALIVE_TIMEOUT_MS = 2_147_483_647 - HEADERS_TIMEOUT_MARGIN_MS;
 
 type HttpServerTimeoutEnvironment = {
   HTTP_KEEP_ALIVE_TIMEOUT_MS?: string;
 };
+
+type HttpServerBacklogEnvironment = {
+  HTTP_SERVER_BACKLOG?: string;
+};
+
+export function serverBacklog(env: HttpServerBacklogEnvironment = process.env): number {
+  const raw = env.HTTP_SERVER_BACKLOG;
+  if (raw === undefined) return DEFAULT_SERVER_BACKLOG;
+
+  const value = Number(raw);
+  if (!/^[1-9]\d*$/.test(raw) || !Number.isSafeInteger(value)) {
+    throw new Error("HTTP_SERVER_BACKLOG must be a positive integer");
+  }
+  return value;
+}
 
 function keepAliveTimeoutMs(env: HttpServerTimeoutEnvironment): number {
   const raw = env.HTTP_KEEP_ALIVE_TIMEOUT_MS;

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -1,6 +1,6 @@
 import "./env.js";
 import { Readable } from "node:stream";
-import { serve } from "@hono/node-server";
+import { createAdaptorServer } from "@hono/node-server";
 import { type Span, SpanStatusCode, metrics, trace } from "@opentelemetry/api";
 import {
   captureServerEvent,
@@ -37,7 +37,7 @@ import {
   transformGcpPubSubLog,
 } from "./gcp-pubsub.js";
 import { mountGcpMetricsPullRoute } from "./gcp-pull-routes.js";
-import { configureHttpServerTimeouts } from "./http-server.js";
+import { configureHttpServerTimeouts, serverBacklog } from "./http-server.js";
 import { stampIssueFingerprintsFailOpen } from "./ingest-fingerprints.js";
 import { createIngestKeyCache, createLastUsedRecorder } from "./ingest-key-auth.js";
 import { IngestQueue, getIngestQueueConfig } from "./ingest-queue.js";
@@ -1141,7 +1141,12 @@ async function forwardFirehose(
   });
 }
 
-const server = serve({ fetch: app.fetch, port: PORT });
+const backlog = serverBacklog();
+const server = createAdaptorServer({ fetch: app.fetch });
+// Pub/Sub and other push integrations can open thousands of connections in a
+// short burst. Queue accepted sockets in the kernel until Node can read them;
+// the platform queue remains the durable backpressure boundary after that.
+server.listen({ port: PORT, backlog });
 // Keep the backend timeout configurable independently from any upstream load
 // balancer. Setting HTTP_KEEP_ALIVE_TIMEOUT_MS=0 leaves idle-connection closure
 // to the upstream, preventing it from reusing a socket while Node closes it.
@@ -1229,6 +1234,7 @@ if (renderSyslogServer) {
 logger.info(
   {
     port: PORT,
+    backlog,
     collector: COLLECTOR_URL,
     ingestQueueEnabled: Boolean(ingestQueue),
     ingestQueueConsumerEnabled: Boolean(ingestQueue && ingestQueueConfig?.consumerEnabled),


### PR DESCRIPTION
## Summary
- configure the Node HTTP listener with a burst-sized accept backlog
- make the backlog configurable and validate it
- cover the default and invalid values with unit tests

This keeps short connection bursts queued in the kernel until the application can accept them, while the existing ingestion queue remains the durable backpressure boundary.

## Tests
- pnpm --dir apps/proxy test -- --test-name-pattern="listener|backlog"
- pnpm --dir apps/proxy typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configures the Node HTTP listener with a burst-sized accept backlog so push integrations can open thousands of connections in a short burst without losing them. Previously the listener used the default backlog; now it defaults to 4096 and can be set via `HTTP_SERVER_BACKLOG`. Invalid values throw at startup instead of silently disabling backpressure.

<sup>Written for commit 6f044f1e0229ecca7c80d2442b68119a5d235938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

