### PR TITLE
Add the DPA, security policy, and subprocessors pages

### DIFF
--- a/apps/web/src/DataProcessingAgreement.tsx
+++ b/apps/web/src/DataProcessingAgreement.tsx
@@ -1,0 +1,313 @@
+import type { ReactNode } from "react";
+import { Wordmark } from "./design/ui.tsx";
+
+const COMMON_PAPER_DPA_URL = "https://commonpaper.com/standards/data-processing-agreement/1.1";
+const TOS_URL = "https://superlog.sh/tos";
+const SUBPROCESSORS_URL = "https://superlog.sh/subprocessors";
+const SECURITY_URL = "https://superlog.sh/security";
+const SECURITY_CONTACT_EMAIL = "legal@superlog.sh";
+
+export function DataProcessingAgreement() {
+  return (
+    <div className="min-h-screen bg-bg font-sans text-fg">
+      <header className="sticky top-0 z-40 border-b border-border bg-bg">
+        <div className="mx-auto flex w-full max-w-[980px] items-center justify-between px-4 py-5 md:px-8">
+          <a href="/" aria-label="Superlog home">
+            <Wordmark />
+          </a>
+          <a
+            href="/tos"
+            className="text-[12px] font-medium text-muted transition-colors hover:text-fg"
+          >
+            Terms
+          </a>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-[980px] px-4 py-14 md:px-8 md:py-20">
+        <article className="max-w-[780px]">
+          <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-subtle">
+            Last Updated: September 1, 2026
+          </p>
+          <h1
+            className="mt-5 text-[2.25rem] leading-tight tracking-tight text-fg md:text-[3.75rem]"
+            style={{ fontWeight: 450 }}
+          >
+            Pulsent Labs Inc. Data Processing Agreement
+          </h1>
+
+          <div className="mt-12 space-y-10 text-[15px] leading-7 text-muted md:text-[16px]">
+            <Section title="Using This DPA">
+              <p>
+                This DPA has 2 parts: (1) the Key Terms below and (2) the{" "}
+                <PageLink href={COMMON_PAPER_DPA_URL} external>
+                  Common Paper DPA Standard Terms Version 1.1
+                </PageLink>{" "}
+                ("DPA Standard Terms"), which are incorporated by reference. If there is any
+                inconsistency between the parts of the DPA, the Key Terms will control over the DPA
+                Standard Terms. Capitalized words have the meanings given in the Key Terms. However,
+                if the Key Terms omit or do not define a term used in the DPA Standard Terms, the
+                default meaning will be "none" or "not applicable" and the correlating clause,
+                sentence, or section does not apply to this DPA. All other capitalized words have the
+                meanings given in the DPA Standard Terms or the Agreement.
+              </p>
+              <p>
+                This DPA supplements the Agreement between Provider and Customer and is entered into
+                when Customer accepts the Agreement.
+              </p>
+            </Section>
+
+            <Section title="Key Terms">
+              <TermRow label="Agreement">
+                This DPA supplements the{" "}
+                <PageLink href={TOS_URL}>Superlog Terms of Service</PageLink> or, if Customer has
+                signed a separate agreement with Provider for the Service, that separate agreement.
+              </TermRow>
+              <TermRow label="Approved Subprocessors">
+                The subprocessors listed at{" "}
+                <PageLink href={SUBPROCESSORS_URL}>superlog.sh/subprocessors</PageLink>.
+              </TermRow>
+              <TermRow label="Provider Security Contact">
+                <PageLink href={`mailto:${SECURITY_CONTACT_EMAIL}`}>
+                  {SECURITY_CONTACT_EMAIL}
+                </PageLink>
+              </TermRow>
+              <TermRow label="Security Policy">
+                The security policy available at{" "}
+                <PageLink href={SECURITY_URL}>superlog.sh/security</PageLink>.
+              </TermRow>
+              <TermRow label="Service Provider Relationship">
+                To the extent California Consumer Privacy Act, Cal. Civ. Code § 1798.100 et seq
+                ("CCPA") applies, the parties acknowledge and agree that Provider is a service
+                provider and is receiving Personal Data from Customer to provide the Service as
+                agreed in the Agreement and detailed below (see Nature and Purpose of Processing),
+                which constitutes a limited and specified business purpose. Provider will not sell
+                or share any Personal Data provided by Customer under the Agreement. In addition,
+                Provider will not retain, use, or disclose any Personal Data provided by Customer
+                under the Agreement except as necessary for providing the Service for Customer, as
+                stated in the Agreement, or as permitted by Applicable Data Protection Laws.
+                Provider certifies that it understands the restrictions of this paragraph and will
+                comply with all Applicable Data Protection Laws. Provider will notify Customer if it
+                can no longer meet its obligations under the CCPA.
+              </TermRow>
+              <TermRow label="Governing Member State">
+                <div className="space-y-2">
+                  <p>EEA Transfers: Ireland</p>
+                  <p>UK Transfers: England and Wales</p>
+                </div>
+              </TermRow>
+            </Section>
+
+            <Section title="Annex I(A) — List of Parties">
+              <TermRow label="Data Exporter">
+                <div className="space-y-2">
+                  <p>Name: the Customer entering into this DPA</p>
+                  <p>Activities relevant to transfer: see Annex I(B)</p>
+                  <p>Role: Controller</p>
+                </div>
+              </TermRow>
+              <TermRow label="Data Importer">
+                <div className="space-y-2">
+                  <p>Name: Pulsent Labs Inc.</p>
+                  <p>
+                    Contact person: Nicolò Magnante, CEO,{" "}
+                    <PageLink href={`mailto:${SECURITY_CONTACT_EMAIL}`}>
+                      {SECURITY_CONTACT_EMAIL}
+                    </PageLink>
+                  </p>
+                  <p>
+                    Address: 1111B S Governors Ave # 88398, Dover, Delaware 19904, United States of
+                    America
+                  </p>
+                  <p>Activities relevant to transfer: see Annex I(B)</p>
+                  <p>Role: Processor</p>
+                </div>
+              </TermRow>
+            </Section>
+
+            <Section title="Annex I(B) — Description of Transfer and Processing Activities">
+              <TermRow label="Service">
+                Superlog, an AI-native observability platform that monitors Customer's applications
+                by ingesting logs, errors, and telemetry from connected integrations, and uses AI
+                agents to investigate issues and propose and apply bug fixes.
+              </TermRow>
+              <TermRow label="Categories of Data Subjects">
+                <List>
+                  <li>Customer's end users or customers</li>
+                  <li>Customer's employees</li>
+                </List>
+              </TermRow>
+              <TermRow label="Categories of Personal Data">
+                <List>
+                  <li>Name</li>
+                  <li>Contact information such as email, phone number, or address</li>
+                  <li>Transactional information such as account information or purchases</li>
+                  <li>User activity and analysis such as device information or IP address</li>
+                  <li>Location information</li>
+                </List>
+              </TermRow>
+              <TermRow label="Special Category Data">
+                Special category data (as defined in Article 9 of the GDPR) is not intended to be
+                Processed, and Customer should not submit it to the Service.
+              </TermRow>
+              <TermRow label="Frequency of Transfer">Continuous</TermRow>
+              <TermRow label="Nature and Purpose of Processing">
+                <div className="space-y-4">
+                  <p>
+                    Provider will Process Customer Personal Data as instructed in Section 2.3 of the
+                    DPA Standard Terms. The nature of processing includes:
+                  </p>
+                  <List>
+                    <li>
+                      Receiving data, including collection, accessing, retrieval, recording, and
+                      data entry
+                    </li>
+                    <li>Holding data, including storage, organization, and structuring</li>
+                    <li>
+                      Using data, including analysis, consultation, testing, automated decision
+                      making, and profiling
+                    </li>
+                    <li>Protecting data, including restricting, encrypting, and security testing</li>
+                    <li>Returning data to the data exporter or data subject</li>
+                    <li>Erasing data, including destruction and deletion</li>
+                  </List>
+                </div>
+              </TermRow>
+              <TermRow label="Duration of Processing">
+                Provider will process Customer Personal Data as long as required (i) to conduct the
+                Processing activities instructed in Section 2.2(a)-(d) of the DPA Standard Terms; or
+                (ii) by Applicable Laws.
+              </TermRow>
+            </Section>
+
+            <Section title="Annex I(C) — Competent Supervisory Authority">
+              <p>
+                The supervisory authority will be the supervisory authority of the data exporter, as
+                determined in accordance with Clause 13 of the EEA SCCs or the relevant provision of
+                the UK Addendum.
+              </p>
+            </Section>
+
+            <Section title="Annex II — Technical and Organizational Security Measures">
+              <p>
+                See the <PageLink href={SECURITY_URL}>Security Policy</PageLink>. The measures
+                include:
+              </p>
+              <TermRow label="Encryption">
+                All Customer Personal Data is encrypted in transit using TLS 1.2 or higher and
+                encrypted at rest using AES-256 via AWS-managed services.
+              </TermRow>
+              <TermRow label="Confidentiality, Integrity, Availability">
+                Superlog maintains technical and organizational safeguards for Customer Personal
+                Data, including encryption, access controls, and network isolation on AWS-managed
+                infrastructure. Current practices are described in the{" "}
+                <PageLink href={SECURITY_URL}>Security Policy</PageLink>.
+              </TermRow>
+              <TermRow label="Restore and Recovery">
+                Customer data is stored in AWS-managed databases with automated backups and
+                point-in-time recovery, enabling restoration of availability and access following a
+                physical or technical incident.
+              </TermRow>
+              <TermRow label="Identification and Authorization">
+                Access to Customer data requires an authenticated user account. Users sign in via
+                GitHub OAuth, Google OAuth, or email magic link, so Superlog stores no passwords;
+                sessions are protected with secure, expiring tokens, and each workspace's data is
+                accessible only to its authorized members.
+              </TermRow>
+              <TermRow label="Protection in Transit">
+                All Customer Personal Data is encrypted in transit using TLS 1.2 or higher;
+                unencrypted connections are not accepted.
+              </TermRow>
+              <TermRow label="Protection at Rest">
+                Customer Personal Data is encrypted at rest using AES-256 via AWS-managed storage
+                services.
+              </TermRow>
+              <TermRow label="Physical Security">
+                Customer Personal Data is processed exclusively in AWS data centers; physical
+                security controls are maintained by AWS and covered by its compliance
+                certifications.
+              </TermRow>
+              <TermRow label="Events Logging">
+                System and application events, including access to production systems, are logged
+                and retained for security monitoring and incident investigation.
+              </TermRow>
+              <TermRow label="Systems Configuration">
+                Infrastructure is defined and version-controlled as code; changes to production
+                configuration are applied through reviewed, automated deployments.
+              </TermRow>
+              <TermRow label="Limited Data Retention">
+                Ingested Customer data is retained for the retention period of the Customer's plan
+                and deleted thereafter; all Customer Personal Data is deleted following termination
+                of the Agreement.
+              </TermRow>
+              <TermRow label="Portability and Erasure">
+                Customers can export their data and can request deletion of Customer Personal Data;
+                upon termination, all Customer Personal Data is deleted within 30 days. Superlog
+                assists Customers in responding to data subject access and erasure requests
+                concerning data held in the Service. Secure disposal of storage hardware is handled
+                by AWS.
+              </TermRow>
+            </Section>
+
+            <Section title="Changes">
+              <p>
+                Provider and Customer have not changed the DPA Standard Terms except for the details
+                in the Key Terms above.
+              </p>
+              <p>
+                Questions about this DPA can be sent to{" "}
+                <PageLink href={`mailto:${SECURITY_CONTACT_EMAIL}`}>
+                  {SECURITY_CONTACT_EMAIL}
+                </PageLink>
+                .
+              </p>
+            </Section>
+          </div>
+        </article>
+      </main>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title?: string; children: ReactNode }) {
+  return (
+    <section className="space-y-5 border-t border-border pt-8 first:border-t-0 first:pt-0">
+      {title && <h2 className="text-[24px] font-semibold tracking-tight text-fg">{title}</h2>}
+      {children}
+    </section>
+  );
+}
+
+function TermRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="grid gap-2 border-t border-border pt-5 first:border-t-0 first:pt-0 md:grid-cols-[210px_1fr]">
+      <div className="font-mono text-[11px] uppercase tracking-[0.18em] text-subtle">{label}</div>
+      <div className="text-muted">{children}</div>
+    </div>
+  );
+}
+
+function List({ children }: { children: ReactNode }) {
+  return <ul className="list-disc space-y-3 pl-5 marker:text-subtle">{children}</ul>;
+}
+
+function PageLink({
+  href,
+  external,
+  children,
+}: {
+  href: string;
+  external?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      target={external ? "_blank" : undefined}
+      rel={external ? "noreferrer" : undefined}
+      className="text-fg underline decoration-border underline-offset-4 transition-colors hover:decoration-fg"
+    >
+      {children}
+    </a>
+  );
+}

