### PR TITLE
Support telemetry hostname during web migration

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -19,6 +19,7 @@ import {
 } from "./email.js";
 import { readSignupAttributionFromCookieHeader } from "./signup-click-ids.js";
 import { enqueueUserCreated } from "./user-created-publisher.js";
+import { configuredWebOrigins } from "./web-origins.js";
 
 // Better Auth server config. Mounted at /api/auth/* by apps/api/src/index.ts.
 //
@@ -33,6 +34,7 @@ import { enqueueUserCreated } from "./user-created-publisher.js";
 // UUIDs for new rows so foreign keys to our existing uuid columns line up.
 
 const WEB_ORIGIN = process.env.WEB_ORIGIN ?? "http://localhost:5173";
+const WEB_ORIGINS = configuredWebOrigins();
 const API_ORIGIN = process.env.BETTER_AUTH_URL ?? "http://localhost:4100";
 
 // Derive the parent domain that web and api share so the OAuth state cookie
@@ -149,7 +151,7 @@ async function mirrorLastUsedOrg(userId: string, activeOrgId: string): Promise<v
 export const auth = betterAuth({
   baseURL: API_ORIGIN,
   secret: BETTER_AUTH_SECRET,
-  trustedOrigins: [WEB_ORIGIN],
+  trustedOrigins: WEB_ORIGINS,
   database: drizzleAdapter(db, {
     provider: "pg",
     schema: {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -181,13 +181,12 @@ import { symbolicateIssueSample, symbolicateTelemetrySample } from "./symbolicat
 import { buildSystemCapabilities } from "./system-capabilities.js";
 import { mountTopology } from "./topology.js";
 import { mountVercelAuthed, mountVercelPublic } from "./vercel.js";
+import { configuredWebOrigins } from "./web-origins.js";
 import { mountWebhooks } from "./webhooks.js";
 
 const PORT = Number(process.env.PORT ?? 4100);
 const WEB_ORIGIN = process.env.WEB_ORIGIN ?? "http://localhost:5173";
-const WEB_CORS_ORIGINS = Array.from(
-  new Set([WEB_ORIGIN, "http://localhost:5173", "http://127.0.0.1:5173"]),
-);
+const WEB_CORS_ORIGINS = configuredWebOrigins();
 
 const ch = createApiClickHouseClient();
 

--- a/apps/api/src/web-origins.test.ts
+++ b/apps/api/src/web-origins.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { configuredWebOrigins } from "./web-origins.js";
+
+test("configured web origins include the canonical origin and valid aliases", () => {
+  assert.deepEqual(
+    configuredWebOrigins({
+      WEB_ORIGIN: "https://telemetry.superlog.sh",
+      WEB_ORIGIN_ALIASES: "https://superlog.sh, https://telemetry.superlog.sh",
+    }),
+    [
+      "https://telemetry.superlog.sh",
+      "https://superlog.sh",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ],
+  );
+});
+
+test("configured web origins ignore malformed aliases", () => {
+  assert.deepEqual(
+    configuredWebOrigins({
+      WEB_ORIGIN: "https://telemetry.superlog.sh",
+      WEB_ORIGIN_ALIASES: "https://superlog.sh, javascript:alert(1), /relative",
+    }),
+    [
+      "https://telemetry.superlog.sh",
+      "https://superlog.sh",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ],
+  );
+});

--- a/apps/api/src/web-origins.ts
+++ b/apps/api/src/web-origins.ts
@@ -1,0 +1,33 @@
+type WebOriginEnv = {
+  WEB_ORIGIN?: string;
+  WEB_ORIGIN_ALIASES?: string;
+};
+
+function validOrigin(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (
+      url.protocol !== "https:" &&
+      url.hostname !== "localhost" &&
+      !url.hostname.endsWith(".localhost")
+    ) {
+      return null;
+    }
+    if (url.username || url.password || url.pathname !== "/" || url.search || url.hash) return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function configuredWebOrigins(env: WebOriginEnv = process.env): string[] {
+  const canonical =
+    validOrigin(env.WEB_ORIGIN ?? "http://localhost:5173") ?? "http://localhost:5173";
+  const aliases = (env.WEB_ORIGIN_ALIASES ?? "")
+    .split(",")
+    .map((value) => validOrigin(value.trim()))
+    .filter((value): value is string => value !== null);
+  return Array.from(
+    new Set([canonical, ...aliases, "http://localhost:5173", "http://127.0.0.1:5173"]),
+  );
+}

--- a/apps/web/scripts/prerender-output.test.ts
+++ b/apps/web/scripts/prerender-output.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { readFile, readdir } from "node:fs/promises";
 import test from "node:test";
 
+const SITE_ORIGIN = process.env.SITE_ORIGIN ?? "https://telemetry.superlog.sh";
+
 const distUrl = new URL("../dist/", import.meta.url);
 const publicUrl = new URL("../public/", import.meta.url);
 
@@ -21,7 +23,12 @@ test("the production homepage contains useful HTML before JavaScript runs", asyn
   assert.match(html, /<meta property="og:type" content="website"/);
   assert.match(html, /<meta property="og:title" content="Superlog \| Fix bugs on autopilot"/);
   assert.match(html, /<meta name="twitter:card" content="summary_large_image"/);
-  assert.match(html, /<meta property="og:image" content="https:\/\/superlog\.sh\/og-image\.png"/);
+  assert.match(
+    html,
+    new RegExp(
+      `<meta property="og:image" content="${SITE_ORIGIN.replaceAll(".", "\\.")}\\/og-image\\.png"`,
+    ),
+  );
   assert.match(html, /<meta property="og:image:type" content="image\/png"/);
   assert.match(html, /<meta property="og:image:width" content="1200"/);
   assert.match(html, /<meta property="og:image:height" content="630"/);
@@ -48,8 +55,8 @@ test("the homepage identifies the website and its publisher as the same organiza
   const organization = data["@graph"].find((entry) => entry["@type"] === "Organization");
   const website = data["@graph"].find((entry) => entry["@type"] === "WebSite");
 
-  assert.equal(organization?.["@id"], "https://superlog.sh/#organization");
-  assert.deepEqual(website?.publisher, { "@id": "https://superlog.sh/#organization" });
+  assert.equal(organization?.["@id"], `${SITE_ORIGIN}/#organization`);
+  assert.deepEqual(website?.publisher, { "@id": `${SITE_ORIGIN}/#organization` });
 });
 
 test("each public route has its own crawlable document and metadata", async () => {
@@ -58,7 +65,10 @@ test("each public route has its own crawlable document and metadata", async () =
   assert.match(html, /<h1[^>]*>Pricing<\/h1>/);
   assert.match(html, /<title>Pricing \| Superlog<\/title>/);
   assert.match(html, /<meta name="description" content="[^"]+"/);
-  assert.match(html, /<link rel="canonical" href="https:\/\/superlog\.sh\/pricing"/);
+  assert.match(
+    html,
+    new RegExp(`<link rel="canonical" href="${SITE_ORIGIN.replaceAll(".", "\\.")}\\/pricing"`),
+  );
 });
 
 test("the blog index and every published post are prerendered", async () => {
@@ -75,7 +85,7 @@ test("the blog index and every published post are prerendered", async () => {
     assert.match(html, /<article|<h1/);
     assert.match(
       html,
-      new RegExp(`<link rel="canonical" href="https://superlog\\.sh/blog/${slug}"`),
+      new RegExp(`<link rel="canonical" href="${SITE_ORIGIN.replaceAll(".", "\\.")}/blog/${slug}"`),
     );
     assert.match(html, /<meta property="og:type" content="article"/);
     assert.match(html, /<meta property="article:modified_time" content="\d{4}-\d{2}-\d{2}"/);
@@ -95,16 +105,16 @@ test("published articles describe their image, author, freshness, and breadcrumb
   const article = data["@graph"].find((entry) => entry["@type"] === "BlogPosting");
   const breadcrumbs = data["@graph"].find((entry) => entry["@type"] === "BreadcrumbList");
 
-  assert.equal(article?.image, "https://superlog.sh/og-image.png");
+  assert.equal(article?.image, `${SITE_ORIGIN}/og-image.png`);
   assert.equal(article?.dateModified, "2026-07-10");
   assert.deepEqual(article?.author, {
     "@type": "Person",
     name: "Arseniy",
-    url: "https://superlog.sh/team",
+    url: `${SITE_ORIGIN}/team`,
   });
   assert.equal(
     (article?.publisher as { logo?: { url?: string } } | undefined)?.logo?.url,
-    "https://superlog.sh/web-app-manifest-512x512.png",
+    `${SITE_ORIGIN}/web-app-manifest-512x512.png`,
   );
   assert.ok(breadcrumbs);
 });
@@ -115,7 +125,10 @@ test("every public content route ships as an indexable static document", async (
   for (const route of routes) {
     const html = await readFile(new URL(`${route}/index.html`, distUrl), "utf8");
     assert.doesNotMatch(html, /<div id="root"><\/div>/);
-    assert.match(html, new RegExp(`<link rel="canonical" href="https://superlog\\.sh/${route}"`));
+    assert.match(
+      html,
+      new RegExp(`<link rel="canonical" href="${SITE_ORIGIN.replaceAll(".", "\\.")}/${route}"`),
+    );
     assert.match(html, /<meta name="description" content="[^"]+"/);
   }
 });
@@ -141,19 +154,31 @@ test("crawlers receive a sitemap of public pages and no product URLs", async () 
   const sitemap = await readFile(new URL("sitemap.xml", distUrl), "utf8");
   const robots = await readFile(new URL("robots.txt", distUrl), "utf8");
 
-  assert.match(sitemap, /<loc>https:\/\/superlog\.sh<\/loc>/);
-  assert.match(sitemap, /<loc>https:\/\/superlog\.sh<\/loc><lastmod>2026-07-28<\/lastmod>/);
-  assert.match(sitemap, /<loc>https:\/\/superlog\.sh\/pricing<\/loc>/);
-  assert.match(sitemap, /<loc>https:\/\/superlog\.sh\/blog\//);
+  assert.match(sitemap, new RegExp(`<loc>${SITE_ORIGIN.replaceAll(".", "\\.")}<\\/loc>`));
+  assert.match(
+    sitemap,
+    new RegExp(`<loc>${SITE_ORIGIN.replaceAll(".", "\\.")}<\\/loc><lastmod>2026-07-28<\\/lastmod>`),
+  );
+  assert.match(sitemap, new RegExp(`<loc>${SITE_ORIGIN.replaceAll(".", "\\.")}\\/pricing<\\/loc>`));
+  assert.match(sitemap, new RegExp(`<loc>${SITE_ORIGIN.replaceAll(".", "\\.")}\\/blog\\/`));
   assert.doesNotMatch(sitemap, /\/app(?:\/|<)/);
-  assert.match(robots, /Sitemap: https:\/\/superlog\.sh\/sitemap\.xml/);
+  assert.match(
+    robots,
+    new RegExp(`Sitemap: ${SITE_ORIGIN.replaceAll(".", "\\.")}\\/sitemap\\.xml`),
+  );
 });
 
 test("AI readers receive a concise index of public pages and full documentation", async () => {
   const llms = await readFile(new URL("llms.txt", distUrl), "utf8");
 
   assert.match(llms, /^# Superlog$/m);
-  assert.match(llms, /\[Pricing\]\(https:\/\/superlog\.sh\/pricing\)/);
+  assert.match(
+    llms,
+    new RegExp(`\\[Pricing\\]\\(${SITE_ORIGIN.replaceAll(".", "\\.")}\\/pricing\\)`),
+  );
   assert.match(llms, /https:\/\/docs\.superlog\.sh\/llms\.txt/);
-  assert.doesNotMatch(llms, /https:\/\/superlog\.sh\/app(?:\/|\s|\))/);
+  assert.doesNotMatch(
+    llms,
+    new RegExp(`${SITE_ORIGIN.replaceAll(".", "\\.")}\\/app(?:\\/|\\s|\\))`),
+  );
 });

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -114,7 +114,7 @@ function CopyPromptCard({ prompt }: { prompt: string }) {
 // ---------------------------------------------------------------------------
 
 const NAV_LINKS: { href: string; label: string; external?: boolean }[] = [
-  { href: "https://responder.superlog.sh", label: "Responder", external: true },
+  { href: "https://superlog.sh", label: "Superlog", external: true },
   { href: LANDING_DOCS_URL, label: "Docs", external: true },
   { href: "/blog", label: "Blog" },
   { href: "/changelog", label: "Changelog" },

--- a/apps/web/src/content/PublicShell.tsx
+++ b/apps/web/src/content/PublicShell.tsx
@@ -7,7 +7,7 @@ import { LANDING_GITHUB_REPO_URL } from "../landingLinks.ts";
 // pages feel part of the marketing surface.
 
 const NAV_LINKS: Array<{ href: string; label: string; external?: boolean }> = [
-  { href: "https://responder.superlog.sh", label: "Responder", external: true },
+  { href: "https://superlog.sh", label: "Superlog", external: true },
   { href: "/blog", label: "Blog" },
   { href: "/changelog", label: "Changelog" },
   { href: "/roadmap", label: "Roadmap" },

--- a/apps/web/src/prerender/entry.tsx
+++ b/apps/web/src/prerender/entry.tsx
@@ -16,7 +16,10 @@ type PublicPage = {
   structuredData?: Record<string, unknown>;
 };
 
-const SITE_ORIGIN = "https://superlog.sh";
+// The legacy product is served from telemetry.superlog.sh after the public
+// marketing/app cutover. Keep this configurable so a rollback build can still
+// be rendered for the former apex without changing application code.
+const SITE_ORIGIN = process.env.SITE_ORIGIN ?? "https://telemetry.superlog.sh";
 const SITE_CONTENT_LAST_MODIFIED = "2026-07-22";
 const HOME_PAGE_LAST_MODIFIED = "2026-07-28";
 const SOCIAL_IMAGE_ALT = "Superlog wordmark over a blue and violet abstract background";


### PR DESCRIPTION
## Summary
- accept configured web origin aliases for CORS and Better Auth trusted origins
- build and prerender the web app with telemetry.superlog.sh as its canonical origin
- update public navigation links and branding references that should point to Superlog

## Validation
- focused API web-origin tests
- API typecheck
- SITE_ORIGIN=https://telemetry.superlog.sh pnpm --filter @superlog/web build

This change keeps api.superlog.sh and intake.superlog.sh stable for provider callbacks and telemetry ingest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Supports migrating the web app to `telemetry.superlog.sh` by letting the API trust additional web origins and prerendering public pages with the new hostname as canonical, while `api.superlog.sh` and `intake.superlog.sh` stay unchanged.

**Changes**
- API reads a new `WEB_ORIGIN_ALIASES` env var and adds valid origins to CORS and Better Auth trusted origins; malformed values are ignored.
- Web prerender defaults the canonical origin to `https://telemetry.superlog.sh`, overridable with `SITE_ORIGIN` for rollback builds.
- Landing and public shell navigation links now point to `superlog.sh` instead of `responder.superlog.sh`.

No onboarding steps; set the env vars only when non-default origins are needed.

<sup>Written for commit f9b1d8c2b5c652eaa091eae14780b14427d515dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/superlog/pull/492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

