### PR TITLE
Prioritize live investigation queue work

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -87,8 +87,8 @@
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
     "google-auth-library": "^10.9.0",
-    "pg": "^8.13.1",
-    "pg-boss": "^12.0.0",
+    "pg": "^8.23.0",
+    "pg-boss": "^12.30.0",
     "pino": "^10.3.1"
   },
   "engines": {

--- a/apps/worker/src/agent-runs/queue-wiring.ts
+++ b/apps/worker/src/agent-runs/queue-wiring.ts
@@ -42,10 +42,10 @@ export async function startAgentRunQueue(boss: AgentRunQueueBoss): Promise<void>
       });
     },
     hasDetachedSessionTermination: hasPendingDetachedAgentRunSession,
-    listActiveRunIds: async () => {
+    listSweepRunIds: async () => {
       const [rows, pendingHandoffs, pendingDetachedSessions] = await Promise.all([
         db
-          .select({ id: schema.agentRuns.id })
+          .select({ id: schema.agentRuns.id, state: schema.agentRuns.state })
           .from(schema.agentRuns)
           .where(
             or(
@@ -60,9 +60,16 @@ export async function startAgentRunQueue(boss: AgentRunQueueBoss): Promise<void>
         listPendingLinearHandoffRunIds(),
         listPendingDetachedAgentRunIds(),
       ]);
-      return [
-        ...new Set([...rows.map((row) => row.id), ...pendingHandoffs, ...pendingDetachedSessions]),
-      ];
+      const progressing = new Set([...pendingHandoffs, ...pendingDetachedSessions]);
+      const parked: string[] = [];
+      for (const row of rows) {
+        if (row.state === "awaiting_human" || row.state === "awaiting_events") {
+          if (!progressing.has(row.id)) parked.push(row.id);
+        } else {
+          progressing.add(row.id);
+        }
+      }
+      return { progressing: [...progressing], parked };
     },
     handlers: {
       terminateSession: async (agentRun) => {

--- a/apps/worker/src/agent-runs/queue-wiring.ts
+++ b/apps/worker/src/agent-runs/queue-wiring.ts
@@ -1,13 +1,18 @@
 // Production wiring for the agent-run queue: binds queue.ts (pure, tested
 // against fakes) to the real database, context loader, and state handlers.
-import { db, schema } from "@superlog/db";
-import { and, asc, eq, inArray, isNotNull, or } from "drizzle-orm";
+import { INBOUND_INTERACTION_EVENT_KINDS, db, schema } from "@superlog/db";
+import { and, asc, eq, exists, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { loadAgentRunContext } from "../agent-run-context.js";
 import { ACTIVE_STATES, createAgentRunLifecycle } from "../agent-run.js";
 import { setAgentRunJobDispatch } from "./enqueue.js";
 import { listPendingLinearHandoffRunIds, reconcilePendingLinearHandoff } from "./linear-handoff.js";
 import { retryQueuedPullRequestDelivery } from "./pr-delivery.js";
-import { type AgentRunQueueBoss, createAgentRunJobSender, registerAgentRunQueue } from "./queue.js";
+import {
+  type AgentRunQueueBoss,
+  createAgentRunJobSender,
+  groupAgentRunSweepIds,
+  registerAgentRunQueue,
+} from "./queue.js";
 import { resumeAgentRunFromHumanInput } from "./resume.js";
 import {
   hasPendingDetachedAgentRunSession,
@@ -43,9 +48,32 @@ export async function startAgentRunQueue(boss: AgentRunQueueBoss): Promise<void>
     },
     hasDetachedSessionTermination: hasPendingDetachedAgentRunSession,
     listSweepRunIds: async () => {
+      const hasPendingInput = exists(
+        db
+          .select({ one: sql`1` })
+          .from(schema.incidentEvents)
+          .where(
+            and(
+              eq(schema.incidentEvents.agentRunId, schema.agentRuns.id),
+              isNull(schema.incidentEvents.processedAt),
+              or(
+                inArray(schema.incidentEvents.kind, [...INBOUND_INTERACTION_EVENT_KINDS]),
+                and(
+                  eq(schema.incidentEvents.kind, "incident_context_changed"),
+                  eq(schema.agentRuns.state, "awaiting_events"),
+                  sql`${schema.agentRuns.result}->>'waitReason' = 'external_cause'`,
+                ),
+              ),
+            ),
+          ),
+      );
       const [rows, pendingHandoffs, pendingDetachedSessions] = await Promise.all([
         db
-          .select({ id: schema.agentRuns.id, state: schema.agentRuns.state })
+          .select({
+            id: schema.agentRuns.id,
+            state: schema.agentRuns.state,
+            hasPendingInput,
+          })
           .from(schema.agentRuns)
           .where(
             or(
@@ -60,16 +88,10 @@ export async function startAgentRunQueue(boss: AgentRunQueueBoss): Promise<void>
         listPendingLinearHandoffRunIds(),
         listPendingDetachedAgentRunIds(),
       ]);
-      const progressing = new Set([...pendingHandoffs, ...pendingDetachedSessions]);
-      const parked: string[] = [];
-      for (const row of rows) {
-        if (row.state === "awaiting_human" || row.state === "awaiting_events") {
-          if (!progressing.has(row.id)) parked.push(row.id);
-        } else {
-          progressing.add(row.id);
-        }
-      }
-      return { progressing: [...progressing], parked };
+      return groupAgentRunSweepIds(
+        rows.map((row) => ({ ...row, hasPendingInput: row.hasPendingInput === true })),
+        [...pendingHandoffs, ...pendingDetachedSessions],
+      );
     },
     handlers: {
       terminateSession: async (agentRun) => {

--- a/apps/worker/src/agent-runs/queue-wiring.ts
+++ b/apps/worker/src/agent-runs/queue-wiring.ts
@@ -73,6 +73,8 @@ export async function startAgentRunQueue(boss: AgentRunQueueBoss): Promise<void>
             id: schema.agentRuns.id,
             state: schema.agentRuns.state,
             hasPendingInput,
+            providerSessionId: schema.agentRuns.providerSessionId,
+            providerSessionStatus: schema.agentRuns.providerSessionStatus,
           })
           .from(schema.agentRuns)
           .where(
@@ -89,7 +91,12 @@ export async function startAgentRunQueue(boss: AgentRunQueueBoss): Promise<void>
         listPendingDetachedAgentRunIds(),
       ]);
       return groupAgentRunSweepIds(
-        rows.map((row) => ({ ...row, hasPendingInput: row.hasPendingInput === true })),
+        rows.map((row) => ({
+          ...row,
+          hasPendingInput: row.hasPendingInput === true,
+          hasPendingOwnedSessionTermination:
+            row.providerSessionStatus === "termination_pending" && row.providerSessionId !== null,
+        })),
         [...pendingHandoffs, ...pendingDetachedSessions],
       );
     },

--- a/apps/worker/src/agent-runs/queue.test.ts
+++ b/apps/worker/src/agent-runs/queue.test.ts
@@ -82,7 +82,7 @@ function makeDeps(overrides: DepsOverrides = {}) {
         calls.push("fail_context_unavailable");
       }),
     hasDetachedSessionTermination: overrides.hasDetachedSessionTermination ?? (async () => false),
-    listActiveRunIds: overrides.listActiveRunIds ?? (async () => []),
+    listSweepRunIds: overrides.listSweepRunIds ?? (async () => ({ progressing: [], parked: [] })),
     handlers: {
       terminateSession: overrides.handlers?.terminateSession ?? handler("terminate_session"),
       reconcileHandoff: overrides.handlers?.reconcileHandoff ?? handler("reconcile_handoff"),
@@ -343,9 +343,14 @@ test("a run with an abandoned in-flight attempt is not advanced concurrently", a
   assert.equal(startCalls, 2, "a settled run must be advanceable again");
 });
 
-test("sweep enqueues one deduped advance job per active run", async () => {
+test("sweep prioritizes progressing runs ahead of parked runs", async () => {
   const fb = fakeBoss();
-  const { deps } = makeDeps({ listActiveRunIds: async () => ["run-1", "run-2"] });
+  const { deps } = makeDeps({
+    listSweepRunIds: async () => ({
+      progressing: ["running-run", "queued-run"],
+      parked: ["awaiting-human-run", "awaiting-events-run"],
+    }),
+  });
   await registerAgentRunQueue(fb.boss, deps);
   const sweep = fb.workers.get(AGENT_RUN_SWEEP_QUEUE);
   assert.ok(sweep);
@@ -355,8 +360,26 @@ test("sweep enqueues one deduped advance job per active run", async () => {
   assert.equal(fb.inserted.length, 1);
   assert.equal(fb.inserted[0]?.name, AGENT_RUN_ADVANCE_QUEUE);
   assert.deepEqual(fb.inserted[0]?.jobs, [
-    { data: { agentRunId: "run-1" }, singletonKey: "run-1" },
-    { data: { agentRunId: "run-2" }, singletonKey: "run-2" },
+    {
+      data: { agentRunId: "running-run" },
+      singletonKey: "running-run",
+      priority: 1,
+    },
+    {
+      data: { agentRunId: "queued-run" },
+      singletonKey: "queued-run",
+      priority: 1,
+    },
+    {
+      data: { agentRunId: "awaiting-human-run" },
+      singletonKey: "awaiting-human-run",
+      priority: 0,
+    },
+    {
+      data: { agentRunId: "awaiting-events-run" },
+      singletonKey: "awaiting-events-run",
+      priority: 0,
+    },
   ]);
 });
 
@@ -369,7 +392,7 @@ test("the job sender enqueues with a per-run singleton key and never throws", as
     {
       name: AGENT_RUN_ADVANCE_QUEUE,
       data: { agentRunId: "run-1" },
-      options: { singletonKey: "run-1" },
+      options: { singletonKey: "run-1", priority: 1 },
     },
   ]);
 

--- a/apps/worker/src/agent-runs/queue.test.ts
+++ b/apps/worker/src/agent-runs/queue.test.ts
@@ -399,16 +399,52 @@ test("sweep prioritizes progressing runs ahead of parked runs", async () => {
 test("pending input promotes a parked run into the progressing lane", () => {
   assert.deepEqual(
     groupAgentRunSweepIds([
-      { id: "waiting", state: "awaiting_human", hasPendingInput: false },
-      { id: "reply-ready", state: "awaiting_human", hasPendingInput: true },
-      { id: "review-ready", state: "awaiting_events", hasPendingInput: true },
-      { id: "running", state: "running", hasPendingInput: false },
+      {
+        id: "waiting",
+        state: "awaiting_human",
+        hasPendingInput: false,
+        hasPendingOwnedSessionTermination: false,
+      },
+      {
+        id: "reply-ready",
+        state: "awaiting_human",
+        hasPendingInput: true,
+        hasPendingOwnedSessionTermination: false,
+      },
+      {
+        id: "review-ready",
+        state: "awaiting_events",
+        hasPendingInput: true,
+        hasPendingOwnedSessionTermination: false,
+      },
+      {
+        id: "running",
+        state: "running",
+        hasPendingInput: false,
+        hasPendingOwnedSessionTermination: false,
+      },
     ]),
     {
       progressing: ["reply-ready", "review-ready", "running"],
       parked: ["waiting"],
     },
   );
+});
+
+test("pending owned-session termination promotes a parked run into the progressing lane", () => {
+  const candidates = [
+    {
+      id: "termination-ready",
+      state: "awaiting_events",
+      hasPendingInput: false,
+      hasPendingOwnedSessionTermination: true,
+    },
+  ];
+
+  assert.deepEqual(groupAgentRunSweepIds(candidates), {
+    progressing: ["termination-ready"],
+    parked: [],
+  });
 });
 
 test("the job sender promotes a queued job with a per-run singleton key and never throws", async () => {

--- a/apps/worker/src/agent-runs/queue.test.ts
+++ b/apps/worker/src/agent-runs/queue.test.ts
@@ -11,13 +11,13 @@ import {
   registerAgentRunQueue,
 } from "./queue.js";
 
-type SentJob = { name: string; data: unknown; options: unknown };
+type UpsertedJob = { name: string; data: unknown; options: unknown };
 type InsertedJob = { name: string; jobs: Array<Record<string, unknown>> };
 type WorkHandler = (jobs: Array<{ id: string; data: unknown }>) => Promise<unknown>;
 type WorkOptions = { batchSize: number; localConcurrency?: number };
 
 function fakeBoss() {
-  const sent: SentJob[] = [];
+  const upserted: UpsertedJob[] = [];
   const inserted: InsertedJob[] = [];
   const queues: Array<{ name: string; options: unknown }> = [];
   const queueUpdates: Array<{ name: string; options: unknown }> = [];
@@ -39,20 +39,30 @@ function fakeBoss() {
       workers.set(name, handler as WorkHandler);
       workOptions.set(name, options as WorkOptions);
     },
-    async send(name, data, options) {
-      sent.push({ name, data, options });
-      return "job-id";
-    },
     async insert(name, jobs) {
       inserted.push({ name, jobs: jobs as Array<Record<string, unknown>> });
       return [];
+    },
+    async upsert(name, data, options) {
+      upserted.push({ name, data, options });
+      return { jobs: [], updated: 0, inserted: 1 };
     },
     async schedule(name, cron) {
       ops.push(`schedule:${name}`);
       schedules.push({ name, cron });
     },
   };
-  return { boss, sent, inserted, queues, queueUpdates, schedules, workers, workOptions, ops };
+  return {
+    boss,
+    upserted,
+    inserted,
+    queues,
+    queueUpdates,
+    schedules,
+    workers,
+    workOptions,
+    ops,
+  };
 }
 
 function runOf(id: string, state: string): schema.AgentRun {
@@ -360,17 +370,19 @@ test("sweep prioritizes progressing runs ahead of parked runs", async () => {
 
   assert.equal(fb.inserted.length, 1);
   assert.equal(fb.inserted[0]?.name, AGENT_RUN_ADVANCE_QUEUE);
-  assert.deepEqual(fb.inserted[0]?.jobs, [
+  assert.deepEqual(fb.upserted, [
     {
+      name: AGENT_RUN_ADVANCE_QUEUE,
       data: { agentRunId: "running-run" },
-      singletonKey: "running-run",
-      priority: 1,
+      options: { singletonKey: "running-run", priority: 1 },
     },
     {
+      name: AGENT_RUN_ADVANCE_QUEUE,
       data: { agentRunId: "queued-run" },
-      singletonKey: "queued-run",
-      priority: 1,
+      options: { singletonKey: "queued-run", priority: 1 },
     },
+  ]);
+  assert.deepEqual(fb.inserted[0]?.jobs, [
     {
       data: { agentRunId: "awaiting-human-run" },
       singletonKey: "awaiting-human-run",
@@ -399,12 +411,12 @@ test("pending input promotes a parked run into the progressing lane", () => {
   );
 });
 
-test("the job sender enqueues with a per-run singleton key and never throws", async () => {
+test("the job sender promotes a queued job with a per-run singleton key and never throws", async () => {
   const fb = fakeBoss();
   const send = createAgentRunJobSender(fb.boss, { warn: () => {}, error: () => {} });
 
   await send("run-1");
-  assert.deepEqual(fb.sent, [
+  assert.deepEqual(fb.upserted, [
     {
       name: AGENT_RUN_ADVANCE_QUEUE,
       data: { agentRunId: "run-1" },
@@ -415,7 +427,7 @@ test("the job sender enqueues with a per-run singleton key and never throws", as
   const failing = createAgentRunJobSender(
     {
       ...fb.boss,
-      async send() {
+      async upsert() {
         throw new Error("pg-boss unavailable");
       },
     },

--- a/apps/worker/src/agent-runs/queue.test.ts
+++ b/apps/worker/src/agent-runs/queue.test.ts
@@ -7,6 +7,7 @@ import {
   type AgentRunQueueBoss,
   type AgentRunQueueDeps,
   createAgentRunJobSender,
+  groupAgentRunSweepIds,
   registerAgentRunQueue,
 } from "./queue.js";
 
@@ -381,6 +382,21 @@ test("sweep prioritizes progressing runs ahead of parked runs", async () => {
       priority: 0,
     },
   ]);
+});
+
+test("pending input promotes a parked run into the progressing lane", () => {
+  assert.deepEqual(
+    groupAgentRunSweepIds([
+      { id: "waiting", state: "awaiting_human", hasPendingInput: false },
+      { id: "reply-ready", state: "awaiting_human", hasPendingInput: true },
+      { id: "review-ready", state: "awaiting_events", hasPendingInput: true },
+      { id: "running", state: "running", hasPendingInput: false },
+    ]),
+    {
+      progressing: ["reply-ready", "review-ready", "running"],
+      parked: ["waiting"],
+    },
+  );
 });
 
 test("the job sender enqueues with a per-run singleton key and never throws", async () => {

--- a/apps/worker/src/agent-runs/queue.ts
+++ b/apps/worker/src/agent-runs/queue.ts
@@ -59,6 +59,35 @@ export type AgentRunSweepIds = {
   parked: string[];
 };
 
+export type AgentRunSweepCandidate = {
+  id: string;
+  state: string;
+  hasPendingInput: boolean;
+};
+
+export function groupAgentRunSweepIds(
+  candidates: AgentRunSweepCandidate[],
+  promotedIds: string[] = [],
+): AgentRunSweepIds {
+  const promoted = new Set(promotedIds);
+  const seen = new Set<string>();
+  const progressing: string[] = [];
+  const parked: string[] = [];
+  for (const candidate of candidates) {
+    seen.add(candidate.id);
+    const isParked = candidate.state === "awaiting_human" || candidate.state === "awaiting_events";
+    if (!isParked || candidate.hasPendingInput || promoted.has(candidate.id)) {
+      progressing.push(candidate.id);
+    } else {
+      parked.push(candidate.id);
+    }
+  }
+  for (const id of promoted) {
+    if (!seen.has(id)) progressing.push(id);
+  }
+  return { progressing, parked };
+}
+
 export type AgentRunQueueBoss = {
   createQueue(name: string, options?: unknown): Promise<unknown>;
   updateQueue(name: string, options?: unknown): Promise<unknown>;

--- a/apps/worker/src/agent-runs/queue.ts
+++ b/apps/worker/src/agent-runs/queue.ts
@@ -63,6 +63,7 @@ export type AgentRunSweepCandidate = {
   id: string;
   state: string;
   hasPendingInput: boolean;
+  hasPendingOwnedSessionTermination: boolean;
 };
 
 export function groupAgentRunSweepIds(
@@ -76,7 +77,12 @@ export function groupAgentRunSweepIds(
   for (const candidate of candidates) {
     seen.add(candidate.id);
     const isParked = candidate.state === "awaiting_human" || candidate.state === "awaiting_events";
-    if (!isParked || candidate.hasPendingInput || promoted.has(candidate.id)) {
+    if (
+      !isParked ||
+      candidate.hasPendingInput ||
+      candidate.hasPendingOwnedSessionTermination ||
+      promoted.has(candidate.id)
+    ) {
       progressing.push(candidate.id);
     } else {
       parked.push(candidate.id);

--- a/apps/worker/src/agent-runs/queue.ts
+++ b/apps/worker/src/agent-runs/queue.ts
@@ -12,12 +12,13 @@
 //     Jobs in a fetch batch run concurrently, so wall-clock throughput no
 //     longer depends on how many other runs exist.
 //   - `agent-run-sweep` fires every minute and blind-enqueues every run in an
-//     active state; the singleton key collapses duplicates. The sweep is both
-//     the pickup for inbound events recorded outside this process (human
-//     replies land as unprocessed incident_events rows) and the safety net
-//     for lost jobs. Run creation additionally enqueues directly (see
-//     enqueue.ts) so new investigations start in seconds, not at the next
-//     sweep.
+//     active state; the singleton key collapses duplicates. Progressing runs
+//     are higher priority than parked runs so hundreds of sessions awaiting a
+//     human or external event cannot delay live model/tool turns. The sweep is
+//     both the pickup for inbound events recorded outside this process (human
+//     replies land as unprocessed incident_events rows) and the safety net for
+//     lost jobs. Run creation additionally enqueues directly (see enqueue.ts)
+//     so new investigations start in seconds, not at the next sweep.
 //
 // Failure semantics match the old tick: a job's error is logged and swallowed
 // (the handlers are not written to be safely re-runnable, so pg-boss retries
@@ -50,6 +51,13 @@ const MAX_CONCURRENCY = 50;
 // re-enqueues the run.
 const DEFAULT_JOB_TIMEOUT_MS = 90_000;
 const JOB_EXPIRY_GRACE_SECONDS = 30;
+const PROGRESSING_RUN_PRIORITY = 1;
+const PARKED_RUN_PRIORITY = 0;
+
+export type AgentRunSweepIds = {
+  progressing: string[];
+  parked: string[];
+};
 
 export type AgentRunQueueBoss = {
   createQueue(name: string, options?: unknown): Promise<unknown>;
@@ -73,7 +81,7 @@ export type AgentRunQueueDeps = {
   // progress, so failing it is the only way it leaves the active set.
   failContextUnavailable(run: schema.AgentRun): Promise<void>;
   hasDetachedSessionTermination(agentRunId: string): Promise<boolean>;
-  listActiveRunIds(): Promise<string[]>;
+  listSweepRunIds(): Promise<AgentRunSweepIds>;
   handlers: {
     terminateSession(run: schema.AgentRun): Promise<void>;
     reconcileHandoff(ctx: AgentRunContext): Promise<void>;
@@ -176,11 +184,18 @@ export async function registerAgentRunQueue(
   await boss.createQueue(AGENT_RUN_SWEEP_QUEUE, { policy: "exclusive" });
 
   await boss.work(AGENT_RUN_SWEEP_QUEUE, { batchSize: 1 }, async () => {
-    const ids = await deps.listActiveRunIds();
-    if (ids.length === 0) return;
+    const ids = await deps.listSweepRunIds();
+    if (ids.progressing.length === 0 && ids.parked.length === 0) return;
     await boss.insert(
       AGENT_RUN_ADVANCE_QUEUE,
-      ids.map((id) => ({ data: { agentRunId: id } satisfies AgentRunJobData, singletonKey: id })),
+      [
+        ...ids.progressing.map((id) => ({ id, priority: PROGRESSING_RUN_PRIORITY })),
+        ...ids.parked.map((id) => ({ id, priority: PARKED_RUN_PRIORITY })),
+      ].map(({ id, priority }) => ({
+        data: { agentRunId: id } satisfies AgentRunJobData,
+        singletonKey: id,
+        priority,
+      })),
     );
   });
   await boss.schedule(AGENT_RUN_SWEEP_QUEUE, SWEEP_SCHEDULE);
@@ -290,6 +305,7 @@ export function createAgentRunJobSender(
     try {
       await boss.send(AGENT_RUN_ADVANCE_QUEUE, { agentRunId } satisfies AgentRunJobData, {
         singletonKey: agentRunId,
+        priority: PROGRESSING_RUN_PRIORITY,
       });
     } catch (err) {
       logger.warn(

--- a/apps/worker/src/agent-runs/queue.ts
+++ b/apps/worker/src/agent-runs/queue.ts
@@ -96,8 +96,8 @@ export type AgentRunQueueBoss = {
     options: { batchSize: number; localConcurrency?: number },
     handler: (jobs: Array<{ id: string; data: unknown }>) => Promise<unknown>,
   ): Promise<unknown>;
-  send(name: string, data: object, options?: object): Promise<unknown>;
   insert(name: string, jobs: object[]): Promise<unknown>;
+  upsert(name: string, data: object, options?: object): Promise<unknown>;
   schedule(name: string, cron: string, data?: unknown, options?: unknown): Promise<unknown>;
 };
 
@@ -215,17 +215,24 @@ export async function registerAgentRunQueue(
   await boss.work(AGENT_RUN_SWEEP_QUEUE, { batchSize: 1 }, async () => {
     const ids = await deps.listSweepRunIds();
     if (ids.progressing.length === 0 && ids.parked.length === 0) return;
-    await boss.insert(
-      AGENT_RUN_ADVANCE_QUEUE,
-      [
-        ...ids.progressing.map((id) => ({ id, priority: PROGRESSING_RUN_PRIORITY })),
-        ...ids.parked.map((id) => ({ id, priority: PARKED_RUN_PRIORITY })),
-      ].map(({ id, priority }) => ({
-        data: { agentRunId: id } satisfies AgentRunJobData,
-        singletonKey: id,
-        priority,
-      })),
+    await Promise.all(
+      ids.progressing.map((id) =>
+        boss.upsert(AGENT_RUN_ADVANCE_QUEUE, { agentRunId: id } satisfies AgentRunJobData, {
+          singletonKey: id,
+          priority: PROGRESSING_RUN_PRIORITY,
+        }),
+      ),
     );
+    if (ids.parked.length > 0) {
+      await boss.insert(
+        AGENT_RUN_ADVANCE_QUEUE,
+        ids.parked.map((id) => ({
+          data: { agentRunId: id } satisfies AgentRunJobData,
+          singletonKey: id,
+          priority: PARKED_RUN_PRIORITY,
+        })),
+      );
+    }
   });
   await boss.schedule(AGENT_RUN_SWEEP_QUEUE, SWEEP_SCHEDULE);
 
@@ -327,12 +334,12 @@ async function advanceWithTimeout(
 // failures are logged and swallowed: the sweep re-enqueues within a minute,
 // so an enqueue must never break the caller's transaction commit path.
 export function createAgentRunJobSender(
-  boss: Pick<AgentRunQueueBoss, "send">,
+  boss: Pick<AgentRunQueueBoss, "upsert">,
   logger: LoggerLike = defaultLogger,
 ): (agentRunId: string) => Promise<void> {
   return async (agentRunId) => {
     try {
-      await boss.send(AGENT_RUN_ADVANCE_QUEUE, { agentRunId } satisfies AgentRunJobData, {
+      await boss.upsert(AGENT_RUN_ADVANCE_QUEUE, { agentRunId } satisfies AgentRunJobData, {
         singletonKey: agentRunId,
         priority: PROGRESSING_RUN_PRIORITY,
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
         version: 1.1.8(@types/node@22.19.17)(@types/react@19.2.14)(typescript@5.9.3)
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
+        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9)
       portless:
         specifier: ^0.11.1
         version: 0.11.1
@@ -176,16 +176,16 @@ importers:
         version: link:../../packages/telemetry-query
       autumn-js:
         specifier: ^1.2.27
-        version: 1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.23.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.6.13
-        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.23.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
+        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9)
       google-auth-library:
         specifier: ^10.9.0
         version: 10.9.0
@@ -291,7 +291,7 @@ importers:
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
+        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9)
       google-auth-library:
         specifier: ^10.9.0
         version: 10.9.0
@@ -419,10 +419,10 @@ importers:
         version: 2.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       autumn-js:
         specifier: ^1.2.27
-        version: 1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.23.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.6.13
-        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.23.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       border-beam:
         specifier: ^1.3.0
         version: 1.3.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -579,22 +579,22 @@ importers:
         version: link:../../packages/topology
       autumn-js:
         specifier: ^1.2.27
-        version: 1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.23.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
+        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9)
       google-auth-library:
         specifier: ^10.9.0
         version: 10.9.0
       pg:
-        specifier: ^8.13.1
-        version: 8.21.0
+        specifier: ^8.23.0
+        version: 8.23.0
       pg-boss:
-        specifier: ^12.0.0
-        version: 12.18.2
+        specifier: ^12.30.0
+        version: 12.30.0
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -640,10 +640,10 @@ importers:
     dependencies:
       better-auth:
         specifier: ^1.6.13
-        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.23.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
+        version: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9)
       nanoid:
         specifier: ^5.0.9
         version: 5.1.9
@@ -3878,6 +3878,10 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cron-parser@5.10.0:
+    resolution: {integrity: sha512-izNAxJyRWUP8ljBoDSub5WyrVOUlT4SLGShswE7eoRBpp6QUsSycYxLBMJlbshgPBMcPT/nrfgjNY2918ayv2A==}
+    engines: {node: '>=18'}
+
   cron-parser@5.5.0:
     resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
     engines: {node: '>=18'}
@@ -5194,11 +5198,16 @@ packages:
     engines: {node: '>=22.12.0'}
     hasBin: true
 
+  pg-boss@12.30.0:
+    resolution: {integrity: sha512-ke4Rr/uMJGwqt7DwKoWS9aa6XFlK43C0fMw1Ma0CoJrVxWSjE7ZwFLwz60dGQODESDA2+yq/B474pOH4n3d3CQ==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+
   pg-cloudflare@1.4.0:
     resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
 
-  pg-connection-string@2.13.0:
-    resolution: {integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==}
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -5209,15 +5218,15 @@ packages:
     peerDependencies:
       pg: '>=8.0'
 
-  pg-protocol@1.14.0:
-    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
+  pg-protocol@1.16.0:
+    resolution: {integrity: sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==}
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
 
-  pg@8.21.0:
-    resolution: {integrity: sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==}
+  pg@8.23.0:
+    resolution: {integrity: sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
       pg-native: '>=3.0.1'
@@ -6806,12 +6815,12 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9))':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9)
 
   '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
@@ -8931,7 +8940,7 @@ snapshots:
   '@types/pg@8.15.6':
     dependencies:
       '@types/node': 22.19.17
-      pg-protocol: 1.14.0
+      pg-protocol: 1.16.0
       pg-types: 2.2.0
 
   '@types/prettier@3.0.0':
@@ -9117,13 +9126,13 @@ snapshots:
       postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  autumn-js@1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
+  autumn-js@1.2.27(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.23.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.3.7(zod@4.4.3))(express@5.2.1)(hono@4.12.30)(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
     dependencies:
       query-string: 9.4.0
       rou3: 0.6.3
       zod: 4.4.3
     optionalDependencies:
-      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.23.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       better-call: 1.3.7(zod@4.4.3)
       express: 5.2.1
       hono: 4.12.30
@@ -9146,10 +9155,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.21: {}
 
-  better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))(next@15.5.20(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9))(next@15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.23.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9))
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9))
       '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
@@ -9167,9 +9176,9 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9)
       next: 15.5.20(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      pg: 8.21.0
+      pg: 8.23.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
@@ -9380,6 +9389,10 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cron-parser@5.10.0:
+    dependencies:
+      luxon: 3.7.2
+
   cron-parser@5.5.0:
     dependencies:
       luxon: 3.7.2
@@ -9507,13 +9520,13 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.23.0)(postgres@3.4.9):
     optionalDependencies:
       '@electric-sql/pglite': 0.2.17
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.15.6
       kysely: 0.28.17
-      pg: 8.21.0
+      pg: 8.23.0
       postgres: 3.4.9
 
   dunder-proto@1.0.1:
@@ -10836,7 +10849,15 @@ snapshots:
   pg-boss@12.18.2:
     dependencies:
       cron-parser: 5.5.0
-      pg: 8.21.0
+      pg: 8.23.0
+      serialize-error: 13.0.1
+    transitivePeerDependencies:
+      - pg-native
+
+  pg-boss@12.30.0:
+    dependencies:
+      cron-parser: 5.10.0
+      pg: 8.23.0
       serialize-error: 13.0.1
     transitivePeerDependencies:
       - pg-native
@@ -10844,15 +10865,15 @@ snapshots:
   pg-cloudflare@1.4.0:
     optional: true
 
-  pg-connection-string@2.13.0: {}
+  pg-connection-string@2.14.0: {}
 
   pg-int8@1.0.1: {}
 
-  pg-pool@3.14.0(pg@8.21.0):
+  pg-pool@3.14.0(pg@8.23.0):
     dependencies:
-      pg: 8.21.0
+      pg: 8.23.0
 
-  pg-protocol@1.14.0: {}
+  pg-protocol@1.16.0: {}
 
   pg-types@2.2.0:
     dependencies:
@@ -10862,11 +10883,11 @@ snapshots:
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
 
-  pg@8.21.0:
+  pg@8.23.0:
     dependencies:
-      pg-connection-string: 2.13.0
-      pg-pool: 3.14.0(pg@8.21.0)
-      pg-protocol: 1.14.0
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.23.0)
+      pg-protocol: 1.16.0
       pg-types: 2.2.0
       pgpass: 1.0.5
     optionalDependencies:


### PR DESCRIPTION
## Summary

- assign higher queue priority to actively progressing investigation runs
- keep parked human/external-event waits as lower-priority sweep safety checks
- promote parked runs when they receive input or require provider-session cleanup
- update already-queued singleton jobs when urgent work arrives

This prevents a large parked-run population from delaying live model, outcome-tool, input, and cleanup turns while preserving per-run singleton behavior and the minute sweep recovery path.

## Validation

- `pnpm --filter @superlog/worker test:agent-run-queue`
- `pnpm --filter @superlog/worker typecheck`
- `pnpm exec biome check apps/worker/src/agent-runs/queue.ts apps/worker/src/agent-runs/queue.test.ts apps/worker/src/agent-runs/queue-wiring.ts apps/worker/package.json`
- `git diff --check`