--- a/apps/web/src/Landing.tsx
+++ b/apps/web/src/Landing.tsx
@@ -1615,6 +1615,12 @@ function Footer() {
               >
                 Privacy Policy
               </a>
+              <a
+                href="/security"
+                className="text-[14px] font-medium text-muted transition-colors hover:text-fg"
+              >
+                Security
+              </a>
             </div>
           </div>
         </div>

--- a/apps/web/src/PrivacyPolicy.tsx
+++ b/apps/web/src/PrivacyPolicy.tsx
@@ -239,7 +239,13 @@ export function PrivacyPolicy() {
                 Questions or privacy requests can be sent to{" "}
                 <ExternalLink href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</ExternalLink>.
               </p>
-              <p>Pulsent Labs Inc.</p>
+              <p>
+                Pulsent Labs Inc.
+                <br />
+                1111B S Governors Ave # 88398
+                <br />
+                Dover, Delaware 19904, United States of America
+              </p>
             </Section>
           </div>
         </article>

--- a/apps/web/src/SecurityPolicyPage.tsx
+++ b/apps/web/src/SecurityPolicyPage.tsx
@@ -1,0 +1,157 @@
+import type { ReactNode } from "react";
+import { Wordmark } from "./design/ui.tsx";
+
+const SECURITY_EMAIL = "security@superlog.sh";
+const LEGAL_EMAIL = "legal@superlog.sh";
+
+export function SecurityPolicyPage() {
+  return (
+    <div className="min-h-screen bg-bg font-sans text-fg">
+      <header className="sticky top-0 z-40 border-b border-border bg-bg">
+        <div className="mx-auto flex w-full max-w-[980px] items-center justify-between px-4 py-5 md:px-8">
+          <a href="/" aria-label="Superlog home">
+            <Wordmark />
+          </a>
+          <a
+            href="/dpa"
+            className="text-[12px] font-medium text-muted transition-colors hover:text-fg"
+          >
+            DPA
+          </a>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-[980px] px-4 py-14 md:px-8 md:py-20">
+        <article className="max-w-[780px]">
+          <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-subtle">
+            Last Updated: September 1, 2026
+          </p>
+          <h1
+            className="mt-5 text-[2.25rem] leading-tight tracking-tight text-fg md:text-[3.75rem]"
+            style={{ fontWeight: 450 }}
+          >
+            Superlog Security Policy
+          </h1>
+
+          <div className="mt-12 space-y-10 text-[15px] leading-7 text-muted md:text-[16px]">
+            <Section>
+              <p>
+                This page describes the technical and organizational measures Pulsent Labs Inc.
+                ("Superlog") uses to protect Customer Content and personal information. It is the
+                Security Policy referenced by the{" "}
+                <PageLink href="/tos">Terms of Service</PageLink> and the{" "}
+                <PageLink href="/dpa">Data Processing Agreement</PageLink>, and we update it as our
+                practices evolve.
+              </p>
+            </Section>
+
+            <Section title="Infrastructure and Network">
+              <p>
+                Superlog runs on Amazon Web Services in the United States. Databases and telemetry
+                stores are deployed in private subnets with no public network access, reachable only
+                from the application services that need them through security-group rules.
+                Administrative access to production systems requires a private network connection
+                and is limited to authorized personnel.
+              </p>
+              <p>
+                Infrastructure is defined and version-controlled as code, and changes to production
+                configuration are applied through reviewed, automated deployments.
+              </p>
+            </Section>
+
+            <Section title="Encryption">
+              <p>
+                All data is encrypted in transit using TLS 1.2 or higher (with TLS 1.3 supported);
+                unencrypted connections are not accepted. Data is encrypted at rest using AES-256
+                across our databases, telemetry stores, and backups via AWS-managed encryption.
+              </p>
+            </Section>
+
+            <Section title="Authentication and Access Control">
+              <p>
+                Users sign in with GitHub OAuth, Google OAuth, or an email magic link, so Superlog
+                stores no passwords. Sessions are protected with secure, expiring tokens. Access to
+                Customer Content is scoped to the customer's workspace: each workspace's data is
+                accessible only to its authorized members, according to their roles.
+              </p>
+            </Section>
+
+            <Section title="Backups and Recovery">
+              <p>
+                Primary databases have automated daily backups with a 14-day retention window and
+                support point-in-time recovery. Telemetry stores are backed up to encrypted object
+                storage. Backups allow restoration of availability and access following a physical
+                or technical incident.
+              </p>
+            </Section>
+
+            <Section title="Data Retention and Deletion">
+              <p>
+                Ingested telemetry is retained according to the customer's plan and settings and
+                deleted thereafter. When an account is terminated, Customer Content is deleted
+                within 30 days. Customers can request an export of their data by contacting{" "}
+                <PageLink href={`mailto:${LEGAL_EMAIL}`}>{LEGAL_EMAIL}</PageLink>.
+              </p>
+            </Section>
+
+            <Section title="AI and Customer Content">
+              <p>
+                Superlog uses large language models to investigate issues and propose fixes. Model
+                inference runs through the AI providers listed on our{" "}
+                <PageLink href="/subprocessors">subprocessors page</PageLink> with training
+                disabled: we do not use Customer Content to train foundation models, and our
+                providers are not permitted to either.
+              </p>
+            </Section>
+
+            <Section title="Subprocessors">
+              <p>
+                The third-party services that process Customer Content on our behalf are listed at{" "}
+                <PageLink href="/subprocessors">superlog.sh/subprocessors</PageLink>, along with how
+                we give notice of changes.
+              </p>
+            </Section>
+
+            <Section title="Physical Security and Certifications">
+              <p>
+                Customer Content is processed exclusively in AWS data centers, whose physical
+                security controls are maintained by AWS and covered by its compliance
+                certifications, including SOC 2 and ISO 27001. Superlog does not yet hold its own
+                SOC 2 or ISO 27001 certification; this page reflects our current practices, and we
+                will update it as our security program matures.
+              </p>
+            </Section>
+
+            <Section title="Reporting a Vulnerability">
+              <p>
+                If you believe you have found a security issue in Superlog, email{" "}
+                <PageLink href={`mailto:${SECURITY_EMAIL}`}>{SECURITY_EMAIL}</PageLink>. We
+                appreciate responsible disclosure and will respond as quickly as we can.
+              </p>
+            </Section>
+          </div>
+        </article>
+      </main>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title?: string; children: ReactNode }) {
+  return (
+    <section className="space-y-5 border-t border-border pt-8 first:border-t-0 first:pt-0">
+      {title && <h2 className="text-[24px] font-semibold tracking-tight text-fg">{title}</h2>}
+      {children}
+    </section>
+  );
+}
+
+function PageLink({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <a
+      href={href}
+      className="text-fg underline decoration-border underline-offset-4 transition-colors hover:decoration-fg"
+    >
+      {children}
+    </a>
+  );
+}

--- a/apps/web/src/Subprocessors.tsx
+++ b/apps/web/src/Subprocessors.tsx
@@ -32,7 +32,7 @@ const SUBPROCESSORS = [
   {
     name: "PostHog",
     purpose: "Product analytics",
-    location: "United States",
+    location: "European Union",
   },
 ];
 

--- a/apps/web/src/Subprocessors.tsx
+++ b/apps/web/src/Subprocessors.tsx
@@ -1,0 +1,133 @@
+import type { ReactNode } from "react";
+import { Wordmark } from "./design/ui.tsx";
+
+const LEGAL_EMAIL = "legal@superlog.sh";
+
+const SUBPROCESSORS = [
+  {
+    name: "Amazon Web Services",
+    purpose: "Cloud infrastructure, data storage, and content delivery",
+    location: "United States",
+  },
+  {
+    name: "Anthropic",
+    purpose: "AI model inference for investigation and remediation agents",
+    location: "United States",
+  },
+  {
+    name: "Stripe",
+    purpose: "Payment processing and billing",
+    location: "United States",
+  },
+  {
+    name: "Resend",
+    purpose: "Transactional email delivery",
+    location: "United States",
+  },
+  {
+    name: "Loops",
+    purpose: "Product and lifecycle email",
+    location: "United States",
+  },
+  {
+    name: "PostHog",
+    purpose: "Product analytics",
+    location: "United States",
+  },
+];
+
+export function Subprocessors() {
+  return (
+    <div className="min-h-screen bg-bg font-sans text-fg">
+      <header className="sticky top-0 z-40 border-b border-border bg-bg">
+        <div className="mx-auto flex w-full max-w-[980px] items-center justify-between px-4 py-5 md:px-8">
+          <a href="/" aria-label="Superlog home">
+            <Wordmark />
+          </a>
+          <a
+            href="/dpa"
+            className="text-[12px] font-medium text-muted transition-colors hover:text-fg"
+          >
+            DPA
+          </a>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-[980px] px-4 py-14 md:px-8 md:py-20">
+        <article className="max-w-[780px]">
+          <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-subtle">
+            Last Updated: September 1, 2026
+          </p>
+          <h1
+            className="mt-5 text-[2.25rem] leading-tight tracking-tight text-fg md:text-[3.75rem]"
+            style={{ fontWeight: 450 }}
+          >
+            Superlog Subprocessors
+          </h1>
+
+          <div className="mt-12 space-y-10 text-[15px] leading-7 text-muted md:text-[16px]">
+            <Section>
+              <p>
+                Pulsent Labs Inc. ("Superlog") uses the third-party subprocessors below to help
+                provide the Service. Each subprocessor processes Customer Content or personal
+                information only for the purpose listed, under a written agreement with data
+                protection obligations. This is the subprocessor list referenced by the{" "}
+                <PageLink href="/dpa">Data Processing Agreement</PageLink>.
+              </p>
+            </Section>
+
+            <Section title="Current Subprocessors">
+              {SUBPROCESSORS.map((subprocessor) => (
+                <TermRow key={subprocessor.name} label={subprocessor.name}>
+                  <div className="space-y-1">
+                    <p>{subprocessor.purpose}</p>
+                    <p className="text-subtle">{subprocessor.location}</p>
+                  </div>
+                </TermRow>
+              ))}
+            </Section>
+
+            <Section title="Changes to This List">
+              <p>
+                Before adding or replacing a subprocessor, we will give customers at least 10
+                business days' notice by emailing workspace administrators, as described in the{" "}
+                <PageLink href="/dpa">Data Processing Agreement</PageLink>. Questions about this
+                list can be sent to{" "}
+                <PageLink href={`mailto:${LEGAL_EMAIL}`}>{LEGAL_EMAIL}</PageLink>.
+              </p>
+            </Section>
+          </div>
+        </article>
+      </main>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title?: string; children: ReactNode }) {
+  return (
+    <section className="space-y-5 border-t border-border pt-8 first:border-t-0 first:pt-0">
+      {title && <h2 className="text-[24px] font-semibold tracking-tight text-fg">{title}</h2>}
+      {children}
+    </section>
+  );
+}
+
+function TermRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="grid gap-2 border-t border-border pt-5 first:border-t-0 first:pt-0 md:grid-cols-[210px_1fr]">
+      <div className="font-mono text-[11px] uppercase tracking-[0.18em] text-subtle">{label}</div>
+      <div className="text-muted">{children}</div>
+    </div>
+  );
+}
+
+function PageLink({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <a
+      href={href}
+      className="text-fg underline decoration-border underline-offset-4 transition-colors hover:decoration-fg"
+    >
+      {children}
+    </a>
+  );
+}

--- a/apps/web/src/TermsOfService.tsx
+++ b/apps/web/src/TermsOfService.tsx
@@ -3,6 +3,7 @@ import { Wordmark } from "./design/ui.tsx";
 
 const COMMON_PAPER_CSA_URL = "https://commonpaper.com/standards/cloud-service-agreement/2.1/";
 const PRICING_URL = "https://superlog.sh/pricing";
+const DPA_URL = "https://superlog.sh/dpa";
 
 export function TermsOfService() {
   return (
@@ -24,7 +25,7 @@ export function TermsOfService() {
       <main className="mx-auto w-full max-w-[980px] px-4 py-14 md:px-8 md:py-20">
         <article className="max-w-[780px]">
           <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-subtle">
-            Last Updated: June 2, 2026
+            Last Updated: September 1, 2026
           </p>
           <h1
             className="mt-5 text-[2.25rem] leading-tight tracking-tight text-fg md:text-[3.75rem]"
@@ -66,8 +67,9 @@ export function TermsOfService() {
                 words have the meanings given in the Cover Page or the Standard Terms.
               </TermRow>
               <TermRow label="Cloud Service">
-                Superlog, an AI-native observability platform that monitors your applications and
-                autonomously investigates and fixes bugs.
+                Superlog, an AI-native observability platform that monitors Customer's applications
+                by ingesting logs, errors, and telemetry from connected integrations, and uses AI
+                agents to investigate issues and propose and apply bug fixes.
               </TermRow>
               <TermRow label="Order Date">The Effective Date</TermRow>
               <TermRow label="Subscription Period">1 month(s)</TermRow>
@@ -85,7 +87,9 @@ export function TermsOfService() {
                 approval.
               </TermRow>
               <TermRow label="Non-Renewal Notice Period">
-                At least 30 days before the end of the current Subscription Period.
+                At least 0 days before the end of the current Subscription Period. Customer may
+                cancel at any time, and the cancellation takes effect at the end of the current
+                Subscription Period.
               </TermRow>
             </Section>
 
@@ -122,12 +126,16 @@ export function TermsOfService() {
                 </div>
               </TermRow>
               <TermRow label="General Cap Amount">
-                The fees paid or payable by Customer to provider in the 12 month period immediately
+                The fees paid or payable by Customer to Provider in the 12 month period immediately
                 before the claim
+              </TermRow>
+              <TermRow label="Attachments">
+                The <ExternalLink href={DPA_URL}>Superlog Data Processing Agreement</ExternalLink>,
+                which is incorporated by reference.
               </TermRow>
               <TermRow label="Notice Address">
                 <div className="space-y-2">
-                  <p>For Provider: nicolo@superlog.sh</p>
+                  <p>For Provider: legal@superlog.sh</p>
                   <p>For Customer: The main email address on Customer's account</p>
                 </div>
               </TermRow>

--- a/apps/web/src/marketing/MarketingApp.tsx
+++ b/apps/web/src/marketing/MarketingApp.tsx
@@ -2,11 +2,14 @@ import { Route, Routes } from "react-router-dom";
 import { Blog } from "../Blog.tsx";
 import { BlogPost } from "../BlogPost.tsx";
 import { Changelog } from "../Changelog.tsx";
+import { DataProcessingAgreement } from "../DataProcessingAgreement.tsx";
 import { Landing } from "../Landing.tsx";
 import { Pricing } from "../Pricing.tsx";
 import { PrivacyPolicy } from "../PrivacyPolicy.tsx";
 import { Roadmap } from "../Roadmap.tsx";
+import { SecurityPolicyPage } from "../SecurityPolicyPage.tsx";
 import { SignupSourceCapture } from "../SignupSourceCapture.tsx";
+import { Subprocessors } from "../Subprocessors.tsx";
 import { Team } from "../Team.tsx";
 import { TermsOfService } from "../TermsOfService.tsx";
 
@@ -24,6 +27,9 @@ export function MarketingApp() {
         <Route path="/team" element={<Team />} />
         <Route path="/privacy" element={<PrivacyPolicy />} />
         <Route path="/tos" element={<TermsOfService />} />
+        <Route path="/dpa" element={<DataProcessingAgreement />} />
+        <Route path="/security" element={<SecurityPolicyPage />} />
+        <Route path="/subprocessors" element={<Subprocessors />} />
       </Routes>
     </>
   );

--- a/apps/web/src/prerender/entry.tsx
+++ b/apps/web/src/prerender/entry.tsx
@@ -169,6 +169,24 @@ const pages: PublicPage[] = [
     description: "Read the Superlog terms of service.",
     lastModified: SITE_CONTENT_LAST_MODIFIED,
   },
+  {
+    path: "/dpa",
+    title: "Data Processing Agreement | Superlog",
+    description: "Read the Superlog data processing agreement.",
+    lastModified: SITE_CONTENT_LAST_MODIFIED,
+  },
+  {
+    path: "/security",
+    title: "Security Policy | Superlog",
+    description: "How Superlog protects customer data: encryption, access control, and backups.",
+    lastModified: SITE_CONTENT_LAST_MODIFIED,
+  },
+  {
+    path: "/subprocessors",
+    title: "Subprocessors | Superlog",
+    description: "The third-party subprocessors Superlog uses to provide the service.",
+    lastModified: SITE_CONTENT_LAST_MODIFIED,
+  },
 ];
 
 function escapeAttribute(value: string): string {


### PR DESCRIPTION
**Read the rendered pages:** the full text of all four pages, plus the open review questions, is at https://claude.ai/code/artifact/06a2adaa-94b8-41e2-915b-f060f7e284a2 (ask Nicolò for access if the link is not shared with you yet).

One reviewable change for all of today's legal work. The terms-of-service cover page update that briefly landed on main this morning was reverted there and is reapplied here, so nothing goes live until this PR is approved and merged.

## What's in here

- **Restore the ToS cover page update** (first commit): 0-day non-renewal notice (cancel any time, effective end of the paid month), DPA attached by reference, notices to legal@superlog.sh, concrete Cloud Service description.
- **`/dpa`** — public-facing Common Paper DPA (Standard Terms v1.1 incorporated by reference). Key terms: subprocessor list at /subprocessors, security policy at /security, CCPA service-provider certification, SCCs governed by Irish law (EEA) and England & Wales (UK), full Annex I/II.
- **`/security`** — the security policy the ToS and DPA reference. Every claim was verified against `superlog-cloud/infra/aws` before writing (see below).
- **`/subprocessors`** — AWS, Anthropic, Stripe, Resend, Loops, PostHog, with the 10-business-day change-notice commitment from the DPA.
- Routes in `MarketingApp`, prerender entries, and a footer "Security" link.

## Infra claims verified against prod Terraform

- TLS 1.2+ only: `ELBSecurityPolicy-TLS13-1-2-2021-06` on the ALB listener, no port-80 listener (`app_tls.tf`)
- At-rest encryption: `storage_encrypted = true` (rds-postgres module), encrypted EBS on ClickHouse nodes, SSE on backup buckets
- Backups: RDS `backup_retention_days = 14` default in effect, ClickHouse backups to encrypted S3
- Private networking: RDS in private subnets, security-group access only from app services and the admin network

## Decisions worth a second pair of eyes

1. ~~Security contact aliases~~ — resolved: both legal@superlog.sh and security@superlog.sh exist as aliases in Google Admin, so the DPA (legal@) and security page (security@) addresses both deliver.
2. **Retention wording** says telemetry is retained "for the retention period of the Customer's plan" — confirm plans actually define retention windows; otherwise this should say "for the duration of the agreement".
3. **Deletion within 30 days of termination** — confirm we can honor this operationally.
4. **Subprocessor change notice** commits us to emailing workspace admins 10 business days before adding a vendor — needs a small ops process.
5. ~~PostHog region~~ — resolved: we are on PostHog's EU cloud, and the page now lists it as European Union.

## After approval

Merge, then bump the gitlink in superlog-cloud to publish /tos, /dpa, /security, and /subprocessors together.
